### PR TITLE
fix: warn when claw migrate source is a remote-mode OpenClaw client

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import importlib.util
+import json
 import logging
 import subprocess
 import sys
@@ -182,6 +183,51 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
     if not auto_yes and not prompt_yes_no("Continue anyway?", default=False):
         print_info("Migration cancelled. Stop the gateway and try again.")
         sys.exit(0)
+
+
+def _warn_if_remote_client(source_dir: Path) -> bool:
+    """Check if the OpenClaw source appears to be a remote-mode client.
+
+    When ``gateway.mode`` is ``\"remote\"``, the full OpenClaw configuration
+    (model settings, channels, MCPs, cron jobs, agent defaults, approvals)
+    lives on the remote server, not in the local ``openclaw.json``.  This
+    function warns the user so they don't expect a full migration.
+
+    Returns ``True`` if remote-mode was detected and a warning was printed.
+    """
+    for name in ("openclaw.json", "clawdbot.json", "moltbot.json"):
+        config_path = source_dir / name
+        if not config_path.exists():
+            continue
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        gateway = data.get("gateway", {})
+        mode = gateway.get("mode", "") if isinstance(gateway, dict) else ""
+
+        if mode == "remote":
+            print()
+            print(color("  ⚠ Remote-mode OpenClaw client detected", Colors.YELLOW))
+            print_info(
+                "This OpenClaw directory is configured as a remote-mode client "
+                "(gateway.mode: \"remote\"). The full configuration (model settings, "
+                "channels, MCPs, cron jobs, agent defaults, approvals) lives on the "
+                "remote server, not in this local directory. Only workspace files "
+                "and skills will be migrated."
+            )
+            print_info(
+                "To migrate the complete configuration, run this tool against "
+                "the server's OpenClaw directory instead."
+            )
+            print()
+            return True
+        # Config found but not remote-mode — nothing to warn about
+        return False
+
+    return False
+
 
 # State files commonly found in OpenClaw workspace directories — listed
 # during cleanup to help the user decide whether to archive
@@ -400,6 +446,9 @@ def _cmd_migrate(args):
 
     # Check if a Hermes gateway is running with connected platforms.
     _warn_if_gateway_running(auto_yes)
+
+    # Warn if the source is a remote-mode client (full config lives remotely).
+    _warn_if_remote_client(source_dir)
 
     # Ensure config.yaml exists before migration tries to read it
     config_path = get_config_path()


### PR DESCRIPTION
## Summary

When `hermes claw migrate` is run against an OpenClaw installation configured as a remote-mode client (`gateway.mode: "remote"`), the tool completes successfully but reports ~33 "No X configuration found" skip entries with no explanation. The user has no indication that the bulk of their configuration lives on the remote server, not in the local `openclaw.json`.

This PR adds a clear warning when the source OpenClaw config has `gateway.mode: "remote"`, following the same pattern as the existing `_warn_if_openclaw_running()` and `_warn_if_gateway_running()` warning functions.

## Changes

- **`hermes_cli/claw.py`**: Added `_warn_if_remote_client(source_dir)` function that reads the source OpenClaw config, detects `gateway.mode: "remote"`, and prints a warning explaining what will and won't be migrated.
- Called from `_cmd_migrate()` alongside the other pre-migration warning checks.

## Warning message

> ⚠ Remote-mode OpenClaw client detected
> This OpenClaw directory is configured as a remote-mode client (gateway.mode: "remote"). The full configuration (model settings, channels, MCPs, cron jobs, agent defaults, approvals) lives on the remote server, not in this local directory. Only workspace files and skills will be migrated.
> To migrate the complete configuration, run this tool against the server's OpenClaw directory instead.

## Testing

- All 48 existing tests pass
- Manually verified all scenarios: remote-mode warns, local-mode silent, no config silent, legacy filenames handled

Closes #38230