### PR TITLE
fix(model_metadata): override models.dev underreports for MiniMax-M3

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1551,15 +1551,14 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale ≤204,800 cache entries for MiniMax-M3.  Pre-catalog
-            # builds resolved M3 via the generic ``minimax`` catch-all (204,800)
-            # and persisted it before the ``minimax-m3`` (1M) entry existed; that
-            # stale value would otherwise stick forever here at step 1.  M3 is 1M,
-            # so any sub-256K cached value for an M3 slug is a leftover — drop it
+            # Invalidate stale cache entries for MiniMax-M3.  M3 is officially
+            # 1,000,000 tokens, so any sub-1M cached value for an M3 slug is a
+            # leftover from before the ``minimax-m3`` (1M) hardcoded entry
+            # existed — and the 512K from models.dev is also stale.  Drop it
             # and fall through to the hardcoded default.
-            elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):
+            elif cached < 1_000_000 and _model_name_suggests_minimax_m3(model):
                 logger.info(
-                    "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-catalog value); "
+                    "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-1M-catalog value); "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )
@@ -1722,6 +1721,19 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
+            # Override underreports against authoritative hardcoded catalog.
+            # models.dev lags behind for newly released models (e.g. MiniMax-M3
+            # catalogued at 512K on 2026-06-01 but officially 1M); the hardcoded
+            # DEFAULT_CONTEXT_LENGTHS entry is the source of truth in that case.
+            # Same pattern as the Kimi-family 32k guard at step 6.
+            hardcoded = _hardcoded_context_length_for(model)
+            if hardcoded and hardcoded > ctx:
+                logger.info(
+                    "models.dev context=%s for %r underreports the hardcoded catalog value; "
+                    "using hardcoded %s",
+                    f"{ctx:,}", model, f"{hardcoded:,}",
+                )
+                return hardcoded
             return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.
@@ -1765,6 +1777,23 @@ def get_model_context_length(
 
     # 10. Default fallback — 256K
     return DEFAULT_FALLBACK_CONTEXT
+
+
+def _hardcoded_context_length_for(model: str) -> int:
+    """Return the hardcoded DEFAULT_CONTEXT_LENGTHS match for ``model``, or 0.
+
+    Mirrors the fuzzy-match logic at step 8 (longest key first, substring on
+    the lowercased model name) so step 5f's underreport guard uses the exact
+    same precedence rules as the hardcoded fallback. Returns 0 (falsy) if no
+    hardcoded entry matches — callers should treat that as "no override".
+    """
+    model_lower = model.lower()
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if default_model in model_lower:
+            return length
+    return 0
 
 
 def estimate_tokens_rough(text: str) -> int:


### PR DESCRIPTION
## Summary

`get_model_context_length()` consults `models.dev` (step 5f) **before** the hardcoded `DEFAULT_CONTEXT_LENGTHS` fallback (step 8). For newly-released models, models.dev lags behind on its catalog values — `MiniMax-M3` was released 2026-06-01 and models.dev still lists its context window as 512,000 tokens, when the official value is 1,000,000. The hardcoded `minimax-m3: 1,000,000` entry in `DEFAULT_CONTEXT_LENGTHS` is therefore never reached, and the TUI status bar displays `64K/512K` instead of the true `64K/1M`. Reasoning quality degrades around the 50% mark because Hermes thinks the context is already half-full.

## Changes

### 1. New hardcoded-override guard at step 5f (`agent/model_metadata.py:1721-1737`)

When models.dev returns a value **smaller** than what `DEFAULT_CONTEXT_LENGTHS` has for the same model, trust the hardcode and log. Same pattern as the existing Kimi-family 32k guard at step 6 — generic, so future newly-released models with stale catalog data get auto-fixed without per-model special-casing.

```python
hardcoded = _hardcoded_context_length_for(model)
if hardcoded and hardcoded > ctx:
    logger.info(
        "models.dev context=%s for %r underreports the hardcoded catalog value; "
        "using hardcoded %s",
        f"{ctx:,}", model, f"{hardcoded:,}",
    )
    return hardcoded
```

### 2. Widen the M3 stale-cache invalidation threshold at step 1 (`agent/model_metadata.py:1554-1566`)

From `<= 204,800` to `< 1,000,000` so existing sessions whose `context_compressor` cached the 512K value get re-resolved on the next lookup instead of staying stuck at the underreport.

### 3. New helper `_hardcoded_context_length_for()` (`agent/model_metadata.py:1781-1795`)

Extracts the longest-key-first fuzzy-match logic from step 8 into a reusable function so the new step 5f guard uses the exact same precedence rules as the hardcoded fallback.

## Why this matters for users

- **TUI status bar shows correct context window** — `X K / 1,000 K` for M3 (was `X K / 512 K`)
- **No more premature "50% full" reasoning degradation** for any model on newly-released entries
- **Generic fix** — covers MiniMax-M3 today and any future model where models.dev's catalog hasn't caught up to a release

## Verification

```python
>>> get_model_context_length('MiniMax-M3', base_url='https://api.minimaxi.com/v1', provider='minimax-cn')
1,000,000   # was 512,000

>>> get_model_context_length('MiniMax-M2.7', base_url='https://api.minimaxi.com/v1', provider='minimax-cn')
204,800     # models.dev value is correct, unchanged
```

- Stale cache entry of 512K auto-invalidates and re-resolves to 1M ✓
- 100 tests in `tests/agent/test_model_metadata.py` and `tests/test_minimax_model_validation.py` pass ✓
- Pyright + py_compile clean ✓

## Related

- `MiniMax-M3` official context: 1,000,000 tokens (https://platform.minimax.io/docs/api-reference/text-chat-openai, https://openrouter.ai/minimax/minimax-m3)
- models.dev `minimax-cn` provider currently lists `MiniMax-M3` with `limit.context: 512,000` (stale)
- Same pattern as the existing Kimi-family underreport guard at step 6
