### PR TITLE
fix(tui): close slash_worker in _finalize_session to prevent zombie processes #38095

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -304,6 +304,14 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         except Exception:
             pass
 
+    # Close slash_worker subprocess to prevent zombie processes (#38095).
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
     _notify_session_boundary("on_session_finalize", session_id)


### PR DESCRIPTION
## Summary

When a TUI session is closed,  was not cleaning up the  subprocess. This left orphaned processes accumulating each time the TUI was opened and closed while the dashboard remained running.

## Problem

 handles memory commits, notification stops, and DB session ending, but does **not** close the  subprocess. Code paths that call  without separately handling worker cleanup (e.g., TUI close without explicit  RPC) leave zombie processes.

## Fix

Add slash_worker cleanup to  so any code path that calls it properly terminates the worker subprocess. The  method is idempotent (checks  before terminating), so double-close from  is safe.

## Testing

- Verified  is idempotent
- Follows existing error-handling pattern (best-effort try/except)
- No lint errors introduced

Fixes #38095