### PR TITLE
fix(update): print native build tools guidance when npm install fails

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8961,6 +8961,39 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     return resolve_uv() or shutil.which("uv")
 
 
+def _maybe_print_native_build_tools_guidance() -> None:
+    """Print actionable guidance when npm install likely failed due to missing
+    native build tools (make, gcc/g++).
+
+    Some Node.js packages (e.g. ``node-pty``) ship prebuilt binaries for
+    common platforms, but fall back to compiling from source via ``node-gyp``
+    when no prebuild matches the current OS/arch/Node version.  That
+    compilation requires ``make`` and a C/C++ compiler, which are often
+    absent on minimal Linux installs (WSL, containers, cloud VMs).
+
+    This heuristic checks whether the essential build tools are missing and,
+    if so, prints distro-specific install commands so the user doesn't have
+    to decipher ``gyp ERR!`` output.
+    """
+    if shutil.which("make") and (shutil.which("gcc") or shutil.which("g++")):
+        return  # Build tools are present — failure is something else.
+
+    print()
+    print("  💡 npm install may have failed because native build tools are missing.")
+    print("     Some Node.js packages (e.g. node-pty) need a C/C++ compiler and make")
+    print("     to compile native extensions when prebuilt binaries are unavailable.")
+    print()
+    print("  Install the required tools for your distro:")
+    print("    Debian/Ubuntu:  sudo apt install -y make gcc g++ python3-dev")
+    print("    Fedora/RHEL:    sudo dnf install -y make gcc gcc-c++ python3-devel")
+    print("    openSUSE:       sudo zypper install -y make gcc gcc-c++ python3-devel")
+    print("    Arch Linux:     sudo pacman -S --noconfirm base-devel")
+    print("    Alpine:         apk add make gcc g++ python3-dev")
+    print()
+    print("  Then re-run: hermes update")
+    print()
+
+
 def _update_node_dependencies() -> None:
     npm = shutil.which("npm")
     if not npm:
@@ -8992,6 +9025,7 @@ def _update_node_dependencies() -> None:
         stderr = (root_result.stderr or "").strip() if root_result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
+        _maybe_print_native_build_tools_guidance()
         return
 
     # Step 2: install only the workspaces update needs (ui-tui, web).
@@ -9010,6 +9044,7 @@ def _update_node_dependencies() -> None:
         stderr = (ws_result.stderr or "").strip() if ws_result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
+        _maybe_print_native_build_tools_guidance()
 
 
 class _UpdateOutputStream:

--- a/tests/hermes_cli/test_native_build_tools_guidance.py
+++ b/tests/hermes_cli/test_native_build_tools_guidance.py
@@ -1,0 +1,51 @@
+"""Tests for _maybe_print_native_build_tools_guidance — native build tool
+detection and actionable guidance when npm install fails."""
+
+from unittest.mock import patch
+import pytest
+
+from hermes_cli.main import _maybe_print_native_build_tools_guidance
+
+
+class TestNativeBuildToolsGuidance:
+    """Verify that guidance is printed only when build tools are missing."""
+
+    def test_no_guidance_when_all_tools_present(self, capsys):
+        """No output when make + gcc are on PATH."""
+        with patch("hermes_cli.main.shutil.which", side_effect=lambda cmd: cmd if cmd in ("make", "gcc") else None):
+            _maybe_print_native_build_tools_guidance()
+        assert capsys.readouterr().out == ""
+
+    def test_no_guidance_when_make_and_gpp_present(self, capsys):
+        """No output when make + g++ are on PATH (gcc missing but g++ suffices)."""
+        with patch("hermes_cli.main.shutil.which", side_effect=lambda cmd: cmd if cmd in ("make", "g++") else None):
+            _maybe_print_native_build_tools_guidance()
+        assert capsys.readouterr().out == ""
+
+    def test_guidance_when_make_missing(self, capsys):
+        """Prints guidance when make is missing."""
+        with patch("hermes_cli.main.shutil.which", side_effect=lambda cmd: cmd if cmd == "gcc" else None):
+            _maybe_print_native_build_tools_guidance()
+        out = capsys.readouterr().out
+        assert "native build tools are missing" in out
+        assert "Debian/Ubuntu" in out
+        assert "Fedora/RHEL" in out
+        assert "openSUSE" in out
+        assert "Arch Linux" in out
+        assert "Alpine" in out
+        assert "hermes update" in out
+
+    def test_guidance_when_compiler_missing(self, capsys):
+        """Prints guidance when both gcc and g++ are missing."""
+        with patch("hermes_cli.main.shutil.which", side_effect=lambda cmd: cmd if cmd == "make" else None):
+            _maybe_print_native_build_tools_guidance()
+        out = capsys.readouterr().out
+        assert "native build tools are missing" in out
+
+    def test_guidance_when_all_tools_missing(self, capsys):
+        """Prints guidance when nothing is available."""
+        with patch("hermes_cli.main.shutil.which", return_value=None):
+            _maybe_print_native_build_tools_guidance()
+        out = capsys.readouterr().out
+        assert "native build tools are missing" in out
+        assert "node-pty" in out


### PR DESCRIPTION
## What does this PR do?

Adds actionable guidance when `npm install` fails during `hermes update` due to missing native build tools (make, gcc/g++). On minimal Linux installs (WSL, containers, cloud VMs), packages like `node-pty` that need native compilation fail with cryptic `gyp ERR!` output. This change detects the missing tools and prints distro-specific install commands.

## Related Issue

Fixes #38311

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `_maybe_print_native_build_tools_guidance()` — checks for `make` + compiler on PATH after npm failure; prints install commands for apt, dnf, zypper, pacman, apk. Called from both root and workspace npm install failure paths.
- `tests/hermes_cli/test_native_build_tools_guidance.py`: 5 tests covering all-missing, partial-missing, and all-present scenarios.

## How to Test

1. On a Linux system without `make` or `gcc` installed, run `hermes update`
2. If npm install fails due to native module compilation, verify the guidance message appears with distro-specific install commands
3. Install the build tools and re-run `hermes update` — verify no guidance is printed
4. Run `pytest tests/hermes_cli/test_native_build_tools_guidance.py -v` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (guidance is for Linux; no-op on macOS where tools are typically available via Xcode)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/main.py:_maybe_print_native_build_tools_guidance()` (callers: 2, both in `_update_node_dependencies`)
- Analyzed: `hermes_cli/main.py:_update_node_dependencies()` (called from: `cmd_update` via `_cmd_update_impl`, `_setup_initial_deps`)
- Blast radius: LOW — additive-only helper; no existing behavior changed; called only on npm failure paths
- Related patterns: `_build_web_ui` also calls npm but is unrelated to update path; `_run_npm_install_deterministic` handles npm ci/install fallback
