### PR TITLE
fix(mattermost): seed first thread turn context

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -272,6 +272,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
     "WHATSAPP_MODE", "WHATSAPP_ENABLED",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
+    "MATTERMOST_THREAD_CONTEXT",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
     "MATRIX_RECOVERY_KEY",
@@ -3274,6 +3275,13 @@ OPTIONAL_ENV_VARS = {
     "MATTERMOST_FREE_RESPONSE_CHANNELS": {
         "description": "Comma-separated Mattermost channel IDs where bot responds without @mention",
         "prompt": "Free-response channel IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATTERMOST_THREAD_CONTEXT": {
+        "description": "First-turn Mattermost thread context policy: allowlisted, off, or all",
+        "prompt": "Thread context policy (allowlisted/off/all)",
         "url": None,
         "password": False,
         "category": "messaging",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4063,6 +4063,12 @@ _PLATFORMS = [
                 "password": False,
                 "help": "off = flat channel messages, thread = replies nest under your message.",
             },
+            {
+                "name": "MATTERMOST_THREAD_CONTEXT",
+                "prompt": "Thread context policy (allowlisted/off/all, default: allowlisted)",
+                "password": False,
+                "help": "allowlisted seeds only allowed authors; off disables seeding; all seeds full thread history.",
+            },
         ],
     },
     {

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -98,6 +98,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+        self._thread_context_user_cache: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -265,6 +266,181 @@ class MattermostAdapter(BasePlatformAdapter):
         if data and data.get("root_id"):
             return data["root_id"]
         return post_id
+
+    async def _resolve_thread_user_name(self, user_id: str) -> str:
+        """Resolve a Mattermost user id for thread-context attribution."""
+        if not user_id:
+            return "unknown"
+        cached = self._thread_context_user_cache.get(user_id)
+        if cached:
+            return cached
+        data = await self._api_get(f"users/{user_id}")
+        name = (
+            str(data.get("username") or data.get("nickname") or "").lstrip("@")
+            if data
+            else ""
+        )
+        if not name:
+            name = user_id
+        self._thread_context_user_cache[user_id] = name
+        return name
+
+    def _thread_context_mode(self) -> str:
+        """Return the thread-history seeding policy."""
+        configured = self.config.extra.get("thread_context") if self.config.extra else None
+        raw = configured if configured is not None else os.getenv(
+            "MATTERMOST_THREAD_CONTEXT",
+            "allowlisted",
+        )
+        mode = str(raw).strip().lower()
+        return mode if mode in {"off", "allowlisted", "all"} else "allowlisted"
+
+    @staticmethod
+    def _truthy_env(name: str) -> bool:
+        return os.getenv(name, "").strip().lower() in {"true", "1", "yes", "on"}
+
+    def _thread_context_author_allowed(self, user_id: str) -> bool:
+        """Return True when an author may contribute injected thread context."""
+        if self._thread_context_mode() == "all":
+            return True
+
+        if self._truthy_env("MATTERMOST_ALLOW_ALL_USERS") or self._truthy_env(
+            "GATEWAY_ALLOW_ALL_USERS"
+        ):
+            return True
+
+        allowed_ids = {
+            value.strip()
+            for raw in (
+                os.getenv("MATTERMOST_ALLOWED_USERS", ""),
+                os.getenv("GATEWAY_ALLOWED_USERS", ""),
+            )
+            for value in raw.split(",")
+            if value.strip()
+        }
+        if "*" in allowed_ids:
+            return True
+        return bool(user_id) and user_id in allowed_ids
+
+    async def _fetch_thread_context(
+        self,
+        root_id: str,
+        current_post_id: str,
+        limit: int = 30,
+    ) -> str:
+        """Fetch prior Mattermost thread posts for first-turn context."""
+        if not root_id:
+            return ""
+
+        try:
+            data = await self._api_get(f"posts/{root_id}/thread")
+            raw_posts = data.get("posts") if isinstance(data, dict) else None
+            if isinstance(raw_posts, dict):
+                posts = list(raw_posts.values())
+            elif isinstance(raw_posts, list):
+                posts = raw_posts
+            else:
+                return ""
+
+            posts.sort(key=lambda p: (p.get("create_at", 0), p.get("id", "")))
+            eligible_posts = []
+            for post in posts:
+                post_id = str(post.get("id") or "")
+                if post_id == current_post_id:
+                    continue
+
+                text = str(post.get("message") or "").strip()
+                if not text or text.startswith("/"):
+                    continue
+
+                if not self._thread_context_author_allowed(
+                    str(post.get("user_id") or "")
+                ):
+                    continue
+
+                eligible_posts.append(post)
+
+            context_parts = []
+            for post in eligible_posts[-limit:]:
+                text = str(post.get("message") or "").strip()
+                props = post.get("props") if isinstance(post.get("props"), dict) else {}
+                name = (
+                    props.get("override_username")
+                    or post.get("username")
+                    or post.get("user_name")
+                )
+                if name:
+                    name = str(name).lstrip("@")
+                else:
+                    name = await self._resolve_thread_user_name(
+                        str(post.get("user_id") or "")
+                    )
+                context_parts.append(f"[{name}]: {text}")
+
+            if not context_parts:
+                return ""
+
+            return (
+                "[Thread context - prior messages in this thread "
+                "(not yet in conversation history):]\n"
+                + "\n".join(context_parts)
+                + "\n[End of thread context]\n\n"
+            )
+        except Exception as exc:
+            logger.warning("Mattermost: failed to fetch thread context: %s", exc)
+            return ""
+
+    def _has_active_session_for_thread(
+        self,
+        channel_id: str,
+        chat_type: str,
+        user_id: str,
+        thread_id: str,
+    ) -> bool:
+        """Return True when this Mattermost thread already has session history."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store or not thread_id:
+            return False
+
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            source = SessionSource(
+                platform=Platform.MATTERMOST,
+                chat_id=channel_id,
+                chat_type=chat_type,
+                user_id=user_id,
+                thread_id=thread_id,
+            )
+            generate_session_key = getattr(session_store, "_generate_session_key", None)
+            session_key = (
+                generate_session_key(source) if callable(generate_session_key) else None
+            )
+            if not isinstance(session_key, str) or not session_key:
+                extra = self.config.extra or {}
+                session_key = build_session_key(
+                    source,
+                    group_sessions_per_user=extra.get("group_sessions_per_user", True),
+                    thread_sessions_per_user=extra.get(
+                        "thread_sessions_per_user",
+                        False,
+                    ),
+                )
+
+            ensure_loaded = getattr(session_store, "_ensure_loaded", None)
+            if callable(ensure_loaded):
+                ensure_loaded()
+            entries = getattr(session_store, "_entries", {})
+            entry = entries.get(session_key) if isinstance(entries, dict) else None
+            if not entry:
+                return False
+
+            should_reset = getattr(session_store, "_should_reset", None)
+            if callable(should_reset) and should_reset(entry, source):
+                return False
+            return True
+        except Exception:
+            return False
 
     async def send(
         self,
@@ -788,6 +964,23 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Thread support: if the post is in a thread, use root_id.
         thread_id = post.get("root_id") or None
+        if (
+            thread_id
+            and not message_text.startswith("/")
+            and self._thread_context_mode() != "off"
+            and not self._has_active_session_for_thread(
+                channel_id=channel_id,
+                chat_type=chat_type,
+                user_id=sender_id,
+                thread_id=thread_id,
+            )
+        ):
+            thread_context = await self._fetch_thread_context(
+                root_id=thread_id,
+                current_post_id=post_id,
+            )
+            if thread_context:
+                message_text = thread_context + message_text
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -1118,6 +1311,9 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+    tc = mattermost_cfg.get("thread_context")
+    if tc is not None and not os.getenv("MATTERMOST_THREAD_CONTEXT"):
+        os.environ["MATTERMOST_THREAD_CONTEXT"] = str(tc)
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_THREAD_CONTEXT
+    description: "First-turn thread context policy: allowlisted, off, or all. Default: allowlisted."
+    prompt: "Thread context policy (allowlisted|off|all)"
+    password: false

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -391,6 +391,306 @@ class TestMattermostWebSocketParsing:
         assert msg_event.source.thread_id == "root_post_123"
 
     @pytest.mark.asyncio
+    async def test_first_thread_turn_omits_prior_slash_commands_from_context(self):
+        """Old slash commands in a Mattermost thread should not seed context."""
+        post_data = {
+            "id": "post_reply",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id summarize this",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@carol",
+            },
+        }
+
+        async def fake_api_get(path):
+            if path == "posts/root_post_123/thread":
+                return {
+                    "posts": {
+                        "root_post_123": {
+                            "id": "root_post_123",
+                            "user_id": "user_789",
+                            "message": "Original question",
+                            "create_at": 1000,
+                        },
+                        "prior_slash": {
+                            "id": "prior_slash",
+                            "user_id": "user_456",
+                            "message": "/todo internal command",
+                            "create_at": 2000,
+                        },
+                        "post_reply": {
+                            "id": "post_reply",
+                            "user_id": "user_123",
+                            "message": "@bot_user_id summarize this",
+                            "create_at": 3000,
+                        },
+                    }
+                }
+            if path == "users/user_789":
+                return {"username": "alice"}
+            if path == "users/user_456":
+                return {"username": "bob"}
+            return {}
+
+        self.adapter._api_get = AsyncMock(side_effect=fake_api_get)
+
+        with patch.dict(os.environ, {"MATTERMOST_ALLOWED_USERS": "user_789"}):
+            os.environ.pop("MATTERMOST_THREAD_CONTEXT", None)
+            os.environ.pop("MATTERMOST_ALLOW_ALL_USERS", None)
+            os.environ.pop("GATEWAY_ALLOWED_USERS", None)
+            os.environ.pop("GATEWAY_ALLOW_ALL_USERS", None)
+            await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("[Thread context")
+        assert "[alice]: Original question" in msg_event.text
+        assert "/todo internal command" not in msg_event.text
+        assert "[carol]: summarize this" not in msg_event.text
+        assert msg_event.text.endswith("summarize this")
+
+    @pytest.mark.asyncio
+    async def test_thread_context_limit_keeps_most_recent_prior_posts(self):
+        """Long threads should keep the newest prior posts, not the oldest."""
+
+        async def fake_api_get(path):
+            if path == "posts/root_post_123/thread":
+                return {
+                    "posts": {
+                        "root_post_123": {
+                            "id": "root_post_123",
+                            "user_id": "user_1",
+                            "username": "alice",
+                            "message": "Oldest root",
+                            "create_at": 1000,
+                        },
+                        "prior_2": {
+                            "id": "prior_2",
+                            "user_id": "user_2",
+                            "username": "bob",
+                            "message": "Middle detail",
+                            "create_at": 2000,
+                        },
+                        "prior_3": {
+                            "id": "prior_3",
+                            "user_id": "user_3",
+                            "username": "carol",
+                            "message": "Newest detail",
+                            "create_at": 3000,
+                        },
+                        "current": {
+                            "id": "current",
+                            "user_id": "user_4",
+                            "username": "dan",
+                            "message": "@bot_user_id summarize",
+                            "create_at": 4000,
+                        },
+                    }
+                }
+            return {}
+
+        self.adapter._api_get = AsyncMock(side_effect=fake_api_get)
+
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "all"}):
+            context = await self.adapter._fetch_thread_context(
+                root_id="root_post_123",
+                current_post_id="current",
+                limit=2,
+            )
+
+        assert "Oldest root" not in context
+        assert "[bob]: Middle detail" in context
+        assert "[carol]: Newest detail" in context
+        assert "summarize" not in context
+        assert context.index("[bob]:") < context.index("[carol]:")
+
+    @pytest.mark.asyncio
+    async def test_thread_context_filters_non_allowlisted_authors(self):
+        """Injected thread history should not leak non-allowlisted authors."""
+        post_data = {
+            "id": "post_reply",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id summarize this",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@carol",
+            },
+        }
+
+        async def fake_api_get(path):
+            if path == "posts/root_post_123/thread":
+                return {
+                    "posts": {
+                        "root_post_123": {
+                            "id": "root_post_123",
+                            "user_id": "allowed_user",
+                            "username": "alice",
+                            "message": "Allowed context",
+                            "create_at": 1000,
+                        },
+                        "prior_unlisted": {
+                            "id": "prior_unlisted",
+                            "user_id": "unlisted_user",
+                            "username": "mallory",
+                            "message": "Private unlisted context",
+                            "create_at": 2000,
+                        },
+                        "post_reply": {
+                            "id": "post_reply",
+                            "user_id": "user_123",
+                            "username": "carol",
+                            "message": "@bot_user_id summarize this",
+                            "create_at": 3000,
+                        },
+                    }
+                }
+            return {}
+
+        self.adapter._api_get = AsyncMock(side_effect=fake_api_get)
+
+        with patch.dict(os.environ, {"MATTERMOST_ALLOWED_USERS": "allowed_user"}):
+            os.environ.pop("MATTERMOST_THREAD_CONTEXT", None)
+            os.environ.pop("MATTERMOST_ALLOW_ALL_USERS", None)
+            os.environ.pop("GATEWAY_ALLOWED_USERS", None)
+            os.environ.pop("GATEWAY_ALLOW_ALL_USERS", None)
+            await self.adapter._handle_ws_event(event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "Allowed context" in msg_event.text
+        assert "Private unlisted context" not in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_thread_context_all_includes_non_allowlisted_authors(self):
+        """MATTERMOST_THREAD_CONTEXT=all is an explicit full-history opt-in."""
+
+        async def fake_api_get(path):
+            if path == "posts/root_post_123/thread":
+                return {
+                    "posts": {
+                        "root_post_123": {
+                            "id": "root_post_123",
+                            "user_id": "allowed_user",
+                            "username": "alice",
+                            "message": "Allowed context",
+                            "create_at": 1000,
+                        },
+                        "prior_unlisted": {
+                            "id": "prior_unlisted",
+                            "user_id": "unlisted_user",
+                            "username": "mallory",
+                            "message": "Unlisted context",
+                            "create_at": 2000,
+                        },
+                        "current": {
+                            "id": "current",
+                            "user_id": "user_123",
+                            "username": "carol",
+                            "message": "@bot_user_id summarize",
+                            "create_at": 3000,
+                        },
+                    }
+                }
+            return {}
+
+        self.adapter._api_get = AsyncMock(side_effect=fake_api_get)
+
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "all"}):
+            context = await self.adapter._fetch_thread_context(
+                root_id="root_post_123",
+                current_post_id="current",
+            )
+
+        assert "Allowed context" in context
+        assert "Unlisted context" in context
+
+    @pytest.mark.asyncio
+    async def test_thread_context_off_skips_context_fetch(self):
+        """MATTERMOST_THREAD_CONTEXT=off disables first-turn context seeding."""
+        post_data = {
+            "id": "post_reply",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id summarize this",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@carol",
+            },
+        }
+        self.adapter._api_get = AsyncMock(return_value={})
+
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "off"}):
+            await self.adapter._handle_ws_event(event)
+
+        self.adapter._api_get.assert_not_called()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "summarize this"
+
+    @pytest.mark.asyncio
+    async def test_existing_thread_session_skips_thread_context_fetch(self):
+        """Thread context should not be fetched again once session exists."""
+        post_data = {
+            "id": "post_reply_2",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Thread reply",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        session_key = "custom-session-store-key"
+        session_store = MagicMock()
+        session_store._entries = {session_key: object()}
+        session_store._generate_session_key = lambda _source: session_key
+        session_store._ensure_loaded = MagicMock()
+        session_store._should_reset = lambda _entry, _source: None
+        self.adapter.set_session_store(session_store)
+        self.adapter._api_get = AsyncMock(
+            return_value={
+                "posts": {
+                    "root_post_123": {
+                        "id": "root_post_123",
+                        "user_id": "user_456",
+                        "username": "bob",
+                        "message": "Original question",
+                        "create_at": 1000,
+                    }
+                }
+            }
+        )
+
+        await self.adapter._handle_ws_event(event)
+
+        self.adapter._api_get.assert_not_called()
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Thread reply"
+
+    @pytest.mark.asyncio
     async def test_invalid_post_json_ignored(self):
         """Invalid JSON in data.post should be silently ignored."""
         event = {


### PR DESCRIPTION
## Summary
- Fetch prior Mattermost thread posts with `GET /api/v4/posts/{root_id}/thread` on the first Hermes turn in a thread.
- Prepend sorted prior messages as thread context while excluding the triggering post and prior slash commands.
- Skip refetching once the thread already has a gateway session, using the session store's key generation when available.

Fixes #37695.

## Tests
- Red: `.\.venv\Scripts\python.exe -m pytest tests/gateway/test_mattermost.py::TestMattermostWebSocketParsing::test_first_thread_turn_omits_prior_slash_commands_from_context -q --timeout-method=thread` failed because only the triggering message reached the agent.
- `.\.venv\Scripts\python.exe -m pytest tests/gateway/test_mattermost.py::TestMattermostWebSocketParsing::test_first_thread_turn_omits_prior_slash_commands_from_context -q --timeout-method=thread` -> `1 passed`
- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_mattermost.py -q --timeout-method=thread` -> `46 passed`
- `.\.venv\Scripts\python.exe -m ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py` -> `All checks passed!`
- `.\.venv\Scripts\python.exe -m py_compile plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py` -> passed
- `git diff --check` -> passed