### PR TITLE
fix: Close inner SDK auth generator to prevent OAuth reconnect deadlock

### DIFF
--- a/tests/tools/test_mcp_oauth_generator_cleanup.py
+++ b/tests/tools/test_mcp_oauth_generator_cleanup.py
@@ -1,0 +1,162 @@
+"""Regression test: closing HermesMCPOAuthProvider.async_auth_flow wrapper
+must close the inner SDK auth generator.
+
+When httpx's auth_flow driver closes the auth generator, the Hermes wrapper
+generator is closed but the inner SDK generator — which is suspended inside
+``async with self.context.lock`` — is left orphaned. Python later finalizes
+that orphaned inner async generator from a different asyncio task. The SDK
+lock is an ``anyio.Lock``, which enforces task ownership on release, so
+release raises::
+
+    RuntimeError("The current task is not holding this lock")
+
+and the lock stays permanently held. Subsequent reconnect attempts on the
+cached provider deadlock, and the MCP server becomes unusable until the
+gateway process is restarted.
+
+This test proves that closing the Hermes wrapper currently does NOT close
+the inner generator and the lock is left held. It will pass once the fix
+(adding ``finally: await inner.aclose()``) is applied.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import sys
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+@pytest.mark.asyncio
+async def test_aclose_hermes_wrapper_releases_sdk_lock(tmp_path, monkeypatch):
+    """Closing the Hermes wrapper generator must release the SDK's anyio.Lock.
+
+    Without the fix, the inner SDK auth-flow generator remains suspended
+    inside ``async with self.context.lock``, and the lock is never released
+    from the owning task. Python's async generator finalizer then tries to
+    release it from a different task, anyio raises RuntimeError, and the
+    lock stays stuck permanently.
+    """
+    import httpx
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    # Seed valid-looking tokens so the SDK won't attempt full registration.
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="test_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="test_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    # Drive the wrapper so the inner SDK generator reaches its yield point
+    # inside ``async with self.context.lock``.
+    outbound = await flow.__anext__()
+    assert outbound is not None, "wrapper must yield the outbound request"
+    assert outbound.url.host == "example.com"
+
+    # The SDK's context.lock should be held at this point — the inner
+    # generator is suspended inside the locked section.
+    assert provider.context.lock.locked(), (
+        "SDK context lock must be held while the inner auth generator "
+        "is suspended at its yield point"
+    )
+
+    # Install a temporary event-loop exception handler to capture any
+    # async-generator finalizer errors (the RuntimeError about cross-task
+    # lock release).
+    captured_exceptions: list[dict] = []
+
+    def _capture_exc(loop, context):
+        captured_exceptions.append({
+            "message": context.get("message", ""),
+            "exception": context.get("exception"),
+        })
+
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(_capture_exc)
+
+    try:
+        # Close the Hermes wrapper. Without the fix, this only closes the
+        # outer wrapper; the inner SDK generator stays suspended with the
+        # lock held.
+        await flow.aclose()
+
+        # Let the event loop breathe and give async generator finalizers a
+        # chance to run.
+        gc.collect()
+        await asyncio.sleep(0.1)
+        await asyncio.sleep(0)  # extra yield to drain finalizer callbacks
+
+        # After the fix: the lock should be released because the inner
+        # generator was explicitly closed.
+        assert not provider.context.lock.locked(), (
+            "SDK context lock must be released after aclose() — "
+            "the inner SDK auth generator should have been properly closed, "
+            "releasing the anyio.Lock it acquired"
+        )
+
+        # No captured exception should mention cross-task lock release.
+        for exc_info in captured_exceptions:
+            msg = exc_info["message"]
+            if msg and "not holding this lock" in msg:
+                pytest.fail(
+                    f"anyio cross-task lock error captured: {msg}. "
+                    "The inner SDK generator was finalized from a different "
+                    "task than the one that acquired the lock."
+                )
+
+    finally:
+        # Restore the default exception handler.
+        loop.set_exception_handler(None)
+
+
+async def _noop_redirect(_url: str) -> None:
+    """Redirect handler that does nothing (won't be invoked in this test)."""
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    """Callback handler that won't be invoked in this test."""
+    raise AssertionError(
+        "callback handler should not be invoked in generator-cleanup test"
+    )

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -323,6 +323,16 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # 401 branch so a subsequent cold-load skips discovery.
                 self._persist_oauth_metadata_if_changed()
                 return
+            finally:
+                # Close the inner SDK auth-flow generator so it can
+                # release its anyio.Lock deterministically from the
+                # owning asyncio task. Without this, the inner generator
+                # is left suspended inside ``async with self.context.lock``
+                # and Python's async generator finalizer later tries to
+                # release from a different task, causing: RuntimeError("The
+                # current task is not holding this lock"). The lock stays
+                # held permanently, deadlocking reconnect.
+                await inner.aclose()
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
This fixes #38193

Add a `finally: await inner.aclose()` block in
HermesMCPOAuthProvider.async_auth_flow to deterministically close the inner MCP SDK auth-flow generator when the Hermes wrapper is closed.

Without this, keepalive transport failures on OAuth-backed MCP servers (e.g. Databricks) orphan the inner SDK generator suspended inside `async with self.context.lock`. When Python's async-generator finalizer later runs from a different task, anyio's task-ownership check on lock release raises RuntimeError("The current task is not holding this lock") and leaves the lock permanently held. Cached provider reuse then makes reconnect hang until the gateway process is restarted.

- Add regression test proving the lock stays held after aclose() without the fix
- Add finally block to close the inner SDK generator and release the anyio.Lock
- Keep existing bidirectional .asend() forwarding logic unchanged
- All 73 existing MCP OAuth tests continue to pass

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

