### PR TITLE
fix(dingtalk): prevent richText fallback from resetting voice to text

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -804,10 +804,52 @@ class DingTalkAdapter(BasePlatformAdapter):
                                 if msg_type == MessageType.TEXT:
                                     msg_type = MessageType.DOCUMENT
 
+        # Extract native voice/audio/video/file payloads from
+        # message.extensions["content"].  The dingtalk-stream SDK does not
+        # convert ``msgtype=voice`` callbacks into typed content objects;
+        # the raw dict lives under ``extensions["content"]`` instead.
+        if not media_urls:
+            ext_content = {}
+            try:
+                ext_content = (getattr(message, "extensions", None) or {}).get("content", {}) or {}
+            except (AttributeError, TypeError):
+                pass
+            if isinstance(ext_content, dict):
+                native_type = ext_content.get("msgtype") or ext_content.get("type", "")
+                dl_code = ext_content.get("downloadCode") or ext_content.get("download_code") or ""
+                if dl_code and native_type:
+                    mapped = DINGTALK_TYPE_MAPPING.get(native_type, "file")
+                    media_urls.append(dl_code)
+                    if mapped == "image":
+                        media_types.append("image")
+                        if msg_type == MessageType.TEXT:
+                            msg_type = MessageType.PHOTO
+                    elif mapped == "audio":
+                        media_types.append("audio")
+                        if msg_type == MessageType.TEXT:
+                            msg_type = MessageType.VOICE if native_type == "voice" else MessageType.AUDIO
+                    elif native_type == "audio":
+                        media_types.append("audio")
+                        if msg_type == MessageType.TEXT:
+                            msg_type = MessageType.AUDIO
+                    elif native_type in ("video",):
+                        media_types.append("video")
+                        if msg_type == MessageType.TEXT:
+                            msg_type = MessageType.VIDEO
+                    elif native_type in ("file",):
+                        media_types.append("application/octet-stream")
+                        if msg_type == MessageType.TEXT:
+                            msg_type = MessageType.DOCUMENT
+
         msg_type_str = getattr(message, "message_type", "") or ""
         if msg_type_str == "picture" and not media_urls:
             msg_type = MessageType.PHOTO
-        elif msg_type_str == "richText":
+        elif msg_type_str == "richText" and msg_type == MessageType.TEXT:
+            # Only apply the richText fallback when _extract_media has not
+            # already classified the message (e.g. voice → VOICE for STT,
+            # audio → AUDIO for attachments).  The earlier loop sets msg_type
+            # for every rich-text media item; resetting unconditionally here
+            # overwrote VOICE back to TEXT, breaking DingTalk voice-note STT.
             msg_type = (
                 MessageType.PHOTO
                 if any("image" in t for t in media_types)

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -581,6 +581,8 @@ class TestExtractMedia:
         msg.image_content = None
         msg.rich_text_content = None
         msg.rich_text = items
+        msg.message_type = "richText"
+        msg.extensions = {}
         return msg
 
     def test_voice_rich_text_item_classified_as_voice(self):
@@ -621,6 +623,81 @@ class TestExtractMedia:
             assert mtypes == ["audio"]
         finally:
             del DINGTALK_TYPE_MAPPING["audio"]
+
+    def test_rich_text_voice_not_reset_to_text(self):
+        """Regression: the richText fallback must not overwrite VOICE back to
+        TEXT when the rich-text loop already classified a voice item."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text(
+            [{"type": "voice", "downloadCode": "dl_voice_reg"}]
+        )
+        # message_type is "richText" (set by helper) — the fallback at
+        # _extract_media line ~810 must NOT reset msg_type to TEXT.
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.VOICE, (
+            f"richText fallback overwrote VOICE to {msg_type}"
+        )
+        assert urls == ["dl_voice_reg"]
+        assert mtypes == ["audio"]
+
+    def test_rich_text_image_still_photo(self):
+        """Image-only richText messages must still be classified as PHOTO."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text(
+            [{"type": "picture", "downloadCode": "dl_img_123"}]
+        )
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.PHOTO
+        assert urls == ["dl_img_123"]
+        assert mtypes == ["image"]
+
+    def test_native_voice_from_extensions(self):
+        """Native msgtype=voice callbacks (not converted by SDK) should be
+        extracted from message.extensions["content"]."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.text = None
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = ""
+        msg.extensions = {"content": {"msgtype": "voice", "downloadCode": "dl_ext_voice"}}
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.VOICE
+        assert urls == ["dl_ext_voice"]
+        assert mtypes == ["audio"]
+
+    def test_native_audio_from_extensions(self):
+        """Native msgtype=audio callbacks should be extracted as AUDIO (not
+        auto-transcribed)."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.text = None
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = ""
+        msg.extensions = {"content": {"msgtype": "audio", "downloadCode": "dl_ext_audio"}}
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.AUDIO
+        assert urls == ["dl_ext_audio"]
+        assert mtypes == ["audio"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in DingTalk's `_extract_media` that prevent inbound voice messages from reaching the STT pipeline:

1. **richText fallback resets VOICE to TEXT** — When `message_type == "richText"`, the fallback at the end of `_extract_media` unconditionally set `msg_type` to `PHOTO` (if any image) or `TEXT` (otherwise), overwriting the `VOICE` classification the rich-text loop had already set for `type: "voice"` items.

2. **Native voice/audio payloads never extracted** — The dingtalk-stream SDK does not convert `msgtype=voice` / `msgtype=audio` callbacks into typed content objects. Their payload lives under `message.extensions["content"]`, but `_extract_media` never inspected that path, so native voice notes were silently skipped.

## Related Issue

Fixes #38211

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/dingtalk.py`: Guard the richText fallback to only apply when `msg_type` is still `MessageType.TEXT`, preserving earlier VOICE/AUDIO/PHOTO classifications. Add extraction of native voice/audio/video/file payloads from `message.extensions["content"]`.
- `tests/gateway/test_dingtalk.py`: Fix `_msg_with_rich_text` helper to set `message_type="richText"` (realistic mock that catches the fallback bug). Add regression tests: `test_rich_text_voice_not_reset_to_text`, `test_rich_text_image_still_photo`, `test_native_voice_from_extensions`, `test_native_audio_from_extensions`.

## How to Test

1. `cd hermes-agent && python3 -m pytest tests/gateway/test_dingtalk.py -x -q` — all 72 tests pass, including the 4 new regression tests
2. The key regression test (`test_rich_text_voice_not_reset_to_text`) would FAIL on the old code because the `message_type="richText"` mock triggers the fallback that resets VOICE to TEXT
3. `test_native_voice_from_extensions` verifies that `msgtype=voice` payloads in `extensions["content"]` are correctly routed to `MessageType.VOICE` for STT

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_dingtalk.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/dingtalk.py::_extract_media` (called from `_process_inbound_message`, single call site)
- Blast radius: LOW — DingTalk platform adapter only, no cross-platform impact
- Related patterns: PR #28993 (original voice→VOICE fix for richText items) introduced the `item_type == "voice"` check but didn't account for the richText fallback overriding it
