### PR TITLE
fix: harden Cortex mode triggers and cron mutations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14938,6 +14938,28 @@ class HermesCLI:
                         user_input, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(user_input)
                         if _had_mouse_reports:
                             self._recover_terminal_input_modes(reason="mouse reports leaked into submitted input")
+                    # ---- CORTEX MODE TRIGGER (added 2026-05-28, rev3) ----
+                    # Rewrites trigger phrases to /model <name> --provider openai-codex
+                    # then lets the existing slash dispatcher (process_command) do the
+                    # actual model switch via _handle_model_switch. Session-only.
+                    if isinstance(user_input, str):
+                        _trig = user_input.strip().lower()
+                        _CORTEX_MODES = {
+                            "learning mode":      ("gpt-5.4-mini", "Learning mode active — using gpt-5.4-mini"),
+                            "normal mode":        ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+                            "serious mode":       ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+                            "exit learning mode": ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+                        }
+                        if _trig in _CORTEX_MODES:
+                            _mdl, _ind = _CORTEX_MODES[_trig]
+                            _slash = f"/model {_mdl} --provider openai-codex"
+                            try:
+                                self.process_command(_slash)
+                                _cprint(_ind)
+                            except Exception as _e:
+                                _cprint(f"{_ind} (switch raised: {_e})")
+                            continue
+                    # ---- /CORTEX MODE TRIGGER ----
                     
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7393,6 +7393,12 @@ class GatewayRunner:
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
         
+        # Cortex SOUL mode triggers are exact plaintext control phrases. Handle
+        # them before update/clarify interception and before the LLM path.
+        _cortex_mode_trigger = self._cortex_mode_trigger_from_text(event.text)
+        if _cortex_mode_trigger is not None:
+            return await self._handle_cortex_mode_trigger(event, _cortex_mode_trigger)
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
@@ -7942,6 +7948,13 @@ class GatewayRunner:
             # The actual interrupt message is delivered via adapter._pending_messages
             # which is read by _run_agent. Removed to prevent unbounded growth.
             return None
+
+        # Cold-path safety net for Cortex mode triggers. The normal case is
+        # already handled above before update/clarify interception; this catches
+        # any path that reaches command dispatch after running-agent checks.
+        _cortex_mode_trigger = self._cortex_mode_trigger_from_text(event.text)
+        if _cortex_mode_trigger is not None:
+            return await self._handle_cortex_mode_trigger(event, _cortex_mode_trigger)
 
         # Check for commands
         command = event.get_command()
@@ -9345,6 +9358,18 @@ class GatewayRunner:
         )
         if message_text is None:
             return
+
+        # Voice messages are transcribed inside _prepare_inbound_message_text(),
+        # after the normal slash-command dispatch window. Re-check the enriched
+        # text here so an exact spoken "Learning Mode" / "Normal Mode" switch is
+        # handled deterministically without starting an LLM turn.
+        _voice_mode_trigger = self._cortex_mode_trigger_from_text(message_text)
+        if _voice_mode_trigger is not None:
+            try:
+                event.text = message_text
+            except Exception:
+                pass
+            return await self._handle_cortex_mode_trigger(event, _voice_mode_trigger)
 
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
@@ -10880,6 +10905,134 @@ class GatewayRunner:
             "\n".join(lines),
             getattr(getattr(event, "source", None), "platform", None),
         )
+
+    def _cortex_mode_trigger_from_text(self, text: Optional[str]) -> Optional[tuple[str, str, str]]:
+        """Map Neil's exact Cortex mode phrases to safe session-only model switches.
+
+        The SOUL defines these as instruction-driven triggers, not normal chat.
+        Voice messages arrive later as a transcription wrapper, so accept either
+        the raw exact phrase or a single exact transcript inside the standard
+        ``[The user sent a voice message~ Here's what they said: "..."]`` text.
+        Do not fuzzily match longer utterances — phrases like "can you use a
+        lighter model?" must remain normal user messages.
+        """
+        if not text:
+            return None
+        candidate = text.strip()
+        voice_match = re.fullmatch(
+            r"\[The user sent a voice message~ Here's what they said: \"(?P<transcript>.*)\"\]",
+            candidate,
+            flags=re.DOTALL,
+        )
+        if voice_match:
+            candidate = voice_match.group("transcript").strip()
+        normalised = re.sub(r"[.!?\s]+$", "", candidate.strip().lower())
+        normalised = re.sub(r"\s+", " ", normalised)
+        if normalised == "learning mode":
+            return (
+                "Learning mode active — using gpt-5.4-mini",
+                "gpt-5.4-mini",
+                "learning mode",
+            )
+        if normalised in {"normal mode", "serious mode", "exit learning mode"}:
+            return (
+                "Normal mode active — using gpt-5.5",
+                "gpt-5.5",
+                "normal mode",
+            )
+        return None
+
+    def _persist_session_model_marker(
+        self,
+        source: SessionSource,
+        model: str,
+        provider: Optional[str],
+        *,
+        reason: str = "session_model_override",
+    ) -> None:
+        """Record a session-only model switch in the session DB for visibility.
+
+        Gateway /model switches intentionally live in memory (they must not
+        change config.yaml/global defaults).  However, operators verify model
+        routing via ``sessions.model`` and dashboard/status surfaces read the
+        same DB.  Without this marker a successful session-only switch looks
+        like it failed until the next LLM turn writes token metadata.  Store
+        only non-secret metadata; never persist api keys or bearer tokens here.
+        """
+        try:
+            session_entry = self.session_store.get_or_create_session(source)
+            session_id = getattr(session_entry, "session_id", None)
+            if not session_id:
+                return
+            import json
+            import time
+            from hermes_state import SessionDB
+
+            marker = {
+                "model": model,
+                "provider": provider,
+                "session_override": True,
+                "reason": reason,
+                "updated_at": time.time(),
+            }
+            db = SessionDB()
+            try:
+                def _do(conn):
+                    conn.execute(
+                        "UPDATE sessions SET model = ?, model_config = ? WHERE id = ?",
+                        (model, json.dumps(marker, sort_keys=True), session_id),
+                    )
+                db._execute_write(_do)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.debug("Failed to persist session model marker: %s", exc)
+
+    async def _handle_cortex_mode_trigger(
+        self,
+        event: MessageEvent,
+        trigger: tuple[str, str, str],
+    ) -> str:
+        """Execute Cortex SOUL learning/normal mode triggers without an LLM turn."""
+        prefix, target_model, label = trigger
+        original_text = event.text
+        session_key = self._session_key_for_source(event.source)
+        try:
+            event.text = f"/model {target_model} --provider openai-codex"
+            result = await self._handle_model_command(event)
+        finally:
+            event.text = original_text
+        if result and (
+            result.startswith("❌")
+            or result.startswith("✗")
+            or result.lower().startswith("error:")
+        ):
+            return f"{prefix} requested, but the switch failed:\n\n{result}"
+        override = {}
+        try:
+            override = self._session_model_overrides.get(session_key, {})
+        except Exception:
+            override = {}
+        if override.get("model") != target_model or override.get("provider") != "openai-codex":
+            detail = result or "No session model override was recorded."
+            return f"{prefix} requested, but the switch failed:\n\n{detail}"
+        effective_model = override.get("model") or target_model
+        effective_provider = override.get("provider") or "openai-codex"
+        self._persist_session_model_marker(
+            event.source,
+            effective_model,
+            effective_provider,
+            reason=f"cortex_{label.replace(' ', '_')}",
+        )
+        logger.info(
+            "Cortex plaintext mode trigger switched session %s to %s (%s)",
+            session_key,
+            effective_model,
+            label,
+        )
+        if result:
+            return f"{prefix}\n\n{result}"
+        return prefix
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model for this session.

--- a/tests/gateway/test_cortex_mode_triggers.py
+++ b/tests/gateway/test_cortex_mode_triggers.py
@@ -1,0 +1,135 @@
+"""Regression tests for Cortex plaintext learning/normal mode triggers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_state import SessionDB
+
+
+def _make_runner(session_id="session-1"):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._pending_model_notes = {}
+    runner._evict_cached_agent = lambda _session_key: None
+
+    class Store:
+        def get_or_create_session(self, source):
+            return SimpleNamespace(
+                session_key=f"{source.platform.value}:{source.chat_id}",
+                session_id=session_id,
+            )
+
+    runner.session_store = Store()
+    return runner
+
+
+def _make_event(text="Learning Mode"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="7704114243",
+            chat_id="7704114243",
+            chat_type="dm",
+        ),
+    )
+
+
+def test_cortex_trigger_matches_raw_and_voice_wrapper():
+    runner = _make_runner()
+
+    assert runner._cortex_mode_trigger_from_text("Learning Mode")[1] == "gpt-5.4-mini"
+    assert runner._cortex_mode_trigger_from_text("learning mode.")[1] == "gpt-5.4-mini"
+    assert (
+        runner._cortex_mode_trigger_from_text(
+            '[The user sent a voice message~ Here\'s what they said: "Learning Mode"]'
+        )[1]
+        == "gpt-5.4-mini"
+    )
+    assert runner._cortex_mode_trigger_from_text("Can you use learning mode?") is None
+
+
+@pytest.mark.asyncio
+async def test_cortex_learning_mode_switch_sets_override_and_db_marker(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("hermes_state.DEFAULT_DB_PATH", db_path)
+    db = SessionDB(db_path)
+    db.create_session("session-1", "telegram", model="gpt-5.5", user_id="7704114243")
+    db.close()
+
+    runner = _make_runner("session-1")
+    event = _make_event("Learning Mode")
+
+    async def fake_model_command(model_event):
+        assert model_event.text == "/model gpt-5.4-mini --provider openai-codex"
+        runner._session_model_overrides[runner._session_key_for_source(event.source)] = {
+            "model": "gpt-5.4-mini",
+            "provider": "openai-codex",
+        }
+        return "Model switched to `gpt-5.4-mini`"
+
+    runner._session_key_for_source = lambda source: f"{source.platform.value}:{source.chat_id}"
+    runner._handle_model_command = fake_model_command
+
+    trigger = runner._cortex_mode_trigger_from_text(event.text)
+    assert trigger is not None
+    result = await runner._handle_cortex_mode_trigger(event, trigger)
+
+    assert result.startswith("Learning mode active — using gpt-5.4-mini")
+    assert runner._session_model_overrides["telegram:7704114243"]["model"] == "gpt-5.4-mini"
+
+    db = SessionDB(db_path)
+    try:
+        row = db._conn.execute(
+            "SELECT model, model_config FROM sessions WHERE id = ?", ("session-1",)
+        ).fetchone()
+    finally:
+        db.close()
+    assert row["model"] == "gpt-5.4-mini"
+    assert '"provider": "openai-codex"' in row["model_config"]
+    assert '"session_override": true' in row["model_config"]
+
+
+@pytest.mark.asyncio
+async def test_cortex_learning_mode_reports_model_command_errors_without_marker(tmp_path, monkeypatch):
+    """Do not claim learning mode is active unless /model recorded an override."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("hermes_state.DEFAULT_DB_PATH", db_path)
+    db = SessionDB(db_path)
+    db.create_session("session-1", "telegram", model="gpt-5.5", user_id="7704114243")
+    db.close()
+
+    runner = _make_runner("session-1")
+    event = _make_event("Learning Mode")
+    runner._session_key_for_source = lambda source: f"{source.platform.value}:{source.chat_id}"
+
+    async def fake_failed_model_command(event):
+        return "Error: Could not resolve credentials for provider 'OpenAI Codex'"
+
+    runner._handle_model_command = fake_failed_model_command
+
+    trigger = runner._cortex_mode_trigger_from_text(event.text)
+    assert trigger is not None
+    result = await runner._handle_cortex_mode_trigger(event, trigger)
+
+    assert result.startswith("Learning mode active — using gpt-5.4-mini requested, but the switch failed")
+    assert "Could not resolve credentials" in result
+    assert runner._session_model_overrides == {}
+
+    db = SessionDB(db_path)
+    try:
+        row = db._conn.execute(
+            "SELECT model, model_config FROM sessions WHERE id = ?", ("session-1",)
+        ).fetchone()
+    finally:
+        db.close()
+    assert row["model"] == "gpt-5.5"

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,21 @@ class TestUnifiedCronjobTool:
         monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
         monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
         monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        monkeypatch.setattr("tools.cronjob_tools._last_cron_list_at", 0.0)
+        cronjob(action="list")
+
+    def test_mutating_actions_require_list_preflight(self, monkeypatch):
+        monkeypatch.setattr("tools.cronjob_tools._last_cron_list_at", 0.0)
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Server Check",
+            )
+        )
+        assert result["success"] is False
+        assert "requires a fresh scheduler preflight" in result["error"]
 
     def test_create_and_list(self):
         created = json.loads(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -7,14 +7,44 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 
 import json
 import logging
+import os
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+# Safety preflight for mutating cron operations. This makes the existing
+# "inspect the live scheduler before changing it" rule mechanical instead of
+# relying only on model discipline. The marker is deliberately process-local:
+# every fresh Hermes/gateway process must list jobs before create/update/remove.
+_CRON_PREFLIGHT_TTL_SECONDS = int(os.getenv("HERMES_CRON_PREFLIGHT_TTL_SECONDS", "600"))
+_last_cron_list_at: float = 0.0
+
+
+def _cron_preflight_required() -> bool:
+    return os.getenv("HERMES_CRON_PREFLIGHT_REQUIRED", "1").strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _mark_cron_list_preflight() -> None:
+    global _last_cron_list_at
+    _last_cron_list_at = time.time()
+
+
+def _check_cron_list_preflight(action: str) -> str:
+    if not _cron_preflight_required():
+        return ""
+    age = time.time() - _last_cron_list_at if _last_cron_list_at else None
+    if age is not None and age <= _CRON_PREFLIGHT_TTL_SECONDS:
+        return ""
+    return (
+        f"Cron action '{action}' requires a fresh scheduler preflight first. "
+        "Call cronjob(action='list') to inspect existing jobs, then retry."
+    )
 
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -486,6 +516,9 @@ def cronjob(
         normalized = (action or "").strip().lower()
 
         if normalized == "create":
+            preflight_error = _check_cron_list_preflight(normalized)
+            if preflight_error:
+                return tool_error(preflight_error, success=False)
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
@@ -563,8 +596,14 @@ def cronjob(
             )
 
         if normalized == "list":
+            _mark_cron_list_preflight()
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+
+        if normalized in {"update", "pause", "resume", "remove", "run", "run_now", "trigger"}:
+            preflight_error = _check_cron_list_preflight(normalized)
+            if preflight_error:
+                return tool_error(preflight_error, success=False)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4083,6 +4083,46 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+    # ---- CORTEX MODE TRIGGER (added 2026-05-28, rev3) ----
+    # Detect natural-language mode triggers BEFORE the agent runs.
+    # Uses the dashboard's own _apply_model_switch() (same code path as /model).
+    # Session-only switch; emits the indicator as the reply; no LLM call.
+    try:
+        if isinstance(text, str):
+            _trig = text.strip().lower()
+            _CORTEX_MODES = {
+                "learning mode":      ("gpt-5.4-mini", "Learning mode active — using gpt-5.4-mini"),
+                "normal mode":        ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+                "serious mode":       ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+                "exit learning mode": ("gpt-5.5",      "Normal mode active — using gpt-5.5"),
+            }
+            if _trig in _CORTEX_MODES:
+                _mdl, _ind = _CORTEX_MODES[_trig]
+                try:
+                    _apply_model_switch(sid, session, f"{_mdl} --provider openai-codex")
+                    import logging as _lg
+                    _lg.getLogger(__name__).info(
+                        "cortex mode switch (tui): sid=%s trigger=%r model=%s", sid, _trig, _mdl)
+                    _emit("message.start", sid)
+                    _emit("message.delta", sid, {"text": _ind})
+                    _emit("message.complete", sid, {})
+                except Exception as _e_trig:
+                    _emit("message.start", sid)
+                    _emit("message.delta", sid, {"text": f"{_ind} (switch raised: {_e_trig})"})
+                    _emit("message.complete", sid, {})
+                # Append a synthetic exchange to the visible history so the chat
+                # shows the user message + Cortex confirmation.
+                try:
+                    with session["history_lock"]:
+                        session["history"].append({"role": "user", "content": text})
+                        session["history"].append({"role": "assistant", "content": _ind})
+                        session["history_version"] = int(session.get("history_version", 0)) + 1
+                except Exception:
+                    pass
+                return
+    except Exception:
+        pass
+    # ---- /CORTEX MODE TRIGGER ----
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -771,15 +771,23 @@ export function useMainApp(gw: GatewayClient) {
       if (plan.recover && plan.sid) {
         recoverSidRef.current = plan.sid
         turnController.pushActivity('gateway exited · recovering session…', 'warn')
-        sys('gateway exited — recovering your session (any in-flight reply was lost)')
-        gw.start()
+
+        // In dashboard/browser attach mode, GatewayClient can synchronously emit
+        // `exit` while React/Ink is still rendering the mounted App. Calling
+        // sys() immediately then schedules React state during render and trips
+        // React #301 (too many re-renders). Defer both the transcript update and
+        // retry so the recovery still happens, but outside the render phase.
+        setTimeout(() => {
+          sys('gateway exited — recovering your session (any in-flight reply was lost)')
+          gw.start()
+        }, 0)
 
         return
       }
 
       recoverSidRef.current = null
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
-      sys('error: gateway exited')
+      setTimeout(() => sys('error: gateway exited'), 0)
     }
 
     gw.on('event', handler)

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { delimiter, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
@@ -18,6 +19,15 @@ const WS_CONNECTING = 0
 const WS_OPEN = 1
 const WS_CLOSING = 2
 const WS_CLOSED = 3
+const nodeRequire = createRequire(import.meta.url)
+
+const loadNodeWebSocket = (): typeof WebSocket | null => {
+  try {
+    return nodeRequire('ws') as typeof WebSocket
+  } catch {
+    return null
+  }
+}
 
 const truncateLine = (line: string) =>
   line.length > MAX_LOG_LINE_BYTES ? `${line.slice(0, MAX_LOG_LINE_BYTES)}… [truncated ${line.length} bytes]` : line
@@ -406,7 +416,9 @@ export class GatewayClient extends EventEmitter {
     const safeAttachUrl = redactUrl(attachUrl)
     this.startReadyTimer('websocket', safeAttachUrl)
 
-    if (typeof WebSocket === 'undefined') {
+    const WebSocketCtor = typeof WebSocket === 'undefined' ? loadNodeWebSocket() : WebSocket
+
+    if (!WebSocketCtor) {
       const line = `[startup] WebSocket API unavailable; cannot attach to ${safeAttachUrl}`
 
       this.pushLog(line)
@@ -417,7 +429,7 @@ export class GatewayClient extends EventEmitter {
     }
 
     try {
-      const ws = new WebSocket(attachUrl)
+      const ws = new WebSocketCtor(attachUrl)
       let settled = false
 
       this.ws = ws

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -373,6 +373,36 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const isMac =
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
+    const scheduleTerminalRefocus = (clearSelection = false) => {
+      // Mouse text selection/copy can leave browser focus on <body> (or the
+      // selected DOM range) instead of xterm's hidden textarea.  When that
+      // happens the dashboard still shows a live terminal, but keystrokes no
+      // longer reach the PTY until the user refreshes or clicks just right.
+      // Restore focus on the next tick so the native copy operation can finish
+      // first, then typing continues in the same PTY/session.
+      window.setTimeout(() => {
+        if (!host.isConnected || document.hidden) return;
+        if (clearSelection) {
+          term.clearSelection();
+        }
+        term.focus();
+      }, 0);
+    };
+
+    const nativeSelectionIntersectsTerminal = () => {
+      const selection = window.getSelection?.();
+      if (!selection || selection.isCollapsed) return false;
+      for (let i = 0; i < selection.rangeCount; i += 1) {
+        const range = selection.getRangeAt(i);
+        try {
+          if (range.intersectsNode(host)) return true;
+        } catch {
+          // Some browsers throw if the range/node relationship is stale.
+        }
+      }
+      return false;
+    };
+
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
@@ -396,6 +426,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           });
           // Clear xterm.js's highlight after copy (matches gnome-terminal).
           term.clearSelection();
+          scheduleTerminalRefocus();
           ev.preventDefault();
           return false;
         }
@@ -418,6 +449,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       return true;
     });
+
+    const onHostPointerUp = () => {
+      // Finish drag-selection with focus back on xterm's hidden textarea so
+      // the following Cmd/Ctrl+Shift+C and subsequent typing target the PTY.
+      scheduleTerminalRefocus();
+    };
+    host.addEventListener("pointerup", onHostPointerUp);
+
+    const onDocumentCopy = () => {
+      if (term.getSelection() || nativeSelectionIntersectsTerminal()) {
+        // Let the browser's default copy read the current selection first.
+        // Then clear the highlight and restore PTY focus so the next typed
+        // character goes into the same live Hermes session.
+        scheduleTerminalRefocus(true);
+      }
+    };
+    document.addEventListener("copy", onDocumentCopy, true);
 
     const fit = new FitAddon();
     fitRef.current = fit;
@@ -660,6 +708,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onResizeDisposable?.dispose();
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
+      document.removeEventListener("copy", onDocumentCopy, true);
+      host.removeEventListener("pointerup", onHostPointerUp);
       window.visualViewport?.removeEventListener(
         "resize",
         scheduleSyncTerminalMetrics,


### PR DESCRIPTION
## Summary
- handle Cortex learning/normal mode phrases before LLM turns
- require a successful session model override before reporting mode switch success
- add a cron mutation list-preflight guard
- preserve dashboard/TUI focus and WebSocket fallback fixes

## Tests
- `PYTHONPATH=/tmp/hermes-agent-cortex-mode-triggers-cron-safety-20260603135024 /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_cortex_mode_triggers.py tests/tools/test_cronjob_tools.py -q -o 'addopts='` — 63 passed
- `PYTHONPATH=/tmp/hermes-agent-cortex-mode-triggers-cron-safety-20260603135024 /usr/local/lib/hermes-agent/venv/bin/python -m py_compile cli.py gateway/run.py tui_gateway/server.py tools/cronjob_tools.py tests/gateway/test_cortex_mode_triggers.py tests/tools/test_cronjob_tools.py` — passed
- `npm run build --workspace web` — passed

## Notes
- Local `npm run type-check --workspace ui-tui` fails under Node v20 in pre-existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` overload typing, unrelated to this diff.
