### PR TITLE
fix(dashboard): surface model-write failure when creating a profile

### DIFF
--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -414,7 +414,7 @@ export default function ProfilesPage() {
             (c) => `${c.provider}\u0000${c.model}` === modelChoice,
           )
         : undefined;
-      await api.createProfile({
+      const res = await api.createProfile({
         name,
         clone_from_default: cloneAll ? false : cloneFromDefault,
         clone_all: cloneAll,
@@ -424,6 +424,12 @@ export default function ProfilesPage() {
         model: picked?.model,
       });
       showToast(`${t.profiles.created}: ${name}`, "success");
+      if (picked && res.model_set === false) {
+        showToast(
+          `Profile created, but the model could not be saved — set it from the profile editor.`,
+          "error",
+        );
+      }
       setNewName("");
       setNewDescription("");
       setNoSkills(false);


### PR DESCRIPTION
## Problem

`POST /api/profiles` returns `model_set: false` when the profile is created successfully but the follow-up model assignment step fails (e.g. filesystem error writing `config.yaml`). `handleCreate` on the Profiles page discarded the entire response with a bare `await`:

```ts
await api.createProfile({ ..., provider: picked?.provider, model: picked?.model });
showToast(`${t.profiles.created}: ${name}`, "success");
```

The user sees a "Profile created" success toast with no indication that their chosen model was not persisted. They then need to discover the mismatch themselves from the profile editor.

## Fix

Capture the response and show a follow-up error toast when the user explicitly selected a model (`picked` is truthy) but `res.model_set` came back `false`:

```ts
const res = await api.createProfile({ ... });
showToast(`${t.profiles.created}: ${name}`, "success");
if (picked && res.model_set === false) {
  showToast(
    `Profile created, but the model could not be saved — set it from the profile editor.`,
    "error",
  );
}
```

Strict `=== false` means the warning is silently skipped when `model_set` is `undefined` (older server that predates the field), keeping backwards compatibility.

## Test plan

- [ ] Create a profile with a model selected, backend write succeeds → only success toast shown
- [ ] Simulate model write failure (e.g. make the profile config.yaml read-only) → success toast followed by the model-failure error toast
- [ ] Create a profile with no model selected → only success toast, no model warning regardless of `model_set`