### PR TITLE
fix(nix): follow root pyproject inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,8 +61,12 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
       },
       "locked": {
         "lastModified": 1772555609,
@@ -75,27 +79,6 @@
       "original": {
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "pyproject-build-systems",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769936401,
-        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
-        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
         "type": "github"
       }
     },
@@ -119,27 +102,6 @@
         "type": "github"
       }
     },
-    "pyproject-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "uv2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1771518446,
-        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -150,37 +112,14 @@
         "uv2nix": "uv2nix_2"
       }
     },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "pyproject-build-systems",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "pyproject-build-systems",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770770348,
-        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "type": "github"
-      }
-    },
     "uv2nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pyproject-nix": "pyproject-nix_3"
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
       },
       "locked": {
         "lastModified": 1773039484,

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,13 @@
     uv2nix = {
       url = "github:pyproject-nix/uv2nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
     };
     pyproject-build-systems = {
       url = "github:pyproject-nix/build-system-pkgs";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
     };
     npm-lockfile-fix = {
       url = "github:jeslie0/npm-lockfile-fix";


### PR DESCRIPTION
## Summary

Remove the stale transitive `nix-community/pyproject.nix` fetch from the flake graph by making nested pyproject-nix/uv2nix inputs follow the repo's root inputs.

This is the root-cause alternative to #30866: the workflow was already passing a GitHub token to the Nix installer action, but the lock graph still contained the old `nix-community/pyproject.nix` transitive input.

## Changes Made

- `flake.nix`: make `uv2nix.inputs.pyproject-nix` follow the root `pyproject-nix` input.
- `flake.nix`: make `pyproject-build-systems.inputs.pyproject-nix` and `pyproject-build-systems.inputs.uv2nix` follow the root inputs.
- `flake.lock`: remove the now-orphaned stale transitive nodes, including `nix-community/pyproject.nix`.

## Validation

- Parsed `flake.lock` as JSON successfully.
- Checked that no `nix-community/pyproject.nix` node remains in the lock graph.
- Checked that nested follows resolve through the root input paths:
  - `pyproject-build-systems.inputs.pyproject-nix -> ["pyproject-nix"]`
  - `pyproject-build-systems.inputs.uv2nix -> ["uv2nix"]`
  - `uv2nix.inputs.pyproject-nix -> ["pyproject-nix"]`
- Ran `git diff --check`.
- GitHub Actions Nix jobs pass on both `ubuntu-latest` and `macos-latest`.
