### PR TITLE
feat(desktop): add comprehensive keyboard shortcuts

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -472,7 +472,6 @@ let forceBootstrapRepair = false
 let connectionConfigCache = null
 const hermesLog = []
 const previewWatchers = new Map()
-let previewShortcutActive = false
 let desktopLogBuffer = ''
 let desktopLogFlushTimer = null
 let desktopLogFlushPromise = Promise.resolve()
@@ -2656,11 +2655,11 @@ function sendBackendExit(payload) {
   webContents.send('hermes:backend-exit', payload)
 }
 
-function sendClosePreviewRequested() {
+function sendCloseRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) return
   const { webContents } = mainWindow
   if (!webContents || webContents.isDestroyed()) return
-  webContents.send('hermes:close-preview-requested')
+  webContents.send('hermes:close-requested')
 }
 
 function getAppIconPath() {
@@ -2719,13 +2718,7 @@ function buildApplicationMenu() {
       IS_MAC
         ? {
             accelerator: 'CommandOrControl+W',
-            click: () => {
-              if (previewShortcutActive) {
-                sendClosePreviewRequested()
-              } else {
-                mainWindow?.close()
-              }
-            },
+            click: () => sendCloseRequested(),
             label: 'Close'
           }
         : { role: 'quit' }
@@ -2822,15 +2815,19 @@ function installDevToolsShortcut(window) {
   })
 }
 
-function installPreviewShortcut(window) {
+function installCloseShortcut(window) {
+  // Cmd/Ctrl+W is always intercepted and forwarded to the renderer, which
+  // runs the cascade (overlay → right sidebar → preview rail → left sidebar
+  // → window close/minimize). This ensures the macOS menu accelerator and the
+  // before-input-event path both hit the same cascade logic.
   window.webContents.on('before-input-event', (event, input) => {
     const key = String(input.key || '').toLowerCase()
-    const isPreviewCloseShortcut = key === 'w' && (IS_MAC ? input.meta : input.control) && !input.alt && !input.shift
+    const isCloseShortcut = key === 'w' && (IS_MAC ? input.meta : input.control) && !input.alt && !input.shift
 
-    if (!isPreviewCloseShortcut || !previewShortcutActive) return
+    if (!isCloseShortcut) return
 
     event.preventDefault()
-    sendClosePreviewRequested()
+    sendCloseRequested()
   })
 }
 
@@ -3444,7 +3441,7 @@ function createWindow() {
   mainWindow.on('will-leave-full-screen', () => sendWindowStateChanged(false))
   mainWindow.on('leave-full-screen', () => sendWindowStateChanged(false))
 
-  installPreviewShortcut(mainWindow)
+  installCloseShortcut(mainWindow)
   installDevToolsShortcut(mainWindow)
   installZoomShortcuts(mainWindow)
   installContextMenu(mainWindow)
@@ -3592,8 +3589,12 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   return sanitizeDesktopConnectionConfig(config)
 })
 
-ipcMain.on('hermes:previewShortcutActive', (_event, active) => {
-  previewShortcutActive = Boolean(active)
+ipcMain.on('hermes:close-window', () => {
+  if (IS_MAC) {
+    mainWindow?.minimize()
+  } else {
+    mainWindow?.close()
+  }
 })
 
 ipcMain.handle('hermes:requestMicrophoneAccess', async () => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -28,7 +28,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   watchPreviewFile: url => ipcRenderer.invoke('hermes:watchPreviewFile', url),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
-  setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
+  closeWindow: () => ipcRenderer.send('hermes:close-window'),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   settings: {
@@ -58,10 +58,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       return () => ipcRenderer.removeListener(channel, listener)
     }
   },
-  onClosePreviewRequested: callback => {
+  onCloseRequested: callback => {
     const listener = () => callback()
-    ipcRenderer.on('hermes:close-preview-requested', listener)
-    return () => ipcRenderer.removeListener('hermes:close-preview-requested', listener)
+    ipcRenderer.on('hermes:close-requested', listener)
+    return () => ipcRenderer.removeListener('hermes:close-requested', listener)
   },
   onOpenUpdatesRequested: callback => {
     const listener = () => callback()

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -14,18 +14,23 @@ import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getSessionMessages, listSessions } from '../hermes'
 import { preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import {
+  $fileBrowserOpen,
   $pinnedSessionIds,
+  $sidebarOpen,
   $sessionsLimit,
   bumpSessionsLimit,
   FILE_BROWSER_DEFAULT_WIDTH,
   FILE_BROWSER_MAX_WIDTH,
   FILE_BROWSER_MIN_WIDTH,
   pinSession,
+  setSidebarOpen,
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH,
+  toggleFileBrowserOpen,
   unpinSession
 } from '../store/layout'
 import { $filePreviewTarget, $previewTarget, closeActiveRightRailTab } from '../store/preview'
+import { resolveCloseAction, setupCloseCascadeListener, setupShortcutListener } from './keyboard-shortcuts'
 import {
   $activeSessionId,
   $currentCwd,
@@ -77,7 +82,7 @@ import { useRouteResume } from './session/hooks/use-route-resume'
 import { useSessionActions } from './session/hooks/use-session-actions'
 import { useSessionStateCache } from './session/hooks/use-session-state-cache'
 import { AppShell } from './shell/app-shell'
-import { useOverlayRouting } from './shell/hooks/use-overlay-routing'
+import { OVERLAY_VIEWS, useOverlayRouting } from './shell/hooks/use-overlay-routing'
 import { useStatusSnapshot } from './shell/hooks/use-status-snapshot'
 import { useStatusbarItems } from './shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from './shell/model-menu-panel'
@@ -159,41 +164,82 @@ export function DesktopController() {
   const { connectionRef, gatewayRef, requestGateway } = useGatewayRequest()
 
   useEffect(() => {
-    window.hermesDesktop?.setPreviewShortcutActive?.(Boolean(chatOpen && (filePreviewTarget || previewTarget)))
-  }, [chatOpen, filePreviewTarget, previewTarget])
-
-  useEffect(() => {
     startUpdatePoller()
-    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
+    const unsubscribeUpdates = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
 
     return () => {
-      unsubscribe?.()
+      unsubscribeUpdates?.()
       stopUpdatePoller()
     }
   }, [])
 
+  // Cmd/Ctrl+W cascade: overlay → right sidebar → preview rail → left sidebar → window close/minimize
   useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!$filePreviewTarget.get() && !$previewTarget.get()) {
-        return
-      }
+    const getCloseState = () => ({
+      overlayOpen: OVERLAY_VIEWS.has(currentView),
+      rightSidebarOpen: $fileBrowserOpen.get(),
+      previewRailOpen: Boolean($filePreviewTarget.get() || $previewTarget.get()),
+      leftSidebarOpen: $sidebarOpen.get()
+    })
 
-      if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'w') {
-        event.preventDefault()
-        event.stopPropagation()
-        closeActiveRightRailTab()
+    const dispatchClose = (action: { type: string }) => {
+      switch (action.type) {
+        case 'close-overlay':
+          closeOverlayToPreviousRoute()
+          break
+        case 'close-right-sidebar':
+          toggleFileBrowserOpen()
+          break
+        case 'close-preview-rail':
+          closeActiveRightRailTab()
+          break
+        case 'close-left-sidebar':
+          setSidebarOpen(false)
+          break
+        case 'close-window':
+          window.hermesDesktop?.closeWindow?.()
+          break
       }
     }
 
-    const unsubscribe = window.hermesDesktop?.onClosePreviewRequested?.(closeActiveRightRailTab)
+    // Renderer-side keydown (works when no macOS menu accelerator intercepts)
+    const cleanupKeydown = setupCloseCascadeListener(getCloseState, dispatchClose)
 
-    window.addEventListener('keydown', onKeyDown, { capture: true })
+    // IPC path (macOS menu accelerator sends this before DOM sees the key)
+    const cleanupIpc = window.hermesDesktop?.onCloseRequested?.(() => {
+      dispatchClose(resolveCloseAction(getCloseState()))
+    })
 
     return () => {
-      unsubscribe?.()
-      window.removeEventListener('keydown', onKeyDown, { capture: true })
+      cleanupKeydown()
+      cleanupIpc?.()
     }
+  }, [currentView, closeOverlayToPreviousRoute])
+
+  // Cmd/Ctrl+, — toggle Settings
+  useEffect(() => {
+    return setupShortcutListener(',', () => {
+      if (settingsOpen) {
+        closeOverlayToPreviousRoute()
+      } else {
+        navigate(SETTINGS_ROUTE)
+      }
+    })
+  }, [settingsOpen, closeOverlayToPreviousRoute, navigate])
+
+  // Cmd/Ctrl+. — toggle right sidebar (file browser)
+  useEffect(() => {
+    return setupShortcutListener('.', () => {
+      toggleFileBrowserOpen()
+    })
   }, [])
+
+  // Cmd/Ctrl+K — toggle Command Center
+  useEffect(() => {
+    return setupShortcutListener('k', () => {
+      toggleCommandCenter()
+    })
+  }, [toggleCommandCenter])
 
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1

--- a/apps/desktop/src/app/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/app/keyboard-shortcuts.test.ts
@@ -290,6 +290,22 @@ describe('setupShortcutListener', () => {
     pressKey(',', { metaKey: true })
     expect(fn).not.toHaveBeenCalled()
   })
+
+  it('does not call callback when event.defaultPrevented is true', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener('k', fn)
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    // Simulate another handler (e.g. composer) already consuming the event
+    event.preventDefault()
+    window.dispatchEvent(event)
+    expect(fn).not.toHaveBeenCalled()
+  })
 })
 
 describe('Cmd+K (command center)', () => {

--- a/apps/desktop/src/app/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/app/keyboard-shortcuts.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type CloseAction, isCleanShortcut, resolveCloseAction, setupCloseCascadeListener, setupShortcutListener } from './keyboard-shortcuts'
+
+describe('resolveCloseAction', () => {
+  it('closes overlay when any overlay is open', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: true,
+        rightSidebarOpen: true,
+        previewRailOpen: true,
+        leftSidebarOpen: true
+      })
+    ).toEqual({ type: 'close-overlay' })
+  })
+
+  it('closes right sidebar when overlay is closed but sidebar is open', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: false,
+        rightSidebarOpen: true,
+        previewRailOpen: true,
+        leftSidebarOpen: true
+      })
+    ).toEqual({ type: 'close-right-sidebar' })
+  })
+
+  it('closes preview rail when overlay and right sidebar are closed', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: false,
+        rightSidebarOpen: false,
+        previewRailOpen: true,
+        leftSidebarOpen: true
+      })
+    ).toEqual({ type: 'close-preview-rail' })
+  })
+
+  it('closes left sidebar when only left sidebar is open', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: false,
+        rightSidebarOpen: false,
+        previewRailOpen: false,
+        leftSidebarOpen: true
+      })
+    ).toEqual({ type: 'close-left-sidebar' })
+  })
+
+  it('closes window when nothing is open', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: false,
+        rightSidebarOpen: false,
+        previewRailOpen: false,
+        leftSidebarOpen: false
+      })
+    ).toEqual({ type: 'close-window' })
+  })
+
+  it('skips closed layers and finds the first open one', () => {
+    expect(
+      resolveCloseAction({
+        overlayOpen: false,
+        rightSidebarOpen: false,
+        previewRailOpen: true,
+        leftSidebarOpen: false
+      })
+    ).toEqual({ type: 'close-preview-rail' })
+  })
+})
+
+describe('isCleanShortcut', () => {
+  function keyEvent(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+    return new KeyboardEvent('keydown', {
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      ...init
+    })
+  }
+
+  it('returns true for Cmd+W on macOS', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w', metaKey: true }), 'w')).toBe(true)
+  })
+
+  it('returns true for Ctrl+W on Windows/Linux', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w', ctrlKey: true }), 'w')).toBe(true)
+  })
+
+  it('returns false when Alt is pressed', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w', metaKey: true, altKey: true }), 'w')).toBe(false)
+  })
+
+  it('returns false when Shift is pressed', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w', metaKey: true, shiftKey: true }), 'w')).toBe(false)
+  })
+
+  it('returns false for wrong key', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w', metaKey: true }), 'k')).toBe(false)
+  })
+
+  it('returns false when no modifier is pressed', () => {
+    expect(isCleanShortcut(keyEvent({ key: 'w' }), 'w')).toBe(false)
+  })
+})
+
+describe('setupCloseCascadeListener', () => {
+  let actions: CloseAction[]
+  let getState: () => { overlayOpen: boolean; rightSidebarOpen: boolean; previewRailOpen: boolean; leftSidebarOpen: boolean }
+  let cleanup: () => void
+
+  beforeEach(() => {
+    actions = []
+    getState = () => ({
+      overlayOpen: false,
+      rightSidebarOpen: false,
+      previewRailOpen: false,
+      leftSidebarOpen: false
+    })
+    cleanup = setupCloseCascadeListener(
+      () => getState(),
+      action => actions.push(action)
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  function pressCmdW() {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'w',
+        metaKey: true,
+        bubbles: true
+      })
+    )
+  }
+
+  function pressCtrlW() {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'w',
+        ctrlKey: true,
+        bubbles: true
+      })
+    )
+  }
+
+  it('dispatches close-overlay when overlay is open', () => {
+    getState = () => ({
+      overlayOpen: true,
+      rightSidebarOpen: true,
+      previewRailOpen: true,
+      leftSidebarOpen: true
+    })
+    pressCmdW()
+    expect(actions).toEqual([{ type: 'close-overlay' }])
+  })
+
+  it('dispatches close-right-sidebar when only sidebar is open', () => {
+    getState = () => ({
+      overlayOpen: false,
+      rightSidebarOpen: true,
+      previewRailOpen: false,
+      leftSidebarOpen: false
+    })
+    pressCmdW()
+    expect(actions).toEqual([{ type: 'close-right-sidebar' }])
+  })
+
+  it('dispatches close-window when nothing is open', () => {
+    pressCmdW()
+    expect(actions).toEqual([{ type: 'close-window' }])
+  })
+
+  it('works with Ctrl+W (Windows/Linux)', () => {
+    pressCtrlW()
+    expect(actions).toEqual([{ type: 'close-window' }])
+  })
+
+  it('does not dispatch on other key combos', () => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true
+      })
+    )
+    expect(actions).toEqual([])
+  })
+
+  it('prevents default on Cmd+W', () => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'w',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    const spy = vi.spyOn(event, 'preventDefault')
+    window.dispatchEvent(event)
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('setupShortcutListener', () => {
+  let cleanup: () => void
+
+  afterEach(() => {
+    cleanup?.()
+  })
+
+  function pressKey(key: string, modifiers: Partial<Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>> = {}) {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key,
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        ...modifiers,
+        bubbles: true,
+        cancelable: true
+      })
+    )
+  }
+
+  it('calls callback when Cmd+, is pressed', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    pressKey(',', { metaKey: true })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls callback when Ctrl+, is pressed (Windows/Linux)', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    pressKey(',', { ctrlKey: true })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call callback for wrong key', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    pressKey('.', { metaKey: true })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback when Alt is held', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    pressKey(',', { metaKey: true, altKey: true })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('does not call callback when Shift is held', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    pressKey(',', { metaKey: true, shiftKey: true })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('prevents default when shortcut matches', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+
+    const event = new KeyboardEvent('keydown', {
+      key: ',',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    const spy = vi.spyOn(event, 'preventDefault')
+    window.dispatchEvent(event)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('cleans up listener on unsubscribe', () => {
+    const fn = vi.fn()
+    cleanup = setupShortcutListener(',', fn)
+    cleanup()
+
+    pressKey(',', { metaKey: true })
+    expect(fn).not.toHaveBeenCalled()
+  })
+})
+
+describe('Cmd+K (command center)', () => {
+  it('triggers callback for Cmd+K', () => {
+    const fn = vi.fn()
+    const cleanup = setupShortcutListener('k', fn)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true
+      })
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+})
+
+describe('Cmd+. (right panel)', () => {
+  it('triggers callback for Cmd+.', () => {
+    const fn = vi.fn()
+    const cleanup = setupShortcutListener('.', fn)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '.',
+        metaKey: true,
+        bubbles: true
+      })
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+})
+
+describe('cascade ordering on repeated presses', () => {
+  it('closes layers one by one on successive Cmd+W presses', () => {
+    // Start with everything open
+    let state = { overlayOpen: true, rightSidebarOpen: true, previewRailOpen: true, leftSidebarOpen: true }
+
+    expect(resolveCloseAction(state)).toEqual({ type: 'close-overlay' })
+
+    state = { ...state, overlayOpen: false }
+    expect(resolveCloseAction(state)).toEqual({ type: 'close-right-sidebar' })
+
+    state = { ...state, rightSidebarOpen: false }
+    expect(resolveCloseAction(state)).toEqual({ type: 'close-preview-rail' })
+
+    state = { ...state, previewRailOpen: false }
+    expect(resolveCloseAction(state)).toEqual({ type: 'close-left-sidebar' })
+
+    state = { ...state, leftSidebarOpen: false }
+    expect(resolveCloseAction(state)).toEqual({ type: 'close-window' })
+  })
+})
+
+describe('shortcuts do not interfere with each other', () => {
+  it('Cmd+K does not trigger Cmd+W cascade', () => {
+    const closeActions: string[] = []
+    const searchFn = vi.fn()
+
+    const cleanupClose = setupCloseCascadeListener(
+      () => ({ overlayOpen: false, rightSidebarOpen: false, previewRailOpen: false, leftSidebarOpen: false }),
+      action => closeActions.push(action.type)
+    )
+    const cleanupSearch = setupShortcutListener('k', searchFn)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+    )
+
+    expect(searchFn).toHaveBeenCalledTimes(1)
+    expect(closeActions).toEqual([])
+
+    cleanupClose()
+    cleanupSearch()
+  })
+})

--- a/apps/desktop/src/app/keyboard-shortcuts.ts
+++ b/apps/desktop/src/app/keyboard-shortcuts.ts
@@ -78,6 +78,9 @@ export function setupCloseCascadeListener(
  */
 export function setupShortcutListener(key: string, callback: () => void): () => void {
   const onKeyDown = (event: KeyboardEvent) => {
+    // Skip if another handler already consumed this event (e.g. the composer's
+    // Cmd+K handler for queue drain calls preventDefault() but not stopPropagation).
+    if (event.defaultPrevented) return
     if (!isCleanShortcut(event, key)) return
 
     event.preventDefault()

--- a/apps/desktop/src/app/keyboard-shortcuts.ts
+++ b/apps/desktop/src/app/keyboard-shortcuts.ts
@@ -1,0 +1,89 @@
+/**
+ * Keyboard shortcut cascade logic for Hermes Desktop.
+ *
+ * `resolveCloseAction` implements the Cmd/Ctrl+W cascade:
+ *   overlay → right sidebar → preview rail → left sidebar → window close/minimize
+ *
+ * The other shortcuts (Cmd/Ctrl + , . K) are handled as renderer-side keydown
+ * listeners, following the same pattern as Cmd/Ctrl+B and Cmd/Ctrl+N.
+ */
+
+export type CloseAction =
+  | { type: 'close-overlay' }
+  | { type: 'close-right-sidebar' }
+  | { type: 'close-preview-rail' }
+  | { type: 'close-left-sidebar' }
+  | { type: 'close-window' }
+
+export interface CloseState {
+  overlayOpen: boolean
+  rightSidebarOpen: boolean
+  previewRailOpen: boolean
+  leftSidebarOpen: boolean
+}
+
+/**
+ * Determines the first UI layer to close in the Cmd/Ctrl+W cascade.
+ *
+ * Cascade order: overlay → right sidebar → preview rail → left sidebar → window.
+ * Returns the first open layer, or 'close-window' if nothing is open.
+ */
+export function resolveCloseAction(state: CloseState): CloseAction {
+  if (state.overlayOpen) return { type: 'close-overlay' }
+  if (state.rightSidebarOpen) return { type: 'close-right-sidebar' }
+  if (state.previewRailOpen) return { type: 'close-preview-rail' }
+  if (state.leftSidebarOpen) return { type: 'close-left-sidebar' }
+  return { type: 'close-window' }
+}
+
+/** Check if Cmd/Ctrl modifier is pressed (platform-aware). */
+export function isModifierPressed(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey
+}
+
+/** Check if the event is a clean modifier+key combo (no alt/shift). */
+export function isCleanShortcut(event: KeyboardEvent, key: string): boolean {
+  return isModifierPressed(event) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === key
+}
+
+/**
+ * Sets up the Cmd/Ctrl+W cascade keydown listener.
+ *
+ * @param getState - returns the current UI layer state (overlay, sidebars, preview)
+ * @param dispatch - called with the resolved close action
+ * @returns cleanup function to remove the listener
+ */
+export function setupCloseCascadeListener(
+  getState: () => CloseState,
+  dispatch: (action: CloseAction) => void
+): () => void {
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (!isCleanShortcut(event, 'w')) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    dispatch(resolveCloseAction(getState()))
+  }
+
+  window.addEventListener('keydown', onKeyDown, { capture: true })
+  return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+}
+
+/**
+ * Sets up a generic Cmd/Ctrl+<key> shortcut listener.
+ *
+ * @param key - the key to match (e.g. ',', '.', 'k')
+ * @param callback - called when the shortcut is pressed
+ * @returns cleanup function to remove the listener
+ */
+export function setupShortcutListener(key: string, callback: () => void): () => void {
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (!isCleanShortcut(event, key)) return
+
+    event.preventDefault()
+    callback()
+  }
+
+  window.addEventListener('keydown', onKeyDown)
+  return () => window.removeEventListener('keydown', onKeyDown)
+}

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
@@ -5,7 +5,7 @@ import { type CommandCenterSection } from '@/app/command-center'
 import { AGENTS_ROUTE, appViewForPath, COMMAND_CENTER_ROUTE, NEW_CHAT_ROUTE } from '@/app/routes'
 
 const SECTIONS = ['sessions', 'system', 'usage'] as const
-const OVERLAY_VIEWS = new Set(['settings', 'command-center', 'agents'])
+export const OVERLAY_VIEWS = new Set(['settings', 'command-center', 'agents'])
 
 export function useOverlayRouting() {
   const location = useLocation()

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -24,7 +24,7 @@ declare global {
       watchPreviewFile: (url: string) => Promise<HermesPreviewWatch>
       stopPreviewFileWatch: (id: string) => Promise<boolean>
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
-      setPreviewShortcutActive?: (active: boolean) => void
+      closeWindow?: () => void
       openExternal: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
       settings: {
@@ -44,7 +44,7 @@ declare global {
         start: (options?: { cols?: number; cwd?: string; rows?: number }) => Promise<HermesTerminalSession>
         write: (id: string, data: string) => Promise<boolean>
       }
-      onClosePreviewRequested?: (callback: () => void) => () => void
+      onCloseRequested?: (callback: () => void) => () => void
       onOpenUpdatesRequested?: (callback: () => void) => () => void
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void

--- a/plans/desktop-keyboard-shortcuts.md
+++ b/plans/desktop-keyboard-shortcuts.md
@@ -1,0 +1,286 @@
+# Hermes Desktop Keyboard Shortcuts Implementation Plan
+
+**Issue**: [#38118](https://github.com/NousResearch/hermes-agent/issues/38118)
+**Branch**: `feat/desktop-keyboard-shortcuts`
+**Status**: Planning
+
+---
+
+## Overview
+
+Add missing keyboard shortcuts and extend `Cmd/Ctrl+W` cascade behavior in Hermes Desktop.
+
+### Already Working (no changes needed)
+
+These shortcuts are already implemented and do NOT need new code:
+
+| Shortcut | Location | Notes |
+|---|---|---|
+| `Cmd/Ctrl+B` (toggle sidebar) | `sidebar.tsx:88-100` | shadcn SidebarProvider handles this |
+| `Cmd/Ctrl+N` (new chat) | `desktop-controller.tsx:390-421` | Also `Shift+N` when no input focused |
+| `Cmd/Ctrl+/-/0` (zoom) | `main.cjs:2837-2861` | Uses `setZoomLevel()` with 0.1 step |
+| `Cmd/Ctrl+Opt/Shift+I` (DevTools) | `main.cjs:2811` | F12 also works |
+| `Cmd/Ctrl+W` (close preview rail) | `main.cjs:2825` + `desktop-controller.tsx:175-196` | Only closes preview tabs, does not cascade |
+| `Escape` (close overlay) | `overlay-view.tsx:33-47` | Each overlay handles its own Escape |
+
+### Work Required
+
+| Task | Effort |
+|---|---|
+| Extend `Cmd+W` cascade to overlays and sidebars | 2-3 days |
+| Add `Cmd/Ctrl+,` for Settings | 0.5 day |
+| Add `Cmd/Ctrl+.` for right panel toggle | 0.5 day |
+| Add `Cmd/Ctrl+K` for search / command center | 1 day |
+| Testing across macOS / Windows / Linux | 2 days |
+| **Total** | **~1 week** |
+
+---
+
+## Phase 1: Extend `Cmd/Ctrl+W` Cascade (2-3 days)
+
+The most impactful change. Currently `Cmd+W` has only two modes: close preview or close window. It should cascade through UI layers before closing the window.
+
+### 1.1 Architecture
+
+The cascade must bridge main process and renderer because overlay state lives in React Router (renderer), not in the main process.
+
+**Protocol:**
+1. Main process `before-input-event` intercepts `Cmd/Ctrl+W`
+2. Main sends `hermes:close-requested` to renderer (new IPC event)
+3. Renderer runs the cascade and decides what to close
+4. If nothing to close, renderer sends `hermes:close-window` back to main (new IPC event)
+5. Main closes/minimizes the window
+
+**File**: `apps/desktop/electron/main.cjs`
+
+- [ ] Rename `installPreviewShortcut` to `installCloseShortcut` (or add to it)
+- [ ] Always intercept `Cmd/Ctrl+W` (not just when `previewShortcutActive`)
+- [ ] Always send `hermes:close-requested` to renderer instead of closing the window
+- [ ] Add `ipcMain.on('hermes:close-window', ...)` handler that calls `mainWindow.close()` (Win/Linux) or `mainWindow.minimize()` (macOS)
+- [ ] Keep macOS menu accelerator (`CommandOrControl+W`) in sync — route through the same IPC
+
+**File**: `apps/desktop/electron/preload.cjs`
+
+- [ ] Expose `hermesDesktop.onCloseRequested(callback)` — listens for `hermes:close-requested`
+- [ ] Expose `hermesDesktop.closeWindow()` — sends `hermes:close-window` to main
+
+### 1.2 Renderer Cascade Logic
+
+**File**: `apps/desktop/src/app/desktop-controller.tsx`
+
+Replace the existing `Cmd+W` `useEffect` (lines 175-196) with a cascade handler:
+
+```ts
+useEffect(() => {
+  const CASCADE = [
+    // 1. Close active overlay (settings, command-center, agents)
+    () => {
+      if (overlayOpen) {
+        closeOverlayToPreviousRoute()
+        return true
+      }
+    },
+    // 2. Close right sidebar (file browser)
+    () => {
+      if ($fileBrowserOpen.get()) {
+        toggleFileBrowserOpen()
+        return true
+      }
+    },
+    // 3. Close preview/file rail
+    () => {
+      if ($filePreviewTarget.get() || $previewTarget.get()) {
+        closeActiveRightRailTab()
+        return true
+      }
+    },
+    // 4. Close left sidebar
+    () => {
+      if ($sidebarOpen.get()) {
+        setSidebarOpen(false)
+        return true
+      }
+    },
+    // 5. Nothing to close — close/minimize the window
+    () => {
+      window.hermesDesktop?.closeWindow()
+      return true
+    },
+  ]
+
+  const onKey = (event: KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return
+    if (event.key.toLowerCase() !== 'w') return
+    event.preventDefault()
+    event.stopPropagation()
+    for (const step of CASCADE) if (step()) break
+  }
+
+  const unsubscribe = window.hermesDesktop?.onCloseRequested?.(() => {
+    for (const step of CASCADE) if (step()) break
+  })
+
+  window.addEventListener('keydown', onKey, { capture: true })
+  return () => {
+    unsubscribe?.()
+    window.removeEventListener('keydown', onKey, { capture: true })
+  }
+}, [overlayOpen, closeOverlayToPreviousRoute])
+```
+
+Note: `overlayOpen` and `closeOverlayToPreviousRoute` come from the existing `useOverlayRouting()` hook — no new overlay store needed.
+
+### 1.3 Remove `previewShortcutActive` Flag
+
+Once the renderer handles the full cascade, the main process no longer needs to know whether a preview is active. The `hermes:previewShortcutActive` IPC channel can be removed.
+
+- [ ] Remove `previewShortcutActive` variable from `main.cjs`
+- [ ] Remove `hermes:previewShortcutActive` IPC listener from `main.cjs`
+- [ ] Remove `setPreviewShortcutActive` calls from `desktop-controller.tsx`
+- [ ] Remove corresponding `send` calls from `preload.cjs`
+
+---
+
+## Phase 2: New Shortcuts (1 day)
+
+All new shortcuts follow the existing pattern: `before-input-event` in main process sends IPC to renderer, renderer dispatches the action.
+
+### 2.1 Settings (`Cmd/Ctrl+,`)
+
+**File**: `apps/desktop/electron/main.cjs` (add to the `before-input-event` chain or as a new `install*` function)
+
+- [ ] Intercept `Cmd/Ctrl+,` (key `,`, modifier Cmd on macOS / Ctrl on others)
+- [ ] Send `hermes:open-settings` to renderer
+
+**File**: `apps/desktop/src/app/desktop-controller.tsx`
+
+- [ ] Listen for `hermes:open-settings` IPC
+- [ ] Call `navigate(SETTINGS_ROUTE)` (same as existing `openSettings()` in `use-session-actions.ts:383`)
+- [ ] If settings already open, close overlay (toggle behavior)
+
+### 2.2 Toggle Right Panel (`Cmd/Ctrl+.`)
+
+**File**: `apps/desktop/electron/main.cjs`
+
+- [ ] Intercept `Cmd/Ctrl+.`
+- [ ] Send `hermes:toggle-right-panel` to renderer
+
+**File**: `apps/desktop/src/app/desktop-controller.tsx`
+
+- [ ] Listen for `hermes:toggle-right-panel` IPC
+- [ ] Call `toggleFileBrowserOpen()` from `store/layout.ts`
+
+### 2.3 Search / Command Center (`Cmd/Ctrl+K`)
+
+**File**: `apps/desktop/electron/main.cjs`
+
+- [ ] Intercept `Cmd/Ctrl+K`
+- [ ] Send `hermes:open-search` to renderer
+
+**File**: `apps/desktop/src/app/desktop-controller.tsx`
+
+- [ ] Listen for `hermes:open-search` IPC
+- [ ] Call `toggleCommandCenter()` from `useOverlayRouting()` (opens command-center overlay)
+- [ ] If command center already open, close it (toggle behavior)
+
+### 2.4 Preload Bridge
+
+**File**: `apps/desktop/electron/preload.cjs`
+
+Add IPC listeners for the three new channels:
+- `hermes:open-settings`
+- `hermes:toggle-right-panel`
+- `hermes:open-search`
+
+Each exposed as `window.hermesDesktop.onXxx(callback)`.
+
+---
+
+## Phase 3: Testing (2 days)
+
+### 3.1 Unit Tests
+
+**File**: `apps/desktop/electron/keyboard-shortcuts.test.cjs` (new)
+
+- [ ] Test that `Cmd/Ctrl+W` always sends IPC to renderer (never closes window directly)
+- [ ] Test that new shortcuts send correct IPC channel names
+- [ ] Test platform detection (Cmd vs Ctrl modifier)
+
+### 3.2 Integration Tests
+
+**File**: `apps/desktop/src/hooks/use-keyboard-shortcuts.test.ts` (new)
+
+- [ ] Test `Cmd+W` cascade: overlay → right panel → preview → sidebar → window close
+- [ ] Test `Cmd+,` opens settings
+- [ ] Test `Cmd+.` toggles right panel
+- [ ] Test `Cmd+K` opens command center
+
+### 3.3 Manual Testing Checklist
+
+**All platforms (macOS, Windows, Linux):**
+- [ ] `Cmd/Ctrl+,` opens Settings; pressing again closes it
+- [ ] `Cmd/Ctrl+.` toggles right sidebar (file browser)
+- [ ] `Cmd/Ctrl+K` opens Command Center; pressing again closes it
+- [ ] `Cmd/Ctrl+B` toggles left sidebar (existing — verify no regression)
+- [ ] `Cmd/Ctrl+N` creates new chat (existing — verify no regression)
+- [ ] `Cmd/Ctrl+/-/0` zoom works (existing — verify no regression)
+
+**`Cmd/Ctrl+W` cascade:**
+- [ ] With Settings overlay open → closes Settings, not the window
+- [ ] With Command Center open → closes Command Center, not the window
+- [ ] With right sidebar open (no overlay) → closes right sidebar
+- [ ] With preview rail open (no overlay/sidebar) → closes preview rail
+- [ ] With left sidebar open (nothing else) → closes left sidebar
+- [ ] With nothing open → minimizes (macOS) / closes window (Win/Linux)
+- [ ] `Cmd/Ctrl+W` works while focus is in a text input
+
+---
+
+## File Changes Summary
+
+| File | Action | Description |
+|---|---|---|
+| `electron/main.cjs` | Modify | Rename `installPreviewShortcut` → `installCloseShortcut`, always forward `Cmd+W` to renderer, add `hermes:close-window` handler, add 3 new shortcut `install*` functions |
+| `electron/preload.cjs` | Modify | Add 4 new IPC listeners (`onCloseRequested`, `onOpenSettings`, `onToggleRightPanel`, `onOpenSearch`) and 1 sender (`closeWindow`) |
+| `src/app/desktop-controller.tsx` | Modify | Replace `Cmd+W` handler with cascade, add IPC listeners for 3 new shortcuts |
+| `plans/desktop-keyboard-shortcuts.md` | Modify | This file |
+
+No new files needed. No new npm packages. No new stores.
+
+---
+
+## Dependencies
+
+- Uses Electron's built-in `before-input-event` API (already in use)
+- Uses existing `useOverlayRouting()` hook for overlay state (no new store)
+- Uses existing `toggleFileBrowserOpen()` from `store/layout.ts`
+- Uses existing `toggleCommandCenter()` from `useOverlayRouting()`
+- Uses existing IPC infrastructure in `main.cjs` and `preload.cjs`
+
+---
+
+## Related Issues
+
+- #37917 - Windows zoom shortcuts broken (already fixed by `installZoomShortcuts`)
+- #37915 - Keyboard navigation bugs
+- #37823 - Arrow key navigation
+- #38072 - Accessibility improvements
+
+---
+
+## Success Criteria
+
+1. `Cmd/Ctrl+W` cascades: overlay → right panel → preview → sidebar → window close/minimize
+2. `Cmd/Ctrl+,` opens Settings
+3. `Cmd/Ctrl+.` toggles right sidebar
+4. `Cmd/Ctrl+K` opens Command Center
+5. All existing shortcuts continue to work (no regressions)
+6. Cascade works on macOS, Windows, and Linux
+
+---
+
+## Notes
+
+- The `previewShortcutActive` boolean flag should be removed once the renderer owns the full cascade — it becomes redundant.
+- `Shift+N` (new chat when no input focused) is an existing undocumented shortcut in `desktop-controller.tsx:407-408`. It should be preserved.
+- Future work: custom keybinding configuration (out of scope for this PR).


### PR DESCRIPTION
## Summary

Implements the keyboard shortcuts requested in #38118.

### New Shortcuts

| Action | macOS | Windows/Linux |
|--------|-------|---------------|
| Close Panel/Modal | `Cmd+W` | `Ctrl+W` |
| Settings | `Cmd+,` | `Ctrl+,` |
| Toggle Right Panel | `Cmd+.` | `Ctrl+.` |
| Search / Command Center | `Cmd+K` | `Ctrl+K` |

### `Cmd/Ctrl+W` Cascade

The close shortcut now cascades through UI layers instead of immediately closing the window:

**Overlay (Settings/Command Center/Agents) → Right Sidebar → Preview Rail → Left Sidebar → Minimize (macOS) / Close (Windows/Linux)**

### Design Decisions

- **Only `Cmd+W` uses the IPC bridge** — macOS has a native "Close" menu accelerator that intercepts `Cmd+W` before the DOM sees it, so it must be routed through the main process. The other shortcuts (`Cmd+,/./K`) are renderer-only keydown listeners, matching the existing `Cmd+B` and `Cmd+N` patterns.
- **Extracted pure `resolveCloseAction(state)` function** — the cascade logic is a pure function testable without React/DOM/Electron.
- **Removed `previewShortcutActive` flag** — the renderer now owns the full cascade, making the main-process boolean redundant.

### Files Changed

| File | Change |
|---|---|
| `src/app/keyboard-shortcuts.ts` | **New** — cascade logic + shortcut listener helpers |
| `src/app/keyboard-shortcuts.test.ts` | **New** — 29 tests covering all behaviors |
| `src/app/desktop-controller.tsx` | Wired up new shortcuts, replaced old `Cmd+W` handler |
| `electron/main.cjs` | `installCloseShortcut` always forwards `Cmd+W` to renderer |
| `electron/preload.cjs` | Added `onCloseRequested` + `closeWindow`, removed `setPreviewShortcutActive` |
| `src/global.d.ts` | Updated type declarations |
| `src/app/shell/hooks/use-overlay-routing.ts` | Exported `OVERLAY_VIEWS` constant |

### Testing

- **29 unit tests** in `keyboard-shortcuts.test.ts`:
  - `resolveCloseAction` cascade ordering (6 tests)
  - `isCleanShortcut` modifier detection (6 tests)
  - `setupCloseCascadeListener` keydown + dispatch (6 tests)
  - `setupShortcutListener` for generic shortcuts (7 tests)
  - Cascade ordering on repeated presses (1 test)
  - Shortcuts don't interfere with each other (1 test)
  - Cmd+K and Cmd+. specific tests (2 tests)
- **TypeScript compiles cleanly** (`tsc --noEmit`)
- **Zero regressions** — all existing tests pass

Closes #38118