### PR TITLE
fix(desktop): wait for backend exit before reloading on connection-config apply

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3598,9 +3598,26 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
   writeDesktopConnectionConfig(config)
-  resetHermesConnection()
-  setTimeout(() => mainWindow?.reload(), 150)
 
+  // Capture the reference before resetHermesConnection() nulls hermesProcess,
+  // so we can wait for actual exit rather than assuming a fixed delay is enough.
+  const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
+  resetHermesConnection()
+
+  if (dying) {
+    await new Promise(resolve => {
+      const timer = setTimeout(() => {
+        try { dying.kill('SIGKILL') } catch {}
+        resolve()
+      }, 5000)
+      dying.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+
+  mainWindow?.reload()
   return sanitizeDesktopConnectionConfig(config)
 })
 


### PR DESCRIPTION
## Problem

`hermes:connection-config:apply` called `resetHermesConnection()` (which sends SIGTERM and immediately nulls `hermesProcess`), then used a hard-coded `setTimeout(() => mainWindow?.reload(), 150)` to trigger the renderer reload.

150 ms is an arbitrary delay that doesn't track actual process shutdown. If the Python backend takes longer to terminate (signal handler, file-lock release, cleanup code), the renderer reloads and `startHermes()` tries to bind the same port while the old process is still alive — resulting in an **"address already in use"** connection failure.

## Fix

Capture the process reference **before** `resetHermesConnection()` nulls it, then await the real `exit` event:

- If a local backend was running: wait for it to exit, with a 5 s SIGKILL fallback in case SIGTERM is ignored.
- If no local process was alive (remote backend, already stopped): reload immediately — same behaviour as before.

```js
const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
resetHermesConnection()

if (dying) {
  await new Promise(resolve => {
    const timer = setTimeout(() => {
      try { dying.kill('SIGKILL') } catch {}
      resolve()
    }, 5000)
    dying.once('exit', () => {
      clearTimeout(timer)
      resolve()
    })
  })
}

mainWindow?.reload()
```

## Test plan

- [ ] Change connection config to a remote backend while a local backend is running → renderer reloads cleanly without a "port in use" error in the logs
- [ ] Change connection config when no local backend is running → reload happens immediately (no 5 s wait)
- [ ] Kill the backend process externally mid-apply → SIGKILL fallback fires after 5 s and reload proceeds