### PR TITLE
fix(desktop): ignore stale backend exits

### DIFF
--- a/apps/desktop/electron/backend-connection-state.cjs
+++ b/apps/desktop/electron/backend-connection-state.cjs
@@ -1,0 +1,70 @@
+function createBackendConnectionState() {
+  let generation = 0
+  let process = null
+  let promise = null
+
+  return {
+    attachProcess(nextProcess) {
+      process = nextProcess
+
+      return { generation, process: nextProcess }
+    },
+
+    clearForCurrentProcess(owner) {
+      if (!owner || owner.generation !== generation || owner.process !== process) {
+        return false
+      }
+
+      process = null
+      promise = null
+
+      return true
+    },
+
+    clearPromiseForAttempt(attempt) {
+      if (!attempt || attempt.generation !== generation || attempt.promise !== promise) {
+        return false
+      }
+
+      promise = null
+
+      return true
+    },
+
+    clearPromise() {
+      promise = null
+    },
+
+    getProcess() {
+      return process
+    },
+
+    getPromise() {
+      return promise
+    },
+
+    invalidate() {
+      generation += 1
+      process = null
+      promise = null
+
+      return generation
+    },
+
+    setPromise(attempt, nextPromise) {
+      if (attempt) {
+        attempt.promise = nextPromise
+      }
+
+      promise = nextPromise
+
+      return nextPromise
+    },
+
+    startAttempt() {
+      return { generation, promise: null }
+    }
+  }
+}
+
+module.exports = { createBackendConnectionState }

--- a/apps/desktop/electron/backend-connection-state.test.cjs
+++ b/apps/desktop/electron/backend-connection-state.test.cjs
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { createBackendConnectionState } = require('./backend-connection-state.cjs')
+
+test('stale local process exit cannot clear a newer connection promise', () => {
+  const state = createBackendConnectionState()
+  const staleProcess = { killed: false }
+  const staleAttempt = state.startAttempt()
+  const stalePromise = Promise.resolve('local')
+
+  state.setPromise(staleAttempt, stalePromise)
+  const staleOwner = state.attachProcess(staleProcess)
+
+  state.invalidate()
+
+  const remoteAttempt = state.startAttempt()
+  const remotePromise = Promise.resolve('remote')
+  state.setPromise(remoteAttempt, remotePromise)
+
+  assert.equal(state.clearForCurrentProcess(staleOwner), false)
+  assert.equal(state.getPromise(), remotePromise)
+})
+
+test('current local process exit clears the active connection promise', () => {
+  const state = createBackendConnectionState()
+  const process = { killed: false }
+  const attempt = state.startAttempt()
+  const promise = Promise.resolve('local')
+
+  state.setPromise(attempt, promise)
+  const owner = state.attachProcess(process)
+
+  assert.equal(state.clearForCurrentProcess(owner), true)
+  assert.equal(state.getProcess(), null)
+  assert.equal(state.getPromise(), null)
+})
+
+test('stale rejected attempt cannot clear a newer connection promise', () => {
+  const state = createBackendConnectionState()
+  const staleAttempt = state.startAttempt()
+  const stalePromise = Promise.resolve('local')
+
+  state.setPromise(staleAttempt, stalePromise)
+  state.invalidate()
+
+  const remoteAttempt = state.startAttempt()
+  const remotePromise = Promise.resolve('remote')
+  state.setPromise(remoteAttempt, remotePromise)
+
+  assert.equal(state.clearPromiseForAttempt(staleAttempt), false)
+  assert.equal(state.getPromise(), remotePromise)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -24,6 +24,7 @@ const net = require('node:net')
 const path = require('node:path')
 const { fileURLToPath, pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
+const { createBackendConnectionState } = require('./backend-connection-state.cjs')
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
@@ -539,11 +540,10 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
-let hermesProcess = null
-let connectionPromise = null
+const backendConnectionState = createBackendConnectionState()
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
-// (the desktop's launch profile) stays managed by hermesProcess +
-// connectionPromise + startHermes(); this pool only holds EXTRA profile
+// (the desktop's launch profile) stays managed by backendConnectionState +
+// startHermes(); this pool only holds EXTRA profile
 // backends spawned lazily when a session belongs to a different profile. A user
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
@@ -1588,15 +1588,16 @@ async function releaseBackendLock(updateRoot, tag) {
 
   // Collect every backend PID the desktop owns: primary window backend + pool.
   const pids = []
-  if (hermesProcess && Number.isInteger(hermesProcess.pid)) pids.push(hermesProcess.pid)
+  const primaryProcess = backendConnectionState.getProcess()
+  if (primaryProcess && Number.isInteger(primaryProcess.pid)) pids.push(primaryProcess.pid)
   for (const entry of backendPool.values()) {
     if (entry.process && Number.isInteger(entry.process.pid)) pids.push(entry.process.pid)
   }
 
   // Graceful first (lets Python flush), then tree-kill to catch grandchildren.
-  if (hermesProcess && !hermesProcess.killed) {
+  if (primaryProcess && !primaryProcess.killed) {
     try {
-      hermesProcess.kill('SIGTERM')
+      primaryProcess.kill('SIGTERM')
     } catch {
       void 0
     }
@@ -1801,6 +1802,7 @@ async function applyUpdatesPosixInApp() {
   // the update reaper. _kill_stale_dashboard_processes accepts a comma-separated
   // list (a single int still parses for back-compat).
   const desktopChildPids = []
+  const hermesProcess = backendConnectionState.getProcess()
   if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
     desktopChildPids.push(hermesProcess.pid)
   }
@@ -4378,13 +4380,13 @@ function resetBootProgressForReconnect() {
 }
 
 function resetHermesConnection() {
-  connectionPromise = null
+  const hermesProcess = backendConnectionState.getProcess()
+  backendConnectionState.invalidate()
 
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
   }
 
-  hermesProcess = null
   resetBootProgressForReconnect()
 }
 
@@ -4393,8 +4395,9 @@ function resetHermesConnection() {
 // startHermes() spawns fresh instead of racing the dying one. Shared by the
 // connection-config and profile switch flows.
 async function teardownPrimaryBackendAndWait() {
-  // Capture the reference before resetHermesConnection() nulls hermesProcess.
-  const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
+  // Capture the reference before resetHermesConnection() invalidates it.
+  const primaryProcess = backendConnectionState.getProcess()
+  const dying = primaryProcess && !primaryProcess.killed ? primaryProcess : null
   resetHermesConnection()
 
   await waitForBackendExit(dying)
@@ -4693,8 +4696,11 @@ async function startHermes() {
   if (bootstrapFailure) {
     throw bootstrapFailure
   }
-  if (connectionPromise) return connectionPromise
+  const existingConnection = backendConnectionState.getPromise()
+  if (existingConnection) return existingConnection
 
+  const connectionAttempt = backendConnectionState.startAttempt()
+  let connectionPromise
   connectionPromise = (async () => {
     await advanceBootProgress('backend.resolve', 'Resolving Hermes backend', 8)
     // Resolve for the desktop's primary profile so a per-profile remote
@@ -4743,7 +4749,7 @@ async function startHermes() {
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)
 
-    hermesProcess = spawn(backend.command, backend.args, hiddenWindowsChildOptions({
+    const hermesProcess = spawn(backend.command, backend.args, hiddenWindowsChildOptions({
       cwd: hermesCwd,
       env: {
         ...process.env,
@@ -4768,6 +4774,7 @@ async function startHermes() {
       stdio: ['ignore', 'pipe', 'pipe']
     }))
 
+    const processOwner = backendConnectionState.attachProcess(hermesProcess)
     hermesProcess.stdout.on('data', rememberLog)
     hermesProcess.stderr.on('data', rememberLog)
     let backendReady = false
@@ -4776,6 +4783,12 @@ async function startHermes() {
       rejectBackendStart = reject
     })
     hermesProcess.once('error', error => {
+      if (!backendConnectionState.clearForCurrentProcess(processOwner)) {
+        rememberLog(`Ignoring stale Hermes backend error: ${error.message}`)
+        rejectBackendStart?.(error)
+        return
+      }
+
       rememberLog(`Hermes backend failed to start: ${error.message}`)
       updateBootProgress(
         {
@@ -4786,15 +4799,19 @@ async function startHermes() {
         },
         { allowDecrease: true }
       )
-      hermesProcess = null
-      connectionPromise = null
       sendBackendExit({ code: null, signal: null, error: error.message })
       rejectBackendStart?.(error)
     })
     hermesProcess.once('exit', (code, signal) => {
+      if (!backendConnectionState.clearForCurrentProcess(processOwner)) {
+        rememberLog(`Ignoring stale Hermes backend exit (${signal || code})`)
+        if (!backendReady) {
+          rejectBackendStart?.(new Error('Hermes backend start was superseded by a newer connection.'))
+        }
+        return
+      }
+
       rememberLog(`Hermes backend exited (${signal || code})`)
-      hermesProcess = null
-      connectionPromise = null
       sendBackendExit({ code, signal })
       if (!backendReady) {
         const message = `Hermes backend exited before it became ready (${signal || code}).`
@@ -4839,20 +4856,21 @@ async function startHermes() {
     }
   })().catch(error => {
     const message = error instanceof Error ? error.message : String(error)
-    updateBootProgress(
-      {
-        error: message,
-        message: `Desktop boot failed: ${message}`,
-        phase: 'backend.error',
-        running: false
-      },
-      { allowDecrease: true }
-    )
-    connectionPromise = null
+    if (backendConnectionState.clearPromiseForAttempt(connectionAttempt)) {
+      updateBootProgress(
+        {
+          error: message,
+          message: `Desktop boot failed: ${message}`,
+          phase: 'backend.error',
+          running: false
+        },
+        { allowDecrease: true }
+      )
+    }
     throw error
   })
 
-  return connectionPromise
+  return backendConnectionState.setPromise(connectionAttempt, connectionPromise)
 }
 
 // Shared navigation guards + window chrome wiring applied to every window
@@ -5074,6 +5092,7 @@ ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(pro
 // not, we drop the cache so the next getConnection() rebuilds it. Local backends
 // self-heal via their child 'exit' handler, so we never touch them here.
 ipcMain.handle('hermes:connection:revalidate', async () => {
+  const connectionPromise = backendConnectionState.getPromise()
   if (!connectionPromise) {
     return { ok: true, rebuilt: false }
   }
@@ -5124,7 +5143,7 @@ ipcMain.handle('hermes:bootstrap:reset', async () => {
   // full backend flow (including a fresh runBootstrap pass).
   rememberLog('[bootstrap] reset requested by renderer; clearing latched failure')
   bootstrapFailure = null
-  connectionPromise = null
+  backendConnectionState.clearPromise()
   bootstrapState = {
     active: false,
     manifest: null,
@@ -6253,6 +6272,7 @@ app.on('before-quit', () => {
   flushDesktopLogBufferSync()
   closePreviewWatchers()
 
+  const hermesProcess = backendConnectionState.getProcess()
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
   }

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -8,7 +8,7 @@ const path = require('node:path')
 const ELECTRON_DIR = __dirname
 
 function readElectronFile(name) {
-  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8')
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
 }
 
 function requireHiddenChildOptions(source, needle) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/backend-connection-state.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
- guard desktop backend connection state with a generation/process owner
- ignore stale local backend `error`/`exit` events after a reconnect switches to a newer connection
- add a node:test regression for stale local exits preserving the newer connection promise

## Root cause
`resetHermesConnection()` cleared the global connection promise and killed the old local backend, but the old process could emit `exit` after a newer remote connection had already started. That stale handler cleared the new connection state and broadcast a backend exit, which could push Desktop back into the boot path and amplify into repeated local spawns/port conflicts.

## Validation
- `node --test electron/backend-connection-state.test.cjs`
- `npm run test:desktop:platforms`
- `node --check electron/main.cjs; node --check electron/backend-connection-state.cjs; node --check electron/backend-connection-state.test.cjs`
- `git diff --check`

Note: local `npm run type-check` could not complete in this checkout because `tsc` is not installed on PATH; CI is running the full workflow on the rebased head.

Closes #38266
