### PR TITLE
fix(desktop): stop chat scroll bounce — at-rest backward jump + wheel-up snap-back

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -415,6 +415,40 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+    await wait(0)
+
+    await act(async () => {
+      fireEvent.wheel(viewport, { deltaY: -120 })
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
   it('renders reasoning text without a leading token space', () => {
     const { container } = render(<ReasoningHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -182,6 +182,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
   // user-driven upward scroll; re-armed when they reach bottom again.
   const armedRef = useRef(true)
   const lastTopRef = useRef(0)
+  const lastHeightRef = useRef(0)
   // Counter that tracks how many scroll events we expect to be ours rather
   // than the user's. `pinToBottom` writes `el.scrollTop`, which fires an
   // async `scroll` event; without this guard the on-scroll handler can race
@@ -206,6 +207,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     programmaticScrollPendingRef.current += 1
     el.scrollTop = el.scrollHeight
     lastTopRef.current = el.scrollTop
+    lastHeightRef.current = el.scrollHeight
   }, [scrollerRef])
 
   const jumpToBottom = useCallback(() => {
@@ -250,6 +252,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
       if (programmaticScrollPendingRef.current > 0) {
         programmaticScrollPendingRef.current -= 1
         lastTopRef.current = top
+        lastHeightRef.current = el.scrollHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
         armedRef.current = true
         const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
@@ -258,11 +261,26 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         return
       }
 
-      if (top + 1 < lastTopRef.current) {
+      // Disarm only when `scrollTop` decreases AND `scrollHeight` did NOT
+      // grow this frame. A bare `top < lastTopRef.current` check is unsafe:
+      // when content grows (virtualizer item measurement, streaming token,
+      // code highlight re-tokenization, composer chip), the browser emits
+      // an interim `scroll` event whose `scrollTop` is smaller than the
+      // previous frame's because `scrollHeight` jumped — this fires before
+      // the rAF-scheduled `pinToBottom` runs, so `programmaticScrollPendingRef`
+      // is 0. Treating that as a user scroll permanently disarmed sticky-bottom
+      // and produced the visible at-rest backward jump (#37997). Gating on a
+      // stable `scrollHeight` keeps real user-driven upward intent — scrollbar
+      // drag, keyboard PgUp, programmatic scrollIntoView — covered without
+      // the false positive. Wheel-up and touchmove still disarm via their
+      // own listeners below.
+      const heightGrew = el.scrollHeight > lastHeightRef.current
+      if (!heightGrew && top + 1 < lastTopRef.current) {
         armedRef.current = false
       }
 
       lastTopRef.current = top
+      lastHeightRef.current = el.scrollHeight
 
       const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
 
@@ -323,8 +341,9 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const observer = new ResizeObserver(schedulePin)
 
-    observer.observe(el)
-
+    // Observe ONLY the content (firstElementChild), not the scroller `el`
+    // itself. Resizes of the viewport/scroller (window resize, devtools
+    // panel toggle) shouldn't trigger a pin — only content growth should.
     if (el.firstElementChild) {
       observer.observe(el.firstElementChild)
     }

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -237,6 +237,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const disarm = () => {
       armedRef.current = false
+      programmaticScrollPendingRef.current = 0
     }
 
     const onScroll = () => {


### PR DESCRIPTION
## Summary
Desktop chat no longer bounces, jumps backward, or snaps back to the bottom while reading. Two distinct disarm bugs in `useThreadScrollAnchor` are fixed together.

The Desktop scroll anchor had two independent failure modes, both reported across Win11/macOS/Linux (#37997, #37811, #37527):

1. **At-rest backward jump** — when content grows mid-frame (virtualizer item measure, streaming token, code re-highlight), the browser emits an interim `scroll` event whose `scrollTop` is lower than last frame because `scrollHeight` just jumped. This fires before the rAF `pinToBottom` runs, so it was misread as a user scroll-up → sticky-bottom disarmed permanently → viewport stuck ~50px above bottom.
2. **Wheel-up snap-back** — `programmaticScrollPendingRef` went stale when the browser was already clamped at bottom (the expected programmatic scroll event never arrived). The user's next real wheel-up was consumed as "ours" → re-armed → next content-growth pin yanked them back down.

The two fixes touch disjoint lines of the same hook and are complementary, not competing.

## Changes
- `thread-virtualizer.tsx` (`onScroll`): gate disarm on `heightGrew` — only disarm when `scrollTop` decreases **and** `scrollHeight` did not grow this frame. Real upward intent (scrollbar drag, PgUp) still disarms; interim content-growth scrolls don't. Also stop observing the scroller element itself in the ResizeObserver (only the content child), so viewport-only resizes don't trigger spurious pins. (#38019, @luyao618)
- `thread-virtualizer.tsx` (`disarm`): clear the stale `programmaticScrollPendingRef` on user wheel/touch so the first upward wheel always registers. (#37831, @ferminquant)
- `streaming.test.tsx`: regression test for the stale-pending-programmatic-scroll path. (#37831)

## Validation
| | Before | After |
|---|---|---|
| streaming.test.tsx | wheel-up regression failed on main | 10/10 pass (both wheel-up tests + at-rest cases) |
| `npx tsc -b` | — | 0 errors |
| `eslint` (changed files) | 6 pre-existing warnings | 0 errors, same pre-existing warnings |

Closes #37997, #37527, #37811.

Salvage of #38019 (@luyao618) + #37831 (@ferminquant), cherry-picked onto current main with authorship preserved.

## Infographic

![desktop-chat-scroll-stabilized](https://v3b.fal.media/files/b/0a9cd073/FnaqU6AW4xzHd3c7BdH-H_DsbrNTXP.png)
