### PR TITLE
fix(conversation_loop): apply ack-continuation guard in chat_completions mode (#38192)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1886,6 +1886,17 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
+        "diagnose",
+        "diagnosing",
+        "troubleshoot",
+        "troubleshooting",
+        "benchmark",
+        "verify",
+        "verifying",
+        "research",
+        "researching",
+        "investigate",
+        "investigating",
     )
     workspace_markers = (
         "directory",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4258,8 +4258,7 @@ def run_conversation(
                 agent._clear_status_buffer()
 
                 if (
-                    agent.api_mode == "codex_responses"
-                    and agent.valid_tool_names
+                    agent.valid_tool_names
                     and codex_ack_continuations < 2
                     and agent._looks_like_codex_intermediate_ack(
                         user_message=user_message,

--- a/tests/agent/test_intermediate_ack_continuation.py
+++ b/tests/agent/test_intermediate_ack_continuation.py
@@ -1,0 +1,73 @@
+"""Tests for the intermediate-ack continuation guard (issue #38192).
+
+The guard previously only ran when ``agent.api_mode == "codex_responses"``.
+For tool-capable ``chat_completions`` deployments the same model behavior
+(replying "Let me diagnose this..." then ending the turn with zero tool
+calls) was not caught.  These tests cover the broadened action-marker set
+and confirm the helper recognizes the diagnostic-acknowledgement pattern
+regardless of ``api_mode``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
+
+
+def _fake_agent() -> SimpleNamespace:
+    return SimpleNamespace(_strip_think_blocks=lambda s: s)
+
+
+def test_let_me_diagnose_search_online_triggers_continuation() -> None:
+    agent = _fake_agent()
+    user = "Diagnose why my repo telegram path fails and search the codebase."
+    assistant = "Let me diagnose this..."
+    assert looks_like_codex_intermediate_ack(agent, user, assistant, []) is True
+
+
+def test_let_me_check_repo_triggers_continuation() -> None:
+    agent = _fake_agent()
+    user = "Please check the repository for the failing path."
+    assistant = "Let me check the project files..."
+    assert looks_like_codex_intermediate_ack(agent, user, assistant, []) is True
+
+
+def test_new_action_markers_recognized() -> None:
+    agent = _fake_agent()
+    user = "Investigate the failure in the codebase."
+    for ack in (
+        "I'll investigate the codebase shortly.",
+        "Let me troubleshoot the project now.",
+        "I will research the repository.",
+        "Let me verify the codebase state.",
+        "I'll benchmark the project hot path.",
+    ):
+        assert looks_like_codex_intermediate_ack(agent, user, ack, []) is True, ack
+
+
+def test_no_future_ack_returns_false() -> None:
+    agent = _fake_agent()
+    assert (
+        looks_like_codex_intermediate_ack(
+            agent,
+            "investigate the codebase",
+            "Here is the final answer.",
+            [],
+        )
+        is False
+    )
+
+
+def test_existing_tool_message_disables_guard() -> None:
+    agent = _fake_agent()
+    msgs = [{"role": "tool", "name": "x", "content": "ok"}]
+    assert (
+        looks_like_codex_intermediate_ack(
+            agent,
+            "diagnose the codebase",
+            "Let me diagnose this...",
+            msgs,
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

Closes #38192.

The intermediate-acknowledgement continuation guard in `run_conversation`
previously ran only when `agent.api_mode == "codex_responses"`. For
tool-capable `chat_completions` deployments the same model behavior
appeared — the model replies *"Let me diagnose this..."* (or similar) and
then ends the turn with zero tool calls, leaving the user with an empty
promise.

This PR:

- Drops the `api_mode == "codex_responses"` gate on the
  continuation guard in `agent/conversation_loop.py`, so it runs whenever
  `agent.valid_tool_names` is populated (i.e. tools are available). The
  retry cap (`< 2`) is unchanged.
- Broadens the `action_markers` tuple in
  `agent/agent_runtime_helpers.py::looks_like_codex_intermediate_ack` to
  include diagnose/diagnosing/troubleshoot/troubleshooting/benchmark/
  verify/verifying/research/researching/investigate/investigating, so
  the diagnostic-ack phrasing reported in the issue is recognized.
- Adds a regression test
  (`tests/agent/test_intermediate_ack_continuation.py`) covering the
  new markers and confirming the helper still bails when there's no
  future-tense ack or when prior tool results exist.

## How was it tested?

```
pytest tests/agent/test_intermediate_ack_continuation.py -q
# 5 passed
```

## Affected component

Agent Core — conversation loop / intermediate-ack continuation guard.
