### PR TITLE
feat(nix): desktop darwin app bundle

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -36,6 +36,21 @@ It builds and launches the GUI against your existing install — same config, ke
 
 Prebuilt installers are built and distributed via [the Hermes Desktop website.](https://hermes-agent.nousresearch.com/).
 
+### Nix (macOS / Linux)
+
+The flake exposes a `#desktop` package that builds a native `.app` bundle on macOS:
+
+```bash
+nix build github:NousResearch/hermes-agent#desktop
+open result/Applications/Hermes.app
+```
+
+The bundle includes the Electron framework, helper apps (GPU, renderer, plugins), the Hermes icon, and a wrapper pointing to the Nix-built `hermes` binary.
+
+On Linux it produces a flat layout suitable for desktop file integration.
+
+See the [Nix setup guide](https://hermes-agent.nousresearch.com/docs/getting-started/nix-setup) for full details.
+
 ---
 
 ## Updating

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -624,6 +624,23 @@ json.dump(load_config(), sys.stdout, default=str)
             (echo "FAIL: install-stamp.json missing at Contents/Resources"; exit 1)
           echo "PASS: install stamp at Contents/Resources/install-stamp.json"
 
+          # Each helper's own Info.plist must be rebranded too, not just its
+          # file/folder names.
+          helper_plist=$(ls "$APP"/Contents/Frameworks/Hermes\ Helper*.app/Contents/Info.plist | head -1)
+          test -n "$helper_plist" || (echo "FAIL: no helper Info.plist found"; exit 1)
+          if grep -q "Electron" "$helper_plist"; then
+            echo "FAIL: $helper_plist still references Electron: $(grep Electron "$helper_plist")"
+            exit 1
+          fi
+          grep -q "com.nousresearch.hermes.helper" "$helper_plist" || \
+            (echo "FAIL: helper Info.plist missing rebranded CFBundleIdentifier"; exit 1)
+          echo "PASS: helper Info.plist rebranded"
+
+          # Bundle must carry a coherent signature end to end (ad-hoc is fine).
+          codesign --verify --deep --strict "$APP" || \
+            (echo "FAIL: codesign --verify --deep --strict failed on $APP"; exit 1)
+          echo "PASS: bundle signature is internally consistent"
+
           echo "=== All desktop layout checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,8 +1,10 @@
 # nix/checks.nix — Build-time verification tests
 #
-# Checks are Linux-only: the full Python venv (via uv2nix) includes
-# transitive deps like onnxruntime that lack compatible wheels on
-# aarch64-darwin. The package and devShell still work on macOS.
+# Full runtime checks are Linux-only: the complete Python venv (via uv2nix)
+# includes transitive deps like onnxruntime that lack compatible wheels on
+# aarch64-darwin. The package and devShell still work on macOS, and a
+# structural Darwin-only check for the desktop .app bundle layout lives at
+# the bottom of this file.
 { inputs, ... }: {
   perSystem = { pkgs, lib, self', ... }:
     let
@@ -574,6 +576,55 @@ json.dump(load_config(), sys.stdout, default=str)
 
           echo ""
           echo "=== All 7 merge scenarios passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+      } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+        # Verify the Darwin .app bundle layout from nix/desktop.nix: the
+        # bundle must ship the wrapped executable, the renderer at
+        # Resources/app, and install-stamp.json at Contents/Resources —
+        # where the runtime's process.resourcesPath lookup reads it
+        # (apps/desktop/electron/main.ts).
+        desktop-app-layout = pkgs.runCommand "hermes-desktop-app-layout" { } ''
+          set -e
+          APP=${self'.packages.desktop}/Applications/Hermes.app
+
+          echo "=== Checking Hermes.app bundle layout ==="
+          test -d "$APP" || (echo "FAIL: Applications/Hermes.app missing"; exit 1)
+          echo "PASS: Applications/Hermes.app exists"
+
+          test -x "$APP/Contents/MacOS/Hermes" || \
+            (echo "FAIL: Contents/MacOS/Hermes missing or not executable"; exit 1)
+          echo "PASS: bundle executable present"
+
+          # CFBundleExecutable must be the real Mach-O binary, not a wrapper
+          # script, or codesign/notarization fails. LSEnvironment in
+          # Info.plist carries the env; $out/bin has the CLI wrapper instead.
+          test ! -e "$APP/Contents/MacOS/Hermes.real" || \
+            (echo "FAIL: wrapper remnant Hermes.real present in bundle"; exit 1)
+          if head -c 2 "$APP/Contents/MacOS/Hermes" | grep -q '#!'; then
+            echo "FAIL: Contents/MacOS/Hermes is a script — must be the Mach-O binary"
+            exit 1
+          fi
+          echo "PASS: bundle main executable is the Mach-O binary (signable)"
+
+          grep -q "LSEnvironment" "$APP/Contents/Info.plist" || \
+            (echo "FAIL: LSEnvironment missing from Info.plist"; exit 1)
+          grep -q "HERMES_DESKTOP_HERMES" "$APP/Contents/Info.plist" || \
+            (echo "FAIL: HERMES_DESKTOP_HERMES missing from LSEnvironment"; exit 1)
+          echo "PASS: LSEnvironment carries HERMES_DESKTOP_HERMES"
+
+          test -d "$APP/Contents/Resources/app" || \
+            (echo "FAIL: Contents/Resources/app missing"; exit 1)
+          test -f "$APP/Contents/Resources/app/dist/electron-main.mjs" || \
+            (echo "FAIL: renderer bundle missing from Resources/app"; exit 1)
+          echo "PASS: Resources/app renderer present"
+
+          test -f "$APP/Contents/Resources/install-stamp.json" || \
+            (echo "FAIL: install-stamp.json missing at Contents/Resources"; exit 1)
+          echo "PASS: install stamp at Contents/Resources/install-stamp.json"
+
+          echo "=== All desktop layout checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result
         '';

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -248,6 +248,17 @@ stdenv.mkDerivation {
       fi
     done
 
+    # Each helper's own Info.plist still says "Electron Helper (...)" /
+    # com.github.Electron.helper internally — rebrand that too, not just the
+    # path. (Temp file instead of `sed -i`: BSD vs GNU sed disagree on it.)
+    for plist in "$out/Applications/Hermes.app/Contents/Frameworks/"Hermes\ Helper*.app/Contents/Info.plist; do
+      sed \
+        -e 's/Electron Helper/Hermes Helper/g' \
+        -e 's/com\.github\.Electron\.helper/com.nousresearch.hermes.helper/g' \
+        "$plist" > "$plist.new"
+      mv "$plist.new" "$plist"
+    done
+
     # Update Info.plist with our custom values
     cp ${infoPlist} $out/Applications/Hermes.app/Contents/Info.plist
 
@@ -277,6 +288,22 @@ stdenv.mkDerivation {
       --add-flags "$out/Applications/Hermes.app/Contents/Resources/app" \
       --set HERMES_DESKTOP_HERMES "${lib.getExe hermesAgent}" \
       --set ELECTRON_IS_DEV 0
+
+    # Renaming/editing the bundle above leaves every Mach-O in it unsigned
+    # (nixpkgs' electron binaries only carry a lightweight adhoc,
+    # linker-signed signature that never covered Info.plist/Resources
+    # anyway). Ad-hoc (`-s -`, no cert/Apple account needed) matches
+    # nixpkgs' own convention for this exact situation (see e.g. the
+    # `opencode` and `lmstudio` derivations, and stdenv's own fixup-phase
+    # sign() in pkgs/os-specific/darwin/by-name/si/signingUtils). Sign
+    # leaf-first — each helper, then the main binary, then the bundle
+    # itself — rather than `--deep`, which nixpkgs avoids for the same
+    # reason Apple's docs discourage it.
+    for helper in "$out/Applications/Hermes.app/Contents/Frameworks/"Hermes\ Helper*.app; do
+      codesign --force --sign - "$helper"
+    done
+    codesign --force --sign - "$out/Applications/Hermes.app/Contents/MacOS/Hermes"
+    codesign --force --sign - "$out/Applications/Hermes.app"
 
     runHook postInstall
   '' else ''

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -141,9 +141,81 @@ let
       '';
     }
   );
+
+  # Generate Info.plist for the macOS .app bundle (XML plist format).
+  infoPlist = pkgs.writeText "Info.plist" ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>CFBundleDevelopmentRegion</key>
+      <string>en</string>
+      <key>CFBundleDisplayName</key>
+      <string>Hermes</string>
+      <key>CFBundleExecutable</key>
+      <string>Hermes</string>
+      <key>CFBundleIconFile</key>
+      <string>icon.icns</string>
+      <key>CFBundleIdentifier</key>
+      <string>com.nousresearch.hermes</string>
+      <key>CFBundleInfoDictionaryVersion</key>
+      <string>6.0</string>
+      <key>CFBundleName</key>
+      <string>Hermes</string>
+      <key>CFBundlePackageType</key>
+      <string>APPL</string>
+      <key>CFBundleShortVersionString</key>
+      <string>${version}</string>
+      <key>CFBundleVersion</key>
+      <string>${version}</string>
+      <key>LSApplicationCategoryType</key>
+      <string>public.app-category.developer-tools</string>
+      <key>LSArchitecturePriority</key>
+      <array>
+        <string>arm64</string>
+      </array>
+      <key>LSMinimumSystemVersion</key>
+      <string>12.0</string>
+      <!-- LaunchServices-only env for the bundle (does not apply to direct
+           CLI exec — $out/bin/hermes-desktop wraps the binary for that).
+           HERMES_DESKTOP_HERMES points the desktop's resolver step 4 at the
+           fully-wrapped nix hermes: venv with all deps, skills, plugins,
+           runtime PATH (ripgrep/git/ffmpeg/etc). -->
+      <key>LSEnvironment</key>
+      <dict>
+        <key>HERMES_DESKTOP_HERMES</key>
+        <string>${lib.getExe hermesAgent}</string>
+        <key>ELECTRON_IS_DEV</key>
+        <string>0</string>
+      </dict>
+      <!-- Usage strings required by the hardened-runtime audio-input
+           entitlement (voice feature) — mirrors electron-builder's
+           extendInfo in apps/desktop/package.json. -->
+      <key>NSAudioCaptureUsageDescription</key>
+      <string>Hermes uses audio capture for voice conversations.</string>
+      <key>NSMicrophoneUsageDescription</key>
+      <string>Hermes uses the microphone for voice input and voice conversations.</string>
+      <key>NSHighResolutionCapable</key>
+      <true/>
+      <key>NSHumanReadableCopyright</key>
+      <string>Copyright Nous Research</string>
+      <key>NSPrincipalClass</key>
+      <string>AtomApplication</string>
+      <key>NSSupportsAutomaticGraphicsSwitching</key>
+      <true/>
+    </dict>
+    </plist>
+  '';
 in
 
 # Electron wrapper: nixpkgs' electron binary pointed at the renderer dir.
+# On Darwin: creates a proper .app bundle under $out/Applications/Hermes.app/
+# with the renamed Electron Mach-O binary as CFBundleExecutable (kept a real
+# binary — not a wrapper script — so the bundle can be codesigned and
+# notarized) and env delivered via Info.plist LSEnvironment.  A thin wrapper
+# at $out/bin/hermes-desktop covers direct CLI exec (`nix run`), where
+# LSEnvironment does not apply.
+# On Linux: flat $out/share/hermes-desktop/ layout (unchanged).
 stdenv.mkDerivation {
   pname = "hermes-desktop";
   inherit version;
@@ -153,7 +225,67 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  installPhase = ''
+  installPhase = if stdenv.hostPlatform.isDarwin then ''
+    runHook preInstall
+
+    # Create the Applications directory first
+    mkdir -p $out/Applications
+
+    # Copy the entire nixpkgs Electron.app structure to get Frameworks and helper apps
+    cp -r ${electron}/Applications/Electron.app $out/Applications/Hermes.app
+    chmod -R u+w $out/Applications/Hermes.app
+
+    # Rename the main binary from Electron to Hermes
+    mv $out/Applications/Hermes.app/Contents/MacOS/Electron \
+       $out/Applications/Hermes.app/Contents/MacOS/Hermes
+
+    # Rename helper apps in Frameworks
+    for helper in $out/Applications/Hermes.app/Contents/Frameworks/Electron\ Helper*.app; do
+      if [ -d "$helper" ]; then
+        newname=$(basename "$helper" | sed 's/Electron/Hermes/g')
+        mv "$helper" "$(dirname "$helper")/$newname"
+        # Rename the binary inside the helper
+        for bin in "$(dirname "$helper")/$newname/Contents/MacOS/"*; do
+          if [ -f "$bin" ]; then
+            newbin=$(basename "$bin" | sed 's/Electron/Hermes/g')
+            mv "$bin" "$(dirname "$bin")/$newbin"
+          fi
+        done
+      fi
+    done
+
+    # Update Info.plist with our custom values
+    cp ${infoPlist} $out/Applications/Hermes.app/Contents/Info.plist
+
+    # Copy the app icon to Resources
+    cp ${npm.src}/apps/desktop/assets/icon.icns $out/Applications/Hermes.app/Contents/Resources/
+
+    # Put our renderer files in Resources/app/ (Electron expects app here)
+    mkdir -p $out/Applications/Hermes.app/Contents/Resources/app
+    cp -r ${renderer}/* $out/Applications/Hermes.app/Contents/Resources/app/
+
+    # The runtime reads install-stamp.json via process.resourcesPath (=
+    # Contents/Resources in a real .app bundle) or APP_ROOT/build/ — copying
+    # the renderer into Resources/app/ would hide it from both lookups, so
+    # install the stamp at Contents/Resources separately.
+    cp ${renderer}/install-stamp.json \
+      $out/Applications/Hermes.app/Contents/Resources/install-stamp.json
+
+    # CLI entry point for `nix run` / profile installs.  The bundle itself
+    # gets its env from Info.plist LSEnvironment, which only applies to
+    # LaunchServices launches — direct exec of the Mach-O binary needs this
+    # wrapper.  It lives outside the .app on purpose: codesign seals
+    # Contents/ only, and CFBundleExecutable must stay the Mach-O binary
+    # above for signing/notarization to work.
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/Hermes.app/Contents/MacOS/Hermes \
+      $out/bin/hermes-desktop \
+      --add-flags "$out/Applications/Hermes.app/Contents/Resources/app" \
+      --set HERMES_DESKTOP_HERMES "${lib.getExe hermesAgent}" \
+      --set ELECTRON_IS_DEV 0
+
+    runHook postInstall
+  '' else ''
     runHook preInstall
 
     mkdir -p $out/share/hermes-desktop $out/bin

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -132,9 +132,81 @@ let
       runHook postInstall
     '';
   };
+
+  # Generate Info.plist for the macOS .app bundle (XML plist format).
+  infoPlist = pkgs.writeText "Info.plist" ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>CFBundleDevelopmentRegion</key>
+      <string>en</string>
+      <key>CFBundleDisplayName</key>
+      <string>Hermes</string>
+      <key>CFBundleExecutable</key>
+      <string>Hermes</string>
+      <key>CFBundleIconFile</key>
+      <string>icon.icns</string>
+      <key>CFBundleIdentifier</key>
+      <string>com.nousresearch.hermes</string>
+      <key>CFBundleInfoDictionaryVersion</key>
+      <string>6.0</string>
+      <key>CFBundleName</key>
+      <string>Hermes</string>
+      <key>CFBundlePackageType</key>
+      <string>APPL</string>
+      <key>CFBundleShortVersionString</key>
+      <string>${renderer.version}</string>
+      <key>CFBundleVersion</key>
+      <string>${renderer.version}</string>
+      <key>LSApplicationCategoryType</key>
+      <string>public.app-category.developer-tools</string>
+      <key>LSArchitecturePriority</key>
+      <array>
+        <string>arm64</string>
+      </array>
+      <key>LSMinimumSystemVersion</key>
+      <string>12.0</string>
+      <!-- LaunchServices-only env for the bundle (does not apply to direct
+           CLI exec — $out/bin/hermes-desktop wraps the binary for that).
+           HERMES_DESKTOP_HERMES points the desktop's resolver step 4 at the
+           fully-wrapped nix hermes: venv with all deps, skills, plugins,
+           runtime PATH (ripgrep/git/ffmpeg/etc). -->
+      <key>LSEnvironment</key>
+      <dict>
+        <key>HERMES_DESKTOP_HERMES</key>
+        <string>${lib.getExe hermesAgent}</string>
+        <key>ELECTRON_IS_DEV</key>
+        <string>0</string>
+      </dict>
+      <!-- Usage strings required by the hardened-runtime audio-input
+           entitlement (voice feature) — mirrors electron-builder's
+           extendInfo in apps/desktop/package.json. -->
+      <key>NSAudioCaptureUsageDescription</key>
+      <string>Hermes uses audio capture for voice conversations.</string>
+      <key>NSMicrophoneUsageDescription</key>
+      <string>Hermes uses the microphone for voice input and voice conversations.</string>
+      <key>NSHighResolutionCapable</key>
+      <true/>
+      <key>NSHumanReadableCopyright</key>
+      <string>Copyright Nous Research</string>
+      <key>NSPrincipalClass</key>
+      <string>AtomApplication</string>
+      <key>NSSupportsAutomaticGraphicsSwitching</key>
+      <true/>
+    </dict>
+    </plist>
+  '';
 in
 
 # Electron wrapper: nixpkgs' electron binary pointed at the renderer dir.
+# On Darwin: creates a proper .app bundle under $out/Applications/Hermes.app/
+# with the renamed Electron Mach-O binary as CFBundleExecutable (kept a real
+# binary — not a wrapper script — so the bundle can be codesigned and
+# notarized) and env delivered via Info.plist LSEnvironment.  A thin wrapper
+# at $out/bin/hermes-desktop covers direct CLI exec (`nix run`), where
+# LSEnvironment does not apply.
+# On Linux: flat $out/share/hermes-desktop/ layout (unchanged).
 stdenv.mkDerivation {
   pname = "hermes-desktop";
   inherit (renderer) version;
@@ -147,7 +219,67 @@ stdenv.mkDerivation {
     python3
   ];
 
-  installPhase = ''
+  installPhase = if stdenv.hostPlatform.isDarwin then ''
+    runHook preInstall
+
+    # Create the Applications directory first
+    mkdir -p $out/Applications
+
+    # Copy the entire nixpkgs Electron.app structure to get Frameworks and helper apps
+    cp -r ${electron}/Applications/Electron.app $out/Applications/Hermes.app
+    chmod -R u+w $out/Applications/Hermes.app
+
+    # Rename the main binary from Electron to Hermes
+    mv $out/Applications/Hermes.app/Contents/MacOS/Electron \
+       $out/Applications/Hermes.app/Contents/MacOS/Hermes
+
+    # Rename helper apps in Frameworks
+    for helper in $out/Applications/Hermes.app/Contents/Frameworks/Electron\ Helper*.app; do
+      if [ -d "$helper" ]; then
+        newname=$(basename "$helper" | sed 's/Electron/Hermes/g')
+        mv "$helper" "$(dirname "$helper")/$newname"
+        # Rename the binary inside the helper
+        for bin in "$(dirname "$helper")/$newname/Contents/MacOS/"*; do
+          if [ -f "$bin" ]; then
+            newbin=$(basename "$bin" | sed 's/Electron/Hermes/g')
+            mv "$bin" "$(dirname "$bin")/$newbin"
+          fi
+        done
+      fi
+    done
+
+    # Update Info.plist with our custom values
+    cp ${infoPlist} $out/Applications/Hermes.app/Contents/Info.plist
+
+    # Copy the app icon to Resources
+    cp ${../apps/desktop/assets/icon.icns} $out/Applications/Hermes.app/Contents/Resources/
+
+    # Put our renderer files in Resources/app/ (Electron expects app here)
+    mkdir -p $out/Applications/Hermes.app/Contents/Resources/app
+    cp -r ${renderer}/* $out/Applications/Hermes.app/Contents/Resources/app/
+
+    # The runtime reads install-stamp.json via process.resourcesPath (=
+    # Contents/Resources in a real .app bundle) or APP_ROOT/build/ — copying
+    # the renderer into Resources/app/ would hide it from both lookups, so
+    # install the stamp at Contents/Resources separately.
+    cp ${renderer}/install-stamp.json \
+      $out/Applications/Hermes.app/Contents/Resources/install-stamp.json
+
+    # CLI entry point for `nix run` / profile installs.  The bundle itself
+    # gets its env from Info.plist LSEnvironment, which only applies to
+    # LaunchServices launches — direct exec of the Mach-O binary needs this
+    # wrapper.  It lives outside the .app on purpose: codesign seals
+    # Contents/ only, and CFBundleExecutable must stay the Mach-O binary
+    # above for signing/notarization to work.
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/Hermes.app/Contents/MacOS/Hermes \
+      $out/bin/hermes-desktop \
+      --add-flags "$out/Applications/Hermes.app/Contents/Resources/app" \
+      --set HERMES_DESKTOP_HERMES "${lib.getExe hermesAgent}" \
+      --set ELECTRON_IS_DEV 0
+
+    runHook postInstall
+  '' else ''
     runHook preInstall
 
     mkdir -p $out/share/hermes-desktop $out/bin

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -65,6 +65,22 @@ The `default` package adds ~700 MB to the closure. If you only need messaging pl
 
 :::
 
+:::info Desktop app (macOS)
+The `#desktop` package builds a native macOS `.app` bundle with the Electron shell:
+
+```bash
+# Build the desktop app
+nix build github:NousResearch/hermes-agent#desktop
+
+# Open it (or copy to /Applications)
+open result/Applications/Hermes.app
+```
+
+The bundle includes the full Electron framework (helper apps for GPU, renderer, plugins), the Hermes icon, and a wrapper that points to the Nix-built `hermes` binary.
+
+On Linux, the same package produces a flat `share/hermes-desktop/` layout suitable for AppImage or desktop file integration.
+:::
+
 <details>
 <summary><strong>Running from a local clone</strong></summary>
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Noticed the desktop app for Darwin lacked an app bundle when used via Nix so I thought on adding it.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- (Darwin only) Modify the `desktop` nix flake output so it creates an app bundle. `Contents/MacOS/Hermes` is the renamed Electron Mach-O binary (not a wrapper script) so the bundle can be codesigned and notarized; runtime env is delivered via `Info.plist` `LSEnvironment`. The `hermes-desktop` command is a thin wrapper launching it for `nix run` / CLI use.
- (Darwin only) Install `install-stamp.json` at `Contents/Resources/` so the runtime's `process.resourcesPath` lookup finds it, and add a `desktop-app-layout` flake check (`nix/checks.nix`) covering the bundle layout.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

On macOS:

1. `nix build .#desktop`.
2. `open result/Applications/Hermes.app`

A structural check of the bundle layout (app, Mach-O executable, `Resources/app`, root-level install stamp) runs on Darwin with:

```bash
nix build .#checks.aarch64-darwin.desktop-app-layout
```

Alternatively (my use case for adding it):

1. Add the `desktop` flake output to an existing `home-manager` configuration (in `home.packages`)
2. Activate this config with `home-manager switch`
3. See the application icon show up on `~/Applications/Home Manager Apps`.
4. Open it by double-click.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
