### PR TITLE
fix(gateway): redact Feishu group session listings (#15538)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -103,6 +103,13 @@ class GatewaySlashCommandsMixin:
 
     async_session_store: AsyncSessionStore
 
+    def _hide_feishu_group_session_details(self, source: SessionSource) -> bool:
+        chat_type = str(source.chat_type or "").strip().lower()
+        return (
+            source.platform == Platform.FEISHU
+            and chat_type in {"group", "forum", "topic_group"}
+        )
+
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
 
@@ -4327,6 +4334,7 @@ class GatewaySlashCommandsMixin:
         allow_all = "--all" in parts
         allow_cross_room = "--cross-room" in parts
         name = " ".join(p for p in parts if p not in {"--all", "--cross-room"}).strip()
+        hide_session_details = self._hide_feishu_group_session_details(source)
 
         # Strip common outer brackets/quotes users may type literally from the
         # usage hint (e.g. ``/resume <abc123>``). Mirrors the CLI behavior.
@@ -4337,6 +4345,7 @@ class GatewaySlashCommandsMixin:
             or (name[0] == "'" and name[-1] == "'")
         ):
             name = name[1:-1].strip()
+        display_name = "selected session" if hide_session_details else name
 
         async def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
@@ -4347,6 +4356,20 @@ class GatewaySlashCommandsMixin:
                 limit=10,
             )
             return [s for s in sessions if s.get("title")][:10]
+
+        def _resume_display_title(
+            session: dict | None = None,
+            *,
+            index: int | None = None,
+            fallback: str = "selected session",
+        ) -> str:
+            if hide_session_details:
+                return f"Session {index}" if index is not None else "selected session"
+            if session:
+                title = session.get("title")
+                if title:
+                    return str(title)
+            return fallback
 
         if not name:
             # List recent titled sessions for this user/platform
@@ -4362,12 +4385,12 @@ class GatewaySlashCommandsMixin:
                     return t("gateway.resume.no_named_sessions")
                 lines = [t("gateway.resume.list_header")]
                 for idx, s in enumerate(titled[:10], start=1):
-                    title = s["title"]
+                    title = _resume_display_title(s, index=idx)
                     if source.platform == Platform.MATRIX and allow_all:
                         origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                         if origin:
                             title = f"{title} — {origin.chat_name or origin.chat_id}"
-                    preview = s.get("preview", "")[:40]
+                    preview = "" if hide_session_details else (s.get("preview") or "")[:40]
                     preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
                     lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
                 lines.append(t("gateway.resume.list_footer_numbered"))
@@ -4392,7 +4415,8 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.resume.out_of_range", index=index)
             target = titled[index - 1]
             target_id = target.get("id")
-            name = target.get("title") or name
+            name = _resume_display_title(target, index=index, fallback=name)
+            display_name = name
         else:
             # Try direct session ID lookup first (so `/resume <session_id>`
             # works in the gateway, not just `/resume <title>`).
@@ -4402,7 +4426,7 @@ class GatewaySlashCommandsMixin:
             else:
                 target_id = await self._session_db.resolve_session_by_title(name)
         if not target_id:
-            return t("gateway.resume.not_found", name=name)
+            return t("gateway.resume.not_found", name=display_name)
         # Compression creates child continuations that hold the live transcript.
         # Follow that chain so gateway /resume matches CLI behavior (#15000).
         try:
@@ -4432,7 +4456,7 @@ class GatewaySlashCommandsMixin:
         # Check if already on that session
         current_entry = await self.async_session_store.get_or_create_session(source)
         if current_entry.session_id == target_id:
-            return t("gateway.resume.already_on", name=name)
+            return t("gateway.resume.already_on", name=display_name)
 
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
@@ -4457,7 +4481,11 @@ class GatewaySlashCommandsMixin:
         self._evict_cached_agent(session_key)
 
         # Get the title for confirmation
-        title = await self._session_db.get_session_title(target_id) or name
+        title = (
+            display_name
+            if hide_session_details
+            else await self._session_db.get_session_title(target_id) or name
+        )
 
         # Count messages for context
         history = await self.async_session_store.load_transcript(target_id)
@@ -4542,6 +4570,11 @@ class GatewaySlashCommandsMixin:
             title = f"Sessions matching “{search_query}”"
         else:
             title = "Sessions" if include_unnamed else "Named Sessions"
+        if self._hide_feishu_group_session_details(source):
+            rows = [
+                {**row, "title": f"Session {idx}", "preview": ""}
+                for idx, row in enumerate(rows, start=1)
+            ]
         return format_gateway_session_listing(
             rows,
             include_source=cross_origin,

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -956,7 +956,7 @@ class GatewaySessionCommandsMixin:
                 origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                 if origin:
                     title = f"{title} — {origin.chat_name or origin.chat_id}"
-            preview = s.get("preview", "")[:40]
+            preview = (s.get("preview") or "")[:40]
             preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
             lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
         if scope_note:

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -99,6 +99,11 @@ def _branch_row(msg: dict) -> dict:
     return row
 
 
+def _hide_feishu_group_session_details(source: SessionSource) -> bool:
+    return (source.platform == Platform.FEISHU
+            and str(source.chat_type or "").strip().lower() in {"group", "forum", "topic_group"})
+
+
 def _strip_resume_name(parts: list[str]) -> str:
     """Join the non-flag /resume tokens; strip literal ``<...>``/``[...]``/quotes typed from the
     usage hint (mirrors the CLI)."""
@@ -838,6 +843,7 @@ class GatewaySessionCommandsMixin:
 
     async def _resolve_resume_target(self, source, session_key: str, name: str, allow_all: bool):
         """``(target_id, name)`` for a numbered choice, session id or title; else the error reply."""
+        hide_details = _hide_feishu_group_session_details(source)
         if name.isdigit():
             try:
                 titled = await self._list_titled_sessions(source, session_key, allow_all)
@@ -848,10 +854,13 @@ class GatewaySessionCommandsMixin:
             if index < 1 or index > len(titled):
                 return t("gateway.resume.out_of_range", index=index)
             target = titled[index - 1]
-            target_id, name = target.get("id"), target.get("title") or name
+            target_id = target.get("id")
+            name = f"Session {index}" if hide_details else target.get("title") or name
         else:  # session id first, then title
             session = await self._session_db.get_session(name)
             target_id = session["id"] if session else await self._session_db.resolve_session_by_title(name)
+            if hide_details:
+                name = "selected session"
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Follow compression continuations to the live transcript (matches CLI /resume).
@@ -921,7 +930,8 @@ class GatewaySessionCommandsMixin:
         # Evict so the next turn rebuilds with the right session_id — the cached AIAgent's memory
         # provider cached _session_id at initialize() and would keep writing to the wrong session.
         self._evict_cached_agent(session_key)
-        title = await self._session_db.get_session_title(target_id) or name
+        title = (name if _hide_feishu_group_session_details(source)
+                 else await self._session_db.get_session_title(target_id) or name)
         try:
             history = await self.async_session_store.load_transcript(target_id)
         except TranscriptReadError:
@@ -950,13 +960,14 @@ class GatewaySessionCommandsMixin:
             base = t("gateway.resume.no_named_sessions")
             return f"{base}\n{scope_note}" if scope_note else base
         lines = [t("gateway.resume.list_header")]
+        hide_details = _hide_feishu_group_session_details(source)
         for idx, s in enumerate(titled[:10], start=1):
-            title = s["title"]
+            title = f"Session {idx}" if hide_details else s["title"]
             if source.platform == Platform.MATRIX and allow_all:
                 origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                 if origin:
                     title = f"{title} — {origin.chat_name or origin.chat_id}"
-            preview = (s.get("preview") or "")[:40]
+            preview = "" if hide_details else (s.get("preview") or "")[:40]
             preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
             lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
         if scope_note:
@@ -1004,6 +1015,11 @@ class GatewaySessionCommandsMixin:
             title = f"Sessions matching “{search_query}”"
         else:
             title = "Sessions" if include_unnamed else "Named Sessions"
+        if _hide_feishu_group_session_details(source):
+            rows = [{**row, "title": f"Session {idx}", "preview": ""}
+                    for idx, row in enumerate(rows, start=1)]
+            if search_query:
+                title = "Matching Sessions"
         return format_gateway_session_listing(rows, include_source=cross_origin, title=title,
                                               notice=scope_notice)
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -15,12 +15,13 @@ from gateway.session import SessionSource, build_session_key
 
 
 def _make_event(text="/resume", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", chat_type="dm"):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
+        chat_type=chat_type,
         user_name="testuser",
     )
     return MessageEvent(text=text, source=source)
@@ -105,6 +106,171 @@ class TestHandleResumeCommand:
         assert "1." in result
         assert "2." in result
         assert "/resume 1" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_list_named_sessions_handles_null_preview(self):
+        """A missing preview should not break gateway resume listing."""
+        db = MagicMock()
+        db.list_sessions_rich.return_value = [
+            {"id": "sess_001", "title": "Research", "preview": None},
+        ]
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_row_visible = AsyncMock(return_value=True)
+        result = await runner._handle_resume_command(event)
+
+        assert "Research" in result
+        assert "None" not in result
+        assert "/resume 1" in result
+
+    @pytest.mark.parametrize("chat_type", ("group", "forum", "topic_group"))
+    @pytest.mark.asyncio
+    async def test_feishu_group_resume_list_hides_titles_and_previews(
+        self, tmp_path, chat_type
+    ):
+        """Feishu group-visible resume lists should not leak conversation summaries."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/resume",
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type=chat_type,
+        )
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=_session_key_for_event(event),
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type=chat_type,
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.append_message(
+            "sess_sensitive", "user", "first message leaks project delta"
+        )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Sensitive acquisition roadmap" not in result
+        assert "project delta" not in result
+        assert "Session 1" in result
+        assert "/resume 1" in result
+        db.close()
+
+    @pytest.mark.parametrize("chat_type", ("dm", "private", "p2p"))
+    @pytest.mark.asyncio
+    async def test_feishu_private_resume_list_keeps_titles_and_previews(
+        self, tmp_path, chat_type
+    ):
+        """Private Feishu DMs keep the normal titled resume affordance."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/resume",
+            platform=Platform.FEISHU,
+            chat_id="ou_private",
+            chat_type=chat_type,
+        )
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=_session_key_for_event(event),
+            user_id="12345",
+            chat_id="ou_private",
+            chat_type=chat_type,
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.append_message(
+            "sess_sensitive", "user", "first message leaks project delta"
+        )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Sensitive acquisition roadmap" in result
+        assert "project delta" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_feishu_group_resume_by_index_hides_confirmation_title(self, tmp_path):
+        """Numeric Feishu group resume should still work without echoing titles."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/resume 1",
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+        )
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type="group",
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.create_session(
+            "current_session_001",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type="group",
+        )
+
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "Sensitive acquisition roadmap" not in result
+        assert "Session 1" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_sensitive"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_feishu_group_resume_not_found_does_not_echo_title(self, tmp_path):
+        """Feishu group lookup failures should not repeat title-shaped input."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/resume Sensitive acquisition roadmap",
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+        )
+        db.create_session(
+            "current_session_001",
+            "feishu",
+            session_key=_session_key_for_event(event),
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type="group",
+        )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        assert "Sensitive acquisition roadmap" not in result
+        assert "selected session" in result
+        runner.session_store.switch_session.assert_not_called()
         db.close()
 
 
@@ -424,6 +590,139 @@ class TestHandleSessionsCommand:
         assert "Foreign Work" not in result
         assert "current_tip" not in result
         assert "current_root" not in result
+        db.close()
+
+    @pytest.mark.parametrize("chat_type", ("group", "forum", "topic_group"))
+    @pytest.mark.asyncio
+    async def test_feishu_group_sessions_list_hides_titles_and_previews(
+        self, tmp_path, chat_type
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/sessions",
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type=chat_type,
+        )
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type=chat_type,
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.append_message(
+            "sess_sensitive", "user", "first message leaks project delta"
+        )
+        db.create_session(
+            "current_session_001",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type=chat_type,
+        )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_sessions_command(event)
+
+        assert "Sensitive acquisition roadmap" not in result
+        assert "project delta" not in result
+        assert "Session 1" in result
+        assert "sess_sensitive" in result
+        db.close()
+
+    @pytest.mark.parametrize("chat_type", ("dm", "private", "p2p"))
+    @pytest.mark.asyncio
+    async def test_feishu_private_sessions_list_keeps_titles_and_previews(
+        self, tmp_path, chat_type
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/sessions",
+            platform=Platform.FEISHU,
+            chat_id="ou_private",
+            chat_type=chat_type,
+        )
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="ou_private",
+            chat_type=chat_type,
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.append_message(
+            "sess_sensitive", "user", "first message leaks project delta"
+        )
+        db.create_session(
+            "current_session_001",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="ou_private",
+            chat_type=chat_type,
+        )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_sessions_command(event)
+
+        assert "Sensitive acquisition roadmap" in result
+        assert "project delta" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_feishu_group_sessions_target_uses_redacted_resume_label(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(
+            text="/sessions 1",
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+        )
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "sess_sensitive",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type="group",
+        )
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.create_session(
+            "current_session_001",
+            "feishu",
+            session_key=lane_key,
+            user_id="12345",
+            chat_id="oc_group",
+            chat_type="group",
+        )
+
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_sessions_command(event)
+
+        assert "Resumed" in result
+        assert "Sensitive acquisition roadmap" not in result
+        assert "Session 1" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_sensitive"
         db.close()
 
     @pytest.mark.asyncio
@@ -766,5 +1065,3 @@ class TestSameMatrixRoomThreadScoping:
         caller = self._msrc(thread_id="thread-a")
         victim_origin = self._msrc(thread_id="thread-b")
         assert runner._same_matrix_room(caller, victim_origin) is False
-
-

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -72,6 +72,23 @@ class TestHandleResumeCommand:
     """Tests for GatewayRunner._handle_resume_command."""
 
     @pytest.mark.asyncio
+    async def test_list_named_sessions_handles_null_preview(self):
+        """A missing preview should not break gateway resume listing."""
+        db = MagicMock()
+        db.list_sessions_rich.return_value = [
+            {"id": "sess_001", "title": "Research", "preview": None},
+        ]
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_row_visible = AsyncMock(return_value=True)
+        result = await runner._handle_resume_command(event)
+
+        assert "Research" in result
+        assert "None" not in result
+        assert "/resume 1" in result
+
+    @pytest.mark.asyncio
     async def test_no_session_db(self):
         """Returns error when session database is unavailable."""
         runner = _make_runner(session_db=None)

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -987,3 +987,93 @@ class TestSameMatrixRoomThreadScoping:
         caller = self._msrc(thread_id="thread-a")
         victim_origin = self._msrc(thread_id="thread-b")
         assert runner._same_matrix_room(caller, victim_origin) is False
+
+
+@pytest.fixture
+def feishu_session(tmp_path):
+    """A real titled transcript; the gateway store remains the existing test double."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "privacy.db")
+
+    def create(command, chat_type="group", platform=Platform.FEISHU, *, already_on=False):
+        event = _make_event(text=command, platform=platform, chat_id="chat")
+        event.source.chat_type = chat_type
+        lane = _session_key_for_event(event)
+        current = "sess_sensitive" if already_on else "current_session_001"
+        for sid in dict.fromkeys(["sess_sensitive", current]):
+            db.create_session(sid, platform.value, session_key=lane, user_id="12345",
+                              chat_id="chat", chat_type=chat_type)
+        db.set_session_title("sess_sensitive", "Sensitive acquisition roadmap")
+        db.append_message("sess_sensitive", "user", "first message leaks project delta")
+        return _make_runner(session_db=db, current_session_id=current, event=event), event
+
+    yield create
+    db.close()
+
+
+@pytest.mark.parametrize("command", ["/resume", "/sessions"])
+@pytest.mark.parametrize("chat_type,hidden", [
+    ("group", True), ("forum", True), ("topic_group", True),
+    ("dm", False), ("private", False), ("p2p", False),
+])
+@pytest.mark.asyncio
+async def test_feishu_session_lists_hide_only_shared_details(feishu_session, command, chat_type, hidden):
+    runner, event = feishu_session(command, chat_type)
+    handler = runner._handle_resume_command if command == "/resume" else runner._handle_sessions_command
+    result = await handler(event)
+    assert ("Sensitive acquisition roadmap" in result) is not hidden
+    assert ("project delta" in result) is not hidden
+    if hidden:
+        assert "Session 1" in result
+    if command == "/resume":
+        assert "/resume 1" in result
+    else:
+        assert "sess_sensitive" in result
+
+
+@pytest.mark.parametrize("command", ["/resume 1", "/sessions 1", "/resume sess_sensitive",
+                                     "/resume Sensitive acquisition roadmap"])
+@pytest.mark.asyncio
+async def test_feishu_group_resume_preserves_selection(feishu_session, command):
+    runner, event = feishu_session(command)
+    handler = runner._handle_sessions_command if command.startswith("/sessions") else runner._handle_resume_command
+    result = await handler(event)
+    assert "Resumed" in result
+    assert "Sensitive acquisition roadmap" not in result
+    assert "project delta" not in result
+    runner.session_store.switch_session.assert_called_once()
+    assert runner.session_store.switch_session.call_args.args[1] == "sess_sensitive"
+
+
+@pytest.mark.parametrize("case", ["not_found", "already_on", "denied"])
+@pytest.mark.asyncio
+async def test_feishu_group_resume_errors_do_not_echo_titles(feishu_session, case):
+    title = "Sensitive acquisition roadmap" if case != "not_found" else "Missing confidential title"
+    runner, event = feishu_session("/resume " + title, already_on=(case == "already_on"))
+    if case == "denied":
+        runner._resume_target_allowed = AsyncMock(return_value=False)
+    result = await runner._handle_resume_command(event)
+    assert title not in result
+    assert "selected session" in result
+    runner.session_store.switch_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_feishu_group_sessions_search_hides_query_and_results(feishu_session):
+    runner, event = feishu_session("/sessions search acquisition")
+    result = await runner._handle_sessions_command(event)
+    assert "acquisition" not in result
+    assert "project delta" not in result
+    assert "Session 1" in result
+    assert "sess_sensitive" in result
+
+
+@pytest.mark.parametrize("command", ["/resume", "/sessions"])
+@pytest.mark.asyncio
+async def test_other_platform_group_lists_keep_existing_details(feishu_session, command):
+    runner, event = feishu_session(command, platform=Platform.TELEGRAM)
+    handler = runner._handle_resume_command if command == "/resume" else runner._handle_sessions_command
+    result = await handler(event)
+    assert "Sensitive acquisition roadmap" in result
+    assert "project delta" in result


### PR DESCRIPTION
## What does this PR do?

Feishu group-visible `/resume` and `/sessions` replies currently display conversation-derived titles and first-message previews. Replace them with generic `Session N` labels in group, forum and topic-group chats. Confirmations, resolution errors and search headings also avoid echoing titles or queries.

Session lookup, numeric selection, lineage resolution and ownership checks remain intact. Private Feishu chats and other platforms keep their existing display. This addresses the display-privacy portion of #15538; it does not add a configurable group-resume policy.

## Related Issue

Part of #15538. Scope follows [@GottZ’s issue triage](https://github.com/NousResearch/hermes-agent/issues/15538#issuecomment-5135253942), which identifies this as a partial display-privacy fix.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- `gateway/slash_commands_session.py`: redact at the reply boundary without changing the stored session or lookup arguments.
- `tests/gateway/test_resume_command.py`: use a shared real-database fixture for group/private listing, numeric/ID/title selection, denied/already-active/missing targets, search output and other-platform controls.
- A separate commit fixes an existing null-preview crash in the numbered resume listing, with a regression test.

## How to Test

Integrated and tested on main `83467c28f78987acdeb55636fb625946ec572a30`. Before the fix, 14 privacy cases failed; the null-preview crash was reproduced independently.

```bash
scripts/run_tests.sh tests/gateway/test_resume_command.py -q
scripts/run_tests.sh tests/gateway/test_feishu.py tests/hermes_state/test_resolve_resume_session_id.py -j 2 -q
```

Result: **136 passed**. Ruff on both changed files and `git diff --check` also pass. The repository runner used the existing interpreter through `HERMES_PYTHON` on Linux.

## Checklist

- [x] Read the contributing guide; checked existing related PRs and issue routing.
- [x] Conventional commits; null-preview repair is separate from display privacy.
- [x] Added regression tests and tested on Linux.
- [x] Considered cross-platform behavior; no configuration or command-syntax changes.
- [x] Documentation, tool schemas and new-skill sections: N/A.

## Not checked

- Full repository suite, native Windows/macOS execution, and a live Feishu tenant.
- CodeRabbit: skipped for this self-authored P2 PR.

## Automation disclosure

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
