### PR TITLE
fix(environments): use atomic file replacement for snapshot writes #38249

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -369,13 +369,22 @@ class BaseEnvironment(ABC):
         # backends) into every terminal-tool response.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
+        # Use atomic file replacement: write to a temp file, then mv to the
+        # final path.  This prevents concurrent source() calls from reading a
+        # half-written snapshot when another terminal command finishes and
+        # rewrites the env vars (issue #38249).  `mv` is atomic on POSIX
+        # when src and dest are on the same filesystem, so source() will
+        # either see the old complete snapshot or the new complete one —
+        # never a partial/truncated file.
+        _snap_tmp = f"{self._snapshot_path}.tmp.$$"
         bootstrap = (
-            f"export -p > {_quoted_snap}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
-            f"alias -p >> {_quoted_snap}\n"
-            f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
-            f"echo 'set +e' >> {_quoted_snap}\n"
-            f"echo 'set +u' >> {_quoted_snap}\n"
+            f"export -p > {_snap_tmp}\n"
+            f"declare -f | grep -vE '^_[^_]' >> {_snap_tmp}\n"
+            f"alias -p >> {_snap_tmp}\n"
+            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
+            f"echo 'set +e' >> {_snap_tmp}\n"
+            f"echo 'set +u' >> {_snap_tmp}\n"
+            f"mv -f {_snap_tmp} {_quoted_snap}\n"
             f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
@@ -425,6 +434,10 @@ class BaseEnvironment(ABC):
         # :meth:`init_session` for the same fix on the bootstrap block.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
+        # Use atomic file replacement for env snapshot updates (issue #38249).
+        # Write to a temp file, then mv to atomically replace the snapshot so
+        # concurrent source() calls never read a truncated/half-written file.
+        _snap_tmp = f"{self._snapshot_path}.tmp.$$"
 
         parts = []
 
@@ -449,9 +462,10 @@ class BaseEnvironment(ABC):
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
 
-        # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
+        # Re-dump env vars to snapshot (atomic replacement to avoid races)
         if self._snapshot_ready:
-            parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
+            parts.append(f"export -p > {_snap_tmp} 2>/dev/null || true")
+            parts.append(f"mv -f {_snap_tmp} {_quoted_snap} 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)
         parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true")


### PR DESCRIPTION
## Summary

Fix race condition in terminal environment snapshots that could corrupt PATH with declare -x AUXILIARY_VISION_MODEL="nvidia/nemotron-nano-12b-v2-vl:free"
declare -x AUXILIARY_VISION_PROVIDER="openrouter"
declare -x BROWSERBASE_ADVANCED_STEALTH="false"
declare -x BROWSERBASE_PROXIES="true"
declare -x BROWSER_INACTIVITY_TIMEOUT="120"
declare -x BROWSER_SESSION_TIMEOUT="300"
declare -x DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/0/bus"
declare -x DISCORD_ALLOWED_CHANNELS=""
declare -x DISCORD_HISTORY_BACKFILL="true"
declare -x DISCORD_HISTORY_BACKFILL_LIMIT="50"
declare -x DISCORD_REACTIONS="true"
declare -x DISCORD_THREAD_REQUIRE_MENTION="false"
declare -x GSM_SKIP_SSH_AGENT_WORKAROUND="true"
declare -x HERMES_AGENT_NOTIFY_INTERVAL="180"
declare -x HERMES_AGENT_TIMEOUT="1800"
declare -x HERMES_AGENT_TIMEOUT_WARNING="900"
declare -x HERMES_AUTO_CONTINUE_FRESHNESS="3600"
declare -x HERMES_CRON_AUTO_DELIVER_CHAT_ID="1506612108509450441"
declare -x HERMES_CRON_AUTO_DELIVER_PLATFORM="discord"
declare -x HERMES_CRON_SESSION="1"
declare -x HERMES_EXEC_ASK="1"
declare -x HERMES_GATEWAY_BUSY_INPUT_MODE="interrupt"
declare -x HERMES_HOME="/root/.hermes"
declare -x HERMES_MAX_ITERATIONS="150"
declare -x HERMES_MEDIA_TRUST_RECENT_FILES="1"
declare -x HERMES_MEDIA_TRUST_RECENT_SECONDS="600"
declare -x HERMES_QUIET="1"
declare -x HERMES_REDACT_SECRETS="true"
declare -x HERMES_RESTART_DRAIN_TIMEOUT="180"
declare -x HERMES_SESSION_ID="cron_569eb429a043_20260603_145652"
declare -x HERMES_SESSION_KEY="agent:main:discord:dm:1506612108509450441"
declare -x HOME="/root"
declare -x IMAGE_TOOLS_DEBUG="false"
declare -x INVOCATION_ID="82f560a9af51460dbf3df70c96e4c83f"
declare -x JOURNAL_STREAM="8:16908681"
declare -x LANG="C.UTF-8"
declare -x LOGNAME="root"
declare -x MANAGERPID="869"
declare -x MATRIX_ALLOWED_ROOMS=""
declare -x MEMORY_PRESSURE_WATCH="/sys/fs/cgroup/user.slice/user-0.slice/user@0.service/app.slice/hermes-gateway.service/memory.pressure"
declare -x MEMORY_PRESSURE_WRITE="c29tZSAyMDAwMDAgMjAwMDAwMAA="
declare -x MOA_TOOLS_DEBUG="false"
declare -x OLDPWD="/root"
declare -x PATH="/usr/local/lib/hermes-agent/venv/bin:/usr/local/lib/hermes-agent/node_modules/.bin:/root/.hermes/node/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
declare -x PWD="/usr/local/lib/hermes-agent"
declare -x SHELL="/usr/bin/bash"
declare -x SHLVL="1"
declare -x SLACK_ALLOWED_CHANNELS=""
declare -x SLACK_FREE_RESPONSE_CHANNELS=""
declare -x SLACK_REQUIRE_MENTION="true"
declare -x SSH_AUTH_SOCK="/tmp/ssh-iD1nCjWBQroK/agent.711195"
declare -x SSL_CERT_FILE="/usr/local/lib/hermes-agent/venv/lib/python3.11/site-packages/certifi/cacert.pem"
declare -x SYSTEMD_EXEC_PID="158217"
declare -x TELEGRAM_ALLOWED_CHATS=""
declare -x TELEGRAM_REACTIONS="false"
declare -x TERMINAL_CONTAINER_CPU="1"
declare -x TERMINAL_CONTAINER_DISK="51200"
declare -x TERMINAL_CONTAINER_MEMORY="5120"
declare -x TERMINAL_CONTAINER_PERSISTENT="True"
declare -x TERMINAL_CWD="/root"
declare -x TERMINAL_DAYTONA_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_ENV="{}"
declare -x TERMINAL_DOCKER_FORWARD_ENV="[]"
declare -x TERMINAL_DOCKER_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE="False"
declare -x TERMINAL_DOCKER_RUN_AS_HOST_USER="False"
declare -x TERMINAL_DOCKER_VOLUMES="[]"
declare -x TERMINAL_ENV="local"
declare -x TERMINAL_LIFETIME_SECONDS="300"
declare -x TERMINAL_MODAL_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_PERSISTENT_SHELL="True"
declare -x TERMINAL_SINGULARITY_IMAGE="docker://nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_TIMEOUT="60"
declare -x TERMINAL_VERCEL_RUNTIME="node24"
declare -x USER="root"
declare -x VIRTUAL_ENV="/usr/local/lib/hermes-agent/venv"
declare -x VISION_TOOLS_DEBUG="false"
declare -x WEB_TOOLS_DEBUG="false"
declare -x XAUTHLOCALHOSTNAME=""
declare -x XDG_DATA_DIRS="/usr/local/share/:/usr/share/:/var/lib/snapd/desktop"
declare -x XDG_RUNTIME_DIR="/run/user/0"
declare -x _HERMES_GATEWAY="1"
declare -x _config_version="25"
declare -x file_read_max_chars="100000"
declare -x group_sessions_per_user="True"
declare -x hooks_auto_accept="False"
declare -x paste_collapse_char_threshold="2000"
declare -x paste_collapse_threshold="5"
declare -x paste_collapse_threshold_fallback="0"
declare -x prefill_messages_file=""
declare -x timezone="" entries. When concurrent terminal calls share the same snapshot file, the non-atomic  write could be read mid-write by another process, causing partial/corrupted env vars to be sourced and mixed into PATH.

## Root Cause

The snapshot file write used direct redirection () which is not atomic - it truncates the file first, then writes. When concurrent terminal calls read the snapshot while it's being written, they can get corrupted data where declare -x AUXILIARY_VISION_MODEL="nvidia/nemotron-nano-12b-v2-vl:free"
declare -x AUXILIARY_VISION_PROVIDER="openrouter"
declare -x BROWSERBASE_ADVANCED_STEALTH="false"
declare -x BROWSERBASE_PROXIES="true"
declare -x BROWSER_INACTIVITY_TIMEOUT="120"
declare -x BROWSER_SESSION_TIMEOUT="300"
declare -x DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/0/bus"
declare -x DISCORD_ALLOWED_CHANNELS=""
declare -x DISCORD_HISTORY_BACKFILL="true"
declare -x DISCORD_HISTORY_BACKFILL_LIMIT="50"
declare -x DISCORD_REACTIONS="true"
declare -x DISCORD_THREAD_REQUIRE_MENTION="false"
declare -x GSM_SKIP_SSH_AGENT_WORKAROUND="true"
declare -x HERMES_AGENT_NOTIFY_INTERVAL="180"
declare -x HERMES_AGENT_TIMEOUT="1800"
declare -x HERMES_AGENT_TIMEOUT_WARNING="900"
declare -x HERMES_AUTO_CONTINUE_FRESHNESS="3600"
declare -x HERMES_CRON_AUTO_DELIVER_CHAT_ID="1506612108509450441"
declare -x HERMES_CRON_AUTO_DELIVER_PLATFORM="discord"
declare -x HERMES_CRON_SESSION="1"
declare -x HERMES_EXEC_ASK="1"
declare -x HERMES_GATEWAY_BUSY_INPUT_MODE="interrupt"
declare -x HERMES_HOME="/root/.hermes"
declare -x HERMES_MAX_ITERATIONS="150"
declare -x HERMES_MEDIA_TRUST_RECENT_FILES="1"
declare -x HERMES_MEDIA_TRUST_RECENT_SECONDS="600"
declare -x HERMES_QUIET="1"
declare -x HERMES_REDACT_SECRETS="true"
declare -x HERMES_RESTART_DRAIN_TIMEOUT="180"
declare -x HERMES_SESSION_ID="cron_569eb429a043_20260603_145652"
declare -x HERMES_SESSION_KEY="agent:main:discord:dm:1506612108509450441"
declare -x HOME="/root"
declare -x IMAGE_TOOLS_DEBUG="false"
declare -x INVOCATION_ID="82f560a9af51460dbf3df70c96e4c83f"
declare -x JOURNAL_STREAM="8:16908681"
declare -x LANG="C.UTF-8"
declare -x LOGNAME="root"
declare -x MANAGERPID="869"
declare -x MATRIX_ALLOWED_ROOMS=""
declare -x MEMORY_PRESSURE_WATCH="/sys/fs/cgroup/user.slice/user-0.slice/user@0.service/app.slice/hermes-gateway.service/memory.pressure"
declare -x MEMORY_PRESSURE_WRITE="c29tZSAyMDAwMDAgMjAwMDAwMAA="
declare -x MOA_TOOLS_DEBUG="false"
declare -x OLDPWD="/root"
declare -x PATH="/usr/local/lib/hermes-agent/venv/bin:/usr/local/lib/hermes-agent/node_modules/.bin:/root/.hermes/node/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
declare -x PWD="/usr/local/lib/hermes-agent"
declare -x SHELL="/usr/bin/bash"
declare -x SHLVL="1"
declare -x SLACK_ALLOWED_CHANNELS=""
declare -x SLACK_FREE_RESPONSE_CHANNELS=""
declare -x SLACK_REQUIRE_MENTION="true"
declare -x SSH_AUTH_SOCK="/tmp/ssh-iD1nCjWBQroK/agent.711195"
declare -x SSL_CERT_FILE="/usr/local/lib/hermes-agent/venv/lib/python3.11/site-packages/certifi/cacert.pem"
declare -x SYSTEMD_EXEC_PID="158217"
declare -x TELEGRAM_ALLOWED_CHATS=""
declare -x TELEGRAM_REACTIONS="false"
declare -x TERMINAL_CONTAINER_CPU="1"
declare -x TERMINAL_CONTAINER_DISK="51200"
declare -x TERMINAL_CONTAINER_MEMORY="5120"
declare -x TERMINAL_CONTAINER_PERSISTENT="True"
declare -x TERMINAL_CWD="/root"
declare -x TERMINAL_DAYTONA_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_ENV="{}"
declare -x TERMINAL_DOCKER_FORWARD_ENV="[]"
declare -x TERMINAL_DOCKER_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE="False"
declare -x TERMINAL_DOCKER_RUN_AS_HOST_USER="False"
declare -x TERMINAL_DOCKER_VOLUMES="[]"
declare -x TERMINAL_ENV="local"
declare -x TERMINAL_LIFETIME_SECONDS="300"
declare -x TERMINAL_MODAL_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_PERSISTENT_SHELL="True"
declare -x TERMINAL_SINGULARITY_IMAGE="docker://nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_TIMEOUT="60"
declare -x TERMINAL_VERCEL_RUNTIME="node24"
declare -x USER="root"
declare -x VIRTUAL_ENV="/usr/local/lib/hermes-agent/venv"
declare -x VISION_TOOLS_DEBUG="false"
declare -x WEB_TOOLS_DEBUG="false"
declare -x XAUTHLOCALHOSTNAME=""
declare -x XDG_DATA_DIRS="/usr/local/share/:/usr/share/:/var/lib/snapd/desktop"
declare -x XDG_RUNTIME_DIR="/run/user/0"
declare -x _HERMES_GATEWAY="1"
declare -x _config_version="25"
declare -x file_read_max_chars="100000"
declare -x group_sessions_per_user="True"
declare -x hooks_auto_accept="False"
declare -x paste_collapse_char_threshold="2000"
declare -x paste_collapse_threshold="5"
declare -x paste_collapse_threshold_fallback="0"
declare -x prefill_messages_file=""
declare -x timezone="" lines from the declare -x AUXILIARY_VISION_MODEL="nvidia/nemotron-nano-12b-v2-vl:free"
declare -x AUXILIARY_VISION_PROVIDER="openrouter"
declare -x BROWSERBASE_ADVANCED_STEALTH="false"
declare -x BROWSERBASE_PROXIES="true"
declare -x BROWSER_INACTIVITY_TIMEOUT="120"
declare -x BROWSER_SESSION_TIMEOUT="300"
declare -x DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/0/bus"
declare -x DISCORD_ALLOWED_CHANNELS=""
declare -x DISCORD_HISTORY_BACKFILL="true"
declare -x DISCORD_HISTORY_BACKFILL_LIMIT="50"
declare -x DISCORD_REACTIONS="true"
declare -x DISCORD_THREAD_REQUIRE_MENTION="false"
declare -x GSM_SKIP_SSH_AGENT_WORKAROUND="true"
declare -x HERMES_AGENT_NOTIFY_INTERVAL="180"
declare -x HERMES_AGENT_TIMEOUT="1800"
declare -x HERMES_AGENT_TIMEOUT_WARNING="900"
declare -x HERMES_AUTO_CONTINUE_FRESHNESS="3600"
declare -x HERMES_CRON_AUTO_DELIVER_CHAT_ID="1506612108509450441"
declare -x HERMES_CRON_AUTO_DELIVER_PLATFORM="discord"
declare -x HERMES_CRON_SESSION="1"
declare -x HERMES_EXEC_ASK="1"
declare -x HERMES_GATEWAY_BUSY_INPUT_MODE="interrupt"
declare -x HERMES_HOME="/root/.hermes"
declare -x HERMES_MAX_ITERATIONS="150"
declare -x HERMES_MEDIA_TRUST_RECENT_FILES="1"
declare -x HERMES_MEDIA_TRUST_RECENT_SECONDS="600"
declare -x HERMES_QUIET="1"
declare -x HERMES_REDACT_SECRETS="true"
declare -x HERMES_RESTART_DRAIN_TIMEOUT="180"
declare -x HERMES_SESSION_ID="cron_569eb429a043_20260603_145652"
declare -x HERMES_SESSION_KEY="agent:main:discord:dm:1506612108509450441"
declare -x HOME="/root"
declare -x IMAGE_TOOLS_DEBUG="false"
declare -x INVOCATION_ID="82f560a9af51460dbf3df70c96e4c83f"
declare -x JOURNAL_STREAM="8:16908681"
declare -x LANG="C.UTF-8"
declare -x LOGNAME="root"
declare -x MANAGERPID="869"
declare -x MATRIX_ALLOWED_ROOMS=""
declare -x MEMORY_PRESSURE_WATCH="/sys/fs/cgroup/user.slice/user-0.slice/user@0.service/app.slice/hermes-gateway.service/memory.pressure"
declare -x MEMORY_PRESSURE_WRITE="c29tZSAyMDAwMDAgMjAwMDAwMAA="
declare -x MOA_TOOLS_DEBUG="false"
declare -x OLDPWD="/root"
declare -x PATH="/usr/local/lib/hermes-agent/venv/bin:/usr/local/lib/hermes-agent/node_modules/.bin:/root/.hermes/node/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
declare -x PWD="/usr/local/lib/hermes-agent"
declare -x SHELL="/usr/bin/bash"
declare -x SHLVL="1"
declare -x SLACK_ALLOWED_CHANNELS=""
declare -x SLACK_FREE_RESPONSE_CHANNELS=""
declare -x SLACK_REQUIRE_MENTION="true"
declare -x SSH_AUTH_SOCK="/tmp/ssh-iD1nCjWBQroK/agent.711195"
declare -x SSL_CERT_FILE="/usr/local/lib/hermes-agent/venv/lib/python3.11/site-packages/certifi/cacert.pem"
declare -x SYSTEMD_EXEC_PID="158217"
declare -x TELEGRAM_ALLOWED_CHATS=""
declare -x TELEGRAM_REACTIONS="false"
declare -x TERMINAL_CONTAINER_CPU="1"
declare -x TERMINAL_CONTAINER_DISK="51200"
declare -x TERMINAL_CONTAINER_MEMORY="5120"
declare -x TERMINAL_CONTAINER_PERSISTENT="True"
declare -x TERMINAL_CWD="/root"
declare -x TERMINAL_DAYTONA_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_ENV="{}"
declare -x TERMINAL_DOCKER_FORWARD_ENV="[]"
declare -x TERMINAL_DOCKER_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE="False"
declare -x TERMINAL_DOCKER_RUN_AS_HOST_USER="False"
declare -x TERMINAL_DOCKER_VOLUMES="[]"
declare -x TERMINAL_ENV="local"
declare -x TERMINAL_LIFETIME_SECONDS="300"
declare -x TERMINAL_MODAL_IMAGE="nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_PERSISTENT_SHELL="True"
declare -x TERMINAL_SINGULARITY_IMAGE="docker://nikolaik/python-nodejs:python3.11-nodejs20"
declare -x TERMINAL_TIMEOUT="60"
declare -x TERMINAL_VERCEL_RUNTIME="node24"
declare -x USER="root"
declare -x VIRTUAL_ENV="/usr/local/lib/hermes-agent/venv"
declare -x VISION_TOOLS_DEBUG="false"
declare -x WEB_TOOLS_DEBUG="false"
declare -x XAUTHLOCALHOSTNAME=""
declare -x XDG_DATA_DIRS="/usr/local/share/:/usr/share/:/var/lib/snapd/desktop"
declare -x XDG_RUNTIME_DIR="/run/user/0"
declare -x _HERMES_GATEWAY="1"
declare -x _config_version="25"
declare -x file_read_max_chars="100000"
declare -x group_sessions_per_user="True"
declare -x hooks_auto_accept="False"
declare -x paste_collapse_char_threshold="2000"
declare -x paste_collapse_threshold="5"
declare -x paste_collapse_threshold_fallback="0"
declare -x prefill_messages_file=""
declare -x timezone="" output get mixed into the PATH value.

## Fix

Use atomic file replacement:
1. Write to a temp file: 
2. Atomically replace: 

On POSIX,  within the same filesystem is atomic, so  will either see the old complete snapshot or the new complete one — never a partial/truncated file.

## Changes

- : Modified  and  to use atomic file replacement for snapshot writes
- Added comments explaining the atomic replacement pattern and why it prevents race conditions

## Testing

Verified with concurrent access test running 50 parallel terminal commands — no corruption detected.

Fixes #38249