### PR TITLE
fix(dingtalk): route native voice media to STT

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -105,7 +105,10 @@ _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 
 # DingTalk message type → runtime content type
 DINGTALK_TYPE_MAPPING = {
+    "audio": "audio",
+    "file": "file",
     "picture": "image",
+    "video": "video",
     "voice": "audio",
 }
 
@@ -764,50 +767,44 @@ class DingTalkAdapter(BasePlatformAdapter):
                 media_types.append("image")
                 msg_type = MessageType.PHOTO
 
-        # Check for rich text with mixed content
-        rich_text = getattr(message, "rich_text_content", None) or getattr(
-            message, "rich_text", None
-        )
-        if rich_text:
-            rich_list = getattr(rich_text, "rich_text_list", None) or rich_text
-            if isinstance(rich_list, list):
-                for item in rich_list:
-                    if isinstance(item, dict):
-                        dl_code = (
-                            item.get("downloadCode") or item.get("download_code") or ""
-                        )
-                        item_type = item.get("type", "")
-                        if dl_code:
-                            mapped = DINGTALK_TYPE_MAPPING.get(item_type, "file")
-                            media_urls.append(dl_code)
-                            if mapped == "image":
-                                media_types.append("image")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.PHOTO
-                            elif mapped == "audio":
-                                media_types.append("audio")
-                                if msg_type == MessageType.TEXT:
-                                    # DingTalk's "voice" rich-text item is a
-                                    # native voice note — route through STT.
-                                    # "audio" comes from file uploads only;
-                                    # keep those as AUDIO (no auto-STT).
-                                    if item_type == "voice":
-                                        msg_type = MessageType.VOICE
-                                    else:
-                                        msg_type = MessageType.AUDIO
-                            elif mapped == "video":
-                                media_types.append("video")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.VIDEO
-                            else:
-                                media_types.append("application/octet-stream")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.DOCUMENT
+        for item in self._iter_media_items(message):
+            dl_code = (
+                item.get("downloadCode")
+                or item.get("download_code")
+                or item.get("pictureDownloadCode")
+                or ""
+            )
+            item_type = item.get("type", "")
+            if dl_code:
+                mapped = DINGTALK_TYPE_MAPPING.get(item_type, "file")
+                media_urls.append(dl_code)
+                if mapped == "image":
+                    media_types.append("image")
+                    if msg_type == MessageType.TEXT:
+                        msg_type = MessageType.PHOTO
+                elif mapped == "audio":
+                    media_types.append("audio")
+                    if msg_type == MessageType.TEXT:
+                        # DingTalk's "voice" item is a native voice note —
+                        # route through STT. Generic "audio" file uploads
+                        # remain AUDIO and skip auto-STT.
+                        if item_type == "voice":
+                            msg_type = MessageType.VOICE
+                        else:
+                            msg_type = MessageType.AUDIO
+                elif mapped == "video":
+                    media_types.append("video")
+                    if msg_type == MessageType.TEXT:
+                        msg_type = MessageType.VIDEO
+                else:
+                    media_types.append("application/octet-stream")
+                    if msg_type == MessageType.TEXT:
+                        msg_type = MessageType.DOCUMENT
 
         msg_type_str = getattr(message, "message_type", "") or ""
         if msg_type_str == "picture" and not media_urls:
             msg_type = MessageType.PHOTO
-        elif msg_type_str == "richText":
+        elif msg_type_str == "richText" and msg_type == MessageType.TEXT:
             msg_type = (
                 MessageType.PHOTO
                 if any("image" in t for t in media_types)
@@ -815,6 +812,35 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
 
         return msg_type, media_urls, media_types
+
+    @staticmethod
+    def _iter_media_items(message: "ChatbotMessage") -> List[Dict[str, Any]]:
+        """Return DingTalk media item dicts from rich text and extensions."""
+        items: List[Dict[str, Any]] = []
+
+        rich_text = getattr(message, "rich_text_content", None) or getattr(
+            message, "rich_text", None
+        )
+        if rich_text:
+            rich_list = getattr(rich_text, "rich_text_list", None) or rich_text
+            if isinstance(rich_list, list):
+                items.extend(item for item in rich_list if isinstance(item, dict))
+
+        extensions = getattr(message, "extensions", None)
+        if isinstance(extensions, dict):
+            content = extensions.get("content")
+            if isinstance(content, str):
+                try:
+                    content = json.loads(content)
+                    extensions["content"] = content
+                except (TypeError, ValueError):
+                    content = None
+            if isinstance(content, dict):
+                items.append(content)
+            elif isinstance(content, list):
+                items.extend(item for item in content if isinstance(item, dict))
+
+        return items
 
     # -- Outbound messaging -------------------------------------------------
 
@@ -1306,15 +1332,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         if img_content and getattr(img_content, "download_code", None):
             codes_to_resolve.append((img_content, "download_code"))
 
-        # 2. Rich text list
-        rich_text = getattr(message, "rich_text_content", None)
-        if rich_text:
-            rich_list = getattr(rich_text, "rich_text_list", []) or []
-            for item in rich_list:
-                if isinstance(item, dict):
-                    for key in ("downloadCode", "pictureDownloadCode", "download_code"):
-                        if item.get(key):
-                            codes_to_resolve.append((item, key))
+        # 2. Rich text and extensions media items
+        for item in self._iter_media_items(message):
+            for key in ("downloadCode", "pictureDownloadCode", "download_code"):
+                if item.get(key):
+                    codes_to_resolve.append((item, key))
 
         if not codes_to_resolve:
             return
@@ -1467,6 +1489,11 @@ class _IncomingHandler(
                 )
                 if raw_flag:
                     chatbot_msg.is_in_at_list = True
+
+            if not getattr(chatbot_msg, "extensions", None) and isinstance(data, dict):
+                extensions = data.get("extensions")
+                if isinstance(extensions, dict):
+                    chatbot_msg.extensions = extensions
 
             msg_id = getattr(chatbot_msg, "message_id", None) or ""
             conversation_id = getattr(chatbot_msg, "conversation_id", None) or ""

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -581,6 +581,9 @@ class TestExtractMedia:
         msg.image_content = None
         msg.rich_text_content = None
         msg.rich_text = items
+        msg.extensions = {}
+        msg.message_type = ""
+        msg.robot_code = ""
         return msg
 
     def test_voice_rich_text_item_classified_as_voice(self):
@@ -599,28 +602,131 @@ class TestExtractMedia:
         assert urls == ["dl_voice_abc"]
         assert mtypes == ["audio"]
 
+    def test_voice_rich_text_item_stays_voice_when_message_type_is_rich_text(self):
+        """SDK-shaped richText voice payloads must not be overwritten to TEXT."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text(
+            [{"type": "voice", "downloadCode": "dl_voice_rich"}]
+        )
+        msg.message_type = "richText"
+
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+
+        assert msg_type == MessageType.VOICE
+        assert urls == ["dl_voice_rich"]
+        assert mtypes == ["audio"]
+
+    def test_native_voice_from_extensions_content_classified_as_voice(self):
+        """Native DingTalk media can live in message.extensions['content']."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text([])
+        msg.extensions = {
+            "content": '[{"type": "voice", "downloadCode": "dl_voice_ext"}]'
+        }
+        msg.message_type = "richText"
+
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+
+        assert msg_type == MessageType.VOICE
+        assert urls == ["dl_voice_ext"]
+        assert mtypes == ["audio"]
+
+    def test_native_audio_from_extensions_content_stays_audio(self):
+        """Generic audio files in extensions content should not trigger STT."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text([])
+        msg.extensions = {"content": [{"type": "audio", "downloadCode": "dl_audio_ext"}]}
+        msg.message_type = "richText"
+
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+
+        assert msg_type == MessageType.AUDIO
+        assert urls == ["dl_audio_ext"]
+        assert mtypes == ["audio"]
+
+    def test_native_video_from_extensions_content_classified_as_video(self):
+        """Native DingTalk video files can live in extensions content."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text([])
+        msg.extensions = {"content": [{"type": "video", "downloadCode": "dl_video_ext"}]}
+        msg.message_type = "richText"
+
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+
+        assert msg_type == MessageType.VIDEO
+        assert urls == ["dl_video_ext"]
+        assert mtypes == ["video"]
+
+    def test_native_file_from_extensions_content_classified_as_document(self):
+        """Native DingTalk files can live in extensions content."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text([])
+        msg.extensions = {"content": [{"type": "file", "downloadCode": "dl_file_ext"}]}
+        msg.message_type = "richText"
+
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+
+        assert msg_type == MessageType.DOCUMENT
+        assert urls == ["dl_file_ext"]
+        assert mtypes == ["application/octet-stream"]
+
+    @pytest.mark.asyncio
+    async def test_extensions_content_download_codes_are_resolved(self):
+        """Extensions content media codes should be downloaded before extraction."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={"client_id": "robot-1"}))
+        adapter._get_access_token = AsyncMock(return_value="token-1")
+        adapter._fetch_download_url = AsyncMock()
+
+        msg = self._msg_with_rich_text([])
+        msg.extensions = {
+            "content": '[{"type": "voice", "downloadCode": "dl_voice_ext"}]'
+        }
+
+        await adapter._resolve_media_codes(msg)
+
+        adapter._fetch_download_url.assert_awaited_once()
+        args = adapter._fetch_download_url.await_args.args
+        assert args[0] == "dl_voice_ext"
+        assert args[1] == "robot-1"
+        assert args[2] == "token-1"
+
     def test_audio_rich_text_item_stays_audio(self):
         """Generic audio uploads (e.g. an mp3 the user attached) must NOT
         be auto-transcribed — they stay MessageType.AUDIO."""
-        from gateway.platforms.dingtalk import DingTalkAdapter, DINGTALK_TYPE_MAPPING
+        from gateway.platforms.dingtalk import DingTalkAdapter
         from gateway.platforms.base import MessageType
 
-        # Simulate a future/non-voice audio rich-text item by extending the
-        # mapping so item_type != "voice" but still routes through the
-        # ``mapped == "audio"`` branch.
-        DINGTALK_TYPE_MAPPING["audio"] = "audio"
-        try:
-            msg = self._msg_with_rich_text(
-                [{"type": "audio", "downloadCode": "dl_audio_xyz"}]
-            )
-            msg_type, urls, mtypes = DingTalkAdapter._extract_media(
-                DingTalkAdapter, msg
-            )
-            assert msg_type == MessageType.AUDIO
-            assert urls == ["dl_audio_xyz"]
-            assert mtypes == ["audio"]
-        finally:
-            del DINGTALK_TYPE_MAPPING["audio"]
+        msg = self._msg_with_rich_text(
+            [{"type": "audio", "downloadCode": "dl_audio_xyz"}]
+        )
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.AUDIO
+        assert urls == ["dl_audio_xyz"]
+        assert mtypes == ["audio"]
 
 
 # ---------------------------------------------------------------------------
@@ -846,6 +952,34 @@ class TestIncomingHandlerProcess:
         adapter._on_message.assert_called_once()
         chatbot_msg = adapter._on_message.call_args[0][0]
         assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=def"
+
+    @pytest.mark.asyncio
+    async def test_process_preserves_extensions_from_raw_payload(self):
+        """Raw DingTalk extensions must survive SDK from_dict mismatches."""
+        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = AsyncMock()
+        handler = _IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = MagicMock()
+        callback.data = {
+            "msgtype": "richText",
+            "text": {"content": ""},
+            "senderId": "user3",
+            "conversationId": "conv3",
+            "msgId": "msg-003",
+            "extensions": {
+                "content": '[{"type": "voice", "downloadCode": "dl_voice_raw"}]'
+            },
+        }
+
+        await handler.process(callback)
+        await asyncio.sleep(0.05)
+
+        adapter._on_message.assert_called_once()
+        chatbot_msg = adapter._on_message.call_args[0][0]
+        assert chatbot_msg.extensions == callback.data["extensions"]
 
     @pytest.mark.asyncio
     async def test_process_returns_ack_immediately(self):


### PR DESCRIPTION
## Summary
- parse DingTalk native media payloads from `message.extensions["content"]` in addition to richText items
- preserve `MessageType.VOICE` for DingTalk voice notes so the gateway STT path runs
- add native audio/video/file mappings and regression coverage for extensions media download-code resolution

## Root cause
DingTalk stream callbacks can keep native voice/audio/video/file payloads inside `extensions["content"]`, and SDK-shaped richText voice items could be classified as VOICE before the richText fallback reset non-image content back to TEXT. That skipped the existing voice/STT pipeline.

Closes #38219.

## Verification
- /Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_dingtalk.py -q
- /Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check gateway/platforms/dingtalk.py tests/gateway/test_dingtalk.py
- git diff --check