### PR TITLE
fix(slack): pass thread_ts in standalone send_message tool path

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -595,6 +595,7 @@ class TestSendToPlatformChunking:
             "***",
             "C123",
             "*hello* from <https://example.com|Hermes>",
+            thread_ts=None,
         )
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -767,7 +767,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_ts=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1049,7 +1049,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_ts=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1063,6 +1063,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_ts:
+                payload["thread_ts"] = thread_ts
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary

- The standalone `_send_slack()` function used by the `send_message` tool and cron delivery fallback was not passing `thread_ts` to the Slack API, causing messages to post to the top-level channel instead of inside threads.
- Adds `thread_ts` parameter to `_send_slack()` and forwards `thread_id` from `_send_to_platform()`.

## Problem

When the agent uses the `send_message` tool to send to Slack (or cron jobs deliver output via the standalone fallback path), messages always posted to the open channel — never inside a thread — because `_send_slack()` never included `thread_ts` in the `chat.postMessage` payload.

The live adapter path (`SlackAdapter.send()`) handled threading correctly via metadata, but the standalone HTTP path (`_send_slack()`) did not.

## Changes

- `tools/send_message_tool.py`:
  - `_send_slack()`: Accept `thread_ts` param, include in Slack API payload when present
  - `_send_to_platform()`: Pass `thread_id` as `thread_ts` to `_send_slack()`
- `tests/tools/test_send_message_tool.py`: Update assertion to expect new kwarg

## Test plan

- [x] `pytest tests/tools/test_send_message_tool.py -k slack` — 121 passed
- [x] `pytest tests/ -k slack` — 375 passed
- [ ] Manual: use `send_message` tool targeting `slack:CHANNEL:THREAD_TS` and verify message lands in thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)