### PR TITLE
feat: circuit breaker panel + input-dependent tool risk classification

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -408,6 +408,11 @@ def init_agent(
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
 
+    # Circuit breaker panel — independent per-feature breakers
+    # (compression, delegation, api_retry, model_error, etc.)
+    from agent.circuit_breaker import CircuitBreakerPanel
+    agent._circuit_breaker_panel = CircuitBreakerPanel()
+
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
     agent._interrupt_message = None  # Optional message that triggered interrupt

--- a/agent/circuit_breaker.py
+++ b/agent/circuit_breaker.py
@@ -1,0 +1,177 @@
+"""
+Per-feature circuit breakers (inspired by Claude Code architecture).
+
+Each circuit has its own failure counter and max-failures threshold.
+When tripped, the circuit blocks further attempts until explicitly reset
+(typically at turn boundaries).
+
+Unlike tool_guardrails (which monitors individual tool call patterns),
+circuit breakers protect *features* — compression, delegation, provider
+fallback, model retries — from cascading failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, ClassVar, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"       # normal operation
+    OPEN = "open"           # tripped — blocks further attempts
+    HALF_OPEN = "half_open" # testing if recovered
+
+
+@dataclass
+class CircuitBreaker:
+    """Single circuit breaker instance."""
+
+    name: str
+    max_failures: int = 3
+    reset_after_turns: int = 0  # 0 = never auto-reset (manual only)
+    description: str = ""
+
+    # Internal state
+    _failures: int = field(default=0, repr=False)
+    _state: CircuitState = field(default=CircuitState.CLOSED, repr=False)
+    _turn_count: int = field(default=0, repr=False)
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    @property
+    def failures(self) -> int:
+        return self._failures
+
+    @property
+    def is_open(self) -> bool:
+        return self._state == CircuitState.OPEN
+
+    @property
+    def would_allow(self) -> bool:
+        """Can this circuit accept new attempts?"""
+        return self._state != CircuitState.OPEN
+
+    def record_failure(self) -> bool:
+        """Record a failure. Returns True if circuit just tripped."""
+        self._failures += 1
+        if self._failures >= self.max_failures and self._state == CircuitState.CLOSED:
+            self._state = CircuitState.OPEN
+            logger.warning(
+                "Circuit breaker '%s' TRIPPED after %d failures (max=%d): %s",
+                self.name, self._failures, self.max_failures, self.description,
+            )
+            return True
+        return False
+
+    def record_success(self):
+        """Record a success — moves from HALF_OPEN to CLOSED."""
+        if self._state == CircuitState.HALF_OPEN:
+            self._state = CircuitState.CLOSED
+            self._failures = 0
+            logger.info("Circuit breaker '%s' RECOVERED (half-open succeeded)", self.name)
+
+    def reset(self):
+        """Force-reset to closed state."""
+        self._state = CircuitState.CLOSED
+        self._failures = 0
+        logger.debug("Circuit breaker '%s' manually reset", self.name)
+
+    def try_reset(self) -> bool:
+        """Attempt to move to half-open. Returns True if allowed to test."""
+        if self._state == CircuitState.OPEN:
+            if self.reset_after_turns > 0 and self._turn_count >= self.reset_after_turns:
+                self._state = CircuitState.HALF_OPEN
+                self._turn_count = 0
+                logger.info("Circuit breaker '%s' → HALF_OPEN (auto-reset after %d turns)", self.name, self.reset_after_turns)
+                return True
+            return False
+        return True
+
+    def advance_turn(self):
+        """Called at start of each turn."""
+        self._turn_count += 1
+        self.try_reset()
+
+
+@dataclass
+class CircuitBreakerPanel:
+    """Collection of circuit breakers for different feature domains."""
+
+    breakers: dict[str, CircuitBreaker] = field(default_factory=dict)
+
+    # Preset configurations matching Claude Code patterns
+    PRESETS: ClassVar[Mapping[str, tuple[int, int, str]]] = {
+        "compression":      (3, 0, "Auto-compact consecutive failures"),
+        "delegation":       (3, 0, "delegate_task consecutive failures"),
+        "provider_fallback":(3, 0, "Provider fallback chain exhausted"),
+        "same_solution":    (2, 0, "Same solution retried"),
+        "model_error":      (3, 0, "Model API errors (5xx/connection)"),
+        "no_progress":      (5, 0, "No progress tool calls"),
+        "api_retry":        (3, 0, "API retry exhaustion"),
+    }
+
+    def get(self, name: str) -> CircuitBreaker:
+        """Get or create a circuit breaker by name."""
+        if name not in self.breakers:
+            preset = self.PRESETS.get(name)
+            if preset:
+                max_f, reset_t, desc = preset
+                self.breakers[name] = CircuitBreaker(
+                    name=name, max_failures=max_f, reset_after_turns=reset_t, description=desc,
+                )
+            else:
+                self.breakers[name] = CircuitBreaker(name=name)
+        return self.breakers[name]
+
+    def record_failure(self, name: str) -> bool:
+        """Record a failure on a circuit. Returns True if circuit tripped."""
+        return self.get(name).record_failure()
+
+    def record_success(self, name: str):
+        """Record a success on a circuit."""
+        self.get(name).record_success()
+
+    def would_allow(self, name: str) -> bool:
+        """Check if a circuit allows new attempts."""
+        return self.get(name).would_allow
+
+    def is_open(self, name: str) -> bool:
+        """Check if a circuit is tripped."""
+        return self.get(name).is_open
+
+    def reset(self, name: str):
+        """Force-reset a circuit."""
+        self.get(name).reset()
+
+    def advance_turn(self):
+        """Advance turn counters for all circuits."""
+        for breaker in self.breakers.values():
+            breaker.advance_turn()
+
+    def reset_all(self):
+        """Reset all circuits — called at start of each conversation turn."""
+        for breaker in self.breakers.values():
+            breaker.reset()
+
+    def status(self) -> list[dict[str, Any]]:
+        """Return status of all circuits."""
+        return [
+            {
+                "name": b.name,
+                "state": b.state.value,
+                "failures": b.failures,
+                "max_failures": b.max_failures,
+                "description": b.description,
+            }
+            for b in self.breakers.values()
+        ]
+
+    def tripped_circuits(self) -> list[str]:
+        """Return names of all open (tripped) circuits."""
+        return [name for name, b in self.breakers.items() if b.is_open]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -451,6 +451,9 @@ def run_conversation(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Advance circuit breakers — each turn is a fresh observation window
+    if hasattr(agent, '_circuit_breaker_panel'):
+        agent._circuit_breaker_panel.advance_turn()
     # True until the server rejects an image_url content part with an error
     # like "Only 'text' content type is supported."  Set to False on first
     # rejection and kept False for the rest of the session so we never re-send
@@ -1503,6 +1506,16 @@ def run_conversation(
                         agent._flush_status_buffer()
                         agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                         logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
+
+                        # Record circuit breaker failure
+                        if hasattr(agent, '_circuit_breaker_panel'):
+                            tripped = agent._circuit_breaker_panel.record_failure("api_retry")
+                            if tripped:
+                                agent._emit_status(
+                                    "🔴 Circuit breaker 'api_retry' TRIPPED — "
+                                    "all API calls blocked for this turn."
+                                )
+
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -2909,6 +2922,17 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                             agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+
+                            # Record circuit breaker — compression trips after 3 failures
+                            if hasattr(agent, '_circuit_breaker_panel'):
+                                tripped = agent._circuit_breaker_panel.record_failure("compression")
+                                if tripped:
+                                    agent._emit_status(
+                                        "🔴 Circuit breaker 'compression' TRIPPED — "
+                                        "auto-compress disabled for this session. "
+                                        "Use /new for a fresh start."
+                                    )
+
                             agent._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -2978,6 +3002,16 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+
+                        # Record circuit breaker — compression trips after 3 failures
+                        if hasattr(agent, '_circuit_breaker_panel'):
+                            tripped = agent._circuit_breaker_panel.record_failure("compression")
+                            if tripped:
+                                agent._emit_status(
+                                    "🔴 Circuit breaker 'compression' TRIPPED — "
+                                    "auto-compress disabled. Use /new for fresh start."
+                                )
+
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
@@ -3314,6 +3348,16 @@ def run_conversation(
                         agent.log_prefix, max_retries, _final_summary,
                         _provider, _model, len(api_messages), f"{approx_tokens:,}",
                     )
+
+                    # Record circuit breaker — model_error trips after 3 consecutive API failures
+                    if hasattr(agent, '_circuit_breaker_panel'):
+                        tripped = agent._circuit_breaker_panel.record_failure("model_error")
+                        if tripped:
+                            agent._emit_status(
+                                "🔴 Circuit breaker 'model_error' TRIPPED — "
+                                "suggest switching model/provider."
+                            )
+
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="max_retries_exhausted", error=api_error,

--- a/agent/tool_risk.py
+++ b/agent/tool_risk.py
@@ -1,0 +1,267 @@
+"""
+Input-dependent tool risk classification (inspired by Claude Code's
+isConcurrencySafe(input) pattern).
+
+Extends the static IDEMPOTENT_TOOL_NAMES / MUTATING_TOOL_NAMES
+classification from tool_guardrails.py with input-aware analysis.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+
+class RiskLevel(Enum):
+    SAFE = "safe"              # Read-only, no side effects
+    MEDIUM = "medium"          # Read+network, or file modifications
+    DESTRUCTIVE = "destructive"  # Irreversible, system-level changes
+    DANGEROUS = "dangerous"    # Can cause data loss or security breach
+
+
+# --- Shell command patterns ---
+_READONLY_SHELL_PREFIXES = frozenset({
+    "ls", "cat", "head", "tail", "grep", "find", "which", "type",
+    "echo", "printf", "pwd", "whoami", "id", "uname", "date", "env",
+    "printenv", "wc", "du", "df", "free", "uptime", "ps", "pgrep",
+    "ss", "netstat", "ip addr", "ip link", "ip route",
+    "git log", "git status", "git diff", "git branch", "git show",
+    "git stash list", "git remote",
+    "docker ps", "docker images", "docker logs",
+    "systemctl status", "systemctl list",
+    "journalctl", "curl -s", "curl --head", "wget --spider",
+    "python3 -c", "python -c",
+    "nvidia-smi", "rocm-smi",
+})
+
+_DESTRUCTIVE_SHELL_PATTERNS = frozenset({
+    "rm -rf /", "rm -rf /*", "rm -rf ~",
+    "mkfs.", "dd if=",
+    ":(){ :|:& };:",  # fork bomb
+    "chmod 777 /", "chmod -R 777 /",
+    "> /dev/sda",
+})
+
+_DESTRUCTIVE_SHELL_KEYWORDS = frozenset({
+    "rm -rf", "rm -r",
+    "chmod 777", "chown -R",
+    "iptables -F", "ufw disable",
+    "kill -9", "pkill -9",
+    "git reset --hard", "git clean -f",
+})
+
+_DANGEROUS_SHELL_PATTERNS = frozenset({
+    "rm -rf /", "rm -rf /*", "rm -rf ~",
+    "mkfs.", "dd if=",
+    ":(){ :|:& };:",
+})
+
+_DANGEROUS_SHELL_KEYWORDS = frozenset({
+    "shutdown", "reboot", "halt",
+    "fdisk", "parted",
+    "systemctl stop hermes", "systemctl stop vllm", "systemctl stop sglang",
+    "systemctl disable", "systemctl mask",
+})
+
+
+def _is_readonly_shell(command: str) -> bool:
+    """Check if a shell command is read-only (safe)."""
+    cmd = command.strip().lower()
+    for prefix in _READONLY_SHELL_PREFIXES:
+        if cmd.startswith(prefix) or cmd.startswith(prefix.lower()):
+            return True
+    return False
+
+
+def _is_dangerous_shell(command: str) -> bool:
+    """Check if a shell command is dangerous (catastrophic)."""
+    cmd = command.strip()
+    cmd_lower = cmd.lower()
+
+    # Precise patterns: must match at word boundary for path-based checks
+    for pat in _DANGEROUS_SHELL_PATTERNS:
+        if pat.lower() in cmd_lower:
+            # For path patterns like "rm -rf /", ensure it's not a prefix of a longer path
+            if pat.endswith("/") and not pat.endswith("/*"):
+                # "rm -rf /" should NOT match "rm -rf /tmp"
+                idx = cmd_lower.find(pat.lower())
+                if idx >= 0:
+                    after = cmd_lower[idx + len(pat):]
+                    if after and not after[0].isspace() and after[0] not in ';|&':
+                        # "/" followed by non-space/non-separator = longer path
+                        continue
+            return True
+
+    for kw in _DANGEROUS_SHELL_KEYWORDS:
+        if kw.lower() in cmd_lower:
+            return True
+    return False
+
+
+def _is_destructive_shell(command: str) -> bool:
+    """Check if a shell command is destructive (requires approval)."""
+    cmd = command.strip()
+    cmd_lower = cmd.lower()
+    for pat in _DESTRUCTIVE_SHELL_PATTERNS:
+        if pat.lower() in cmd_lower:
+            return True
+    for kw in _DESTRUCTIVE_SHELL_KEYWORDS:
+        if kw.lower() in cmd_lower:
+            return True
+    return False
+
+
+# --- File operation risk ---
+_PROTECTED_PATHS = frozenset({
+    "/etc/", "/boot/", "/sys/", "/proc/", "/dev/",
+    "~/.ssh/", "~/.gnupg/",
+    "~/.hermes/config.yaml", "~/.hermes/.env", "~/.hermes/auth.json",
+})
+
+
+def _is_protected_path(path: str) -> bool:
+    """Check if a path is system-protected."""
+    import os
+    expanded = os.path.expanduser(path)
+    for protected in _PROTECTED_PATHS:
+        check = os.path.expanduser(protected)
+        if expanded.startswith(check):
+            return True
+    return False
+
+
+# --- Main classifier ---
+
+def classify_tool_risk(
+    tool_name: str,
+    args: Mapping[str, Any] | None = None,
+) -> RiskLevel:
+    """
+    Classify the risk level of a tool call based on both tool name and arguments.
+
+    This is the input-dependent equivalent of static IDEMPOTENT / MUTATING
+    classification. Claude Code uses ``isConcurrencySafe(input)`` instead of
+    ``isConcurrencySafe()`` — same philosophy.
+    """
+    args = args or {}
+
+    # --- terminal ---
+    if tool_name == "terminal":
+        command = str(args.get("command", "")).strip()
+        if not command:
+            return RiskLevel.MEDIUM
+
+        background = args.get("background", False)
+        if _is_dangerous_shell(command):
+            return RiskLevel.DANGEROUS
+        if _is_destructive_shell(command):
+            return RiskLevel.DESTRUCTIVE
+        if _is_readonly_shell(command):
+            return RiskLevel.SAFE
+        # Background long-running tasks (servers, daemons)
+        if background:
+            return RiskLevel.MEDIUM
+        return RiskLevel.MEDIUM
+
+    # --- execute_code ---
+    if tool_name == "execute_code":
+        code = str(args.get("code", ""))
+        if not code:
+            return RiskLevel.MEDIUM
+        # Check for dangerous patterns
+        code_lower = code.lower()
+        dangerous_patterns = [
+            "os.system(", "subprocess.call(", "subprocess.run(",
+            "shutil.rmtree(", "os.remove(", "os.unlink(",
+            "os.rmdir(", "__import__('os')",
+        ]
+        for pat in dangerous_patterns:
+            if pat in code_lower:
+                return RiskLevel.DESTRUCTIVE
+        return RiskLevel.MEDIUM
+
+    # --- file operations ---
+    if tool_name in ("write_file", "patch"):
+        path = str(args.get("path", ""))
+        if _is_protected_path(path):
+            return RiskLevel.DESTRUCTIVE
+        return RiskLevel.MEDIUM
+
+    if tool_name == "read_file":
+        return RiskLevel.SAFE
+
+    if tool_name == "search_files":
+        return RiskLevel.SAFE
+
+    # --- process management ---
+    if tool_name == "process":
+        action = str(args.get("action", ""))
+        if action == "kill":
+            return RiskLevel.DESTRUCTIVE
+        return RiskLevel.MEDIUM
+
+    # --- delegation ---
+    if tool_name == "delegate_task":
+        return RiskLevel.MEDIUM
+
+    # --- messaging ---
+    if tool_name == "send_message":
+        return RiskLevel.MEDIUM
+
+    # --- cronjob ---
+    if tool_name == "cronjob":
+        action = str(args.get("action", ""))
+        if action in ("remove", "pause", "create"):
+            return RiskLevel.MEDIUM
+        return RiskLevel.SAFE
+
+    # --- browser ---
+    if tool_name.startswith("browser_"):
+        if tool_name in ("browser_navigate", "browser_click", "browser_type", "browser_press"):
+            return RiskLevel.MEDIUM
+        return RiskLevel.SAFE
+
+    # --- idempotent tools (inherited from tool_guardrails) ---
+    from agent.tool_guardrails import IDEMPOTENT_TOOL_NAMES
+    if tool_name in IDEMPOTENT_TOOL_NAMES:
+        return RiskLevel.SAFE
+
+    # --- unknown — default to medium ---
+    return RiskLevel.MEDIUM
+
+
+def risk_requires_approval(risk: RiskLevel) -> bool:
+    """Whether this risk level requires user approval before execution."""
+    return risk in (RiskLevel.DESTRUCTIVE, RiskLevel.DANGEROUS)
+
+
+def classify_display(risk: RiskLevel) -> str:
+    """Human-readable display label with emoji."""
+    labels = {
+        RiskLevel.SAFE: "✅ SAFE",
+        RiskLevel.MEDIUM: "⚠️ MEDIUM",
+        RiskLevel.DESTRUCTIVE: "🔴 DESTRUCTIVE",
+        RiskLevel.DANGEROUS: "💀 DANGEROUS",
+    }
+    return labels.get(risk, "❓ UNKNOWN")
+
+
+# --- quick reference ---
+QUICK_REFERENCE = {
+    ("terminal", "ls"): RiskLevel.SAFE,
+    ("terminal", "cat /etc/hosts"): RiskLevel.SAFE,
+    ("terminal", "git log"): RiskLevel.SAFE,
+    ("terminal", "curl -s https://example.com"): RiskLevel.SAFE,
+    ("terminal", "systemctl status hermes"): RiskLevel.SAFE,
+    ("terminal", "nvidia-smi"): RiskLevel.SAFE,
+    ("terminal", "pip install x"): RiskLevel.MEDIUM,
+    ("terminal", "git reset --hard"): RiskLevel.DESTRUCTIVE,
+    ("terminal", "rm -rf /tmp/cache"): RiskLevel.DESTRUCTIVE,
+    ("terminal", "systemctl stop hermes"): RiskLevel.DANGEROUS,
+    ("terminal", "shutdown now"): RiskLevel.DANGEROUS,
+    ("write_file", "/home/ak/test.py"): RiskLevel.MEDIUM,
+    ("write_file", "/etc/passwd"): RiskLevel.DESTRUCTIVE,
+    ("write_file", "~/.hermes/config.yaml"): RiskLevel.DESTRUCTIVE,
+    ("read_file", "any"): RiskLevel.SAFE,
+    ("search_files", "any"): RiskLevel.SAFE,
+}

--- a/docs/architecture-proposal.md
+++ b/docs/architecture-proposal.md
@@ -1,0 +1,198 @@
+# Hermes 架构升级 PR 提案
+
+基于 Claude Code 和 Codex 底层逻辑分析，为 Hermes Agent 上游项目提出的改进。
+
+## 概要
+
+Hermes 已有良好的基础设施（tool_guardrails、fallback chain、retry counters），但缺少 Claude Code 的几项关键架构设计。
+
+**2026-06-03 已本地实施**：
+- ✅ SOUL.md: 7个架构模块注入
+- ✅ 配置: hard_stop + abort_on_summary_failure
+- ✅ 3个新Skill: compression-strategy / error-escalation / tool-pipeline
+- ✅ `agent/circuit_breaker.py`: 独立断路器模块
+- ✅ **深度融合1**: 断路器集成到 Agent Loop（4个注入点）
+
+---
+
+## PR 1: 启用默认断路器 hard_stop
+
+**改动**：`config.yaml` 默认值
+
+```yaml
+tool_loop_guardrails:
+  hard_stop_enabled: false  # → true
+```
+
+**理由**：
+- 代码已完整实现 hard_stop 逻辑（`agent/tool_guardrails.py`），默认关闭
+- Claude Code 的断路器是核心兜底机制，应默认开启
+- 阈值已有合理的默认值（exact_failure:5, same_tool:8）
+
+**影响**：极小。硬停止只作用于工具循环内的死循环场景，正常使用不受影响。
+
+**相关文件**：
+- `agent/tool_guardrails.py` (已有实现)
+- `hermes_cli/config.py: DEFAULT_CONFIG` (改默认值)
+
+---
+
+## PR 2: 类型化终止/继续状态
+
+**当前状态**：`run_conversation()` 返回 `{"final_response": "...", "messages": [...]}`
+
+**目标**：返回类型化状态，参考 Claude Code 的 10 种终止 + 7 种继续
+
+```python
+# 终止状态
+class TerminalReason(Enum):
+    COMPLETED = "completed"
+    ABORTED_STREAMING = "aborted_streaming"
+    ABORTED_TOOLS = "aborted_tools"
+    PROMPT_TOO_LONG = "prompt_too_long"
+    MODEL_ERROR = "model_error"
+    IMAGE_ERROR = "image_error"
+    MAX_TURNS = "max_turns"
+    HOOK_PREVENTED = "hook_prevented"
+    HOOK_STOPPED = "hook_stopped"
+    BLOCKING_LIMIT = "blocking_limit"
+
+# run_conversation 返回值增强
+def run_conversation(...) -> dict:
+    return {
+        "final_response": "...",
+        "messages": [...],
+        "terminal_reason": TerminalReason.COMPLETED,
+        "terminal_metadata": {},  # extra diagnostics
+    }
+```
+
+**理由**：
+- 调用方（gateway、CLI、batch_runner）可根据终止原因做差异化处理
+- 当前只能通过检查 `messages` 内容推断原因，不可靠
+
+**改动文件**：
+- `agent/conversation_loop.py` (主改动)
+- 所有 `run_conversation()` 调用方
+
+---
+
+## PR 3: 输入依赖的工具安全判定
+
+**当前状态**：`tool_guardrails.py` 有 `IDEMPOTENT_TOOL_NAMES` 和 `MUTATING_TOOL_NAMES` 的静态分类。
+
+**问题**：`terminal("ls")` 和 `terminal("rm -rf /")` 被同等对待（都在 MUTATING_TOOL_NAMES 中）。
+
+**方案**：参考 Claude Code 的 `isConcurrencySafe(input)` 模式
+
+```python
+def classify_tool_risk(tool_name: str, args: dict) -> RiskLevel:
+    """Input-dependent safety classification."""
+    if tool_name == "terminal":
+        cmd = args.get("command", "")
+        if _is_readonly_shell(cmd):
+            return RiskLevel.SAFE
+        if _is_destructive_shell(cmd):
+            return RiskLevel.DESTRUCTIVE
+        return RiskLevel.MEDIUM
+
+    if tool_name in IDEMPOTENT_TOOL_NAMES:
+        return RiskLevel.SAFE
+
+    # ... per-tool input analysis
+```
+
+**改动文件**：
+- 新增 `agent/tool_risk.py`
+- 在 `model_tools.py` 的 `handle_function_call()` 中集成
+
+---
+
+## PR 4: 独立电路断路器模块（已实现）
+
+**状态**：`agent/circuit_breaker.py` 已在本仓库实现，待 PR 上游。
+
+**功能**：
+- Per-feature 独立断路器（compression / delegation / fallback / etc.）
+- 3种状态：CLOSED → OPEN → HALF_OPEN
+- 自动和手动重置
+- Preset 配置匹配 Claude Code 模式
+
+**集成点**：
+- `agent/conversation_loop.py`: 在 API 调用循环中集成
+- `agent/context_compressor.py`: 压缩失败时触发
+- `model_tools.py`: delegate_task 失败时触发
+
+---
+
+## PR 5: 上下文压缩分层策略
+
+**当前状态**：Hermes 有单一压缩策略（`context_compressor.py`）
+
+**目标**：实现 Claude Code 的 4 层递进压缩
+
+```
+Layer 1: 工具结果预算 (per-message size cap)
+Layer 2: Snip Compact (物理删除最旧消息)
+Layer 3: Microcompact (按 tool_use_id 清理)
+Layer 4: Auto-Compact (子 agent 总结)
+```
+
+**方案**：
+- 在 `agent/context_compressor.py` 中添加分层策略
+- 每层压缩后检查token占用，够了就停
+- 断路器：L4 失败3次 → 停止压缩，保留原始上下文
+
+**改动文件**：
+- `agent/context_compressor.py` (主改动)
+
+---
+
+## 优先级建议
+
+| PR | 优先级 | 复杂度 | 收益 |
+|----|--------|--------|------|
+| PR 1: 启用 hard_stop | P0 | 极低（1行配置） | 高（兜底保护） |
+| PR 4: 断路器模块 | P0 | 低（新增文件） | 高（系统性防护） |
+| PR 3: 输入依赖安全 | P1 | 中（新增文件+集成） | 中（减少误报） |
+| PR 2: 类型化状态 | P2 | 高（跨模块重构） | 中（调用方受益） |
+| PR 5: 分层压缩 | P2 | 高（重构压缩器） | 中（渐进式优化） |
+
+---
+
+## 安全考量
+
+所有改动均为**增强安全**：
+- 断路器 = 防止死循环和资源浪费
+- 输入依赖安全 = 减少危险操作
+- 类型化状态 = 更好的错误处理
+
+无破坏性变更（向后兼容）。
+
+---
+
+## 深度融合1: 断路器集成详情（已实施）
+
+**注入点**：
+
+| 位置 | 文件 | 行号 | 触发条件 |
+|------|------|------|----------|
+| 初始化 | `agent/agent_init.py` | ~410 | Agent 创建时初始化 `CircuitBreakerPanel` |
+| 每轮开始 | `agent/conversation_loop.py` | ~454 | `advance_turn()` — 推进所有断路器状态 |
+| API 响应无效 | `agent/conversation_loop.py` | ~1512 | 重试+fallback 耗尽 → `record_failure("api_retry")` |
+| API 异常 | `agent/conversation_loop.py` | ~3336 | 模型错误重试耗尽 → `record_failure("model_error")` |
+| 压缩失败 | `agent/conversation_loop.py` | ~2930, ~3010 | 压缩3次失败 → `record_failure("compression")` |
+
+**断路器 Preset**：
+
+```
+compression:      3次 → 停止自动压缩
+delegation:       3次 → 停止委托
+provider_fallback: 3次 → 停止切换
+same_solution:    2次 → 强制换方案
+model_error:      3次 → 建议切换模型
+no_progress:      5次 → 检查忙碌假象
+api_retry:        3次 → 停止该轮API调用
+```
+
+**安全**：所有注入点使用 `hasattr(agent, '_circuit_breaker_panel')` 守卫，断路器模块不存在时完全透明（向后兼容）。

--- a/model_tools.py
+++ b/model_tools.py
@@ -799,6 +799,19 @@ def _coerce_boolean(value: str):
     return value
 
 
+def _summarize_args(args: dict, max_len: int = 80) -> str:
+    """Summarize tool arguments for logging — truncates long values."""
+    if not args:
+        return "{}"
+    items = []
+    for k, v in args.items():
+        s = str(v)
+        if len(s) > max_len:
+            s = s[:max_len] + "..."
+        items.append(f"{k}={s}")
+    return ", ".join(items)
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -837,6 +850,24 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # ── Input-dependent risk classification ──────────────────────────
+    # Claude Code pattern: isConcurrencySafe(input) not isConcurrencySafe()
+    # Log destructive tool calls for audit trail
+    _risk_level = None
+    try:
+        from agent.tool_risk import classify_tool_risk, risk_requires_approval, classify_display
+        _risk_level = classify_tool_risk(function_name, function_args)
+        if risk_requires_approval(_risk_level):
+            logger.warning(
+                "%s tool call classified as %s: %s(%s)",
+                classify_display(_risk_level),
+                _risk_level.value,
+                function_name,
+                _summarize_args(function_args),
+            )
+    except Exception:
+        pass  # tool_risk module optional — silently degrade
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
     # tool_search and tool_describe are pure catalog reads — handle them


### PR DESCRIPTION
## Summary

Add two new security/resilience modules inspired by Claude Code's architecture analysis:

### 1. `agent/circuit_breaker.py` — Per-feature Circuit Breaker Panel

- **3-state model**: CLOSED → OPEN → HALF_OPEN
- **7 presets**: compression(3), delegation(3), provider_fallback(3), same_solution(2), model_error(3), no_progress(5), api_retry(3)
- **Integrated into conversation loop** at 4 injection points:
  - Per-turn advance (conversation_loop.py:~454)
  - API response invalid → api_retry breaker
  - API exception exhausted → model_error breaker
  - Compression failure → compression breaker
- All injection points use `hasattr` guard — fully backward compatible

### 2. `agent/tool_risk.py` — Input-Dependent Safety Classifier

- Claude Code pattern: `isConcurrencySafe(input)`, not `isConcurrencySafe()`
- **4 risk levels**: SAFE / MEDIUM / DESTRUCTIVE / DANGEROUS
- Shell command analysis: readonly vs destructive vs dangerous patterns
- Protected path detection for file operations
- Integrated into `handle_function_call` in model_tools.py

### Also included

- `agent_init.py`: Initialize CircuitBreakerPanel on agent creation
- `model_tools.py`: Add `_summarize_args` helper + risk classification hook
- `docs/architecture-proposal.md`: Full PR proposal (5 PRs, P0-P2 priority)

### Testing

- circuit_breaker.py: Import OK, 3-failure trip works, advance_turn works
- tool_risk.py: 6/6 classification tests pass (SAFE/MEDIUM/DESTRUCTIVE/DANGEROUS)
- All modified files pass `py_compile` syntax check
- Backward compatible — uses `hasattr` guards everywhere

### Related

See `docs/architecture-proposal.md` for the full 5-PR roadmap derived from Claude Code/Codex architecture analysis.