### PR TITLE
fix: make Codex compression timeout tolerant

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4734,6 +4734,82 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
     return {}
 
 
+_CODEX_COMPRESSION_MIN_TIMEOUT = 360.0
+
+
+def _is_codex_responses_backend(provider: str, client: Any = None, base_url: str = "") -> bool:
+    """Return True for ChatGPT/Codex Responses-backed auxiliary clients."""
+    if _normalize_aux_provider(provider or "") == "openai-codex":
+        return True
+    actual_base = str(base_url or getattr(client, "base_url", "") or "")
+    if base_url_host_matches(actual_base, "chatgpt.com") and "codex" in actual_base.lower():
+        return True
+    # CodexAuxiliaryClient exposes the wrapped OpenAI client but tests and
+    # adapters may use lightweight stand-ins; type-name detection keeps this
+    # helper dependency-free and harmless for mocks.
+    return type(client).__name__ in {"CodexAuxiliaryClient", "AsyncCodexAuxiliaryClient"}
+
+
+def _adjust_timeout_for_resolved_client(
+    task: str,
+    timeout: float,
+    provider: str,
+    client: Any,
+    base_url: str = "",
+) -> float:
+    """Apply provider-sensitive timeout floors after client resolution.
+
+    Context compression prompts can be very large (often 100k+ tokens right
+    before compaction).  Codex/ChatGPT Responses frequently needs longer than
+    the generic 120s auxiliary timeout for that workload, and generated
+    config.yaml files already contain the old default explicitly, so changing
+    DEFAULT_CONFIG alone would not heal existing installs.  Treat the old
+    120s value as too small for Codex compression and lift it at runtime while
+    leaving other tasks/providers unchanged.
+    """
+    if task != "compression" or timeout is None:
+        return timeout
+    try:
+        timeout_f = float(timeout)
+    except (TypeError, ValueError):
+        return timeout
+    if timeout_f >= _CODEX_COMPRESSION_MIN_TIMEOUT:
+        return timeout_f
+    if not _is_codex_responses_backend(provider, client=client, base_url=base_url):
+        return timeout_f
+    logger.info(
+        "Auxiliary compression: raising Codex timeout from %.1fs to %.1fs for large context summarization",
+        timeout_f,
+        _CODEX_COMPRESSION_MIN_TIMEOUT,
+    )
+    return _CODEX_COMPRESSION_MIN_TIMEOUT
+
+
+def _apply_codex_compression_defaults(
+    task: str,
+    extra_body: Dict[str, Any],
+    provider: str,
+    client: Any,
+    base_url: str = "",
+) -> Dict[str, Any]:
+    """Default Codex compression to low reasoning unless user configured it.
+
+    Compression is a lossy summarization side-task, not primary reasoning.
+    Low effort materially reduces timeout risk on large compaction prompts
+    while preserving explicit auxiliary.compression.extra_body.reasoning
+    overrides when the user provides them.
+    """
+    if task != "compression":
+        return extra_body
+    if not _is_codex_responses_backend(provider, client=client, base_url=base_url):
+        return extra_body
+    if "reasoning" in extra_body:
+        return extra_body
+    updated = dict(extra_body)
+    updated["reasoning"] = {"effort": "low"}
+    return updated
+
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------
@@ -5028,6 +5104,12 @@ def call_llm(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    effective_timeout = _adjust_timeout_for_resolved_client(
+        task, effective_timeout, resolved_provider, client, _base_info or resolved_base_url or ""
+    )
+    effective_extra_body = _apply_codex_compression_defaults(
+        task, effective_extra_body, resolved_provider, client, _base_info or resolved_base_url or ""
+    )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",
@@ -5506,6 +5588,12 @@ async def async_call_llm(
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    effective_timeout = _adjust_timeout_for_resolved_client(
+        task, effective_timeout, resolved_provider, client, _client_base or resolved_base_url or ""
+    )
+    effective_extra_body = _apply_codex_compression_defaults(
+        task, effective_extra_body, resolved_provider, client, _client_base or resolved_base_url or ""
+    )
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1173,7 +1173,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 360,        # seconds — compression summarises large contexts; Codex can exceed 120s
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -29,6 +29,8 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    _adjust_timeout_for_resolved_client,
+    _apply_codex_compression_defaults,
 )
 
 
@@ -88,6 +90,46 @@ class TestAuxiliaryMaxTokensParam:
         with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com/chat/completions", "key", None)), \
              patch("agent.auxiliary_client._read_nous_auth", return_value=None):
             assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
+
+
+class TestCodexCompressionDefaults:
+    def test_codex_compression_timeout_lifts_old_120s_default(self):
+        client = SimpleNamespace(base_url="https://chatgpt.com/backend-api/codex/")
+
+        timeout = _adjust_timeout_for_resolved_client(
+            "compression", 120, "auto", client, str(client.base_url)
+        )
+
+        assert timeout == 360.0
+
+    def test_codex_compression_uses_low_reasoning_by_default(self):
+        client = SimpleNamespace(base_url="https://chatgpt.com/backend-api/codex/")
+
+        extra_body = _apply_codex_compression_defaults(
+            "compression", {}, "auto", client, str(client.base_url)
+        )
+
+        assert extra_body["reasoning"] == {"effort": "low"}
+
+    def test_codex_compression_preserves_user_reasoning_override(self):
+        client = SimpleNamespace(base_url="https://chatgpt.com/backend-api/codex/")
+        configured = {"reasoning": {"effort": "high"}}
+
+        extra_body = _apply_codex_compression_defaults(
+            "compression", configured, "auto", client, str(client.base_url)
+        )
+
+        assert extra_body is configured
+        assert extra_body["reasoning"] == {"effort": "high"}
+
+    def test_non_codex_compression_timeout_unchanged(self):
+        client = SimpleNamespace(base_url="https://openrouter.ai/api/v1")
+
+        timeout = _adjust_timeout_for_resolved_client(
+            "compression", 120, "openrouter", client, str(client.base_url)
+        )
+
+        assert timeout == 120.0
 
 
 class TestBuildCallKwargsMaxTokens:


### PR DESCRIPTION
## Summary
- raise Codex-backed context compression timeout from the old 120s default to a 360s runtime floor
- default Codex compression auxiliary calls to low reasoning unless explicitly configured otherwise
- update default config and add regression coverage for Codex/non-Codex compression behavior

## Evidence
- Observed repeated gateway logs: `Codex auxiliary Responses stream exceeded 120.0s total timeout` during preflight compression of ~136k-148k token sessions
- Current fallback chain had no viable fallback in this profile: OpenRouter payment error, Nous unauthenticated, no local/custom/api-key fallback

## Tests
- `uv run --extra dev pytest tests/agent/test_auxiliary_client.py::TestCodexCompressionDefaults -q`
- `uv run --extra dev pytest tests/agent/test_auxiliary_client.py -q`
- `uv run --extra dev ruff check agent/auxiliary_client.py hermes_cli/config.py tests/agent/test_auxiliary_client.py`