### PR TITLE
fix(signal): send explicit sendTyping stop on cleanup

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1369,7 +1369,13 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _stop_typing_indicator(self, chat_id: str) -> None:
-        """Stop a typing indicator loop for a chat."""
+        """Stop a typing indicator loop for a chat.
+
+        Cancels the local refresh task *and* sends an explicit ``sendTyping``
+        stop request to signal-cli so that remote Signal clients clear their
+        "typing…" / "writing…" bubble immediately instead of waiting for the
+        normal timeout to expire.
+        """
         task = self._typing_tasks.pop(chat_id, None)
         if task:
             task.cancel()
@@ -1377,6 +1383,28 @@ class SignalAdapter(BasePlatformAdapter):
                 await task
             except asyncio.CancelledError:
                 pass
+
+        # Tell signal-cli to clear the typing indicator on remote clients.
+        # Best-effort: swallow failures (e.g. signal-cli offline, chat_id
+        # unresolved) so that cleanup never raises.
+        try:
+            params: Dict[str, Any] = {
+                "account": self.account,
+                "stop": True,
+            }
+            if chat_id.startswith("group:"):
+                params["groupId"] = chat_id[6:]
+            else:
+                params["recipient"] = [await self._resolve_recipient(chat_id)]
+            await self._rpc(
+                "sendTyping",
+                params,
+                rpc_id="typing-stop",
+                log_failures=False,
+            )
+        except Exception:
+            pass
+
         # Reset per-chat typing backoff state so the next agent turn starts
         # fresh rather than inheriting a cooldown from a prior conversation.
         self._typing_failures.pop(chat_id, None)

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1016,6 +1016,77 @@ class TestSignalTypingBackoff:
         assert "+155****4567" not in adapter._typing_failures
         assert "+155****4567" not in adapter._typing_skip_until
 
+    @pytest.mark.asyncio
+    async def test_stop_typing_indicator_sends_stop_signal_to_signal_cli(
+        self, monkeypatch
+    ):
+        """_stop_typing_indicator must send sendTyping(stop=True) so that
+        remote Signal clients clear their typing bubble immediately."""
+        adapter = _make_signal_adapter(monkeypatch)
+        # Pre-populate recipient cache to avoid listContacts RPC in _resolve_recipient
+        adapter._recipient_uuid_by_number["+155****4567"] = "+155****4567"
+        rpc_calls = []
+
+        async def _capture_rpc(method, params, rpc_id=None, *, log_failures=True):
+            rpc_calls.append({"method": method, "params": dict(params)})
+            return {"ok": True}
+
+        adapter._rpc = _capture_rpc
+
+        await adapter._stop_typing_indicator("+155****4567")
+
+        # Must have sent exactly one sendTyping stop RPC
+        stop_calls = [c for c in rpc_calls if c["method"] == "sendTyping"]
+        assert len(stop_calls) == 1
+        assert stop_calls[0]["params"]["stop"] is True
+        assert "account" in stop_calls[0]["params"]
+        assert "recipient" in stop_calls[0]["params"]
+        assert isinstance(stop_calls[0]["params"]["recipient"], list)
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_indicator_sends_stop_for_group(self, monkeypatch):
+        """Group chats must use groupId instead of recipient."""
+        adapter = _make_signal_adapter(monkeypatch)
+        rpc_calls = []
+
+        async def _capture_rpc(method, params, rpc_id=None, *, log_failures=True):
+            rpc_calls.append({"method": method, "params": dict(params)})
+            return {"ok": True}
+
+        adapter._rpc = _capture_rpc
+
+        await adapter._stop_typing_indicator("group:abc123")
+
+        stop_calls = [c for c in rpc_calls if c["method"] == "sendTyping"]
+        assert len(stop_calls) == 1
+        assert stop_calls[0]["params"]["stop"] is True
+        assert stop_calls[0]["params"]["groupId"] == "abc123"
+        assert "recipient" not in stop_calls[0]["params"]
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_indicator_stop_failure_does_not_raise(
+        self, monkeypatch
+    ):
+        """If the stop RPC fails (e.g. signal-cli offline), cleanup must
+        not raise — the typing state should still be cleared."""
+        adapter = _make_signal_adapter(monkeypatch)
+        # Pre-populate recipient cache to avoid listContacts RPC
+        adapter._recipient_uuid_by_number["+155****4567"] = "+155****4567"
+
+        async def _fail_rpc(method, params, rpc_id=None, *, log_failures=True):
+            raise ConnectionError("signal-cli offline")
+
+        adapter._rpc = _fail_rpc
+        adapter._typing_failures["+155****4567"] = 3
+        adapter._typing_skip_until["+155****4567"] = 999.0
+
+        # Must not raise despite RPC failure
+        await adapter._stop_typing_indicator("+155****4567")
+
+        # Backoff state must still be cleared
+        assert "+155****4567" not in adapter._typing_failures
+        assert "+155****4567" not in adapter._typing_skip_until
+
 
 # ---------------------------------------------------------------------------
 # Reply quote extraction


### PR DESCRIPTION
## What does this PR do?

Fixes the Signal adapter's `stop_typing()` not sending an explicit `sendTyping(stop=True)` RPC to signal-cli. Previously, cleanup only cancelled local refresh tasks and cleared backoff state, leaving remote Signal clients showing a "typing…" / "writing…" bubble until the normal timeout expired.

## Related Issue

Fixes #38303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py`: `_stop_typing_indicator()` now sends a best-effort `sendTyping` RPC with `stop=True` after cancelling the local task. Uses the same `account`/`recipient`/`groupId` params as `send_typing()`. Failures are swallowed (logged at DEBUG via `log_failures=False`) so cleanup never raises.
- `tests/gateway/test_signal.py`: Added 3 regression tests:
  - `test_stop_typing_indicator_sends_stop_signal_to_signal_cli`: verifies stop RPC is sent for direct chats
  - `test_stop_typing_indicator_sends_stop_for_group`: verifies `groupId` is used for group chats
  - `test_stop_typing_indicator_stop_failure_does_not_raise`: verifies cleanup succeeds even when signal-cli is offline

## How to Test

1. Start a Signal-connected Hermes instance
2. Send a message that triggers agent processing (typing indicator appears)
3. After the agent responds, verify the Signal "typing…" bubble disappears immediately (not after ~30s timeout)
4. Run `pytest tests/gateway/test_signal.py -x -q` — all 106 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable for worktree — grep-based fallback used.
- Analyzed: `gateway/platforms/signal.py:_stop_typing_indicator` (called from `stop_typing`, `send_text`, `send_multiple_images`, `send_image`, `send_video`, `send_voice`, `send_audio`)
- Blast radius: LOW — single method change, best-effort RPC with `try/except`, no behavioral change on failure
- Related patterns: Other adapters (Discord `stop_typing`, Slack `stop_typing`) send platform-level stop signals; Signal was the only adapter that only cancelled local state
