### PR TITLE
feat(teams): surface Teams channel/team Graph ids in session context

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4604,6 +4604,8 @@ class BasePlatformAdapter(ABC):
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
+        teams_graph_team_id: Optional[str] = None,
+        teams_graph_channel_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -4624,6 +4626,8 @@ class BasePlatformAdapter(ABC):
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,
+            teams_graph_team_id=str(teams_graph_team_id) if teams_graph_team_id else None,
+            teams_graph_channel_id=str(teams_graph_channel_id) if teams_graph_channel_id else None,
         )
     
     @abstractmethod

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,8 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    teams_graph_team_id: Optional[str] = None  # Teams: Graph team (AAD group) id from channelData
+    teams_graph_channel_id: Optional[str] = None  # Teams: Graph channel id for cap-m365 channel reads
     
     @property
     def description(self) -> str:
@@ -134,6 +136,10 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.teams_graph_team_id:
+            d["teams_graph_team_id"] = self.teams_graph_team_id
+        if self.teams_graph_channel_id:
+            d["teams_graph_channel_id"] = self.teams_graph_channel_id
         return d
 
     @classmethod
@@ -152,6 +158,8 @@ class SessionSource:
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            teams_graph_team_id=data.get("teams_graph_team_id"),
+            teams_graph_channel_id=data.get("teams_graph_channel_id"),
         )
     
 
@@ -373,6 +381,32 @@ def build_session_context_prompt(
             "Use target='yuanbao:direct:<account_id>' for DM "
             "and target='yuanbao:group:<group_code>' for group chat."
         )
+    elif context.source.platform.value == "teams":
+        src = context.source
+        id_lines = [
+            "",
+            "**Teams IDs (for cap-m365 `teams_get_chat_messages` / `teams_get_channel_messages`):**",
+        ]
+        if src.teams_graph_team_id:
+            id_lines.append(
+                f"  - Team (Graph group) id: `{src.teams_graph_team_id}` "
+                "— use as `team_id` in `teams_get_channel_messages`"
+            )
+        if src.teams_graph_channel_id:
+            id_lines.append(
+                f"  - Channel id: `{src.teams_graph_channel_id}` "
+                "— use as `channel_id` in `teams_get_channel_messages`"
+            )
+        if src.chat_type in ("dm", "group") and src.chat_id:
+            id_lines.append(
+                f"  - Chat id: `{src.chat_id}` — use as `chat_id` in `teams_get_chat_messages`"
+            )
+        id_lines.append(
+            "  - Never use the 32-hex segment inside a channel id "
+            "(e.g. `19:<hex>@thread.tacv2`) as `team_id`; it is not the team (group) GUID."
+        )
+        if len(id_lines) > 2:
+            lines.extend(id_lines)
 
     # Connected platforms
     platforms_list = ["local (files on this machine)"]

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -116,6 +116,48 @@ def _parse_bool(value: Any, *, default: bool = False) -> bool:
     return default
 
 
+def extract_teams_graph_ids(
+    activity: Any,
+    *,
+    conversation_type: str,
+    conversation_id: str,
+) -> tuple[Optional[str], Optional[str]]:
+    """Parse Graph team/channel ids from Teams ``channelData`` on an inbound activity.
+
+    The microsoft-teams-apps SDK exposes ``activity.channel_data`` with
+    ``team.aad_group_id`` (Graph team / AAD group id) and ``channel.id`` (Graph
+    channel id). There is no ``get_team_details`` helper on the SDK App class —
+    channelData is the zero-permission source of truth for the current scope.
+
+    Returns ``(teams_graph_team_id, teams_graph_channel_id)``. Either value may
+    be ``None`` when channelData is absent (Web Chat / Emulator) or the message
+    is not in a team channel.
+    """
+    teams_graph_team_id: Optional[str] = None
+    teams_graph_channel_id: Optional[str] = None
+    try:
+        channel_data = getattr(activity, "channel_data", None)
+        if channel_data is not None:
+            team = getattr(channel_data, "team", None)
+            if team is not None:
+                raw_team = getattr(team, "aad_group_id", None)
+                if raw_team:
+                    teams_graph_team_id = str(raw_team).strip() or None
+            channel_info = getattr(channel_data, "channel", None)
+            if channel_info is not None:
+                raw_channel = getattr(channel_info, "id", None)
+                if raw_channel:
+                    teams_graph_channel_id = str(raw_channel).strip() or None
+        if conversation_type == "channel" and not teams_graph_channel_id and conversation_id:
+            teams_graph_channel_id = str(conversation_id).strip() or None
+    except Exception:
+        logger.debug(
+            "[teams] Failed to extract Graph ids from channelData; continuing without them",
+            exc_info=True,
+        )
+    return teams_graph_team_id, teams_graph_channel_id
+
+
 def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
     try:
         return int(value)
@@ -770,6 +812,12 @@ class TeamsAdapter(BasePlatformAdapter):
         user_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
         user_name = getattr(from_account, "name", None) or ""
 
+        teams_graph_team_id, teams_graph_channel_id = extract_teams_graph_ids(
+            activity,
+            conversation_type=conv_type,
+            conversation_id=str(getattr(conv, "id", None) or ""),
+        )
+
         source = self.build_source(
             chat_id=conv.id,
             chat_name=getattr(conv, "name", None) or "",
@@ -777,6 +825,9 @@ class TeamsAdapter(BasePlatformAdapter):
             user_id=str(user_id),
             user_name=user_name,
             guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
+            teams_graph_team_id=teams_graph_team_id,
+            teams_graph_channel_id=teams_graph_channel_id,
+            message_id=str(msg_id) if msg_id else None,
         )
 
         # Handle image attachments

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -42,6 +42,20 @@ class TestSessionSourceRoundtrip:
         assert restored.user_name == "alice"
         assert restored.thread_id == "t1"
 
+    def test_teams_graph_ids_roundtrip(self):
+        source = SessionSource(
+            platform=Platform("teams"),
+            chat_id="19:abc@thread.tacv2",
+            chat_type="channel",
+            teams_graph_team_id="929251d7-2427-4a4a-a633-435589d4508c",
+            teams_graph_channel_id="19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2",
+        )
+        restored = SessionSource.from_dict(source.to_dict())
+        assert restored.teams_graph_team_id == "929251d7-2427-4a4a-a633-435589d4508c"
+        assert restored.teams_graph_channel_id == (
+            "19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2"
+        )
+
     def test_full_roundtrip_with_chat_topic(self):
         """chat_topic should survive to_dict/from_dict roundtrip."""
         source = SessionSource(
@@ -313,6 +327,30 @@ class TestBuildSessionContextPrompt:
 
         assert "Local" in prompt
         assert "machine running this agent" in prompt
+
+    def test_teams_prompt_injects_graph_ids_for_cap_m365(self):
+        config = GatewayConfig(
+            platforms={
+                Platform("teams"): PlatformConfig(enabled=True, extra={}),
+            },
+        )
+        source = SessionSource(
+            platform=Platform("teams"),
+            chat_id="19:chat@thread.v2",
+            chat_name="General",
+            chat_type="channel",
+            user_name="alice",
+            teams_graph_team_id="929251d7-2427-4a4a-a633-435589d4508c",
+            teams_graph_channel_id="19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "Teams IDs" in prompt
+        assert "929251d7-2427-4a4a-a633-435589d4508c" in prompt
+        assert "19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2" in prompt
+        assert "teams_get_channel_messages" in prompt
+        assert "Never use the 32-hex segment" in prompt
 
     def test_local_delivery_path_uses_display_hermes_home(self):
         config = GatewayConfig()

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -885,3 +885,44 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "Bot Framework conversation ID" in result["error"]
         assert len(session.calls) == 0
+
+
+class TestExtractTeamsGraphIds:
+    def test_channel_activity_extracts_aad_group_and_channel(self):
+        activity = SimpleNamespace(
+            channel_data=SimpleNamespace(
+                team=SimpleNamespace(
+                    aad_group_id="929251d7-2427-4a4a-a633-435589d4508c",
+                ),
+                channel=SimpleNamespace(
+                    id="19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2",
+                ),
+            ),
+        )
+        team_id, channel_id = _teams_mod.extract_teams_graph_ids(
+            activity,
+            conversation_type="channel",
+            conversation_id="19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2",
+        )
+        assert team_id == "929251d7-2427-4a4a-a633-435589d4508c"
+        assert channel_id == "19:44dcb7bdc60149c3b0a5a169cbeb98dc@thread.tacv2"
+
+    def test_channel_falls_back_to_conversation_id_without_channel_info(self):
+        activity = SimpleNamespace(channel_data=SimpleNamespace(team=None, channel=None))
+        team_id, channel_id = _teams_mod.extract_teams_graph_ids(
+            activity,
+            conversation_type="channel",
+            conversation_id="19:abc@thread.tacv2",
+        )
+        assert team_id is None
+        assert channel_id == "19:abc@thread.tacv2"
+
+    def test_missing_channel_data_degrades_gracefully(self):
+        activity = SimpleNamespace()
+        team_id, channel_id = _teams_mod.extract_teams_graph_ids(
+            activity,
+            conversation_type="personal",
+            conversation_id="dm-id",
+        )
+        assert team_id is None
+        assert channel_id is None


### PR DESCRIPTION
## What does this PR do?

The Microsoft Teams platform adapter did not persist inbound `channelData`, so the agent session never received the Microsoft Graph **team** (AAD group) id or **channel** id needed for channel-scoped Graph API calls. This change parses those ids from each inbound activity, stores them on `SessionSource`, and surfaces them in `build_session_context_prompt` in a **Teams IDs** block—following the same pattern as the existing **Discord IDs** block for Discord sessions.

## Related Issue

N/A (upstream contribution)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/teams/adapter.py` — add `extract_teams_graph_ids()` to read `channelData.team.aad_group_id` and `channelData.channel.id` (with channel conversation-id fallback); wire into `_on_message` via `build_source`
- `gateway/session.py` — extend `SessionSource` with `teams_graph_team_id` / `teams_graph_channel_id` (serialize round-trip); inject Teams IDs block in `build_session_context_prompt` when ids are present
- `gateway/platforms/base.py` — pass new optional fields through `build_source`
- `tests/gateway/test_teams.py`, `tests/gateway/test_session.py` — unit tests for extraction, round-trip, and prompt output

## Approach

- **Source of truth:** Bot Framework `channelData` on the inbound activity ([Get Teams context](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/get-teams-context) — `team.aadGroupId`, `channel.id`)
- **Graceful degradation:** When `channelData` is missing (Web Chat, Emulator, personal chats without team context), no Teams IDs block is added; existing sessions behave as before
- **Backward compatible:** New `SessionSource` fields are optional; no API or config changes

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_teams.py::TestExtractTeamsGraphIds tests/gateway/test_session.py -q -k teams`
2. (Optional) Run the Teams gateway against a team channel bot and confirm the session context prompt includes team/channel Graph ids

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to avoid duplicates
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted gateway tests run locally; full suite not run in this submission)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A — no user-facing docs or config keys changed


Made with [Cursor](https://cursor.com)