### PR TITLE
fix(install): quote UV_CMD to handle spaces in home directory path (fixes #38163)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -483,7 +483,7 @@ install_uv() {
 
     if [ -x "$_managed_uv" ]; then
         UV_CMD="$_managed_uv"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv found ($UV_VERSION)"
         return 0
     fi
@@ -519,7 +519,7 @@ install_uv() {
             exit 1
         fi
         rm -f "$_uv_install_log"
-        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        UV_VERSION=$("$UV_CMD" --version 2>/dev/null)
         log_success "Managed uv installed ($UV_VERSION)"
     else
         log_error "Failed to install uv"
@@ -1185,7 +1185,7 @@ setup_venv() {
     fi
 
     # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    "$UV_CMD" venv venv --python "$PYTHON_VERSION"
 
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
 }
@@ -1318,7 +1318,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" "$UV_CMD" sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1399,7 +1399,7 @@ PY
     install_tier() {
         local name="$1"; local spec="$2"
         log_info "Trying tier: $name ..."
-        if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
+        if "$UV_CMD" pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"


### PR DESCRIPTION
When `$HOME` contains a space (e.g. `/Volumes/2T Home/cameron/`), `$UV_CMD` resolves to an unquoted path like `/Volumes/2T Home/cameron/.hermes/bin/uv`. Bash word-splits this into two tokens, so every uv invocation fails with `/Volumes/2T: No such file or directory`.

This hits at `venv` creation (line 1188), `uv sync` (line 1321), and every `pip install` tier (line 1402) — all three dependency tiers fail the same way. Two uses inside `$()` for `--version` checks were also unquoted.

`$UV_CMD` was already quoted correctly at lines 558 and 566. This brings the remaining 5 sites in line with those.

Closes #38163
