### PR TITLE
feat: port Alice memory wiki dashboard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -110,6 +110,29 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+def _ensure_cron_session_title(session_db, session_id: str, job_name: str) -> None:
+    """Give cron-created sessions a stable human-readable title.
+
+    ``AIAgent`` creates the SQLite session row lazily on first message flush,
+    so cron runs used to appear as "Untitled" in recent sessions until the
+    scheduler's final cleanup renamed them. Long-running jobs and failed jobs
+    were therefore confusing in the dashboard. Set the title as soon as the
+    row exists, and keep the final cleanup as a safety net for older/edge paths.
+    """
+    if not session_db or not session_id:
+        return
+    try:
+        existing = session_db.get_session_title(session_id)
+    except Exception:
+        existing = None
+    if existing:
+        return
+    base_title = f"Cron job: {job_name}"
+    title = session_db.get_next_title_in_lineage(base_title)
+    session_db.set_session_title(session_id, title)
+
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -1738,6 +1761,16 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+        if _session_db:
+            try:
+                # Create the DB row now instead of waiting for the first flush,
+                # so Recent Sessions never shows this run as "Untitled" while
+                # the cron job is still executing.
+                if hasattr(agent, "_ensure_db_session"):
+                    agent._ensure_db_session()
+                _ensure_cron_session_title(_session_db, _cron_session_id, job_name)
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to pre-title cron session: %s", job_id, e)
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
@@ -1910,6 +1943,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:
+            try:
+                _ensure_cron_session_title(_session_db, _cron_session_id, job_name)
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to title cron session: %s", job_id, e)
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -848,7 +848,40 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _job_inference_env(job: dict) -> dict[str, str]:
+    """Return environment variables that make scripts honor per-job model overrides.
+
+    Normal agent cron jobs already pass ``job['model']`` / ``job['provider']``
+    into AIAgent construction.  Script jobs can still invoke Hermes internally
+    (for example via ``hermes_cli.oneshot._run_agent``), so bridge the same
+    override through the standard inference env vars.
+    """
+    env: dict[str, str] = {}
+    model = str(job.get("model") or "").strip()
+    provider = str(job.get("provider") or "").strip()
+    base_url = str(job.get("base_url") or "").strip()
+    if not model:
+        try:
+            from hermes_cli.model_routing import route_model_for_task
+            routed = route_model_for_task(job=job)
+            model = routed.model
+            provider = provider or routed.provider
+            if routed.task_class:
+                env["HERMES_ROUTING_CLASS"] = routed.task_class
+            if routed.reason:
+                env["HERMES_ROUTING_REASON"] = routed.reason
+        except Exception:
+            pass
+    if model:
+        env["HERMES_INFERENCE_MODEL"] = model
+    if provider:
+        env["HERMES_INFERENCE_PROVIDER"] = provider
+    if base_url:
+        env["HERMES_INFERENCE_BASE_URL"] = base_url
+    return env
+
+
+def _run_job_script(script_path: str, env_overrides: Optional[dict[str, str]] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -928,6 +961,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())
+    if env_overrides:
+        run_env.update({str(k): str(v) for k, v in env_overrides.items() if str(v).strip()})
     try:
         from hermes_constants import get_subprocess_home
 
@@ -1021,7 +1056,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(script_path, _job_inference_env(job))
         if success:
             if script_output:
                 prompt = (
@@ -1290,7 +1325,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, _job_inference_env(job))
         finally:
             if _prior_cwd is not None:
                 try:
@@ -1518,6 +1553,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        routed_provider = str(job.get("provider") or "").strip()
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -1530,10 +1566,24 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _cfg = _expand_env_vars(_cfg)
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
-                    if isinstance(_model_cfg, str):
-                        model = _model_cfg
-                    elif isinstance(_model_cfg, dict):
-                        model = _model_cfg.get("default", model)
+                    try:
+                        from hermes_cli.model_routing import route_model_for_task
+                        routed = route_model_for_task(job=job, config=_cfg)
+                        model = routed.model or model
+                        routed_provider = routed.provider or routed_provider
+                        logger.info(
+                            "Job '%s': model router selected %s/%s (%s)",
+                            job_id,
+                            routed_provider or "default-provider",
+                            model or "default-model",
+                            routed.reason,
+                        )
+                    except Exception as route_exc:
+                        logger.debug("Job '%s': model router unavailable: %s", job_id, route_exc)
+                        if isinstance(_model_cfg, str):
+                            model = _model_cfg
+                        elif isinstance(_model_cfg, dict):
+                            model = _model_cfg.get("default", model)
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
@@ -1586,7 +1636,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # circuits that precedence and can resurrect old providers (for
             # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
-                "requested": job.get("provider"),
+                "requested": routed_provider or job.get("provider"),
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -739,6 +739,14 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "model_routing": {
+        "enabled": False,
+        "policy": "conservative",
+        "auto_route_no_agent_scripts": False,
+        "default_model": {"provider": "", "model": ""},
+        "cheap_model": {"provider": "", "model": ""},
+        "critical_model": {"provider": "", "model": ""},
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     "agent": {

--- a/hermes_cli/model_routing.py
+++ b/hermes_cli/model_routing.py
@@ -1,0 +1,123 @@
+"""Conservative model routing helpers.
+
+This module intentionally does not hot-swap the main interactive agent.  It is
+for separate runs (cron jobs, one-shots, scripts, and future helper agents)
+where a caller can ask for a task class and receive the configured provider /
+model pair.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from hermes_cli.config import load_config
+
+
+TaskClass = str
+
+
+@dataclass(frozen=True)
+class RoutedModel:
+    provider: str
+    model: str
+    task_class: TaskClass
+    reason: str
+    uses_default: bool = False
+    routing_enabled: bool = False
+
+
+def _model_pair_from_config(model_cfg: Any) -> Tuple[str, str]:
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider") or "").strip()
+        model = str(model_cfg.get("default") or model_cfg.get("name") or "").strip()
+        return provider, model
+    return "", str(model_cfg or "").strip()
+
+
+def get_model_routing_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    cfg = config if config is not None else load_config()
+    routing = cfg.get("model_routing")
+    if not isinstance(routing, dict):
+        routing = {}
+    main_provider, main_model = _model_pair_from_config(cfg.get("model", {}))
+    default_raw = routing.get("default_model")
+    cheap_raw = routing.get("cheap_model")
+    critical_raw = routing.get("critical_model")
+    default_cfg: Dict[str, Any] = default_raw if isinstance(default_raw, dict) else {}
+    cheap_cfg: Dict[str, Any] = cheap_raw if isinstance(cheap_raw, dict) else {}
+    critical_cfg: Dict[str, Any] = critical_raw if isinstance(critical_raw, dict) else {}
+    return {
+        "enabled": bool(routing.get("enabled", False)),
+        "policy": str(routing.get("policy") or "conservative"),
+        "auto_route_no_agent_scripts": bool(routing.get("auto_route_no_agent_scripts", False)),
+        "default_model": {
+            "provider": str(default_cfg.get("provider") or main_provider or "").strip(),
+            "model": str(default_cfg.get("model") or main_model or "").strip(),
+        },
+        "cheap_model": {
+            "provider": str(cheap_cfg.get("provider") or main_provider or "").strip(),
+            "model": str(cheap_cfg.get("model") or "").strip(),
+        },
+        "critical_model": {
+            "provider": str(critical_cfg.get("provider") or main_provider or "").strip(),
+            "model": str(critical_cfg.get("model") or main_model or "").strip(),
+        },
+        "rules": routing.get("rules") if isinstance(routing.get("rules"), dict) else {},
+    }
+
+
+def route_model_for_task(
+    task_class: Optional[TaskClass] = None,
+    *,
+    job: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> RoutedModel:
+    """Resolve provider/model for a task class using conservative routing.
+
+    Explicit job provider/model always wins.  If routing is disabled or the task
+    is not safely classed as ``simple``, the default/critical model is returned.
+    """
+    cfg = config if config is not None else load_config()
+    routing = get_model_routing_config(cfg)
+
+    if job:
+        explicit_model = str(job.get("model") or "").strip()
+        explicit_provider = str(job.get("provider") or "").strip()
+        if explicit_model:
+            return RoutedModel(
+                provider=explicit_provider or routing["default_model"]["provider"],
+                model=explicit_model,
+                task_class=str(job.get("routing_class") or task_class or "explicit"),
+                reason="explicit job model override",
+                uses_default=False,
+                routing_enabled=routing["enabled"],
+            )
+        if not task_class:
+            task_class = str(job.get("routing_class") or "").strip() or None
+        if not task_class and routing["auto_route_no_agent_scripts"] and job.get("no_agent") and job.get("script"):
+            task_class = "simple"
+
+    task = str(task_class or "critical").strip().lower()
+    default = routing["default_model"]
+    critical = routing["critical_model"] or default
+    cheap = routing["cheap_model"]
+
+    if routing["enabled"] and task == "simple" and cheap.get("model"):
+        return RoutedModel(
+            provider=cheap.get("provider") or default.get("provider") or "",
+            model=cheap["model"],
+            task_class="simple",
+            reason="conservative router: simple task",
+            uses_default=False,
+            routing_enabled=True,
+        )
+
+    return RoutedModel(
+        provider=critical.get("provider") or default.get("provider") or "",
+        model=critical.get("model") or default.get("model") or "",
+        task_class=task or "critical",
+        reason="conservative router: default/critical fallback",
+        uses_default=True,
+        routing_enabled=routing["enabled"],
+    )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -603,6 +603,7 @@ class ModelAssignment(BaseModel):
     scope="auxiliary"   → writes auxiliary.<task>.provider + auxiliary.<task>.model
     scope="auxiliary" with task=""  → applied to every auxiliary.* slot
     scope="auxiliary" with task="__reset__"  → resets every slot to provider="auto"
+    scope="routing"     → writes model_routing.<task>_model (task=cheap/default/critical)
     """
     scope: str
     provider: str
@@ -1783,7 +1784,13 @@ def get_auxiliary_models():
         else:
             main = {"provider": "", "model": str(model_cfg) if model_cfg else ""}
 
-        return {"tasks": tasks, "main": main}
+        try:
+            from hermes_cli.model_routing import get_model_routing_config
+            routing = get_model_routing_config(cfg)
+        except Exception:
+            routing = {"enabled": False, "policy": "conservative"}
+
+        return {"tasks": tasks, "main": main, "routing": routing}
     except Exception:
         _log.exception("GET /api/model/auxiliary failed")
         raise HTTPException(status_code=500, detail="Failed to read auxiliary config")
@@ -1802,8 +1809,8 @@ async def set_model_assignment(body: ModelAssignment):
     model = (body.model or "").strip()
     task = (body.task or "").strip().lower()
 
-    if scope not in {"main", "auxiliary"}:
-        raise HTTPException(status_code=400, detail="scope must be 'main' or 'auxiliary'")
+    if scope not in {"main", "auxiliary", "routing"}:
+        raise HTTPException(status_code=400, detail="scope must be 'main', 'auxiliary', or 'routing'")
 
     try:
         cfg = load_config()
@@ -1862,6 +1869,21 @@ async def set_model_assignment(body: ModelAssignment):
                 "model": model,
                 "gateway_tools": gateway_tools,
             }
+
+        if scope == "routing":
+            if task not in {"cheap", "default", "critical"}:
+                raise HTTPException(status_code=400, detail="routing task must be cheap, default, or critical")
+            if not provider or not model:
+                raise HTTPException(status_code=400, detail="provider and model required for routing")
+            routing = cfg.get("model_routing")
+            if not isinstance(routing, dict):
+                routing = {}
+            routing.setdefault("enabled", True)
+            routing.setdefault("policy", "conservative")
+            routing[f"{task}_model"] = {"provider": provider, "model": model}
+            cfg["model_routing"] = routing
+            save_config(cfg)
+            return {"ok": True, "scope": "routing", "task": task, "provider": provider, "model": model}
 
         # scope == "auxiliary"
         aux = cfg.get("auxiliary")
@@ -4154,6 +4176,597 @@ async def cancel_oauth_session(session_id: str, request: Request):
 
 
 # ---------------------------------------------------------------------------
+# Memory Wiki endpoints
+# ---------------------------------------------------------------------------
+
+
+_MEMORY_WIKI_STOPWORDS = {
+    "a", "about", "an", "and", "are", "as", "at", "be", "by", "can", "for", "from", "get", "got",
+    "has", "have", "help", "how", "i", "in", "is", "it", "let", "lets", "me", "my", "of", "on", "or",
+    "our", "setup", "the", "this", "to", "up", "we", "web", "what", "with", "you",
+    # Dashboard/session mechanics are too generic to be useful wiki subjects.
+    "browse", "browser", "chat", "check", "create", "debug", "error", "fix", "fixed", "log", "logs",
+    "message", "messages", "open", "page", "query", "result", "results", "search", "session", "sessions",
+    "show", "test", "testing", "update", "use", "using",
+    "summarize", "summary", "daily", "internal", "cron",
+}
+
+_MEMORY_WIKI_DENY_PHRASES = {
+    "summarize hermes",
+    "summarize memory",
+    "memory daily",
+    "research top",
+    "able access",
+}
+
+
+def _memory_wiki_hidden_subjects_path() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "memory_wiki" / "hidden_subjects.json"
+
+
+def _memory_wiki_hidden_subjects() -> set[str]:
+    path = _memory_wiki_hidden_subjects_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return {_memory_wiki_slug(str(item)) for item in data if str(item).strip()}
+    except (OSError, json.JSONDecodeError):
+        pass
+    return set()
+
+
+def _memory_wiki_save_hidden_subjects(hidden: set[str]) -> None:
+    path = _memory_wiki_hidden_subjects_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(hidden), ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _memory_wiki_is_internal_summary_text(text: str) -> bool:
+    compact = " ".join((text or "").lower().split())
+    return "summarize this hermes memory wiki daily log" in compact
+
+
+def _memory_wiki_date(timestamp: float) -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime(float(timestamp or 0)))
+
+
+def _memory_wiki_day_bounds(date: str) -> tuple[float, float]:
+    import datetime as _dt
+
+    try:
+        start = _dt.datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=_dt.timezone.utc)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Date must be YYYY-MM-DD")
+    return start.timestamp(), (start + _dt.timedelta(days=1)).timestamp()
+
+
+def _memory_wiki_slug(text: str) -> str:
+    import re as _re
+
+    slug = _re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return slug or "untitled"
+
+
+def _memory_wiki_title_from_slug(slug: str) -> str:
+    return " ".join(part.capitalize() for part in (slug or "").split("-") if part)
+
+
+def _memory_wiki_preview(text: str, limit: int = 180) -> str:
+    compact = " ".join((text or "").split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1].rstrip() + "…"
+
+
+def _memory_wiki_subject_for_text(text: str) -> tuple[str, str, list[str]] | None:
+    import re as _re
+
+    raw_text = text or ""
+    if _memory_wiki_is_internal_summary_text(raw_text):
+        return None
+    if _re.fullmatch(r"\d{8}(?:[_-][a-f0-9]{6,})?", raw_text.strip().lower()):
+        return None
+    words = [w.lower().strip("'") for w in _re.findall(r"[A-Za-z][A-Za-z0-9']*", raw_text)]
+    significant = [w for w in words if w not in _MEMORY_WIKI_STOPWORDS and len(w) > 2]
+    if len(significant) < 2:
+        return None
+
+    # Prefer the first meaningful phrase. Session titles tend to lead with
+    # the thing the user thinks the conversation was about, while later words
+    # are usually actions/details ("balance", "keepalive", "notes", etc.).
+    chosen: list[str] = []
+    for word in significant:
+        if word in chosen:
+            continue
+        chosen.append(word)
+        if len(chosen) == 2:
+            break
+    if len(chosen) < 2:
+        return None
+    phrase = " ".join(chosen)
+    if phrase in _MEMORY_WIKI_DENY_PHRASES:
+        return None
+    title = " ".join(part.capitalize() for part in chosen)
+    return _memory_wiki_slug(phrase), title, chosen
+
+
+def _memory_wiki_session_rows(db, *, limit: int = 500) -> list[dict[str, Any]]:
+    conn = getattr(db, "_conn", None)
+    if conn is None:
+        return db.list_sessions_rich(limit=limit, offset=0)
+    rows = conn.execute(
+        """
+        SELECT
+            s.id,
+            s.source,
+            s.model,
+            s.title,
+            s.started_at,
+            s.ended_at,
+            s.message_count,
+            COALESCE(m.last_active, s.started_at) AS last_active,
+            first_msg.content AS preview
+        FROM sessions s
+        LEFT JOIN (
+            SELECT session_id, MAX(timestamp) AS last_active
+            FROM messages
+            GROUP BY session_id
+        ) m ON m.session_id = s.id
+        LEFT JOIN messages first_msg ON first_msg.id = (
+            SELECT id FROM messages
+            WHERE session_id = s.id AND role IN ('user', 'assistant') AND content IS NOT NULL AND content != ''
+            ORDER BY timestamp ASC, id ASC
+            LIMIT 1
+        )
+        ORDER BY s.started_at DESC, s.id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _memory_wiki_message_rows(db, session_ids: list[str] | None = None, *, limit: int = 500) -> list[dict[str, Any]]:
+    conn = getattr(db, "_conn", None)
+    if conn is None:
+        return []
+    params: list[Any] = []
+    where = "WHERE m.content IS NOT NULL AND m.content != '' AND m.role IN ('user', 'assistant')"
+    if session_ids:
+        placeholders = ",".join("?" for _ in session_ids)
+        where += f" AND m.session_id IN ({placeholders})"
+        params.extend(session_ids)
+    params.append(limit)
+    rows = conn.execute(
+        f"""
+        SELECT
+            m.id,
+            m.session_id,
+            m.role,
+            m.content,
+            m.timestamp,
+            s.title AS session_title,
+            s.source,
+            s.started_at AS session_started
+        FROM messages m
+        JOIN sessions s ON s.id = m.session_id
+        {where}
+        ORDER BY m.timestamp DESC, m.id DESC
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _memory_wiki_cache_path(kind: str, key: str) -> Path:
+    from hermes_constants import get_hermes_home
+
+    safe_key = _memory_wiki_slug(key)
+    return get_hermes_home() / "memory_wiki" / kind / f"{safe_key}.json"
+
+
+def _memory_wiki_signature(payload: dict[str, Any]) -> str:
+    import hashlib as _hashlib
+
+    raw = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return _hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _memory_wiki_cached_summary(kind: str, key: str, signature_payload: dict[str, Any], generator) -> dict[str, Any]:
+    signature = _memory_wiki_signature(signature_payload)
+    path = _memory_wiki_cache_path(kind, key)
+    try:
+        if path.exists():
+            cached = json.loads(path.read_text(encoding="utf-8"))
+            cached_summary = cached.get("summary")
+            if cached.get("signature") == signature and isinstance(cached_summary, dict):
+                return cached_summary
+            # Daily AI captain's logs should remain visible even when the
+            # underlying day receives a few new messages after manual backfill.
+            # The nightly/script generator overwrites this cache with a fresh
+            # signature; until then, prefer the readable AI log over falling
+            # back to the all-caps local extraction.
+            if kind == "days" and isinstance(cached_summary, dict):
+                generated_by = str(cached_summary.get("generated_by") or "")
+                if generated_by.startswith("ai-"):
+                    cached_summary["stale"] = True
+                    return cached_summary
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    summary = generator()
+    summary.setdefault("generated_at", time.time())
+    summary["cache_kind"] = kind
+    summary["cache_key"] = key
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"signature": signature, "summary": summary}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def _memory_wiki_write_cached_summary(kind: str, key: str, signature_payload: dict[str, Any], summary: dict[str, Any]) -> dict[str, Any]:
+    signature = _memory_wiki_signature(signature_payload)
+    path = _memory_wiki_cache_path(kind, key)
+    summary.setdefault("generated_at", time.time())
+    summary["cache_kind"] = kind
+    summary["cache_key"] = key
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"signature": signature, "summary": summary}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def _memory_wiki_sentence_fragment(text: str, limit: int = 140) -> str:
+    fragment = _memory_wiki_preview(text, limit=limit)
+    return fragment.rstrip(". ")
+
+
+def _memory_wiki_normalize_ai_bullet(text: str, date: str) -> str | None:
+    import re as _re
+
+    bullet = _re.sub(r"^[-*•\d.)\s]+", "", (text or "").strip()).strip()
+    if not bullet:
+        return None
+    if bullet.startswith(f"{date} — "):
+        return bullet
+    if bullet.startswith(f"{date} - "):
+        return f"{date} — {bullet[len(date) + 3:].strip()}"
+    return f"{date} — {bullet}"
+
+
+def _memory_wiki_parse_ai_daily_summary(raw: str, date: str) -> dict[str, Any]:
+    import re as _re
+
+    bullets: list[str] = []
+    text = (raw or "").strip()
+    if text:
+        try:
+            parsed = json.loads(text)
+            candidate = parsed.get("bullets") if isinstance(parsed, dict) else parsed
+            if isinstance(candidate, list):
+                for item in candidate:
+                    normalized = _memory_wiki_normalize_ai_bullet(str(item), date)
+                    if normalized:
+                        bullets.append(normalized)
+        except json.JSONDecodeError:
+            pass
+    if not bullets:
+        for line in text.splitlines():
+            if _re.match(r"^\s*(?:[-*•]|\d+[.)])\s+", line):
+                normalized = _memory_wiki_normalize_ai_bullet(line, date)
+                if normalized:
+                    bullets.append(normalized)
+    if not bullets and text:
+        for sentence in _re.split(r"(?<=[.!?])\s+", text):
+            normalized = _memory_wiki_normalize_ai_bullet(sentence, date)
+            if normalized:
+                bullets.append(normalized)
+    return {
+        "headline": date,
+        "bullets": bullets[:7] or [f"{date} — No clear accomplishments or attempts were identified."],
+        "generated_by": "ai-daily-v1",
+    }
+
+
+def _memory_wiki_day_signature_payload(date: str, sessions: list[dict[str, Any]], summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "date": date,
+        "summary": summary,
+        "sessions": [
+            {
+                "id": s.get("id"),
+                "title": s.get("title"),
+                "message_count": s.get("message_count"),
+                "last_active": s.get("last_active"),
+                "preview": s.get("preview"),
+            }
+            for s in sessions
+        ],
+    }
+
+
+def _memory_wiki_day_summary(date: str, sessions: list[dict[str, Any]], summary: dict[str, Any]) -> dict[str, Any]:
+    def _generate() -> dict[str, Any]:
+        session_count = int(summary.get("session_count") or 0)
+        message_count = int(summary.get("message_count") or 0)
+        sources = summary.get("sources") or []
+        source_text = f" via {', '.join(sources)}" if sources else ""
+        headline = f"{date}: {session_count} session{'s' if session_count != 1 else ''}, {message_count} message{'s' if message_count != 1 else ''}{source_text}."
+        bullets = []
+        for session in sessions[:6]:
+            title = session.get("title") or session.get("id") or "Untitled session"
+            preview = _memory_wiki_sentence_fragment(session.get("preview") or "")
+            if preview:
+                bullets.append(f"{title}: {preview}")
+            else:
+                bullets.append(str(title))
+        if not bullets:
+            bullets.append("No readable session messages were captured for this day yet.")
+        return {
+            "headline": headline,
+            "bullets": bullets,
+            "generated_by": "local-extractive-v1",
+        }
+
+    signature_payload = _memory_wiki_day_signature_payload(date, sessions, summary)
+    return _memory_wiki_cached_summary("days", date, signature_payload, _generate)
+
+
+def _memory_wiki_subject_summary(title: str, slug: str, query_terms: list[str], sessions: list[dict[str, Any]], hits: list[dict[str, Any]], summary: dict[str, Any]) -> dict[str, Any]:
+    def _generate() -> dict[str, Any]:
+        session_count = int(summary.get("session_count") or 0)
+        message_count = int(summary.get("message_count") or 0)
+        headline = f"{title}: found across {session_count} session{'s' if session_count != 1 else ''} and {message_count} related message{'s' if message_count != 1 else ''}."
+        bullets: list[str] = []
+        for hit in hits[:6]:
+            content = _memory_wiki_sentence_fragment(hit.get("content") or "", limit=180)
+            if not content:
+                continue
+            session_title = hit.get("session_title") or hit.get("session_id") or "Session"
+            bullets.append(f"{session_title}: {content}")
+        if not bullets:
+            for session in sessions[:6]:
+                title_text = session.get("title") or session.get("id") or "Untitled session"
+                preview = _memory_wiki_sentence_fragment(session.get("preview") or "", limit=180)
+                bullets.append(f"{title_text}: {preview}" if preview else str(title_text))
+        if not bullets:
+            bullets.append("No readable message snippets were captured for this subject yet.")
+        return {
+            "headline": headline,
+            "bullets": bullets,
+            "generated_by": "local-extractive-v1",
+            "query_terms": query_terms,
+        }
+
+    signature_payload = {
+        "slug": slug,
+        "title": title,
+        "query_terms": query_terms,
+        "summary": summary,
+        "sessions": [
+            {
+                "id": s.get("id"),
+                "title": s.get("title"),
+                "message_count": s.get("message_count"),
+                "last_active": s.get("last_active"),
+                "preview": s.get("preview"),
+            }
+            for s in sessions
+        ],
+        "hits": [
+            {
+                "id": h.get("id"),
+                "session_id": h.get("session_id"),
+                "timestamp": h.get("timestamp"),
+                "content": h.get("content"),
+            }
+            for h in hits[:50]
+        ],
+    }
+    return _memory_wiki_cached_summary("subjects", slug, signature_payload, _generate)
+
+
+@app.get("/api/memory-wiki/days")
+async def get_memory_wiki_days(limit: int = 90):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        buckets: dict[str, dict[str, Any]] = {}
+        for session in _memory_wiki_session_rows(db, limit=5000):
+            date = _memory_wiki_date(session.get("started_at") or 0)
+            bucket = buckets.setdefault(
+                date,
+                {"date": date, "session_count": 0, "message_count": 0, "sources": set(), "latest_at": 0},
+            )
+            bucket["session_count"] += 1
+            bucket["message_count"] += int(session.get("message_count") or 0)
+            if session.get("source"):
+                bucket["sources"].add(session["source"])
+            bucket["latest_at"] = max(float(bucket["latest_at"] or 0), float(session.get("last_active") or session.get("started_at") or 0))
+        days = sorted(buckets.values(), key=lambda item: item["date"], reverse=True)[:limit]
+        for day in days:
+            day["sources"] = sorted(day["sources"])
+        return {"days": days}
+    finally:
+        db.close()
+
+
+@app.get("/api/memory-wiki/days/{date}")
+async def get_memory_wiki_day(date: str):
+    from hermes_state import SessionDB
+
+    start, end = _memory_wiki_day_bounds(date)
+    db = SessionDB()
+    try:
+        sessions = [
+            session for session in _memory_wiki_session_rows(db, limit=5000)
+            if start <= float(session.get("started_at") or 0) < end
+        ]
+        sessions.sort(key=lambda item: float(item.get("started_at") or 0), reverse=True)
+        response_sessions = []
+        sources = set()
+        message_count = 0
+        for session in sessions:
+            sources.add(session.get("source"))
+            message_count += int(session.get("message_count") or 0)
+            response_sessions.append({
+                "id": session.get("id"),
+                "title": session.get("title") or session.get("id"),
+                "source": session.get("source"),
+                "model": session.get("model"),
+                "started_at": session.get("started_at"),
+                "last_active": session.get("last_active"),
+                "message_count": session.get("message_count") or 0,
+                "preview": _memory_wiki_preview(session.get("preview") or ""),
+            })
+        day_summary = {
+            "session_count": len(response_sessions),
+            "message_count": message_count,
+            "sources": sorted(s for s in sources if s),
+        }
+        return {
+            "date": date,
+            "summary": day_summary,
+            "wiki_summary": _memory_wiki_day_summary(date, response_sessions, day_summary),
+            "sessions": response_sessions,
+        }
+    finally:
+        db.close()
+
+
+def _memory_wiki_subject_index(db) -> dict[str, dict[str, Any]]:
+    subjects: dict[str, dict[str, Any]] = {}
+    session_by_id = {s.get("id"): s for s in _memory_wiki_session_rows(db, limit=5000)}
+    messages = _memory_wiki_message_rows(db, limit=20000)
+
+    for session in session_by_id.values():
+        candidate = _memory_wiki_subject_for_text(session.get("title") or session.get("preview") or session.get("id") or "")
+        if not candidate:
+            continue
+        slug, title, query_terms = candidate
+        entry = subjects.setdefault(slug, {"slug": slug, "title": title, "query_terms": query_terms, "session_ids": set(), "message_count": 0, "latest_at": 0})
+        entry["session_ids"].add(session.get("id"))
+        entry["latest_at"] = max(float(entry["latest_at"] or 0), float(session.get("last_active") or session.get("started_at") or 0))
+
+    for message in messages:
+        session = session_by_id.get(message.get("session_id"), {})
+        candidate = _memory_wiki_subject_for_text(session.get("title") or message.get("content") or "")
+        if not candidate:
+            continue
+        slug, title, query_terms = candidate
+        entry = subjects.setdefault(slug, {"slug": slug, "title": title, "query_terms": query_terms, "session_ids": set(), "message_count": 0, "latest_at": 0})
+        entry["session_ids"].add(message.get("session_id"))
+        entry["message_count"] += 1
+        entry["latest_at"] = max(float(entry["latest_at"] or 0), float(message.get("timestamp") or 0))
+
+    return subjects
+
+
+@app.get("/api/memory-wiki/subjects")
+async def get_memory_wiki_subjects(limit: int = 100):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        subjects = []
+        hidden = _memory_wiki_hidden_subjects()
+        for entry in _memory_wiki_subject_index(db).values():
+            if entry["slug"] in hidden:
+                continue
+            subjects.append({
+                "slug": entry["slug"],
+                "title": entry["title"],
+                "query_terms": entry.get("query_terms") or [],
+                "session_count": len(entry["session_ids"]),
+                "message_count": entry["message_count"],
+                "latest_at": entry["latest_at"],
+            })
+        subjects.sort(key=lambda item: (item["session_count"], item["message_count"], item["latest_at"]), reverse=True)
+        return {"subjects": subjects[:limit]}
+    finally:
+        db.close()
+
+
+@app.post("/api/memory-wiki/subjects/{slug}/hide")
+async def hide_memory_wiki_subject(slug: str):
+    safe_slug = _memory_wiki_slug(slug)
+    hidden = _memory_wiki_hidden_subjects()
+    hidden.add(safe_slug)
+    _memory_wiki_save_hidden_subjects(hidden)
+    return {"slug": safe_slug, "hidden": True}
+
+
+@app.get("/api/memory-wiki/subjects/{slug}")
+async def get_memory_wiki_subject(slug: str):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        subjects = _memory_wiki_subject_index(db)
+        entry = subjects.get(slug)
+        if not entry or slug in _memory_wiki_hidden_subjects():
+            raise HTTPException(status_code=404, detail="Subject not found")
+        session_ids = sorted(entry["session_ids"])
+        sessions_by_id = {s.get("id"): s for s in _memory_wiki_session_rows(db, limit=5000) if s.get("id") in session_ids}
+        sessions = []
+        for sid in session_ids:
+            session = sessions_by_id.get(sid)
+            if not session:
+                continue
+            sessions.append({
+                "id": sid,
+                "title": session.get("title") or sid,
+                "source": session.get("source"),
+                "started_at": session.get("started_at"),
+                "last_active": session.get("last_active"),
+                "message_count": session.get("message_count") or 0,
+                "preview": _memory_wiki_preview(session.get("preview") or ""),
+            })
+        sessions.sort(key=lambda item: float(item.get("last_active") or item.get("started_at") or 0), reverse=True)
+        query_terms = entry.get("query_terms") or [part.lower() for part in entry["title"].split()]
+        hits = []
+        for message in _memory_wiki_message_rows(db, session_ids=session_ids, limit=500):
+            content_lc = (message.get("content") or "").lower()
+            if query_terms and not all(term in content_lc for term in query_terms):
+                # Keep session-level matches even when only the title mentions the subject,
+                # but prioritize direct message hits for the detail view.
+                continue
+            hits.append({
+                "id": message.get("id"),
+                "session_id": message.get("session_id"),
+                "role": message.get("role"),
+                "content": _memory_wiki_preview(message.get("content") or "", limit=500),
+                "timestamp": message.get("timestamp"),
+                "session_title": message.get("session_title"),
+                "source": message.get("source"),
+            })
+        subject_summary = {
+            "session_count": len(sessions),
+            "message_count": entry["message_count"],
+            "latest_at": entry["latest_at"],
+        }
+        return {
+            "slug": slug,
+            "title": entry["title"],
+            "query_terms": query_terms,
+            "summary": subject_summary,
+            "wiki_summary": _memory_wiki_subject_summary(entry["title"], slug, query_terms, sessions, hits, subject_summary),
+            "sessions": sessions,
+            "message_hits": hits[:50],
+        }
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # Session detail endpoints
 # ---------------------------------------------------------------------------
 
@@ -4582,6 +5195,8 @@ class CronJobCreate(BaseModel):
     schedule: str
     name: str = ""
     deliver: str = "local"
+    model: Optional[str] = None
+    provider: Optional[str] = None
 
 
 class CronJobUpdate(BaseModel):
@@ -4616,12 +5231,61 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
     return canon, profiles_mod.get_profile_dir(canon)
 
 
+def _cron_profile_config_and_default_model(home: Path) -> Tuple[Dict[str, Any], str, str]:
+    """Return (config, provider, model) configured for a profile, best-effort."""
+    try:
+        import yaml
+
+        cfg_path = home / "config.yaml"
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
+    except Exception:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    model_cfg = cfg.get("model") or {}
+    if isinstance(model_cfg, str):
+        return cfg, "", model_cfg
+    if isinstance(model_cfg, dict):
+        provider = str(model_cfg.get("provider") or "").strip()
+        model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+        return cfg, provider, model
+    return cfg, "", ""
+
+
+def _cron_profile_default_model(home: Path) -> Tuple[str, str]:
+    """Return (provider, model) configured for a profile, best-effort."""
+    _, provider, model = _cron_profile_config_and_default_model(home)
+    return provider, model
+
+
 def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
     annotated = dict(job)
     annotated["profile"] = profile
     annotated["profile_name"] = profile
     annotated["hermes_home"] = str(home)
     annotated["is_default_profile"] = profile == "default"
+
+    explicit_provider = str(job.get("provider") or "").strip()
+    explicit_model = str(job.get("model") or "").strip()
+    cfg, default_provider, default_model = _cron_profile_config_and_default_model(home)
+    routed_provider = default_provider
+    routed_model = default_model
+    routing_class = "default"
+    routing_reason = "default model"
+    try:
+        from hermes_cli.model_routing import route_model_for_task
+        routed = route_model_for_task(job=job, config=cfg)
+        routed_provider = routed.provider or routed_provider
+        routed_model = routed.model or routed_model
+        routing_class = routed.task_class
+        routing_reason = routed.reason
+    except Exception:
+        pass
+    annotated["uses_default_model"] = not bool(explicit_model or explicit_provider) and routed_model == default_model
+    annotated["effective_provider"] = explicit_provider or routed_provider
+    annotated["effective_model"] = explicit_model or routed_model
+    annotated["routing_class"] = job.get("routing_class") or routing_class
+    annotated["routing_reason"] = routing_reason
     return annotated
 
 
@@ -4707,6 +5371,8 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
             schedule=body.schedule,
             name=body.name,
             deliver=body.deliver,
+            model=body.model,
+            provider=body.provider,
         )
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")
@@ -6423,6 +7089,18 @@ async def get_models_analytics(days: int = 30):
     try:
         cutoff = time.time() - (days * 86400)
 
+        from datetime import datetime, time as dt_time, timedelta
+        try:
+            from zoneinfo import ZoneInfo
+            local_tz = ZoneInfo(os.environ.get("TZ") or "Europe/Prague")
+        except Exception:
+            local_tz = None
+        now_local = datetime.now(local_tz) if local_tz else datetime.now().astimezone()
+        today_start_local = datetime.combine(now_local.date(), dt_time(4, 0), tzinfo=now_local.tzinfo)
+        if now_local < today_start_local:
+            today_start_local -= timedelta(days=1)
+        today_cutoff = today_start_local.timestamp()
+
         cur = db._conn.execute("""
             SELECT model,
                    billing_provider,
@@ -6443,10 +7121,37 @@ async def get_models_analytics(days: int = 30):
         """, (cutoff,))
         rows = [dict(r) for r in cur.fetchall()]
 
-        models = []
-        for row in rows:
-            provider = row.get("billing_provider") or ""
-            model_name = row["model"]
+        def _usage_by_model(where_sql: str, params: tuple) -> dict[tuple[str, str], dict]:
+            usage_cur = db._conn.execute(f"""
+                SELECT model,
+                       billing_provider,
+                       COALESCE(SUM(input_tokens), 0) as input_tokens,
+                       COALESCE(SUM(output_tokens), 0) as output_tokens,
+                       COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                       COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens
+                FROM sessions
+                WHERE {where_sql} AND model IS NOT NULL AND model != ''
+                GROUP BY model, billing_provider
+            """, params)
+            return {
+                (r["model"], r["billing_provider"] or ""): dict(r)
+                for r in usage_cur.fetchall()
+            }
+
+        lifetime_usage = _usage_by_model("1=1", ())
+        today_usage = _usage_by_model("started_at >= ?", (today_cutoff,))
+
+        def _total_tokens(row: dict | None) -> int:
+            if not row:
+                return 0
+            return (
+                int(row.get("input_tokens") or 0)
+                + int(row.get("output_tokens") or 0)
+                + int(row.get("cache_read_tokens") or 0)
+                + int(row.get("reasoning_tokens") or 0)
+            )
+
+        def _capabilities(provider: str, model_name: str) -> dict:
             caps = {}
             try:
                 from agent.models_dev import get_model_capabilities
@@ -6462,6 +7167,64 @@ async def get_models_analytics(days: int = 30):
                     }
             except Exception:
                 pass
+            return caps
+
+        def _known_configured_models() -> set[tuple[str, str]]:
+            """Models configured on cron/model routing should appear before much usage accrues."""
+            known: set[tuple[str, str]] = set()
+            try:
+                from cron.jobs import list_jobs
+                for job in list_jobs(include_disabled=True):
+                    model_name = str(job.get("model") or "").strip()
+                    provider = str(job.get("provider") or "").strip()
+                    if model_name:
+                        known.add((model_name, provider))
+            except Exception:
+                pass
+            try:
+                cfg = load_config()
+                routing = cfg.get("model_routing") if isinstance(cfg, dict) else None
+                if isinstance(routing, dict):
+                    for key in ("default_model", "cheap_model", "critical_model"):
+                        entry = routing.get(key)
+                        if isinstance(entry, dict):
+                            model_name = str(entry.get("model") or "").strip()
+                            provider = str(entry.get("provider") or "").strip()
+                            if model_name:
+                                known.add((model_name, provider))
+            except Exception:
+                pass
+            return known
+
+        def _empty_row(model_name: str, provider: str) -> dict:
+            return {
+                "model": model_name,
+                "billing_provider": provider,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "reasoning_tokens": 0,
+                "estimated_cost": 0,
+                "actual_cost": 0,
+                "sessions": 0,
+                "api_calls": 0,
+                "tool_calls": 0,
+                "last_used_at": None,
+                "avg_tokens_per_session": 0,
+            }
+
+        row_by_key = {(r["model"], r.get("billing_provider") or ""): r for r in rows}
+        for key in sorted(_known_configured_models()):
+            row_by_key.setdefault(key, _empty_row(*key))
+
+        models = []
+        for row in row_by_key.values():
+            provider = row.get("billing_provider") or ""
+            model_name = row["model"]
+            key = (model_name, provider)
+            lifetime = lifetime_usage.get(key)
+            today = today_usage.get(key)
+            caps = _capabilities(provider, model_name)
 
             models.append({
                 "model": model_name,
@@ -6477,8 +7240,24 @@ async def get_models_analytics(days: int = 30):
                 "tool_calls": row["tool_calls"],
                 "last_used_at": row["last_used_at"],
                 "avg_tokens_per_session": row["avg_tokens_per_session"],
+                "tokens_to_date": _total_tokens(lifetime),
+                "today_input_tokens": int(today.get("input_tokens") or 0) if today else 0,
+                "today_output_tokens": int(today.get("output_tokens") or 0) if today else 0,
+                "today_cache_read_tokens": int(today.get("cache_read_tokens") or 0) if today else 0,
+                "today_reasoning_tokens": int(today.get("reasoning_tokens") or 0) if today else 0,
+                "today_total_tokens": _total_tokens(today),
+                "today_started_at": today_cutoff,
                 "capabilities": caps,
             })
+
+        models.sort(
+            key=lambda m: (
+                int(m.get("tokens_to_date") or 0),
+                int(m.get("today_total_tokens") or 0),
+                int(m.get("input_tokens") or 0) + int(m.get("output_tokens") or 0),
+            ),
+            reverse=True,
+        )
 
         totals_cur = db._conn.execute("""
             SELECT COUNT(DISTINCT model) as distinct_models,
@@ -6493,6 +7272,31 @@ async def get_models_analytics(days: int = 30):
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
         """, (cutoff,))
         totals = dict(totals_cur.fetchone())
+        totals["distinct_models"] = len(models)
+
+        lifetime_totals_cur = db._conn.execute("""
+            SELECT COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens
+            FROM sessions WHERE model IS NOT NULL AND model != ''
+        """)
+        today_totals_cur = db._conn.execute("""
+            SELECT COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens
+            FROM sessions WHERE started_at >= ? AND model IS NOT NULL AND model != ''
+        """, (today_cutoff,))
+        lifetime_totals = dict(lifetime_totals_cur.fetchone())
+        today_totals = dict(today_totals_cur.fetchone())
+        totals["tokens_to_date"] = _total_tokens(lifetime_totals)
+        totals["today_input_tokens"] = int(today_totals.get("input_tokens") or 0)
+        totals["today_output_tokens"] = int(today_totals.get("output_tokens") or 0)
+        totals["today_cache_read_tokens"] = int(today_totals.get("cache_read_tokens") or 0)
+        totals["today_reasoning_tokens"] = int(today_totals.get("reasoning_tokens") or 0)
+        totals["today_total_tokens"] = _total_tokens(today_totals)
+        totals["today_started_at"] = today_cutoff
 
         return {
             "models": models,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -875,6 +875,8 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
         }
         fake_db = MagicMock()
+        fake_db.get_session_title.side_effect = [None, "Cron job: test"]
+        fake_db.get_next_title_in_lineage.return_value = "Cron job: test"
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
@@ -909,6 +911,12 @@ class TestRunJobSessionPersistence:
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")
         assert call_args[0][1] == "cron_complete"
+        mock_agent._ensure_db_session.assert_called_once()
+        fake_db.get_next_title_in_lineage.assert_called_once_with("Cron job: test")
+        fake_db.set_session_title.assert_called_once()
+        title_args = fake_db.set_session_title.call_args.args
+        assert title_args[0].startswith("cron_test-job_")
+        assert title_args[1] == "Cron job: test"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1845,6 +1845,245 @@ class TestNewEndpoints:
         assert top_skill["total_count"] == 1
         assert top_skill["last_used_at"] is not None
 
+    def _seed_memory_wiki_sessions(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("mw-infinite-racing", source="discord", model="test-model")
+            db.set_session_title("mw-infinite-racing", "Infinite Racing card balance")
+            db.append_message(
+                "mw-infinite-racing",
+                role="user",
+                content="Let's tune Infinite Racing pit stop cards and card balance.",
+            )
+            db.append_message(
+                "mw-infinite-racing",
+                role="assistant",
+                content="We adjusted Infinite Racing card balance notes.",
+            )
+
+            db.create_session("mw-hermes-gateway", source="cli", model="test-model")
+            db.set_session_title("mw-hermes-gateway", "Hermes Gateway keepalive")
+            db.append_message(
+                "mw-hermes-gateway",
+                role="user",
+                content="Fix Hermes Gateway WSL keepalive setup.",
+            )
+
+            db.create_session("mw-generic-search", source="cli", model="test-model")
+            db.set_session_title("mw-generic-search", "Search web")
+            db.append_message(
+                "mw-generic-search",
+                role="assistant",
+                content="Search results returned from a web lookup.",
+            )
+
+            def _retime(session_id, started_at):
+                def _do(conn):
+                    conn.execute(
+                        "UPDATE sessions SET started_at = ? WHERE id = ?",
+                        (started_at, session_id),
+                    )
+                    conn.execute(
+                        "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+                        (started_at + 60, session_id),
+                    )
+                db._execute_write(_do)
+
+            _retime("mw-infinite-racing", 1704067200.0)
+            _retime("mw-hermes-gateway", 1704153600.0)
+            _retime("mw-generic-search", 1704240000.0)
+        finally:
+            db.close()
+
+    def test_memory_wiki_days_lists_days_with_session_counts(self):
+        self._seed_memory_wiki_sessions()
+
+        resp = self.client.get("/api/memory-wiki/days")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["days"][0]["date"] == "2024-01-03"
+        assert data["days"][0]["session_count"] == 1
+        assert data["days"][1]["date"] == "2024-01-02"
+        assert data["days"][1]["session_count"] == 1
+        assert data["days"][2]["date"] == "2024-01-01"
+        assert data["days"][2]["sources"] == ["discord"]
+
+    def test_memory_wiki_day_detail_returns_sessions_for_date(self):
+        self._seed_memory_wiki_sessions()
+
+        resp = self.client.get("/api/memory-wiki/days/2024-01-01")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["date"] == "2024-01-01"
+        assert data["summary"]["session_count"] == 1
+        assert data["sessions"][0]["id"] == "mw-infinite-racing"
+        assert data["sessions"][0]["title"] == "Infinite Racing card balance"
+        assert data["sessions"][0]["preview"]
+        assert data["wiki_summary"]["headline"]
+        assert any("Infinite Racing card balance" in bullet for bullet in data["wiki_summary"]["bullets"])
+
+    def test_memory_wiki_day_detail_caches_summary(self):
+        from hermes_constants import get_hermes_home
+
+        self._seed_memory_wiki_sessions()
+
+        first = self.client.get("/api/memory-wiki/days/2024-01-01").json()
+        second = self.client.get("/api/memory-wiki/days/2024-01-01").json()
+
+        assert first["wiki_summary"] == second["wiki_summary"]
+        cache_path = get_hermes_home() / "memory_wiki" / "days" / "2024-01-01.json"
+        assert cache_path.exists()
+
+    def test_memory_wiki_day_detail_prefers_stale_ai_summary_over_local_fallback(self):
+        from hermes_cli.web_server import _memory_wiki_write_cached_summary
+
+        self._seed_memory_wiki_sessions()
+        _memory_wiki_write_cached_summary(
+            "days",
+            "2024-01-01",
+            {"old": "signature"},
+            {
+                "headline": "2024-01-01",
+                "bullets": ["2024-01-01 — Tuned Infinite Racing card balance."],
+                "generated_by": "ai-daily-v1",
+            },
+        )
+
+        resp = self.client.get("/api/memory-wiki/days/2024-01-01")
+
+        assert resp.status_code == 200
+        summary = resp.json()["wiki_summary"]
+        assert summary["generated_by"] == "ai-daily-v1"
+        assert summary["stale"] is True
+        assert summary["bullets"] == ["2024-01-01 — Tuned Infinite Racing card balance."]
+
+    def test_memory_wiki_ai_daily_summary_parser_returns_concise_timestamped_bullets(self):
+        from hermes_cli.web_server import _memory_wiki_parse_ai_daily_summary
+
+        parsed = _memory_wiki_parse_ai_daily_summary(
+            """
+            {
+              "bullets": [
+                "Tuned Infinite Racing pit stop cards.",
+                "Updated card balance notes.",
+                "Attempted to verify the new wiki summary behavior."
+              ]
+            }
+            """,
+            "2024-01-01",
+        )
+
+        assert parsed["headline"] == "2024-01-01"
+        assert parsed["generated_by"] == "ai-daily-v1"
+        assert parsed["bullets"] == [
+            "2024-01-01 — Tuned Infinite Racing pit stop cards.",
+            "2024-01-01 — Updated card balance notes.",
+            "2024-01-01 — Attempted to verify the new wiki summary behavior.",
+        ]
+
+    def test_memory_wiki_ai_daily_summary_parser_limits_to_seven_bullets(self):
+        from hermes_cli.web_server import _memory_wiki_parse_ai_daily_summary
+
+        parsed = _memory_wiki_parse_ai_daily_summary(
+            "\n".join(f"- bullet {idx}" for idx in range(10)),
+            "2024-01-01",
+        )
+
+        assert len(parsed["bullets"]) == 7
+        assert all(item.startswith("2024-01-01 — ") for item in parsed["bullets"])
+
+    def test_memory_wiki_subjects_groups_related_sessions(self):
+        self._seed_memory_wiki_sessions()
+
+        resp = self.client.get("/api/memory-wiki/subjects")
+
+        assert resp.status_code == 200
+        subjects = {item["slug"]: item for item in resp.json()["subjects"]}
+        assert "infinite-racing" in subjects
+        assert subjects["infinite-racing"]["session_count"] == 1
+        assert subjects["infinite-racing"]["message_count"] >= 2
+        assert subjects["infinite-racing"]["query_terms"] == ["infinite", "racing"]
+        assert "hermes-gateway" in subjects
+        assert "search-web" not in subjects
+
+    def test_memory_wiki_subjects_excludes_internal_summary_prompts_and_raw_ids(self):
+        from hermes_state import SessionDB
+
+        self._seed_memory_wiki_sessions()
+        db = SessionDB()
+        try:
+            db.create_session("20260524_012007_884131", source="cli", model="test-model")
+            db.append_message(
+                "20260524_012007_884131",
+                role="user",
+                content="Summarize this Hermes Memory Wiki daily log for 2026-05-23.",
+            )
+            db.create_session("20260524_deadbeef", source="cli", model="test-model")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/memory-wiki/subjects")
+
+        assert resp.status_code == 200
+        slugs = {item["slug"] for item in resp.json()["subjects"]}
+        assert "summarize-this" not in slugs
+        assert "hermes-memory" not in slugs
+        assert "deadbeef" not in " ".join(slugs)
+
+    def test_memory_wiki_hide_subject_stores_slug_and_excludes_from_list(self):
+        from hermes_constants import get_hermes_home
+
+        self._seed_memory_wiki_sessions()
+
+        hide_resp = self.client.post("/api/memory-wiki/subjects/infinite-racing/hide")
+        list_resp = self.client.get("/api/memory-wiki/subjects")
+
+        assert hide_resp.status_code == 200
+        assert hide_resp.json()["hidden"] is True
+        assert "infinite-racing" not in {item["slug"] for item in list_resp.json()["subjects"]}
+        hidden_path = get_hermes_home() / "memory_wiki" / "hidden_subjects.json"
+        assert hidden_path.exists()
+        assert "infinite-racing" in hidden_path.read_text(encoding="utf-8")
+
+    def test_memory_wiki_hidden_subject_detail_returns_404(self):
+        self._seed_memory_wiki_sessions()
+        self.client.post("/api/memory-wiki/subjects/infinite-racing/hide")
+
+        resp = self.client.get("/api/memory-wiki/subjects/infinite-racing")
+
+        assert resp.status_code == 404
+
+    def test_memory_wiki_subject_detail_returns_matching_messages(self):
+        self._seed_memory_wiki_sessions()
+
+        resp = self.client.get("/api/memory-wiki/subjects/infinite-racing")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slug"] == "infinite-racing"
+        assert data["title"] == "Infinite Racing"
+        assert data["query_terms"] == ["infinite", "racing"]
+        assert data["sessions"][0]["id"] == "mw-infinite-racing"
+        assert data["wiki_summary"]["headline"]
+        assert any("pit stop cards" in bullet for bullet in data["wiki_summary"]["bullets"])
+        assert any("Infinite Racing" in hit["content"] for hit in data["message_hits"])
+
+    def test_memory_wiki_subject_detail_caches_summary(self):
+        from hermes_constants import get_hermes_home
+
+        self._seed_memory_wiki_sessions()
+
+        first = self.client.get("/api/memory-wiki/subjects/infinite-racing").json()
+        second = self.client.get("/api/memory-wiki/subjects/infinite-racing").json()
+
+        assert first["wiki_summary"] == second["wiki_summary"]
+        cache_path = get_hermes_home() / "memory_wiki" / "subjects" / "infinite-racing.json"
+        assert cache_path.exists()
+
     def test_session_token_endpoint_removed(self):
         """GET /api/auth/session-token no longer exists."""
         resp = self.client.get("/api/auth/session-token")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,7 @@ import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
+import MemoryWikiPage from "@/pages/MemoryWikiPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
@@ -124,6 +125,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/memory-wiki": MemoryWikiPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -155,6 +157,11 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+  },
+  {
+    path: "/memory-wiki",
+    label: "Memory Wiki",
+    icon: BookOpen,
   },
   {
     path: "/analytics",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -160,7 +160,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   {
     path: "/memory-wiki",
-    label: "Memory Wiki",
+    label: "Session Summary",
     icon: BookOpen,
   },
   {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -228,6 +228,8 @@ export const api = {
     }),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
+  getSession: (id: string) =>
+    fetchJSON<SessionInfo>(`/api/sessions/${encodeURIComponent(id)}`),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
   getSessionLatestDescendant: (id: string) =>
@@ -333,7 +335,7 @@ export const api = {
   // Cron jobs
   getCronJobs: (profile = "all") =>
     fetchJSON<CronJob[]>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`),
-  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string }, profile = "default") =>
+  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string; model?: string; provider?: string }, profile = "default") =>
     fetchJSON<CronJob>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -415,6 +417,18 @@ export const api = {
   // Session search (FTS5)
   searchSessions: (q: string) =>
     fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}`),
+
+  // Memory Wiki
+  getMemoryWikiDays: () => fetchJSON<MemoryWikiDaysResponse>("/api/memory-wiki/days"),
+  getMemoryWikiDay: (date: string) =>
+    fetchJSON<MemoryWikiDayDetail>(`/api/memory-wiki/days/${encodeURIComponent(date)}`),
+  getMemoryWikiSubjects: () => fetchJSON<MemoryWikiSubjectsResponse>("/api/memory-wiki/subjects"),
+  getMemoryWikiSubject: (slug: string) =>
+    fetchJSON<MemoryWikiSubjectDetail>(`/api/memory-wiki/subjects/${encodeURIComponent(slug)}`),
+  hideMemoryWikiSubject: (slug: string) =>
+    fetchJSON<{ slug: string; hidden: boolean }>(`/api/memory-wiki/subjects/${encodeURIComponent(slug)}/hide`, {
+      method: "POST",
+    }),
 
   // OAuth provider management
   getOAuthProviders: () =>
@@ -1173,6 +1187,87 @@ export interface SessionMessagesResponse {
   messages: SessionMessage[];
 }
 
+export interface MemoryWikiDayEntry {
+  date: string;
+  session_count: number;
+  message_count: number;
+  sources: string[];
+  latest_at: number;
+}
+
+export interface MemoryWikiDaysResponse {
+  days: MemoryWikiDayEntry[];
+}
+
+export interface MemoryWikiSessionSummary {
+  id: string;
+  title: string;
+  source: string | null;
+  model?: string | null;
+  started_at: number;
+  last_active: number;
+  message_count: number;
+  preview: string;
+}
+
+export interface MemoryWikiCachedSummary {
+  headline: string;
+  bullets: string[];
+  generated_by: string;
+  generated_at: number;
+  cache_kind: string;
+  cache_key: string;
+  query_terms?: string[];
+}
+
+export interface MemoryWikiDayDetail {
+  date: string;
+  summary: {
+    session_count: number;
+    message_count: number;
+    sources: string[];
+  };
+  wiki_summary: MemoryWikiCachedSummary;
+  sessions: MemoryWikiSessionSummary[];
+}
+
+export interface MemoryWikiSubjectEntry {
+  slug: string;
+  title: string;
+  query_terms: string[];
+  session_count: number;
+  message_count: number;
+  latest_at: number;
+}
+
+export interface MemoryWikiSubjectsResponse {
+  subjects: MemoryWikiSubjectEntry[];
+}
+
+export interface MemoryWikiMessageHit {
+  id: number;
+  session_id: string;
+  role: string;
+  content: string;
+  timestamp: number;
+  session_title: string | null;
+  source: string | null;
+}
+
+export interface MemoryWikiSubjectDetail {
+  slug: string;
+  title: string;
+  query_terms: string[];
+  summary: {
+    session_count: number;
+    message_count: number;
+    latest_at: number;
+  };
+  wiki_summary: MemoryWikiCachedSummary;
+  sessions: MemoryWikiSessionSummary[];
+  message_hits: MemoryWikiMessageHit[];
+}
+
 export interface LogsResponse {
   file: string;
   lines: string[];
@@ -1258,6 +1353,13 @@ export interface ModelsAnalyticsModelEntry {
   tool_calls: number;
   last_used_at: number;
   avg_tokens_per_session: number;
+  tokens_to_date: number;
+  today_input_tokens: number;
+  today_output_tokens: number;
+  today_cache_read_tokens: number;
+  today_reasoning_tokens: number;
+  today_total_tokens: number;
+  today_started_at: number;
   capabilities: {
     supports_tools?: boolean;
     supports_vision?: boolean;
@@ -1280,6 +1382,13 @@ export interface ModelsAnalyticsResponse {
     total_actual_cost: number;
     total_sessions: number;
     total_api_calls: number;
+    tokens_to_date: number;
+    today_input_tokens: number;
+    today_output_tokens: number;
+    today_cache_read_tokens: number;
+    today_reasoning_tokens: number;
+    today_total_tokens: number;
+    today_started_at: number;
   };
   period_days: number;
 }
@@ -1298,6 +1407,11 @@ export interface CronJob {
   enabled: boolean;
   state?: string | null;
   deliver?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  effective_model?: string | null;
+  effective_provider?: string | null;
+  uses_default_model?: boolean;
   last_run_at?: string | null;
   next_run_at?: string | null;
   last_error?: string | null;
@@ -1376,16 +1490,26 @@ export interface AuxiliaryTaskAssignment {
   base_url: string;
 }
 
+export interface ModelRoutingConfig {
+  enabled: boolean;
+  policy: string;
+  auto_route_no_agent_scripts?: boolean;
+  default_model?: { provider: string; model: string };
+  cheap_model?: { provider: string; model: string };
+  critical_model?: { provider: string; model: string };
+}
+
 export interface AuxiliaryModelsResponse {
   tasks: AuxiliaryTaskAssignment[];
   main: { provider: string; model: string };
+  routing?: ModelRoutingConfig;
 }
 
 export interface ModelAssignmentRequest {
-  scope: "main" | "auxiliary";
+  scope: "main" | "auxiliary" | "routing";
   provider: string;
   model: string;
-  /** For auxiliary: task slot name, "" for all, "__reset__" to reset all. */
+  /** For auxiliary: task slot name, "" for all, "__reset__" to reset all. For routing: cheap/default/critical. */
   task?: string;
 }
 

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -93,6 +93,21 @@ function getJobProfile(job: CronJob): string {
   return asText(job.profile) || asText(job.profile_name) || "default";
 }
 
+function getJobModelLabel(job: CronJob): string {
+  const model = asText(job.effective_model) || asText(job.model);
+  if (!model) return "model: default";
+  const shortModel = model.split("/").pop() || model;
+  return job.uses_default_model ? `default: ${shortModel}` : shortModel;
+}
+
+function getJobModelTitle(job: CronJob): string {
+  const provider = asText(job.effective_provider) || asText(job.provider) || "default provider";
+  const model = asText(job.effective_model) || asText(job.model) || "default model";
+  return job.uses_default_model
+    ? `Uses default model: ${provider} / ${model}`
+    : `Explicit model: ${provider} / ${model}`;
+}
+
 function getJobKey(job: CronJob): string {
   return `${getJobProfile(job)}:${job.id}`;
 }
@@ -643,6 +658,9 @@ export default function CronPage() {
                       {state}
                     </Badge>
                     <Badge tone="outline">{profileLabel(profile)}</Badge>
+                    <Badge tone="outline" title={getJobModelTitle(job)}>
+                      {getJobModelLabel(job)}
+                    </Badge>
                     {deliver && deliver !== "local" && (
                       <Badge tone="outline">{deliver}</Badge>
                     )}

--- a/web/src/pages/MemoryWikiPage.tsx
+++ b/web/src/pages/MemoryWikiPage.tsx
@@ -1,0 +1,526 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { BookOpen, CalendarDays, MessageSquare, RefreshCw, Search, Tag } from "lucide-react";
+import { api } from "@/lib/api";
+import type {
+  MemoryWikiDayDetail,
+  MemoryWikiDayEntry,
+  MemoryWikiSubjectDetail,
+  MemoryWikiSubjectEntry,
+} from "@/lib/api";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { timeAgo } from "@/lib/utils";
+
+type WikiTab = "subjects" | "days";
+
+type SelectedWikiItem =
+  | { kind: "subject"; slug: string; title: string }
+  | { kind: "day"; date: string; title: string }
+  | null;
+
+function formatDate(date: string): string {
+  try {
+    return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return date;
+  }
+}
+
+function formatDateTime(timestamp?: number | null): string {
+  if (!timestamp) return "Unknown time";
+  try {
+    return new Date(timestamp * 1000).toLocaleString();
+  } catch {
+    return String(timestamp);
+  }
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function EmptyState({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded border border-dashed border-border bg-card/40 p-8 text-center">
+      <BookOpen className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+      <div className="font-medium">{title}</div>
+      <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function SummaryCard({ summary }: { summary: { headline: string; bullets: string[]; generated_by: string; generated_at: number } }) {
+  return (
+    <Card className="border-primary/30 bg-primary/[0.04]">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <BookOpen className="h-4 w-4 text-primary" />
+          Captain&apos;s log
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm font-medium leading-relaxed">{summary.headline}</p>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          {summary.bullets.map((bullet, index) => (
+            <li key={`${index}-${bullet}`} className="flex gap-2">
+              <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/70" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="text-xs text-muted-foreground">
+          Cached summary · {summary.generated_by} · {formatDateTime(summary.generated_at)}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CollapsibleDetailSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: ReactNode;
+}) {
+  return (
+    <details className="rounded border border-border bg-card">
+      <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium hover:bg-secondary/30">
+        {title}{typeof count === "number" ? ` (${count})` : ""}
+      </summary>
+      <div className="border-t border-border p-4">{children}</div>
+    </details>
+  );
+}
+
+function SessionList({ sessions }: { sessions: MemoryWikiDayDetail["sessions"] }) {
+  if (sessions.length === 0) {
+    return <EmptyState title="No sessions found" detail="This slice of the wiki does not have any sessions yet." />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {sessions.map((session) => (
+        <Link
+          key={session.id}
+          to={`/sessions?session=${encodeURIComponent(session.id)}`}
+          title={`Open session ${session.id}`}
+          className="block rounded border border-border bg-card p-4 transition-colors hover:bg-secondary/30"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-medium">{session.title || session.id}</div>
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span>{formatDateTime(session.started_at)}</span>
+                {session.source && <Badge tone="secondary">{session.source}</Badge>}
+                <span>{countLabel(session.message_count, "message")}</span>
+              </div>
+            </div>
+            <MessageSquare className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </div>
+          {session.preview && <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{session.preview}</p>}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function SubjectsList({
+  subjects,
+  selected,
+  onSelect,
+}: {
+  subjects: MemoryWikiSubjectEntry[];
+  selected: SelectedWikiItem;
+  onSelect: (subject: MemoryWikiSubjectEntry) => void;
+}) {
+  if (subjects.length === 0) {
+    return <EmptyState title="No subjects yet" detail="Subjects are built from session titles and message text once conversations exist." />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {subjects.map((subject) => {
+        const active = selected?.kind === "subject" && selected.slug === subject.slug;
+        return (
+          <button
+            key={subject.slug}
+            type="button"
+            onClick={() => onSelect(subject)}
+            className={`w-full rounded border p-3 text-left transition-colors ${
+              active ? "border-primary bg-primary/10" : "border-border bg-card hover:bg-secondary/30"
+            }`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate font-medium">{subject.title}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {countLabel(subject.session_count, "session")} · {countLabel(subject.message_count, "message")}
+                </div>
+              </div>
+              <Tag className="h-4 w-4 shrink-0 text-muted-foreground" />
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function DaysList({
+  days,
+  selected,
+  onSelect,
+}: {
+  days: MemoryWikiDayEntry[];
+  selected: SelectedWikiItem;
+  onSelect: (day: MemoryWikiDayEntry) => void;
+}) {
+  if (days.length === 0) {
+    return <EmptyState title="No daily logs yet" detail="Daily logs appear automatically as Hermes records sessions." />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {days.map((day) => {
+        const active = selected?.kind === "day" && selected.date === day.date;
+        return (
+          <button
+            key={day.date}
+            type="button"
+            onClick={() => onSelect(day)}
+            className={`w-full rounded border p-3 text-left transition-colors ${
+              active ? "border-primary bg-primary/10" : "border-border bg-card hover:bg-secondary/30"
+            }`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate font-medium">{formatDate(day.date)}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {countLabel(day.session_count, "session")} · {countLabel(day.message_count, "message")}
+                </div>
+              </div>
+              <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SubjectDetail({ detail }: { detail: MemoryWikiSubjectDetail }) {
+  return (
+    <div className="space-y-4">
+      <SummaryCard summary={detail.wiki_summary} />
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-semibold">{detail.summary.session_count}</div>
+            <div className="text-xs text-muted-foreground">Sessions</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-semibold">{detail.summary.message_count}</div>
+            <div className="text-xs text-muted-foreground">Related messages</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-sm font-medium">{detail.summary.latest_at ? timeAgo(detail.summary.latest_at) : "Unknown"}</div>
+            <div className="text-xs text-muted-foreground">Latest activity</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <CollapsibleDetailSection title="Related sessions" count={detail.sessions.length}>
+        <SessionList sessions={detail.sessions} />
+      </CollapsibleDetailSection>
+
+      <CollapsibleDetailSection title="Message hits" count={detail.message_hits.length}>
+        {detail.message_hits.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No direct message hits found yet; this subject may come from session titles.</p>
+        ) : (
+          <div className="space-y-3">
+            {detail.message_hits.map((hit) => (
+              <Link
+                key={hit.id}
+                to={`/sessions?session=${encodeURIComponent(hit.session_id)}`}
+                title={`Open session ${hit.session_id}`}
+                className="block rounded border border-border bg-background p-3 hover:bg-secondary/30"
+              >
+                <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <Badge tone="secondary">{hit.role}</Badge>
+                  <span>{hit.session_title || hit.session_id}</span>
+                  <span>{formatDateTime(hit.timestamp)}</span>
+                </div>
+                <p className="text-sm">{hit.content}</p>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CollapsibleDetailSection>
+    </div>
+  );
+}
+
+function DayDetail({ detail }: { detail: MemoryWikiDayDetail }) {
+  return (
+    <div className="space-y-4">
+      <SummaryCard summary={detail.wiki_summary} />
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-semibold">{detail.summary.session_count}</div>
+            <div className="text-xs text-muted-foreground">Sessions</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-semibold">{detail.summary.message_count}</div>
+            <div className="text-xs text-muted-foreground">Messages</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-sm font-medium">{detail.summary.sources.join(", ") || "No source"}</div>
+            <div className="text-xs text-muted-foreground">Sources</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <CollapsibleDetailSection title={`Sessions on ${formatDate(detail.date)}`} count={detail.sessions.length}>
+        <SessionList sessions={detail.sessions} />
+      </CollapsibleDetailSection>
+    </div>
+  );
+}
+
+export default function MemoryWikiPage() {
+  const [tab, setTab] = useState<WikiTab>("days");
+  const [query, setQuery] = useState("");
+  const [days, setDays] = useState<MemoryWikiDayEntry[]>([]);
+  const [subjects, setSubjects] = useState<MemoryWikiSubjectEntry[]>([]);
+  const [selected, setSelected] = useState<SelectedWikiItem>(null);
+  const [subjectDetail, setSubjectDetail] = useState<MemoryWikiSubjectDetail | null>(null);
+  const [dayDetail, setDayDetail] = useState<MemoryWikiDayDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const detailScrollRef = useRef<HTMLDivElement | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [subjectResponse, dayResponse] = await Promise.all([
+        api.getMemoryWikiSubjects(),
+        api.getMemoryWikiDays(),
+      ]);
+      setSubjects(subjectResponse.subjects);
+      setDays(dayResponse.days);
+      if (!selected) {
+        if (dayResponse.days.length > 0) {
+          setSelected({ kind: "day", date: dayResponse.days[0].date, title: formatDate(dayResponse.days[0].date) });
+          setTab("days");
+        } else if (subjectResponse.subjects.length > 0) {
+          setSelected({ kind: "subject", slug: subjectResponse.subjects[0].slug, title: subjectResponse.subjects[0].title });
+          setTab("subjects");
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load memory wiki");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selected) return;
+    detailScrollRef.current?.scrollTo({ top: 0 });
+    setDetailLoading(true);
+    setError(null);
+    if (selected.kind === "subject") {
+      api
+        .getMemoryWikiSubject(selected.slug)
+        .then((detail) => {
+          setSubjectDetail(detail);
+          setDayDetail(null);
+        })
+        .catch((err) => setError(err instanceof Error ? err.message : "Failed to load subject"))
+        .finally(() => setDetailLoading(false));
+    } else {
+      api
+        .getMemoryWikiDay(selected.date)
+        .then((detail) => {
+          setDayDetail(detail);
+          setSubjectDetail(null);
+        })
+        .catch((err) => setError(err instanceof Error ? err.message : "Failed to load day"))
+        .finally(() => setDetailLoading(false));
+    }
+  }, [selected]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(<span className="text-xs text-muted-foreground">Browse remembered conversations by subject or day</span>);
+    setEnd(
+      <Button size="sm" outlined onClick={() => void refresh()} disabled={loading}>
+        <RefreshCw className={`mr-2 h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+        Refresh
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, setAfterTitle, setEnd]);
+
+  const filteredSubjects = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return subjects;
+    return subjects.filter((subject) => subject.title.toLowerCase().includes(q) || subject.slug.includes(q));
+  }, [query, subjects]);
+
+  const filteredDays = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return days;
+    return days.filter((day) => day.date.includes(q) || formatDate(day.date).toLowerCase().includes(q));
+  }, [days, query]);
+
+  const hideSelectedSubject = async () => {
+    if (!selected || selected.kind !== "subject") return;
+    setDetailLoading(true);
+    setError(null);
+    try {
+      await api.hideMemoryWikiSubject(selected.slug);
+      const nextSubjects = subjects.filter((subject) => subject.slug !== selected.slug);
+      setSubjects(nextSubjects);
+      setSubjectDetail(null);
+      if (nextSubjects.length > 0) {
+        setSelected({ kind: "subject", slug: nextSubjects[0].slug, title: nextSubjects[0].title });
+      } else if (days.length > 0) {
+        setTab("days");
+        setSelected({ kind: "day", date: days[0].date, title: formatDate(days[0].date) });
+      } else {
+        setSelected(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to hide subject");
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  return (
+    <div className="normal-case p-4 sm:p-6 lg:h-[calc(100vh-5rem)] lg:overflow-hidden">
+      <div className="grid gap-4 lg:h-full lg:min-h-0 lg:grid-cols-[360px_1fr]">
+        <div className="space-y-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <BookOpen className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Memory Wiki</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-2">
+                <Button outlined={tab !== "days"} onClick={() => setTab("days")}>
+                  Daily Logs
+                </Button>
+                <Button outlined={tab !== "subjects"} onClick={() => setTab("subjects")}>
+                  Subjects
+                </Button>
+              </div>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={tab === "subjects" ? "Search subjects…" : "Search days…"}
+                  className="h-10 w-full rounded border border-input bg-background pl-9 pr-3 text-sm outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {loading ? (
+            <div className="flex items-center justify-center p-8"><Spinner /></div>
+          ) : tab === "subjects" ? (
+            <SubjectsList
+              subjects={filteredSubjects}
+              selected={selected}
+              onSelect={(subject) => setSelected({ kind: "subject", slug: subject.slug, title: subject.title })}
+            />
+          ) : (
+            <DaysList
+              days={filteredDays}
+              selected={selected}
+              onSelect={(day) => setSelected({ kind: "day", date: day.date, title: formatDate(day.date) })}
+            />
+          )}
+        </div>
+
+        <div ref={detailScrollRef} className="min-w-0 space-y-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1">
+          {error && <div className="rounded border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
+
+          {!selected && !loading ? (
+            <EmptyState title="Nothing selected" detail="Choose a subject or daily log from the left to inspect the conversations behind it." />
+          ) : (
+            <Card>
+              <CardHeader>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-xl">{selected?.title ?? "Loading…"}</CardTitle>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {selected?.kind === "subject" ? "Subject detail" : "Daily log detail"}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {selected?.kind === "subject" && (
+                      <Button size="sm" outlined onClick={() => void hideSelectedSubject()} disabled={detailLoading}>
+                        Hide subject
+                      </Button>
+                    )}
+                    {selected?.kind === "subject" ? <Tag className="h-5 w-5 text-muted-foreground" /> : <CalendarDays className="h-5 w-5 text-muted-foreground" />}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {detailLoading ? (
+                  <div className="flex items-center justify-center p-12"><Spinner /></div>
+                ) : selected?.kind === "subject" && subjectDetail ? (
+                  <SubjectDetail detail={subjectDetail} />
+                ) : selected?.kind === "day" && dayDetail ? (
+                  <DayDetail detail={dayDetail} />
+                ) : (
+                  <EmptyState title="No detail loaded" detail="Select another item or refresh the wiki." />
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/MemoryWikiPage.tsx
+++ b/web/src/pages/MemoryWikiPage.tsx
@@ -440,16 +440,16 @@ export default function MemoryWikiPage() {
             <CardHeader>
               <div className="flex items-center gap-2">
                 <BookOpen className="h-5 w-5 text-muted-foreground" />
-                <CardTitle className="text-base">Memory Wiki</CardTitle>
+                <CardTitle className="text-base">Session Summary</CardTitle>
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-2 gap-2">
                 <Button outlined={tab !== "days"} onClick={() => setTab("days")}>
-                  Daily Logs
+                  By Day
                 </Button>
                 <Button outlined={tab !== "subjects"} onClick={() => setTab("subjects")}>
-                  Subjects
+                  By Subject
                 </Button>
               </div>
               <div className="relative">

--- a/web/src/pages/MemoryWikiPage.tsx
+++ b/web/src/pages/MemoryWikiPage.tsx
@@ -11,7 +11,7 @@ import type {
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { timeAgo } from "@/lib/utils";
 

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -211,7 +211,7 @@ function UseAsMenu({
   const [error, setError] = useState<string | null>(null);
 
   const assign = async (
-    scope: "main" | "auxiliary",
+    scope: "main" | "auxiliary" | "routing",
     task: string,
   ) => {
     if (!provider || !model) {
@@ -271,6 +271,18 @@ function UseAsMenu({
                 current
               </span>
             )}
+          </button>
+
+          <div className="border-t border-border/50 px-3 py-1.5 text-display text-xs tracking-wider text-text-tertiary">
+            Router
+          </div>
+          <button
+            type="button"
+            onClick={() => assign("routing", "cheap")}
+            disabled={busy}
+            className="flex w-full items-center justify-between px-3 py-1.5 text-xs uppercase hover:bg-muted/50 disabled:opacity-40"
+          >
+            <span>Cheap/simple model</span>
           </button>
 
           <div className="border-t border-border/50 px-3 py-1.5 text-display text-xs tracking-wider text-text-tertiary">
@@ -335,7 +347,6 @@ function ModelCard({
 }) {
   const { t } = useI18n();
   const provider = entry.provider || modelVendor(entry.model);
-  const totalTokens = entry.input_tokens + entry.output_tokens;
   const caps = entry.capabilities;
 
   const isMain =
@@ -393,18 +404,25 @@ function ModelCard({
             </div>
           </div>
           <div className="flex flex-col items-end gap-1 shrink-0">
-            {showTokens ? (
-              <div className="text-right">
+            <div className="text-right space-y-1">
+              <div>
                 <div className="text-xs font-mono font-semibold">
-                  {formatTokens(totalTokens)}
+                  {formatTokens(entry.tokens_to_date)}
                 </div>
                 <div className="text-xs text-text-tertiary">
                   {t.models.tokens}
                 </div>
               </div>
-            ) : (
-              entry.sessions > 0 && (
-                <div className="text-right">
+              <div>
+                <div className="text-xs font-mono font-semibold text-primary">
+                  {formatTokens(entry.today_total_tokens)}
+                </div>
+                <div className="text-[10px] text-muted-foreground">
+                  Today's usage
+                </div>
+              </div>
+              {entry.sessions > 0 && (
+                <div>
                   <div className="text-xs font-mono font-semibold">
                     {entry.sessions}
                   </div>
@@ -412,8 +430,8 @@ function ModelCard({
                     {t.models.sessions}
                   </div>
                 </div>
-              )
-            )}
+              )}
+            </div>
             <UseAsMenu
               provider={provider}
               model={entry.model}
@@ -667,7 +685,7 @@ function ModelSettingsPanel({
     provider,
     model,
   }: {
-    scope: "main" | "auxiliary";
+    scope: "main" | "auxiliary" | "routing";
     task: string;
     provider: string;
     model: string;
@@ -718,6 +736,37 @@ function ModelSettingsPanel({
           </Button>
         </div>
 
+        {/* Conservative router row */}
+        <div className="flex min-w-0 flex-col gap-2 bg-muted/20 border border-border/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-0.5">
+              <Zap className="h-3 w-3 text-amber-500" />
+              <span className="text-xs font-medium uppercase tracking-wider">
+                Conservative router
+              </span>
+              <Badge tone={aux?.routing?.enabled ? "secondary" : "outline"} className="text-[9px]">
+                {aux?.routing?.enabled ? "enabled" : "off"}
+              </Badge>
+            </div>
+            <div className="text-xs font-mono text-muted-foreground truncate">
+              cheap/simple: {aux?.routing?.cheap_model?.provider || "(unset)"}
+              {aux?.routing?.cheap_model?.provider && aux?.routing?.cheap_model?.model && " · "}
+              {aux?.routing?.cheap_model?.model || "(unset)"}
+            </div>
+            <div className="text-[10px] text-muted-foreground/70">
+              Policy: {aux?.routing?.policy || "conservative"}; main chat remains on the main model.
+            </div>
+          </div>
+          <Button
+            size="sm"
+            outlined
+            onClick={() => setPicker({ kind: "aux", task: "__routing_cheap__" })}
+            className="shrink-0 self-start text-xs sm:self-center"
+          >
+            Set cheap
+          </Button>
+        </div>
+
         {/* Auxiliary tasks summary + open modal */}
         <div className="flex min-w-0 flex-col gap-2 bg-muted/20 border border-border/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <div className="min-w-0 flex-1">
@@ -748,11 +797,12 @@ function ModelSettingsPanel({
             key={`picker-${refreshKey}`}
             loader={api.getModelOptions}
             alwaysGlobal
-            title="Set Main Model"
+            title={picker.kind === "aux" && picker.task === "__routing_cheap__" ? "Set Cheap/Simple Router Model" : "Set Main Model"}
             onApply={async ({ provider, model }) => {
+              const isRoutingCheap = picker.kind === "aux" && picker.task === "__routing_cheap__";
               await applyAssignment({
-                scope: "main",
-                task: "",
+                scope: isRoutingCheap ? "routing" : "main",
+                task: isRoutingCheap ? "cheap" : "",
                 provider,
                 model,
               });
@@ -897,9 +947,17 @@ export default function ModelsPage() {
                           value: String(data.totals.distinct_models),
                         },
                         {
+                          label: "Tokens to date",
+                          value: formatTokens(data.totals.tokens_to_date),
+                        },
+                        {
+                          label: "Today's usage",
+                          value: formatTokens(data.totals.today_total_tokens),
+                        },
+                        {
                           label: t.analytics.totalTokens,
                           value: formatTokens(
-                            data.totals.total_input + data.totals.total_output,
+                            data.totals.total_input + data.totals.total_output + data.totals.total_cache_read + data.totals.total_reasoning,
                           ),
                         },
                         {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useRef,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -659,6 +659,8 @@ export default function SessionsPage() {
   const { setAfterTitle, setEnd } = usePageHeader();
   const { activeAction, actionStatus, dismissLog } = useSystemActions();
   const resumeInChatEnabled = isDashboardEmbeddedChatEnabled();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const deepLinkedSessionId = searchParams.get("session");
 
   const refreshEmptyCount = useCallback(() => {
     api
@@ -731,6 +733,24 @@ export default function SessionsPage() {
     loadSessions(page);
     refreshEmptyCount();
   }, [loadSessions, page, refreshEmptyCount]);
+
+  useEffect(() => {
+    if (!deepLinkedSessionId) return;
+    setExpandedId(deepLinkedSessionId);
+    api
+      .getSession(deepLinkedSessionId)
+      .then((session) => {
+        setSessions((prev) => {
+          if (prev.some((item) => item.id === session.id)) return prev;
+          return [session, ...prev];
+        });
+      })
+      .catch(() => {
+        const next = new URLSearchParams(searchParams);
+        next.delete("session");
+        setSearchParams(next, { replace: true });
+      });
+  }, [deepLinkedSessionId, searchParams, setSearchParams]);
 
   useEffect(() => {
     const loadOverview = () => {


### PR DESCRIPTION
## Summary
- Ports Alice/Memory Wiki dashboard work onto the real `vhnizda/hermes-agent` fork from current upstream `main`
- Ports cron session title fix
- Preserves the Memory Wiki label rename
- Adds a current-upstream compatibility fix for the Memory Wiki card import

## Test plan
- `PYTHONPATH=. /home/vaclav/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_web_server.py tests/cron/test_scheduler.py -q -o 'addopts='`
  - 351 passed, 1 warning
- `cd web && npm ci && npm run build`
  - build succeeded

## Notes
- Skipped old Dependabot action-bump commits because current upstream/fork dependency state is newer.
- Did not port old custom contributor-map/test-stabilization commits unless CI proves they are still needed.