### PR TITLE
fix(agent): bounded in-place retry for transient azure-foundry 401s

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -63,6 +63,19 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+# Azure Foundry endpoints fronted by Azure API Management have been observed
+# to intermittently return a spurious ``401 Invalid token`` for a fully valid
+# static API key (empirically ~20% of identical requests on some resources),
+# and the failures arrive in correlated bursts lasting several seconds where
+# concurrent requests all fail at once.  A single transient 401 would
+# otherwise abort the turn AND mark the sole credential ``exhausted`` in the
+# pool.  We retry the same key in-place a bounded number of times, with a
+# backoff window wide enough to outlast a typical burst, before falling
+# through to normal (terminal) auth handling — so a genuinely-invalid key
+# still fails, just after a few retries.
+AZURE_FOUNDRY_TRANSIENT_401_MAX_RETRIES = 6
+AZURE_FOUNDRY_TRANSIENT_401_MAX_BACKOFF = 10.0
+
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
@@ -1140,6 +1153,7 @@ def run_conversation(
         nous_auth_retry_attempted=False
         nous_paid_entitlement_refresh_attempted=False
         copilot_auth_retry_attempted=False
+        azure_foundry_transient_401_retries = 0
         thinking_sig_retry_attempted = False
         invalid_encrypted_content_retry_attempted = False
         image_shrink_retry_attempted = False
@@ -2294,6 +2308,78 @@ def run_conversation(
                             "refreshed runtime credentials and retrying request...",
                             force=True,
                         )
+                        continue
+
+                # ── Azure Foundry transient 401 retry ─────────────────
+                # Some Azure-API-Management-fronted Foundry endpoints
+                # intermittently reject a valid static API key with a
+                # spurious ``401 Invalid token``.  Retry the SAME key
+                # in-place (the already-built client) BEFORE the credential
+                # pool can mark the sole credential ``exhausted``.  Excludes
+                # Entra ID auth (a callable token provider) — there a 401 is
+                # a real RBAC/token failure that retrying won't fix.  When a
+                # multi-credential pool exists we only retry once before
+                # falling through to normal rotation, preserving pool
+                # semantics for genuinely-bad keys.
+                if (
+                    status_code == 401
+                    and classified.is_auth
+                    and (agent.provider or "") == "azure-foundry"
+                    and agent.api_mode == "chat_completions"
+                    and isinstance(agent.api_key, str)
+                    and agent.api_key.strip()
+                ):
+                    _t401_pool = getattr(agent, "_credential_pool", None)
+                    _t401_multi = bool(
+                        _t401_pool is not None and len(_t401_pool.entries()) > 1
+                    )
+                    _t401_max = 1 if _t401_multi else AZURE_FOUNDRY_TRANSIENT_401_MAX_RETRIES
+                    if azure_foundry_transient_401_retries < _t401_max:
+                        azure_foundry_transient_401_retries += 1
+                        wait_time = min(
+                            jittered_backoff(
+                                azure_foundry_transient_401_retries,
+                                base_delay=0.5,
+                                max_delay=AZURE_FOUNDRY_TRANSIENT_401_MAX_BACKOFF,
+                            ),
+                            AZURE_FOUNDRY_TRANSIENT_401_MAX_BACKOFF,
+                        )
+                        agent._buffer_vprint(
+                            f"🔁 Azure Foundry returned a transient 401 "
+                            f"(attempt {azure_foundry_transient_401_retries}/{_t401_max}) — "
+                            f"retrying the same key in {wait_time:.1f}s..."
+                        )
+                        logger.warning(
+                            "Azure Foundry transient 401 (attempt %s/%s) — retrying in-place; "
+                            "provider=%s base_url=%s model=%s",
+                            azure_foundry_transient_401_retries, _t401_max,
+                            agent.provider, getattr(agent, "base_url", ""), getattr(agent, "model", ""),
+                        )
+                        # Sleep in small increments to stay responsive to interrupts.
+                        sleep_end = time.time() + wait_time
+                        _t401_touch_counter = 0
+                        while time.time() < sleep_end:
+                            if agent._interrupt_requested:
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚡ Interrupt detected during Azure 401 retry wait, aborting.",
+                                    force=True,
+                                )
+                                agent._persist_session(messages, conversation_history)
+                                agent.clear_interrupt()
+                                return {
+                                    "final_response": "Operation interrupted during Azure Foundry 401 retry.",
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "interrupted": True,
+                                }
+                            time.sleep(0.2)
+                            _t401_touch_counter += 1
+                            if _t401_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
+                                agent._touch_activity(
+                                    f"Azure Foundry 401 retry "
+                                    f"({azure_foundry_transient_401_retries}/{_t401_max})"
+                                )
                         continue
 
                 recovered_with_pool, has_retried_429 = agent._recover_with_credential_pool(

--- a/tests/agent/test_azure_foundry_transient_401.py
+++ b/tests/agent/test_azure_foundry_transient_401.py
@@ -1,0 +1,173 @@
+"""Regression tests for the Azure Foundry transient-401 retry path.
+
+Some Azure-API-Management-fronted Foundry endpoints intermittently reject a
+fully valid static API key with a spurious ``401 Invalid token`` (empirically
+~20% of identical requests on some resources). Before the fix, a single
+transient 401 aborted the whole turn AND marked the sole credential
+``exhausted`` in the credential pool.
+
+The fix (``agent/conversation_loop.py``) retries the same key in-place a
+bounded number of times BEFORE the credential pool can mutate state, but only
+for static-string-key chat-completions on ``azure-foundry``. Entra ID auth (a
+callable bearer-token provider) is excluded because there a 401 is a real
+RBAC/token failure that retrying cannot fix.
+
+These tests lock in:
+  * a transient 401 followed by success recovers WITHOUT touching the pool
+  * Entra ID (callable key) does NOT use the transient retry path
+  * a persistent 401 still gives up after the bounded retries
+  * non-azure providers are unaffected by the new block
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from agent.conversation_loop import AZURE_FOUNDRY_TRANSIENT_401_MAX_RETRIES
+
+
+def _make_agent(provider, api_mode="chat_completions", api_key="valid-azure-key-123"):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key=api_key,
+            base_url="https://claude-44.services.ai.azure.com/openai/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.client = MagicMock()
+    a.provider = provider
+    a.api_mode = api_mode
+    a.api_key = api_key
+    a._credential_pool = None
+    a._persist_session = lambda *args, **kwargs: None
+    a._save_trajectory = lambda *args, **kwargs: None
+    a.suppress_status_output = True
+    return a
+
+
+class _Auth401Error(Exception):
+    status_code = 401
+
+    def __str__(self):
+        return "Error code: 401 - {'error': {'code': 'unauthorized', 'message': 'Invalid token'}}"
+
+
+def _mock_response(content="Recovered"):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        role="assistant",
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="Kimi-K2.6-1", usage=None)
+
+
+def _sequenced_api_call(responses):
+    def _call(api_kwargs):
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    return _call
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep():
+    # jittered_backoff -> 0 makes the interrupt-aware sleep loop exit
+    # immediately; patch time.sleep too as belt-and-suspenders.
+    with (
+        patch("agent.conversation_loop.jittered_backoff", return_value=0.0),
+        patch("agent.conversation_loop.time.sleep", return_value=None),
+    ):
+        yield
+
+
+class TestAzureFoundryTransient401:
+    def test_transient_401_then_success_recovers_without_pool(self):
+        """A single transient 401 retries in-place and recovers, never
+        invoking credential-pool recovery (so the key isn't marked exhausted)."""
+        agent = _make_agent("azure-foundry")
+        agent._recover_with_credential_pool = MagicMock(return_value=(False, False))
+        agent._interruptible_api_call = _sequenced_api_call(
+            [_Auth401Error(), _mock_response("Recovered")]
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        # The transient retry pre-empts pool recovery entirely.
+        assert agent._recover_with_credential_pool.call_count == 0
+
+    def test_multiple_transient_401s_within_budget_recover(self):
+        """Several consecutive transient 401s (within the retry budget) still
+        recover without touching the pool."""
+        agent = _make_agent("azure-foundry")
+        agent._recover_with_credential_pool = MagicMock(return_value=(False, False))
+        errs = [_Auth401Error() for _ in range(AZURE_FOUNDRY_TRANSIENT_401_MAX_RETRIES)]
+        agent._interruptible_api_call = _sequenced_api_call(
+            errs + [_mock_response("Recovered")]
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert agent._recover_with_credential_pool.call_count == 0
+
+    def test_persistent_401_gives_up_after_max_retries(self):
+        """A genuinely-rejected key still aborts after the bounded retries,
+        falling through to the normal pool-recovery / abort path."""
+        agent = _make_agent("azure-foundry")
+        agent._recover_with_credential_pool = MagicMock(return_value=(False, False))
+        # One more 401 than the retry budget guarantees the fall-through.
+        errs = [_Auth401Error() for _ in range(AZURE_FOUNDRY_TRANSIENT_401_MAX_RETRIES + 2)]
+        agent._interruptible_api_call = _sequenced_api_call(errs + [_mock_response("late")])
+
+        result = agent.run_conversation("hello")
+
+        # Falls through to pool recovery (which can't help a single bad key).
+        assert agent._recover_with_credential_pool.called
+        assert result.get("completed") is not True
+
+    def test_entra_callable_key_skips_transient_retry(self):
+        """Entra ID auth (callable token provider) must NOT use the transient
+        retry path — a 401 there is a real auth failure."""
+        token_provider = lambda: "minted-bearer-jwt"  # noqa: E731
+        agent = _make_agent("azure-foundry", api_key=token_provider)
+        agent._recover_with_credential_pool = MagicMock(return_value=(False, False))
+        agent._interruptible_api_call = _sequenced_api_call(
+            [_Auth401Error(), _mock_response("should-not-reach")]
+        )
+
+        result = agent.run_conversation("hello")
+
+        # No transient retry: the first 401 goes straight to pool recovery.
+        assert agent._recover_with_credential_pool.called
+        assert result.get("completed") is not True
+
+    def test_non_azure_provider_unaffected(self):
+        """A non-azure provider 401 must not enter the azure transient path —
+        it goes straight to pool recovery as before."""
+        agent = _make_agent("openrouter")
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._recover_with_credential_pool = MagicMock(return_value=(False, False))
+        agent._interruptible_api_call = _sequenced_api_call(
+            [_Auth401Error(), _mock_response("nope")]
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert agent._recover_with_credential_pool.called
+        assert result.get("completed") is not True


### PR DESCRIPTION
# PR: bounded in-place retry for transient azure-foundry 401s

**Branch:** `fix/azure-foundry-transient-401-retry`
**Base:** `NousResearch/hermes-agent` `main`
**Commit:** `fix(agent): bounded in-place retry for transient azure-foundry 401s`

---

## Title

fix(agent): bounded in-place retry for transient azure-foundry 401s

## Summary

Azure Foundry endpoints fronted by APIM intermittently return spurious
`401 Invalid token` responses on a fraction of otherwise-valid requests,
arriving in short correlated bursts. With a byte-identical, known-good key I
measured ~20% 401s over multi-second windows (the other ~80% returned 200,
randomly interleaved).

Hermes classifies `401` as a non-retryable auth failure, so the conversation
loop aborts the run and `_recover_with_credential_pool` marks the sole static
credential `exhausted`. The result: `hermes` invocations and cron jobs die with
`Non-retryable client error (HTTP 401). Aborting.` even though the key is valid.

This PR adds a **bounded, in-place retry** for that specific transient case.

## Approach

The retry is inserted **just before** the credential-pool recovery call, so it
reuses the already-built client/key and never pollutes pool state.

Guard conditions (all must hold):
- `provider == "azure-foundry"`
- `api_mode == "chat_completions"`
- HTTP `401` **and** `classified.is_auth`
- `api_key` is a **non-empty string**

Behavior:
- **Entra ID auth excluded:** Entra uses a *callable* token provider, not a
  string key, so the string guard skips it — genuine RBAC 401s still fail fast.
- **Single / no pool:** up to **6** retries, jittered backoff capped at **10s**
  (~25s total window), interrupt-aware sleep mirroring the existing 429 path.
- **Multi-key pool:** a **single** retry, then fall through to normal rotation,
  so genuinely-bad keys surface quickly.
- After retries are exhausted, the **unchanged** pool/abort path runs — so
  persistently-bad credentials behave exactly as before this change.

## Why these numbers

Observed bursts lasted up to ~8s. A 4-retry/~7.5s window occasionally lost the
race, so it was widened to 6 retries / 10s max backoff (~25s worst case),
comfortably inside cron's 3-minute hard interrupt while keeping worst-case
latency on a truly-bad key bounded.

## Tests

`tests/agent/test_azure_foundry_transient_401.py` (5 tests):
1. transient 401 then success — recovers without calling the credential pool
2. multiple transient 401s within budget — recovers
3. persistent 401 — gives up after the cap (pool/abort path runs)
4. Entra callable key — retry is skipped
5. non-azure provider — unaffected

All pass; full suite green.

```
$ ./scripts/run_tests.sh tests/agent/test_azure_foundry_transient_401.py
=== Summary: 1 files, 5 tests passed, 0 failed ===
```

## Risk / blast radius

- Scoped strictly to azure-foundry + chat_completions + string-key + auth-401.
- No behavior change for other providers, Entra auth, non-401 errors, or
  persistently-invalid keys.
- Adds bounded latency (≤ ~25s) only on the affected transient-401 path.

## Notes

The underlying flaky endpoint is an upstream Azure/APIM issue; this is a
client-side resilience measure. Retry count/backoff could be made
config-driven in a follow-up if bursts ever exceed the current window.
