### PR TITLE
fix(docs): add --tui to the remote-gateway command

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -642,7 +642,7 @@ echo "$TOKEN"   # copy this value into the desktop app
 # 2. Run the dashboard bound to a reachable address.
 #    --insecure is required for any non-loopback bind and keeps the
 #    legacy session-token auth path (instead of the OAuth gate).
-hermes dashboard --no-open --insecure --host 0.0.0.0 --port 9119
+hermes dashboard --tui --no-open --insecure --host 0.0.0.0 --port 9119
 ```
 
 If you run the dashboard as a systemd service, `~/.hermes/.env` is picked up automatically when the unit has `EnvironmentFile=%h/.hermes/.env`, so the token is in the environment at boot.


### PR DESCRIPTION
## What does this PR do?

Updates the Desktop remote backend setup documentation to include the required `--tui` flag when launching `hermes dashboard`.

Without `--tui`, the remote dashboard can pass the `/api/status` readiness check, but the Desktop app may not proceed after logging `Remote Hermes backend is ready`. Starting the remote backend with `--tui` enables the PTY-backed TUI mode expected by the Desktop app.

## Related Issue

No related issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated the documented Desktop remote backend command to include `--tui`.
- Clarified the command needed when connecting Hermes Desktop to a remote backend.

Changed:

```bash
hermes dashboard --no-open --insecure --host 0.0.0.0 --port 9119
```

to:

```bash
hermes dashboard --tui --no-open --insecure --host 0.0.0.0 --port 9119
```

## How to Test

1. Start a remote Hermes backend with:

```bash
hermes dashboard --tui --no-open --insecure --host 0.0.0.0 --port 9119
```

2. Connect to it from the Hermes Desktop app.

3. Verify that the Desktop app connects successfully after the backend readiness check.

I also verified the failure mode before this documentation change: without `--tui`, the backend returned `200 OK` from `/api/status`, but the Desktop app stopped after logging:

```text
[hermes] [boot] Resolving Hermes backend
[hermes] [boot] Connecting to remote Hermes backend at http://100.79.130.70:9119
[hermes] [boot] Remote Hermes backend is ready
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, remote backend on Linux over Tailscale

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before adding `--tui`, the remote backend readiness check succeeded, but the Desktop app stopped after:

```text
[hermes] [boot] Resolving Hermes backend
[hermes] [boot] Connecting to remote Hermes backend at http://100.79.130.70:9119
[hermes] [boot] Remote Hermes backend is ready
```

After starting the remote backend with:

```bash
hermes dashboard --tui --no-open --insecure --host 0.0.0.0 --port 9119
```

the Desktop app was able to connect successfully.