### PR TITLE
fix(plugins): tolerate transient scan directories

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1542,7 +1542,13 @@ class PluginManager:
         if not path.is_dir():
             return manifests
 
-        for child in sorted(path.iterdir()):
+        try:
+            children = sorted(path.iterdir())
+        except FileNotFoundError:
+            logger.debug("Skipping %s (disappeared during plugin scan)", path)
+            return manifests
+
+        for child in children:
             if not child.is_dir():
                 continue
             if depth == 0 and skip_names and child.name in skip_names:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -231,6 +231,35 @@ class TestPluginDiscovery:
         assert mgr._aux_tasks == {}
         assert mgr._slack_action_handlers == []
 
+    def test_discover_skips_directory_that_disappears_during_scan(
+        self, tmp_path, monkeypatch
+    ):
+        """Transient directories should not abort plugin discovery."""
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        volatile_dir = plugins_dir / "__pycache__"
+        volatile_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(path):
+            if path == volatile_dir:
+                volatile_dir.rmdir()
+                raise FileNotFoundError(str(path))
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        non_bundled = {
+            n: p for n, p in mgr._plugins.items()
+            if p.manifest.source != "bundled"
+        }
+        assert len(non_bundled) == 0
+
 
 # ── TestPluginLoading ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- ignore plugin directories that disappear between directory checks and recursive scans
- add a regression test for a transient `plugins/__pycache__` directory disappearing during discovery

## Root cause
PluginManager scanned directory entries recursively after a prior `is_dir()` check. A transient cache directory such as `plugins/__pycache__` can disappear before `Path.iterdir()` runs, raising `FileNotFoundError` and aborting all plugin discovery. This showed up as a CI failure in `tests/hermes_cli/test_plugins_transcription_registration.py::TestRegisterTranscriptionProvider::test_rejects_non_provider`.

## Verification
- /Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_plugins.py::TestPluginDiscovery::test_discover_skips_directory_that_disappears_during_scan -q
- /Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_plugins.py::TestPluginDiscovery tests/hermes_cli/test_plugins_transcription_registration.py tests/hermes_cli/test_plugins_tts_registration.py -q
- /Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugins.py
- git diff --check