### PR TITLE
feat: add shared browser-tools sidecar

### DIFF
--- a/deploy/browser-tools-sidecar/Dockerfile
+++ b/deploy/browser-tools-sidecar/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.13-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    BROWSER_TOOLS_ARTIFACT_DIR=/tmp/browser-tools-artifacts
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install fastapi 'uvicorn[standard]' pydantic 'scrapling[fetchers]'
+
+WORKDIR /app
+COPY server.py /app/server.py
+
+EXPOSE 8790
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -fsS http://127.0.0.1:8790/health || exit 1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8790"]

--- a/deploy/browser-tools-sidecar/server.py
+++ b/deploy/browser-tools-sidecar/server.py
@@ -1,0 +1,236 @@
+"""Browser-tools sidecar service.
+
+A small FastAPI service that gives Hermes agents one shared place for heavy
+browser/scraping dependencies. It combines:
+
+- CloakBrowser CLI/runtime for stealth rendering, humanized browsing, and
+  screenshots when available.
+- Scrapling for fast HTTP fetching, CSS/XPath extraction, and future crawling
+  when available.
+- urllib fallback for basic public pages when neither optional runtime exists.
+
+The API is intentionally simple JSON so any Hermes profile, worker, or external
+agent can call it over an internal Docker network.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Hermes browser-tools sidecar", version="0.1.0")
+
+MAX_TIMEOUT_MS = 120_000
+MAX_TEXT_LIMIT = 50_000
+CLOAK_FETCH = os.getenv("CLOAK_FETCH", "/opt/data/bin/cloak-fetch")
+
+
+def _clamp(value: int | None, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _capabilities() -> dict[str, bool]:
+    def has_module(name: str) -> bool:
+        try:
+            __import__(name)
+            return True
+        except Exception:
+            return False
+
+    return {
+        "cloak_fetch_cli": Path(CLOAK_FETCH).exists() or bool(shutil.which("cloak-fetch")),
+        "scrapling": has_module("scrapling"),
+        "playwright": has_module("playwright"),
+        "patchright": has_module("patchright"),
+    }
+
+
+def _plain_http(url: str, timeout_ms: int, text_limit: int) -> dict[str, Any]:
+    started = time.time()
+    req = urllib.request.Request(url, headers={"User-Agent": "HermesBrowserTools/0.1"})
+    with urllib.request.urlopen(req, timeout=(timeout_ms / 1000.0)) as resp:
+        raw = resp.read(2_000_000)
+        final_url = resp.geturl()
+        status = getattr(resp, "status", None)
+        content_type = resp.headers.get_content_charset() or "utf-8"
+    body = raw.decode(content_type, errors="replace")
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", body, re.I | re.S)
+    title = html.unescape(re.sub(r"\s+", " ", title_match.group(1)).strip()) if title_match else ""
+    text = html.unescape(re.sub(r"<[^>]+>", " ", body))
+    text = re.sub(r"\s+", " ", text).strip()
+    return {
+        "success": True,
+        "mode_used": "plain_http",
+        "url": url,
+        "final_url": final_url,
+        "title": title,
+        "response_status": status,
+        "html_length": len(body),
+        "text_length": len(text),
+        "text": text[:text_limit],
+        "text_truncated": len(text) > text_limit,
+        "duration_s": round(time.time() - started, 3),
+    }
+
+
+def _scrapling_http(url: str, timeout_ms: int, text_limit: int) -> dict[str, Any]:
+    started = time.time()
+    from scrapling.fetchers import Fetcher
+
+    page = Fetcher.get(url, timeout=max(1, int(timeout_ms / 1000)))
+    text = page.css("body::text").get(default="") or page.text
+    text = re.sub(r"\s+", " ", text or "").strip()
+    title = page.css("title::text").get(default="") or ""
+    status = getattr(page, "status", None) or getattr(page, "status_code", None)
+    return {
+        "success": True,
+        "mode_used": "scrapling_http",
+        "url": url,
+        "final_url": getattr(page, "url", url),
+        "title": title,
+        "response_status": status,
+        "html_length": len(str(page.body)) if getattr(page, "body", None) is not None else None,
+        "text_length": len(text),
+        "text": text[:text_limit],
+        "text_truncated": len(text) > text_limit,
+        "duration_s": round(time.time() - started, 3),
+    }
+
+
+def _cloak_fetch(url: str, timeout_ms: int, text_limit: int, screenshot: bool, humanize: bool, headless: bool = True) -> dict[str, Any]:
+    started = time.time()
+    exe = CLOAK_FETCH if Path(CLOAK_FETCH).exists() else shutil.which("cloak-fetch")
+    if not exe:
+        raise RuntimeError("cloak-fetch executable not found")
+    cmd = [exe, url, "--timeout-ms", str(timeout_ms), "--text-limit", str(text_limit), "--headless", "true" if headless else "false"]
+    if humanize:
+        cmd.append("--humanize")
+    if screenshot:
+        out_dir = Path(os.getenv("BROWSER_TOOLS_ARTIFACT_DIR", "/tmp/browser-tools-artifacts"))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        shot = out_dir / f"screenshot-{int(time.time() * 1000)}.png"
+        cmd.extend(["--screenshot", str(shot)])
+    proc = subprocess.run(cmd, text=True, capture_output=True, timeout=(timeout_ms / 1000.0) + 30)
+    if not proc.stdout.strip():
+        return {"success": False, "mode_used": "cloak", "error": proc.stderr.strip() or "no output", "exit_code": proc.returncode}
+    data = json.loads(proc.stdout)
+    data["mode_used"] = "cloak"
+    data["duration_s"] = round(time.time() - started, 3)
+    data.setdefault("exit_code", proc.returncode)
+    return data
+
+
+def _select_fetch_mode(requested: str, wants_screenshot: bool) -> list[str]:
+    if requested and requested != "auto":
+        return [requested]
+    if wants_screenshot:
+        return ["cloak", "scrapling_dynamic", "scrapling_http", "plain_http"]
+    return ["scrapling_http", "cloak", "plain_http"]
+
+
+class FetchRequest(BaseModel):
+    url: str
+    mode: Literal["auto", "cloak", "scrapling_http", "scrapling_dynamic", "scrapling_stealth", "plain_http"] = "auto"
+    timeout_ms: int = Field(30_000, ge=1_000, le=MAX_TIMEOUT_MS)
+    text_limit: int = Field(12_000, ge=0, le=MAX_TEXT_LIMIT)
+    screenshot: bool = False
+    humanize: bool = False
+    headless: bool = True
+    wait_until: str = "domcontentloaded"
+
+
+class ExtractRequest(BaseModel):
+    url: str
+    mode: Literal["auto", "scrapling_http", "scrapling_dynamic", "scrapling_stealth"] = "scrapling_http"
+    selectors: dict[str, str] = Field(default_factory=dict)
+    timeout_ms: int = Field(30_000, ge=1_000, le=MAX_TIMEOUT_MS)
+    text_limit: int = Field(12_000, ge=0, le=MAX_TEXT_LIMIT)
+    include_links: bool = True
+
+
+# Pydantic v2 can need an explicit rebuild when this file is imported through
+# importlib in tests instead of normal module loading.
+FetchRequest.model_rebuild()
+ExtractRequest.model_rebuild()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {"ok": True, "capabilities": _capabilities()}
+
+
+@app.post("/fetch")
+def fetch(req: FetchRequest) -> dict[str, Any]:
+    timeout_ms = _clamp(req.timeout_ms, 30_000, 1_000, MAX_TIMEOUT_MS)
+    text_limit = _clamp(req.text_limit, 12_000, 0, MAX_TEXT_LIMIT)
+    errors: list[dict[str, str]] = []
+    for mode in _select_fetch_mode(req.mode, req.screenshot):
+        try:
+            if mode == "cloak":
+                return _cloak_fetch(req.url, timeout_ms, text_limit, req.screenshot, req.humanize, req.headless)
+            if mode == "scrapling_http":
+                return _scrapling_http(req.url, timeout_ms, text_limit)
+            if mode in {"scrapling_dynamic", "scrapling_stealth"}:
+                # Kept explicit for routing clarity. Implementations require browser
+                # installs and can be enabled later without changing the client API.
+                raise RuntimeError(f"{mode} requires browser runtime setup; use cloak or scrapling_http for now")
+            if mode == "plain_http":
+                return _plain_http(req.url, timeout_ms, text_limit)
+        except Exception as e:
+            errors.append({"mode": mode, "error": str(e), "error_type": type(e).__name__})
+    return {"success": False, "url": req.url, "errors": errors, "capabilities": _capabilities()}
+
+
+def _selector_values(page: Any, selector: str) -> list[str]:
+    if selector.startswith("xpath:"):
+        values = page.xpath(selector.removeprefix("xpath:")).getall()
+    else:
+        values = page.css(selector).getall()
+    return [str(v).strip() for v in values if str(v).strip()]
+
+
+@app.post("/extract")
+def extract(req: ExtractRequest) -> dict[str, Any]:
+    timeout_ms = _clamp(req.timeout_ms, 30_000, 1_000, MAX_TIMEOUT_MS)
+    text_limit = _clamp(req.text_limit, 12_000, 0, MAX_TEXT_LIMIT)
+    try:
+        from scrapling.fetchers import Fetcher
+
+        page = Fetcher.get(req.url, timeout=max(1, int(timeout_ms / 1000)))
+        fields = {name: _selector_values(page, selector) for name, selector in req.selectors.items()}
+        text = re.sub(r"\s+", " ", (page.css("body::text").get(default="") or page.text or "")).strip()
+        links: list[str] = []
+        if req.include_links:
+            base = getattr(page, "url", req.url)
+            links = [urllib.parse.urljoin(base, href) for href in page.css("a::attr(href)").getall() if href]
+        return {
+            "success": True,
+            "mode_used": "scrapling_http",
+            "url": req.url,
+            "final_url": getattr(page, "url", req.url),
+            "title": page.css("title::text").get(default="") or "",
+            "response_status": getattr(page, "status", None) or getattr(page, "status_code", None),
+            "fields": fields,
+            "links": links,
+            "text": text[:text_limit],
+            "text_length": len(text),
+            "text_truncated": len(text) > text_limit,
+        }
+    except Exception as e:
+        return {"success": False, "url": req.url, "error": str(e), "error_type": type(e).__name__, "capabilities": _capabilities()}

--- a/docker-compose.browser-tools.yml
+++ b/docker-compose.browser-tools.yml
@@ -1,0 +1,14 @@
+services:
+  browser-tools:
+    build:
+      context: ./deploy/browser-tools-sidecar
+    image: hermes-browser-tools:local
+    environment:
+      BROWSER_TOOLS_ARTIFACT_DIR: /tmp/browser-tools-artifacts
+    ports:
+      - "127.0.0.1:8790:8790"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8790/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/tests/tools/test_browser_tools_sidecar.py
+++ b/tests/tools/test_browser_tools_sidecar.py
@@ -1,0 +1,79 @@
+import json
+import os
+from io import BytesIO
+
+from tools import browser_tools_sidecar as sidecar
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, *_args, **_kwargs):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_check_requirements_requires_env(monkeypatch):
+    monkeypatch.delenv("BROWSER_TOOLS_URL", raising=False)
+    assert sidecar.check_browser_tools_sidecar_requirements() is False
+
+    monkeypatch.setenv("BROWSER_TOOLS_URL", "http://browser-tools:8790")
+    assert sidecar.check_browser_tools_sidecar_requirements() is True
+
+
+def test_fetch_posts_to_sidecar(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse({"success": True, "title": "Example Domain"})
+
+    monkeypatch.setenv("BROWSER_TOOLS_URL", "http://browser-tools:8790/")
+    monkeypatch.setattr(sidecar.urllib.request, "urlopen", fake_urlopen)
+
+    result = json.loads(sidecar.browser_tools_fetch("https://example.com", text_limit=999999))
+
+    assert result["success"] is True
+    assert result["title"] == "Example Domain"
+    assert captured["url"] == "http://browser-tools:8790/fetch"
+    assert captured["body"]["url"] == "https://example.com"
+    assert captured["body"]["text_limit"] == sidecar.MAX_TEXT_LIMIT
+
+
+def test_extract_posts_selectors_to_sidecar(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse({"success": True, "fields": {"quotes": ["hello"]}})
+
+    monkeypatch.setenv("BROWSER_TOOLS_URL", "http://browser-tools:8790")
+    monkeypatch.setattr(sidecar.urllib.request, "urlopen", fake_urlopen)
+
+    result = json.loads(sidecar.browser_tools_extract(
+        "https://quotes.toscrape.com/",
+        selectors={"quotes": ".quote .text::text"},
+    ))
+
+    assert result["success"] is True
+    assert result["fields"]["quotes"] == ["hello"]
+    assert captured["url"] == "http://browser-tools:8790/extract"
+    assert captured["body"]["selectors"] == {"quotes": ".quote .text::text"}
+
+
+def test_missing_sidecar_env_returns_helpful_error(monkeypatch):
+    monkeypatch.delenv("BROWSER_TOOLS_URL", raising=False)
+
+    result = json.loads(sidecar.browser_tools_fetch("https://example.com"))
+
+    assert result["success"] is False
+    assert "BROWSER_TOOLS_URL" in result["error"]

--- a/tools/browser_tools_sidecar.py
+++ b/tools/browser_tools_sidecar.py
@@ -1,0 +1,197 @@
+"""Shared browser/scraping sidecar tools.
+
+This module exposes a small Hermes tool wrapper around an internal
+``browser-tools`` HTTP sidecar. The sidecar can combine multiple runtimes such
+as CloakBrowser for stealth/visual rendering and Scrapling for structured
+fetching, extraction, and crawling. Keeping those heavy browser dependencies in
+one service lets many agents share them without installing Playwright/Patchright
+inside every Hermes container.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from tools.registry import registry
+
+
+DEFAULT_BROWSER_TOOLS_URL = "http://browser-tools:8790"
+MAX_TIMEOUT_MS = 120_000
+MAX_TEXT_LIMIT = 50_000
+
+
+def _base_url() -> str:
+    return os.getenv("BROWSER_TOOLS_URL", "").rstrip("/")
+
+
+def check_browser_tools_sidecar_requirements() -> bool:
+    """Expose tools only when the caller configured a sidecar URL."""
+    return bool(_base_url())
+
+
+def _clamp_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _post_json(path: str, payload: dict[str, Any], timeout_ms: int) -> str:
+    base = _base_url()
+    if not base:
+        return json.dumps({
+            "success": False,
+            "error": "BROWSER_TOOLS_URL is not configured",
+            "hint": f"Set BROWSER_TOOLS_URL={DEFAULT_BROWSER_TOOLS_URL} in the agent/container environment.",
+        })
+
+    timeout_ms = _clamp_int(timeout_ms, 30_000, 1_000, MAX_TIMEOUT_MS)
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}{path}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=(timeout_ms / 1000.0) + 5) as resp:
+            raw = resp.read(MAX_TEXT_LIMIT + 100_000).decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        detail = e.read(20_000).decode("utf-8", errors="replace")
+        return json.dumps({"success": False, "error": f"sidecar HTTP {e.code}", "detail": detail})
+    except Exception as e:
+        return json.dumps({"success": False, "error": str(e), "error_type": type(e).__name__})
+
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return json.dumps({"success": False, "error": "invalid JSON from browser-tools sidecar", "body": raw[:20_000]})
+    return json.dumps(data, ensure_ascii=False)
+
+
+def browser_tools_fetch(
+    url: str,
+    mode: str = "auto",
+    timeout_ms: int = 30_000,
+    text_limit: int = 12_000,
+    screenshot: bool = False,
+    humanize: bool = False,
+    wait_until: str = "domcontentloaded",
+    task_id: str | None = None,
+) -> str:
+    """Fetch a webpage through the shared browser-tools sidecar."""
+    if not url:
+        return json.dumps({"success": False, "error": "url is required"})
+    timeout_ms = _clamp_int(timeout_ms, 30_000, 1_000, MAX_TIMEOUT_MS)
+    text_limit = _clamp_int(text_limit, 12_000, 0, MAX_TEXT_LIMIT)
+    payload = {
+        "url": url,
+        "mode": mode or "auto",
+        "timeout_ms": timeout_ms,
+        "text_limit": text_limit,
+        "screenshot": bool(screenshot),
+        "humanize": bool(humanize),
+        "wait_until": wait_until or "domcontentloaded",
+    }
+    return _post_json("/fetch", payload, timeout_ms)
+
+
+def browser_tools_extract(
+    url: str,
+    selectors: dict[str, str] | None = None,
+    mode: str = "scrapling_http",
+    timeout_ms: int = 30_000,
+    text_limit: int = 12_000,
+    include_links: bool = True,
+    task_id: str | None = None,
+) -> str:
+    """Run structured selector extraction through Scrapling in the sidecar."""
+    if not url:
+        return json.dumps({"success": False, "error": "url is required"})
+    timeout_ms = _clamp_int(timeout_ms, 30_000, 1_000, MAX_TIMEOUT_MS)
+    text_limit = _clamp_int(text_limit, 12_000, 0, MAX_TEXT_LIMIT)
+    payload = {
+        "url": url,
+        "mode": mode or "scrapling_http",
+        "selectors": selectors or {},
+        "timeout_ms": timeout_ms,
+        "text_limit": text_limit,
+        "include_links": bool(include_links),
+    }
+    return _post_json("/extract", payload, timeout_ms)
+
+
+registry.register(
+    name="browser_tools_fetch",
+    toolset="browser",
+    description="Fetch a page through a shared browser/scraping sidecar that can route to CloakBrowser or Scrapling.",
+    emoji="🌐",
+    schema={
+        "name": "browser_tools_fetch",
+        "description": "Fetch a webpage using the shared browser-tools sidecar. Use this when BROWSER_TOOLS_URL is configured and agents should share one container that combines CloakBrowser stealth rendering with Scrapling scraping/extraction.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "URL to fetch."},
+                "mode": {"type": "string", "description": "Routing mode: auto, cloak, scrapling_http, scrapling_dynamic, scrapling_stealth, or plain_http.", "default": "auto"},
+                "timeout_ms": {"type": "integer", "description": "Request/navigation timeout in milliseconds, capped at 120000.", "default": 30000},
+                "text_limit": {"type": "integer", "description": "Maximum visible text characters to return, capped at 50000.", "default": 12000},
+                "screenshot": {"type": "boolean", "description": "Capture a screenshot when supported by the chosen mode.", "default": False},
+                "humanize": {"type": "boolean", "description": "Ask the sidecar to use humanized browser behavior when supported.", "default": False},
+                "wait_until": {"type": "string", "description": "Browser wait condition for rendered modes.", "default": "domcontentloaded"},
+            },
+            "required": ["url"],
+        },
+    },
+    handler=lambda args, **kwargs: browser_tools_fetch(
+        url=args.get("url", ""),
+        mode=args.get("mode", "auto"),
+        timeout_ms=args.get("timeout_ms", 30_000),
+        text_limit=args.get("text_limit", 12_000),
+        screenshot=bool(args.get("screenshot", False)),
+        humanize=bool(args.get("humanize", False)),
+        wait_until=args.get("wait_until", "domcontentloaded"),
+        task_id=kwargs.get("task_id"),
+    ),
+    check_fn=check_browser_tools_sidecar_requirements,
+    max_result_size_chars=100_000,
+)
+
+registry.register(
+    name="browser_tools_extract",
+    toolset="browser",
+    description="Extract structured fields from a webpage through the shared Scrapling-enabled browser-tools sidecar.",
+    emoji="🧩",
+    schema={
+        "name": "browser_tools_extract",
+        "description": "Extract structured webpage fields through the shared browser-tools sidecar. Best for CSS/XPath extraction, links, headings, product/docs pages, and tool-enrichment workflows.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "URL to extract from."},
+                "selectors": {"type": "object", "description": "Mapping of output field name to Scrapling-compatible CSS/XPath selector. CSS is default; prefix values with xpath: for XPath.", "additionalProperties": {"type": "string"}, "default": {}},
+                "mode": {"type": "string", "description": "Extraction mode: scrapling_http, scrapling_dynamic, scrapling_stealth, or auto.", "default": "scrapling_http"},
+                "timeout_ms": {"type": "integer", "description": "Request/navigation timeout in milliseconds, capped at 120000.", "default": 30000},
+                "text_limit": {"type": "integer", "description": "Maximum page text characters to include, capped at 50000.", "default": 12000},
+                "include_links": {"type": "boolean", "description": "Include discovered links in the response.", "default": True},
+            },
+            "required": ["url"],
+        },
+    },
+    handler=lambda args, **kwargs: browser_tools_extract(
+        url=args.get("url", ""),
+        selectors=args.get("selectors") if isinstance(args.get("selectors"), dict) else {},
+        mode=args.get("mode", "scrapling_http"),
+        timeout_ms=args.get("timeout_ms", 30_000),
+        text_limit=args.get("text_limit", 12_000),
+        include_links=bool(args.get("include_links", True)),
+        task_id=kwargs.get("task_id"),
+    ),
+    check_fn=check_browser_tools_sidecar_requirements,
+    max_result_size_chars=100_000,
+)

--- a/website/docs/developer-guide/browser-tools-sidecar.md
+++ b/website/docs/developer-guide/browser-tools-sidecar.md
@@ -1,0 +1,175 @@
+---
+title: Browser-tools Sidecar
+---
+
+# Browser-tools sidecar
+
+The browser-tools sidecar is an optional shared HTTP service for agent fleets
+that need browser rendering, stealth fetches, structured scraping, and webpage
+enrichment without installing heavy browser dependencies in every Hermes agent
+container.
+
+It is designed to combine complementary tools:
+
+- **CloakBrowser** for stealth/humanized browser rendering, screenshots, and
+  visual artifact capture.
+- **Scrapling** for fast HTTP scraping, CSS/XPath extraction, adaptive selectors,
+  and crawler/spider workflows.
+- **Plain HTTP fallback** for simple public pages when optional runtimes are not
+  installed.
+
+This should be used as a shared capability layer, not as a replacement for
+platform-specific ingestion routes such as YouTube transcript extraction,
+Cobalt media capture, `yt-dlp`, Instagram discovery, or other social APIs.
+
+## Architecture
+
+```text
+Hermes agent / worker / SocialScraperAgent
+        │
+        │ BROWSER_TOOLS_URL=http://browser-tools:8790
+        ▼
+browser-tools sidecar
+        ├── CloakBrowser runtime: stealth render, screenshot, humanized browsing
+        ├── Scrapling: HTTP fetch, selectors, extraction, future crawls
+        └── plain HTTP fallback
+```
+
+Run it on the same internal Docker network as the agents. Expose the port to
+`127.0.0.1` only for operator smoke tests.
+
+## Compose
+
+A minimal compose file is included at the repository root:
+
+```bash
+docker compose -f docker-compose.browser-tools.yml up --build browser-tools
+```
+
+For dependent agent containers, inject:
+
+```yaml
+environment:
+  BROWSER_TOOLS_URL: http://browser-tools:8790
+```
+
+## API
+
+### `GET /health`
+
+Returns service liveness and installed runtime capabilities:
+
+```json
+{
+  "ok": true,
+  "capabilities": {
+    "cloak_fetch_cli": true,
+    "scrapling": true,
+    "playwright": true,
+    "patchright": true
+  }
+}
+```
+
+### `POST /fetch`
+
+Fetch a page with automatic or explicit routing.
+
+```json
+{
+  "url": "https://example.com",
+  "mode": "auto",
+  "timeout_ms": 30000,
+  "text_limit": 12000,
+  "screenshot": false,
+  "humanize": false,
+  "wait_until": "domcontentloaded"
+}
+```
+
+Modes:
+
+- `auto` — choose the best available runtime.
+- `scrapling_http` — fast HTTP fetch and text extraction.
+- `cloak` — CloakBrowser-backed render/fetch, useful for screenshots and
+  fingerprint-sensitive pages.
+- `plain_http` — low-dependency fallback.
+- `scrapling_dynamic` / `scrapling_stealth` — reserved API modes for future
+  browser-backed Scrapling routes once browser installation is pinned.
+
+### `POST /extract`
+
+Run structured extraction with Scrapling selectors.
+
+```json
+{
+  "url": "https://quotes.toscrape.com/",
+  "mode": "scrapling_http",
+  "selectors": {
+    "quotes": ".quote .text::text",
+    "authors": ".quote .author::text",
+    "links": "a::attr(href)"
+  },
+  "include_links": true
+}
+```
+
+Selector values default to CSS. Prefix with `xpath:` for XPath selectors.
+
+## Hermes tools
+
+When `BROWSER_TOOLS_URL` is configured, Hermes exposes two browser-toolset
+functions:
+
+- `browser_tools_fetch` — fetch through the sidecar.
+- `browser_tools_extract` — structured selector extraction through the sidecar.
+
+These tools are intentionally gated by the environment variable so ordinary
+Hermes installs do not see sidecar-specific tools unless the service is wired.
+
+## Routing guidance
+
+Use the sidecar this way:
+
+```text
+Need ordinary webpage text?          -> browser_tools_fetch mode=scrapling_http
+Need structured CSS/XPath fields?    -> browser_tools_extract
+Need screenshot / visual artifact?   -> browser_tools_fetch mode=cloak screenshot=true
+Need fingerprint-sensitive render?   -> browser_tools_fetch mode=cloak
+Need social video/transcript?        -> keep platform-specific ingestion routes
+Need multi-page docs/product crawl?  -> future Scrapling spider endpoint
+```
+
+## Smoke tests
+
+From the host, if the compose file maps `127.0.0.1:8790`:
+
+```bash
+curl -fsS http://127.0.0.1:8790/health
+
+curl -fsS -X POST http://127.0.0.1:8790/fetch \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com","text_limit":120}'
+
+curl -fsS -X POST http://127.0.0.1:8790/extract \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://quotes.toscrape.com/","selectors":{"quotes":".quote .text::text"}}'
+```
+
+Expected results:
+
+- `/health` returns `ok: true`.
+- `/fetch` returns title `Example Domain` and status `200`.
+- `/extract` returns quote text in `fields.quotes`.
+
+## Security and operations
+
+- Keep the service on an internal Docker network by default.
+- Map the port to `127.0.0.1` only for local smoke tests.
+- Treat browser runtimes and downloaded Chromium builds as privileged third-party
+  binaries; pin versions for production images.
+- Use stealth/fingerprint-sensitive modes only for owned, permitted, or
+  contracted automation. The sidecar removes a technical blocker; it does not
+  grant legal or Terms-of-Service permission.
+- Do not install every browser runtime into every agent. Keep this service as the
+  shared dependency boundary.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -762,6 +762,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'developer-guide/tools-runtime',
             'developer-guide/browser-supervisor',
+            'developer-guide/browser-tools-sidecar',
             'developer-guide/acp-internals',
             'developer-guide/cron-internals',
             'developer-guide/trajectory-format',


### PR DESCRIPTION
## Summary

Adds an optional shared `browser-tools` sidecar pattern for Hermes deployments that want reusable browser rendering + structured scraping without installing heavy browser dependencies into every agent container.

This PR combines two complementary capabilities behind one internal HTTP service:

- **CloakBrowser-compatible fetch path** for stealth/humanized rendering, screenshots, and visual capture when a `cloak-fetch` binary is available.
- **Scrapling-powered extraction path** for fast HTTP fetching, CSS/XPath selectors, text extraction, link discovery, and future crawler/spider workflows.

Hermes agents get two new browser-toolset wrappers when `BROWSER_TOOLS_URL` is configured:

- `browser_tools_fetch`
- `browser_tools_extract`

The tools are environment-gated, so ordinary Hermes installs do not see or pay schema/context cost for sidecar-specific tools unless the sidecar is explicitly wired.

## Why

Multi-agent deployments often need browser/scraping capabilities across many containers. Installing Playwright/Patchright/browser runtimes into every agent is heavy and hard to keep pinned. A sidecar gives us a cleaner dependency boundary:

```text
Hermes agent / worker / external agent
        │
        │ BROWSER_TOOLS_URL=http://browser-tools:8790
        ▼
browser-tools sidecar
        ├── CloakBrowser runtime: stealth render, screenshot, humanized browsing
        ├── Scrapling: HTTP fetch, selectors, extraction, future crawls
        └── plain HTTP fallback
```

This keeps the core Hermes runtime light while still making powerful browser/scrape capabilities available to any agent on the internal network.

## What changed

- Adds `tools/browser_tools_sidecar.py`
  - registers `browser_tools_fetch`
  - registers `browser_tools_extract`
  - gates both tools on `BROWSER_TOOLS_URL`
  - clamps timeouts/text limits and returns JSON errors for unavailable sidecars

- Adds `deploy/browser-tools-sidecar/`
  - FastAPI `server.py`
  - Dockerfile
  - `/health`, `/fetch`, and `/extract` endpoints
  - auto/plain routing with Scrapling HTTP, CloakBrowser CLI, and plain urllib fallback

- Adds `docker-compose.browser-tools.yml`
  - local build/run pattern
  - loopback-only port mapping for smoke tests

- Adds developer documentation
  - architecture
  - API shapes
  - routing guidance
  - smoke tests
  - security/ops notes

- Adds unit tests for the Hermes tool wrapper

## Test plan

Ran targeted tests and smoke checks locally:

```bash
/tmp/hermes-sidecar-test-venv/bin/python -m pytest tests/tools/test_browser_tools_sidecar.py -q -o 'addopts=' --basetemp=/tmp/pytest-hermes-sidecar
```

Result:

```text
4 passed in 0.11s
```

Syntax check:

```bash
/tmp/hermes-sidecar-test-venv/bin/python -m py_compile tools/browser_tools_sidecar.py deploy/browser-tools-sidecar/server.py
```

Sidecar module smoke with Scrapling installed:

```text
health {'ok': True, 'capabilities': {'cloak_fetch_cli': True, 'scrapling': True, 'playwright': True, 'patchright': True}}
fetch {'success': True, 'mode_used': 'scrapling_http', 'title': 'Example Domain', 'response_status': 200}
extract_success True first_quote ['“The world as we have created it is a process of our thinking. It cannot be changed without changing our thinking.”']
```

## Notes / follow-ups

- `scrapling_dynamic` and `scrapling_stealth` are reserved API modes in this first pass. They intentionally return a setup error until browser runtime installation/pinning is finalized.
- The current sidecar Dockerfile installs `scrapling[fetchers]`; production deployments should pin runtime versions as needed.
- The service should run on an internal Docker network. Host port mapping should stay loopback-only for smoke tests.
- This does not replace platform-specific ingestion routes like YouTube transcripts, Cobalt, yt-dlp, or social APIs; it is a reusable webpage/browser enrichment layer.
