### PR TITLE
fix(tui): ship bundled module metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ opencode.json
 config/mcporter.json
 
 hermes_cli/tui_dist/*
+!hermes_cli/tui_dist/package.json
 hermes_cli/scripts/
 docs/superpowers/*
 # Working directory for the Hermes Agent's session state (~/.hermes/ at runtime;

--- a/hermes_cli/tui_dist/package.json
+++ b/hermes_cli/tui_dist/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -1,3 +1,14 @@
+import json
+from pathlib import Path
+
+
+def test_tui_dist_declares_module_type():
+    """Bundled TUI package data includes ESM metadata for Node."""
+    repo_root = Path(__file__).resolve().parents[2]
+    package_json = repo_root / "hermes_cli" / "tui_dist" / "package.json"
+
+    assert package_json.is_file()
+    assert json.loads(package_json.read_text(encoding="utf-8"))["type"] == "module"
 
 
 def test_tui_finds_bundled_entry_js(tmp_path):


### PR DESCRIPTION
## Summary
- add a minimal `hermes_cli/tui_dist/package.json` with `"type": "module"` so packaged `entry.js` is parsed as ESM without Node MODULE_TYPELESS_PACKAGE_JSON warnings
- keep generated TUI bundle files ignored while allowing the package metadata file to be tracked
- add a bundled TUI regression test for the module metadata

## Root cause
The source-tree TUI has `ui-tui/package.json` next to `dist/entry.js`, but the wheel fallback path launches `hermes_cli/tui_dist/entry.js`. The packaged `tui_dist` directory had no adjacent package metadata, so Node walked upward, failed to find `type: module`, and reparsed the ESM bundle with a visible warning.

## Validation
- Red: `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_tui_bundled.py -q` failed with missing `hermes_cli/tui_dist/package.json`
- Green: `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_tui_bundled.py -q` -> `3 passed`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check tests/hermes_cli/test_tui_bundled.py` -> `All checks passed!`
- `git diff --check`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pip wheel . --no-deps -w /tmp/hermes-wheel-38304`
- inspected the built wheel and confirmed `hermes_cli/tui_dist/package.json` is present with `{"type":"module"}`

Closes #38304