### PR TITLE
fix(agent): focus automatic compression on recent user turns

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -110,6 +110,9 @@ _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 # become another unbounded transcript copy after the LLM summarizer failed.
 _FALLBACK_SUMMARY_MAX_CHARS = 8_000
 _FALLBACK_TURN_MAX_CHARS = 700
+_AUTO_FOCUS_MAX_TURNS = 3
+_AUTO_FOCUS_TURN_MAX_CHARS = 260
+_AUTO_FOCUS_MAX_CHARS = 700
 
 
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
@@ -1374,7 +1377,7 @@ Use this exact structure:
             prompt += f"""
 
 FOCUS TOPIC: "{focus_topic}"
-The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
             call_kwargs = {
@@ -1542,6 +1545,41 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
+
+    @classmethod
+    def _derive_auto_focus_topic(
+        cls,
+        messages: List[Dict[str, Any]],
+        tail_start: int,
+    ) -> Optional[str]:
+        """Infer a compact focus hint from the most recent real user turns."""
+        candidates: list[str] = []
+        del tail_start  # Reserved for callers that already know the protected-tail boundary.
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if cls._is_context_summary_content(content):
+                continue
+            text = redact_sensitive_text(_content_text_for_contains(content).strip())
+            if not text:
+                continue
+            text = " ".join(text.split())
+            if len(text) > _AUTO_FOCUS_TURN_MAX_CHARS:
+                text = text[: _AUTO_FOCUS_TURN_MAX_CHARS - 1].rstrip() + "…"
+            candidates.append(text)
+            if len(candidates) >= _AUTO_FOCUS_MAX_TURNS:
+                break
+
+        if not candidates:
+            return None
+
+        candidates.reverse()
+        focus = "Recent user focus:\n" + "\n".join(f"- {item}" for item in candidates)
+        if len(focus) > _AUTO_FOCUS_MAX_CHARS:
+            focus = focus[: _AUTO_FOCUS_MAX_CHARS - 1].rstrip() + "…"
+        return focus
 
     @classmethod
     def _find_latest_context_summary(
@@ -1933,7 +1971,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages, compress_end)
+        summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -116,7 +116,7 @@ def test_compress_passes_focus_to_generate_summary():
 
 
 def test_compress_none_focus_by_default():
-    """compress() passes None focus_topic by default."""
+    """Auto compression derives focus_topic from recent user turns by default."""
     compressor = _make_compressor()
 
     received_kwargs = {}
@@ -141,4 +141,32 @@ def test_compress_none_focus_by_default():
 
     compressor.compress(messages, current_tokens=100000)
 
-    assert received_kwargs.get("focus_topic") is None
+    focus_topic = received_kwargs.get("focus_topic")
+    assert focus_topic.startswith("Recent user focus:")
+    assert "- second" in focus_topic
+    assert "- third" in focus_topic
+    assert "- fourth" in focus_topic
+
+
+def test_auto_focus_skips_context_summary_handoff():
+    """Persisted handoff messages should not become the inferred focus."""
+    compressor = _make_compressor()
+    messages = [
+        {"role": "system", "content": "System prompt"},
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] stale Bybit topic",
+        },
+        {"role": "assistant", "content": "handoff acknowledged"},
+        {"role": "user", "content": "Can OpenViking support sqlite backends?"},
+        {"role": "assistant", "content": "Let's inspect that."},
+        {"role": "user", "content": "Compare OpenViking postgres and sqlite options."},
+        {"role": "assistant", "content": "Working on it."},
+        {"role": "user", "content": "Now focus on OpenViking database support."},
+        {"role": "assistant", "content": "Latest tail response"},
+    ]
+
+    focus_topic = compressor._derive_auto_focus_topic(messages, tail_start=1)
+
+    assert "OpenViking" in focus_topic
+    assert "Bybit" not in focus_topic


### PR DESCRIPTION
## What does this PR do?

Automatic context compression now derives a compact focus hint from the latest real user turns when no manual focus topic is supplied. That hint is passed into the existing summary prompt so iterative compactions preserve the current task/topic more strongly and demote stale completed topics.

## Related Issue

Fixes #9631

## Addressing maintainer feedback

#10088 - maintainer-referenced partial mitigation/template work. The current branch already contains the described template improvements (`Completed Actions`, `Active State`, and stronger iterative-summary instructions); this PR builds on that by adding the missing automatic focus derivation path for ordinary auto-compactions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test update

## Changes Made

- `agent/context_compressor.py`: derives an automatic `Recent user focus` hint from the latest real user turns, skips persisted summary handoff messages, redacts sensitive text, and passes the hint into summary generation when no explicit focus topic is provided.
- `tests/agent/test_compress_focus.py`: updates default-focus expectations and covers skipping stale context-summary handoff content.

## How to Test

1. `pytest tests/agent/test_compress_focus.py -q` - passes (`5 passed`).
2. `pytest tests/agent/test_context_compressor_summary_continuity.py -q` - passes (`3 passed`).
3. `ruff check agent/context_compressor.py tests/agent/test_compress_focus.py` - passes.
4. `python scripts/check-windows-footguns.py agent/context_compressor.py tests/agent/test_compress_focus.py` - passes.
5. `git diff --check` - passes.
6. `scripts/run_tests.sh` - ran the broad suite, but exited non-zero locally with unrelated sandbox/environment failures across other modules (`27375 passed`, `781 failed`). Representative failures include restricted socket binds, denied writes under `~/.hermes`, live-system guard blocks around process-signal tests, and optional SDK import timeouts.

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the existing code style
- [x] I have added or updated tests for my changes
- [ ] I have run the full test suite and all tests pass (wrapper ran locally but failed for unrelated sandbox/environment reasons noted above)
- [x] I have considered cross-platform compatibility (`scripts/check-windows-footguns.py` passed for changed files)
- [x] My changes are focused and do not include unrelated files

## Screenshots / Logs

N/A - agent compression behavior change only.

<!-- autocontrib:worker-id=issue-new-57f6ea9c kind=pr-open -->