### PR TITLE
fix(desktop): stop in-app update from killing its own backend (#37532)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1412,6 +1412,18 @@ async function applyUpdatesPosixInApp(opts = {}) {
     PATH: [extraPath, process.env.PATH].filter(Boolean).join(path.delimiter)
   }
 
+  // `hermes update` reaps stale `hermes dashboard` backends (a code update
+  // leaves the running process serving old Python against the freshly-updated
+  // JS bundle). But OUR backend is one of those processes, and killing it
+  // mid-update produces the boot→kill→crash loop in #37532 — the desktop
+  // already restarts its own backend via the rebuild+relaunch below, so the
+  // reap must spare it. Hand the live backend's PID to the update process;
+  // _kill_stale_dashboard_processes reads HERMES_DESKTOP_CHILD_PID and excludes
+  // it while still reaping any genuinely-orphaned dashboards. (#37532)
+  if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
+    env.HERMES_DESKTOP_CHILD_PID = String(hermesProcess.pid)
+  }
+
   // Branch-pin so a non-main checkout doesn't get switched to main (and self-heal
   // to main when the pinned branch no longer exists on origin).
   let branchArgs = []

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7363,7 +7363,10 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
-def _find_stale_dashboard_pids() -> list[int]:
+def _find_stale_dashboard_pids(
+    *,
+    exclude_pids: set[int] | None = None,
+) -> list[int]:
     """Return PIDs of ``hermes dashboard`` processes other than ourselves.
 
     ``hermes dashboard`` is a long-lived server process commonly started and
@@ -7377,6 +7380,15 @@ def _find_stale_dashboard_pids() -> list[int]:
     after an update is to kill the stale process and let the user restart
     it.  This helper is just the detection step; see
     ``_kill_stale_dashboard_processes`` for the kill.
+
+    *exclude_pids* is an optional set of PIDs that must never be returned.
+    This is used by the Hermes Desktop Electron app to protect its own
+    backend child process: when the desktop spawns ``hermes dashboard`` as
+    a backend and triggers an auto-update, the update must not kill the
+    dashboard that the desktop itself manages.  The desktop sets the
+    environment variable ``HERMES_DESKTOP_CHILD_PID`` on the spawned
+    backend process; ``_kill_stale_dashboard_processes`` reads it and
+    passes it here.  (#37532)
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
@@ -7453,6 +7465,8 @@ def _find_stale_dashboard_pids() -> list[int]:
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
 
+    if exclude_pids:
+        dashboard_pids = [p for p in dashboard_pids if p not in exclude_pids]
     return dashboard_pids
 
 
@@ -7604,7 +7618,18 @@ def _kill_stale_dashboard_processes(
     launch args (--host, --port, --insecure, --tui, --no-open).  The user
     restarts it manually; a hint is printed.
     """
-    pids = _find_stale_dashboard_pids()
+    # When the Hermes Desktop Electron app spawns this dashboard as a
+    # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
+    # path can skip killing the desktop-managed process.  (#37532)
+    exclude: set[int] | None = None
+    raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
+    if raw_pid:
+        try:
+            exclude = {int(raw_pid)}
+        except (ValueError, TypeError):
+            pass
+
+    pids = _find_stale_dashboard_pids(exclude_pids=exclude)
     if not pids:
         return
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -185,6 +185,48 @@ class TestFindStaleDashboardPids:
             pids = _find_stale_dashboard_pids()
         assert pids == [12345]
 
+    def test_exclude_pids_filters_specified_pids(self):
+        """exclude_pids removes specific PIDs from the result — used by
+        the Desktop Electron app to protect its own backend child.  (#37532)
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(11111, "hermes dashboard --port 9119"),
+                    _ps_line(22222, "hermes dashboard --port 9120"),
+                    _ps_line(33333, "hermes dashboard --port 9121"),
+                ]) + "\n",
+                stderr="",
+            )
+            # Exclude the desktop-managed backend PID
+            pids = _find_stale_dashboard_pids(exclude_pids={22222})
+        assert 11111 in pids
+        assert 22222 not in pids
+        assert 33333 in pids
+
+    def test_exclude_pids_none_is_noop(self):
+        """Passing exclude_pids=None (the default) changes nothing."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(12345, "hermes dashboard --port 9119") + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids(exclude_pids=None)
+        assert pids == [12345]
+
+    def test_exclude_all_pids_returns_empty(self):
+        """If all matched PIDs are excluded, the result is empty."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(12345, "hermes dashboard --port 9119") + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids(exclude_pids={12345})
+        assert pids == []
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
 class TestKillStaleDashboardPosix:


### PR DESCRIPTION
## Summary
Completes the #37532 fix end-to-end: the Hermes Desktop in-app update no longer SIGTERMs its own backend, ending the boot→kill→crash loop where the desktop never reconnects after "Update".

Root cause: `applyUpdatesPosixInApp` runs `hermes update`, which calls `_kill_stale_dashboard_processes()` → reaps every `hermes dashboard` process, including the Electron app's own managed backend.

## Changes
- `hermes_cli/main.py` (@liuhao1024): `_find_stale_dashboard_pids()` gains a keyword-only `exclude_pids`; `_kill_stale_dashboard_processes()` reads `HERMES_DESKTOP_CHILD_PID` and excludes it — still reaps genuinely-orphaned dashboards.
- `apps/desktop/electron/main.cjs` (follow-up): `applyUpdatesPosixInApp` now passes `HERMES_DESKTOP_CHILD_PID=<live backend pid>` in the `hermes update` env. Without this the Python half was a no-op (nothing set the var).

## Why two commits
PR #37538 (liuhao1024) shipped only the Python half and touched zero desktop files, so `exclude` was always `None` and the backend still got killed. The desktop wiring is the load-bearing half; added on top with contributor authorship preserved.

## Validation
| Scenario | Before | After |
|---|---|---|
| Desktop update (POSIX) | own backend killed → crash loop | own backend spared, orphans reaped |
| `hermes update` (no env) | reaps all stale dashboards | unchanged (legacy intact) |
| Malformed env var | n/a | ignored, no crash |

- `node --check` + `py_compile` clean
- `tests/hermes_cli/test_update_stale_dashboard.py`: 22/22 pass
- E2E against real `_kill_stale_dashboard_processes` (mocked `ps`/`os.kill`): env→backend spared + orphan reaped; no-env→both reaped; garbage env→ignored

Notes: POSIX backends spawn with `shell:false`, so `hermesProcess.pid` is the actual python process whose cmdline the scan matches — PID equality holds. The POSIX in-app path is the only one running `hermes update` directly (Windows hands off to the Tauri installer, untouched).

Fixes #37532. Supersedes #37538 (cherry-picked with authorship preserved).

## Infographic

![desktop-update-self-kill-fixed](https://v3b.fal.media/files/b/0a9cce2d/rNzsbJiCwAev-xHdvyG79_QEZVQ58P.png)
