### PR TITLE
fix(browser): smart JS scroll for SPAs with custom scroll containers.

### DIFF
--- a/tests/tools/test_browser_scroll.py
+++ b/tests/tools/test_browser_scroll.py
@@ -1,0 +1,321 @@
+"""Tests for browser_scroll smart JS scroll (SPA container fallback).
+
+Regression coverage for the bug where browser_scroll was a no-op on SPAs
+that set body{overflow:hidden} and use a child element as the real scroll
+container (e.g. LinkedIn's <main id="workspace">).
+
+Root cause: the native agent-browser binary calls window.scrollBy(), which
+does nothing when the page has locked the body overflow. The fix adds a JS
+IIFE as the primary scroll path that walks the DOM to find the real scrollable
+container. The native call is retained as a last-resort fallback.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _js_ok(container: str, by: int = 500) -> str:
+    """Simulate a successful _browser_eval response from the IIFE."""
+    return json.dumps({"result": {"scrolled": True, "by": by, "container": container}})
+
+
+def _js_no_scroll() -> str:
+    """Simulate the IIFE reporting that nothing moved (e.g. already at bottom)."""
+    return json.dumps({"result": {"scrolled": False, "by": 0, "container": "none"}})
+
+
+def _native_ok(direction: str) -> dict:
+    """Simulate a successful native agent-browser scroll response."""
+    return {"success": True, "scrolled": direction}
+
+
+def _native_fail(msg: str = "No browser session") -> dict:
+    return {"success": False, "error": msg}
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScrollJSPrimaryPath:
+    """JS IIFE fires first; native binary is not called when JS succeeds."""
+
+    def test_normal_page_window_scroll_down(self):
+        """Standard page: window.scrollBy works → no container_fallback key."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=_js_ok("window")) as mock_eval,
+            patch("tools.browser_tool._run_browser_command") as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        assert result["success"] is True
+        assert result["scrolled"] == "down"
+        assert "method" not in result, "window scroll should not set method=container_fallback"
+        assert "container" not in result
+        mock_eval.assert_called_once()
+        mock_native.assert_not_called()
+
+    def test_normal_page_window_scroll_up(self):
+        """Scroll up on a standard page uses window path."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=_js_ok("window", by=-500)),
+            patch("tools.browser_tool._run_browser_command") as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("up", task_id="test"))
+
+        assert result["success"] is True
+        assert result["scrolled"] == "up"
+        mock_native.assert_not_called()
+
+    def test_spa_custom_container_sets_container_fallback(self):
+        """SPA with body{overflow:hidden}: IIFE finds MAIN#workspace → sets method."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=_js_ok("MAIN#workspace")),
+            patch("tools.browser_tool._run_browser_command") as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        assert result["success"] is True
+        assert result["scrolled"] == "down"
+        assert result["method"] == "container_fallback"
+        assert result["container"] == "MAIN#workspace"
+        mock_native.assert_not_called()
+
+    def test_spa_scrolling_element_fallback(self):
+        """Third IIFE stage: scrollingElement used → reports as container_fallback."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=_js_ok("scrollingElement")),
+            patch("tools.browser_tool._run_browser_command") as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        assert result["success"] is True
+        assert result["method"] == "container_fallback"
+        assert result["container"] == "scrollingElement"
+        mock_native.assert_not_called()
+
+    def test_dy_is_positive_for_down(self):
+        """IIFE receives +500 when direction is 'down'."""
+        from tools.browser_tool import browser_scroll
+
+        captured = {}
+
+        def capture_js(js_str, *args, **kwargs):
+            captured["js"] = js_str
+            return _js_ok("window")
+
+        with (
+            patch("tools.browser_tool._browser_eval", side_effect=capture_js),
+            patch("tools.browser_tool._run_browser_command"),
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            browser_scroll("down", task_id="test")
+
+        assert captured["js"].endswith(")(500)")
+
+    def test_dy_is_negative_for_up(self):
+        """IIFE receives -500 when direction is 'up'."""
+        from tools.browser_tool import browser_scroll
+
+        captured = {}
+
+        def capture_js(js_str, *args, **kwargs):
+            captured["js"] = js_str
+            return _js_ok("window", by=-500)
+
+        with (
+            patch("tools.browser_tool._browser_eval", side_effect=capture_js),
+            patch("tools.browser_tool._run_browser_command"),
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            browser_scroll("up", task_id="test")
+
+        assert captured["js"].endswith(")(-500)")
+
+
+# ---------------------------------------------------------------------------
+# Native fallback
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScrollNativeFallback:
+    """Native binary is used only when the JS path fails entirely."""
+
+    def test_falls_back_to_native_when_browser_eval_raises(self):
+        """Exception from _browser_eval → native scroll called."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", side_effect=RuntimeError("CDP gone")),
+            patch("tools.browser_tool._run_browser_command", return_value=_native_ok("down")) as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        assert result["success"] is True
+        assert result["scrolled"] == "down"
+        mock_native.assert_called_once()
+
+    def test_falls_back_to_native_when_js_reports_no_scroll(self):
+        """IIFE returns scrolled:false (page already at boundary) → try native."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=_js_no_scroll()),
+            patch("tools.browser_tool._run_browser_command", return_value=_native_ok("down")) as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        # Native succeeded
+        assert result["success"] is True
+        mock_native.assert_called_once()
+
+    def test_falls_back_to_native_when_eval_returns_invalid_json(self):
+        """Malformed JSON from _browser_eval → falls through to native."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value="not-json"),
+            patch("tools.browser_tool._run_browser_command", return_value=_native_ok("up")) as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("up", task_id="test"))
+
+        assert result["success"] is True
+        mock_native.assert_called_once()
+
+    def test_native_failure_propagated(self):
+        """If JS fails AND native fails, return success:false with native error."""
+        from tools.browser_tool import browser_scroll
+
+        with (
+            patch("tools.browser_tool._browser_eval", side_effect=RuntimeError("no CDP")),
+            patch("tools.browser_tool._run_browser_command", return_value=_native_fail("No session")),
+            patch("tools.browser_tool._last_session_key", return_value="test"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="test"))
+
+        assert result["success"] is False
+        assert "No session" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScrollValidation:
+    def test_invalid_direction_returns_error(self):
+        from tools.browser_tool import browser_scroll
+
+        result = json.loads(browser_scroll("sideways", task_id="test"))
+
+        assert result["success"] is False
+        assert "Invalid direction" in result["error"]
+        assert "sideways" in result["error"]
+
+    def test_empty_direction_returns_error(self):
+        from tools.browser_tool import browser_scroll
+
+        result = json.loads(browser_scroll("", task_id="test"))
+
+        assert result["success"] is False
+        assert "Invalid direction" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: original bug (window.scrollBy no-op on SPAs)
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScrollSPARegressionLinkedIn:
+    """Regression test for the LinkedIn/SPA scroll bug.
+
+    Before the fix, browser_scroll called window.scrollBy via the native
+    agent-browser binary. On pages with body{overflow:hidden} this was a
+    complete no-op — scrollY never changed — but the tool still returned
+    {"success": true}. Downstream callers received stale DOM snapshots.
+
+    The fix: JS IIFE as primary path, ancestor walk to find the real
+    scrollable container (e.g. <main id="workspace">).
+    """
+
+    def test_spa_scroll_succeeds_without_native_binary(self):
+        """Simulate LinkedIn: body locked, MAIN#workspace is the real container."""
+        from tools.browser_tool import browser_scroll
+
+        # Simulate: window.scrollY didn't move, but MAIN#workspace did
+        iife_response = json.dumps({
+            "result": {"scrolled": True, "by": 500, "container": "MAIN#workspace"}
+        })
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value=iife_response),
+            patch("tools.browser_tool._run_browser_command") as mock_native,
+            patch("tools.browser_tool._last_session_key", return_value="linkedin-session"),
+            patch("tools.browser_tool._is_camofox_mode", return_value=False),
+        ):
+            result = json.loads(browser_scroll("down", task_id="linkedin-session"))
+
+        assert result["success"] is True
+        assert result["method"] == "container_fallback"
+        assert result["container"] == "MAIN#workspace"
+        # Critical: native binary must NOT be called — it would be a no-op
+        mock_native.assert_not_called()
+
+    def test_old_behaviour_was_silent_noop(self):
+        """Document the pre-fix behaviour for clarity.
+
+        Before the fix: _browser_eval was never called; only the native binary
+        ran. On SPAs the native binary returned success:true even though nothing
+        moved. This test confirms that if we skip _browser_eval entirely and
+        only call the native binary we get a misleading success with no
+        container_fallback information.
+        """
+        # Simulate the old code path: native binary only, claims success
+        fake_native_result = {"success": True, "scrolled": "down"}
+
+        # Reconstruct the old one-liner result manually (no JS path)
+        import json as _json
+        from tools.browser_tool import _copy_fallback_warning
+        response = {"success": True, "scrolled": "down"}
+        old_result = _json.loads(_json.dumps(_copy_fallback_warning(response, fake_native_result)))
+
+        # The old result has no indication of which container actually moved
+        assert old_result["success"] is True
+        assert "method" not in old_result  # no container_fallback info
+        assert "container" not in old_result  # silent lie on SPAs

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2665,7 +2665,52 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
         return result
 
     effective_task_id = _last_session_key(task_id or "default")
+    dy = _SCROLL_PIXELS if direction == "down" else -_SCROLL_PIXELS
 
+    # --- Smart JS scroll (primary path) ------------------------------------
+    # Uses a JS IIFE that handles both normal pages (window.scrollBy) and
+    # SPAs that lock body { overflow: hidden } and scroll a child container
+    # (e.g. LinkedIn's <main id="workspace">).  Tried first because it's
+    # more reliable than the native agent-browser scroll command which only
+    # calls window.scrollBy and silently does nothing on such SPAs.
+    smart_js = (
+        "(function(dy){"
+        "var before=window.scrollY;"
+        "window.scrollBy(0,dy);"
+        "if(window.scrollY!==before){return{scrolled:true,by:window.scrollY-before,container:'window'};}"
+        "var el=document.elementFromPoint(window.innerWidth/2,window.innerHeight/2);"
+        "while(el&&el!==document.body&&el!==document.documentElement){"
+        "var st=getComputedStyle(el),ov=st.overflow+' '+st.overflowY;"
+        "if((ov.indexOf('scroll')!==-1||ov.indexOf('auto')!==-1)&&el.scrollHeight>el.clientHeight){"
+        "var b2=el.scrollTop;"
+        "el.scrollTop+=dy;"
+        "if(el.scrollTop!==b2){return{scrolled:true,by:el.scrollTop-b2,container:el.tagName+(el.id?'#'+el.id:'')};}"
+        "}"
+        "el=el.parentElement;"
+        "}"
+        "var se=document.scrollingElement;"
+        "if(se&&se.scrollHeight>se.clientHeight){"
+        "var b3=se.scrollTop;"
+        "se.scrollTop+=dy;"
+        "if(se.scrollTop!==b3){return{scrolled:true,by:se.scrollTop-b3,container:'scrollingElement'};}"
+        "}"
+        "return{scrolled:false,by:0,container:'none'};"
+        "})(" + str(dy) + ")"
+    )
+    try:
+        js_raw = _browser_eval(smart_js, task_id)
+        js_data = json.loads(js_raw)
+        js_result = js_data.get("result", {})
+        if isinstance(js_result, dict) and js_result.get("scrolled"):
+            response: Dict[str, Any] = {"success": True, "scrolled": direction}
+            if js_result.get("container") not in (None, "window"):
+                response["method"] = "container_fallback"
+                response["container"] = js_result["container"]
+            return json.dumps(response, ensure_ascii=False)
+    except Exception as exc:
+        logger.debug("browser_scroll: JS smart-scroll path failed (%s), falling back to native", exc)
+
+    # --- Native agent-browser fallback ------------------------------------
     result = _run_browser_command(effective_task_id, "scroll", [direction, str(_SCROLL_PIXELS)])
     if not result.get("success"):
         response = {

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2711,6 +2711,8 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
         logger.debug("browser_scroll: JS smart-scroll path failed (%s), falling back to native", exc)
 
     # --- Native agent-browser fallback ------------------------------------
+    # Runs when JS threw an exception OR when JS reported scrolled=False
+    # (nothing moved — page already at boundary or non-scrollable container).
     result = _run_browser_command(effective_task_id, "scroll", [direction, str(_SCROLL_PIXELS)])
     if not result.get("success"):
         response = {


### PR DESCRIPTION
## What does this PR do?

The native agent-browser scroll command calls `window.scrollBy()` which is a no-op on SPAs like LinkedIn that set `body{overflow:hidden}` and use a child element (e.g. `<main id="workspace">`) as the real scroll container.

Replace the single native call with a JS IIFE primary path that:
1. Tries `window.scrollBy` + checks `scrollY` (fast path for normal pages)
2. Walks ancestors from the element at the viewport centre, looking for a scrollable container (`overflow:scroll/auto` + `scrollHeight` greater than `clientHeight`)
3. Falls back to `document.scrollingElement`

The native agent-browser scroll call is retained as a last-resort fallback if the JS eval fails entirely (e.g. browser not connected).

The JS return values use explicit `{return...;}` blocks to avoid ASI edge cases that caused a silent SyntaxError in an earlier iteration of this fix.

Verified on LinkedIn (MAIN#workspace scrolls correctly) and Wikipedia (window.scrollY path).


## Related Issue

Fixes #38215

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`tools/browser_tool.py`

Replace the single native-binary call with a JS IIFE primary path. The IIFE tries three strategies in order:

1. `window.scrollBy` + verify `window.scrollY` moved (fast path — normal pages).
2. Walk DOM ancestors from `document.elementFromPoint(cx, cy)`, find the first element with `overflow: scroll/auto` and `scrollHeight > clientHeight`, scroll it directly.
3. Fall back to `document.scrollingElement`.

The native `agent-browser scroll` call is retained as a last-resort fallback for environments where JS eval is unavailable.

- 

## How to Test

1. Connect to a browser using `/browser connect`
2. Navigate to a page that uses a custom scroll container — LinkedIn (linkedin.com/in/*) is a reliable reproducer.
3. Call `browser_scroll(direction="down")`.
4. Observe the tool returns `{"success": true, "scrolled": "down"}`.
5. Inspect the page — the viewport has moved; content below the fold is visible.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



