### PR TITLE
fix(gateway): catch UnicodeDecodeError in _read_json_file

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -229,6 +229,8 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
         raw = path.read_text(encoding="utf-8").strip()
     except OSError:
         return None
+    except UnicodeDecodeError:
+        return None
     if not raw:
         return None
     try:


### PR DESCRIPTION
## Problem

`path.read_text(encoding="utf-8")` raises `UnicodeDecodeError` when the file contains non-UTF-8 bytes — not `OSError`. `_read_json_file` in `gateway/status.py` caught `OSError` and `json.JSONDecodeError` but not `UnicodeDecodeError`, so a corrupted status file (e.g. stale TLS data appended to `gateway_state.json`) fell through as an unhandled exception and surfaced as a 500 on the dashboard's `/api/status` endpoint.

## Fix

Add `except UnicodeDecodeError: return None` alongside the existing `except OSError` handler. Corrupted files now behave the same as missing or empty ones.

## Verification

- All 54 existing tests in `tests/gateway/test_status.py` pass
- Manually tested with a file containing TLS garbage bytes (the exact corruption from production): `_read_json_file` returns `None` instead of raising