### PR TITLE
fix: preserve goals across compression sessions

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -530,6 +530,16 @@ def compress_context(
                 except (ValueError, Exception) as e:
                     logger.debug("Could not propagate title on compression: %s", e)
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            try:
+                from hermes_cli.goals import migrate_goal_to_session
+
+                migrate_goal_to_session(
+                    old_session_id,
+                    agent.session_id,
+                    reason="compression",
+                )
+            except Exception as goal_err:
+                logger.debug("GoalManager migration on compression failed: %s", goal_err)
             # Reset flush cursor — new session starts with no messages written
             agent._last_flushed_db_idx = 0
         except Exception as e:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -8,7 +8,9 @@ goal is done, turn budget is exhausted, the user pauses/clears it, or the
 user sends a new message (which takes priority and pauses the goal loop).
 
 State is persisted in SessionDB's ``state_meta`` table keyed by
-``goal:<session_id>`` so ``/resume`` picks it up.
+``goal:<session_id>`` so ``/resume`` picks it up. Compression rotates the
+physical session id, so unfinished goal state is copied to the continuation
+session and the old row is archived as non-active.
 
 Design notes / invariants:
 
@@ -219,7 +221,8 @@ def _get_session_db() -> Optional[Any]:
         from hermes_constants import get_hermes_home
         from hermes_state import SessionDB
 
-        home = str(get_hermes_home())
+        home_path = get_hermes_home()
+        home = str(home_path)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB bootstrap failed (%s)", exc)
         return None
@@ -228,7 +231,7 @@ def _get_session_db() -> Optional[Any]:
     if cached is not None:
         return cached
     try:
-        db = SessionDB()
+        db = SessionDB(db_path=home_path / "state.db")
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB() raised (%s)", exc)
         return None
@@ -277,6 +280,127 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+
+
+def _copy_goal_state(state: GoalState) -> GoalState:
+    """Return an independent serializable copy of a goal state."""
+    return GoalState.from_json(state.to_json())
+
+
+def migrate_goal_to_session(
+    old_session_id: str,
+    new_session_id: str,
+    *,
+    reason: str = "session switch",
+) -> bool:
+    """Copy an unfinished persistent goal across a logical-session boundary.
+
+    Goal state is stored under ``goal:<session_id>``. Context compression and
+    continuation flows can rotate the SQLite session id while the user's
+    logical task continues; without rebinding, the new GoalManager sees no
+    state and the goal loop stops silently.
+
+    Returns True when an active/paused goal was copied to ``new_session_id``.
+    Finished/cleared/missing source goals are no-ops. Existing destination
+    active/paused/done state is never overwritten; the caller can retry later
+    or resolve the conflict explicitly.
+    """
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+
+    try:
+        source = load_goal(old_session_id)
+        if source is None or source.status not in {"active", "paused"}:
+            return False
+
+        dest = load_goal(new_session_id)
+        if dest is not None and dest.status in {"active", "paused", "done"}:
+            logger.debug(
+                "GoalManager: not migrating %s to %s; destination already has %s goal",
+                old_session_id,
+                new_session_id,
+                dest.status,
+            )
+            return False
+
+        save_goal(new_session_id, _copy_goal_state(source))
+
+        archived = _copy_goal_state(source)
+        archived.status = "cleared"
+        archived.paused_reason = (
+            f"migrated to continuation session {new_session_id} ({reason})"
+        )
+        save_goal(old_session_id, archived)
+        logger.debug(
+            "GoalManager: migrated goal from %s to %s (%s)",
+            old_session_id,
+            new_session_id,
+            reason,
+        )
+        return True
+    except Exception as exc:
+        # Goal migration must never break the primary conversation turn.
+        logger.debug(
+            "GoalManager: migration from %s to %s failed: %s",
+            old_session_id,
+            new_session_id,
+            exc,
+        )
+        return False
+
+
+def _maybe_recover_goal_from_compression_lineage(session_id: str) -> Optional[GoalState]:
+    """Recover a goal orphaned on a compression parent, if lineage proves it.
+
+    This is a fail-soft compatibility path for sessions created by builds that
+    rotated ``session_id`` before goal migration existed. Only parents ended
+    with ``end_reason='compression'`` are considered, so normal branches,
+    delegates, and /new sessions do not inherit an unrelated goal.
+    """
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        return None
+
+    try:
+        current = db.get_session(session_id)
+    except Exception as exc:
+        logger.debug("GoalManager: could not inspect session lineage for %s: %s", session_id, exc)
+        return None
+
+    seen = {session_id}
+    while current:
+        parent_id = (current.get("parent_session_id") or "").strip()
+        if not parent_id or parent_id in seen:
+            return None
+        seen.add(parent_id)
+
+        try:
+            parent = db.get_session(parent_id)
+        except Exception as exc:
+            logger.debug("GoalManager: could not load parent session %s: %s", parent_id, exc)
+            return None
+        if not parent or parent.get("end_reason") != "compression":
+            return None
+
+        migrated = migrate_goal_to_session(
+            parent_id,
+            session_id,
+            reason="compression lineage recovery",
+        )
+        if migrated:
+            return load_goal(session_id)
+
+        parent_goal = load_goal(parent_id)
+        if parent_goal is not None and parent_goal.status in {"active", "paused"}:
+            # A destination conflict or write failure prevented migration. Do
+            # not walk past an unfinished parent goal and risk stealing older
+            # lineage state.
+            return None
+
+        current = parent
+    return None
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -489,6 +613,8 @@ class GoalManager:
         self.session_id = session_id
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
         self._state: Optional[GoalState] = load_goal(session_id)
+        if self._state is None:
+            self._state = _maybe_recover_goal_from_compression_lineage(session_id)
 
     # --- introspection ------------------------------------------------
 
@@ -907,6 +1033,7 @@ __all__ = [
     "load_goal",
     "save_goal",
     "clear_goal",
+    "migrate_goal_to_session",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -24,11 +24,19 @@ def hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(home))
 
     # Bust the goal-module's DB cache for each test so it re-resolves HERMES_HOME.
+    # Some agent tests use context-local Hermes home overrides; set our own so
+    # this fixture remains isolated even when those modules run in the same
+    # pytest process.
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
     from hermes_cli import goals
 
+    token = set_hermes_home_override(home)
     goals._DB_CACHE.clear()
-    yield home
-    goals._DB_CACHE.clear()
+    try:
+        yield home
+    finally:
+        goals._DB_CACHE.clear()
+        reset_hermes_home_override(token)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -251,6 +259,123 @@ class TestGoalManager:
         assert mgr2.state is not None
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
+
+    def test_migrate_unfinished_goal_to_compression_continuation_session(self, hermes_home):
+        """Regression: a /compress-created session id must not orphan /goal state."""
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_to_session, save_goal
+
+        old_mgr = GoalManager(session_id="goal-before-compress", default_max_turns=7)
+        old_mgr.set("finish the long-running task")
+        old_mgr.state.turns_used = 3
+        old_mgr.state.subgoals.append("preserve this criterion too")
+        save_goal(old_mgr.session_id, old_mgr.state)
+
+        migrated = migrate_goal_to_session(
+            "goal-before-compress",
+            "goal-after-compress",
+            reason="compression",
+        )
+
+        assert migrated is True
+        new_mgr = GoalManager(session_id="goal-after-compress")
+        assert new_mgr.state is not None
+        assert new_mgr.state.goal == "finish the long-running task"
+        assert new_mgr.state.status == "active"
+        assert new_mgr.state.max_turns == 7
+        assert new_mgr.state.turns_used == 3
+        assert new_mgr.state.subgoals == ["preserve this criterion too"]
+
+        old_state = load_goal("goal-before-compress")
+        assert old_state is not None
+        assert old_state.status == "cleared"
+        assert "goal-after-compress" in (old_state.paused_reason or "")
+
+    def test_migrate_paused_goal_to_continuation_session(self, hermes_home):
+        from hermes_cli.goals import GoalManager, migrate_goal_to_session
+
+        old_mgr = GoalManager(session_id="paused-before-compress")
+        old_mgr.set("paused long task")
+        old_mgr.pause(reason="waiting for budget")
+
+        assert migrate_goal_to_session("paused-before-compress", "paused-after-compress") is True
+
+        new_mgr = GoalManager(session_id="paused-after-compress")
+        assert new_mgr.state is not None
+        assert new_mgr.state.goal == "paused long task"
+        assert new_mgr.state.status == "paused"
+        assert new_mgr.state.paused_reason == "waiting for budget"
+
+    def test_migrate_goal_does_not_overwrite_existing_destination_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager, migrate_goal_to_session
+
+        old_mgr = GoalManager(session_id="old-with-goal")
+        old_mgr.set("old goal that should stay put")
+        new_mgr = GoalManager(session_id="new-with-goal")
+        new_mgr.set("existing destination goal")
+
+        assert migrate_goal_to_session("old-with-goal", "new-with-goal") is False
+
+        old_reloaded = GoalManager(session_id="old-with-goal")
+        new_reloaded = GoalManager(session_id="new-with-goal")
+        assert old_reloaded.state.status == "active"
+        assert old_reloaded.state.goal == "old goal that should stay put"
+        assert new_reloaded.state.status == "active"
+        assert new_reloaded.state.goal == "existing destination goal"
+
+    def test_migrate_goal_noops_for_missing_finished_or_same_session(self, hermes_home):
+        from hermes_cli.goals import GoalManager, migrate_goal_to_session
+
+        assert migrate_goal_to_session("", "new") is False
+        assert migrate_goal_to_session("same", "same") is False
+        assert migrate_goal_to_session("missing", "new") is False
+
+        done_mgr = GoalManager(session_id="done-goal")
+        done_mgr.set("already finished")
+        done_mgr.mark_done("complete")
+        assert migrate_goal_to_session("done-goal", "done-new") is False
+        assert GoalManager(session_id="done-new").state is None
+
+        cleared_mgr = GoalManager(session_id="cleared-goal")
+        cleared_mgr.set("already cleared")
+        cleared_mgr.clear()
+        assert migrate_goal_to_session("cleared-goal", "cleared-new") is False
+        assert GoalManager(session_id="cleared-new").state is None
+
+    def test_goal_manager_recovers_goal_from_compression_parent_lineage(self, hermes_home):
+        """If a previous build missed the migration hook, the child can recover via lineage."""
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, load_goal
+
+        db = SessionDB(db_path=hermes_home / "state.db")
+        db.create_session("lineage-parent", "cli")
+        parent_mgr = GoalManager(session_id="lineage-parent")
+        parent_mgr.set("recover me after compression")
+        db.end_session("lineage-parent", "compression")
+        db.create_session("lineage-child", "cli", parent_session_id="lineage-parent")
+
+        child_mgr = GoalManager(session_id="lineage-child")
+
+        assert child_mgr.state is not None
+        assert child_mgr.state.goal == "recover me after compression"
+        assert child_mgr.state.status == "active"
+        parent_state = load_goal("lineage-parent")
+        assert parent_state is not None
+        assert parent_state.status == "cleared"
+
+    def test_goal_manager_does_not_inherit_non_compression_parent_goal(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager
+
+        db = SessionDB(db_path=hermes_home / "state.db")
+        db.create_session("branch-parent", "cli")
+        parent_mgr = GoalManager(session_id="branch-parent")
+        parent_mgr.set("do not copy to branch")
+        db.create_session("branch-child", "cli", parent_session_id="branch-parent")
+
+        child_mgr = GoalManager(session_id="branch-child")
+
+        assert child_mgr.state is None
+        assert GoalManager(session_id="branch-parent").is_active()
 
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -90,6 +90,56 @@ class TestCompressionBoundaryHook:
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
 
+    def test_compression_rotates_goal_state_to_new_session(self):
+        """Compression split carries active /goal state to the new physical session."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager, load_goal
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"HERMES_HOME": str(Path(tmpdir))}):
+                db = SessionDB(db_path=Path(tmpdir) / "test.db")
+                agent = self._make_agent(db)
+                goals._DB_CACHE.clear()
+                goals._DB_CACHE[str(Path(tmpdir))] = db
+
+                compressor = MagicMock()
+                compressor.compress.return_value = [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": "tail question"},
+                ]
+                compressor.compression_count = 1
+                compressor.last_prompt_tokens = 0
+                compressor.last_completion_tokens = 0
+                compressor._last_summary_error = None
+                compressor._last_compress_aborted = False
+                agent.context_compressor = compressor
+
+                original_sid = agent.session_id
+                db.create_session(original_sid, "cli")
+                goal_mgr = GoalManager(session_id=original_sid, default_max_turns=9)
+                goal_mgr.set("survive compression")
+
+                try:
+                    agent._compress_context(
+                        [{"role": "user", "content": f"m{i}"} for i in range(10)],
+                        "sys",
+                        approx_tokens=10_000,
+                    )
+
+                    assert agent.session_id != original_sid
+                    continued = GoalManager(session_id=agent.session_id)
+                    assert continued.state is not None
+                    assert continued.state.goal == "survive compression"
+                    assert continued.state.status == "active"
+                    assert continued.state.max_turns == 9
+
+                    old_state = load_goal(original_sid)
+                    assert old_state is not None
+                    assert old_state.status == "cleared"
+                finally:
+                    goals._DB_CACHE.clear()
+
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary
- preserve persistent `/goal` state when compression rotates `agent.session_id` into a continuation session
- add fail-soft goal migration helper that copies only unfinished goals and archives the source as non-active
- add lineage recovery for already-created compression children plus regression coverage for direct migration and the real compression boundary

## Why
`GoalManager` stores state in `SessionDB.state_meta` under `goal:<session_id>`. Compression creates a new child session id, so the next `GoalManager(new_session_id)` used to miss the active goal and the judging/continuation loop stopped silently.

## Safety
- no-op for missing, done, cleared, blank, or same-session goals
- does not overwrite destination `active`, `paused`, or `done` goals
- migration errors are logged at debug level and never break the main conversation turn
- source goal is archived as `cleared` instead of deleting metadata

## Tests
- `python3 -m pytest tests/hermes_cli/test_goals.py tests/run_agent/test_compression_boundary_hook.py -q -o 'addopts='` — 60 passed, 1 warning
- `python3 -m pytest tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_boundary.py tests/gateway/test_compression_session_id_persistence.py tests/agent/test_compression_concurrent_fork.py tests/hermes_cli/test_goals.py -q -o 'addopts='` — 76 passed, 1 warning

Fixes #33618.
