### PR TITLE
fix: remove redundant _turn_exit_reason assignment

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -815,7 +815,6 @@ def run_conversation(
         if agent._budget_grace_call:
             agent._budget_grace_call = False
         elif not agent.iteration_budget.consume():
-            _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break


### PR DESCRIPTION
Closes #38162

The line '_turn_exit_reason = "budget_exhausted"' is redundant because the variable is unconditionally overwritten by 'max_iterations_reached(...)' on the very next lines. Removing it has no behavioral effect.