### PR TITLE
fix(cli): restore session cwd on resume (-c)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5086,6 +5086,17 @@ class HermesCLI:
                 self._session_db._conn.commit()
             except Exception:
                 pass
+            # Restore the session working directory so the agent resumes
+            # where it left off. Design #19242: the local CLI backend does
+            # NOT use TERMINAL_CWD for live tracking, that env var stays at
+            # launch dir. Instead we chdir(2) the process so the local
+            # environment initial cwd matches the persisted one.
+            try:
+                session_cwd = session_meta.get("cwd")
+                if session_cwd and os.path.isdir(session_cwd):
+                    os.chdir(session_cwd)
+            except Exception:
+                pass
         
         try:
             runtime = runtime_override or {

--- a/run_agent.py
+++ b/run_agent.py
@@ -485,6 +485,7 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                cwd=os.getcwd(),
             )
             self._session_db_created = True
         except Exception as e:
@@ -1418,6 +1419,16 @@ class AIAgent:
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+        # Persist the live terminal cwd so resume (-c) picks up any cd
+        # the agent performed during the session.  Best-effort; never
+        # fails the session persistence.
+        try:
+            from tools.terminal_tool import get_live_terminal_cwd
+            live_cwd = get_live_terminal_cwd("default")
+            if live_cwd and os.path.isdir(live_cwd) and self._session_db:
+                self._session_db.update_session_cwd(self.session_id, live_cwd)
+        except Exception:
+            pass
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/tests/cli/test_cli_resume_cwd.py
+++ b/tests/cli/test_cli_resume_cwd.py
@@ -1,0 +1,103 @@
+"""Tests for cwd restore on CLI resume (-c).
+
+Design #19242: the local CLI backend does not use TERMINAL_CWD for live
+tracking -- that env var stays at launch dir. Instead _init_agent calls
+os.chdir() to the persisted cwd so the terminal environment starts in
+the right directory.
+"""
+import os
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli(session_id="20260524_111111_xyz", db=None):
+    """Build a minimal HermesCLI for the _init_agent resume code path."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = session_id
+    cli._resumed = True
+    cli.conversation_history = []
+    cli._session_db = db
+    cli.tool_progress_mode = "full"
+    cli.session_start = datetime.now()
+    cli.agent = None
+    cli._install_tool_callbacks = lambda: None
+    cli._ensure_tirith_security = lambda: None
+    cli._ensure_runtime_credentials = lambda: True
+    return cli
+
+
+def _make_db(session_id="20260524_111111_xyz", cwd=None):
+    db = MagicMock()
+    meta = {"id": session_id, "title": "demo"}
+    if cwd is not None:
+        meta["cwd"] = cwd
+    db.get_session.return_value = meta
+    db.resolve_resume_session_id.return_value = session_id
+    db.get_messages_as_conversation.return_value = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hey"},
+    ]
+    db._conn = MagicMock()
+    return db
+
+
+class TestResumeCwdRestore:
+    """Resume restores the session working directory from session_meta["cwd"]."""
+
+    def test_restores_cwd_when_present_in_session_meta(self, monkeypatch, tmp_path):
+        """os.getcwd() must equal session_meta["cwd"] after resume."""
+        restore_dir = tmp_path / "workspace"
+        restore_dir.mkdir()
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+        monkeypatch.chdir(str(launch_dir))
+
+        db = _make_db(cwd=str(restore_dir))
+        cli = _make_cli(db=db)
+
+        with patch("cli._prepare_deferred_agent_startup"):
+            try:
+                cli._init_agent()
+            except Exception:
+                # AIAgent construction fails in stubbed context -- we only
+                # care that chdir happened before that point.
+                pass
+
+        assert os.getcwd() == str(restore_dir)
+
+    def test_skips_restore_when_cwd_is_absent(self, monkeypatch, tmp_path):
+        """NULL cwd in session_meta must not change the process directory."""
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+        monkeypatch.chdir(str(launch_dir))
+
+        db = _make_db()  # no cwd key -- simulates pre-fix session row
+        cli = _make_cli(db=db)
+
+        with patch("cli._prepare_deferred_agent_startup"):
+            try:
+                cli._init_agent()
+            except Exception:
+                pass
+
+        assert os.getcwd() == str(launch_dir)
+
+    def test_skips_restore_when_cwd_dir_does_not_exist(self, monkeypatch, tmp_path):
+        """A persisted cwd pointing to a deleted directory must not crash."""
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+        monkeypatch.chdir(str(launch_dir))
+
+        missing_dir = str(tmp_path / "gone")
+        db = _make_db(cwd=missing_dir)
+        cli = _make_cli(db=db)
+
+        with patch("cli._prepare_deferred_agent_startup"):
+            try:
+                cli._init_agent()
+            except Exception:
+                pass
+
+        assert os.getcwd() == str(launch_dir)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -988,6 +988,27 @@ def clear_task_env_overrides(task_id: str):
     _task_env_overrides.pop(task_id, None)
 
 
+def get_live_terminal_cwd(task_id: str = "default") -> Optional[str]:
+    """Return the terminal environment's live working directory, if active.
+
+    env.cwd is the authoritative per-session directory — updated by
+    _update_cwd after every command (local backend reads it from a
+    temp file written by pwd -P).  This is not TERMINAL_CWD
+    (which is frozen at launch time per design #19242); it's the actual
+    directory the agent cd'd into during the session.
+
+    Returns None when no environment is active for task_id.
+    """
+    lookup = _resolve_container_task_id(task_id)
+    with _env_lock:
+        env = _active_environments.get(lookup)
+    if env is not None:
+        live = getattr(env, "cwd", None)
+        if isinstance(live, str) and live.strip():
+            return live
+    return None
+
+
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
     """
     Map a tool-call ``task_id`` to the container/sandbox key used by


### PR DESCRIPTION
## Summary
Restores the session working directory when resuming a CLI session with -c.

---

## Root cause
`_init_agent()` in `cli.py` loaded conversation history and reopened the session in the DB but never restored the working directory. The `sessions` table already has a `cwd` column and `update_session_cwd()` exists, but the CLI path never wrote to or read from it, only the TUI gateway did.

---

## Behavioral change
Before: `hermes -c` / `hermes --resume <id>` restores conversation history but starts in the launch directory, ignoring any `cd` the agent performed during the previous session.

After: the working directory is restored to where the previous session left off.

---

## What changed

**`tools/terminal_tool.py`**
- Added `get_live_terminal_cwd(task_id)`, a public getter for the terminal environment's live `env.cwd`. Symmetric with the existing `register_task_env_overrides` and `clear_task_env_overrides` pair.

**`run_agent.py`**
- `_ensure_db_session()`: passes `cwd=os.getcwd()` to `create_session()` so the initial working directory is persisted on session creation.
- `_persist_session()`: calls `update_session_cwd()` with the live terminal cwd after every turn so any `cd` performed during the session is persisted for the next resume.

**`cli.py`**
- `_init_agent()` resume block: reads `session_meta["cwd"]` and calls `os.chdir()` to restore the working directory before the agent starts. Follows design #19242: local CLI backend does not touch `TERMINAL_CWD`, uses `os.chdir()` instead.

**`tests/cli/test_cli_resume_cwd.py`**
- 3 new tests in `TestResumeCwdRestore`: canary test that fails without the fix, guard for NULL cwd in pre-fix session rows, guard for deleted directory that must not crash.

---

## What is NOT changed
- Gateway and TUI sessions are unaffected, they already have their own cwd save/restore path in `tui_gateway/server.py`.
- `TERMINAL_CWD` is never modified, the local backend contract (#19242) is preserved.

---

Implements the fix discussed in Discord (May 31) following a user report about the agent losing its working directory after resume. @teknium1 noted: "this is a good point. I'll see if I can make resume and -c reload with the last working dir it was in."