### PR TITLE
chore: add bbednarski9 to AUTHOR_MAP for #29722 salvage

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -918,6 +918,7 @@ AUTHOR_MAP = {
     "54813621+xxxigm@users.noreply.github.com": "xxxigm",
     "asurla@nvidia.com": "anniesurla",
     "kchantharuan@nvidia.com": "nv-kasikritc",
+    "bbednarski@nvidia.com": "bbednarski9",
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",
     "draixagent@gmail.com": "draix",


### PR DESCRIPTION
## Summary

Adds `bbednarski@nvidia.com → bbednarski9` to `AUTHOR_MAP` in `scripts/release.py`.

Required by `contributor_audit.py` strict mode for the #29722 salvage (observer-grade telemetry hooks), which cherry-picks Bryan Bednarski's commit with authorship preserved. Merge this **before** the salvage PR so the audit passes when the salvage commit lands on main.

## Test plan
- `AUTHOR_MAP` loads and resolves the new email (`release.AUTHOR_MAP["bbednarski@nvidia.com"] == "bbednarski9"`).
- Salvage committer (`kshitijk4poor`) already mapped — self-check passes.
