### PR TITLE
fix(desktop): refresh external gateway sessions

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -78,6 +78,7 @@ import { usePreviewRouting } from './session/hooks/use-preview-routing'
 import { usePromptActions } from './session/hooks/use-prompt-actions'
 import { useRouteResume } from './session/hooks/use-route-resume'
 import { useSessionActions } from './session/hooks/use-session-actions'
+import { type RefreshSessionsOptions, useSessionListAutoRefresh } from './session/hooks/use-session-list-auto-refresh'
 import { useSessionStateCache } from './session/hooks/use-session-state-cache'
 import { AppShell } from './shell/app-shell'
 import { useOverlayRouting } from './shell/hooks/use-overlay-routing'
@@ -105,6 +106,7 @@ export function DesktopController() {
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
+  const refreshSessionsLoadingRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
 
   const gatewayState = useStore($gatewayState)
@@ -226,10 +228,15 @@ export function DesktopController() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [toggleCommandCenter])
 
-  const refreshSessions = useCallback(async () => {
+  const refreshSessions = useCallback(async (options: RefreshSessionsOptions = {}) => {
+    const showLoading = options.showLoading ?? true
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
-    setSessionsLoading(true)
+
+    if (showLoading) {
+      refreshSessionsLoadingRequestRef.current = requestId
+      setSessionsLoading(true)
+    }
 
     try {
       const limit = $sessionsLimit.get()
@@ -249,7 +256,7 @@ export function DesktopController() {
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
       }
     } finally {
-      if (refreshSessionsRequestRef.current === requestId) {
+      if (showLoading && refreshSessionsLoadingRequestRef.current === requestId) {
         setSessionsLoading(false)
       }
     }
@@ -532,6 +539,11 @@ export function DesktopController() {
       void refreshSessions().catch(() => undefined)
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions])
+
+  useSessionListAutoRefresh({
+    enabled: gatewayState === 'open',
+    refreshSessions
+  })
 
   useRouteResume({
     activeSessionId,

--- a/apps/desktop/src/app/session/hooks/use-session-list-auto-refresh.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-auto-refresh.test.tsx
@@ -1,0 +1,75 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSessionListAutoRefresh } from './use-session-list-auto-refresh'
+
+describe('useSessionListAutoRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('polls the session list silently while enabled', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderHook(() =>
+      useSessionListAutoRefresh({
+        enabled: true,
+        intervalMs: 1000,
+        refreshSessions
+      })
+    )
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(refreshSessions).toHaveBeenCalledWith({ showLoading: false })
+  })
+
+  it('does not poll while disabled', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderHook(() =>
+      useSessionListAutoRefresh({
+        enabled: false,
+        intervalMs: 1000,
+        refreshSessions
+      })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+  })
+
+  it('stops polling after unmount', () => {
+    const refreshSessions = vi.fn(async () => undefined)
+
+    const { unmount } = renderHook(() =>
+      useSessionListAutoRefresh({
+        enabled: true,
+        intervalMs: 1000,
+        refreshSessions
+      })
+    )
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-auto-refresh.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-auto-refresh.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react'
+
+export const SESSION_LIST_AUTO_REFRESH_MS = 15_000
+
+export interface RefreshSessionsOptions {
+  showLoading?: boolean
+}
+
+interface UseSessionListAutoRefreshOptions {
+  enabled: boolean
+  intervalMs?: number
+  refreshSessions: (options?: RefreshSessionsOptions) => Promise<void>
+}
+
+export function useSessionListAutoRefresh({
+  enabled,
+  intervalMs = SESSION_LIST_AUTO_REFRESH_MS,
+  refreshSessions
+}: UseSessionListAutoRefreshOptions) {
+  const refreshSessionsRef = useRef(refreshSessions)
+
+  useEffect(() => {
+    refreshSessionsRef.current = refreshSessions
+  }, [refreshSessions])
+
+  useEffect(() => {
+    if (!enabled || intervalMs <= 0) {
+      return undefined
+    }
+
+    const timer = window.setInterval(() => {
+      void refreshSessionsRef.current({ showLoading: false }).catch(() => undefined)
+    }, intervalMs)
+
+    return () => window.clearInterval(timer)
+  }, [enabled, intervalMs])
+}


### PR DESCRIPTION
## Summary
- add a desktop session-list auto refresh while the gateway is connected
- keep auto refresh silent so the sidebar loading state does not flicker
- preserve the existing explicit loading behavior for manual/open-time refreshes

## Root cause
Desktop only refreshed the session list after desktop-owned events such as gateway boot, message completion, or explicit reloads. Sessions created by external surfaces like the Telegram gateway can be persisted in the shared SessionDB without any desktop event that invalidates the sidebar list.

## Validation
- `npm run test:ui -- --run src/app/session/hooks/use-session-list-auto-refresh.test.tsx src/app/session/hooks/use-route-resume.test.tsx src/store/session.test.ts` -> 3 files / 15 tests passed
- `npm run type-check` -> passed
- `npx eslint src/app/desktop-controller.tsx src/app/session/hooks/use-session-list-auto-refresh.ts src/app/session/hooks/use-session-list-auto-refresh.test.tsx` -> passed
- `git diff --check` -> passed

Closes #38270
