### PR TITLE
fix(gateway): de-dup already-delivered MEDIA across turns; capture assistant-emitted paths

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -766,6 +766,58 @@ def _collect_auto_append_media_tags(
 
     return media_tags, has_voice_directive
 
+
+def _collect_history_media_paths(history: List[Dict[str, Any]]) -> set:
+    """Collect MEDIA: paths already delivered in prior turns.
+
+    Scans producer-tool results (role ``tool``/``function``) AND ``assistant``
+    messages. The model can surface a MEDIA: path directly in an assistant
+    reply (it was delivered then); the earlier tool-only scan missed those, so
+    when the model re-emitted the same path on a later turn it was delivered a
+    second time. Including the assistant role closes that duplicate-send gap.
+
+    Reuses the module-level ``_TOOL_MEDIA_RE`` (the old inline copy recompiled
+    it on every history message) and guards against non-string content so a
+    multimodal content list (blocks) is skipped instead of raising.
+    """
+    history_media_paths: set = set()
+    for msg in history or []:
+        if msg.get("role") not in {"tool", "function", "assistant"}:
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str) or "MEDIA:" not in content:
+            continue
+        for match in _TOOL_MEDIA_RE.finditer(content):
+            path = match.group(1).strip().rstrip('",}')
+            if path:
+                history_media_paths.add(path)
+    return history_media_paths
+
+
+def _strip_already_delivered_media(
+    final_response: str,
+    history_media_paths: set,
+) -> str:
+    """Drop MEDIA:<path> tags the model re-emitted whose path was already
+    delivered in a prior turn, so the adapter's ``extract_media()`` does not
+    send the same artifact twice.
+
+    Only tags whose path is in ``history_media_paths`` are removed; genuinely
+    new MEDIA: paths are preserved verbatim. When stripping removes every tag
+    the caller's auto-append path still runs and surfaces this turn's real
+    tool media as usual.
+    """
+    if not history_media_paths or "MEDIA:" not in final_response:
+        return final_response
+
+    def _drop_if_old(match: "re.Match") -> str:
+        path = match.group(1).strip().rstrip('",}')
+        if path in history_media_paths:
+            return ""  # already delivered earlier — strip the whole tag
+        return match.group(0)  # new path — leave untouched
+
+    return _TOOL_MEDIA_RE.sub(_drop_if_old, final_response)
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -14223,25 +14275,11 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 channel_prompt=channel_prompt,
             )
             
-            # Collect MEDIA paths already in history so we can exclude them
-            # from the current turn's extraction. This is compression-safe:
-            # even if the message list shrinks, we know which paths are old.
-            _history_media_paths: set = set()
-            for _hm in agent_history:
-                if _hm.get("role") in {"tool", "function"}:
-                    _hc = _hm.get("content", "")
-                    if "MEDIA:" in _hc:
-                        _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                            r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
-                            re.IGNORECASE
-                        )
-                        for _match in _TOOL_MEDIA_RE.finditer(_hc):
-                            _p = _match.group(1).strip().rstrip('",}')
-                            if _p:
-                                _history_media_paths.add(_p)
+            # Collect MEDIA paths already delivered in prior turns (tool results
+            # AND assistant replies) so we can exclude them from this turn's
+            # extraction. Compression-safe: path-based, independent of how the
+            # message list is later sliced or shrunk.
+            _history_media_paths = _collect_history_media_paths(agent_history)
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -14540,6 +14578,16 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
             # also the sole guard on the fallback branch taken when mid-run
             # context compression shrinks the message list below the original
             # history length, preserving the compression-safe behaviour of #160.
+            #
+            # The model also sometimes echoes a MEDIA: path that was already
+            # delivered in a prior turn back into its final text. Strip those
+            # first so the adapter's extract_media() does not re-deliver them;
+            # genuinely new paths are kept. If stripping clears every tag, the
+            # auto-append below still runs to surface this turn's real media.
+            final_response = _strip_already_delivered_media(
+                final_response, _history_media_paths
+            )
+
             if "MEDIA:" not in final_response:
                 media_tags, has_voice_directive = _collect_auto_append_media_tags(
                     result.get("messages", []),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,6 +79,7 @@ AUTHOR_MAP = {
     "copii.list@gmail.com": "stremtec",
     "solaiagent@gmail.com": "solaitken",
     "cryptoworlldz@gmail.com": "worlldz",
+    "martin.alca@gmail.com": "draix",
     "prostoandrei9@gmail.com": "vladkvlchk",
     "116314616+ThyFriendlyFox@users.noreply.github.com": "ThyFriendlyFox",
     "liliangjya@gmail.com": "truenorth-lj",

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -371,5 +371,104 @@ class TestStaleToolMediaLeak:
         )
 
 
+class TestHistoryMediaPathCollection:
+    """Regression tests for the real ``_collect_history_media_paths`` helper.
+
+    Issue 1: the prior inline history scan only looked at ``tool``/``function``
+    roles, so a MEDIA: path the model surfaced in an *assistant* reply was never
+    recorded as already-delivered. When the model re-emitted that path on a
+    later turn it was delivered a second time. These exercise the real helper.
+    """
+
+    def test_collects_from_tool_role(self):
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "user", "content": "say hi"},
+            {"role": "tool", "tool_call_id": "1",
+             "content": "MEDIA:/tmp/hi.ogg"},
+        ]
+        assert _collect_history_media_paths(history) == {"/tmp/hi.ogg"}
+
+    def test_collects_from_assistant_role(self):
+        """The Issue 1 fix: assistant-emitted MEDIA paths are now captured."""
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "user", "content": "show me the chart"},
+            {"role": "assistant",
+             "content": "Here it is:\nMEDIA:/tmp/chart.png"},
+        ]
+        assert _collect_history_media_paths(history) == {"/tmp/chart.png"}
+
+    def test_ignores_user_role(self):
+        """A MEDIA: token in a user message is not a delivered artifact."""
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "user", "content": "what about MEDIA:/tmp/user_typed.png ?"},
+        ]
+        assert _collect_history_media_paths(history) == set()
+
+    def test_ignores_non_string_content(self):
+        """Multimodal (list) content must be skipped, not raise."""
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "MEDIA:/tmp/in_block.png"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ]},
+            {"role": "tool", "tool_call_id": "2", "content": "MEDIA:/tmp/real.mp3"},
+        ]
+        # The list-content message is skipped; only the string tool result counts.
+        assert _collect_history_media_paths(history) == {"/tmp/real.mp3"}
+
+    def test_ignores_bare_media_without_deliverable_extension(self):
+        """A bare ``MEDIA:`` token in prose (no media extension) is ignored."""
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {"role": "assistant",
+             "content": "The format is MEDIA:<path>, e.g. MEDIA:/notes.unknownext"},
+        ]
+        assert _collect_history_media_paths(history) == set()
+
+
+class TestStripAlreadyDeliveredMedia:
+    """Regression tests for the real ``_strip_already_delivered_media`` helper.
+
+    Issue 2: when the model echoes a MEDIA: path already delivered in a prior
+    turn into its final reply, the adapter would deliver it again. The helper
+    strips only already-delivered paths and preserves genuinely new ones.
+    """
+
+    def test_strips_already_delivered_path(self):
+        from gateway.run import _strip_already_delivered_media
+
+        out = _strip_already_delivered_media(
+            "Here it is again: MEDIA:/tmp/old.png",
+            {"/tmp/old.png"},
+        )
+        assert "MEDIA:/tmp/old.png" not in out
+        assert "Here it is again:" in out
+
+    def test_preserves_new_path(self):
+        from gateway.run import _strip_already_delivered_media
+
+        text = "Fresh render: MEDIA:/tmp/new.png"
+        out = _strip_already_delivered_media(text, {"/tmp/old.png"})
+        assert out == text  # untouched — path not in history
+
+    def test_mixed_strips_old_keeps_new(self):
+        """Old path stripped, new path kept (so auto-append still sees MEDIA:)."""
+        from gateway.run import _strip_already_delivered_media
+
+        text = "MEDIA:/tmp/old.png and MEDIA:/tmp/new.png"
+        out = _strip_already_delivered_media(text, {"/tmp/old.png"})
+        assert "MEDIA:/tmp/old.png" not in out
+        assert "MEDIA:/tmp/new.png" in out
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What & why

Two related bugs in the gateway's MEDIA: auto-append / de-dup path could cause the **same media artifact to be delivered twice across turns**.

**Issue 1 — assistant-emitted paths were never recorded as delivered.**
The history scan that builds the "already-delivered" path set only looked at `tool`/`function` results. When the model surfaced a `MEDIA:<path>` directly in an *assistant* reply (it was delivered then), that path was never recorded — so if the model re-emitted it on a later turn it was delivered a second time. The inline scan also recompiled the matcher regex on every history message and could raise on non-string (multimodal list) content.

**Issue 2 — re-emitted already-delivered tags were not stripped.**
When the model echoes an already-delivered `MEDIA:<path>` back into its final reply, the existing `"MEDIA:" not in final_response` guard skipped auto-append but left the tag in the text, so the adapter's `extract_media()` re-delivered the artifact.

## Changes

- `_collect_history_media_paths()` — new module-level helper (replaces the inline block). Scans `assistant` in addition to `tool`/`function`, reuses the module-level `_TOOL_MEDIA_RE`, and skips non-string content instead of raising.
- `_strip_already_delivered_media()` — new helper, run before the auto-append guard. Drops only `MEDIA:` tags whose path is already in history; genuinely new paths are preserved, so a fresh tool media this turn still auto-appends.
- 8 regression tests that import and exercise the **real** `gateway.run` helpers (not mirrors).
- `scripts/release.py`: AUTHOR_MAP entry for attribution.

## Real behavior proof

**Behavior addressed:** Duplicate cross-turn delivery of a `MEDIA:` artifact that was already sent (via an assistant reply) on a prior turn and re-emitted by the model.

**Real environment tested:** Local hermes-agent checkout, `.venv` with the package installed editable; importing the real `gateway.run` module (no mocks).

**Exact steps or command run after this patch:**
```
# regression suite (real helpers)
TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 .venv/bin/python -m pytest tests/gateway/test_media_extraction.py -v
# all related media tests
.venv/bin/python -m pytest tests/gateway/test_media_extraction.py tests/gateway/test_run_tool_media_re.py \
  tests/gateway/test_tts_media_routing.py tests/gateway/test_media_download_retry.py \
  tests/gateway/test_discord_media_metadata.py
```

**Evidence after fix** — runtime trace importing the real helpers:
```
>>> from gateway.run import _collect_history_media_paths, _strip_already_delivered_media
# Turn 1: model delivered the image inside an ASSISTANT reply
history = [{"role":"assistant","content":"Here's your cover:\nMEDIA:/tmp/cover.png"}]
history_media_paths : {'/tmp/cover.png'}        # Issue 1: assistant path now captured
# Turn 2: model echoes the old path + a genuinely new one
before: As I showed: MEDIA:/tmp/cover.png — and a fresh one MEDIA:/tmp/new.png
after : As I showed:  — and a fresh one MEDIA:/tmp/new.png   # Issue 2: old dropped, new kept
```

**Observed result after fix:**
```
tests/gateway/test_media_extraction.py ............ 17 passed in 0.71s
(media suite, 5 files) ............................. 92 passed in 0.58s
```
- `ruff check` (the repo's blocking PLW1514 rule): All checks passed
- `ty`: 0 new diagnostics in the changed code (total count identical to base, 155 == 155)

**What was not tested:** No live end-to-end run against a real chat platform adapter (Telegram/Discord) — the fix is exercised at the helper boundary that the adapter delivery path consumes. The `[[audio_as_voice]]` directive token is intentionally not stripped (it is an internal directive, not a user-facing path).
