### PR TITLE
fix: mask secrets in status and config output

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5704,6 +5704,35 @@ def redact_key(key: str) -> str:
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
+_DISPLAY_SECRET_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "auth",
+    "private_key",
+)
+
+
+def _display_key_is_sensitive(key: object) -> bool:
+    normalized = str(key or "").lower().replace("-", "_")
+    return any(part in normalized for part in _DISPLAY_SECRET_KEY_PARTS)
+
+
+def _redact_config_value_for_display(value, *, key: object = ""):
+    """Return config data safe to render in human-facing CLI output."""
+    if _display_key_is_sensitive(key):
+        return redact_key(str(value) if value is not None else "")
+    if isinstance(value, dict):
+        return {k: _redact_config_value_for_display(v, key=k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_config_value_for_display(item) for item in value]
+    return value
+
+
 def show_config():
     """Display current configuration."""
     config = load_config()
@@ -5746,7 +5775,8 @@ def show_config():
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
-    print(f"  Model:        {config.get('model', 'not set')}")
+    model_display = _redact_config_value_for_display(config.get('model', 'not set'), key="model")
+    print(f"  Model:        {model_display}")
     _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
     print(f"  Max turns:    {_cfg_max_turns}")
     # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with
@@ -5872,7 +5902,10 @@ def show_config():
                 key = var["key"]
                 value = resolved.get(key, "")
                 skill_name = var.get("skill", "")
-                display_val = str(value) if value else color("(not set)", Colors.DIM)
+                if _display_key_is_sensitive(key):
+                    display_val = redact_key(str(value) if value else "")
+                else:
+                    display_val = str(value) if value else color("(not set)", Colors.DIM)
                 print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
     except Exception:
         pass

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,16 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # ``--all`` widens component coverage; it must never widen secret
+        # exposure.  Status output is routinely captured in terminal
+        # transcripts, cron logs, and agent sessions, so credentials stay
+        # masked even when the caller asks for the full status view.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -25,6 +25,27 @@ from hermes_cli.config import (
 )
 
 
+
+def test_show_config_masks_nested_secret_values(monkeypatch, capsys, tmp_path):
+    from hermes_cli.config import show_config
+
+    sentinel = "config-secret-should-not-leak-1234567890"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom\n"
+        "  default: custom/model\n"
+        f"  api_key: {sentinel}\n",
+        encoding="utf-8",
+    )
+
+    show_config()
+
+    output = capsys.readouterr().out
+    assert sentinel not in output
+    assert "conf...7890" in output
+
+
 class TestGetHermesHome:
     def test_default_path(self):
         with patch.dict(os.environ, {}, clear=False):

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,25 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_masks_api_key_values(monkeypatch, capsys, tmp_path):
+    """--all must not downgrade credential masking in status output."""
+    sentinel_values = {
+        "NVIDIA_API_KEY": "nim-secret-should-not-leak-1234567890",
+        "KIMI_API_KEY": "kimi-secret-should-not-leak-0987654321",
+    }
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for env_key, sentinel in sentinel_values.items():
+        monkeypatch.setenv(env_key, sentinel)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    for sentinel in sentinel_values.values():
+        assert sentinel not in output
+    assert "nim-...7890" in output
+    assert "kimi...4321" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- keep API key rows masked in hermes status even with --all
- redact nested secret-like config values before hermes config renders them
- mask secret-like skill settings in config output

## Test Plan
- python -m pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_config.py tests/hermes_cli/test_redact_config_bridge.py -q -o 'addopts='
- function-level smoke check with fake NVIDIA/Kimi/config secrets: status_all_leaks=none, config_display_leaks=False