### PR TITLE
fix: ignore support files during skill lookup

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1205,6 +1205,26 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "LOCAL VERSION" in result["content"]
 
+    def test_supporting_reference_markdown_does_not_collide_with_skill(self, tmp_path):
+        """A support file named <skill>.md inside another skill should not make
+        a bare skill name ambiguous. Only standalone legacy flat files count."""
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+
+        _make_skill(local_dir, "notion", category="productivity", body="REAL NOTION")
+        other_skill = _make_skill(local_dir, "popular-web-designs", category="creative", body="OTHER")
+        support = other_skill / "templates" / "notion.md"
+        support.parent.mkdir(parents=True, exist_ok=True)
+        support.write_text("support file, not a skill", encoding="utf-8")
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("notion")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "REAL NOTION" in result["content"]
+
     def test_external_skill_resolves_when_no_collision(self, tmp_path):
         """External-only skills still resolve normally when there's no
         local skill of the same name."""

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -961,9 +961,23 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            # Do NOT treat supporting files inside canonical skill directories
+            # (references/templates/assets/scripts) as standalone skills. A file
+            # like ``popular-web-designs/templates/notion.md`` is reference
+            # material, not a skill named ``notion``.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                if found_md.name == "SKILL.md":
+                    continue
+                try:
+                    inside_skill_dir = any(
+                        parent != search_dir and (parent / "SKILL.md").exists()
+                        for parent in found_md.parents
+                    )
+                except Exception:
+                    inside_skill_dir = False
+                if inside_skill_dir:
+                    continue
+                _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## Summary
- prevent legacy flat skill lookup from treating canonical support files as standalone skills
- add regression coverage for support files like templates/notion.md not colliding with an actual notion skill
- cleaned local stale backup files and generated caches before updating branch

## Test Plan
- python -m pytest tests/tools/test_skills_tool.py -k 'supporting_reference_markdown_does_not_collide_with_skill or SkillViewCollisionDetection' -q
- python -m pytest tests/tools/test_skills_tool.py -q