### PR TITLE
fix(dashboard): prevent stale saving indicator when desc requests overlap

### DIFF
--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -333,6 +333,10 @@ export default function ProfilesPage() {
   // Tracks the latest description request (save / auto-describe) so a late
   // response can't overwrite state for a different, newly-opened editor.
   const activeDescRequest = useRef<string | null>(null);
+  // Counts in-flight save / auto-describe requests so the saving indicator
+  // is only cleared when the last concurrent request settles.
+  const descSavingCount = useRef(0);
+  const describingCount = useRef(0);
 
   // Inline model editor state
   const [editingModelFor, setEditingModelFor] = useState<string | null>(null);
@@ -545,6 +549,7 @@ export default function ProfilesPage() {
   );
 
   const handleSaveDesc = async (name: string) => {
+    descSavingCount.current += 1;
     setDescSaving(true);
     activeDescRequest.current = name;
     try {
@@ -571,11 +576,13 @@ export default function ProfilesPage() {
         showToast(`${t.status.error}: ${e}`, "error");
       }
     } finally {
-      setDescSaving(false);
+      descSavingCount.current -= 1;
+      if (descSavingCount.current === 0) setDescSaving(false);
     }
   };
 
   const handleAutoDescribe = async (name: string) => {
+    describingCount.current += 1;
     setDescribing(true);
     activeDescRequest.current = name;
     try {
@@ -603,7 +610,8 @@ export default function ProfilesPage() {
         showToast(`${t.status.error}: ${e}`, "error");
       }
     } finally {
-      setDescribing(false);
+      describingCount.current -= 1;
+      if (describingCount.current === 0) setDescribing(false);
     }
   };
 


### PR DESCRIPTION
## Problem

`handleSaveDesc` and `handleAutoDescribe` on the Profiles page both set `descSaving` / `describing` to `true` at the start of a request, then unconditionally cleared them in `finally`:

```ts
} finally {
  setDescSaving(false);   // always runs
}
```

All other side-effects in these handlers are already guarded by `if (activeDescRequest.current === name)` to ignore stale responses — but the loading flag was not.

**Reproduction:**
1. Open Profile A's description editor and click Save (request in-flight).
2. Quickly open Profile B's description editor and click Save.
3. Profile A's request resolves → `finally` fires → `setDescSaving(false)` clears the indicator even though Profile B's request is still in-flight.
4. The "Saving…" button reverts to "Save" while the write hasn't completed.

The same race exists in `handleAutoDescribe` with `setDescribing`.

## Fix

Add `descSavingCount` and `describingCount` refs that count concurrent in-flight requests. The loading flag is cleared only when the counter reaches zero — i.e. all overlapping requests have settled:

```ts
const descSavingCount = useRef(0);

const handleSaveDesc = async (name: string) => {
  descSavingCount.current += 1;
  setDescSaving(true);
  ...
  } finally {
    descSavingCount.current -= 1;
    if (descSavingCount.current === 0) setDescSaving(false);
  }
};
```

This mirrors the existing `activeDescRequest` guard pattern already used throughout these handlers.

## Test plan

- [ ] Open Profile A description editor, click Save, then immediately open Profile B description editor and click Save → "Saving…" stays visible until both writes complete
- [ ] Single save (normal case) → loading indicator clears after the single request settles
- [ ] Auto-generate description while a manual save is in-flight → `describing` indicator is not cleared early