### PR TITLE
fix(dashboard): preserve user terminal background themes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7325,6 +7325,15 @@ def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0)
     return None
 
 
+def _parse_theme_hex_color(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    color = value.strip()
+    if re.fullmatch(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})", color):
+        return color
+    return None
+
+
 _THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
     "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
     "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace',
@@ -7504,6 +7513,13 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         "layout": layout,
         "layoutVariant": layout_variant,
     }
+    terminal_background = _parse_theme_hex_color(
+        data.get("terminalBackground")
+        or palette_src.get("terminalBackground")
+        or colors_src.get("terminalBackground")
+    )
+    if terminal_background:
+        result["terminalBackground"] = terminal_background
     if color_overrides:
         result["colorOverrides"] = color_overrides
     if assets_out:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2466,6 +2466,24 @@ class TestNormaliseThemeDefinition:
         })
         assert r["palette"]["background"]["alpha"] == 1.0
 
+    @pytest.mark.parametrize(
+        "theme_data",
+        [
+            {"terminalBackground": "#ffffff"},
+            {"palette": {"terminalBackground": "#f8fafc"}},
+            {"colors": {"terminalBackground": "#fff"}},
+        ],
+    )
+    def test_terminal_background_passthrough(self, theme_data):
+        from hermes_cli.web_server import _normalise_theme_definition
+        result = _normalise_theme_definition({"name": "light-chat", **theme_data})
+        expected = (
+            theme_data.get("terminalBackground")
+            or theme_data.get("palette", {}).get("terminalBackground")
+            or theme_data.get("colors", {}).get("terminalBackground")
+        )
+        assert result["terminalBackground"] == expected
+
 
 class TestDiscoverUserThemes:
     """Tests for _discover_user_themes() — scans ~/.hermes/dashboard-themes/."""


### PR DESCRIPTION
## Summary
- preserve `terminalBackground` in user-authored dashboard themes
- accept the field at the top level, under `palette`, or under `colors`
- add regression coverage for the normalizer passthrough

## Root cause
The dashboard frontend already consumes `terminalBackground`, but the backend user-theme normalizer dropped the field before sending user YAML theme definitions to the browser.

Closes #38238.

## Verification
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestNormaliseThemeDefinition::test_terminal_background_passthrough tests/hermes_cli/test_web_server.py::TestNormaliseThemeDefinition tests/hermes_cli/test_web_server.py::TestDiscoverUserThemes -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`