### PR TITLE
fix(codex): persist app-server session turns

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -32,6 +32,7 @@ def run_codex_app_server_turn(
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
+    conversation_history: List[Dict[str, Any]] | None = None,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -109,6 +110,8 @@ def run_codex_app_server_turn(
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
+
+    agent._persist_session(messages, conversation_history)
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -794,6 +794,7 @@ def run_conversation(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
+            conversation_history=conversation_history,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -4854,11 +4854,20 @@ class AIAgent:
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
+        conversation_history: List[Dict[str, Any]] = None,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            conversation_history=conversation_history,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_state import SessionDB
 import run_agent
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
@@ -49,7 +50,7 @@ def fake_session(monkeypatch):
     )
 
 
-def _make_codex_agent():
+def _make_codex_agent(*, session_db=None):
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
@@ -61,6 +62,7 @@ def _make_codex_agent():
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
+        session_db=session_db,
     )
 
 
@@ -97,6 +99,25 @@ class TestRunConversationCodexPath:
         final = [m for m in msgs if m.get("role") == "assistant"
                  and m.get("content") == "echo: hello"]
         assert final, f"expected final assistant message in {msgs}"
+
+    def test_codex_turn_persists_session_messages(self, fake_session, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            agent = _make_codex_agent(session_db=db)
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("hello")
+
+            assert result["completed"] is True
+            rows = db.get_messages(agent.session_id)
+            assert [(row["role"], row["content"]) for row in rows] == [
+                ("user", "hello"),
+                ("assistant", None),
+                ("tool", "ok"),
+                ("assistant", "echo: hello"),
+            ]
+            assert db.get_session(agent.session_id)["message_count"] == 4
+        finally:
+            db.close()
 
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across


### PR DESCRIPTION
## Summary
- persist Codex app-server projected turns through the existing session persistence path
- pass `conversation_history` into the Codex runtime so resume/compression skip logic stays aligned
- add regression coverage proving Codex app-server turns write user, assistant tool-call, tool, and final assistant messages to SessionDB

## Root cause
`api_mode=codex_app_server` returns early from the conversation loop after the Codex transport projects messages into memory. That bypassed the normal `_persist_session()` call, so desktop resume/session.info reconciled against an empty `messages` table and dropped the streamed reply.

Closes #38210.

## Verification
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_codex_app_server_integration.py -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_persistence.py -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check agent/codex_runtime.py agent/conversation_loop.py run_agent.py tests/run_agent/test_codex_app_server_integration.py`
- `git diff --check`