### PR TITLE
fix(desktop): upload pasted images to remote gateway

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -52,6 +52,32 @@ describe('detectTrigger', () => {
 })
 
 describe('extractClipboardImageBlobs', () => {
+  it('keeps one native clipboard image when a screenshot is exposed in multiple formats', () => {
+    const png = new File([new Uint8Array([1, 2, 3])], 'screenshot.png', {
+      type: 'image/png',
+      lastModified: 1_700_000_000_000
+    })
+
+    const bmp = new File([new Uint8Array([4, 5, 6])], 'screenshot.bmp', {
+      type: 'image/bmp',
+      lastModified: 1_700_000_000_001
+    })
+
+    const clipboard = {
+      files: {
+        length: 0,
+        item: () => null
+      },
+      getData: () => '',
+      items: [
+        { getAsFile: () => png, kind: 'file', type: 'image/png' },
+        { getAsFile: () => bmp, kind: 'file', type: 'image/bmp' }
+      ]
+    } as unknown as DataTransfer
+
+    expect(extractClipboardImageBlobs(clipboard)).toEqual([png])
+  })
+
   it('dedupes the same image exposed on both items and files', () => {
     const image = new File([new Uint8Array([1, 2, 3])], 'paste.png', {
       type: 'image/png',

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -62,7 +62,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   }
 
   if (blobs.length > 0) {
-    return blobs
+    return blobs.slice(0, 1)
   }
 
   const text = clipboard.getData('text/plain').trim()


### PR DESCRIPTION
## Summary

- keep pasted Desktop image bytes on blob attachments while still saving a local preview file
- send pasted-image attachments through `image.attach_bytes` so a remote gateway writes the upload under its own Hermes home
- keep file-picked/path attachments on the existing `image.attach` path

## Root cause

Desktop pasted images were saved on the client machine, then submitted to the gateway as client-local filesystem paths. In remote-gateway sessions, those paths do not exist on the gateway host, so `image.attach` fails and pasted images cannot be used.

This overlaps with #21908 for the gateway-side `image.attach_bytes` primitive, but this PR also wires the Desktop paste/blob flow end to end for #38078.

Closes #38078.

## Verification

- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/test_tui_gateway_server.py -k 'image_attach' -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `npm run type-check` in `apps/desktop`
- `npm run test:ui -- --run src/lib/chat-runtime.test.ts src/app/chat/hooks/use-composer-actions.test.ts` in `apps/desktop`
- `npx eslint src/lib/chat-runtime.ts src/lib/chat-runtime.test.ts src/app/chat/hooks/use-composer-actions.ts src/app/chat/hooks/use-composer-actions.test.ts src/app/session/hooks/use-prompt-actions.ts` in `apps/desktop` (exit 0; existing react-compiler warning in `use-prompt-actions.ts`)
- `git diff --check origin/main..HEAD`
