### PR TITLE
fix(agent): remove memory tool from surface when skip_memory=True (#38129)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -909,7 +909,17 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
-    
+
+    # When memory is disabled (e.g. cron with skip_memory=True), remove the
+    # memory tool from the surface so the agent never sees a tool that will
+    # always fail at runtime.  Without this, cron sessions expose "memory" in
+    # the tool schema but calls return "Memory is not available." — confusing.
+    if skip_memory and agent.tools:
+        agent.tools = [
+            t for t in agent.tools
+            if t.get("function", {}).get("name") != "memory"
+        ]
+
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:

--- a/tests/run_agent/test_skip_memory_removes_tool.py
+++ b/tests/run_agent/test_skip_memory_removes_tool.py
@@ -1,0 +1,78 @@
+"""Tests that skip_memory=True removes the memory tool from the agent surface."""
+
+import pytest
+from run_agent import AIAgent
+
+
+class TestSkipMemoryRemovesTool:
+    """When skip_memory=True, the memory tool should not be in agent.tools."""
+
+    def test_memory_tool_present_without_skip(self):
+        """Without skip_memory, the memory tool should be available."""
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_memory=False,
+            skip_context_files=True,
+        )
+        tool_names = {t["function"]["name"] for t in (agent.tools or [])}
+        assert "memory" in tool_names, "memory tool should be present when skip_memory=False"
+
+    def test_memory_tool_absent_with_skip(self):
+        """With skip_memory=True, the memory tool should be removed."""
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+        )
+        tool_names = {t["function"]["name"] for t in (agent.tools or [])}
+        assert "memory" not in tool_names, (
+            "memory tool must be removed when skip_memory=True; "
+            "leaving it causes runtime failures in cron-like sessions"
+        )
+
+    def test_valid_tool_names_excludes_memory_with_skip(self):
+        """valid_tool_names should also exclude memory when skip_memory=True."""
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+        )
+        assert "memory" not in agent.valid_tool_names
+
+    def test_skip_memory_false_preserves_valid_tool_names(self):
+        """valid_tool_names should include memory when skip_memory=False."""
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_memory=False,
+            skip_context_files=True,
+        )
+        assert "memory" in agent.valid_tool_names
+
+    def test_other_tools_unaffected_by_skip_memory(self):
+        """Core tools like read_file, write_file, terminal should remain."""
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+        )
+        tool_names = {t["function"]["name"] for t in (agent.tools or [])}
+        # These tools should always be present regardless of skip_memory
+        for expected in ("read_file", "write_file", "terminal", "web_search"):
+            assert expected in tool_names, (
+                f"{expected} tool should still be present when skip_memory=True"
+            )


### PR DESCRIPTION
## Problem

When skip_memory=True (used by cron sessions), the memory tool was still
exposed in the agent's tool schema but always failed at runtime with
'Memory is not available. It may be disabled in config or this environment.'

This caused confusing behavior: cron jobs could see and attempt to call the
memory tool, but every invocation would fail.

## Root Cause

cron/scheduler.py creates agents with skip_memory=True, which correctly
prevents memory store initialization. However, the memory tool was still
included in the tool definitions because hermes-cron inherits
_HERMES_CORE_TOOLS which includes memory.

## Fix

Filter the memory tool out of agent.tools when skip_memory=True in
agent_init.py. Since agent.valid_tool_names is derived from agent.tools,
it is automatically consistent.

## Testing

Added tests/run_agent/test_skip_memory_removes_tool.py with 5 tests
verifying correct behavior in both skip_memory modes and confirming other
core tools remain unaffected.

Fixes #38129