### PR TITLE
fix(kanban): preserve runner metadata on tasks

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -74,6 +74,10 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "model_override": t.model_override,
+        "runner": t.runner,
+        "runner_mode": t.runner_mode,
+        "runner_config": t.runner_config,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -332,6 +336,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--runner",
+                          choices=sorted(kb.VALID_RUNNERS),
+                          default=None,
+                          help="Explicit implementation runner intent (default: hermes)")
+    p_create.add_argument("--runner-mode",
+                          choices=sorted(kb.VALID_CODEX_RUNNER_MODES),
+                          default=None,
+                          help="Runner mode for --runner codex-cli (default: exec)")
+    p_create.add_argument("--runner-config", default=None,
+                          help="JSON object of runner-specific options")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1338,6 +1352,17 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    runner_config = None
+    raw_runner_config = getattr(args, "runner_config", None)
+    if raw_runner_config:
+        try:
+            runner_config = json.loads(raw_runner_config)
+        except json.JSONDecodeError as exc:
+            print(f"kanban: --runner-config must be valid JSON: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(runner_config, dict):
+            print("kanban: --runner-config must be a JSON object", file=sys.stderr)
+            return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1355,6 +1380,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            runner=getattr(args, "runner", None),
+            runner_mode=getattr(args, "runner_mode", None),
+            runner_config=runner_config,
             max_retries=max_retries,
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,6 +99,8 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+VALID_RUNNERS = {"hermes", "codex-cli"}
+VALID_CODEX_RUNNER_MODES = {"exec", "goal"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 
@@ -717,6 +719,13 @@ class Task:
     # list = explicitly no extra skills.
     skills: Optional[list] = None
     model_override: Optional[str] = None
+    # Explicit implementation runner intent and runner-specific metadata.
+    # These are intentionally advisory to the core dispatcher: product
+    # scripts and worker profiles use them to select/record lanes such as
+    # Codex CLI without losing Hermes/Kanban lifecycle ownership.
+    runner: Optional[str] = None
+    runner_mode: Optional[str] = None
+    runner_config: Optional[dict] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -757,6 +766,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        runner_config_value: Optional[dict] = None
+        if "runner_config" in keys and row["runner_config"]:
+            try:
+                parsed_runner_config = json.loads(row["runner_config"])
+                if isinstance(parsed_runner_config, dict):
+                    runner_config_value = parsed_runner_config
+            except Exception:
+                runner_config_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -807,6 +824,9 @@ class Task:
             ),
             skills=skills_value,
             model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            runner=row["runner"] if "runner" in keys and row["runner"] else None,
+            runner_mode=row["runner_mode"] if "runner_mode" in keys and row["runner_mode"] else None,
+            runner_config=runner_config_value,
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
@@ -959,6 +979,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- to the worker, overriding the profile's default model. NULL = use
     -- the profile default.
     model_override       TEXT,
+    -- Explicit implementation runner intent. NULL/hermes = normal Hermes
+    -- worker path; codex-cli = route implementation through Codex CLI.
+    runner               TEXT,
+    -- Runner-specific mode. For codex-cli, NULL defaults to exec.
+    runner_mode          TEXT,
+    -- Runner-specific structured metadata/options, stored as JSON object.
+    runner_config        TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -1613,6 +1640,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "model_override" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
 
+    if "runner" not in cols:
+        _add_column_if_missing(conn, "tasks", "runner", "runner TEXT")
+    if "runner_mode" not in cols:
+        _add_column_if_missing(conn, "tasks", "runner_mode", "runner_mode TEXT")
+    if "runner_config" not in cols:
+        _add_column_if_missing(conn, "tasks", "runner_config", "runner_config TEXT")
+
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
         # default) = classic single-shot worker, preserving the behaviour
@@ -2009,6 +2043,9 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    runner: Optional[str] = None,
+    runner_mode: Optional[str] = None,
+    runner_config: Optional[dict] = None,
     max_retries: Optional[int] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
@@ -2103,6 +2140,34 @@ def create_task(
             )
         skills_list = cleaned
 
+    runner_value = (str(runner).strip().lower() if runner is not None else None) or None
+    if runner_value is not None and runner_value not in VALID_RUNNERS:
+        raise ValueError(
+            f"runner must be one of {sorted(VALID_RUNNERS)}, got {runner!r}"
+        )
+
+    runner_mode_value = (str(runner_mode).strip().lower() if runner_mode is not None else None) or None
+    if runner_value == "codex-cli":
+        runner_mode_value = runner_mode_value or "exec"
+        if runner_mode_value not in VALID_CODEX_RUNNER_MODES:
+            raise ValueError(
+                "runner_mode must be one of "
+                f"{sorted(VALID_CODEX_RUNNER_MODES)} for runner='codex-cli', "
+                f"got {runner_mode!r}"
+            )
+    elif runner_mode_value is not None:
+        raise ValueError("runner_mode is only valid when runner='codex-cli'")
+
+    runner_config_value: Optional[dict] = None
+    if runner_config is not None:
+        if not isinstance(runner_config, dict):
+            raise ValueError("runner_config must be a JSON object/dict")
+        try:
+            json.dumps(runner_config)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"runner_config must be JSON-serializable: {exc}") from exc
+        runner_config_value = dict(runner_config)
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -2179,8 +2244,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, runner, runner_mode, runner_config, max_retries,
+                        goal_mode, goal_max_turns, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2198,6 +2264,9 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        runner_value,
+                        runner_mode_value,
+                        json.dumps(runner_config_value) if runner_config_value is not None else None,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
@@ -2220,6 +2289,9 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "runner": runner_value,
+                        "runner_mode": runner_mode_value,
+                        "runner_config": runner_config_value,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -581,6 +581,9 @@ class CreateTaskBody(BaseModel):
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
     skills: Optional[list[str]] = None
+    runner: Optional[str] = None
+    runner_mode: Optional[str] = None
+    runner_config: Optional[dict[str, Any]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
 
@@ -605,6 +608,9 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
+            runner=payload.runner,
+            runner_mode=payload.runner_mode,
+            runner_config=payload.runner_config,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
         )

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -252,6 +252,37 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
         )
 
 
+def test_create_task_persists_runner_metadata(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="codex lane",
+            runner="codex-cli",
+            runner_mode="goal",
+            runner_config={"source": "tracker", "identifier": "TICKET-123"},
+        )
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert task is not None
+    assert task.runner == "codex-cli"
+    assert task.runner_mode == "goal"
+    assert task.runner_config == {"source": "tracker", "identifier": "TICKET-123"}
+    assert events[0].payload is not None
+    assert events[0].payload["runner"] == "codex-cli"
+    assert events[0].payload["runner_mode"] == "goal"
+
+
+def test_create_task_rejects_invalid_runner_metadata(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="runner must be"):
+            kb.create_task(conn, title="bad runner", runner="not-a-runner")
+        with pytest.raises(ValueError, match="runner_mode is only valid"):
+            kb.create_task(conn, title="bad mode", runner_mode="exec")
+        with pytest.raises(ValueError, match="runner_config must be"):
+            kb.create_task(conn, title="bad config", runner_config=["not", "object"])  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # Links + dependency resolution
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -762,6 +762,13 @@ def _handle_create(args: dict, **kw) -> str:
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
+    runner = args.get("runner")
+    runner_mode = args.get("runner_mode")
+    runner_config = args.get("runner_config")
+    if runner_config is not None and not isinstance(runner_config, dict):
+        return tool_error(
+            f"runner_config must be an object/dict, got {type(runner_config).__name__}"
+        )
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
         skills = [skills]
@@ -809,6 +816,9 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                runner=runner,
+                runner_mode=runner_mode,
+                runner_config=runner_config,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1276,6 +1286,24 @@ KANBAN_CREATE_SCHEMA = {
                     "The names must match skills installed on the "
                     "assignee's profile."
                 ),
+            },
+            "runner": {
+                "type": "string",
+                "enum": ["codex-cli", "hermes"],
+                "description": (
+                    "Explicit implementation runner intent. Omit or use "
+                    "'hermes' for the normal Hermes worker path; use "
+                    "'codex-cli' to request Codex CLI as the implementation lane."
+                ),
+            },
+            "runner_mode": {
+                "type": "string",
+                "enum": ["exec", "goal"],
+                "description": "Runner mode for runner='codex-cli' (default: exec).",
+            },
+            "runner_config": {
+                "type": "object",
+                "description": "Runner-specific structured metadata/options.",
             },
             "goal_mode": {
                 "type": "boolean",


### PR DESCRIPTION
## What does this PR do?

Preserves Kanban task runner metadata across the public task model, SQLite schema/migrations, CLI, dashboard API, and `kanban_create` tool surface.

Existing boards can already contain runner-oriented task metadata such as `runner`, `runner_mode`, and `runner_config`, but current task read/write paths can drop or hide those fields. That makes downstream code that reads `Task.runner_config` crash with:

```text
AttributeError: 'Task' object has no attribute 'runner_config'
```

This keeps the fields advisory to the core dispatcher while making them reliably round-trip for integrations that use explicit worker lanes such as Hermes vs Codex CLI.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Adds `Task.runner`, `Task.runner_mode`, and `Task.runner_config`.
  - Adds additive migrations for `runner`, `runner_mode`, and `runner_config` columns.
  - Parses `runner_config` JSON safely from task rows.
  - Allows `create_task(..., runner=..., runner_mode=..., runner_config=...)`.
  - Validates supported runners and Codex runner modes.
- `hermes_cli/kanban.py`
  - Includes runner metadata in task JSON/show output.
  - Adds `kanban create --runner`, `--runner-mode`, and `--runner-config` flags.
- `tools/kanban_tools.py`
  - Exposes runner metadata through the structured `kanban_create` tool schema/handler.
- `plugins/kanban/dashboard/plugin_api.py`
  - Accepts runner metadata in dashboard task creation payloads.
- `tests/hermes_cli/test_kanban_db.py`
  - Adds regression coverage for runner metadata persistence and invalid metadata rejection.

## How to Test

1. Run targeted Kanban tests:

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_decompose.py \
  tests/tools/test_kanban_tools.py \
  tests/plugins/test_kanban_dashboard_plugin.py \
  tests/plugins/test_kanban_worker_runs.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/hermes_cli/test_kanban_boards.py \
  tests/hermes_cli/test_kanban_diagnostics.py \
  tests/gateway/test_kanban_notifier.py \
  tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py \
  -- -q
```

Result locally on Linux:

```text
734 tests passed, 0 failed
```

2. Run focused regression tests:

```bash
python -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -q
```

Result locally:

```text
385 passed, 1 warning
```

3. Run static checks:

```bash
git diff --check
ruff check .
python scripts/check-windows-footguns.py --all
```

Result locally:

```text
All checks passed!
✓ No Windows footguns found (543 file(s) scanned).
```

Platform tested: Linux.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
