### PR TITLE
fix(agent): inject process HERMES_HOME into subprocess env when context override unset

### DIFF
--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -177,6 +177,29 @@ class TestMakeRunEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_process_hermes_home_bridges_when_context_unset(self, tmp_path, monkeypatch):
+        """#4707: with the ContextVar UNSET (background/PTY/cron spawns), the
+        subprocess must still inherit the process's own HERMES_HOME, matching the
+        profile HOME override. Otherwise the child's get_hermes_home() falls back
+        to ~/.hermes and reads the wrong profile (cross-profile data corruption)."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from hermes_constants import get_hermes_home_override
+        from tools.environments.local import _make_run_env
+
+        # Precondition: the context override is genuinely unset for this spawn.
+        assert get_hermes_home_override() is None
+
+        result = _make_run_env({})
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert result["HERMES_HOME"] == str(hermes_home)
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection
@@ -228,6 +251,28 @@ class TestSanitizeSubprocessEnvHomeInjection:
 
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
+
+    def test_process_hermes_home_bridges_when_context_unset(self, tmp_path, monkeypatch):
+        """#4707: background/PTY spawns build env from base_env (not os.environ)
+        and usually run with the ContextVar UNSET. The sanitized env must still
+        carry the process's own HERMES_HOME so the child resolves to the right
+        profile instead of falling back to the default ~/.hermes."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_constants import get_hermes_home_override
+        from tools.environments.local import _sanitize_subprocess_env
+
+        # Precondition: the context override is genuinely unset for this spawn.
+        assert get_hermes_home_override() is None
+
+        base_env = {"HOME": "/root", "PATH": "/usr/bin"}
+        result = _sanitize_subprocess_env(base_env)
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert result["HERMES_HOME"] == str(hermes_home)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -195,7 +195,13 @@ def _inject_context_hermes_home(env: dict) -> None:
     try:
         from hermes_constants import get_hermes_home_override
 
-        value = get_hermes_home_override()
+        # The ContextVar wins (per-session profile mutation, #1976). Fall back to
+        # the process's own HERMES_HOME so the common single-profile gateway case
+        # is covered even when the ContextVar was never set (background/PTY/cron
+        # spawns). Without this, the child's HOME is pinned to the profile but
+        # HERMES_HOME is absent, so get_hermes_home() falls back to ~/.hermes and
+        # the subprocess reads the wrong profile. Fixes #4707.
+        value = get_hermes_home_override() or os.getenv("HERMES_HOME")
         if value:
             env["HERMES_HOME"] = value
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Subprocesses spawned under a profile-scoped gateway lose their `HERMES_HOME`, so the child resolves `get_hermes_home()` to the default `~/.hermes` and reads the **wrong profile's** config/auth/memory — the cross-profile data-corruption / isolation break tracked in #4707.

Both subprocess env builders in `tools/environments/local.py` — `_sanitize_subprocess_env` (background + PTY spawns) and `_make_run_env` — pin `HOME` to the profile's `home/` dir, but inject `HERMES_HOME` **only** from the `_HERMES_HOME_OVERRIDE` ContextVar via `_inject_context_hermes_home()`. That ContextVar is unset for the common background/PTY/cron spawns, so the child ends up with `HOME={profile}/home` and **no** `HERMES_HOME`. `_sanitize_subprocess_env` makes this worse because it builds from `base_env or {}` (not `os.environ`), so even the parent's own `HERMES_HOME` doesn't carry through.

This fixes it **centrally**, at the one shared seam both builders already call, rather than adding yet another per-spawner pin. A single `os.getenv("HERMES_HOME")` fallback in `_inject_context_hermes_home()` covers the common single-profile-gateway case while preserving ContextVar precedence:

```python
value = get_hermes_home_override() or os.getenv("HERMES_HOME")
```

### Why this shape (vs. another per-spawner fix)

The repo already carries several narrow, per-call-site `HERMES_HOME`/HOME propagation fixes (e.g. #4729, #15330, #36742, #25151, #27260), and #4707 keeps re-surfacing because each new spawner re-opens the same class of bug. `_inject_context_hermes_home()` is the single seam both env builders funnel through, so fixing it here closes the current spawners **and** future ones in one place — and subsumes the narrower open PRs against #4707.

### Security / isolation

This is the *secure* direction, not a leak:

- **Only one key** is touched — `HERMES_HOME`, a non-secret path var — inside the helper whose sole job is already to inject that one key. The secret-stripping machinery (`_HERMES_PROVIDER_ENV_BLOCKLIST`, `is_env_passthrough`, the `_HERMES_FORCE_` allowlist) and the `base_env or {}` build are **untouched** — zero new secret-exposure surface.
- **ContextVar keeps precedence** (`get_hermes_home_override() or …`), so multi-profile-per-process sessions that mutate the home per session (#1976) still get the right value; `os.getenv` is only the fallback when the ContextVar was never set.
- The **unpatched** state is the actual isolation hole: a profile subprocess silently reading the default profile's `auth.json`/config/memory. Pinning the correct `HERMES_HOME` **shrinks** blast radius — a compromised/injected profile-scoped skill stays in its own profile instead of reaching the default profile.

One honest edge: multi-profile-in-one-process **with the ContextVar unset** → `os.getenv` returns the process's startup `HERMES_HOME`. But the override still wins when set, so this only hits the unset case, and even then it's strictly no worse than today (today injects nothing → default fallback). Happy to instead pin directly in `_sanitize_subprocess_env` if maintainers prefer keeping the helper ContextVar-only.

## Related Issue

Fixes #4707

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/environments/local.py` — `_inject_context_hermes_home()`: fall back to `os.getenv("HERMES_HOME")` when the context override is unset (ContextVar still wins). One-line behavior change + explanatory comment.
- `tests/test_subprocess_home_isolation.py` — add `test_process_hermes_home_bridges_when_context_unset` to both `TestSanitizeSubprocessEnvHomeInjection` and `TestMakeRunEnvHomeInjection`, exercising the #4707 pattern (ContextVar unset, profile `home/` exists).

## How to Test

1. The new `_sanitize_subprocess_env` test **fails on `main`** (`KeyError: 'HERMES_HOME'`) and **passes** with this change — that delta is the bug and the fix.
2. `uv run pytest tests/test_subprocess_home_isolation.py tests/tools/test_local_env_blocklist.py -q` → all pass (40).
3. `uv run ruff check tools/environments/local.py tests/test_subprocess_home_isolation.py` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests above and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] No docs/config/architecture changes needed — N/A
- [x] Cross-platform: pure env-var logic, no platform-specific paths — N/A
