### PR TITLE
fix(desktop): recover dirty Windows install checkout

### DIFF
--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -37,7 +37,18 @@ const { execFileSync } = require('node:child_process')
 const PROBE_TIMEOUT_MS = 5000
 
 /**
- * Return true iff `python -c "import hermes_cli"` exits 0.
+ * Return the Python snippet used to verify Hermes can import far enough to
+ * launch the CLI. Kept exported for tests so dependency regressions are
+ * caught without needing a real broken venv fixture.
+ *
+ * @returns {string}
+ */
+function hermesRuntimeImportProbe() {
+  return 'import yaml; import hermes_cli.config'
+}
+
+/**
+ * Return true iff the Hermes runtime import probe exits 0.
  *
  * Used to gate the "fallback to system Python with hermes_cli installed"
  * rung of resolveHermesBackend. Without this, a system Python 3.11-3.13
@@ -46,13 +57,20 @@ const PROBE_TIMEOUT_MS = 5000
  * site-packages -- and the resolver returns a backend that immediately
  * dies on spawn.
  *
+ * The probe intentionally imports hermes_cli.config, not just the top-level
+ * package: a broken/empty Windows launcher venv can still see the source tree
+ * through PYTHONPATH but lack PyYAML, then die on the first real CLI import.
+ *
  * @param {string} pythonPath - Absolute path to a python.exe / python.
+ * @param {object} [opts]
+ * @param {object} [opts.env] - Additional environment for the probe.
  * @returns {boolean}
  */
-function canImportHermesCli(pythonPath) {
+function canImportHermesCli(pythonPath, opts = {}) {
   if (!pythonPath) return false
   try {
-    execFileSync(pythonPath, ['-c', 'import hermes_cli'], {
+    execFileSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
+      env: { ...process.env, ...(opts.env || {}) },
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
       windowsHide: true
@@ -101,6 +119,7 @@ function verifyHermesCli(hermesCommand, opts = {}) {
 
 module.exports = {
   canImportHermesCli,
+  hermesRuntimeImportProbe,
   verifyHermesCli,
   PROBE_TIMEOUT_MS
 }

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -11,7 +11,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { canImportHermesCli, hermesRuntimeImportProbe, verifyHermesCli } = require('./backend-probes.cjs')
 
 // Resolve the host's own Node binary -- guaranteed to be on disk and
 // runnable. We use it as both a stand-in for "a python that doesn't
@@ -38,6 +38,12 @@ test('canImportHermesCli returns false when interpreter cannot run -c', () => {
 test('canImportHermesCli returns false when binary does not exist', () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
   assert.equal(canImportHermesCli(ghost), false)
+})
+
+test('hermes runtime import probe checks config dependencies', () => {
+  const probe = hermesRuntimeImportProbe()
+  assert.match(probe, /\bimport yaml\b/)
+  assert.match(probe, /\bimport hermes_cli\.config\b/)
 })
 
 test('verifyHermesCli returns false when command is falsy', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1583,6 +1583,24 @@ function readBootstrapMarker() {
   return readJson(BOOTSTRAP_COMPLETE_MARKER)
 }
 
+// Marker-independent: is the canonical install at ACTIVE_HERMES_ROOT actually
+// runnable right now? A complete CLI install (`install.sh --include-desktop`)
+// or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
+// ever having written the bootstrap marker -- so we must be able to recognise
+// "already installed" off the filesystem alone, not just the marker.
+function isActiveRuntimeUsable() {
+  const venvPython = getVenvPython(VENV_ROOT)
+  return (
+    isHermesSourceRoot(ACTIVE_HERMES_ROOT) &&
+    fileExists(venvPython) &&
+    canImportHermesCli(venvPython, {
+      env: {
+        PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+      }
+    })
+  )
+}
+
 function isBootstrapComplete() {
   const marker = readBootstrapMarker()
   if (!marker || typeof marker !== 'object') return false
@@ -1595,7 +1613,7 @@ function isBootstrapComplete() {
   // a runnable venv: an interrupted or split-home install can leave the marker
   // + checkout without a venv, and trusting that spawns a dead backend
   // ("gateway offline") instead of re-running bootstrap to repair it.
-  return isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(getVenvPython(VENV_ROOT))
+  return isActiveRuntimeUsable()
 }
 
 function writeBootstrapMarker(payload) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1020,6 +1020,29 @@ function Install-SystemPackages {
 # Installation
 # ============================================================================
 
+function Repair-ManagedCheckoutBeforeUpdate {
+    <#
+    The Windows desktop installer owns $InstallDir as app code; user data lives
+    under $HermesHome. A failed prior update can leave tracked files dirty
+    (often only CRLF churn) or deleted, and pinned `git checkout <commit>` then
+    refuses to proceed. Normalize line endings for this repo and reset tracked
+    app files before switching refs. `git clean -fd` removes only untracked
+    non-ignored files, preserving ignored caches such as venv/ and node_modules/.
+    #>
+    Write-Info "Preparing managed checkout for update..."
+
+    git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+    if ($LASTEXITCODE -ne 0) { Write-Warn "Could not set core.autocrlf=false; continuing" }
+    git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+    if ($LASTEXITCODE -ne 0) { Write-Warn "Could not set windows.appendAtomically=false; continuing" }
+
+    git -c windows.appendAtomically=false reset --hard HEAD
+    if ($LASTEXITCODE -ne 0) { throw "git reset --hard HEAD failed (exit $LASTEXITCODE)" }
+
+    git -c windows.appendAtomically=false clean -fd
+    if ($LASTEXITCODE -ne 0) { throw "git clean -fd failed (exit $LASTEXITCODE)" }
+}
+
 function Install-Repository {
     Write-Info "Installing to $InstallDir..."
 
@@ -1064,19 +1087,7 @@ function Install-Repository {
             $prevEAP = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
             try {
-                # This is a MANAGED checkout, not a repo the user edits. Git for
-                # Windows defaults to core.autocrlf=true, which renormalizes the
-                # repo's LF-only text files to CRLF in the working tree -- so
-                # tracked files (.envrc, AGENTS.md, agent/*.py, workflows, ...)
-                # show as locally modified even though nobody touched them. A
-                # bare `git checkout` then aborts with "Your local changes would
-                # be overwritten by checkout", which is exactly the failure GUI
-                # users hit on update. Two-part fix: (1) stop creating the dirt
-                # by pinning autocrlf=false on this clone, (2) discard any
-                # pre-existing dirt with a hard reset before the checkout. Safe
-                # because nothing here is user-authored.
-                git -c windows.appendAtomically=false config core.autocrlf false 2>$null
-                git -c windows.appendAtomically=false reset --hard HEAD 2>$null
+                Repair-ManagedCheckoutBeforeUpdate
                 git -c windows.appendAtomically=false fetch origin
                 if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)" }
                 # Precedence: Commit > Tag > Branch.  Commit and Tag check

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -355,6 +355,15 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "git":
+            if "fetch" in cmd and "origin" in cmd:
+                return SimpleNamespace(stdout="", stderr="", returncode=0)
+            if "rev-parse" in cmd and "--abbrev-ref" in cmd:
+                return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+            if "rev-list" in cmd:
+                return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+            if "pull" in cmd and "--ff-only" in cmd:
+                return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         if cmd == ["git", "fetch", "origin"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
@@ -404,6 +413,15 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "git":
+            if "fetch" in cmd and "origin" in cmd:
+                return SimpleNamespace(stdout="", stderr="", returncode=0)
+            if "rev-parse" in cmd and "--abbrev-ref" in cmd:
+                return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+            if "rev-list" in cmd:
+                return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+            if "pull" in cmd and "--ff-only" in cmd:
+                return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         if cmd == ["git", "fetch", "origin"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
@@ -563,7 +581,7 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    assert reset_calls[0][-3:] == ["reset", "--hard", "origin/main"]
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out

--- a/tests/hermes_cli/test_windows_installer_update_recovery.py
+++ b/tests/hermes_cli/test_windows_installer_update_recovery.py
@@ -1,0 +1,40 @@
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_windows_repository_stage_repairs_managed_checkout_before_checkout():
+    text = _install_ps1()
+
+    helper_match = re.search(
+        r"function Repair-ManagedCheckoutBeforeUpdate \{(?P<body>.*?)\nfunction Install-Repository",
+        text,
+        re.DOTALL,
+    )
+    assert helper_match, "Install-Repository should use a named checkout repair helper"
+    helper = helper_match.group("body")
+
+    assert "core.autocrlf false" in helper
+    assert "reset --hard HEAD" in helper
+    assert "clean -fd" in helper
+
+    update_block_match = re.search(
+        r"Existing installation found, updating\.\.\.(?P<body>.*?)\$didUpdate = \$true",
+        text,
+        re.DOTALL,
+    )
+    assert update_block_match, "could not find Install-Repository's existing-install update block"
+    update_block = update_block_match.group("body")
+
+    repair_idx = update_block.find("Repair-ManagedCheckoutBeforeUpdate")
+    checkout_idx = update_block.find("checkout --detach $Commit")
+    assert repair_idx != -1, "existing install updates should repair the managed checkout"
+    assert checkout_idx != -1, "test expected the pinned commit checkout path"
+    assert repair_idx < checkout_idx


### PR DESCRIPTION
## Summary
- reset and clean the managed Windows install checkout before fetching/checking out update refs, so line-ending churn or partial tracked-file changes do not trap the Desktop updater
- configure the managed checkout with `core.autocrlf=false` to avoid recurring CRLF churn
- make Desktop adoption verify that the active launcher venv can import `yaml` and `hermes_cli.config`, so broken/empty venvs fall back to bootstrap repair instead of looping into a dead backend
- make updater tests tolerate the Windows `git -c windows.appendAtomically=false ...` wrapper so the Windows recovery suite can run on Windows hosts

Fixes #38122.

## Tests
- `node --check apps/desktop/electron/backend-probes.cjs`
- `node --check apps/desktop/electron/main.cjs`
- `node --test apps/desktop/electron/backend-probes.test.cjs` -> 8 passed
- `.venv\\Scripts\\python.exe -m pytest tests/hermes_cli/test_windows_installer_update_recovery.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_yes_flag.py -q --timeout-method=thread` -> 31 passed
- `.venv\\Scripts\\python.exe -m ruff check tests/hermes_cli/test_windows_installer_update_recovery.py tests/hermes_cli/test_update_autostash.py` -> passed
- PowerShell AST parse of `scripts/install.ps1` -> parsed
- `git diff --check` -> passed
