### PR TITLE
fix(desktop): explicitly destroy mainWindow in before-quit to prevent orphaned renderer

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4223,6 +4223,12 @@ app.on('before-quit', () => {
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
   }
+
+  // Explicitly destroy mainWindow to prevent orphaned renderer processes
+  // (backgroundThrottling: false can keep renderer alive during app quit)
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.destroy()
+  }
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Problem

Cmd+Q 退出 Hermes Desktop 时，渲染进程没有被正确清理，导致孤儿进程残留。

## Root Cause

Electron 在 macOS 上的退出流程中，`before-quit` 处理程序只清理了：
- 安装控制器
- 日志定时器
- 文件观察器
- Hermes 后端进程

但没有显式销毁主窗口和渲染进程。由于 `backgroundThrottling: false` 配置，渲染进程可能保持活跃状态。

## Fix

在 `before-quit` 处理程序末尾添加显式销毁主窗口的逻辑：

```javascript
if (mainWindow && !mainWindow.isDestroyed()) {
  mainWindow.destroy()
}
```

## Testing

- 启动 Hermes Desktop
- 使用 Cmd+Q 退出
- 检查进程列表，确认没有残留的 Electron 或渲染进程

## Files Changed

- `apps/desktop/electron/main.cjs`: 添加 mainWindow.destroy() 清理逻辑
