### PR TITLE
Add skill: crypto-alpha-research

### DIFF
--- a/skills/crypto-alpha-research/SKILL.md
+++ b/skills/crypto-alpha-research/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: crypto-alpha-research
+description: >-
+  Structured due-diligence on a crypto project from an X/Twitter handle, a token
+  contract address, or a project name. Produces a decision-first comparison table
+  and a risk-flagged verdict — authenticity / brand-squatting checks, on-chain
+  facts, team background, narrative timing, competitor position, and the "real
+  project vs good token" value-capture test. Use when vetting or tracking a crypto
+  token/project before investing, or when asked to "research / look into / add" a
+  crypto project, handle, or contract.
+license: MIT
+version: 0.1.0
+metadata:
+  author: catfrommarss
+  category: research
+  tags: [crypto, due-diligence, research, web3, tokens]
+---
+
+# Crypto Alpha Research
+
+Turn a raw lead (an X handle, a contract address, or a project name) into a
+**decision**. Always output a comparison table first, then a one-line verdict
+from a fixed set of decision templates — never "to be confirmed".
+
+## When to use
+- Vetting a new token / project before tracking or buying.
+- A message contains an X/Twitter handle, a contract address, or a project name
+  and asks to "research / look into / vet / add" it.
+- Refreshing a project you already track (delta-focused).
+
+## When NOT to use
+- A pure price check with no project context (just query a price source).
+- Generic market commentary unrelated to a specific project.
+
+## Inputs
+Accept any of: X/Twitter handle (`@name`), contract address (chain may be missing
+— infer it), project name, or several targets in one message. With ≥2 targets,
+run the batch path and produce one comparison table for all.
+
+## Required mindset (hard rules)
+- **Comparison table first**, even when the data looks great.
+- **Real project ≠ good token.** If the product runs fine without the token, flag
+  value-capture as missing — do not soften it to "worth watching".
+- **Verify before trusting.** Never treat a user-supplied handle/contract as
+  genuine; brand-squatting and impostor tokens are the default assumption.
+- **Surface risks, don't decide for the user.** List death / red-flag signals and
+  let the user call it. Never auto-conclude "dead".
+- **State on-chain numbers as facts**, not death verdicts.
+- Every verdict uses a decision template below — never "TBD".
+- If a data point can't be retrieved, label it "not found" — never fabricate.
+
+## Procedure
+Run steps 1–6 to gather, then step 7 to synthesize. Parallelize independent
+lookups where the runtime allows.
+
+1. **Profile** — handle, bio, creation date, followers/following, tweet count,
+   verified status. (Use an X/Twitter data tool or MCP if available.)
+2. **Activity & narrative** — read tweet *content*, not just timestamps: what the
+   project ships, posting cadence, pinned/positioning, market reaction (quotes /
+   retweets), deleted tweets (= red flag), and who follows it.
+3. **Authenticity / brand-squatting** — suspicious signals: `_ai / _base /
+   _official`-style suffixes; <50 followers but a polished bio; <5 tweets; a copy
+   of a real account (incl. typos); <30 days old with no notable followers. ≥1 →
+   find the real account and compare. For tokens: assume multiple same-name
+   contracts exist (incl. impostors on other chains); confirm the official one via
+   the project's own channels. ≥2 signals → label "likely impostor".
+4. **On-chain facts** (only if a contract is in scope) — price, FDV / market cap,
+   liquidity, holders, circulating supply, deployer history. **List the numbers
+   as-is**; do not call it "dead". Use a price/explorer tool, a public read-only
+   API, or an MCP — never bundle credentials.
+5. **Team** — for each member: name, title, LinkedIn, X handle, web2 résumé, past
+   crypto projects, rug/scam history. Red flags: unverifiable identity; refuses to
+   disclose past work; LinkedIn mismatch; prior rug; serial launcher. Anonymity is
+   NOT itself a red flag if backed by public VCs, credible KOL vouching, active
+   GitHub, or verifiable past work — otherwise "watch first". Cross-check
+   reputable crypto media (real reporting vs PR).
+6. **Ecosystem & external signals**
+   - *Narrative / meta + timing*: which meta, and is it early / peak / fading?
+   - *Competitors*: who else does this; is the project leading / following / a clone?
+   - *KOL tiers*: institutional / ecosystem backing (high quality) vs small-cap
+     shill callers (discount heavily) vs engagement pods (yellow flag).
+   - *Tokenomics / value capture*: run the "remove the token — does the product
+     still run?" test. Missing sink/utility → flag "real project ≠ good token".
+   - *Triggered (only if applicable, else "not found")*: GitHub activity; VC
+     backing / funding rounds; media coverage; valuation vs last round; unlock /
+     vesting schedule (→ note an upcoming catalyst if found).
+7. **Synthesize** — build the comparison table, assign a verdict, and offer the
+   user the track/insert options.
+
+## Output: comparison table (first, always)
+Columns (rename/trim to fit any tracker):
+
+| Column | Meaning |
+|---|---|
+| Name | Project name |
+| One-liner | One-sentence positioning |
+| Stage | concept / testnet / mainnet / token-live / dead (never auto-set "dead") |
+| Tags | from your own tag set |
+| FDV | fully-diluted valuation, USD |
+| URL | X / site / contract |
+| Team | vetted / anonymous / not-found / red-flag |
+| Narrative / meta | which meta + timing (early / peak / fading) |
+| Competitor position | leading / following / clone |
+| KOL quality | institutional vs shill vs engagement pod |
+| Token utility | has sink / missing (real ≠ good token) |
+| Risk signals | red flags, listed |
+
+For batch (≥2 targets), a lighter first pass also works: `handle | one-liner |
+followers | tweets | authenticity | on-chain | team | narrative | take`. Sort:
+suspicious → team red flag → high quality → stable. Every row carries a take.
+
+Example tag set (adapt): AI · L1 · L2 · DeFi · DePIN · GameFi · RWA · meme ·
+Infra · Stablecoin · Perp · Prediction · Privacy · Consumer · Social · ZK ·
+Cross-chain · Cosmos · Restaking · BTCFi · DeSci · MOVE.
+
+## Output: decision templates (pick exactly one — never "TBD")
+Pairs are allowed (e.g. "High priority" + "Real project ≠ good token").
+- **Worth tracking** — solid; monitor.
+- **High priority** — strong signal; watch closely.
+- **Impostor risk** — likely brand-squat / fake token.
+- **Team red flag** — unresolved team concern.
+- **Dead candidate** — ≥2 death signals; surface, don't auto-conclude.
+- **Stage upgrade** — moved concept → testnet → mainnet → token-live.
+- **Watch first** — anonymous / early; insufficient signal.
+- **Real project ≠ good token** — genuine project, value capture missing.
+- **Narrative fading** — the meta is rotating out.
+- **Valuation stretched** — FDV ahead of fundamentals / last round.
+- **Slideware (low delivery)** — far more promised than shipped + slippage + non-trivial FDV.
+
+Death signals (need ≥2 for "Dead candidate"): account 30 days silent / suspended
+/ bio reset · liquidity collapsing / holders falling / deployer dumped · site 404
+/ Discord disbanded / GitHub ~6 months no commits. List the specific ones found.
+
+## Optional: Notion backend
+If the user tracks projects in Notion, results can be written via the Notion MCP.
+The user supplies their own database; never hardcode IDs in the skill. Read IDs
+(e.g. `ALPHA_DB_ID`) from the user's config at runtime; if unset, fall back to
+Markdown or CSV. Write rules: `Stage`/`Tags` use the user's enums; `FDV` in USD;
+relations append/update only (never delete); on refresh, show a delta table first.
+Never commit real database IDs, API keys, tokens, or endpoints.
+
+## Pitfalls
+- Dumping raw data instead of a judgment — lead with the table + verdict.
+- Trusting a handle/contract because the user provided it.
+- Calling a token "dead" from thin liquidity / low holders alone.
+- Letting a real, impressive project mask a token with no value capture.
+- Omitting the team section for anonymous teams — still write "anonymous + signals".
+- Writing "TBD" — always commit to a decision template.
+
+## Verification (before declaring done)
+- [ ] Comparison table present with all columns.
+- [ ] Authenticity / brand-squatting explicitly checked (especially for contracts).
+- [ ] Team section present (named, or "anonymous + signals").
+- [ ] Value-capture test applied; "real ≠ good token" flagged if relevant.
+- [ ] Every claim sourced or labeled "not found" — nothing fabricated.
+- [ ] Verdict uses a decision template, not "TBD".

--- a/skills/crypto-alpha-research/SKILL.md
+++ b/skills/crypto-alpha-research/SKILL.md
@@ -139,6 +139,19 @@ Markdown or CSV. Write rules: `Stage`/`Tags` use the user's enums; `FDV` in USD;
 relations append/update only (never delete); on refresh, show a delta table first.
 Never commit real database IDs, API keys, tokens, or endpoints.
 
+## On-chain helper (optional)
+For step 4, a bundled read-only helper is available — no API key required:
+
+```bash
+python scripts/price.py <token_address>        # price, FDV, market cap, liquidity, 24h volume/change
+python scripts/price.py --search "<name>"      # list same-name tokens across chains (brand-squatting check)
+```
+
+It calls the public DexScreener API (read-only, GET only; `api.dexscreener.com`)
+and prints JSON; no credentials are bundled. Holders count is not provided by this
+source — label it "not found" or use an explorer if you have one. Treat the
+numbers as facts (step 4), not as a death verdict.
+
 ## Pitfalls
 - Dumping raw data instead of a judgment — lead with the table + verdict.
 - Trusting a handle/contract because the user provided it.

--- a/skills/crypto-alpha-research/scripts/price.py
+++ b/skills/crypto-alpha-research/scripts/price.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+price.py -- read-only on-chain token facts via the public DexScreener API.
+
+No API key or credentials. GET requests only. Documented public service:
+https://docs.dexscreener.com/  (api.dexscreener.com)
+
+Usage:
+  python price.py <token_address>             # facts for one token (highest-liquidity pair)
+  python price.py --search "<name or symbol>" # find same-name tokens (brand-squatting check)
+
+Prints JSON to stdout. Designed to never crash: on any failure it prints
+{"error": "..."} so the calling agent can record "not found" instead of breaking.
+"""
+import json
+import argparse
+import urllib.request
+import urllib.parse
+import urllib.error
+
+DEX_TOKENS = "https://api.dexscreener.com/latest/dex/tokens/"
+DEX_SEARCH = "https://api.dexscreener.com/latest/dex/search?q="
+TIMEOUT = 15
+UA = "crypto-alpha-research-skill/0.1 (+https://github.com/catfrommarss/hermes-skills)"
+
+
+def _get(url):
+    req = urllib.request.Request(
+        url, headers={"User-Agent": UA, "Accept": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _num(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _summary(pair):
+    liquidity = pair.get("liquidity") or {}
+    base = pair.get("baseToken") or {}
+    return {
+        "chain": pair.get("chainId"),
+        "dex": pair.get("dexId"),
+        "name": base.get("name"),
+        "symbol": base.get("symbol"),
+        "address": base.get("address"),
+        "priceUsd": _num(pair.get("priceUsd")),
+        "fdv": _num(pair.get("fdv")),
+        "marketCap": _num(pair.get("marketCap")),
+        "liquidityUsd": _num(liquidity.get("usd")),
+        "volume24h": _num((pair.get("volume") or {}).get("h24")),
+        "priceChange": pair.get("priceChange") or {},
+        "pairAddress": pair.get("pairAddress"),
+        "url": pair.get("url"),
+    }
+
+
+def _by_liquidity(pairs):
+    return sorted(
+        pairs, key=lambda p: (p.get("liquidity") or {}).get("usd") or 0, reverse=True
+    )
+
+
+def token_facts(address):
+    data = _get(DEX_TOKENS + urllib.parse.quote(address))
+    pairs = data.get("pairs") or []
+    if not pairs:
+        return {
+            "address": address,
+            "found": False,
+            "note": "no DEX pairs found (unlisted, wrong chain, or not a token)",
+        }
+    ranked = _by_liquidity(pairs)
+    best = _summary(ranked[0])
+    best["found"] = True
+    best["pairsCount"] = len(pairs)
+    best["otherPairs"] = [_summary(p) for p in ranked[1:4]]
+    best["source"] = "dexscreener"
+    return best
+
+
+def search_name(query):
+    data = _get(DEX_SEARCH + urllib.parse.quote(query))
+    pairs = data.get("pairs") or []
+    seen = set()
+    candidates = []
+    for pair in _by_liquidity(pairs):
+        addr = (pair.get("baseToken") or {}).get("address")
+        if not addr or addr in seen:
+            continue
+        seen.add(addr)
+        candidates.append(_summary(pair))
+        if len(candidates) >= 15:
+            break
+    return {
+        "query": query,
+        "candidatesCount": len(candidates),
+        "note": (
+            "Multiple distinct addresses with the same name = brand-squatting "
+            "risk. Confirm the official contract via the project's own channels."
+        ),
+        "candidates": candidates,
+        "source": "dexscreener",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read-only token facts via the public DexScreener API (no key)."
+    )
+    parser.add_argument("address", nargs="?", help="token contract / mint address")
+    parser.add_argument(
+        "--search", metavar="NAME", help="find tokens by name/symbol (brand-squat check)"
+    )
+    args = parser.parse_args()
+    try:
+        if args.search:
+            result = search_name(args.search)
+        elif args.address:
+            result = token_facts(args.address)
+        else:
+            result = {"error": "provide a token address, or --search <name>"}
+    except urllib.error.URLError as exc:
+        result = {"error": "network error: %s" % exc}
+    except (ValueError, OSError) as exc:
+        result = {"error": "request failed: %s" % exc}
+    except Exception as exc:  # never crash the agent's tool call
+        result = {"error": "unexpected: %s" % exc}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Submitting the `crypto-alpha-research` skill.

Structured crypto due-diligence: from an X/Twitter handle, a token contract address, or a project name, it produces a decision-first comparison table and a risk-flagged verdict — authenticity / brand-squatting checks, on-chain facts, team background, narrative & competitor position, and a 'real project != good token' value-capture test.

- Format: agentskills.io SKILL.md standard, single self-contained file at `skills/crypto-alpha-research/SKILL.md`.
- No bundled credentials, API keys, or private database IDs. On-chain and social lookups use whatever read-only tools/MCPs the agent already has. Optional Notion backend via MCP using user-supplied config (no IDs hardcoded).
- License: MIT.
