### PR TITLE
fix(terminal): serialize environment snapshot execution

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,6 +4,8 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import threading
+import time
 from unittest.mock import MagicMock
 
 from tools.environments.base import BaseEnvironment
@@ -19,6 +21,11 @@ class _TestableEnv(BaseEnvironment):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
+        pass
+
+
+class _FakeProcess:
+    def kill(self):
         pass
 
 
@@ -88,6 +95,45 @@ class TestWrapCommand:
         wrapped = env._wrap_command("ls", "/nonexistent")
 
         assert "exit 126" in wrapped
+
+
+class TestExecuteSerialization:
+    def test_execute_serializes_same_environment_instance(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        active = 0
+        max_active = 0
+        active_lock = threading.Lock()
+        start = threading.Barrier(2)
+
+        def fake_run_bash(*_args, **_kwargs):
+            nonlocal active, max_active
+            with active_lock:
+                active += 1
+                max_active = max(max_active, active)
+            return _FakeProcess()
+
+        def fake_wait(*_args, **_kwargs):
+            nonlocal active
+            time.sleep(0.05)
+            with active_lock:
+                active -= 1
+            return {"output": "ok", "returncode": 0}
+
+        env._run_bash = fake_run_bash
+        env._wait_for_process = fake_wait
+
+        def run():
+            start.wait(timeout=2)
+            env.execute("echo ok")
+
+        threads = [threading.Thread(target=run) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        assert max_active == 1
 
 
 class TestExtractCwdFromOutput:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -319,6 +319,7 @@ class BaseEnvironment(ABC):
         self._cwd_file = f"{temp_dir}/hermes-cwd-{self._session_id}.txt"
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
+        self._execute_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Abstract methods
@@ -836,43 +837,44 @@ class BaseEnvironment(ABC):
         rewrite_compound_background: bool = True,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}."""
-        self._before_execute()
+        with self._execute_lock:
+            self._before_execute()
 
-        exec_command, sudo_stdin = self._prepare_command(command)
-        # Guard against the `A && B &` subshell-wait trap by default.
-        # Some callers (spawn_via_env) already produce shell-safe wrappers and
-        # pass rewrite_compound_background=False.
-        if rewrite_compound_background:
-            from tools.terminal_tool import _rewrite_compound_background
-            exec_command = _rewrite_compound_background(exec_command)
-        effective_timeout = timeout or self.timeout
-        effective_cwd = cwd or self.cwd
+            exec_command, sudo_stdin = self._prepare_command(command)
+            # Guard against the `A && B &` subshell-wait trap by default.
+            # Some callers (spawn_via_env) already produce shell-safe wrappers and
+            # pass rewrite_compound_background=False.
+            if rewrite_compound_background:
+                from tools.terminal_tool import _rewrite_compound_background
+                exec_command = _rewrite_compound_background(exec_command)
+            effective_timeout = timeout or self.timeout
+            effective_cwd = cwd or self.cwd
 
-        # Merge sudo stdin with caller stdin
-        if sudo_stdin is not None and stdin_data is not None:
-            effective_stdin = sudo_stdin + stdin_data
-        elif sudo_stdin is not None:
-            effective_stdin = sudo_stdin
-        else:
-            effective_stdin = stdin_data
+            # Merge sudo stdin with caller stdin
+            if sudo_stdin is not None and stdin_data is not None:
+                effective_stdin = sudo_stdin + stdin_data
+            elif sudo_stdin is not None:
+                effective_stdin = sudo_stdin
+            else:
+                effective_stdin = stdin_data
 
-        # Embed stdin as heredoc for backends that need it
-        if effective_stdin and self._stdin_mode == "heredoc":
-            exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
-            effective_stdin = None
+            # Embed stdin as heredoc for backends that need it
+            if effective_stdin and self._stdin_mode == "heredoc":
+                exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
+                effective_stdin = None
 
-        wrapped = self._wrap_command(exec_command, effective_cwd)
+            wrapped = self._wrap_command(exec_command, effective_cwd)
 
-        # Use login shell if snapshot failed (so user's profile still loads)
-        login = not self._snapshot_ready
+            # Use login shell if snapshot failed (so user's profile still loads)
+            login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
-        self._update_cwd(result)
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+            self._update_cwd(result)
 
-        return result
+            return result
 
     # ------------------------------------------------------------------
     # Shared helpers


### PR DESCRIPTION
## Summary
- add a per-environment execute mutex around foreground BaseEnvironment commands
- serialize source/run/wait/snapshot rewrite/CWD update for a shared terminal environment
- add a concurrency regression test proving one environment instance cannot overlap execute calls

## Root cause
Terminal env lookup/creation was locked, but foreground env.execute() ran outside that lock. Multiple terminal tool calls sharing the same environment could source and rewrite the same snapshot file concurrently, risking corrupted PATH/export state.

Closes #38249.

## Verification
- /Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/tools/test_base_environment.py tests/tools/test_terminal_task_cwd.py tests/tools/test_terminal_tool_pty_fallback.py tests/tools/test_terminal_output_transform_hook.py -q
- /Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check tools/environments/base.py tests/tools/test_base_environment.py
- git diff --check