### PR TITLE
fix(security): add scoped safe delete roots

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -863,6 +863,29 @@ code_execution:
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================
+# Approval Prompts
+# =============================================================================
+# Controls how Hermes handles commands classified as dangerous.
+#
+# mode:
+#   manual — always prompt the user (default)
+#   smart  — use an auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
+#   off    — skip all approval prompts (equivalent to --yolo)
+#
+# safe_delete_roots allows literal child `rm` targets under disposable roots to
+# skip approval. Deleting the root itself, traversal, globs, shell expansion,
+# compound commands, and mixed safe/unsafe target lists remain approval-gated.
+approvals:
+  mode: "manual"
+  timeout: 60
+  cron_mode: "deny"  # Cron jobs deny dangerous commands by default.
+  safe_delete_roots:
+    - "/tmp"
+    - "/private/tmp"
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1907,6 +1907,10 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # Absolute roots where literal child rm targets can skip approval.
+        # This is for disposable sandboxes such as /tmp; deleting the root
+        # itself, globs, traversal, and shell-expanded targets stay gated.
+        "safe_delete_roots": ["/tmp", "/private/tmp"],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -53,7 +53,7 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
     def test_rm_recursive_long_flag(self):
-        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /tmp/stuff")
+        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /workspace/stuff")
         assert is_dangerous is True
         assert key is not None
         assert "delete" in desc.lower()
@@ -231,7 +231,7 @@ class TestRmRecursiveFlagVariants:
         assert "recursive" in desc.lower() or "delete" in desc.lower()
 
     def test_rm_rf(self):
-        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/test")
+        dangerous, key, desc = detect_dangerous_command("rm -rf /workspace/test")
         assert dangerous is True
         assert key is not None
 
@@ -259,6 +259,84 @@ class TestRmRecursiveFlagVariants:
         dangerous, key, desc = detect_dangerous_command("sudo rm -rf /tmp")
         assert dangerous is True
         assert key is not None
+
+
+class TestScopedSafeDeleteRoots:
+    """Scoped sandbox cleanup should avoid prompts without broad rm bypasses."""
+
+    def test_default_tmp_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm /tmp/hermes-output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_tmp_recursive_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm /workfolder/output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_recursive_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run-123/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_safe_root_itself_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_glob_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/*")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_traversal_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/../etc")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_sibling_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder2/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_multiple_targets_require_every_target_scoped(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_shell_expansion_target_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/$RUN_ID")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_compound_safe_then_dangerous_rm_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run; rm -rf /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
 
 
 class TestMultilineBypass:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -11,7 +11,9 @@ This module is the single source of truth for the dangerous command system:
 import contextvars
 import logging
 import os
+import posixpath
 import re
+import shlex
 import sys
 import threading
 import time
@@ -540,15 +542,128 @@ def _normalize_command_for_detection(command: str) -> str:
     return command
 
 
+_DEFAULT_SAFE_DELETE_ROOTS = ("/tmp", "/private/tmp")
+_DELETE_TARGET_UNSAFE_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}")
+
+
+def _configured_safe_delete_roots() -> tuple[str, ...]:
+    """Return absolute roots where scoped rm targets can skip approvals."""
+    roots = list(_DEFAULT_SAFE_DELETE_ROOTS)
+    configured = _get_approval_config().get("safe_delete_roots", [])
+    if isinstance(configured, str):
+        configured = [configured]
+    elif not isinstance(configured, (list, tuple, set)):
+        configured = []
+
+    for root in configured:
+        roots.append(str(root))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        root = root.strip()
+        if not root.startswith("/"):
+            continue
+        root = posixpath.normpath(root)
+        if root in {"/", "."} or root in seen:
+            continue
+        normalized.append(root)
+        seen.add(root)
+    return tuple(normalized)
+
+
+def _contains_shell_separator(command: str) -> bool:
+    """Conservatively reject compound commands from scoped delete bypasses."""
+    return any(sep in command for sep in ("\n", "&&", "||", ";", "|"))
+
+
+def _rm_tokens(command: str) -> list[str]:
+    if _contains_shell_separator(command):
+        return []
+    try:
+        tokens = shlex.split(command.strip(), posix=True)
+    except ValueError:
+        return []
+    return tokens if tokens and tokens[0] == "rm" else []
+
+
+def _rm_flag_is_recursive(flag: str) -> bool:
+    if flag == "--recursive":
+        return True
+    if flag.startswith("--"):
+        return False
+    return "r" in flag[1:] or "R" in flag[1:]
+
+
+def _rm_targets(command: str, require_recursive: bool) -> list[str]:
+    tokens = _rm_tokens(command)
+    if not tokens:
+        return []
+
+    flags: list[str] = []
+    targets: list[str] = []
+    after_double_dash = False
+    for token in tokens[1:]:
+        if after_double_dash:
+            targets.append(token)
+        elif token == "--":
+            after_double_dash = True
+        elif token.startswith("-") and token != "-":
+            flags.append(token)
+        else:
+            targets.append(token)
+
+    if require_recursive and not any(_rm_flag_is_recursive(flag) for flag in flags):
+        return []
+    return targets
+
+
+def _is_scoped_safe_delete_target(target: str) -> bool:
+    """True only for literal child paths under configured safe delete roots."""
+    if any(marker in target for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+        return False
+    if not target.startswith("/"):
+        return False
+
+    normalized = posixpath.normpath(target)
+    if normalized != target.rstrip("/"):
+        return False
+
+    for root in _configured_safe_delete_roots():
+        prefix = root + "/"
+        if not normalized.startswith(prefix):
+            continue
+        rest = normalized[len(prefix):]
+        first_component = rest.split("/", 1)[0]
+        return bool(first_component) and first_component not in {".", ".."}
+    return False
+
+
+def _is_allowed_root_delete(command: str) -> bool:
+    """Allow non-recursive rm of literal children under safe delete roots."""
+    targets = _rm_targets(command, require_recursive=False)
+    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+
+
+def _is_allowed_recursive_delete(command: str) -> bool:
+    """Allow scoped recursive cleanup while keeping broad rm -r gated."""
+    targets = _rm_targets(command, require_recursive=True)
+    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = _normalize_command_for_detection(command).lower()
+    command_normalized = _normalize_command_for_detection(command)
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-        if pattern_re.search(command_lower):
+        if pattern_re.search(command_normalized):
+            if description == "delete in root path" and _is_allowed_root_delete(command_normalized):
+                continue
+            if description.startswith("recursive delete") and _is_allowed_recursive_delete(command_normalized):
+                continue
             pattern_key = description
             return (True, pattern_key, description)
     return (False, None, None)


### PR DESCRIPTION
## What does this PR do?

Adds a conservative, configurable safe-delete allowlist so generated/cache cleanup under sandbox roots can proceed without approval, while preserving dangerous-command approval for risky delete patterns.

The motivating case is deleting literal child paths under an isolated work folder such as `/workfolder` without treating that as equivalent to deleting the filesystem root. The implementation only bypasses approval when every `rm` target is a literal descendant of a configured safe-delete root. Root deletes, traversal, glob/wildcard patterns, shell expansion, command separators, and mixed safe/unsafe target lists remain dangerous and still require approval.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: adds `approvals.safe_delete_roots` with conservative defaults for temporary directories.
- `cli-config.yaml.example`: documents the new approvals configuration and safe-delete root behavior.
- `tools/approval.py`: adds scoped safe-delete parsing and validation helpers, then wires them into dangerous-command detection.
- `tests/tools/test_approval.py`: adds regression coverage for default roots, configured roots such as `/workfolder`, and unsafe root/glob/traversal/shell/mixed-target cases.

## Documentation Status

The configuration surface is documented in `cli-config.yaml.example`, which is the relevant example/config reference for this change. No separate website doc page was changed because this only affects the approval matcher internals plus the example config key.

## How to Test

1. `uv run --extra dev python -m pytest tests/tools/test_approval.py -q` -> `208 passed`.
2. `scripts/run_tests.sh tests/tools/test_approval.py` -> `1 file, 208 tests passed`.
3. `git diff --check` -> passed.
4. Manual matcher smoke checks confirmed `rm /tmp/hermes-output.txt` and `rm -rf /tmp/hermes-run/cache` are allowed, while `rm -rf /tmp`, `rm -rf /tmp/*`, `rm -rf /workspace/run`, `rm -rf /workfolder/$RUN_ID`, mixed unsafe targets, and compound commands remain dangerous.
5. Full suite was attempted but is not marked as passing: `pytest tests/ -q` is not on PATH in this shell, and `.venv/bin/pytest tests/ -q` fails during collection with unrelated missing `acp` imports in ACP tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(security): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no duplicate scoped safe-delete-root approval bypass found)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; blocked during collection as noted above)
- [x] I've added tests for my changes (safe/default/configured root and unsafe target regression coverage)
- [x] I've tested on my platform: Linux 5.15.0-171-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — documented the config surface in `cli-config.yaml.example`; no separate website docs added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — added `approvals.safe_delete_roots`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — approval parser is platform-agnostic; safe-root defaults are POSIX temp/cache paths and configured roots are explicit
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, internal approval decision logic only; no tool schema changed

## Screenshots / Logs

Not applicable; this is approval-rule behavior covered by unit tests and matcher smoke checks.
