### PR TITLE
docs: add Hermes self-troubleshooting preflight

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -813,8 +813,7 @@ Use local evidence first only long enough to name the symptom and component
 repo for matching issues and PRs:
 
 ```bash
-cd ~/.hermes/hermes-agent
-repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo NousResearch/hermes-agent)"
+repo="NousResearch/hermes-agent"
 
 gh issue list --repo "$repo" --state all \
   --search '<component symptom keywords>' \

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -801,6 +801,61 @@ and logs — avoids shell-escaping backslashes in bash.
 
 ## Troubleshooting
 
+### Hermes self-troubleshooting preflight
+
+When troubleshooting Hermes itself — CLI, gateway, profiles, tools, skills,
+providers, cron, memory, plugins, or platform adapters — check whether the
+problem is already known before deep bespoke debugging or proposing a custom
+patch.
+
+Use local evidence first only long enough to name the symptom and component
+(log line, command failure, platform, OS, config area). Then search the Hermes
+repo for matching issues and PRs:
+
+```bash
+cd ~/.hermes/hermes-agent
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo NousResearch/hermes-agent)"
+
+gh issue list --repo "$repo" --state all \
+  --search '<component symptom keywords>' \
+  --limit 20 \
+  --json number,title,state,url,labels,updatedAt
+
+gh pr list --repo "$repo" --state all \
+  --search '<component symptom keywords>' \
+  --limit 20 \
+  --json number,title,state,url,labels,updatedAt
+```
+
+If a plausible PR exists, inspect it before inventing a fix:
+
+```bash
+gh pr view <num> --repo "$repo" --json number,title,state,url,body,files
+gh pr diff <num> --repo "$repo"
+```
+
+Treat existing issues and PRs as evidence, not authority. A matching issue may
+validate that the problem is real or recurring; a matching PR may include useful
+diagnostics, reproduction steps, or a partial implementation. Do not assume the
+proposed fix is correct just because it names the same problem.
+
+Report findings separately:
+
+- **Local evidence** — what was observed on this machine.
+- **Known upstream issue** — matching issue(s), if any, and whether they match
+  symptom/platform/logs.
+- **Problem confidence** — how strongly upstream evidence matches the local
+  failure.
+- **Candidate upstream fix** — matching PR(s), if any.
+- **Fix confidence** — whether the PR appears correct, partial, brittle, stale,
+  untested, or architecture-aligned.
+- **Recommended action** — use as-is, use evidence only, adapt the approach,
+  avoid as likely wrong, ask for maintainer input, file a narrower issue, or
+  propose a better fix.
+
+Do not open duplicate issues or PRs. If existing work matches, help move that
+issue/PR forward instead.
+
 ### Voice not working
 1. Check `stt.enabled: true` in config.yaml
 2. Verify provider: `pip install faster-whisper` or set API key


### PR DESCRIPTION
## Summary

- add a Hermes self-troubleshooting preflight to the bundled `hermes-agent` skill
- tell agents to search existing Hermes issues and PRs before deep bespoke debugging
- explicitly treat issues/PRs as evidence, not authority, so matching PRs still need independent fix-quality review

## Why

When Hermes is debugging Hermes, existing issues and PRs often contain useful prior art: reproduction steps, logs, platform details, maintainer comments, or partial fixes. Agents should check that context early enough to avoid duplicating known work or cargo-culting a bad patch.

This is intentionally scoped to Hermes self-troubleshooting, not a broad generic repo-backed software policy.

Fixes #38284.

## Testing

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
p = Path('skills/autonomous-ai-agents/hermes-agent/SKILL.md')
text = p.read_text()
assert 'Hermes self-troubleshooting preflight' in text
assert 'evidence, not authority' in text
assert text.count('```') % 2 == 0, 'unbalanced fenced code blocks'
print('sanity checks passed')
PY
```
