### PR TITLE
fix(delegation): toolsets=[] now means empty toolset, not inherit parent

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -942,7 +942,9 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    if toolsets is not None:
+        # toolsets=[] explicitly means "no tools" (pure-reasoning subagent).
+        # toolsets=None (default) falls through to inherit from parent.
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.


### PR DESCRIPTION
## Problem

`toolsets=[]` in `delegate_task()` inherits the parent's full toolset instead of disabling tools.

## Fix

Change `if toolsets:` to `if toolsets is not None:` in `_build_child_agent()`.

## Tests

- `test_delegate_toolset_scope.py` - 5/5 passed
- `test_delegate_composite_toolsets.py` - 5/5 passed
- `test_delegate.py` - 135/135 passed