### PR TITLE
fix(install.ps1): handle dirty worktree on Windows update

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1044,6 +1044,19 @@ function Install-Repository {
             $prevEAP = $ErrorActionPreference
             $ErrorActionPreference = "Continue"
             try {
+                # This is a MANAGED checkout, not a repo the user edits. Git for
+                # Windows defaults to core.autocrlf=true, which renormalizes the
+                # repo's LF-only text files to CRLF in the working tree -- so
+                # tracked files (.envrc, AGENTS.md, agent/*.py, workflows, ...)
+                # show as locally modified even though nobody touched them. A
+                # bare `git checkout` then aborts with "Your local changes would
+                # be overwritten by checkout", which is exactly the failure GUI
+                # users hit on update. Two-part fix: (1) stop creating the dirt
+                # by pinning autocrlf=false on this clone, (2) discard any
+                # pre-existing dirt with a hard reset before the checkout. Safe
+                # because nothing here is user-authored.
+                git -c windows.appendAtomically=false config core.autocrlf false 2>$null
+                git -c windows.appendAtomically=false reset --hard HEAD 2>$null
                 git -c windows.appendAtomically=false fetch origin
                 if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)" }
                 # Precedence: Commit > Tag > Branch.  Commit and Tag check
@@ -1178,6 +1191,11 @@ function Install-Repository {
     # Set per-repo config (harmless if it fails)
     Push-Location $InstallDir
     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
+    # Pin autocrlf=false on the managed clone so git never renormalizes the
+    # repo's LF text files to CRLF in the working tree. Without this, the very
+    # next `hermes update` checkout aborts on a "dirty" tree the user never
+    # touched (see the update path above).
+    git -c windows.appendAtomically=false config core.autocrlf false 2>$null
 
     # Post-clone pin: when a clone (or ZIP-fallback init) just landed us on
     # $Branch's tip, honour the higher-precedence $Commit / $Tag by checking


### PR DESCRIPTION
## Summary
Windows desktop install/update no longer fails at `stage=repository` on a dirty worktree.

Root cause: Git for Windows defaults to `core.autocrlf=true`, which renormalizes the repo's LF-only text files to CRLF in the working tree. On the managed, never-user-edited clone this makes tracked files (`.envrc`, `AGENTS.md`, `agent/*.py`, `.github/workflows/*.yml`) show as locally modified, so the update path's bare `git checkout` aborts with *"Your local changes would be overwritten by checkout"* and the desktop bootstrap fails (`git checkout <sha> failed (exit 1)`). The bash installer already autostashes before checkout; `install.ps1` had no dirty-tree handling and never pinned `autocrlf`.

## Changes
- `scripts/install.ps1` (update path): `git reset --hard HEAD` before fetch/checkout to discard pre-existing dirt; pin `core.autocrlf=false`.
- `scripts/install.ps1` (fresh-clone path): pin `core.autocrlf=false` so the dirt is never created in the first place.

Both are best-effort (`2>$null`), additive, and touch no control flow.

## Validation
| | Before | After |
|---|---|---|
| Windows update on CRLF-dirtied tree | `git checkout` aborts, bootstrap FAILS | reset discards dirt, checkout succeeds |
| Fresh Windows clone | `autocrlf=true` → next update dirty | `autocrlf=false` → tree stays clean |

Matches Brooklyn's confirmed manual workaround (`git reset --hard`). Note: the Electron desktop bootstrapper (`hermes_bootstrap_lib`, separate repo) replicates the same bare-checkout-no-stash logic and needs the matching fix there.

## Infographic

![windows-install-ps1-dirty-worktree-fix](https://v3b.fal.media/files/b/0a9cd166/7vYd1Y4nxDvraALI4iQMw_RG2NcxGJ.png)
