### PR TITLE
fix(feishu): allow quoted empty mentions via config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -699,6 +699,11 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#
+# Feishu-specific settings (config.yaml top-level, not under platforms:):
+#
+# feishu:
+#   allow_empty_at_reply: false      # When true, keep a reply-to message alive even if only the @mention remains after text stripping
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -863,6 +863,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "allow_empty_at_reply" in platform_cfg:
+                    bridged["allow_empty_at_reply"] = platform_cfg["allow_empty_at_reply"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:
@@ -1163,6 +1165,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(feishu_cfg, dict):
                 if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
                     os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+                if "allow_empty_at_reply" in feishu_cfg and not os.getenv("FEISHU_ALLOW_EMPTY_AT_REPLY"):
+                    os.environ["FEISHU_ALLOW_EMPTY_AT_REPLY"] = str(feishu_cfg["allow_empty_at_reply"]).lower()
 
     except Exception as e:
         logger.warning(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -395,6 +395,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    allow_empty_at_reply: bool = False
 
 
 @dataclass
@@ -1573,6 +1574,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            allow_empty_at_reply=_to_boolean(
+                extra.get("allow_empty_at_reply", os.getenv("FEISHU_ALLOW_EMPTY_AT_REPLY", "false"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1605,6 +1609,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._allow_empty_at_reply = settings.allow_empty_at_reply
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -3043,21 +3048,6 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> None:
         text, inbound_type, media_urls, media_types, mentions = await self._extract_message_content(message)
 
-        if inbound_type == MessageType.TEXT:
-            text = _strip_edge_self_mentions(text, mentions)
-            if text.startswith("/"):
-                inbound_type = MessageType.COMMAND
-
-        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
-        if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
-
-        if inbound_type != MessageType.COMMAND:
-            hint = _build_mention_hint(mentions)
-            if hint:
-                text = f"{hint}\n\n{text}" if text else hint
-
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
@@ -3066,6 +3056,26 @@ class FeishuAdapter(BasePlatformAdapter):
             or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+
+        if inbound_type == MessageType.TEXT:
+            text = _strip_edge_self_mentions(text, mentions)
+            if text.startswith("/"):
+                inbound_type = MessageType.COMMAND
+
+        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
+        # Optional exception: keep an explicit reply alive so reply_to_text can
+        # still provide the missing context for a mention-only ping.
+        if inbound_type == MessageType.TEXT and not text and not media_urls:
+            if reply_to_message_id and self._allow_empty_at_reply:
+                text = "[Replying to the quoted message without additional text]"
+            else:
+                logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+                return
+
+        if inbound_type != MessageType.COMMAND:
+            hint = _build_mention_hint(mentions)
+            if hint:
+                text = f"{hint}\n\n{text}" if text else hint
 
         sender_primary = (
             getattr(sender_id, "open_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -78,6 +78,31 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_xxx",
+        "FEISHU_APP_SECRET": "secret_xxx",
+        "FEISHU_ALLOW_EMPTY_AT_REPLY": "true",
+    }, clear=False)
+    def test_feishu_allow_empty_at_reply_loaded_from_env(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        self.assertTrue(adapter._allow_empty_at_reply)
+
+    def test_feishu_yaml_allow_empty_at_reply_loaded_into_platform_extra(self):
+        from gateway.config import Platform, load_gateway_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text("feishu:\n  allow_empty_at_reply: true\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("gateway.config.get_hermes_home", return_value=Path(tmpdir)):
+                    config = load_gateway_config()
+
+            self.assertTrue(config.platforms[Platform.FEISHU].extra["allow_empty_at_reply"])
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):
@@ -4420,6 +4445,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
+        adapter._allow_empty_at_reply = False
         adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
         adapter._fetch_message_text = AsyncMock(return_value=None)
         adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
@@ -4594,6 +4620,94 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             )
         )
         adapter._dispatch_inbound_event.assert_not_called()
+
+    def test_mention_only_reply_keeps_quoted_context(self):
+        adapter = self._build_adapter()
+        adapter._allow_empty_at_reply = True
+        message = SimpleNamespace(
+            content=json.dumps({"text": ""}),
+            message_type="text",
+            message_id="m_reply",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="m_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "父消息内容")
+        self.assertIn("Replying to the quoted message", event.text)
+
+    def test_mention_only_reply_is_dropped_by_default(self):
+        adapter = self._build_adapter()
+        adapter._allow_empty_at_reply = False
+        message = SimpleNamespace(
+            content=json.dumps({"text": ""}),
+            message_type="text",
+            message_id="m_reply_default_drop",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="m_reply_default_drop",
+            )
+        )
+
+        adapter._dispatch_inbound_event.assert_not_called()
+
+    def test_parent_reply_text_is_fetched(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "reply"}),
+            message_type="text",
+            message_id="m_reply_fetch",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="m_reply_fetch",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "父消息内容")
 
 
 class TestFeishuFetchMessageText(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Feishu setting that preserves reply context when a user re-mentions the bot without any additional body text. This fixes the case where a quoted reply survives mention gating conceptually, but gets dropped earlier because the stripped message body becomes empty.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `feishu.allow_empty_at_reply` / `FEISHU_ALLOW_EMPTY_AT_REPLY` to control whether Feishu keeps a reply event alive when only the @mention remains after text stripping.
- Move Feishu reply target extraction ahead of the empty-text guard so quoted-message context is available when deciding whether to keep the event.
- Keep the default behavior unchanged: mention-only empty messages still drop unless the new setting is enabled.
- Add focused regression tests for env config, YAML config loading, default drop behavior, and the preserved quoted-reply path.
- Document the new Feishu config key in `cli-config.yaml.example`.

## How to Test

1. Enable `feishu.allow_empty_at_reply: true` in `~/.hermes/config.yaml`.
2. In Feishu, send a message, then reply to it with only an @mention to Hermes and no extra body text.
3. Verify Hermes still processes the message and receives the quoted parent text in context.
4. Disable the setting (or leave it unset) and verify the same mention-only empty reply is dropped.
5. Run:
   `python3.11 -m unittest tests.gateway.test_feishu.TestConfigEnvOverrides.test_feishu_allow_empty_at_reply_loaded_from_env tests.gateway.test_feishu.TestConfigEnvOverrides.test_feishu_yaml_allow_empty_at_reply_loaded_into_platform_extra tests.gateway.test_feishu.TestFeishuProcessInboundMessage.test_mention_only_reply_is_dropped_by_default tests.gateway.test_feishu.TestFeishuProcessInboundMessage.test_mention_only_reply_keeps_quoted_context tests.gateway.test_feishu.TestFeishuProcessInboundMessage.test_parent_reply_text_is_fetched tests.gateway.test_feishu.TestFeishuProcessInboundMessage.test_pure_self_mention_message_is_ignored`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression result:

```text
......
----------------------------------------------------------------------
Ran 6 tests in 1.869s

OK
```