### PR TITLE
fix(desktop): show session compression count

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { SidebarSessionRow } from './session-row'
+
+const baseSession: SessionInfo = {
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'session-1',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1_780_000_000,
+  message_count: 3,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  source: 'cli',
+  started_at: 1_780_000_000,
+  title: 'Compressed work',
+  tool_call_count: 0
+}
+
+function renderRow(session: SessionInfo) {
+  render(
+    <SidebarSessionRow
+      isPinned={false}
+      isSelected={false}
+      isWorking={false}
+      onArchive={vi.fn()}
+      onDelete={vi.fn()}
+      onPin={vi.fn()}
+      onResume={vi.fn()}
+      session={session}
+    />
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SidebarSessionRow', () => {
+  it('shows compression count for compressed sessions', () => {
+    renderRow({ ...baseSession, compress_count: 2 })
+
+    expect(screen.getByTitle('Compressed 2 times').textContent).toBe('x2')
+  })
+
+  it('hides compression count for uncompressed sessions', () => {
+    renderRow(baseSession)
+
+    expect(screen.queryByTitle(/Compressed/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -80,6 +80,7 @@ export function SidebarSessionRow({
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  const compressionCount = Math.max(0, session.compress_count ?? 0)
 
   return (
     <SessionContextMenu
@@ -204,6 +205,14 @@ export function SidebarSessionRow({
           <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
             {title}
           </span>
+          {compressionCount > 0 && (
+            <span
+              className="shrink-0 rounded-[0.25rem] border border-(--ui-stroke-tertiary) px-1 text-[0.5625rem] font-medium leading-3 text-(--ui-text-tertiary)"
+              title={`Compressed ${compressionCount} time${compressionCount === 1 ? '' : 's'}`}
+            >
+              x{compressionCount}
+            </span>
+          )}
         </button>
         <div className="relative z-2 grid w-[1.375rem] place-items-center">
           {!isWorking && (

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -25,6 +25,7 @@ import { requestDesktopOnboarding } from '@/store/onboarding'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   setCurrentBranch,
+  setCurrentCompressCount,
   setCurrentCwd,
   setCurrentFastMode,
   setCurrentModel,
@@ -616,9 +617,11 @@ export function useMessageStream({
     (event: RpcEvent) => {
       const payload = event.payload as GatewayEventPayload | undefined
       const explicitSid = event.session_id || ''
+
       if (!explicitSid && gatewayEventRequiresSessionId(event.type)) {
         return
       }
+
       const sessionId = explicitSid || activeSessionIdRef.current
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
@@ -636,7 +639,15 @@ export function useMessageStream({
           const runtimeInfo: Partial<
             Pick<
               ClientSessionState,
-              'branch' | 'cwd' | 'fast' | 'model' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+              | 'branch'
+              | 'compressCount'
+              | 'cwd'
+              | 'fast'
+              | 'model'
+              | 'provider'
+              | 'reasoningEffort'
+              | 'serviceTier'
+              | 'yolo'
             >
           > = {}
 
@@ -658,6 +669,12 @@ export function useMessageStream({
           if (typeof payload?.branch === 'string') {
             setCurrentBranch(payload.branch)
             runtimeInfo.branch = payload.branch
+          }
+
+          if (typeof payload?.compress_count === 'number') {
+            const count = Math.max(0, payload.compress_count)
+            setCurrentCompressCount(count)
+            runtimeInfo.compressCount = count
           }
 
           if (typeof payload?.personality === 'string') {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -23,6 +23,7 @@ import {
   setAwaitingResponse,
   setBusy,
   setCurrentBranch,
+  setCurrentCompressCount,
   setCurrentCwd,
   setCurrentFastMode,
   setCurrentModel,
@@ -210,14 +211,20 @@ function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
 }
 
 function applyRuntimeInfo(info: SessionCreateResponse['info'] | undefined): Partial<
-  Pick<ClientSessionState, 'branch' | 'cwd' | 'fast' | 'model' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'>
+  Pick<
+    ClientSessionState,
+    'branch' | 'compressCount' | 'cwd' | 'fast' | 'model' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+  >
 > | null {
   if (!info) {
     return null
   }
 
   const sessionState: Partial<
-    Pick<ClientSessionState, 'branch' | 'cwd' | 'fast' | 'model' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'>
+    Pick<
+      ClientSessionState,
+      'branch' | 'compressCount' | 'cwd' | 'fast' | 'model' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+    >
   > = {}
 
   reportBackendContract(info.desktop_contract)
@@ -270,6 +277,12 @@ function applyRuntimeInfo(info: SessionCreateResponse['info'] | undefined): Part
     sessionState.yolo = info.yolo
   }
 
+  if (typeof info.compress_count === 'number') {
+    const count = Math.max(0, info.compress_count)
+    setCurrentCompressCount(count)
+    sessionState.compressCount = count
+  }
+
   if (info.usage) {
     setCurrentUsage(current => ({ ...current, ...info.usage }))
   }
@@ -316,6 +329,7 @@ export function useSessionActions({
         output: 0,
         total: 0
       })
+      setCurrentCompressCount(0)
       setSessionStartedAt(null)
       setTurnStartedAt(null)
       // New chats start in the configured default project dir when set,
@@ -474,6 +488,7 @@ export function useSessionActions({
         syncSessionStateToView(cachedRuntimeId, cachedState)
         setCurrentCwd(cachedState.cwd)
         setCurrentBranch(cachedState.branch)
+        setCurrentCompressCount(cachedState.compressCount)
         setSessionStartedAt(Date.now())
 
         try {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -9,6 +9,7 @@ import {
   $busy,
   $messages,
   noteSessionActivity,
+  setCurrentCompressCount,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
@@ -146,6 +147,7 @@ export function useSessionStateCache({
     setBusy(pending.state.busy)
     setMutableRef(busyRef, pending.state.busy)
     setAwaitingResponse(pending.state.awaitingResponse)
+    setCurrentCompressCount(pending.state.compressCount)
     // Mirror the focused session's per-session turn clock into the global
     // atom the statusbar timer reads. Keeps a backgrounded turn's elapsed
     // time intact on focus instead of zeroing it (the "timer restarts" bug).

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -13,6 +13,7 @@ import {
   Clock,
   Command,
   Hash,
+  Layers3,
   Loader2,
   Sparkles,
   Terminal,
@@ -30,6 +31,7 @@ import {
   $activeSessionId,
   $busy,
   $connection,
+  $currentCompressCount,
   $currentFastMode,
   $currentModel,
   $currentProvider,
@@ -98,6 +100,7 @@ export function useStatusbarItems({
   const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
   const currentFastMode = useStore($currentFastMode)
+  const currentCompressCount = useStore($currentCompressCount)
   const currentModel = useStore($currentModel)
   const currentProvider = useStore($currentProvider)
   const currentReasoningEffort = useStore($currentReasoningEffort)
@@ -396,6 +399,15 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
+        detail: `x${currentCompressCount}`,
+        hidden: currentCompressCount <= 0,
+        icon: <Layers3 className="size-3" />,
+        id: 'compression-count',
+        label: 'Compressed',
+        title: `Session compressed ${currentCompressCount} time${currentCompressCount === 1 ? '' : 's'}`,
+        variant: 'text'
+      },
+      {
         detail: <LiveDuration since={sessionStartedAt} />,
         hidden: !sessionStartedAt,
         id: 'session-timer',
@@ -465,6 +477,7 @@ export function useStatusbarItems({
       contextBar,
       contextUsage,
       copy,
+      currentCompressCount,
       currentFastMode,
       currentModel,
       currentProvider,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -122,6 +122,7 @@ export interface ClientSessionState {
   storedSessionId: string | null
   messages: ChatMessage[]
   branch: string
+  compressCount: number
   cwd: string
   model: string
   provider: string

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -48,6 +48,7 @@ export type GatewayEventPayload = {
   running?: boolean
   cwd?: string
   branch?: string
+  compress_count?: number
   credential_warning?: string
   personality?: string
   usage?: Partial<UsageStats>

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -39,6 +39,7 @@ export function createClientSessionState(
     storedSessionId,
     messages,
     branch: '',
+    compressCount: 0,
     cwd: '',
     model: '',
     provider: '',

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -184,6 +184,7 @@ export const $currentFastMode = atom(false)
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
 export const $yoloActive = atom(false)
+export const $currentCompressCount = atom(0)
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $currentBranch = atom('')
 export const $currentUsage = atom<UsageStats>({
@@ -227,6 +228,7 @@ export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
+export const setCurrentCompressCount = (next: Updater<number>) => updateAtom($currentCompressCount, next)
 
 export const setCurrentCwd = (next: Updater<string>) => {
   updateAtom($currentCwd, next)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -279,6 +279,7 @@ export interface SessionCreateResponse {
 
 export interface SessionInfo {
   archived?: boolean
+  compress_count?: number
   cwd?: null | string
   ended_at: null | number
   id: string
@@ -344,6 +345,7 @@ export interface SessionResumeResponse {
 
 export interface SessionRuntimeInfo {
   branch?: string
+  compress_count?: number
   config_warning?: string
   credential_warning?: string
   cwd?: string

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1307,7 +1307,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "_lineage_root_id", "compress_count",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1872,6 +1872,52 @@ class SessionDB:
             current = row["id"]
         return current
 
+    def get_compression_count(self, session_id: str) -> int:
+        """Return how many compression boundaries precede ``session_id``.
+
+        Only counts parent links that are actual compression continuations:
+        the parent ended with ``end_reason='compression'`` and the child was
+        created at or after that parent ended. This deliberately ignores
+        delegate subagents and branch children that also have a parent.
+        """
+        if not session_id:
+            return 0
+
+        count = 0
+        current = session_id
+        seen = set()
+        with self._lock:
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                row = self._conn.execute(
+                    "SELECT child.parent_session_id, child.started_at AS child_started_at, "
+                    "       parent.ended_at AS parent_ended_at, parent.end_reason AS parent_end_reason "
+                    "FROM sessions child "
+                    "LEFT JOIN sessions parent ON parent.id = child.parent_session_id "
+                    "WHERE child.id = ?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    break
+                parent_id = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+                if not parent_id:
+                    break
+                child_started_at = row["child_started_at"] if hasattr(row, "keys") else row[1]
+                parent_ended_at = row["parent_ended_at"] if hasattr(row, "keys") else row[2]
+                parent_end_reason = row["parent_end_reason"] if hasattr(row, "keys") else row[3]
+                if (
+                    parent_end_reason != "compression"
+                    or parent_ended_at is None
+                    or child_started_at is None
+                    or child_started_at < parent_ended_at
+                ):
+                    break
+                count += 1
+                current = parent_id
+        return count
+
     def list_sessions_rich(
         self,
         source: str = None,
@@ -2078,6 +2124,7 @@ class SessionDB:
                 s["preview"] = ""
             # Drop the internal ordering column so callers see a clean dict.
             s.pop("_effective_last_active", None)
+            s["compress_count"] = self.get_compression_count(s.get("id", ""))
             sessions.append(s)
 
         # Project compression roots forward to their tips. Each row whose
@@ -2111,6 +2158,7 @@ class SessionDB:
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
+                merged["compress_count"] = self.get_compression_count(tip_id)
                 projected.append(merged)
             sessions = projected
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2914,9 +2914,20 @@ class TestCompressionChainProjection:
         # The row surfaces the tip's identity but preserves the root's start
         # timestamp for stable ordering and lineage tracking.
         assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["compress_count"] == 2
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
+
+    def test_compression_count_ignores_delegate_children(self, db):
+        """Only compression continuations count toward the surfaced total."""
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        assert db.get_compression_count("tip1") == 2
+        assert db.get_compression_count("delegate1") == 0
+        assert db.get_compression_count("root1") == 0
 
     def test_list_projection_uses_tip_cwd(self, db):
         """Projected lineage rows should carry cwd from the live tip row.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3731,6 +3731,22 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_includes_compression_count(monkeypatch):
+    class FakeDB:
+        def get_compression_count(self, session_id):
+            assert session_id == "tip-session"
+            return 3
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+
+    info = server._session_info(
+        types.SimpleNamespace(tools=[], model="", session_id="fallback"),
+        {"session_key": "tip-session"},
+    )
+
+    assert info["compress_count"] == 3
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2293,7 +2293,16 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "update_command": "",
         "usage": _get_usage(agent),
         "profile_name": _current_profile_name(),
+        "compress_count": 0,
     }
+    session_key = str((session or {}).get("session_key") or getattr(agent, "session_id", "") or "")
+    if session_key:
+        db = _get_db()
+        if db is not None and hasattr(db, "get_compression_count"):
+            try:
+                info["compress_count"] = db.get_compression_count(session_key)
+            except Exception:
+                logger.exception("failed to compute compression count for session %s", session_key)
     try:
         from hermes_cli import __version__, __release_date__
 
@@ -3719,7 +3728,9 @@ def _(rid, params: dict) -> dict:
                         "preview": s.get("preview") or "",
                         "started_at": s.get("started_at") or 0,
                         "message_count": s.get("message_count") or 0,
+                        "compress_count": s.get("compress_count") or 0,
                         "source": s.get("source") or "",
+                        "_lineage_root_id": s.get("_lineage_root_id"),
                     }
                     for s in rows
                 ]


### PR DESCRIPTION
## Summary
- add a lineage-aware `compress_count` to SessionDB session listings and runtime `session.info` payloads
- surface compressed session counts in the Desktop sidebar and status bar
- keep the current-session compression count synchronized across create/resume/session.info flows

## Root cause
Hermes already projected compressed lineage roots to their live continuation tips, but only exposed `_lineage_root_id`. The UI had no count for how many compression boundaries existed in the lineage.

Closes #38246.

## Verification
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/test_hermes_state.py::TestCompressionChainProjection tests/test_tui_gateway_server.py::test_session_info_includes_compression_count -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check hermes_state.py tui_gateway/server.py gateway/platforms/api_server.py tests/test_hermes_state.py tests/test_tui_gateway_server.py`
- `npm run test:ui -- --run src/app/chat/sidebar/session-row.test.tsx src/store/session.test.ts`
- `npm run type-check`
- `npx eslint src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/session-row.test.tsx src/app/shell/hooks/use-statusbar-items.tsx src/app/session/hooks/use-session-actions.ts src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-session-state-cache.ts src/lib/chat-messages.ts src/lib/chat-runtime.ts src/store/session.ts src/types/hermes.ts`
- `git diff --check`