### PR TITLE
fix(signal): send explicit typing stop

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1002,6 +1002,19 @@ class SignalAdapter(BasePlatformAdapter):
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
                 self._recent_sent_timestamps.pop()
 
+    async def _build_typing_params(self, chat_id: str) -> Dict[str, Any]:
+        """Build signal-cli sendTyping params for a DM or group."""
+        params: Dict[str, Any] = {
+            "account": self.account,
+        }
+
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            params["recipient"] = [await self._resolve_recipient(chat_id)]
+
+        return params
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator.
 
@@ -1025,15 +1038,7 @@ class SignalAdapter(BasePlatformAdapter):
         if now < skip_until:
             return
 
-        params: Dict[str, Any] = {
-            "account": self.account,
-        }
-
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
-
+        params = await self._build_typing_params(chat_id)
         fails = self._typing_failures.get(chat_id, 0)
         result = await self._rpc(
             "sendTyping",
@@ -1382,10 +1387,29 @@ class SignalAdapter(BasePlatformAdapter):
         self._typing_failures.pop(chat_id, None)
         self._typing_skip_until.pop(chat_id, None)
 
+    async def _send_typing_stop(self, chat_id: str) -> None:
+        """Send a best-effort platform-level typing stop."""
+        try:
+            params = await self._build_typing_params(chat_id)
+            params["stop"] = True
+            await self._rpc(
+                "sendTyping",
+                params,
+                rpc_id="typing-stop",
+                log_failures=False,
+            )
+        except Exception:
+            logger.debug(
+                "Signal typing stop failed for %s",
+                chat_id,
+                exc_info=True,
+            )
+
     async def stop_typing(self, chat_id: str) -> None:
         """Public interface for stopping typing — called by base adapter's
         _keep_typing finally block to clean up platform-level typing tasks."""
         await self._stop_typing_indicator(chat_id)
+        await self._send_typing_stop(chat_id)
 
     # ------------------------------------------------------------------
     # Reactions

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1386,6 +1386,7 @@ class SignalAdapter(BasePlatformAdapter):
         # fresh rather than inheriting a cooldown from a prior conversation.
         self._typing_failures.pop(chat_id, None)
         self._typing_skip_until.pop(chat_id, None)
+        await self._send_typing_stop(chat_id)
 
     async def _send_typing_stop(self, chat_id: str) -> None:
         """Send a best-effort platform-level typing stop."""
@@ -1409,7 +1410,6 @@ class SignalAdapter(BasePlatformAdapter):
         """Public interface for stopping typing — called by base adapter's
         _keep_typing finally block to clean up platform-level typing tasks."""
         await self._stop_typing_indicator(chat_id)
-        await self._send_typing_stop(chat_id)
 
     # ------------------------------------------------------------------
     # Reactions

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -874,10 +874,99 @@ class TestSignalStopTyping:
     async def test_stop_typing_calls_private_method(self, monkeypatch):
         adapter = _make_signal_adapter(monkeypatch)
         adapter._stop_typing_indicator = AsyncMock()
+        adapter._send_typing_stop = AsyncMock()
 
         await adapter.stop_typing("+155****4567")
 
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
+        adapter._send_typing_stop.assert_awaited_once_with("+155****4567")
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_sends_signal_stop_for_dm(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._resolve_recipient = AsyncMock(return_value="+15551230000")
+        adapter._typing_failures["+15551230000"] = 2
+        adapter._typing_skip_until["+15551230000"] = 123.0
+        calls = []
+
+        async def _fake_rpc(method, params, rpc_id=None, **kwargs):
+            calls.append(
+                {
+                    "method": method,
+                    "params": dict(params),
+                    "rpc_id": rpc_id,
+                    "kwargs": dict(kwargs),
+                }
+            )
+            return {"ok": True}
+
+        adapter._rpc = _fake_rpc
+
+        await adapter.stop_typing("+15551230000")
+
+        assert calls == [
+            {
+                "method": "sendTyping",
+                "params": {
+                    "account": adapter.account,
+                    "recipient": ["+15551230000"],
+                    "stop": True,
+                },
+                "rpc_id": "typing-stop",
+                "kwargs": {"log_failures": False},
+            }
+        ]
+        assert "+15551230000" not in adapter._typing_failures
+        assert "+15551230000" not in adapter._typing_skip_until
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_sends_signal_stop_for_group(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        calls = []
+
+        async def _fake_rpc(method, params, rpc_id=None, **kwargs):
+            calls.append(
+                {
+                    "method": method,
+                    "params": dict(params),
+                    "rpc_id": rpc_id,
+                    "kwargs": dict(kwargs),
+                }
+            )
+            return {"ok": True}
+
+        adapter._rpc = _fake_rpc
+
+        await adapter.stop_typing("group:abc123")
+
+        assert calls == [
+            {
+                "method": "sendTyping",
+                "params": {
+                    "account": adapter.account,
+                    "groupId": "abc123",
+                    "stop": True,
+                },
+                "rpc_id": "typing-stop",
+                "kwargs": {"log_failures": False},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_ignores_signal_stop_failure(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._typing_failures["group:abc123"] = 2
+        adapter._typing_skip_until["group:abc123"] = 123.0
+
+        async def _fake_rpc(method, params, rpc_id=None, **kwargs):
+            return None
+
+        adapter._rpc = _fake_rpc
+
+        await adapter.stop_typing("group:abc123")
+
+        assert "group:abc123" not in adapter._typing_failures
+        assert "group:abc123" not in adapter._typing_skip_until
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -874,12 +874,10 @@ class TestSignalStopTyping:
     async def test_stop_typing_calls_private_method(self, monkeypatch):
         adapter = _make_signal_adapter(monkeypatch)
         adapter._stop_typing_indicator = AsyncMock()
-        adapter._send_typing_stop = AsyncMock()
 
         await adapter.stop_typing("+155****4567")
 
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
-        adapter._send_typing_stop.assert_awaited_once_with("+155****4567")
 
     @pytest.mark.asyncio
     async def test_stop_typing_sends_signal_stop_for_dm(self, monkeypatch):
@@ -953,13 +951,48 @@ class TestSignalStopTyping:
         ]
 
     @pytest.mark.asyncio
+    async def test_private_stop_typing_indicator_sends_signal_stop(
+        self, monkeypatch
+    ):
+        adapter = _make_signal_adapter(monkeypatch)
+        calls = []
+
+        async def _fake_rpc(method, params, rpc_id=None, **kwargs):
+            calls.append(
+                {
+                    "method": method,
+                    "params": dict(params),
+                    "rpc_id": rpc_id,
+                    "kwargs": dict(kwargs),
+                }
+            )
+            return {"ok": True}
+
+        adapter._rpc = _fake_rpc
+
+        await adapter._stop_typing_indicator("group:abc123")
+
+        assert calls == [
+            {
+                "method": "sendTyping",
+                "params": {
+                    "account": adapter.account,
+                    "groupId": "abc123",
+                    "stop": True,
+                },
+                "rpc_id": "typing-stop",
+                "kwargs": {"log_failures": False},
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_stop_typing_ignores_signal_stop_failure(self, monkeypatch):
         adapter = _make_signal_adapter(monkeypatch)
         adapter._typing_failures["group:abc123"] = 2
         adapter._typing_skip_until["group:abc123"] = 123.0
 
         async def _fake_rpc(method, params, rpc_id=None, **kwargs):
-            return None
+            raise ConnectionError("signal-cli unavailable")
 
         adapter._rpc = _fake_rpc
 


### PR DESCRIPTION
## Summary
- build Signal typing params through a shared DM/group helper
- send a best-effort `sendTyping` stop request with `stop: true` from the shared typing cleanup path
- cover public `stop_typing()` and direct send/media cleanup callers without duplicating stop RPCs
- keep local typing task/backoff cleanup intact and silence stop failures

## Root cause
The base gateway cleanup path calls platform `stop_typing()`, but the Signal implementation only canceled local refresh tasks and cleared local backoff state. It never translated cleanup into a signal-cli `sendTyping` stop request, so Signal clients could keep showing a typing bubble until the normal timeout. Some Signal send/media methods also call `_stop_typing_indicator(chat_id)` directly, so the platform-level stop has to live in that shared cleanup path rather than only in the public wrapper.

## Validation
- Red: `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_signal.py::TestSignalStopTyping -q` failed because no `sendTyping` stop RPC was sent
- Green: `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_signal.py::TestSignalStopTyping tests/gateway/test_signal.py::TestSignalTypingBackoff -q` -> `9 passed`
- Green after direct-cleanup follow-up: `.\.venv\Scripts\python.exe -m pytest tests/gateway/test_signal.py::TestSignalStopTyping tests/gateway/test_signal.py::TestSignalTypingBackoff -q --timeout-method=thread` -> `10 passed`
- `.\.venv\Scripts\python.exe -m pytest tests/gateway/test_signal.py -q --timeout-method=thread` -> `107 passed`
- `.\.venv\Scripts\python.exe -m ruff check gateway/platforms/signal.py tests/gateway/test_signal.py` -> `All checks passed!`
- `git diff --check` -> passed

Closes #38303