### PR TITLE
fix(gateway): skip auto-continue System note in interrupt mode / fix(qqbot): recognize dm chat_type

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1086,7 +1086,8 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # "dm" = gateway generic (source.chat_type), "c2c" = QQ API term
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18038,14 +18038,21 @@ class GatewayRunner:
                     + message
                 )
             elif _has_fresh_tool_tail:
-                message = (
-                    "[System note: Your previous turn was interrupted before you could "
-                    "process the last tool result(s). The conversation history contains "
-                    "tool outputs you haven't responded to yet. Please finish processing "
-                    "those results and summarize what was accomplished, then address the "
-                    "user's new message below.]\n\n"
-                    + message
-                )
+                # #interrupt-mode — when busy_input_mode is "interrupt", the user
+                # explicitly sent a message to STOP the current task.  Injecting a
+                # System note that says "please finish processing those results"
+                # would make the agent resume the very task the user interrupted.
+                # Skip the note and let the agent respond to the new message.
+                _busy_mode = getattr(self, '_busy_input_mode', 'interrupt')
+                if _busy_mode != 'interrupt':
+                    message = (
+                        "[System note: Your previous turn was interrupted before you could "
+                        "process the last tool result(s). The conversation history contains "
+                        "tool outputs you haven't responded to yet. Please finish processing "
+                        "those results and summarize what was accomplished, then address the "
+                        "user's new message below.]\n\n"
+                        + message
+                    )
 
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1732,6 +1732,31 @@ class TestDefaultInteractionDispatch:
         finally:
             tools.approval.resolve_gateway_approval = orig
 
+    @pytest.mark.asyncio
+    async def test_approval_click_dm_chat_type_authorized(self):
+        """'dm' chat_type (gateway generic) should be authorized like 'c2c'."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 2, "user_openid": "u",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u:deny"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u", "deny", False)]
+
 
 class TestSendExecApproval:
     """Verify the gateway contract: QQAdapter.send_exec_approval(...)."""


### PR DESCRIPTION
## Two small fixes

### 1. interrupt mode System note

When `busy_input_mode` (or `busy_text_mode`) is set to `interrupt`, the user sending a text message is an explicit signal to **stop** the current task. However, the gateway unconditionally injects a `[System note: ...]` telling the agent to **continue processing interrupted tool results**, which makes the agent resume the very work the user intended to abort.

**Fix:** Gate the fresh-tool-tail System note on `busy_input_mode != "interrupt"`. In interrupt mode, the agent responds to the new message directly instead.

### 2. QQ bot dm chat_type

The gateway uses `"dm"` as its generic `chat_type` for direct messages (`source.chat_type`), but `QQAdapter._is_chat()` only matched the QQ API-specific term `"c2c"`. This caused inline keyboard approval clicks in DM channels to fail silently — the event was never routed to the right session.

**Fix:** Accept both `"c2c"` and `"dm"` in the chat matching logic. A test is included that validates the path with a `"dm"` chat_type button event.

---

Closes the interrupt-mode resume loop on responsive setups where the user expects `/stop`-like behaviour from any text message.