### PR TITLE
Fix abandoned session cleanup

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2108,9 +2108,11 @@ DEFAULT_CONFIG = {
     # reports 384MB+ databases with 68K+ messages, which slows down FTS5
     # inserts, /resume listing, and insights queries.
     "sessions": {
-        # When true, prune ended sessions older than retention_days once
-        # per (roughly) min_interval_hours at CLI/gateway/cron startup.
-        # Only touches ended sessions — active sessions are always preserved.
+        # When true, mark abandoned unended sessions as ended, then prune
+        # ended sessions older than retention_days once per (roughly)
+        # min_interval_hours at CLI/gateway/cron startup. Abandoned detection
+        # is based on last activity so recently/currently active sessions are
+        # preserved.
         # Default false: session history is valuable for search recall, and
         # silently deleting it could surprise users.  Opt in explicitly.
         "auto_prune": False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14501,14 +14501,21 @@ Examples:
             source_msg = f" from '{args.source}'" if args.source else ""
             if not args.yes:
                 if not _confirm_prompt(
-                    f"Delete all ended sessions older than {days} days{source_msg}? [y/N] "
+                    "Mark abandoned unended sessions as ended, then delete all "
+                    f"ended sessions older than {days} days{source_msg}? [y/N] "
                 ):
                     print("Cancelled.")
                     return
             sessions_dir = get_hermes_home() / "sessions"
+            finalized = db.finalize_abandoned_sessions(
+                older_than_days=days,
+                source=args.source,
+            )
             count = db.prune_sessions(
                 older_than_days=days, source=args.source, sessions_dir=sessions_dir
             )
+            if finalized:
+                print(f"Marked {finalized} abandoned session(s) as ended.")
             print(f"Pruned {count} session(s).")
 
         elif action == "rename":

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1307,6 +1307,52 @@ class SessionDB:
 
         return self._execute_write(_do) or 0
 
+    def finalize_abandoned_sessions(
+        self,
+        older_than_days: int,
+        source: str = None,
+        end_reason: str = "abandoned_cleanup",
+    ) -> int:
+        """Mark old unended sessions as abandoned so pruning can delete them.
+
+        Uses last activity (latest message timestamp, falling back to
+        ``started_at``) rather than ``started_at`` alone. This protects
+        long-lived sessions that are still receiving messages while allowing
+        genuinely abandoned unended rows to become prune-eligible. The method
+        is intentionally non-destructive: it only sets ``ended_at`` and
+        ``end_reason`` for rows whose ``ended_at`` is still NULL.
+        """
+        if older_than_days is None or older_than_days <= 0:
+            return 0
+        cutoff = time.time() - (older_than_days * 86400)
+        reason = str(end_reason or "abandoned_cleanup").strip() or "abandoned_cleanup"
+
+        def _do(conn):
+            now = time.time()
+            params: list[Any] = [now, reason, cutoff]
+            source_clause = ""
+            if source:
+                source_clause = " AND source = ?"
+                params.append(source)
+            result = conn.execute(
+                f"""
+                UPDATE sessions
+                SET ended_at = ?,
+                    end_reason = ?
+                WHERE ended_at IS NULL
+                  AND COALESCE((
+                        SELECT MAX(messages.timestamp)
+                        FROM messages
+                        WHERE messages.session_id = sessions.id
+                      ), started_at) < ?
+                  {source_clause}
+                """,
+                tuple(params),
+            )
+            return result.rowcount
+
+        return self._execute_write(_do) or 0
+
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
         with self._lock:
@@ -3973,11 +4019,17 @@ class SessionDB:
 
         Returns a dict with keys:
           - ``"skipped"`` (bool) — true if within min_interval_hours of last run
+          - ``"finalized_abandoned"`` (int) — old unended sessions marked ended
           - ``"pruned"`` (int)   — number of sessions deleted
           - ``"vacuumed"`` (bool) — true if VACUUM ran
           - ``"error"`` (str, optional) — present only on failure
         """
-        result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        result: Dict[str, Any] = {
+            "skipped": False,
+            "finalized_abandoned": 0,
+            "pruned": 0,
+            "vacuumed": False,
+        }
         try:
             # Skip if another process/call did maintenance recently.
             last_raw = self.get_meta("last_auto_prune")
@@ -3990,6 +4042,11 @@ class SessionDB:
                         return result
                 except (TypeError, ValueError):
                     pass  # corrupt meta; treat as no prior run
+
+            finalized = self.finalize_abandoned_sessions(
+                older_than_days=retention_days,
+            )
+            result["finalized_abandoned"] = finalized
 
             pruned = self.prune_sessions(
                 older_than_days=retention_days,
@@ -4010,9 +4067,10 @@ class SessionDB:
             # every startup within the min_interval_hours window.
             self.set_meta("last_auto_prune", str(now))
 
-            if pruned > 0:
+            if finalized > 0 or pruned > 0:
                 logger.info(
-                    "state.db auto-maintenance: pruned %d session(s) older than %d days%s",
+                    "state.db auto-maintenance: finalized %d abandoned + pruned %d session(s) older than %d days%s",
+                    finalized,
                     pruned,
                     retention_days,
                     " + VACUUM" if result["vacuumed"] else "",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3195,6 +3195,52 @@ class TestAutoMaintenance:
         )
         db._conn.commit()
 
+    def _make_old_unended(self, db, sid: str, days_old: int = 100, source: str = "cli"):
+        """Create an unended session whose start time is `days_old` days ago."""
+        db.create_session(session_id=sid, source=source)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (time.time() - days_old * 86400, sid),
+        )
+        db._conn.commit()
+
+    def test_finalize_abandoned_then_prune_old_unended(self, db):
+        self._make_old_unended(db, "abandoned", days_old=100)
+
+        finalized = db.finalize_abandoned_sessions(older_than_days=90)
+        assert finalized == 1
+        session = db.get_session("abandoned")
+        assert session["ended_at"] is not None
+        assert session["end_reason"] == "abandoned_cleanup"
+
+        pruned = db.prune_sessions(older_than_days=90)
+        assert pruned == 1
+        assert db.get_session("abandoned") is None
+
+    def test_finalize_abandoned_protects_recent_and_recently_active(self, db):
+        self._make_old_unended(db, "old_empty", days_old=100)
+        self._make_old_unended(db, "recent_empty", days_old=1)
+        self._make_old_unended(db, "old_but_active", days_old=100)
+        db.append_message("old_but_active", role="user", content="recent activity")
+
+        finalized = db.finalize_abandoned_sessions(older_than_days=90)
+        assert finalized == 1
+        assert db.get_session("old_empty")["end_reason"] == "abandoned_cleanup"
+        assert db.get_session("recent_empty")["ended_at"] is None
+        assert db.get_session("old_but_active")["ended_at"] is None
+
+    def test_finalize_abandoned_respects_source_filter(self, db):
+        self._make_old_unended(db, "old_cli", days_old=100, source="cli")
+        self._make_old_unended(db, "old_tg", days_old=100, source="telegram")
+
+        finalized = db.finalize_abandoned_sessions(
+            older_than_days=90,
+            source="telegram",
+        )
+        assert finalized == 1
+        assert db.get_session("old_cli")["ended_at"] is None
+        assert db.get_session("old_tg")["end_reason"] == "abandoned_cleanup"
+
     def test_first_run_prunes_and_vacuums(self, db):
         self._make_old_ended(db, "old1", days_old=100)
         self._make_old_ended(db, "old2", days_old=100)
@@ -3209,6 +3255,17 @@ class TestAutoMaintenance:
         assert db.get_session("old2") is None
         assert db.get_session("new") is not None
 
+    def test_auto_maintenance_finalizes_abandoned_before_prune(self, db):
+        self._make_old_unended(db, "abandoned", days_old=100)
+        db.create_session(session_id="recent", source="cli")
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+        assert result["skipped"] is False
+        assert result["finalized_abandoned"] == 1
+        assert result["pruned"] == 1
+        assert db.get_session("abandoned") is None
+        assert db.get_session("recent") is not None
+
     def test_second_call_within_interval_skips(self, db):
         self._make_old_ended(db, "old", days_old=100)
         first = db.maybe_auto_prune_and_vacuum(
@@ -3220,12 +3277,15 @@ class TestAutoMaintenance:
         # Create another prunable session; a second call within
         # min_interval_hours should still skip without touching it.
         self._make_old_ended(db, "old2", days_old=100)
+        self._make_old_unended(db, "abandoned2", days_old=100)
         second = db.maybe_auto_prune_and_vacuum(
             retention_days=90, min_interval_hours=24
         )
         assert second["skipped"] is True
+        assert second["finalized_abandoned"] == 0
         assert second["pruned"] == 0
         assert db.get_session("old2") is not None  # untouched
+        assert db.get_session("abandoned2")["ended_at"] is None
 
     def test_second_call_after_interval_runs_again(self, db):
         self._make_old_ended(db, "old", days_old=100)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -346,7 +346,10 @@ hermes sessions prune --older-than 30 --yes
 ```
 
 :::info
-Pruning only deletes **ended** sessions (sessions that have been explicitly ended or auto-reset). Active sessions are never pruned.
+Pruning deletes **ended** sessions. Before deleting, Hermes also marks old
+unended sessions whose last activity is beyond the prune threshold as
+`end_reason='abandoned_cleanup'`, making abandoned rows prune-eligible while
+protecting recently active sessions.
 :::
 
 ### Session Statistics
@@ -515,7 +518,7 @@ Key tables in `state.db`:
 
 - Gateway sessions auto-reset based on the configured reset policy
 - Before reset, the agent saves memories and skills from the expiring session
-- Opt-in auto-pruning: when `sessions.auto_prune` is `true`, ended sessions older than `sessions.retention_days` (default 90) are pruned at CLI/gateway startup
+- Opt-in auto-pruning: when `sessions.auto_prune` is `true`, old abandoned unended sessions are first marked ended, then ended sessions older than `sessions.retention_days` (default 90) are pruned at CLI/gateway startup
 - After a prune that actually removed rows, `state.db` is `VACUUM`ed to reclaim disk space (SQLite does not shrink the file on plain DELETE)
 - Pruning runs at most once per `sessions.min_interval_hours` (default 24); the last-run timestamp is tracked inside `state.db` itself so it's shared across every Hermes process in the same `HERMES_HOME`
 
@@ -529,7 +532,9 @@ sessions:
   min_interval_hours: 24    # don't re-run the sweep more often than this
 ```
 
-Active sessions are never auto-pruned, regardless of age.
+Recently active sessions are never auto-pruned. Abandoned cleanup uses the
+latest message timestamp, falling back to session start time for empty
+sessions.
 
 ### Manual Cleanup
 


### PR DESCRIPTION
## Summary
- Mark old unended sessions as `abandoned_cleanup` before pruning so abandoned rows do not bypass retention forever
- Wire the same finalize-then-prune behavior into `hermes sessions prune` and startup auto-maintenance
- Update session maintenance docs for abandoned-session cleanup behavior

## Test Plan
- `python -m pytest tests/test_hermes_state.py::TestAutoMaintenance tests/hermes_cli/test_sessions_delete.py -q`
- `python -m pytest tests/test_hermes_state.py tests/gateway/test_session_store_prune.py tests/gateway/test_session_state_cleanup.py tests/hermes_cli/test_sessions_delete.py -q`
- `python -m py_compile hermes_state.py hermes_cli/main.py hermes_cli/config.py`
- `git diff --check HEAD~1..HEAD`

## Notes
This is a defensive cleanup fix for long-lived/gateway installs where sessions may remain unended after crashes, restarts, or abandoned threads. Recently active sessions are protected by checking latest message timestamp, falling back to session start time for empty sessions.
