### PR TITLE
feat(matrix): support bang command aliases (salvage #28025)

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -113,35 +113,55 @@ _MATRIX_BANG_COMMAND_RE = re.compile(
 )
 
 
-def _is_known_matrix_bang_command(name: str) -> bool:
-    """Return True when *name* is a Hermes command worth normalizing.
+def _resolve_matrix_bang_command(name: str) -> str | None:
+    """Resolve a ``!command`` token to a dispatchable Hermes command token.
 
     Matrix clients often reserve leading ``/`` for local client commands.
     Hermes accepts ``!command`` as a Matrix-friendly alias, but only for
     commands that the gateway can actually dispatch so ordinary exclamations
     remain normal chat text.
+
+    Returns the token form that actually resolves (which may differ from
+    *name* only by underscore→hyphen normalization, e.g. ``reload_skills`` →
+    ``reload-skills``) so the emitted ``/command`` always resolves downstream,
+    or ``None`` when *name* is not a known command. Aliases are intentionally
+    left as-is — the gateway dispatcher resolves them to their canonical name.
     """
     if not name:
-        return False
-    candidates = {name.lower(), name.lower().replace("_", "-")}
+        return None
+    # Try the raw lowercased token first, then its hyphenated variant, so
+    # forms like ``!reload_skills`` resolve against ``reload-skills``. We emit
+    # whichever candidate resolved (not a forced canonical form) to preserve
+    # alias passthrough — the gateway dispatcher canonicalizes aliases itself.
+    candidates = [name.lower()]
+    hyphenated = name.lower().replace("_", "-")
+    if hyphenated != candidates[0]:
+        candidates.append(hyphenated)
+
     try:
         from hermes_cli.commands import is_gateway_known_command
 
-        if any(is_gateway_known_command(candidate) for candidate in candidates):
-            return True
+        for candidate in candidates:
+            if is_gateway_known_command(candidate):
+                return candidate
     except Exception:
-        pass
+        logger.debug(
+            "Matrix: is_gateway_known_command failed for %r", name, exc_info=True
+        )
 
     try:
         from agent.skill_commands import get_skill_commands
 
         skill_commands = get_skill_commands() or {}
-        if any(candidate in skill_commands for candidate in candidates):
-            return True
+        # Skill command keys are stored slash-prefixed (e.g. "/arxiv"), so
+        # compare against the "/candidate" form, not the bare token.
+        for candidate in candidates:
+            if f"/{candidate}" in skill_commands:
+                return candidate
     except Exception:
-        pass
+        logger.debug("Matrix: get_skill_commands failed for %r", name, exc_info=True)
 
-    return False
+    return None
 
 
 def _normalize_matrix_bang_command(text: str) -> str:
@@ -151,10 +171,10 @@ def _normalize_matrix_bang_command(text: str) -> str:
     match = _MATRIX_BANG_COMMAND_RE.match(text)
     if not match:
         return text
-    command = match.group(1).lower()
-    if not _is_known_matrix_bang_command(command):
+    resolved = _resolve_matrix_bang_command(match.group(1))
+    if resolved is None:
         return text
-    return f"/{command}{match.group(2) or ''}"
+    return f"/{resolved}{match.group(2) or ''}"
 
 
 @dataclass
@@ -1900,6 +1920,11 @@ class MatrixAdapter(BasePlatformAdapter):
                     past_fallback = True
                 stripped.append(line)
             body = "\n".join(stripped) if stripped else body
+
+        # Re-run bang normalization after reply-fallback stripping so a quoted
+        # reply whose actual content is a bang command (e.g. ``> quoted\n\n!model``)
+        # is treated as a command, matching how ``/command`` is recognized below.
+        body = _normalize_matrix_bang_command(body)
 
         msg_type = MessageType.TEXT
         if body.startswith("/"):

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -107,6 +107,55 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+_MATRIX_BANG_COMMAND_RE = re.compile(
+    r"^!([A-Za-z][A-Za-z0-9_-]*)(?=$|\s)(.*)$",
+    re.DOTALL,
+)
+
+
+def _is_known_matrix_bang_command(name: str) -> bool:
+    """Return True when *name* is a Hermes command worth normalizing.
+
+    Matrix clients often reserve leading ``/`` for local client commands.
+    Hermes accepts ``!command`` as a Matrix-friendly alias, but only for
+    commands that the gateway can actually dispatch so ordinary exclamations
+    remain normal chat text.
+    """
+    if not name:
+        return False
+    candidates = {name.lower(), name.lower().replace("_", "-")}
+    try:
+        from hermes_cli.commands import is_gateway_known_command
+
+        if any(is_gateway_known_command(candidate) for candidate in candidates):
+            return True
+    except Exception:
+        pass
+
+    try:
+        from agent.skill_commands import get_skill_commands
+
+        skill_commands = get_skill_commands() or {}
+        if any(candidate in skill_commands for candidate in candidates):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _normalize_matrix_bang_command(text: str) -> str:
+    """Convert Matrix ``!command`` aliases to normal Hermes ``/command`` text."""
+    if not text or not text.startswith("!"):
+        return text
+    match = _MATRIX_BANG_COMMAND_RE.match(text)
+    if not match:
+        return text
+    command = match.group(1).lower()
+    if not _is_known_matrix_bang_command(command):
+        return text
+    return f"/{command}{match.group(2) or ''}"
+
 
 @dataclass
 class _MatrixApprovalPrompt:
@@ -1747,8 +1796,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
             is_free_room = room_id in self._free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._threads)
+            is_command = body.startswith("/")
             if self._require_mention and not is_free_room and not in_bot_thread:
-                if not is_mentioned:
+                if not is_mentioned and not is_command:
                     logger.debug(
                         "Matrix: ignoring message %s in %s — no @mention "
                         "(set MATRIX_REQUIRE_MENTION=false to disable)",
@@ -1815,6 +1865,7 @@ class MatrixAdapter(BasePlatformAdapter):
         body = source_content.get("body", "") or ""
         if not body:
             return
+        body = _normalize_matrix_bang_command(body)
 
         ctx = await self._resolve_message_context(
             room_id,
@@ -1851,7 +1902,7 @@ class MatrixAdapter(BasePlatformAdapter):
             body = "\n".join(stripped) if stripped else body
 
         msg_type = MessageType.TEXT
-        if body.startswith(("!", "/")):
+        if body.startswith("/"):
             msg_type = MessageType.COMMAND
 
         msg_event = MessageEvent(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "liliangjya@gmail.com": "truenorth-lj",
+    "16943149+nepenth@users.noreply.github.com": "nepenth",
     "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
     "subw3@mail2.sysu.edu.cn": "Subway2023",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -567,6 +567,30 @@ class TestMatrixBangCommandAlias:
         )
         return captured_event
 
+    async def _dispatch_text_reply(self, body: str, *, is_dm: bool = True):
+        """Dispatch a message that is a Matrix reply (m.in_reply_to set), so
+        the reply-fallback quote stripping path runs before command detection.
+        """
+        captured_event = None
+        self.adapter._is_dm_room = AsyncMock(return_value=is_dm)
+        self.adapter._require_mention = True
+        self.adapter._free_rooms = set()
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        await self.adapter._handle_text_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$matrix-reply-command-test",
+            event_ts=0.0,
+            source_content={"msgtype": "m.text", "body": body},
+            relates_to={"m.in_reply_to": {"event_id": "$parent-event"}},
+        )
+        return captured_event
+
     def test_known_bang_command_normalizes_to_slash_command(self):
         from gateway.platforms.matrix import _normalize_matrix_bang_command
 
@@ -638,6 +662,68 @@ class TestMatrixBangCommandAlias:
         captured_event = await self._dispatch_text("!important note", is_dm=False)
 
         assert captured_event is None
+
+    def test_bang_alias_underscore_resolves_to_hyphen_form(self):
+        """!set_home must emit a dispatchable token even though set_home is
+        not itself registered — the hyphenated alias set-home is."""
+        from gateway.platforms.matrix import _normalize_matrix_bang_command
+
+        # set_home (underscore) is NOT a registered command/alias, but
+        # set-home (hyphen) is. The normalizer must emit the resolvable form.
+        assert _normalize_matrix_bang_command("!set_home") == "/set-home"
+        # The hyphen alias passes through unchanged.
+        assert _normalize_matrix_bang_command("!set-home") == "/set-home"
+        # The canonical command resolves directly.
+        assert _normalize_matrix_bang_command("!sethome") == "/sethome"
+
+    def test_bang_skill_command_normalizes(self):
+        """The get_skill_commands() branch normalizes installed skill
+        commands, not just built-in gateway commands. Skill keys are stored
+        slash-prefixed (e.g. "/arxiv"), which the resolver must account for."""
+        import agent.skill_commands as skill_commands_mod
+
+        fake_skills = {"/arxiv": {}, "/obsidian": {}}
+        with patch.object(
+            skill_commands_mod, "get_skill_commands", return_value=fake_skills
+        ):
+            from gateway.platforms.matrix import _normalize_matrix_bang_command
+
+            # is_gateway_known_command won't know these; the skill branch must.
+            assert _normalize_matrix_bang_command("!arxiv") == "/arxiv"
+            assert (
+                _normalize_matrix_bang_command("!obsidian search foo")
+                == "/obsidian search foo"
+            )
+            # A name in neither registry stays plain text.
+            assert (
+                _normalize_matrix_bang_command("!definitelynotacommand")
+                == "!definitelynotacommand"
+            )
+
+    @pytest.mark.asyncio
+    async def test_bang_command_in_quoted_reply_normalizes(self):
+        """A bang command that follows a Matrix reply-fallback quote is
+        normalized after the quote is stripped, matching /command behavior."""
+        captured_event = await self._dispatch_text_reply(
+            "> <@bob:example.org> earlier message\n\n!model"
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == "/model"
+        assert captured_event.message_type == MessageType.COMMAND
+        assert captured_event.get_command() == "model"
+
+    @pytest.mark.asyncio
+    async def test_slash_command_in_quoted_reply_normalizes(self):
+        """Sanity: the slash equivalent already works post-strip — the bang
+        form above must reach parity with this."""
+        captured_event = await self._dispatch_text_reply(
+            "> <@bob:example.org> earlier message\n\n/model"
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == "/model"
+        assert captured_event.message_type == MessageType.COMMAND
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -533,6 +533,114 @@ class TestMatrixReplyFallbackStripping:
 
 
 # ---------------------------------------------------------------------------
+# Matrix-friendly command aliases
+# ---------------------------------------------------------------------------
+
+class TestMatrixBangCommandAlias:
+    """Matrix clients may reserve /commands, so Hermes supports !commands."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter._background_read_receipt = MagicMock()
+        self.adapter._text_batch_delay_seconds = 0
+
+    async def _dispatch_text(self, body: str, *, is_dm: bool = True):
+        captured_event = None
+        self.adapter._is_dm_room = AsyncMock(return_value=is_dm)
+        self.adapter._require_mention = True
+        self.adapter._free_rooms = set()
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter.handle_message = capture
+        await self.adapter._handle_text_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$matrix-command-test",
+            event_ts=0.0,
+            source_content={"msgtype": "m.text", "body": body},
+            relates_to={},
+        )
+        return captured_event
+
+    def test_known_bang_command_normalizes_to_slash_command(self):
+        from gateway.platforms.matrix import _normalize_matrix_bang_command
+
+        assert _normalize_matrix_bang_command("!model") == "/model"
+        assert (
+            _normalize_matrix_bang_command("!queue continue the plan")
+            == "/queue continue the plan"
+        )
+        assert (
+            _normalize_matrix_bang_command("!btw research this")
+            == "/btw research this"
+        )
+        assert _normalize_matrix_bang_command("!tasks") == "/tasks"
+
+    def test_unknown_bang_text_is_not_treated_as_command(self):
+        from gateway.platforms.matrix import _normalize_matrix_bang_command
+
+        assert _normalize_matrix_bang_command("!important note") == "!important note"
+        assert _normalize_matrix_bang_command("! wow") == "! wow"
+        assert _normalize_matrix_bang_command("plain text") == "plain text"
+        assert _normalize_matrix_bang_command("/model") == "/model"
+
+    @pytest.mark.asyncio
+    async def test_bang_model_reaches_gateway_as_slash_command(self):
+        captured_event = await self._dispatch_text("!model")
+
+        assert captured_event is not None
+        assert captured_event.text == "/model"
+        assert captured_event.message_type == MessageType.COMMAND
+        assert captured_event.get_command() == "model"
+
+    @pytest.mark.asyncio
+    async def test_bang_queue_preserves_arguments(self):
+        captured_event = await self._dispatch_text("!queue keep going")
+
+        assert captured_event is not None
+        assert captured_event.text == "/queue keep going"
+        assert captured_event.message_type == MessageType.COMMAND
+        assert captured_event.get_command() == "queue"
+        assert captured_event.get_command_args() == "keep going"
+
+    @pytest.mark.asyncio
+    async def test_unknown_bang_text_stays_normal_text(self):
+        captured_event = await self._dispatch_text("!important note")
+
+        assert captured_event is not None
+        assert captured_event.text == "!important note"
+        assert captured_event.message_type == MessageType.TEXT
+        assert captured_event.get_command() is None
+
+    @pytest.mark.asyncio
+    async def test_bang_command_bypasses_room_mention_requirement(self):
+        captured_event = await self._dispatch_text("!commands", is_dm=False)
+
+        assert captured_event is not None
+        assert captured_event.text == "/commands"
+        assert captured_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_slash_command_bypasses_room_mention_requirement(self):
+        captured_event = await self._dispatch_text("/sethome", is_dm=False)
+
+        assert captured_event is not None
+        assert captured_event.text == "/sethome"
+        assert captured_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_unknown_bang_text_does_not_bypass_room_mention_requirement(self):
+        captured_event = await self._dispatch_text("!important note", is_dm=False)
+
+        assert captured_event is None
+
+
+# ---------------------------------------------------------------------------
 # Thread detection
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -20,6 +20,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Rooms** | By default, Hermes requires an `@mention` to respond. Set `MATRIX_REQUIRE_MENTION=false` or add room IDs to `MATRIX_FREE_RESPONSE_ROOMS` for free-response rooms. Room invites are auto-accepted. |
 | **Threads** | Hermes supports Matrix threads (MSC3440). If you reply in a thread, Hermes keeps the thread context isolated from the main room timeline. Threads where the bot has already participated do not require a mention. |
 | **Auto-threading** | By default, Hermes auto-creates a thread for each message it responds to in a room. This keeps conversations isolated. Set `MATRIX_AUTO_THREAD=false` to disable. |
+| **Commands** | Hermes accepts normal `/commands` when your Matrix client sends them. If your client reserves `/` for local commands, use `!commands` instead; Hermes normalizes known `!command` aliases to `/command`. |
 | **Shared rooms with multiple users** | By default, Hermes isolates session history per user inside the room. Two people talking in the same room do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -336,6 +337,7 @@ You can designate a "home room" where the bot sends proactive messages (such as 
 ### Using the Slash Command
 
 Type `/sethome` in any Matrix room where the bot is present. That room becomes the home room.
+If your Matrix client intercepts slash commands, type `!sethome` instead.
 
 ### Manual Configuration
 
@@ -376,6 +378,29 @@ See also: [admin/user slash command split](../../reference/slash-commands.md#per
 :::tip
 To find a Room ID: in Element, go to the room → **Settings** → **Advanced** → the **Internal room ID** is shown there (starts with `!`).
 :::
+
+## Commands in Matrix
+
+Hermes supports the same gateway commands in Matrix that it supports on other
+messaging platforms, including `/commands`, `/model`, `/stop`, `/queue`,
+`/steer`, `/goal`, `/subgoal`, `/background`, `/bg`, `/btw`, `/tasks`, and
+`/yolo`.
+
+Some Matrix clients reserve leading `/` for local client commands and may not
+send unknown slash commands to the room. In that case, use `!` as a Matrix-safe
+alias:
+
+```text
+!commands
+!model
+!model gpt-5.5 --provider openrouter
+!queue continue with the next task
+!stop
+```
+
+Hermes only normalizes `!command` when the command is known to the gateway, a
+registered plugin command, or an installed skill command. Ordinary exclamations
+such as `!important` remain normal chat messages.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Matrix users can now type `!command` aliases (e.g. `!model`, `!stop`, `!queue ...`) for gateway slash commands, since many Matrix clients (Element etc.) reserve leading `/` for local client commands. Salvages #28025 by @nepenth onto current `main`, plus follow-up hardening.

## Changes
- **gateway/platforms/matrix.py**: normalize known `!command` → `/command` before dispatch; only known gateway/plugin/skill commands normalize, so `!important` stays chat text. Slash/bang commands bypass room mention-gating.
- **Follow-up fixes (commit 2):**
  - Underscore→hyphen tolerance now emits a *resolvable* token: `!set_home` → `/set-home` (was `/set_home`, which the dispatcher couldn't resolve). Aliases left as-is; the gateway canonicalizes them.
  - Fixed a dead code path: skill-command keys are stored slash-prefixed (`/arxiv`) in `get_skill_commands()`, but the check compared the bare token, so `!arxiv` never normalized. Now `!gif-search` etc. work.
  - Re-run normalization after Matrix reply-fallback stripping so a quoted-reply bang command reaches parity with the slash form.
  - Replaced silent `except: pass` with `logger.debug(exc_info=True)`.
- **website/docs/user-guide/messaging/matrix.md**: documents `!command` usage.

## Validation
| | Result |
|---|---|
| Matrix tests | 162 passed (155 original + 7 new) |
| New tests | underscore-alias, skill-command branch, quoted-reply bang + slash parity |
| py_compile / `git diff --check` | clean |
| E2E (real imports) | normalization + skill-branch verified |

## Credit
Original work by @nepenth (#28025), cherry-picked with authorship preserved. Duplicate #28710 (@NlDev-hub) targeted the same feature a day later.
