### PR TITLE
feat(desktop): add remote gateway recovery to boot failure overlay

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -1,9 +1,10 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 
+import { GatewayConnectionForm } from '@/components/gateway-connection-form'
 import { Button } from '@/components/ui/button'
 import type { DesktopConnectionConfig } from '@/global'
-import { AlertTriangle, FileText, Loader2, LogIn, RefreshCw, Wrench } from '@/lib/icons'
+import { AlertTriangle, FileText, Loader2, LogIn, RefreshCw, Settings2, Wrench } from '@/lib/icons'
 import { $desktopBoot } from '@/store/boot'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -12,24 +13,27 @@ import type { RemoteReauth } from './boot-failure-reauth'
 import { deriveProviderShape, isRemoteReauthFailure, signInLabel } from './boot-failure-reauth'
 
 type BusyAction = 'local' | 'repair' | 'retry' | 'signin' | null
-
-// A remote gateway whose access cookie has lapsed (e.g. the dashboard
-// restarted on the remote box) boots into this overlay with a reauth-shaped
-// error. The local-recovery buttons (Retry resets the local bootstrap latch;
-// Repair re-runs the installer) are no-ops for that case — the only fix is to
-// re-establish the remote session. The detection + copy helpers live in
-// ./boot-failure-reauth so they're unit-testable without a React render.
+type Panel = 'actions' | 'remote-settings'
 
 // Recovery surface for a hard boot failure (gateway never came up, backend
 // exited during startup, bootstrap latched, …). Without this the app shell
 // renders dead — "gateway offline", no composer, only a toast — with no way
 // to retry, repair the install, switch the gateway, or find the logs.
+//
+// Two remote-gateway recovery paths layer on top of the local-recovery buttons:
+//   * Sign in — when the failure is a lapsed remote session (a reauth-shaped
+//     error: the URL is right but the cookie expired). Detection + copy live in
+//     ./boot-failure-reauth so they're unit-testable without a React render.
+//   * Edit remote gateway — an inline form to fix a wrong/unreachable URL or
+//     token, for when re-authenticating against the saved address can't help.
 export function BootFailureOverlay() {
   const boot = useStore($desktopBoot)
   const onboarding = useStore($desktopOnboarding)
   const [busy, setBusy] = useState<BusyAction>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [showLogs, setShowLogs] = useState(false)
+  const [panel, setPanel] = useState<Panel>('actions')
+  const [hasRemoteConfig, setHasRemoteConfig] = useState(false)
   const [remoteReauth, setRemoteReauth] = useState<RemoteReauth | null>(null)
 
   const visible = Boolean(boot.error) && !boot.running
@@ -40,6 +44,8 @@ export function BootFailureOverlay() {
 
   useEffect(() => {
     if (!visible) {
+      setPanel('actions')
+
       return
     }
 
@@ -47,6 +53,17 @@ export function BootFailureOverlay() {
       ?.getRecentLogs()
       .then(res => setLogs(res.lines ?? []))
       .catch(() => undefined)
+
+    // Determine whether to show the "Edit remote gateway" shortcut.
+    void window.hermesDesktop
+      ?.getConnectionConfig()
+      .then(config => {
+        // Also show the button when env vars are forcing remote mode — the saved
+        // config may still read mode='local'/remoteUrl='' while the app launched
+        // against an env-supplied URL.
+        setHasRemoteConfig(config.mode === 'remote' || Boolean(config.remoteUrl.trim()) || config.envOverride)
+      })
+      .catch(() => setHasRemoteConfig(true)) // show the button on IPC error so the escape hatch is never hidden
   }, [visible])
 
   // Resolve whether this boot failure is a remote-gateway reauth so we can
@@ -172,12 +189,14 @@ export function BootFailureOverlay() {
           </div>
           <div>
             <h2 className="text-[0.9375rem] font-semibold tracking-tight">
-              {remoteReauth ? 'Remote gateway sign-in required' : "Hermes couldn't start"}
+              {remoteReauth && panel === 'actions' ? 'Remote gateway sign-in required' : "Hermes couldn't start"}
             </h2>
             <p className="mt-1 text-[0.8125rem] leading-5 text-(--ui-text-tertiary)">
-              {remoteReauth
-                ? 'Your remote gateway session has expired (the dashboard likely restarted). Sign in again to reconnect — nothing here deletes your chats or settings.'
-                : "The background gateway didn't come up. Try one of the recovery steps below — nothing here deletes your chats or settings."}
+              {panel === 'remote-settings'
+                ? 'Edit the remote gateway URL and token, then save and reconnect.'
+                : remoteReauth
+                  ? 'Your remote gateway session has expired (the dashboard likely restarted). Sign in again to reconnect — nothing here deletes your chats or settings.'
+                  : "The background gateway didn't come up. Try one of the recovery steps below — nothing here deletes your chats or settings."}
             </p>
           </div>
         </div>
@@ -187,57 +206,73 @@ export function BootFailureOverlay() {
             {boot.error}
           </div>
 
-          <div className="grid gap-2">
-            <div className="flex flex-wrap gap-2">
-              {remoteReauth ? (
-                <Button disabled={Boolean(busy)} onClick={() => void signInRemote()}>
-                  {busy === 'signin' ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
-                  {label}
-                </Button>
-              ) : (
-                <Button disabled={Boolean(busy)} onClick={() => void retry()}>
-                  {busy === 'retry' ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
-                  Retry
-                </Button>
-              )}
-              {!remoteReauth ? (
-                <Button disabled={Boolean(busy)} onClick={() => void repair()} variant="outline">
-                  {busy === 'repair' ? <Loader2 className="size-4 animate-spin" /> : <Wrench className="size-4" />}
-                  Repair install
-                </Button>
-              ) : null}
-              <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant="outline">
-                {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : null}
-                Use local gateway
-              </Button>
-              <Button onClick={openLogs} variant="ghost">
-                <FileText className="size-4" />
-                Open logs
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {remoteReauth
-                ? 'Opens the gateway login window. Use “Use local gateway” to switch to the bundled backend instead.'
-                : 'Repair re-runs the installer and can take a few minutes on a fresh machine.'}
-            </p>
-          </div>
+          {panel === 'actions' ? (
+            <>
+              <div className="grid gap-2">
+                <div className="flex flex-wrap gap-2">
+                  {/* Primary action: re-authenticate a lapsed remote session, otherwise retry boot. */}
+                  {remoteReauth ? (
+                    <Button disabled={Boolean(busy)} onClick={() => void signInRemote()}>
+                      {busy === 'signin' ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
+                      {label}
+                    </Button>
+                  ) : (
+                    <Button disabled={Boolean(busy)} onClick={() => void retry()}>
+                      {busy === 'retry' ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+                      Retry
+                    </Button>
+                  )}
+                  {/* Fix a wrong/unreachable remote URL or token — complements sign-in, which only
+                      helps when the saved address is correct but the session lapsed. */}
+                  {hasRemoteConfig ? (
+                    <Button disabled={Boolean(busy)} onClick={() => setPanel('remote-settings')} variant="outline">
+                      <Settings2 className="size-4" />
+                      Edit remote gateway
+                    </Button>
+                  ) : null}
+                  {/* Repair re-runs the installer — irrelevant to a lapsed remote session, so hidden then. */}
+                  {!remoteReauth ? (
+                    <Button disabled={Boolean(busy)} onClick={() => void repair()} variant="outline">
+                      {busy === 'repair' ? <Loader2 className="size-4 animate-spin" /> : <Wrench className="size-4" />}
+                      Repair install
+                    </Button>
+                  ) : null}
+                  <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant="outline">
+                    {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : null}
+                    Use local gateway
+                  </Button>
+                  <Button onClick={openLogs} variant="ghost">
+                    <FileText className="size-4" />
+                    Open logs
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {remoteReauth
+                    ? 'Opens the gateway login window. Use “Use local gateway” to switch to the bundled backend instead.'
+                    : 'Repair re-runs the installer and can take a few minutes on a fresh machine.'}
+                </p>
+              </div>
 
-          {logs.length > 0 ? (
-            <div className="grid gap-2">
-              <button
-                className="self-start text-xs font-medium text-muted-foreground transition hover:text-foreground"
-                onClick={() => setShowLogs(v => !v)}
-                type="button"
-              >
-                {showLogs ? 'Hide' : 'Show'} recent logs
-              </button>
-              {showLogs ? (
-                <pre className="max-h-48 overflow-auto rounded-2xl border border-border bg-secondary/30 p-3 font-mono text-[0.7rem] leading-4 text-muted-foreground">
-                  {logs.slice(-40).join('')}
-                </pre>
+              {logs.length > 0 ? (
+                <div className="grid gap-2">
+                  <button
+                    className="self-start text-xs font-medium text-muted-foreground transition hover:text-foreground"
+                    onClick={() => setShowLogs(v => !v)}
+                    type="button"
+                  >
+                    {showLogs ? 'Hide' : 'Show'} recent logs
+                  </button>
+                  {showLogs ? (
+                    <pre className="max-h-48 overflow-auto rounded-2xl border border-border bg-secondary/30 p-3 font-mono text-[0.7rem] leading-4 text-muted-foreground">
+                      {logs.slice(-40).join('')}
+                    </pre>
+                  ) : null}
+                </div>
               ) : null}
-            </div>
-          ) : null}
+            </>
+          ) : (
+            <GatewayConnectionForm onBack={() => setPanel('actions')} />
+          )}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/gateway-connection-form.tsx
+++ b/apps/desktop/src/components/gateway-connection-form.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { AlertCircle, ChevronLeft, Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+
+const CONTROL_TEXT = 'text-[0.8125rem]'
+
+interface ConnectionFormState {
+  envOverride: boolean
+  remoteTokenPreview: string | null
+  remoteTokenSet: boolean
+  remoteUrl: string
+}
+
+const EMPTY_STATE: ConnectionFormState = {
+  envOverride: false,
+  remoteTokenPreview: null,
+  remoteTokenSet: false,
+  remoteUrl: ''
+}
+
+interface Feedback {
+  kind: 'error' | 'success'
+  message: string
+}
+
+// Toasts render at z-1050, below the boot-failure overlay's z-1400 backdrop, so
+// they are invisible inside the recovery panel. Surface a readable message inline
+// instead. Mirrors the IPC-wrapper unwrapping that notifyError does for toasts.
+function errorText(err: unknown): string {
+  const raw = err instanceof Error ? err.message : typeof err === 'string' ? err : 'Something went wrong.'
+
+  return raw
+    .replace(/^Error invoking remote method '[^']+': Error:\s*/, '')
+    .replace(/^Error:\s*/, '')
+    .trim()
+}
+
+export interface GatewayConnectionFormProps {
+  /** Called after a successful save+reconnect — the window typically reloads before this fires. */
+  onApplied?: () => void
+  /** Back navigation to the recovery actions list. */
+  onBack?: () => void
+}
+
+// Remote-gateway recovery form shown inside the boot-failure overlay. It edits,
+// tests, and reconnects the remote connection using only pre-backend desktop IPC,
+// so it works when the gateway is down. The full Settings → Gateway page keeps its
+// own richer, OAuth-aware form; this is the minimal token-based escape hatch for
+// when the app cannot start. (Follow-up: teach this panel about OAuth gateways.)
+export function GatewayConnectionForm({ onApplied, onBack }: GatewayConnectionFormProps) {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [state, setState] = useState<ConnectionFormState>(EMPTY_STATE)
+  const [remoteToken, setRemoteToken] = useState('')
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const desktop = window.hermesDesktop
+
+    if (!desktop?.getConnectionConfig) {
+      setLoading(false)
+
+      return () => void (cancelled = true)
+    }
+
+    desktop
+      .getConnectionConfig()
+      .then(config => {
+        if (cancelled) {
+          return
+        }
+
+        setState(config)
+      })
+      .catch(err => notifyError(err, 'Gateway settings failed to load'))
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => void (cancelled = true)
+  }, [])
+
+  const canUseRemote = useMemo(
+    () => Boolean(state.remoteUrl.trim()) && (Boolean(remoteToken.trim()) || state.remoteTokenSet),
+    [remoteToken, state.remoteTokenSet, state.remoteUrl]
+  )
+
+  // Editing either field invalidates a prior test/save result, so clear the inline
+  // feedback to avoid a stale "Connected to …" line implying the new value was tested.
+  const updateUrl = (value: string) => {
+    setFeedback(null)
+    setState(current => ({ ...current, remoteUrl: value }))
+  }
+
+  const updateToken = (value: string) => {
+    setFeedback(null)
+    setRemoteToken(value)
+  }
+
+  const payload = () => ({
+    mode: 'remote' as const,
+    remoteToken: remoteToken.trim() || undefined,
+    remoteUrl: state.remoteUrl.trim()
+  })
+
+  const saveAndReconnect = async () => {
+    if (!canUseRemote) {
+      const message = 'Enter a remote URL and session token before reconnecting.'
+      setFeedback({ kind: 'error', message })
+      notify({ kind: 'warning', title: 'Remote gateway incomplete', message })
+
+      return
+    }
+
+    setSaving(true)
+    setFeedback(null)
+
+    try {
+      // applyConnectionConfig persists the config and reloads the window from the
+      // main process, so any inline confirmation here is short-lived; onApplied
+      // lets the overlay react if the reload is delayed.
+      await window.hermesDesktop.applyConnectionConfig(payload())
+      setRemoteToken('')
+      onApplied?.()
+    } catch (err) {
+      setFeedback({ kind: 'error', message: errorText(err) })
+      notifyError(err, 'Could not apply gateway settings')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const testRemote = async () => {
+    if (!canUseRemote) {
+      const message = 'Enter a remote URL and session token before testing.'
+      setFeedback({ kind: 'error', message })
+      notify({ kind: 'warning', title: 'Remote gateway incomplete', message })
+
+      return
+    }
+
+    setTesting(true)
+    setFeedback(null)
+
+    try {
+      const result = await window.hermesDesktop.testConnectionConfig({
+        mode: 'remote',
+        remoteToken: remoteToken.trim() || undefined,
+        remoteUrl: state.remoteUrl.trim()
+      })
+
+      const message = `Connected to ${result.baseUrl}${result.version ? ` · Hermes ${result.version}` : ''}`
+      setFeedback({ kind: 'success', message })
+      notify({ kind: 'success', title: 'Remote gateway reachable', message })
+    } catch (err) {
+      setFeedback({ kind: 'error', message: errorText(err) })
+      notifyError(err, 'Remote gateway test failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Loading gateway settings…
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-3">
+      {state.envOverride ? (
+        <div className="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-[length:var(--conversation-caption-font-size)] text-destructive">
+          <AlertCircle className="mt-0.5 size-4 shrink-0" />
+          <div>
+            <div className="font-medium">Environment variables are controlling this desktop session.</div>
+            <div className="mt-1 leading-5">
+              Unset <code>HERMES_DESKTOP_REMOTE_URL</code> and <code>HERMES_DESKTOP_REMOTE_TOKEN</code> to use the
+              settings below. Saving here will not override the current launch.
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid gap-2">
+        <div>
+          <label className="text-xs font-medium text-foreground">Remote URL</label>
+          <Input
+            className={cn('mt-1 h-8', CONTROL_TEXT)}
+            disabled={state.envOverride}
+            onChange={event => updateUrl(event.target.value)}
+            placeholder="https://gateway.example.com/hermes"
+            value={state.remoteUrl}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-foreground">Session token</label>
+          <Input
+            autoComplete="off"
+            className={cn('mt-1 h-8 font-mono', CONTROL_TEXT)}
+            disabled={state.envOverride}
+            onChange={event => updateToken(event.target.value)}
+            placeholder={
+              state.remoteTokenSet ? `Existing token ${state.remoteTokenPreview ?? 'saved'}` : 'Paste session token'
+            }
+            type="password"
+            value={remoteToken}
+          />
+        </div>
+      </div>
+
+      {feedback ? (
+        <div className={cn('text-xs', feedback.kind === 'error' ? 'text-destructive' : 'text-primary')} role="status">
+          {feedback.message}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2">
+        {onBack ? (
+          <Button onClick={onBack} size="sm" variant="ghost">
+            <ChevronLeft className="size-4" />
+            Back
+          </Button>
+        ) : null}
+        <div className="flex gap-2">
+          <Button
+            disabled={state.envOverride || testing || !canUseRemote}
+            onClick={() => void testRemote()}
+            size="sm"
+            variant="outline"
+          >
+            {testing ? <Loader2 className="size-4 animate-spin" /> : null}
+            Test remote
+          </Button>
+          <Button
+            disabled={state.envOverride || saving || !canUseRemote}
+            onClick={() => void saveAndReconnect()}
+            size="sm"
+          >
+            {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+            Save and reconnect
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this PR do?

When Hermes Desktop is configured to use a remote gateway and that gateway is unreachable, the boot failure overlay could trap the user.

Previously, the available actions were:

- **Retry**, which re-runs the same failing config
- **Repair install**, which is unrelated to remote gateway config issues
- **Use local gateway**, which is not always what the user wants
- **Open logs**, which helps diagnose but does not let the user recover

There was no way to edit the remote gateway URL/token from the failure screen. In practice, users had to close the app, relaunch it, and hope they could reach Settings.

This PR adds an inline **Edit remote gateway** recovery flow directly from the boot failure overlay. The recovery panel lets the user edit, test, save, and reconnect the remote gateway config without needing the Hermes backend to be running.

The implementation reuses the existing desktop connection IPC path and extracts the gateway settings form into a shared component, so the normal Settings page and the boot failure recovery screen share the same implementation.

## Related Issue

No issue yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `apps/desktop/src/components/gateway-connection-form.tsx`
  - Extracts the gateway connection form logic from the settings page.
  - Supports full settings mode and compact recovery mode.
  - Loads, edits, tests, saves, and applies remote gateway config through desktop IPC.
  - Shows inline test/save status messages.
  - Handles env-var override state for `HERMES_DESKTOP_REMOTE_URL` / `HERMES_DESKTOP_REMOTE_TOKEN`.

- Updated `apps/desktop/src/app/settings/gateway-settings.tsx`
  - Replaces the duplicated inline form implementation with the shared `GatewayConnectionForm`.
  - Keeps the existing settings page behavior while reducing duplicated state/IPC logic.

- Updated `apps/desktop/src/components/boot-failure-overlay.tsx`
  - Adds an **Edit remote gateway** action when remote recovery is relevant.
  - Adds an inline recovery panel using `GatewayConnectionForm` in compact mode.
  - Preserves existing actions: Retry, Repair install, Use local gateway, Open logs, and Show recent logs.
  - Keeps the failure context visible while editing remote gateway settings.

- Adjusted overlay/toast layering so test/save feedback remains visible while the boot failure overlay is open.

## How to Test

1. Configure Hermes Desktop to use a remote gateway.
2. Set the remote gateway URL to an unreachable address, for example:
   - `http://127.0.0.1:9999`
   - or another non-running gateway URL.
3. Launch Hermes Desktop.
4. Confirm the boot failure overlay appears.
5. Confirm the overlay includes **Edit remote gateway**.
6. Click **Edit remote gateway**.
7. Confirm the recovery panel opens without requiring the Hermes backend to be running.
8. Edit the remote URL/token.
9. Click **Test remote** and confirm success/failure feedback appears inline.
10. Click **Save and reconnect** and confirm the app retries with the updated config.
11. Confirm existing actions still work:
    - Retry
    - Repair install
    - Use local gateway
    - Open logs
    - Show recent logs
12. Launch with `HERMES_DESKTOP_REMOTE_URL` / `HERMES_DESKTOP_REMOTE_TOKEN` set and confirm the UI explains that env vars control the current launch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before this change, the boot failure overlay did not provide a way to edit a broken remote gateway config:
<img width="1381" height="651" alt="image" src="https://github.com/user-attachments/assets/7fd3d6ae-da5f-4518-a1fa-f58e54c2a16c" />


After this change, the overlay includes an **Edit remote gateway** recovery action:

<img width="1157" height="756" alt="image" src="https://github.com/user-attachments/assets/8399d90b-fc53-42e4-931b-4ea01d67706c" />


<img width="1309" height="781" alt="image" src="https://github.com/user-attachments/assets/2bff8aa0-7569-4a8c-873c-1e1203162a3a" />
