### PR TITLE
feat(auth): share Codex CLI auth across gateway profiles

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1349,7 +1349,7 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
 
 
 def _read_codex_access_token() -> Optional[str]:
-    """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
+    """Read a valid, non-expired Codex OAuth access token.
 
     If a credential pool exists but currently has no selectable runtime entry
     (for example all pool slots are marked exhausted), fall back to the
@@ -1357,6 +1357,15 @@ def _read_codex_access_token() -> Optional[str]:
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
     """
+    try:
+        from hermes_cli.auth import resolve_codex_runtime_credentials
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        token = str(creds.get("api_key") or "").strip()
+        if token:
+            return token
+    except Exception as exc:
+        logger.debug("Could not resolve Codex runtime auth for auxiliary client: %s", exc)
+
     pool_present, entry = _select_pool_entry("openai-codex")
     if pool_present:
         token = _pool_runtime_api_key(entry)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3570,6 +3570,132 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+def _codex_cli_shared_auth_enabled() -> bool:
+    raw = os.getenv("HERMES_CODEX_SHARED_AUTH", "").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _codex_cli_auth_path() -> Path:
+    codex_home = os.getenv("CODEX_HOME", "").strip()
+    if not codex_home:
+        codex_home = str(Path.home() / ".codex")
+    return Path(codex_home).expanduser() / "auth.json"
+
+
+@contextmanager
+def _codex_cli_auth_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    auth_path = _codex_cli_auth_path()
+    lock_path = auth_path.with_suffix(auth_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+")
+    start = time.monotonic()
+    try:
+        if fcntl is not None:
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() - start > timeout_seconds:
+                        raise TimeoutError(f"Timed out waiting for Codex CLI auth lock: {lock_path}")
+                    time.sleep(0.05)
+        yield
+    finally:
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+def _read_codex_cli_auth_payload() -> Dict[str, Any]:
+    auth_path = _codex_cli_auth_path()
+    if not auth_path.is_file():
+        raise AuthError(
+            f"Codex CLI auth is missing at {auth_path}. Run `codex login` as this user.",
+            provider="openai-codex",
+            code="codex_cli_auth_missing",
+            relogin_required=True,
+        )
+    try:
+        payload = json.loads(auth_path.read_text())
+    except Exception as exc:
+        raise AuthError(
+            f"Codex CLI auth at {auth_path} is not readable JSON.",
+            provider="openai-codex",
+            code="codex_cli_auth_invalid_json",
+            relogin_required=True,
+        ) from exc
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        raise AuthError(
+            f"Codex CLI auth at {auth_path} is missing tokens. Run `codex login`.",
+            provider="openai-codex",
+            code="codex_cli_auth_missing_tokens",
+            relogin_required=True,
+        )
+    if not tokens.get("access_token") or not tokens.get("refresh_token"):
+        raise AuthError(
+            f"Codex CLI auth at {auth_path} is incomplete. Run `codex login`.",
+            provider="openai-codex",
+            code="codex_cli_auth_incomplete",
+            relogin_required=True,
+        )
+    return payload
+
+
+def _write_codex_cli_auth_payload(payload: Dict[str, Any]) -> None:
+    auth_path = _codex_cli_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = auth_path.with_name(f".{auth_path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}")
+    tmp_path.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        os.chmod(tmp_path, 0o600)
+    except OSError:
+        pass
+    atomic_replace(tmp_path, auth_path)
+
+
+def _resolve_codex_cli_shared_tokens(
+    *,
+    force_refresh: bool,
+    refresh_if_expiring: bool,
+    refresh_skew_seconds: int,
+    refresh_timeout_seconds: float,
+) -> Dict[str, Any]:
+    with _codex_cli_auth_lock(
+        timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0),
+    ):
+        payload = _read_codex_cli_auth_payload()
+        tokens = dict(payload["tokens"])
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        should_refresh = bool(force_refresh)
+        if (not should_refresh) and refresh_if_expiring:
+            should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+        if should_refresh:
+            refreshed = refresh_codex_oauth_pure(
+                access_token,
+                str(tokens.get("refresh_token", "") or ""),
+                timeout_seconds=refresh_timeout_seconds,
+            )
+            tokens.update({
+                "access_token": refreshed["access_token"],
+                "refresh_token": refreshed["refresh_token"],
+            })
+            payload["tokens"] = tokens
+            payload["last_refresh"] = refreshed.get("last_refresh") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            if not payload.get("auth_mode"):
+                payload["auth_mode"] = "chatgpt"
+            _write_codex_cli_auth_payload(payload)
+            access_token = str(tokens.get("access_token", "") or "").strip()
+        return {
+            "tokens": tokens,
+            "last_refresh": payload.get("last_refresh"),
+            "auth_path": str(_codex_cli_auth_path()),
+            "access_token": access_token,
+        }
+
+
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -3587,6 +3713,43 @@ def resolve_codex_runtime_credentials(
     HTTP 401 ``Missing Authentication header`` from the wire instead of a usable
     credential. See issue #32992.
     """
+    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    base_url = (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
+
+    if _codex_cli_shared_auth_enabled():
+        try:
+            shared = _resolve_codex_cli_shared_tokens(
+                force_refresh=force_refresh,
+                refresh_if_expiring=refresh_if_expiring,
+                refresh_skew_seconds=refresh_skew_seconds,
+                refresh_timeout_seconds=refresh_timeout_seconds,
+            )
+            return {
+                "provider": "openai-codex",
+                "base_url": base_url,
+                "api_key": shared["access_token"],
+                "source": "codex-cli-shared",
+                "last_refresh": shared.get("last_refresh"),
+                "auth_mode": "codex_cli_shared",
+                "auth_path": shared.get("auth_path"),
+            }
+        except AuthError as exc:
+            # If the shared Codex CLI auth file exists but is invalid, fail
+            # closed with the direct `codex login` remediation.  If it is
+            # simply absent, fall back to upstream Hermes auth for compatibility.
+            if exc.code != "codex_cli_auth_missing":
+                raise
+        except Exception as exc:
+            raise AuthError(
+                f"Codex CLI shared auth failed: {exc}",
+                provider="openai-codex",
+                code="codex_cli_shared_auth_failed",
+                relogin_required=True,
+            ) from exc
+
     try:
         data = _read_codex_tokens()
     except AuthError:
@@ -3608,8 +3771,6 @@ def resolve_codex_runtime_credentials(
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
-
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
@@ -3627,11 +3788,6 @@ def resolve_codex_runtime_credentials(
             if should_refresh:
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
                 access_token = str(tokens.get("access_token", "") or "").strip()
-
-    base_url = (
-        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-        or DEFAULT_CODEX_BASE_URL
-    )
 
     return {
         "provider": "openai-codex",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1470,14 +1470,34 @@ class SystemScopeRequiresRootError(RuntimeError):
 
 def _user_dbus_socket_path() -> Path:
     """Return the expected per-user D-Bus socket path (regardless of existence)."""
-    xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    xdg = _current_user_runtime_dir()
     return Path(xdg) / "bus"
 
 
 def _user_systemd_private_socket_path() -> Path:
     """Return the per-user systemd private socket path (regardless of existence)."""
-    xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    xdg = _current_user_runtime_dir()
     return Path(xdg) / "systemd" / "private"
+
+
+def _current_user_runtime_dir() -> str:
+    """Return a usable runtime dir for the current uid.
+
+    SSH/tmux/container launches can inherit XDG_RUNTIME_DIR from another user.
+    Trusting that value makes pathlib.exists() raise PermissionError before
+    Hermes can show the normal systemd remediation. Prefer /run/user/$UID when
+    the inherited directory is missing, inaccessible, or owned by another uid.
+    """
+    uid = os.getuid()  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    fallback = f"/run/user/{uid}"
+    xdg = os.environ.get("XDG_RUNTIME_DIR") or fallback
+    try:
+        st = Path(xdg).stat()
+        if st.st_uid == uid:
+            return xdg
+    except OSError:
+        pass
+    return fallback
 
 
 def _user_systemd_socket_ready() -> bool:
@@ -1502,17 +1522,17 @@ def _ensure_user_systemd_env() -> None:
     We detect the standard socket path and set the vars so all subsequent
     subprocess calls inherit them.
     """
-    uid = os.getuid()  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
-    if "XDG_RUNTIME_DIR" not in os.environ:
-        runtime_dir = f"/run/user/{uid}"
-        if Path(runtime_dir).exists():
-            os.environ["XDG_RUNTIME_DIR"] = runtime_dir
+    runtime_dir = _current_user_runtime_dir()
+    if Path(runtime_dir).exists():
+        os.environ["XDG_RUNTIME_DIR"] = runtime_dir
 
-    if "DBUS_SESSION_BUS_ADDRESS" not in os.environ:
-        xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")
-        bus_path = Path(xdg_runtime) / "bus"
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", runtime_dir)
+    bus_path = Path(xdg_runtime) / "bus"
+    try:
         if bus_path.exists():
             os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
+    except OSError:
+        os.environ.pop("DBUS_SESSION_BUS_ADDRESS", None)
 
 
 def _wait_for_user_dbus_socket(timeout: float = 3.0) -> bool:
@@ -2022,9 +2042,6 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
     if not is_linux():
         return None, "not supported on this platform"
 
-    if not shutil.which("loginctl"):
-        return None, "loginctl not found"
-
     username = os.getenv("USER") or os.getenv("LOGNAME")
     if not username:
         try:
@@ -2033,6 +2050,16 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
             username = pwd.getpwuid(os.getuid()).pw_name  # windows-footgun: ok — POSIX loginctl helper, never invoked on Windows
         except Exception:
             return None, "could not determine current user"
+
+    linger_file = Path(f"/var/lib/systemd/linger/{username}")
+    try:
+        if linger_file.exists():
+            return True, ""
+    except OSError:
+        pass
+
+    if not shutil.which("loginctl"):
+        return None, "loginctl not found"
 
     try:
         result = subprocess.run(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1283,6 +1283,8 @@ def resolve_runtime_provider(
         return explicit_runtime
 
     should_use_pool = provider != "openrouter"
+    if provider == "openai-codex" and auth_mod._codex_cli_shared_auth_enabled():
+        should_use_pool = False
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()

--- a/run_agent.py
+++ b/run_agent.py
@@ -3082,6 +3082,7 @@ class AIAgent:
     def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
         from unittest.mock import Mock
 
+        self._sync_shared_codex_cli_credentials()
         primary_client = self._ensure_primary_openai_client(reason=reason)
         if isinstance(primary_client, Mock):
             return primary_client
@@ -3104,6 +3105,64 @@ class AIAgent:
         ):
             request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
         return self._create_openai_client(request_kwargs, reason=reason, shared=False)
+
+    def _sync_shared_codex_cli_credentials(self) -> bool:
+        """Adopt the current ``codex login`` token before a Codex request.
+
+        Long-lived gateway agents keep ``api_key`` and ``_client_kwargs`` in
+        memory.  Shared Codex auth intentionally points every Hermes profile at
+        ``~/.codex/auth.json``, so a fresh ``codex login`` should become visible
+        on the next request without restarting the gateway.
+        """
+        if self.api_mode != "codex_responses" or self.provider != "openai-codex":
+            return False
+
+        try:
+            from hermes_cli.auth import (
+                _codex_cli_shared_auth_enabled,
+                resolve_codex_runtime_credentials,
+            )
+
+            if not _codex_cli_shared_auth_enabled():
+                return False
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        except Exception as exc:
+            logger.debug("Shared Codex CLI credential sync skipped: %s", exc)
+            return False
+
+        if creds.get("source") != "codex-cli-shared":
+            return False
+        api_key = creds.get("api_key")
+        base_url = creds.get("base_url")
+        if not isinstance(api_key, str) or not api_key.strip():
+            return False
+        if not isinstance(base_url, str) or not base_url.strip():
+            return False
+
+        api_key = api_key.strip()
+        base_url = base_url.strip().rstrip("/")
+        with self._openai_client_lock():
+            changed = (
+                self.api_key != api_key
+                or self.base_url != base_url
+                or (self._client_kwargs or {}).get("api_key") != api_key
+                or (self._client_kwargs or {}).get("base_url") != base_url
+            )
+            if not changed:
+                return False
+            self.api_key = api_key
+            self.base_url = base_url
+            if not isinstance(getattr(self, "_client_kwargs", None), dict):
+                self._client_kwargs = {}
+            self._client_kwargs["api_key"] = api_key
+            self._client_kwargs["base_url"] = base_url
+            if getattr(self, "client", None) is not None and hasattr(self.client, "api_key"):
+                self.client.api_key = api_key
+            logger.info(
+                "Adopted refreshed shared Codex CLI credentials from %s",
+                creds.get("auth_path") or "~/.codex/auth.json",
+            )
+        return True
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -22,6 +22,11 @@ from hermes_cli.auth import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _disable_shared_codex_auth_by_default(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_SHARED_AUTH", "0")
+
+
 def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
     """Write Codex tokens into the Hermes auth store."""
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -120,6 +125,63 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     assert called["count"] == 1
     assert resolved["api_key"] == "access-forced"
+
+
+def test_resolve_codex_runtime_credentials_uses_shared_codex_cli_auth(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    access_token = _jwt_with_exp(int(time.time()) + 3600)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": "shared-refresh",
+        },
+        "last_refresh": "2026-06-03T00:00:00Z",
+    }))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("HERMES_CODEX_SHARED_AUTH", "1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == access_token
+    assert resolved["source"] == "codex-cli-shared"
+    assert resolved["auth_mode"] == "codex_cli_shared"
+    assert resolved["auth_path"] == str(codex_home / "auth.json")
+
+
+def test_resolve_codex_runtime_credentials_refreshes_shared_codex_cli_auth(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(json.dumps({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": _jwt_with_exp(int(time.time()) - 60),
+            "refresh_token": "shared-refresh-old",
+        },
+    }))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("HERMES_CODEX_SHARED_AUTH", "1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        assert refresh_token == "shared-refresh-old"
+        return {
+            "access_token": "shared-access-new",
+            "refresh_token": "shared-refresh-new",
+            "last_refresh": "2026-06-03T01:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _fake_refresh)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "shared-access-new"
+    payload = json.loads((codex_home / "auth.json").read_text())
+    assert payload["tokens"]["access_token"] == "shared-access-new"
+    assert payload["tokens"]["refresh_token"] == "shared-refresh-new"
+    assert payload["last_refresh"] == "2026-06-03T01:00:00Z"
 
 
 def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_empty(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1390,14 +1390,40 @@ class TestEnsureUserSystemdEnv:
 
         assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_socket}"
 
-    def test_preserves_existing_env_vars(self, monkeypatch):
-        monkeypatch.setenv("XDG_RUNTIME_DIR", "/custom/runtime")
+    def test_preserves_existing_env_vars(self, tmp_path, monkeypatch):
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
         monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/custom/bus")
 
         gateway_cli._ensure_user_systemd_env()
 
-        assert os.environ["XDG_RUNTIME_DIR"] == "/custom/runtime"
+        assert os.environ["XDG_RUNTIME_DIR"] == str(runtime)
         assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/custom/bus"
+
+    def test_replaces_inherited_runtime_dir_for_different_uid(self, monkeypatch):
+        monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setattr(os, "getuid", lambda: 1002)
+
+        def fake_stat(self):
+            if str(self) == "/run/user/1000":
+                return SimpleNamespace(st_uid=1000)
+            if str(self) == "/run/user/1002":
+                return SimpleNamespace(st_uid=1002)
+            raise FileNotFoundError(str(self))
+
+        def fake_exists(self):
+            return str(self) in {"/run/user/1002", "/run/user/1002/bus"}
+
+        monkeypatch.setattr(gateway_cli.Path, "stat", fake_stat)
+        monkeypatch.setattr(gateway_cli.Path, "exists", fake_exists)
+
+        gateway_cli._ensure_user_systemd_env()
+
+        assert os.environ["XDG_RUNTIME_DIR"] == "/run/user/1002"
+        assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1002/bus"
 
     def test_no_dbus_when_bus_socket_missing(self, tmp_path, monkeypatch):
         runtime = tmp_path / "runtime"
@@ -1427,6 +1453,19 @@ class TestEnsureUserSystemdEnv:
         result = gateway_cli._systemctl_cmd(system=True)
         assert result == ["systemctl"]
         assert calls == []
+
+
+class TestSystemdLingerStatus:
+    def test_uses_linger_marker_before_loginctl(self, monkeypatch):
+        monkeypatch.setenv("USER", "jasper")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: None)
+
+        def fake_exists(self):
+            return str(self) == "/var/lib/systemd/linger/jasper"
+
+        monkeypatch.setattr(gateway_cli.Path, "exists", fake_exists)
+
+        assert gateway_cli.get_systemd_linger_status() == (True, "")
 
 
 class TestPreflightUserSystemd:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1028,6 +1028,49 @@ def test_try_refresh_codex_client_credentials_rebuilds_client(monkeypatch):
     assert isinstance(agent.client, _RebuiltClient)
 
 
+def test_create_request_openai_client_adopts_shared_codex_cli_login(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    captured = {"kwargs": None}
+
+    class _RequestClient:
+        pass
+
+    def _fake_openai(**kwargs):
+        captured["kwargs"] = kwargs
+        return _RequestClient()
+
+    def _fake_resolve(refresh_if_expiring=True, **_):
+        return {
+            "provider": "openai-codex",
+            "source": "codex-cli-shared",
+            "auth_mode": "codex_cli_shared",
+            "api_key": "fresh-codex-cli-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "auth_path": "/home/jasper/.codex/auth.json",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_cli_shared_auth_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        _fake_resolve,
+    )
+    monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
+
+    request_client = agent._create_request_openai_client(
+        reason="test_shared_codex_cli_login",
+        api_kwargs=_codex_request_kwargs(),
+    )
+
+    assert isinstance(request_client, _RequestClient)
+    assert agent.api_key == "fresh-codex-cli-token"
+    assert agent._client_kwargs["api_key"] == "fresh-codex-cli-token"
+    assert captured["kwargs"]["api_key"] == "fresh-codex-cli-token"
+    assert captured["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
 def test_try_refresh_copilot_client_credentials_rebuilds_client(monkeypatch):
     agent = _build_copilot_agent(monkeypatch)
     closed = {"value": False}


### PR DESCRIPTION
## What does this PR do?

Makes `openai-codex` use the user-level Codex CLI login as the shared default auth source for multi-profile Hermes gateway deployments.

When shared auth is enabled, Hermes resolves Codex credentials from `~/.codex/auth.json` / `CODEX_HOME`, refreshes expiring OAuth tokens under a file lock, and lets long-lived Codex agents adopt a freshly updated `codex login` token on the next request without requiring a gateway restart.

Authored by @nathan-deepmm.

## Related Issue

Fixes #38176

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: resolve `openai-codex` from shared Codex CLI auth by default, refresh expiring tokens with a lock, and keep `HERMES_CODEX_SHARED_AUTH=0` as an opt-out.
- `hermes_cli/runtime_provider.py`: prefer shared Codex CLI auth over stale per-profile Codex credential pools.
- `agent/auxiliary_client.py`: make auxiliary Codex token reads use the shared runtime credential resolver.
- `run_agent.py`: hot-reload shared Codex CLI credentials before Codex request-client creation.
- `hermes_cli/gateway.py`: harden user systemd runtime detection for gateway service management.
- Tests cover shared Codex resolution, refresh behavior, runtime provider selection, gateway service runtime detection, and live agent credential hot-reload.

## How to Test

1. Run `pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_runtime_provider_resolution.py -k "codex or Codex" -q`.
2. Run `pytest tests/run_agent/test_run_agent_codex_responses.py -q`.
3. Run `pytest tests/hermes_cli/test_gateway_service.py -k "EnsureUserSystemdEnv or SystemdLingerStatus or ServiceWorkingDirIsStable" -q`.
4. In a multi-profile gateway setup, run `codex login` once in the user home directory and verify each `openai-codex` profile reports logged in / can make Codex requests.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu/Linux user systemd gateway deployment

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact per the compatibility guide — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests run locally:

```text
pytest tests/run_agent/test_run_agent_codex_responses.py -q
72 passed

pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_runtime_provider_resolution.py -k "codex or Codex" -q
30 passed

pytest tests/hermes_cli/test_gateway_service.py -k "EnsureUserSystemdEnv or SystemdLingerStatus or ServiceWorkingDirIsStable" -q
12 passed
```