### PR TITLE
fix(cron): show real next scheduled run instead of forced-tick value

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -873,6 +873,9 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    # Compute the real next scheduled run from the cron expression so
+    # user-facing output can distinguish "running now" from "next scheduled".
+    scheduled_next = compute_next_run(job["schedule"], last_run_at=job.get("last_run_at"))
     return update_job(
         job["id"],
         {
@@ -881,6 +884,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "paused_at": None,
             "paused_reason": None,
             "next_run_at": _hermes_now().isoformat(),
+            "scheduled_next_run_at": scheduled_next,
         },
     )
 
@@ -944,6 +948,9 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
+                # Clear the forced-tick display hint — it was only needed
+                # between trigger_job and the actual execution.
+                job.pop("scheduled_next_run_at", None)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -316,10 +316,14 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         return 1
     job = result.get("job") or result.get("removed_job") or {}
     print(color(f"{success_verb} job: {job.get('name', job_id)} ({job_id})", Colors.GREEN))
-    if action in {"resume", "run"} and result.get("job", {}).get("next_run_at"):
-        print(f"  Next run: {result['job']['next_run_at']}")
     if action == "run":
-        print("  It will run on the next scheduler tick.")
+        scheduled = job.get("scheduled_next_run_at")
+        if scheduled:
+            print(f"  Running now; next scheduled: {scheduled}")
+        else:
+            print("  It will run on the next scheduler tick.")
+    elif action == "resume" and job.get("next_run_at"):
+        print(f"  Next run: {job['next_run_at']}")
     return 0
 
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -408,6 +408,41 @@ class TestResolveJobRef:
         assert result is not None
         assert result["id"] == job["id"]
 
+    def test_trigger_sets_scheduled_next_run_at(self, tmp_cron_dir):
+        """trigger_job must store the real next scheduled run so user-facing
+        output can distinguish 'running now' from 'next scheduled'."""
+        pytest.importorskip("croniter")
+        from cron.jobs import trigger_job
+
+        job = create_job(prompt="A", schedule="0 9 * * 1-5", name="vault")
+        result = trigger_job("vault")
+        assert result is not None
+        # next_run_at should be ~now (forced-tick value)
+        assert result["next_run_at"] is not None
+        # scheduled_next_run_at should be the real next 09:00 weekday
+        assert result["scheduled_next_run_at"] is not None
+        assert result["scheduled_next_run_at"] != result["next_run_at"]
+        # The scheduled next run must be in the future
+        from datetime import datetime, timezone
+        scheduled = datetime.fromisoformat(result["scheduled_next_run_at"])
+        now = datetime.now(timezone.utc)
+        # Allow 6 days margin (if triggered on Friday, next weekday is Monday)
+        assert scheduled > now - timedelta(seconds=5)
+
+    def test_trigger_clears_scheduled_next_run_on_execution(self, tmp_cron_dir):
+        """After mark_job_run, scheduled_next_run_at should be cleared."""
+        pytest.importorskip("croniter")
+        from cron.jobs import trigger_job
+
+        job = create_job(prompt="A", schedule="0 9 * * 1-5", name="vault")
+        trigger_job("vault")
+        mark_job_run(job["id"], success=True)
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert "scheduled_next_run_at" not in updated
+        # next_run_at should now be the real croniter-computed value
+        assert updated["next_run_at"] is not None
+
     def test_pause_by_name(self, tmp_cron_dir):
         job = create_job(prompt="A", schedule="1h", name="alpha")
         result = pause_job("alpha", reason="manual")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -443,6 +443,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    # Include the real scheduled next run when trigger_job stored it
+    # (distinguishes "running now" from "next scheduled fire time").
+    if job.get("scheduled_next_run_at"):
+        result["scheduled_next_run_at"] = job["scheduled_next_run_at"]
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):


### PR DESCRIPTION
## What does this PR do?

After `hermes cron run <id>`, the CLI and chat-agent reported `next_run_at = now` (the forced-tick value) instead of the real next scheduled fire time. This made it look like the recurring schedule was lost.

This PR separates the internal forced-tick scheduling (`next_run_at = now`) from the user-facing display (`scheduled_next_run_at` computed from the cron expression). The CLI now shows "Running now; next scheduled: <real time>" and the cronjob tool includes the scheduled time in its result.

## Related Issue

Fixes #38281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: `trigger_job` now computes the real next scheduled run via `compute_next_run()` and stores it in `scheduled_next_run_at`. `mark_job_run` clears this field after recomputing `next_run_at` from the schedule expression.
- `hermes_cli/cron.py`: `_job_action` displays "Running now; next scheduled: ..." for the `run` action instead of the misleading "Next run: <now>".
- `tools/cronjob_tools.py`: `_format_job` includes `scheduled_next_run_at` in the tool result so the chat agent can report the real next scheduled run.
- `tests/cron/test_jobs.py`: Two regression tests — one verifying `trigger_job` sets `scheduled_next_run_at`, another verifying `mark_job_run` clears it.

## How to Test

1. Create a recurring cron job: `hermes cron create "0 9 * * 1-5" "test" --name vault-review`
2. Run `hermes cron list` → should show correct next scheduled run (e.g., tomorrow 09:00)
3. Run `hermes cron run <id>` → should now show "Running now; next scheduled: <tomorrow 09:00>" instead of "Next run: <now>"
4. After the job executes, `hermes cron list` should again show the correct croniter-computed next run
5. Run `pytest tests/cron/test_jobs.py -x` → all 89 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/jobs.py:trigger_job` (callers: 2 — `cronjob` tool + test; calls: `compute_next_run`, `update_job`)
- Blast radius: LOW — `trigger_job` is only called from the cronjob tool and `hermes cron run` CLI path
- Related patterns: `resume_job` already computes `next_run_at` correctly via `compute_next_run`; this fix applies the same pattern to `trigger_job`'s user-facing output
