### PR TITLE
fix(desktop): render bare URLs visibly in assistant messages

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -201,7 +201,13 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   }
 
   const text = childrenToText(children)
-  const fallbackLabel = text && normalizeExternalUrl(text) !== target ? text : undefined
+  // Always preserve the link text as fallback label so bare URLs remain
+  // visibly rendered even when PrettyLink cannot fetch a title or derive
+  // a slug label. Previously this was set to `undefined` when the child
+  // text matched the target URL (the bare-URL case), which caused PrettyLink
+  // to fall through to urlSlugTitleLabel — potentially rendering a partial
+  // hostname or slug instead of the original URL text. (Fixes #38209)
+  const fallbackLabel = text || undefined
 
   return (
     <PrettyLink className={cn('wrap-anywhere', className)} fallbackLabel={fallbackLabel} href={target} {...props} />

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -140,6 +140,50 @@ describe('external link helpers', () => {
     expect(link.textContent).toBe('Puerto Rico El Yunque')
   })
 
+  it('renders bare localhost URL text visibly via fallbackLabel', () => {
+    installDesktopBridge()
+    const url = 'http://localhost:8080/'
+
+    render(<PrettyLink fallbackLabel={url} href={url} />)
+
+    const link = screen.getByTitle(url)
+
+    expect(link.textContent).toContain('http://localhost:8080/')
+  })
+
+  it('renders bare example.com URL text visibly via fallbackLabel', () => {
+    installDesktopBridge()
+    const url = 'http://example.com/'
+
+    render(<PrettyLink fallbackLabel={url} href={url} />)
+
+    const link = screen.getByTitle(url)
+
+    expect(link.textContent).toContain('http://example.com/')
+  })
+
+  it('renders bare path URL text visibly via fallbackLabel', () => {
+    installDesktopBridge()
+    const url = 'https://example.com/path'
+
+    render(<PrettyLink fallbackLabel={url} href={url} />)
+
+    const link = screen.getByTitle(url)
+
+    expect(link.textContent).toContain('https://example.com/path')
+  })
+
+  it('preserves markdown link label via fallbackLabel', () => {
+    installDesktopBridge()
+    const url = 'http://example.com/'
+
+    render(<PrettyLink fallbackLabel="Example" href={url} />)
+
+    const link = screen.getByTitle(url)
+
+    expect(link.textContent).toContain('Example')
+  })
+
   it('ignores error-like fetched titles and falls back to slug label', async () => {
     const bridge = vi.fn().mockResolvedValue('GetYourGuide – Error')
     installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })


### PR DESCRIPTION
Fixes #38209.

## Summary
- Preserve bare URL text as the fallback label in Desktop assistant markdown links
- Add regression coverage for bare URLs including localhost/example URLs
- Keep existing explicit markdown link behavior unchanged

## Behavior
Before: bare URLs like `http://localhost:8080/` rendered as blank/invisible text in Desktop assistant messages.
After: bare URLs render visibly with their full URL text.

## Tests
- External link tests pass: 15 total, 11 existing + 4 new

## Conflict check
No conflict expected with #38143. That PR touches a different section of `markdown-text.tsx`.