### PR TITLE
fix(tui): save TUI /save snapshots under Hermes home with system prompt

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5473,3 +5473,60 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         assert requeued["session_id"] == "proc_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
+
+
+def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
+    """TUI /save (session.save RPC) must snapshot under the Hermes profile
+    home — not the project/workspace CWD — and include the system prompt,
+    mirroring the classic CLI /save and the dashboard save export.
+
+    Regression: the gateway handler wrote ``hermes_conversation_*.json`` to
+    ``os.path.abspath(...)`` (the workspace CWD) and only exported ``model``
+    and ``messages``, so ``system_prompt`` was missing.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Run from a different CWD to prove the snapshot does NOT leak there.
+    work = tmp_path / "workspace"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    sid = "save-sid"
+    agent = types.SimpleNamespace(
+        model="hermes-test",
+        session_id="20260101_120000_abc123",
+        _cached_system_prompt="You are Hermes.",
+    )
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    server._sessions[sid] = {
+        "agent": agent,
+        "session_key": "save-key",
+        "history": history,
+        "history_lock": threading.Lock(),
+        "created_at": 1735732800.0,
+    }
+    try:
+        resp = server._methods["session.save"]("1", {"session_id": sid})
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "result" in resp, resp
+    saved_file = Path(resp["result"]["file"])
+
+    # Must NOT leak into the workspace/project CWD.
+    assert not list(work.glob("hermes_conversation_*.json"))
+
+    saved_dir = home / "sessions" / "saved"
+    assert saved_file.parent == saved_dir
+    assert saved_file.exists()
+
+    payload = json.loads(saved_file.read_text())
+    assert payload["model"] == "hermes-test"
+    assert payload["session_id"] == "20260101_120000_abc123"
+    assert payload["system_prompt"] == "You are Hermes."
+    assert payload["messages"] == history

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import time
 import types
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -5497,6 +5498,7 @@ def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, t
     agent = types.SimpleNamespace(
         model="hermes-test",
         session_id="20260101_120000_abc123",
+        session_start=datetime(2026, 1, 1, 12, 0, 0),
         _cached_system_prompt="You are Hermes.",
     )
     history = [
@@ -5528,5 +5530,6 @@ def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, t
     payload = json.loads(saved_file.read_text())
     assert payload["model"] == "hermes-test"
     assert payload["session_id"] == "20260101_120000_abc123"
+    assert payload["session_start"] == "2026-01-01T12:00:00"
     assert payload["system_prompt"] == "You are Hermes."
     assert payload["messages"] == history

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3485,23 +3485,46 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
-    import time as _time
 
-    filename = os.path.abspath(
-        f"hermes_conversation_{_time.strftime('%Y%m%d_%H%M%S')}.json"
-    )
+    agent = session["agent"]
+    # Mirror the classic CLI /save: snapshot under the Hermes profile home
+    # (~/.hermes/sessions/saved/) rather than the project/workspace CWD, and
+    # include the system prompt so the export matches the dashboard save.
+    saved_dir = get_hermes_home() / "sessions" / "saved"
     try:
-        with open(filename, "w", encoding="utf-8") as f:
+        saved_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        return _err(rid, 5011, f"failed to create save directory {saved_dir}: {e}")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = saved_dir / f"hermes_conversation_{timestamp}.json"
+
+    with session["history_lock"]:
+        messages = list(session.get("history", []))
+
+    session_id = getattr(agent, "session_id", None) or session.get("session_key") or ""
+    created_at = session.get("created_at")
+    session_start = (
+        datetime.fromtimestamp(created_at).isoformat()
+        if isinstance(created_at, (int, float))
+        else ""
+    )
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(
                 {
-                    "model": getattr(session["agent"], "model", ""),
-                    "messages": session.get("history", []),
+                    "model": getattr(agent, "model", ""),
+                    "session_id": session_id,
+                    "session_start": session_start,
+                    "system_prompt": getattr(agent, "_cached_system_prompt", "") or "",
+                    "messages": messages,
                 },
                 f,
                 indent=2,
                 ensure_ascii=False,
             )
-        return _ok(rid, {"file": filename})
+        return _ok(rid, {"file": str(path)})
     except Exception as e:
         return _err(rid, 5011, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3503,12 +3503,18 @@ def _(rid, params: dict) -> dict:
         messages = list(session.get("history", []))
 
     session_id = getattr(agent, "session_id", None) or session.get("session_key") or ""
-    created_at = session.get("created_at")
-    session_start = (
-        datetime.fromtimestamp(created_at).isoformat()
-        if isinstance(created_at, (int, float))
-        else ""
-    )
+    # Prefer the agent's session_start datetime (matches the classic CLI export);
+    # fall back to the gateway session's created_at timestamp.
+    agent_start = getattr(agent, "session_start", None)
+    if isinstance(agent_start, datetime):
+        session_start = agent_start.isoformat()
+    else:
+        created_at = session.get("created_at")
+        session_start = (
+            datetime.fromtimestamp(created_at).isoformat()
+            if isinstance(created_at, (int, float))
+            else ""
+        )
 
     try:
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI `/save` slash command so it saves session JSON snapshots to the correct location and includes the system prompt.

`/save` in the TUI is handled separately from the classic CLI: it goes through the `session.save` RPC in `tui_gateway/server.py`. That handler wrote `hermes_conversation_<timestamp>.json` via `os.path.abspath(...)` — i.e. into the current workspace/project directory (e.g. `/workspace`) — and only exported `model` and `messages`.

This diverged from:
- the **classic CLI `/save`** (`HermesCLI.save_conversation`), which already writes under the Hermes profile home (`get_hermes_home()/sessions/saved/`), and
- the **dashboard save** button, whose export includes the `system_prompt`.

This PR brings the TUI path in line with both: snapshots land under the profile-aware Hermes home and include the system prompt (plus `session_id`/`session_start` to match the CLI export shape).

## Related Issue

<!-- User-reported: after the profiles update, TUI /save wrote to /workspace instead of the profile home, and the JSON was missing system_prompt. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `session.save` RPC handler now:
  - writes to `get_hermes_home()/sessions/saved/hermes_conversation_<ts>.json` instead of `os.path.abspath(...)` (CWD);
  - includes `system_prompt` (from `agent._cached_system_prompt`, the same source `session.info` uses), plus `session_id` and `session_start`;
  - snapshots history under `history_lock` for consistency with other handlers.
- `tests/test_tui_gateway_server.py` — added `test_session_save_writes_under_hermes_home_with_system_prompt` regression test asserting the snapshot lands under the Hermes home, does not leak into the CWD, and includes `system_prompt`.

The TUI frontend (`ui-tui/.../slash/commands/core.ts`) just echoes the returned `file` path, so the "conversation saved to: …" message now reflects the correct location with no frontend change.

## How to Test

1. From the TUI, run a turn so the agent + system prompt are built, then run `/save`.
2. Confirm the printed path is under `~/.hermes/sessions/saved/` (or the active profile's home), not the project/workspace dir.
3. Open the saved JSON and confirm it contains a non-empty `system_prompt` (alongside `model`, `session_id`, `session_start`, `messages`).
4. Run the tests: `pytest tests/test_tui_gateway_server.py::test_session_save_writes_under_hermes_home_with_system_prompt tests/cli/test_save_conversation_location.py -q`.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — paths use `pathlib`/`get_hermes_home()`, no CWD or separator assumptions — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: `conversation saved to: /workspace/hermes_conversation_20260603_011012.json` (and no `system_prompt` in the JSON).

After: snapshot written under `~/.hermes/sessions/saved/` with `system_prompt` populated.