### PR TITLE
docs: add remote-backend section to the Desktop App page

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -104,6 +104,21 @@ To launch via the CLI, simply run `hermes desktop`. By default it installs works
 
 The packaged app ships only the Electron shell. On first launch it installs the Hermes Agent runtime into `HERMES_HOME` (`~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows) — **the same layout a CLI install uses**, which is why the two are interchangeable. The React renderer talks to a `hermes dashboard --tui` backend over the standard gateway APIs and reuses the agent rather than reimplementing it. Install, backend-resolution, and self-update logic live in the Electron main process.
 
+## Connecting to a remote backend
+
+By default the app starts and manages its own **local** backend. You can instead point it at a Hermes backend running on another machine — a VPS, a home server, or a Mini behind Tailscale — under **Settings → Gateway → Remote gateway**. It asks for two things:
+
+- **Remote URL** — the backend's dashboard URL, e.g. `http://<host>:9119`
+- **Session token** — the backend's dashboard session token
+
+The session token is the part that trips people up. **Hermes does not print it for you to copy** — by default the backend mints a fresh random token on every boot and injects it straight into the served HTML, so there is nothing in `config.yaml`, in `/gateway`, or in the logs to grab. For a remote connection you pin the token yourself on the backend (via `HERMES_DASHBOARD_SESSION_TOKEN`), run the backend with `--insecure`, then paste that same value into the app.
+
+The full backend setup — minting the token, the `--insecure`-vs-OAuth-gate detail, the `HERMES_DESKTOP_REMOTE_URL` / `HERMES_DESKTOP_REMOTE_TOKEN` environment-variable override, Tailscale guidance, and a troubleshooting list — lives on the dashboard page, since the desktop app talks to the same backend the web dashboard does:
+
+➜ **[Web Dashboard → Connecting Hermes Desktop to a remote backend](./features/web-dashboard.md#connecting-hermes-desktop-to-a-remote-backend)**
+
+The relevant environment variables are also catalogued under [Environment Variables → Web Dashboard & Hermes Desktop](../reference/environment-variables.md#web-dashboard--hermes-desktop).
+
 ## Troubleshooting
 
 Boot logs land in `HERMES_HOME/logs/desktop.log` (it includes backend output and recent Python tracebacks) — check it first if the app reports a boot failure. You can also tail it from the CLI:

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -620,7 +620,7 @@ The dashboard's React StatusPage shows the same fields under "Web server". A sid
 
 ## Connecting Hermes Desktop to a remote backend
 
-Hermes Desktop can drive a Hermes backend running on another machine (a VPS, a home server, a Mini behind Tailscale). In the app this lives under **Settings → Gateway → Remote gateway**, which asks for a **Remote URL** and a **Session token**.
+Hermes Desktop can drive a Hermes backend running on another machine (a VPS, a home server, a Mini behind Tailscale). In the app this lives under **Settings → Gateway → Remote gateway**, which asks for a **Remote URL** and a **Session token**. (For the desktop app itself — install, settings, chat — see the [Hermes Desktop](/user-guide/desktop) page.)
 
 The "session token" is the dashboard's session token — the same secret the local web UI uses for `/api` and WebSocket calls. **Hermes does not print it for you to copy.** By default the dashboard mints a fresh random token on every boot and injects it straight into the served HTML, so there is nothing sitting in `config.yaml`, in `/gateway`, or in the logs to grab. For a remote connection you set the token yourself on the backend, then paste that same value into the desktop app.
 


### PR DESCRIPTION
## Summary
The Desktop App docs page covered install, settings, and chat but never explained how to connect the app to a backend on another machine — the exact thing @PedjaDrazic asked about. Adds a "Connecting to a remote backend" section to the existing page.

The "Session token" the app asks for is the dashboard session token Hermes never surfaces (ephemeral per boot, injected into served HTML). The new section says so and links to the web-dashboard page for the full backend setup rather than duplicating it; a reciprocal link points the web-dashboard remote section back to the Desktop App page.

## Changes
- `user-guide/desktop.md`: new **"Connecting to a remote backend"** section (between "How it works" and "Troubleshooting") — Remote URL + Session token, why the token isn't surfaced, `HERMES_DASHBOARD_SESSION_TOKEN` + `--insecure`, and links to the dashboard page for full setup and to the env-var reference.
- `user-guide/features/web-dashboard.md`: one reciprocal link from the remote-backend section back to the Desktop App page.

Docs-only, additive (+15/-1). Builds on the existing Desktop App page; no rewrite.

## Validation
English Docusaurus build `[SUCCESS]`; the new section's two cross-links (`web-dashboard#connecting-…`, `environment-variables#web-dashboard--hermes-desktop`) resolve. The three broken-link warnings in build output (`/docs/integrations/mcp`, `llms.txt`, `llms-full.txt`) are pre-existing and not in this diff.

## Infographic

![desktop-app-remote-backend](https://v3b.fal.media/files/b/0a9ccee6/g8P3U-DeeTozsr-pAovcU_5pddvsS4.png)
