### PR TITLE
fix(tui): start MCP discovery for websocket sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5216,6 +5216,24 @@ def test_make_agent_reads_nested_max_turns(monkeypatch):
     assert mock_agent.call_args.kwargs["max_iterations"] == 200
 
 
+def test_make_agent_waits_for_shared_mcp_discovery_before_tool_snapshot(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {})
+    waited = {"done": False}
+
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+        lambda timeout=0.75: waited.__setitem__("done", True),
+    )
+
+    def _fake_agent(*_args, **_kwargs):
+        assert waited["done"] is True
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr("run_agent.AIAgent", _fake_agent)
+
+    server._make_agent("sid1", "key1")
+
+
 def test_make_agent_nested_max_turns_takes_priority(monkeypatch):
     _setup_make_agent_mocks(
         monkeypatch, {"agent": {"max_turns": 500}, "max_turns": 100}

--- a/tests/tui_gateway/test_mcp_discovery_startup.py
+++ b/tests/tui_gateway/test_mcp_discovery_startup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway import ws as ws_mod
+
+
+class _DisconnectingWebSocket:
+    client = None
+
+    def __init__(self) -> None:
+        self.accepted = False
+        self.closed = False
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, line: str) -> None:
+        self.sent.append(line)
+
+    async def receive_text(self) -> str:
+        raise ws_mod._WebSocketDisconnect(1000)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_ws_startup_starts_shared_mcp_discovery_before_ready(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def _fake_start_background_mcp_discovery(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        _fake_start_background_mcp_discovery,
+    )
+
+    websocket = _DisconnectingWebSocket()
+
+    await ws_mod.handle_ws(websocket)
+
+    assert websocket.accepted is True
+    assert websocket.sent, "expected gateway.ready frame to be sent"
+    assert calls == [
+        {
+            "logger": ws_mod._log,
+            "thread_name": "tui-ws-mcp-discovery",
+        }
+    ]

--- a/tests/tui_gateway/test_wait_for_mcp_discovery.py
+++ b/tests/tui_gateway/test_wait_for_mcp_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for tui_gateway.entry.wait_for_mcp_discovery (PR #35245).
+"""Tests for shared MCP startup wait handling (PR #35245).
 
 MCP tool discovery runs in a background daemon thread so a slow/dead server
 can't freeze ``gateway.ready``.  The agent snapshots its tool list once at
@@ -10,21 +10,21 @@ the startup hang, and a no-op once discovery has finished.
 import threading
 import time
 
-import tui_gateway.entry as entry
+from hermes_cli import mcp_startup
 
 
 def _restore_thread_slot(saved):
-    entry._mcp_discovery_thread = saved
+    mcp_startup._mcp_discovery_thread = saved
 
 
 def test_no_thread_is_noop():
     """When no discovery thread was started (the common no-MCP case), the
     helper returns immediately and never blocks."""
-    saved = entry._mcp_discovery_thread
+    saved = mcp_startup._mcp_discovery_thread
     try:
-        entry._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_thread = None
         start = time.monotonic()
-        entry.wait_for_mcp_discovery(timeout=5.0)
+        mcp_startup.wait_for_mcp_discovery(timeout=5.0)
         assert time.monotonic() - start < 0.1
     finally:
         _restore_thread_slot(saved)
@@ -32,14 +32,14 @@ def test_no_thread_is_noop():
 
 def test_already_finished_thread_is_noop():
     """A thread that has already finished is not joined-on (dead thread)."""
-    saved = entry._mcp_discovery_thread
+    saved = mcp_startup._mcp_discovery_thread
     try:
         t = threading.Thread(target=lambda: None, daemon=True)
         t.start()
         t.join()  # ensure it's finished
-        entry._mcp_discovery_thread = t
+        mcp_startup._mcp_discovery_thread = t
         start = time.monotonic()
-        entry.wait_for_mcp_discovery(timeout=5.0)
+        mcp_startup.wait_for_mcp_discovery(timeout=5.0)
         assert time.monotonic() - start < 0.1
     finally:
         _restore_thread_slot(saved)
@@ -48,12 +48,12 @@ def test_already_finished_thread_is_noop():
 def test_fast_thread_is_joined():
     """A reachable-but-still-connecting (fast) server lands before the agent
     snapshots tools — the helper waits for it to finish."""
-    saved = entry._mcp_discovery_thread
+    saved = mcp_startup._mcp_discovery_thread
     try:
         t = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
         t.start()
-        entry._mcp_discovery_thread = t
-        entry.wait_for_mcp_discovery(timeout=1.0)
+        mcp_startup._mcp_discovery_thread = t
+        mcp_startup.wait_for_mcp_discovery(timeout=1.0)
         assert not t.is_alive()  # joined to completion
     finally:
         _restore_thread_slot(saved)
@@ -62,14 +62,14 @@ def test_fast_thread_is_joined():
 def test_hung_thread_is_bounded_by_timeout():
     """A slow/dead server must NOT re-introduce the startup hang — the join is
     bounded by the timeout and returns even though the thread is still alive."""
-    saved = entry._mcp_discovery_thread
+    saved = mcp_startup._mcp_discovery_thread
     stop = threading.Event()
     try:
         t = threading.Thread(target=stop.wait, daemon=True)  # blocks until set
         t.start()
-        entry._mcp_discovery_thread = t
+        mcp_startup._mcp_discovery_thread = t
         start = time.monotonic()
-        entry.wait_for_mcp_discovery(timeout=0.3)
+        mcp_startup.wait_for_mcp_discovery(timeout=0.3)
         elapsed = time.monotonic() - start
         assert 0.25 <= elapsed < 1.0  # bounded near the timeout, not forever
         assert t.is_alive()  # thread still running; we did not block on it

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -17,16 +17,12 @@ import signal
 import time
 import traceback
 
+from hermes_cli.mcp_startup import start_background_mcp_discovery, wait_for_mcp_discovery
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
 from tui_gateway.transport import TeeTransport
 
 logger = logging.getLogger(__name__)
-
-# Handle for the background MCP tool-discovery thread (see main()).  The first
-# agent build briefly joins this so already-spawning fast servers land before
-# the agent snapshots its tool list (see wait_for_mcp_discovery).
-_mcp_discovery_thread = None
 
 
 def _install_sidecar_publisher() -> None:
@@ -192,24 +188,6 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly block until background MCP discovery finishes, up to ``timeout``.
-
-    MCP discovery runs in a daemon thread spawned at startup (see main()) so a
-    slow/dead server can't freeze ``gateway.ready``.  But the agent snapshots
-    its tool list ONCE at build time and never re-reads it, so a reachable-but-
-    slow server that finishes connecting *after* the first prompt would be
-    invisible for the whole session.  Joining with a short bounded timeout
-    before the first agent build lets already-spawning fast servers land
-    without re-introducing the startup hang: a dead server simply isn't waited
-    on beyond ``timeout``.  No-op when no discovery thread was started.
-    """
-    thread = _mcp_discovery_thread
-    if thread is None or not thread.is_alive():
-        return
-    thread.join(timeout=timeout)
-
-
 def main():
     _install_sidecar_publisher()
 
@@ -233,35 +211,10 @@ def main():
     # wasted.  Check the config first (cheap) and only spawn the discovery
     # thread when there's actually MCP work to do, so the import cost stays
     # off the path entirely for the common case.
-    try:
-        from hermes_cli.config import read_raw_config
-        _mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        _has_mcp_servers = isinstance(_mcp_servers, dict) and len(_mcp_servers) > 0
-    except Exception:
-        # Be conservative: if we can't decide, fall back to attempting
-        # discovery (still backgrounded, so it can't block startup).
-        _has_mcp_servers = True
-    if _has_mcp_servers:
-        def _discover_mcp_background() -> None:
-            try:
-                from tools.mcp_tool import discover_mcp_tools
-                discover_mcp_tools()
-            except Exception:
-                logger.warning(
-                    "Background MCP tool discovery failed", exc_info=True
-                )
-
-        import threading as _mcp_threading
-        _mcp_thread = _mcp_threading.Thread(
-            target=_discover_mcp_background,
-            name="tui-mcp-discovery",
-            daemon=True,
-        )
-        _mcp_thread.start()
-        # Publish the handle so the first agent build can briefly wait for
-        # already-spawning fast servers to land (see wait_for_mcp_discovery).
-        global _mcp_discovery_thread
-        _mcp_discovery_thread = _mcp_thread
+    start_background_mcp_discovery(
+        logger=logger,
+        thread_name="tui-mcp-discovery",
+    )
 
     if not write_json({
         "jsonrpc": "2.0",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2340,7 +2340,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
     # server still can't block.  No-op once discovery has finished (every build
     # after the first during a slow startup).
     try:
-        from tui_gateway.entry import wait_for_mcp_discovery
+        from hermes_cli.mcp_startup import wait_for_mcp_discovery
 
         wait_for_mcp_discovery()
     except Exception:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -153,6 +153,12 @@ async def handle_ws(ws: Any) -> None:
         _log.info("ws accepted peer=%s", peer)
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=_log,
+            thread_name="tui-ws-mcp-discovery",
+        )
 
         ready_ok = await transport.write_async(
             {


### PR DESCRIPTION
## Summary
- start shared background MCP discovery for TUI WebSocket sessions before `gateway.ready`
- make TUI agent construction wait on the shared MCP startup state instead of the stdio-only entry module state
- reuse the same MCP startup helper from stdio TUI and WebSocket TUI paths

## Root cause
The stdio TUI path started MCP discovery inside `tui_gateway.entry.main()`, but Desktop/dashboard WebSocket sessions enter through `tui_gateway.ws.handle_ws()` and never execute that startup path. `_make_agent()` also waited on `tui_gateway.entry.wait_for_mcp_discovery()`, so WebSocket-created agents had no discovery thread to wait for before snapshotting tools. Manual `/reload-mcp` worked because it explicitly re-ran discovery and refreshed the session's tool list.

## Scope
This addresses the Desktop/WebSocket startup-discovery half of #37589 and the duplicate report #38271. It intentionally does not include the separate `uvx`/GUI PATH fallback from #37589; that should be a smaller follow-up if still needed.

## Validation
- `.venv\\Scripts\\python.exe -m pytest tests/tui_gateway/test_mcp_discovery_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/test_tui_gateway_server.py::test_make_agent_waits_for_shared_mcp_discovery_before_tool_snapshot tests/hermes_cli/test_mcp_startup.py -q --timeout-method=thread` -> `10 passed`
- `.venv\\Scripts\\python.exe -m ruff check tui_gateway/entry.py tui_gateway/server.py tui_gateway/ws.py tests/tui_gateway/test_mcp_discovery_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/test_tui_gateway_server.py` -> `All checks passed!`
- `.venv\\Scripts\\python.exe -m py_compile tui_gateway/entry.py tui_gateway/server.py tui_gateway/ws.py hermes_cli/mcp_startup.py` -> passed
- `git diff --check` -> passed

Addresses #37589
Addresses #38271
