### PR TITLE
fix(cli): migrate gateway token from gateway.remote.token (OpenClaw 2026.5.x schema)

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -2410,10 +2410,15 @@ class Migrator:
         self.record("gateway-config", "openclaw.json gateway.*", "archive/gateway-config.json",
                     "archived", "Gateway config archived. Use 'hermes gateway' to configure.")
 
-        # Extract gateway auth token to .env if present
+        # Extract gateway auth token to .env if present.
+        # OpenClaw 2026.5.x stores the token at gateway.remote.token (remote-mode
+        # clients) while older local-mode installs use gateway.auth.token.
+        # Check both paths so migrations work regardless of which schema is present.
         auth = gateway.get("auth") or {}
-        if auth.get("token") and self.migrate_secrets:
-            self._set_env_var("HERMES_GATEWAY_TOKEN", auth["token"], "gateway.auth.token")
+        remote = gateway.get("remote") or {}
+        token = auth.get("token") or remote.get("token")
+        if token and self.migrate_secrets:
+            self._set_env_var("HERMES_GATEWAY_TOKEN", token, "gateway.auth.token or gateway.remote.token")
 
     # ── Session config ────────────────────────────────────────
     def migrate_session_config(self, config: Optional[Dict[str, Any]] = None) -> None:

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -1107,3 +1107,95 @@ def test_migrate_model_config_no_catalog_leaves_value_alone(tmp_path: Path):
         {"agents": {"defaults": {"model": "some-model-id"}}},
     )
     assert _extract_model(parsed) == "some-model-id"
+
+
+# ── Gateway token migration ──────────────────────────────────────────────────
+
+
+def test_gateway_token_migrated_from_remote_path(tmp_path: Path):
+    """HERMES_GATEWAY_TOKEN is extracted from gateway.remote.token.
+
+    OpenClaw 2026.5.7 stores the gateway token at gateway.remote.token, not
+    at gateway.auth.token.  The migration must handle this real-world schema.
+    """
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    (source / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "gateway": {
+                    "mode": "remote",
+                    "remote": {
+                        "url": "wss://example.com/gateway",
+                        "token": "test-token-abc123",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=True,
+        output_dir=None,
+        selected_options={"gateway-config"},
+    )
+    migrator.migrate()
+
+    env_path = target / ".env"
+    assert env_path.exists(), ".env was not created by migration"
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "HERMES_GATEWAY_TOKEN=test-token-abc123" in env_text
+
+
+def test_gateway_token_migrated_from_auth_path(tmp_path: Path):
+    """HERMES_GATEWAY_TOKEN is also extracted from gateway.auth.token (legacy path).
+
+    Older OpenClaw versions stored the token at gateway.auth.token.  Both
+    paths must be supported for backward compatibility.
+    """
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    (source / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "gateway": {
+                    "mode": "local",
+                    "auth": {
+                        "token": "legacy-token-xyz789",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=True,
+        output_dir=None,
+        selected_options={"gateway-config"},
+    )
+    migrator.migrate()
+
+    env_path = target / ".env"
+    assert env_path.exists(), ".env was not created by migration"
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "HERMES_GATEWAY_TOKEN=legacy-token-xyz789" in env_text

--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -159,7 +159,7 @@ TTS settings are read from **two** OpenClaw config locations with this priority:
 | Browser CDP URL | `browser.cdpUrl` | `config.yaml` → `browser.cdp_url` | |
 | Browser headless | `browser.headless` | `config.yaml` → `browser.headless` | |
 | Brave search key | `tools.web.search.brave.apiKey` | `.env` → `BRAVE_API_KEY` | Requires `--migrate-secrets` |
-| Gateway auth token | `gateway.auth.token` | `.env` → `HERMES_GATEWAY_TOKEN` | Requires `--migrate-secrets` |
+| Gateway auth token | `gateway.auth.token` or `gateway.remote.token` | `.env` → `HERMES_GATEWAY_TOKEN` | Requires `--migrate-secrets`. OpenClaw 2026.5.x remote-mode clients store the token at `gateway.remote.token`; older local installs use `gateway.auth.token`. Both paths are checked. |
 | Working directory | `agents.defaults.workspace` | `config.yaml` → `terminal.cwd` | Legacy migrations may still emit `MESSAGING_CWD` as a compatibility fallback |
 
 ### Archived (no direct Hermes equivalent)


### PR DESCRIPTION
Closes #38228

### What changed

`migrate_gateway_config()` in `openclaw_to_hermes.py` previously read the gateway token only from `gateway.auth.token`. OpenClaw 2026.5.x remote-mode clients store it at `gateway.remote.token` instead, so `HERMES_GATEWAY_TOKEN` was silently dropped during migration even when `--migrate-secrets` was passed.

The fix checks both paths with `auth.get("token") or remote.get("token")`, preferring `gateway.auth.token` when both are present (preserves existing behavior for legacy configs). Updated the doc table in `migrate-from-openclaw.md` to reflect both source paths.

### Changes

- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`: read token from `gateway.auth.token` or `gateway.remote.token`, whichever is set.
- `tests/skills/test_openclaw_migration.py`: two new tests - one for each schema path. The `remote_path` test was confirmed failing on main before the fix.
- `website/docs/guides/migrate-from-openclaw.md`: updated the gateway token row to document both source paths.

### Test plan

- [x] `test_gateway_token_migrated_from_remote_path` - was FAILED before fix, PASSED after
- [x] `test_gateway_token_migrated_from_auth_path` - was PASSED before fix (backward compat preserved), still PASSES after
- [x] Full migration test suite: 69 passed, 0 failed, 0 regressions

### OS tested

macOS 15.x (Apple Silicon), Python 3.11.15

### Supply chain

Zero new dependencies. Change touches only the migration script, one test file, and one doc page.