### PR TITLE
fix(webhook): resolve deliver:origin to a concrete platform

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -105,6 +105,12 @@ class WebhookAdapter(BasePlatformAdapter):
         self._host: str = config.extra.get("host", DEFAULT_HOST)
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
         self._global_secret: str = config.extra.get("secret", "")
+        # Fallback target for `deliver: origin` routes. When a route's deliver
+        # is the literal string "origin" the webhook has no inbound user-chat
+        # to reflect to, so we redirect to a configured platform (e.g.
+        # "telegram") or — if unset — to the first connected platform with a
+        # home channel. Per-route `origin_deliver` overrides this global.
+        self._origin_deliver: str = config.extra.get("origin_deliver", "")
         self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
         self._dynamic_routes: Dict[str, dict] = {}
         self._dynamic_routes_mtime: float = 0.0
@@ -238,6 +244,23 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
+        # ``origin`` is a placeholder meaning "send back where the request
+        # came from".  Webhooks have no inbound user chat, so we map it to a
+        # concrete platform: per-route override → adapter-level config →
+        # first connected platform with a home channel.  If no candidate is
+        # found we fall back to log delivery so the response is not lost.
+        if deliver_type == "origin":
+            resolved = self._resolve_origin_target(delivery)
+            if resolved:
+                deliver_type = resolved
+            else:
+                logger.warning(
+                    "[webhook] deliver=origin for %s could not be resolved; "
+                    "logging response instead",
+                    chat_id,
+                )
+                deliver_type = "log"
+
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)
@@ -263,6 +286,40 @@ class WebhookAdapter(BasePlatformAdapter):
         return SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
         )
+
+    def _resolve_origin_target(self, delivery: dict) -> str:
+        """Map a ``deliver: origin`` directive to a concrete platform name.
+
+        Resolution order:
+
+        1. ``origin_deliver`` on the delivery info (i.e. the route config).
+        2. ``self._origin_deliver`` — webhook-adapter-wide fallback set in
+           ``platforms.webhook.extra.origin_deliver``.
+        3. The first connected adapter (excluding webhook itself) whose
+           config exposes a home channel.
+
+        Returns the resolved platform name (a key understood by ``send()``)
+        or an empty string when no candidate exists.
+        """
+        route_override = delivery.get("origin_deliver")
+        if route_override:
+            return str(route_override).strip()
+        if self._origin_deliver:
+            return self._origin_deliver.strip()
+        runner = self.gateway_runner
+        if runner is None:
+            return ""
+        try:
+            adapters = getattr(runner, "adapters", {}) or {}
+            for platform, adapter in adapters.items():
+                if platform == Platform.WEBHOOK:
+                    continue
+                home = runner.config.get_home_channel(platform)
+                if home and getattr(home, "chat_id", ""):
+                    return platform.value
+        except Exception as exc:
+            logger.debug("[webhook] origin auto-resolve failed: %s", exc)
+        return ""
 
     def _prune_delivery_info(self, now: float) -> None:
         """Drop delivery_info entries older than the idempotency TTL.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -840,6 +840,112 @@ class TestDeliveryCleanup:
 
 
 # ===================================================================
+# deliver: origin resolution
+# ===================================================================
+
+
+class TestDeliverOrigin:
+    """Tests for the ``deliver: origin`` placeholder resolution.
+
+    The webhook has no inbound user chat, so ``origin`` is mapped to a
+    concrete platform via per-route override, adapter-wide config, or the
+    first connected platform with a home channel. Falls back to log when
+    nothing is configured so the response is never silently dropped.
+    """
+
+    def test_resolve_origin_uses_per_route_override(self):
+        adapter = _make_adapter()
+        delivery = {"deliver": "origin", "origin_deliver": "discord"}
+        assert adapter._resolve_origin_target(delivery) == "discord"
+
+    def test_resolve_origin_uses_adapter_global(self):
+        config = _make_config()
+        config.extra["origin_deliver"] = "telegram"
+        adapter = WebhookAdapter(config)
+        assert adapter._resolve_origin_target({"deliver": "origin"}) == "telegram"
+
+    def test_resolve_origin_per_route_beats_global(self):
+        config = _make_config()
+        config.extra["origin_deliver"] = "telegram"
+        adapter = WebhookAdapter(config)
+        delivery = {"deliver": "origin", "origin_deliver": "slack"}
+        assert adapter._resolve_origin_target(delivery) == "slack"
+
+    def test_resolve_origin_returns_empty_when_unconfigured(self):
+        adapter = _make_adapter()
+        assert adapter._resolve_origin_target({"deliver": "origin"}) == ""
+
+    def test_resolve_origin_falls_back_to_first_home_channel(self):
+        adapter = _make_adapter()
+        home = MagicMock()
+        home.chat_id = "12345"
+        runner = MagicMock()
+        runner.adapters = {
+            Platform.WEBHOOK: MagicMock(),
+            Platform.TELEGRAM: MagicMock(),
+        }
+        runner.config.get_home_channel = MagicMock(
+            side_effect=lambda p: home if p == Platform.TELEGRAM else None
+        )
+        adapter.gateway_runner = runner
+        assert adapter._resolve_origin_target({"deliver": "origin"}) == "telegram"
+
+    def test_resolve_origin_skips_webhook_platform(self):
+        adapter = _make_adapter()
+        home = MagicMock()
+        home.chat_id = "should-not-pick"
+        runner = MagicMock()
+        runner.adapters = {Platform.WEBHOOK: MagicMock()}
+        runner.config.get_home_channel = MagicMock(return_value=home)
+        adapter.gateway_runner = runner
+        assert adapter._resolve_origin_target({"deliver": "origin"}) == ""
+
+    @pytest.mark.asyncio
+    async def test_send_with_origin_falls_back_to_log_when_unresolved(self):
+        """Unresolvable origin must log rather than fail or 404."""
+        adapter = _make_adapter()
+        chat_id = "webhook:test:abc"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "origin",
+            "deliver_extra": {},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+        result = await adapter.send(chat_id, "hello")
+        assert result.success is True  # logged, not failed
+
+    @pytest.mark.asyncio
+    async def test_send_with_origin_routes_to_resolved_platform(self):
+        """When origin resolves to a real platform, cross-platform delivery runs."""
+        config = _make_config()
+        config.extra["origin_deliver"] = "telegram"
+        adapter = WebhookAdapter(config)
+
+        # Stub gateway_runner so _deliver_cross_platform finds the adapter.
+        target_adapter = MagicMock()
+        target_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        home = MagicMock()
+        home.chat_id = "tg-home"
+        runner = MagicMock()
+        runner.adapters = {Platform.TELEGRAM: target_adapter}
+        runner.config.get_home_channel = MagicMock(return_value=home)
+        adapter.gateway_runner = runner
+
+        chat_id = "webhook:test:def"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "origin",
+            "deliver_extra": {},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+
+        result = await adapter.send(chat_id, "agent response")
+        assert result.success is True
+        target_adapter.send.assert_awaited_once()
+        args, _ = target_adapter.send.call_args
+        assert args[0] == "tg-home"
+        assert args[1] == "agent response"
+
+
+# ===================================================================
 # check_webhook_requirements
 # ===================================================================
 


### PR DESCRIPTION
## Problem

Webhook routes configured with `deliver: origin` (e.g. agent-dispatch routes registered from a local dashboard) currently fall through to:

```
WARNING [webhook] Unknown deliver type: origin
WARNING [Webhook] Send failed: Unknown deliver type: origin — trying plain-text fallback
ERROR   [Webhook] Fallback send also failed: Unknown deliver type: origin
```

The agent runs to completion but every status message **and** the final response is silently dropped — the user sees the webhook 202-accept and then nothing.

This is because the webhook has no inbound user chat to reflect to, so `"origin"` is meaningless as a literal delivery target — it needs to be resolved to a concrete platform.

## Fix

`WebhookAdapter._resolve_origin_target()` maps `origin` to a real platform name with this priority:

1. **Per-route override** — `origin_deliver` field on the route config.
2. **Adapter-wide fallback** — `platforms.webhook.extra.origin_deliver` in `config.yaml` (e.g. `telegram`).
3. **Auto-discovery** — first connected non-webhook platform whose config exposes a home channel.
4. **Log fallback** — if nothing resolves, log the response rather than fail-loud, so it's not lost.

`send()` consults the resolver before the existing `log` / `github_comment` / cross-platform branches, then re-enters the normal dispatch path so `deliver_extra` (chat_id overrides, thread_id, etc.) keeps working unchanged.

## Tests

8 new tests in `tests/gateway/test_webhook_adapter.py::TestDeliverOrigin` covering:

- per-route override beats adapter global
- adapter global used when no route override
- empty when nothing is configured (no runner attached)
- auto-discovery picks first home channel
- webhook platform is excluded from auto-discovery
- `send(origin)` logs (success=True) when unresolved
- `send(origin)` invokes cross-platform delivery to the resolved adapter

Full webhook suite: **107/107 passing**.

## Smoke

Reproduced the original warning on a route with `deliver: origin` against the real gateway; with `platforms.webhook.extra.origin_deliver: telegram` set, the agent response now reaches the configured Telegram home channel and the `Unknown deliver type: origin` warnings disappear.

## Backwards compatibility

- Adapters with no `origin_deliver` config and no `origin` routes are unaffected.
- Existing routes using `deliver: telegram` / `deliver: discord` / etc. unchanged.
- Routes that were silently failing with `origin` will now actually deliver (or log on a misconfigured deployment, which surfaces louder than the previous warning-then-drop).