### PR TITLE
fix(install): require Node >=20.19/22.12 for the desktop build

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,9 @@
   "author": "Nous Research",
   "type": "module",
   "main": "electron/main.cjs",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:electron\"",
     "dev:fake-boot": "cross-env HERMES_DESKTOP_BOOT_FAKE=1 HERMES_DESKTOP_BOOT_FAKE_STEP_MS=650 npm run dev",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -714,19 +714,39 @@ function Set-GitBashEnvVar {
     Write-Info "If needed, set HERMES_GIT_BASH_PATH manually to your bash.exe path."
 }
 
+# The desktop build runs Vite ^8, which refuses to start on Node outside
+# `^20.19 || >=22.12` -- older Node lacks node:util.styleText, so `vite build`
+# crashes with a SyntaxError that surfaces only as the opaque "Build desktop
+# app ... exit code 1" install failure. Returns $true when a `node --version`
+# string clears that floor.
+function Test-NodeVersionOk {
+    param([string]$Version)
+    try {
+        $v = [version]($Version -replace '^v', '' -replace '-.*$', '')
+    } catch {
+        return $false
+    }
+    if ($v.Major -eq 20 -and $v.Minor -ge 19) { return $true }
+    if ($v.Major -ge 22 -and ($v.Major -gt 22 -or $v.Minor -ge 12)) { return $true }
+    return $false
+}
+
 function Test-Node {
     Write-Info "Checking Node.js (for browser tools)..."
 
     if (Get-Command node -ErrorAction SilentlyContinue) {
         $version = node --version
-        Write-Success "Node.js $version found"
-        $script:HasNode = $true
-        return $true
+        if (Test-NodeVersionOk $version) {
+            Write-Success "Node.js $version found"
+            $script:HasNode = $true
+            return $true
+        }
+        Write-Warn "Node.js $version is too old for the desktop build (need ^20.19 or >=22.12)"
     }
 
-    # Check our own managed install from a previous run
+    # Prefer a Hermes-managed Node from a previous run over a too-old system one.
     $managedNode = "$HermesHome\node\node.exe"
-    if (Test-Path $managedNode) {
+    if ((Test-Path $managedNode) -and (Test-NodeVersionOk (& $managedNode --version))) {
         $version = & $managedNode --version
         $env:Path = "$HermesHome\node;$env:Path"
         Write-Success "Node.js $version found (Hermes-managed)"
@@ -734,7 +754,7 @@ function Test-Node {
         return $true
     }
 
-    Write-Info "Node.js not found -- installing Node.js $NodeVersion LTS..."
+    Write-Info "Installing Hermes-managed Node.js $NodeVersion LTS..."
 
     # Try the portable-zip path FIRST -- no UAC, no admin, no winget MSI.
     # winget install OpenJS.NodeJS.LTS triggers a system-wide MSI install
@@ -1906,16 +1926,17 @@ function Install-Desktop {
     # so an "unpacked" build (electron-builder --dir) is enough — we
     # don't need to produce an NSIS/MSI artifact here.
 
-    if (-not $HasNode) {
-        # Cross-process driver mode: each `-Stage NAME` invocation runs in a
-        # fresh PowerShell process, so $script:HasNode set by Stage-Node
-        # in the previous process isn't visible. Re-detect rather than
-        # trusting the global.
-        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-            Write-Warn "Skipping desktop build (Node.js / npm not on PATH)"
-            $script:_StageSkippedReason = "Node.js not available"
-            return
-        }
+    # Always re-resolve Node here. Stages run in separate PowerShell processes,
+    # so $script:HasNode from Stage-Node isn't visible; more importantly Test-Node
+    # enforces the build floor (^20.19 || >=22.12) and prepends the Hermes-managed
+    # Node to PATH, so the build never runs on a too-old system Node -- the cause
+    # of the opaque "Build desktop app ... exit code 1" failure (Vite crashes on
+    # old Node).
+    Test-Node | Out-Null
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Warn "Skipping desktop build (Node.js / npm not on PATH)"
+        $script:_StageSkippedReason = "Node.js not available"
+        return
     }
 
     $desktopDir = "$InstallDir\apps\desktop"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -702,26 +702,43 @@ check_git() {
     exit 1
 }
 
+# The desktop build runs Vite ^8, which refuses to start on Node outside
+# `^20.19 || >=22.12` — older Node lacks `node:util.styleText`, so `vite build`
+# crashes with a SyntaxError that surfaces only as the opaque "Build desktop
+# app … exit code 1" install failure. Returns 0 when the given `node --version`
+# string clears that floor; anything below it is replaced with the Hermes-
+# managed Node $NODE_VERSION LTS.
+node_satisfies_build() {
+    local ver="${1#v}"
+    local major="${ver%%.*}"
+    local minor="${ver#*.}"; minor="${minor%%.*}"
+    case "$major" in ''|*[!0-9]*) return 1 ;; esac
+    case "$minor" in ''|*[!0-9]*) minor=0 ;; esac
+    if [ "$major" -eq 20 ] && [ "$minor" -ge 19 ]; then return 0; fi
+    if [ "$major" -ge 22 ] && { [ "$major" -gt 22 ] || [ "$minor" -ge 12 ]; }; then return 0; fi
+    return 1
+}
+
 check_node() {
     log_info "Checking Node.js (for browser tools)..."
 
-    if command -v node &> /dev/null; then
-        local found_ver=$(node --version)
-        log_success "Node.js $found_ver found"
+    if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
+        log_success "Node.js $(node --version) found"
         HAS_NODE=true
         return 0
     fi
 
-    # Check our own managed install from a previous run
-    if [ -x "$HERMES_HOME/node/bin/node" ]; then
+    # Prefer a Hermes-managed Node from a previous run over a too-old system one.
+    if [ -x "$HERMES_HOME/node/bin/node" ] && node_satisfies_build "$("$HERMES_HOME/node/bin/node" --version)"; then
         export PATH="$HERMES_HOME/node/bin:$PATH"
-        local found_ver=$("$HERMES_HOME/node/bin/node" --version)
-        log_success "Node.js $found_ver found (Hermes-managed)"
+        log_success "Node.js $("$HERMES_HOME/node/bin/node" --version) found (Hermes-managed)"
         HAS_NODE=true
         return 0
     fi
 
-    if [ "$DISTRO" = "termux" ]; then
+    if command -v node &> /dev/null; then
+        log_warn "Node.js $(node --version) is too old for the desktop build (need ^20.19 or >=22.12) — installing Hermes-managed Node $NODE_VERSION LTS..."
+    elif [ "$DISTRO" = "termux" ]; then
         log_info "Node.js not found — installing Node.js via pkg..."
     else
         log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
@@ -2235,11 +2252,12 @@ install_desktop() {
     # (--include-desktop / 'desktop' stage), so a missing toolchain is a hard
     # failure, not a silent skip — a silent skip yields a "complete" install
     # with no app and a confusing "couldn't find a built desktop" at launch.
-    # Try the Hermes-managed Node first (check_node adds $HERMES_HOME/node/bin
-    # to PATH or installs it) before giving up.
-    if ! command -v npm >/dev/null 2>&1; then
-        check_node
-    fi
+    # Always re-resolve Node here. Stages run in separate processes, so we can't
+    # trust an earlier check; more importantly check_node now enforces the build
+    # floor (^20.19 || >=22.12) and prepends the Hermes-managed Node to PATH, so
+    # the build never runs on a too-old system Node — the cause of the opaque
+    # "Build desktop app … exit code 1" failure (Vite crashes on old Node).
+    check_node
     if ! command -v npm >/dev/null 2>&1; then
         log_error "Cannot build desktop app: Node.js / npm unavailable"
         log_info "Install Node.js and retry: cd $desktop_dir && npm run pack"


### PR DESCRIPTION
## Summary

The **"Build desktop app"** install step fails with an opaque `exit code 1` on machines with an old Node (reported on Apple Silicon by @Pixo14 / others). I reproduced the exact failure rather than guessing.

**Reproduced** — same repo, same deps, only Node version changed:

| Node | `npm run build` (tsc + vite) |
|------|------------------------------|
| v22.22.3 | ✅ builds in ~10s |
| v20.5.1  | ❌ `exit code 1` |

On v20.5.1:
```
You are using Node.js 20.5.1. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version.
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
```

**Root cause.** Vite 8 (via rolldown) imports `styleText` from `node:util`, which doesn't exist before Node 20.12 — so `vite build` hard-crashes before producing the app. It dies right after `write-build-stamp` / `stage-native-deps`, matching the reporter's screenshot. The installer accepted **any** pre-existing Node with no version floor:

```705:712:scripts/install.sh
check_node() {
    log_info "Checking Node.js (for browser tools)..."

    if command -v node &> /dev/null; then
        local found_ver=$(node --version)
        log_success "Node.js $found_ver found"
        HAS_NODE=true
        return 0
```

`Test-Node` in `install.ps1` had the identical gap. So a too-old system Node was used for the build instead of the bundled Node 22.

## Fix

- Add a version floor matching Vite's range (`^20.19 || >=22.12`) to `check_node` (`install.sh`) and `Test-Node` (`install.ps1`). A too-old system Node is replaced with the Hermes-managed Node 22 LTS the installer already knows how to fetch.
- Make the desktop build stage **re-resolve Node** (it previously only did so when `npm` was entirely missing, so an old system Node slipped through).
- Declare `"engines": { "node": "^20.19.0 || >=22.12.0" }` in `apps/desktop/package.json`.

## Test plan
- [x] Reproduced the failure on Node 20.5.1 and the pass on Node 22 (above)
- [x] `npm run build` still green on Node 22 after the change
- [x] `bash -n scripts/install.sh` clean
- [x] Unit-tested the `node_satisfies_build` floor across boundary versions — rejects 18.x / 20.5.1 / 20.18.9 / 21.7.0 / 22.11.0; accepts 20.19 / 20.20 / 22.12 / 22.22 / 24.0
- [ ] **`install.ps1` not run** — no `pwsh` on my machine; the PowerShell mirrors the bash logic 1:1 but needs a Windows/old-Node run to confirm

## Scope note
This fixes the build failure itself. It does **not** touch the separate "the failure produced no readable log" diagnosability issue — intentionally kept out of scope.