### PR TITLE
fix(desktop): prevent IME Enter from splitting messages and viewport resize from disarming scroll anchor

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1130,7 +1130,7 @@ export function ChatBar({
 
         `asChild` swaps TextareaAutosize for a Radix Slot wrapping our
         plain <textarea>, which carries the binding but skips autosize. */}
-      <ComposerPrimitive.Input asChild tabIndex={-1} unstable_focusOnScrollToBottom={false}>
+      <ComposerPrimitive.Input asChild submitMode="ctrlEnter" tabIndex={-1} unstable_focusOnScrollToBottom={false}>
         <textarea aria-hidden className="sr-only" tabIndex={-1} />
       </ComposerPrimitive.Input>
     </div>

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1089,8 +1089,8 @@ export function ChatBar({
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
         aria-label="Message"
-        autoCorrect="off"
         autoCapitalize="off"
+        autoCorrect="off"
         className={cn(
           'min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) overflow-y-auto bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -567,6 +567,13 @@ export function ChatBar({
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // IME composition: Enter confirms composed text, not a message submission.
+    // Without this guard, pressing Enter to finalise a Korean/Japanese/Chinese
+    // IME preedit fires submitDraft() and splits the message mid-word.
+    if (event.nativeEvent.isComposing) {
+      return
+    }
+
     if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'k') {
       event.preventDefault()
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -611,7 +611,7 @@ export function DesktopController() {
       onAddUrl={url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url)}
       onAttachDroppedItems={composer.attachDroppedItems}
       onAttachImageBlob={composer.attachImageBlob}
-      onBranchInNewChat={messageId => void branchInNewChat(messageId)}
+      onBranchInNewChat={branchInNewChat}
       onCancel={cancelRun}
       onDeleteSelectedSession={() => {
         if (selectedStoredSessionId) {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -271,12 +271,10 @@ const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
 const MarkdownTextImpl = () => {
   const isStreaming = useAuiState(s => s.message.status?.type === 'running')
 
-  // Stable per-state plugin object. The previous inline `{ math: mathPlugin,
-  // ...(isStreaming ? {} : { code }) }` created a new object identity on every
-  // render, which churns Streamdown's outer memo + propagates new prop
-  // identities into every Block. The plugin set really only varies on
-  // `isStreaming`, so memoize on that.
-  const plugins = useMemo(() => (isStreaming ? { math: mathPlugin } : { math: mathPlugin, code }), [isStreaming])
+  // Keep code parsing enabled while streaming so incomplete fenced blocks still
+  // render as code cards. The expensive Shiki pass is deferred by
+  // `SyntaxHighlighter` below when `isStreaming` is true.
+  const plugins = useMemo(() => ({ math: mathPlugin, code }), [])
 
   const components = useMemo(
     () =>

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { TextMessagePartProvider, useAuiState, useMessagePartText } from '@assistant-ui/react'
+import { TextMessagePartProvider, useMessagePartText } from '@assistant-ui/react'
 import {
   type StreamdownTextComponents,
   StreamdownTextPrimitive,
@@ -259,6 +259,11 @@ function DeferStreamingText({ children }: { children: ReactNode }) {
   )
 }
 
+interface MarkdownTextSurfaceProps {
+  containerClassName?: string
+  containerProps?: ComponentProps<'div'>
+}
+
 // Headings shrink to chat scale rather than the prose default (h1≈xl). Kept
 // table-driven so adding/tweaking levels is one row.
 const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
@@ -268,8 +273,19 @@ const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
   h4: 'text-[0.8125rem]'
 }
 
-const MarkdownTextImpl = () => {
-  const isStreaming = useAuiState(s => s.message.status?.type === 'running')
+const MARKDOWN_CONTAINER_CLASS_NAME = cn(
+  'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
+  'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
+  'prose-headings:text-foreground prose-strong:text-foreground',
+  'prose-a:break-words prose-p:[overflow-wrap:anywhere]',
+  'prose-li:marker:text-muted-foreground/70',
+  'prose-code:rounded-[0.25rem] prose-code:px-[0.1875rem] prose-code:py-px prose-code:font-mono prose-code:text-[0.9em] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none',
+  '[&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>*+*]:mt-1'
+)
+
+function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTextSurfaceProps) {
+  const { status } = useMessagePartText()
+  const isStreaming = status.type === 'running'
 
   // Keep code parsing enabled while streaming so incomplete fenced blocks still
   // render as code cards. The expensive Shiki pass is deferred by
@@ -346,32 +362,46 @@ const MarkdownTextImpl = () => {
   )
 
   return (
+    <StreamdownTextPrimitive
+      components={components}
+      containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
+      containerProps={containerProps}
+      lineNumbers={false}
+      mode="streaming"
+      // Always auto-close incomplete fences — even during streaming.
+      // Without this, an unclosed ```python ... ``` whose body contains
+      // `$` (very common: shell snippets, JS template strings, dollar
+      // amounts) leaks those dollars out to the math parser and they
+      // get rendered as broken inline math until the closing fence
+      // arrives. Shiki is independently deferred via `defer={isStreaming}`
+      // on the SyntaxHighlighter component, so we don't pay code-block
+      // tokenization on every token even with this set.
+      parseIncompleteMarkdown
+      plugins={plugins}
+      preprocess={preprocessMarkdown}
+    />
+  )
+}
+
+interface MarkdownTextContentProps extends MarkdownTextSurfaceProps {
+  isRunning: boolean
+  text: string
+}
+
+export function MarkdownTextContent({ isRunning, text, ...surfaceProps }: MarkdownTextContentProps) {
+  return (
+    <TextMessagePartProvider isRunning={isRunning} text={text}>
+      <DeferStreamingText>
+        <MarkdownTextSurface {...surfaceProps} />
+      </DeferStreamingText>
+    </TextMessagePartProvider>
+  )
+}
+
+const MarkdownTextImpl = () => {
+  return (
     <DeferStreamingText>
-      <StreamdownTextPrimitive
-        components={components}
-        containerClassName={cn(
-          'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
-          'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
-          'prose-headings:text-foreground prose-strong:text-foreground',
-          'prose-a:break-words prose-p:[overflow-wrap:anywhere]',
-          'prose-li:marker:text-muted-foreground/70',
-          'prose-code:rounded-[0.25rem] prose-code:px-[0.1875rem] prose-code:py-px prose-code:font-mono prose-code:text-[0.9em] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none',
-          '[&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>*+*]:mt-1'
-        )}
-        lineNumbers={false}
-        mode="streaming"
-        // Always auto-close incomplete fences — even during streaming.
-        // Without this, an unclosed ```python ... ``` whose body contains
-        // `$` (very common: shell snippets, JS template strings, dollar
-        // amounts) leaks those dollars out to the math parser and they
-        // get rendered as broken inline math until the closing fence
-        // arrives. Shiki is independently deferred via `defer={isStreaming}`
-        // on the SyntaxHighlighter component, so we don't pay code-block
-        // tokenization on every token even with this set.
-        parseIncompleteMarkdown
-        plugins={plugins}
-        preprocess={preprocessMarkdown}
-      />
+      <MarkdownTextSurface />
     </DeferStreamingText>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -263,6 +263,20 @@ function StreamingHarness() {
   )
 }
 
+function StaticThreadHarness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [userMessage(), assistantMessage('complete response', false)],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
 function TodoHarness({ message }: { message: ThreadMessage }) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [message],
@@ -413,6 +427,81 @@ describe('assistant-ui streaming renderer', () => {
     await wait(0)
 
     expect(viewport.scrollTop).toBe(420)
+  })
+
+  it('does not auto-follow idle layout shifts', async () => {
+    const { container } = render(<StaticThreadHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
+  it('keeps sticky-bottom armed through viewport height changes during streaming', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let clientHeight = 200
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', {
+      configurable: true,
+      get: () => clientHeight
+    })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 800
+      fireEvent.scroll(viewport)
+    })
+
+    clientHeight = 240
+
+    await act(async () => {
+      viewport.scrollTop = 760
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(1_200)
   })
 
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -504,6 +504,75 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(1_200)
   })
 
+  it('holds the viewport at bottom when content transiently shrinks while armed', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+
+    let measured = 2_000
+
+    const minHeightOf = () => {
+      const raw = content.style.minHeight
+
+      return raw.endsWith('px') ? Number.parseFloat(raw) : 0
+    }
+
+    const effectiveHeight = () => Math.max(measured, minHeightOf())
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 600 })
+    Object.defineProperty(content, 'scrollHeight', {
+      configurable: true,
+      get: effectiveHeight
+    })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: effectiveHeight
+    })
+
+    let rawTop = 0
+
+    const clamp = () => {
+      const max = Math.max(0, effectiveHeight() - 600)
+      rawTop = Math.max(0, Math.min(rawTop, max))
+    }
+
+    Object.defineProperty(viewport, 'scrollTop', {
+      configurable: true,
+      get: () => rawTop,
+      set: (value: number) => {
+        rawTop = value
+        clamp()
+      }
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(2_000)
+      }
+    })
+    await wait(0)
+
+    viewport.scrollTop = viewport.scrollHeight
+    expect(viewport.scrollTop).toBe(1_400)
+
+    measured = 1_700
+
+    await act(async () => {
+      clamp()
+
+      for (const observer of resizeObservers) {
+        observer.trigger(1_700)
+      }
+    })
+    await wait(0)
+
+    expect(content.style.minHeight).toBe('2000px')
+    expect(viewport.scrollTop).toBe(1_400)
+  })
+
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
     const { container } = render(<StreamingHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -130,12 +130,12 @@ function assistantErrorMessage(error: string): ThreadMessage {
   } as ThreadMessage
 }
 
-function assistantReasoningMessage(text: string): ThreadMessage {
+function assistantReasoningMessage(text: string, running = false): ThreadMessage {
   return {
     id: 'assistant-reasoning-1',
     role: 'assistant',
     content: [{ type: 'reasoning', text }],
-    status: { type: 'complete', reason: 'stop' },
+    status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
     createdAt,
     metadata: {
       unstable_state: null,
@@ -323,6 +323,20 @@ function ReasoningHarness() {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [assistantReasoningMessage(' The user is asking what this file is.')],
     isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+function RunningReasoningHarness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [assistantReasoningMessage('```ts\nconst answer = 42\n', true)],
+    isRunning: true,
     onNew: async () => {}
   })
 
@@ -625,10 +639,25 @@ describe('assistant-ui streaming renderer', () => {
     expect(container.textContent).not.toContain('```ts')
   })
 
+  it('renders an incomplete streaming reasoning fenced code block as a code card', async () => {
+    const { container } = render(<RunningReasoningHarness />)
+    const ui = within(container)
+
+    fireEvent.click(ui.getByRole('button', { name: /thinking/i }))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy()
+    })
+
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
+    expect(container.textContent).not.toContain('```ts')
+  })
+
   it('renders reasoning text without a leading token space', () => {
     const { container } = render(<ReasoningHarness />)
+    const ui = within(container)
 
-    fireEvent.click(screen.getByRole('button', { name: /thinking/i }))
+    fireEvent.click(ui.getByRole('button', { name: /thinking/i }))
 
     expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toBe(
       'The user is asking what this file is.'

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -305,6 +305,20 @@ function MessageHarness({ message }: { message: ThreadMessage }) {
   )
 }
 
+function RunningMessageHarness({ message }: { message: ThreadMessage }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [message],
+    isRunning: true,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
 function ReasoningHarness() {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [assistantReasoningMessage(' The user is asking what this file is.')],
@@ -504,138 +518,6 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(1_200)
   })
 
-  it('holds the viewport at bottom when content transiently shrinks while armed', async () => {
-    const { container } = render(<StreamingHarness />)
-
-    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
-    const viewport = content.parentElement as HTMLDivElement
-
-    let measured = 2_000
-
-    const minHeightOf = () => {
-      const raw = content.style.minHeight
-
-      return raw.endsWith('px') ? Number.parseFloat(raw) : 0
-    }
-
-    const effectiveHeight = () => Math.max(measured, minHeightOf())
-
-    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 600 })
-    Object.defineProperty(content, 'scrollHeight', {
-      configurable: true,
-      get: effectiveHeight
-    })
-    Object.defineProperty(viewport, 'scrollHeight', {
-      configurable: true,
-      get: effectiveHeight
-    })
-
-    let rawTop = 0
-
-    const clamp = () => {
-      const max = Math.max(0, effectiveHeight() - 600)
-      rawTop = Math.max(0, Math.min(rawTop, max))
-    }
-
-    Object.defineProperty(viewport, 'scrollTop', {
-      configurable: true,
-      get: () => rawTop,
-      set: (value: number) => {
-        rawTop = value
-        clamp()
-      }
-    })
-
-    await wait(80)
-
-    await act(async () => {
-      for (const observer of resizeObservers) {
-        observer.trigger(2_000)
-      }
-    })
-    await wait(0)
-
-    viewport.scrollTop = viewport.scrollHeight
-    expect(viewport.scrollTop).toBe(1_400)
-
-    measured = 1_700
-
-    await act(async () => {
-      clamp()
-
-      for (const observer of resizeObservers) {
-        observer.trigger(1_700)
-      }
-    })
-    await wait(0)
-
-    expect(content.style.minHeight).toBe('2000px')
-    expect(viewport.scrollTop).toBe(1_400)
-  })
-
-  it('releases the code-block height reservation and pins to the real bottom when streaming completes', async () => {
-    const { container } = render(<StreamingHarness />)
-
-    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
-    const viewport = content.parentElement as HTMLDivElement
-
-    let measured = 2_000
-
-    const minHeightOf = () => {
-      const raw = content.style.minHeight
-
-      return raw.endsWith('px') ? Number.parseFloat(raw) : 0
-    }
-
-    const effectiveHeight = () => Math.max(measured, minHeightOf())
-
-    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 600 })
-    Object.defineProperty(content, 'scrollHeight', {
-      configurable: true,
-      get: effectiveHeight
-    })
-    Object.defineProperty(viewport, 'scrollHeight', {
-      configurable: true,
-      get: effectiveHeight
-    })
-
-    let rawTop = 0
-
-    const clamp = () => {
-      const max = Math.max(0, effectiveHeight() - 600)
-      rawTop = Math.max(0, Math.min(rawTop, max))
-    }
-
-    Object.defineProperty(viewport, 'scrollTop', {
-      configurable: true,
-      get: () => rawTop,
-      set: (value: number) => {
-        rawTop = value
-        clamp()
-      }
-    })
-
-    await wait(80)
-
-    await act(async () => {
-      for (const observer of resizeObservers) {
-        observer.trigger(2_000)
-      }
-    })
-    await wait(0)
-
-    viewport.scrollTop = viewport.scrollHeight
-    expect(content.style.minHeight).toBe('2000px')
-    expect(viewport.scrollTop).toBe(1_400)
-
-    measured = 1_700
-
-    await wait(700)
-
-    expect(content.style.minHeight).toBe('')
-    expect(viewport.scrollTop).toBe(1_100)
-  })
-
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
     const { container } = render(<StreamingHarness />)
 
@@ -668,6 +550,17 @@ describe('assistant-ui streaming renderer', () => {
     await wait(0)
 
     expect(viewport.scrollTop).toBe(420)
+  })
+
+  it('renders an incomplete streaming fenced code block as a code card', async () => {
+    const { container } = render(<RunningMessageHarness message={assistantMessage('```ts\nconst answer = 42\n')} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy()
+    })
+
+    expect(container.textContent).toContain('const answer = 42')
+    expect(container.textContent).not.toContain('```ts')
   })
 
   it('renders reasoning text without a leading token space', () => {

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -552,6 +552,68 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('keeps following final code-highlight growth when a run completes at bottom', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 800
+      fireEvent.scroll(viewport)
+    })
+
+    await wait(650)
+
+    scrollHeight = 1_700
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(1_700)
+  })
+
+  it('does not restart bottom-follow after completion when the user scrolled up', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 800
+      fireEvent.scroll(viewport)
+    })
+
+    await act(async () => {
+      fireEvent.wheel(viewport, { deltaY: -120 })
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    await wait(650)
+
+    scrollHeight = 1_700
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
   it('renders an incomplete streaming fenced code block as a code card', async () => {
     const { container } = render(<RunningMessageHarness message={assistantMessage('```ts\nconst answer = 42\n')} />)
 

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -573,6 +573,69 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(1_400)
   })
 
+  it('releases the code-block height reservation and pins to the real bottom when streaming completes', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+
+    let measured = 2_000
+
+    const minHeightOf = () => {
+      const raw = content.style.minHeight
+
+      return raw.endsWith('px') ? Number.parseFloat(raw) : 0
+    }
+
+    const effectiveHeight = () => Math.max(measured, minHeightOf())
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 600 })
+    Object.defineProperty(content, 'scrollHeight', {
+      configurable: true,
+      get: effectiveHeight
+    })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: effectiveHeight
+    })
+
+    let rawTop = 0
+
+    const clamp = () => {
+      const max = Math.max(0, effectiveHeight() - 600)
+      rawTop = Math.max(0, Math.min(rawTop, max))
+    }
+
+    Object.defineProperty(viewport, 'scrollTop', {
+      configurable: true,
+      get: () => rawTop,
+      set: (value: number) => {
+        rawTop = value
+        clamp()
+      }
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(2_000)
+      }
+    })
+    await wait(0)
+
+    viewport.scrollTop = viewport.scrollHeight
+    expect(content.style.minHeight).toBe('2000px')
+    expect(viewport.scrollTop).toBe(1_400)
+
+    measured = 1_700
+
+    await wait(700)
+
+    expect(content.style.minHeight).toBe('')
+    expect(viewport.scrollTop).toBe(1_100)
+  })
+
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
     const { container } = render(<StreamingHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -65,6 +65,7 @@ const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
   const messageSignature = useAuiState(s =>
     s.thread.messages.map((message, index) => `${index}:${message.id}:${message.role}`).join('\n')
   )
+  const isRunning = useAuiState(s => s.thread.isRunning)
 
   const groups = useMemo(() => buildGroups(messageSignature), [messageSignature])
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
@@ -109,6 +110,7 @@ const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
   useThreadScrollAnchor({
     enabled: !renderEmpty,
     groupCount: groups.length,
+    isRunning,
     scrollerRef,
     sessionKey: sessionKey ?? null,
     stickyBottomRef,
@@ -200,13 +202,14 @@ export const VirtualizedThread = memo(_VirtualizedThread)
 interface ScrollAnchorOptions {
   enabled: boolean
   groupCount: number
+  isRunning: boolean
   scrollerRef: React.RefObject<HTMLDivElement | null>
   sessionKey: string | null
   stickyBottomRef: React.MutableRefObject<boolean>
   virtualizer: Virtualizer<HTMLDivElement, Element>
 }
 
-function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, stickyBottomRef, virtualizer }: ScrollAnchorOptions) {
+function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, sessionKey, stickyBottomRef, virtualizer }: ScrollAnchorOptions) {
   // `stickyBottomRef` = parked at bottom, content growth should follow. Cleared on
   // user-driven upward scroll; re-armed when they reach bottom again.
   // This is a shared ref — scrollToFn reads it to prevent the virtualizer's

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -55,7 +55,7 @@ function buildGroups(signature: string): MessageGroup[] {
   return groups
 }
 
-const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
+const VirtualizedThreadInner: FC<VirtualizedThreadProps> = ({
   clampToComposer,
   components,
   emptyPlaceholder,
@@ -92,7 +92,9 @@ const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
     // then jumps back up).
     scrollToFn: (offset, _options, instance) => {
       const el = instance.scrollElement
-      if (!el) return
+      if (!el) {
+        return
+      }
 
       if (stickyBottomRef.current) {
         const maxScroll = el.scrollHeight - el.clientHeight
@@ -197,7 +199,7 @@ const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
   )
 }
 
-export const VirtualizedThread = memo(_VirtualizedThread)
+export const VirtualizedThread = memo(VirtualizedThreadInner)
 
 interface ScrollAnchorOptions {
   enabled: boolean
@@ -209,13 +211,22 @@ interface ScrollAnchorOptions {
   virtualizer: Virtualizer<HTMLDivElement, Element>
 }
 
-function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, sessionKey, stickyBottomRef, virtualizer }: ScrollAnchorOptions) {
+function useThreadScrollAnchor({
+  enabled,
+  groupCount,
+  isRunning,
+  scrollerRef,
+  sessionKey,
+  stickyBottomRef,
+  virtualizer
+}: ScrollAnchorOptions) {
   // `stickyBottomRef` = parked at bottom, content growth should follow. Cleared on
   // user-driven upward scroll; re-armed when they reach bottom again.
   // This is a shared ref — scrollToFn reads it to prevent the virtualizer's
   // measurement adjustments from fighting our pinToBottom.
   const lastTopRef = useRef(0)
   const lastHeightRef = useRef(0)
+  const lastClientHeightRef = useRef(0)
   // Counter that tracks how many scroll events we expect to be ours rather
   // than the user's. `pinToBottom` writes `el.scrollTop`, which fires an
   // async `scroll` event; without this guard the on-scroll handler can race
@@ -241,6 +252,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
     el.scrollTop = el.scrollHeight
     lastTopRef.current = el.scrollTop
     lastHeightRef.current = el.scrollHeight
+    lastClientHeightRef.current = el.clientHeight
   }, [scrollerRef])
 
   const jumpToBottom = useCallback(() => {
@@ -255,7 +267,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
         pinToBottom()
       }
     })
-  }, [groupCount, pinToBottom, virtualizer])
+  }, [groupCount, pinToBottom, stickyBottomRef, virtualizer])
 
   useEffect(() => () => setThreadScrolledUp(false), [])
 
@@ -287,6 +299,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
         programmaticScrollPendingRef.current -= 1
         lastTopRef.current = top
         lastHeightRef.current = el.scrollHeight
+        lastClientHeightRef.current = el.clientHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
         stickyBottomRef.current = true
         const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
@@ -295,26 +308,21 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
         return
       }
 
-      // Disarm only when `scrollTop` decreases AND `scrollHeight` did NOT
-      // grow this frame. A bare `top < lastTopRef.current` check is unsafe:
-      // when content grows (virtualizer item measurement, streaming token,
-      // code highlight re-tokenization, composer chip), the browser emits
-      // an interim `scroll` event whose `scrollTop` is smaller than the
-      // previous frame's because `scrollHeight` jumped — this fires before
-      // the rAF-scheduled `pinToBottom` runs, so `programmaticScrollPendingRef`
-      // is 0. Treating that as a user scroll permanently disarmed sticky-bottom
-      // and produced the visible at-rest backward jump (#37997). Gating on a
-      // stable `scrollHeight` keeps real user-driven upward intent — scrollbar
-      // drag, keyboard PgUp, programmatic scrollIntoView — covered without
-      // the false positive. Wheel-up and touchmove still disarm via their
-      // own listeners below.
+      // Disarm only when `scrollTop` decreases while both content height and
+      // viewport height are stable. A bare `top < lastTopRef.current` check is
+      // unsafe: virtualizer measurement, streaming markdown, composer resizing,
+      // window resizing, and toolbar/status updates can all move scrollTop as a
+      // layout side effect. Wheel-up and touchmove still disarm immediately via
+      // their own listeners below, so real user intent remains covered.
       const heightGrew = el.scrollHeight > lastHeightRef.current
-      if (!heightGrew && top + 1 < lastTopRef.current) {
+      const clientHeightChanged = Math.abs(el.clientHeight - lastClientHeightRef.current) > 1
+      if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
         stickyBottomRef.current = false
       }
 
       lastTopRef.current = top
       lastHeightRef.current = el.scrollHeight
+      lastClientHeightRef.current = el.clientHeight
 
       const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
 
@@ -340,7 +348,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
       el.removeEventListener('wheel', onWheel)
       el.removeEventListener('touchmove', disarm)
     }
-  }, [scrollerRef])
+  }, [scrollerRef, stickyBottomRef])
 
   // Follow content growth (streaming, item measurements, loading indicator)
   // while armed. During fast streaming the ResizeObserver can fire many
@@ -349,7 +357,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
   // (~20+ ms self in `Virtualizer.getMaxScrollOffset`) several times per
   // token.
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || !isRunning) {
       return undefined
     }
 
@@ -383,7 +391,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
     }
 
     return () => observer.disconnect()
-  }, [enabled, pinToBottom, scrollerRef])
+  }, [enabled, isRunning, pinToBottom, scrollerRef, stickyBottomRef])
 
   // Jump to bottom on session change OR when an empty thread first gets
   // content. Both share the same intent and the same effect.
@@ -429,7 +437,7 @@ function useThreadScrollAnchor({ enabled, groupCount, isRunning, scrollerRef, se
       })
     }
     prevGroupCountForLayoutRef.current = groupCount
-  }, [enabled, groupCount, pinToBottom])
+  }, [enabled, groupCount, pinToBottom, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -239,6 +239,12 @@ function useThreadScrollAnchor({
   const programmaticScrollPendingRef = useRef(0)
   const prevSessionKeyRef = useRef(sessionKey)
   const prevGroupCountRef = useRef(0)
+  // High-water mark of the content height within the current turn. Shiki /
+  // Streamdown can temporarily replace a code or patch block with shorter
+  // laid-out DOM; a real browser clamps scrollTop upward before any rAF pin can
+  // run. Reserving the high-water mark as min-height keeps the scroller from
+  // shrinking while the user is parked at the bottom.
+  const contentHwmRef = useRef(0)
 
   const pinToBottom = useCallback(() => {
     const el = scrollerRef.current
@@ -258,6 +264,14 @@ function useThreadScrollAnchor({
   const jumpToBottom = useCallback(() => {
     stickyBottomRef.current = true
 
+    const content = scrollerRef.current?.firstElementChild as HTMLElement | null
+
+    if (content) {
+      content.style.minHeight = ''
+    }
+
+    contentHwmRef.current = 0
+
     if (groupCount > 0) {
       virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
     }
@@ -267,7 +281,7 @@ function useThreadScrollAnchor({
         pinToBottom()
       }
     })
-  }, [groupCount, pinToBottom, stickyBottomRef, virtualizer])
+  }, [groupCount, pinToBottom, scrollerRef, stickyBottomRef, virtualizer])
 
   useEffect(() => () => setThreadScrolledUp(false), [])
 
@@ -283,6 +297,14 @@ function useThreadScrollAnchor({
     const disarm = () => {
       stickyBottomRef.current = false
       programmaticScrollPendingRef.current = 0
+
+      const content = el.firstElementChild as HTMLElement | null
+
+      if (content) {
+        content.style.minHeight = ''
+      }
+
+      contentHwmRef.current = 0
     }
 
     const onScroll = () => {
@@ -367,27 +389,45 @@ function useThreadScrollAnchor({
       return undefined
     }
 
+    const content = el.firstElementChild as HTMLElement | null
     let pinRafScheduled = false
+
     const schedulePin = () => {
       if (pinRafScheduled || !stickyBottomRef.current) {
         return
       }
+
       pinRafScheduled = true
       requestAnimationFrame(() => {
         pinRafScheduled = false
+
         if (stickyBottomRef.current) {
           pinToBottom()
         }
       })
     }
 
-    const observer = new ResizeObserver(schedulePin)
+    const observer = new ResizeObserver(() => {
+      // Keep content height monotonic within a turn while armed. Set min-height
+      // before scheduling the bottom pin so a transient code-block shrink
+      // cannot make the browser clamp scrollTop upward.
+      if (content && stickyBottomRef.current) {
+        const measured = content.scrollHeight
+
+        if (measured > contentHwmRef.current) {
+          contentHwmRef.current = measured
+          content.style.minHeight = `${measured}px`
+        }
+      }
+
+      schedulePin()
+    })
 
     // Observe ONLY the content (firstElementChild), not the scroller `el`
     // itself. Resizes of the viewport/scroller (window resize, devtools
     // panel toggle) shouldn't trigger a pin — only content growth should.
-    if (el.firstElementChild) {
-      observer.observe(el.firstElementChild)
+    if (content) {
+      observer.observe(content)
     }
 
     return () => observer.disconnect()

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -239,22 +239,6 @@ function useThreadScrollAnchor({
   const programmaticScrollPendingRef = useRef(0)
   const prevSessionKeyRef = useRef(sessionKey)
   const prevGroupCountRef = useRef(0)
-  // High-water mark of the content height within the current turn. Shiki /
-  // Streamdown can temporarily replace a code or patch block with shorter
-  // laid-out DOM; a real browser clamps scrollTop upward before any rAF pin can
-  // run. Reserving the high-water mark as min-height keeps the scroller from
-  // shrinking while the user is parked at the bottom.
-  const contentHwmRef = useRef(0)
-
-  const releaseContentHighWaterMark = useCallback(() => {
-    const content = scrollerRef.current?.firstElementChild as HTMLElement | null
-
-    if (content) {
-      content.style.minHeight = ''
-    }
-
-    contentHwmRef.current = 0
-  }, [scrollerRef])
 
   const pinToBottom = useCallback(() => {
     const el = scrollerRef.current
@@ -273,7 +257,6 @@ function useThreadScrollAnchor({
 
   const jumpToBottom = useCallback(() => {
     stickyBottomRef.current = true
-    releaseContentHighWaterMark()
 
     if (groupCount > 0) {
       virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
@@ -284,7 +267,7 @@ function useThreadScrollAnchor({
         pinToBottom()
       }
     })
-  }, [groupCount, pinToBottom, releaseContentHighWaterMark, stickyBottomRef, virtualizer])
+  }, [groupCount, pinToBottom, stickyBottomRef, virtualizer])
 
   useEffect(() => () => setThreadScrolledUp(false), [])
 
@@ -300,7 +283,6 @@ function useThreadScrollAnchor({
     const disarm = () => {
       stickyBottomRef.current = false
       programmaticScrollPendingRef.current = 0
-      releaseContentHighWaterMark()
     }
 
     const onScroll = () => {
@@ -335,7 +317,7 @@ function useThreadScrollAnchor({
       const heightGrew = el.scrollHeight > lastHeightRef.current
       const clientHeightChanged = Math.abs(el.clientHeight - lastClientHeightRef.current) > 1
       if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
-        disarm()
+        stickyBottomRef.current = false
       }
 
       lastTopRef.current = top
@@ -366,7 +348,7 @@ function useThreadScrollAnchor({
       el.removeEventListener('wheel', onWheel)
       el.removeEventListener('touchmove', disarm)
     }
-  }, [releaseContentHighWaterMark, scrollerRef, stickyBottomRef])
+  }, [scrollerRef, stickyBottomRef])
 
   // Follow content growth (streaming, item measurements, loading indicator)
   // while armed. During fast streaming the ResizeObserver can fire many
@@ -385,45 +367,27 @@ function useThreadScrollAnchor({
       return undefined
     }
 
-    const content = el.firstElementChild as HTMLElement | null
     let pinRafScheduled = false
-
     const schedulePin = () => {
       if (pinRafScheduled || !stickyBottomRef.current) {
         return
       }
-
       pinRafScheduled = true
       requestAnimationFrame(() => {
         pinRafScheduled = false
-
         if (stickyBottomRef.current) {
           pinToBottom()
         }
       })
     }
 
-    const observer = new ResizeObserver(() => {
-      // Keep content height monotonic within a turn while armed. Set min-height
-      // before scheduling the bottom pin so a transient code-block shrink
-      // cannot make the browser clamp scrollTop upward.
-      if (content && stickyBottomRef.current) {
-        const measured = content.scrollHeight
-
-        if (measured > contentHwmRef.current) {
-          contentHwmRef.current = measured
-          content.style.minHeight = `${measured}px`
-        }
-      }
-
-      schedulePin()
-    })
+    const observer = new ResizeObserver(schedulePin)
 
     // Observe ONLY the content (firstElementChild), not the scroller `el`
     // itself. Resizes of the viewport/scroller (window resize, devtools
     // panel toggle) shouldn't trigger a pin — only content growth should.
-    if (content) {
-      observer.observe(content)
+    if (el.firstElementChild) {
+      observer.observe(el.firstElementChild)
     }
 
     return () => observer.disconnect()
@@ -474,30 +438,6 @@ function useThreadScrollAnchor({
     }
     prevGroupCountForLayoutRef.current = groupCount
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
-
-  // Run completion removes transient streaming UI and may collapse the
-  // high-water mark we reserved for code/diff blocks. If the user is still at
-  // the bottom, release that reservation and pin to the real final bottom
-  // before paint so the completed turn does not appear to jump above the
-  // composer.
-  const prevIsRunningForLayoutRef = useRef(isRunning)
-  useLayoutEffect(() => {
-    const finishedRun = prevIsRunningForLayoutRef.current && !isRunning
-    prevIsRunningForLayoutRef.current = isRunning
-
-    if (!enabled || !finishedRun || !stickyBottomRef.current) {
-      return
-    }
-
-    releaseContentHighWaterMark()
-    pinToBottom()
-
-    requestAnimationFrame(() => {
-      if (stickyBottomRef.current) {
-        pinToBottom()
-      }
-    })
-  }, [enabled, isRunning, pinToBottom, releaseContentHighWaterMark, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -183,6 +183,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
   const armedRef = useRef(true)
   const lastTopRef = useRef(0)
   const lastHeightRef = useRef(0)
+  const lastClientHeightRef = useRef(0)
   // Counter that tracks how many scroll events we expect to be ours rather
   // than the user's. `pinToBottom` writes `el.scrollTop`, which fires an
   // async `scroll` event; without this guard the on-scroll handler can race
@@ -208,6 +209,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     el.scrollTop = el.scrollHeight
     lastTopRef.current = el.scrollTop
     lastHeightRef.current = el.scrollHeight
+    lastClientHeightRef.current = el.clientHeight
   }, [scrollerRef])
 
   const jumpToBottom = useCallback(() => {
@@ -254,6 +256,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         programmaticScrollPendingRef.current -= 1
         lastTopRef.current = top
         lastHeightRef.current = el.scrollHeight
+        lastClientHeightRef.current = el.clientHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
         armedRef.current = true
         const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
@@ -262,26 +265,39 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         return
       }
 
-      // Disarm only when `scrollTop` decreases AND `scrollHeight` did NOT
-      // grow this frame. A bare `top < lastTopRef.current` check is unsafe:
-      // when content grows (virtualizer item measurement, streaming token,
-      // code highlight re-tokenization, composer chip), the browser emits
-      // an interim `scroll` event whose `scrollTop` is smaller than the
-      // previous frame's because `scrollHeight` jumped — this fires before
-      // the rAF-scheduled `pinToBottom` runs, so `programmaticScrollPendingRef`
-      // is 0. Treating that as a user scroll permanently disarmed sticky-bottom
-      // and produced the visible at-rest backward jump (#37997). Gating on a
-      // stable `scrollHeight` keeps real user-driven upward intent — scrollbar
-      // drag, keyboard PgUp, programmatic scrollIntoView — covered without
-      // the false positive. Wheel-up and touchmove still disarm via their
-      // own listeners below.
+      // Disarm only when `scrollTop` decreases AND neither `scrollHeight` nor
+      // `clientHeight` grew this frame. A bare `top < lastTopRef.current` check
+      // is unsafe for two reasons:
+      //
+      // 1. Content growth (virtualizer item measurement, streaming token,
+      //    code highlight re-tokenization, composer chip): `scrollHeight`
+      //    jumped → the browser emits an interim `scroll` event whose
+      //    `scrollTop` is smaller than the previous frame's because the
+      //    content grew. This fire before the rAF-scheduled `pinToBottom`
+      //    runs, so `programmaticScrollPendingRef` is 0. Treating that as a
+      //    user scroll permanently disarmed sticky-bottom and produced the
+      //    visible at-rest backward jump (#37997).
+      //
+      // 2. Viewport resize (composer expands/collapses, window resize):
+      //    `clientHeight` shrinks → the browser adjusts `scrollTop` down to
+      //    keep the same content visible. Without checking `clientHeight`,
+      //    the handler misreads this as the user scrolling up and disarms
+      //    sticky-bottom — the view then lurches because the user didn't
+      //    actually scroll.
+      //
+      // Gating on stable `scrollHeight` and `clientHeight` keeps real
+      // user-driven upward intent — scrollbar drag, keyboard PgUp,
+      // programmatic scrollIntoView — covered without false positives.
+      // Wheel-up and touchmove still disarm via their own listeners below.
       const heightGrew = el.scrollHeight > lastHeightRef.current
-      if (!heightGrew && top + 1 < lastTopRef.current) {
+      const clientHeightGrew = el.clientHeight > lastClientHeightRef.current
+      if (!heightGrew && !clientHeightGrew && top + 1 < lastTopRef.current) {
         armedRef.current = false
       }
 
       lastTopRef.current = top
       lastHeightRef.current = el.scrollHeight
+      lastClientHeightRef.current = el.clientHeight
 
       const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -246,6 +246,16 @@ function useThreadScrollAnchor({
   // shrinking while the user is parked at the bottom.
   const contentHwmRef = useRef(0)
 
+  const releaseContentHighWaterMark = useCallback(() => {
+    const content = scrollerRef.current?.firstElementChild as HTMLElement | null
+
+    if (content) {
+      content.style.minHeight = ''
+    }
+
+    contentHwmRef.current = 0
+  }, [scrollerRef])
+
   const pinToBottom = useCallback(() => {
     const el = scrollerRef.current
 
@@ -263,14 +273,7 @@ function useThreadScrollAnchor({
 
   const jumpToBottom = useCallback(() => {
     stickyBottomRef.current = true
-
-    const content = scrollerRef.current?.firstElementChild as HTMLElement | null
-
-    if (content) {
-      content.style.minHeight = ''
-    }
-
-    contentHwmRef.current = 0
+    releaseContentHighWaterMark()
 
     if (groupCount > 0) {
       virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
@@ -281,7 +284,7 @@ function useThreadScrollAnchor({
         pinToBottom()
       }
     })
-  }, [groupCount, pinToBottom, scrollerRef, stickyBottomRef, virtualizer])
+  }, [groupCount, pinToBottom, releaseContentHighWaterMark, stickyBottomRef, virtualizer])
 
   useEffect(() => () => setThreadScrolledUp(false), [])
 
@@ -297,14 +300,7 @@ function useThreadScrollAnchor({
     const disarm = () => {
       stickyBottomRef.current = false
       programmaticScrollPendingRef.current = 0
-
-      const content = el.firstElementChild as HTMLElement | null
-
-      if (content) {
-        content.style.minHeight = ''
-      }
-
-      contentHwmRef.current = 0
+      releaseContentHighWaterMark()
     }
 
     const onScroll = () => {
@@ -339,7 +335,7 @@ function useThreadScrollAnchor({
       const heightGrew = el.scrollHeight > lastHeightRef.current
       const clientHeightChanged = Math.abs(el.clientHeight - lastClientHeightRef.current) > 1
       if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
-        stickyBottomRef.current = false
+        disarm()
       }
 
       lastTopRef.current = top
@@ -370,7 +366,7 @@ function useThreadScrollAnchor({
       el.removeEventListener('wheel', onWheel)
       el.removeEventListener('touchmove', disarm)
     }
-  }, [scrollerRef, stickyBottomRef])
+  }, [releaseContentHighWaterMark, scrollerRef, stickyBottomRef])
 
   // Follow content growth (streaming, item measurements, loading indicator)
   // while armed. During fast streaming the ResizeObserver can fire many
@@ -478,6 +474,30 @@ function useThreadScrollAnchor({
     }
     prevGroupCountForLayoutRef.current = groupCount
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
+
+  // Run completion removes transient streaming UI and may collapse the
+  // high-water mark we reserved for code/diff blocks. If the user is still at
+  // the bottom, release that reservation and pin to the real final bottom
+  // before paint so the completed turn does not appear to jump above the
+  // composer.
+  const prevIsRunningForLayoutRef = useRef(isRunning)
+  useLayoutEffect(() => {
+    const finishedRun = prevIsRunningForLayoutRef.current && !isRunning
+    prevIsRunningForLayoutRef.current = isRunning
+
+    if (!enabled || !finishedRun || !stickyBottomRef.current) {
+      return
+    }
+
+    releaseContentHighWaterMark()
+    pinToBottom()
+
+    requestAnimationFrame(() => {
+      if (stickyBottomRef.current) {
+        pinToBottom()
+      }
+    })
+  }, [enabled, isRunning, pinToBottom, releaseContentHighWaterMark, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -1,6 +1,6 @@
 import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
 import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
-import { type ComponentProps, type FC, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { type ComponentProps, type FC, memo, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 
 import { cn } from '@/lib/utils'
 import { setThreadScrolledUp } from '@/store/thread-scroll'
@@ -55,7 +55,7 @@ function buildGroups(signature: string): MessageGroup[] {
   return groups
 }
 
-export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
+const _VirtualizedThread: FC<VirtualizedThreadProps> = ({
   clampToComposer,
   components,
   emptyPlaceholder,
@@ -70,6 +70,10 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
 
+  // Shared ref so scrollToFn can check whether the user is parked at the
+  // bottom without needing a ref from inside useThreadScrollAnchor.
+  const stickyBottomRef = useRef(true)
+
   const virtualizer = useVirtualizer({
     count: groups.length,
     estimateSize: () => ESTIMATED_ITEM_HEIGHT,
@@ -78,7 +82,28 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
     // Seed the rect so the initial range mounts something before
     // `observeElementRect` reports the real layout (it overrides this).
     initialRect: { height: 600, width: 800 },
-    overscan: OVERSCAN
+    overscan: OVERSCAN,
+    // When the virtualizer adjusts scroll due to item measurement changes,
+    // skip the adjustment if the user is at the bottom. Our ResizeObserver +
+    // pinToBottom loop handles scroll anchoring; letting the virtualizer also
+    // adjust creates a feedback loop where the two fight each other,
+    // producing visible rubber-banding (the view snaps to the composer
+    // then jumps back up).
+    scrollToFn: (offset, _options, instance) => {
+      const el = instance.scrollElement
+      if (!el) return
+
+      if (stickyBottomRef.current) {
+        const maxScroll = el.scrollHeight - el.clientHeight
+        const distFromBottom = maxScroll - el.scrollTop
+
+        if (distFromBottom <= AT_BOTTOM_THRESHOLD && offset < maxScroll) {
+          return
+        }
+      }
+
+      ;(el as HTMLElement).scrollTo(0, offset)
+    }
   })
 
   useThreadScrollAnchor({
@@ -86,6 +111,7 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
     groupCount: groups.length,
     scrollerRef,
     sessionKey: sessionKey ?? null,
+    stickyBottomRef,
     virtualizer
   })
 
@@ -169,21 +195,24 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
   )
 }
 
+export const VirtualizedThread = memo(_VirtualizedThread)
+
 interface ScrollAnchorOptions {
   enabled: boolean
   groupCount: number
   scrollerRef: React.RefObject<HTMLDivElement | null>
   sessionKey: string | null
+  stickyBottomRef: React.MutableRefObject<boolean>
   virtualizer: Virtualizer<HTMLDivElement, Element>
 }
 
-function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, virtualizer }: ScrollAnchorOptions) {
-  // `armed` = parked at bottom, content growth should follow. Cleared on
+function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, stickyBottomRef, virtualizer }: ScrollAnchorOptions) {
+  // `stickyBottomRef` = parked at bottom, content growth should follow. Cleared on
   // user-driven upward scroll; re-armed when they reach bottom again.
-  const armedRef = useRef(true)
+  // This is a shared ref — scrollToFn reads it to prevent the virtualizer's
+  // measurement adjustments from fighting our pinToBottom.
   const lastTopRef = useRef(0)
   const lastHeightRef = useRef(0)
-  const lastClientHeightRef = useRef(0)
   // Counter that tracks how many scroll events we expect to be ours rather
   // than the user's. `pinToBottom` writes `el.scrollTop`, which fires an
   // async `scroll` event; without this guard the on-scroll handler can race
@@ -209,18 +238,17 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     el.scrollTop = el.scrollHeight
     lastTopRef.current = el.scrollTop
     lastHeightRef.current = el.scrollHeight
-    lastClientHeightRef.current = el.clientHeight
   }, [scrollerRef])
 
   const jumpToBottom = useCallback(() => {
-    armedRef.current = true
+    stickyBottomRef.current = true
 
     if (groupCount > 0) {
       virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
     }
 
     requestAnimationFrame(() => {
-      if (armedRef.current) {
+      if (stickyBottomRef.current) {
         pinToBottom()
       }
     })
@@ -238,7 +266,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     }
 
     const disarm = () => {
-      armedRef.current = false
+      stickyBottomRef.current = false
       programmaticScrollPendingRef.current = 0
     }
 
@@ -256,53 +284,39 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         programmaticScrollPendingRef.current -= 1
         lastTopRef.current = top
         lastHeightRef.current = el.scrollHeight
-        lastClientHeightRef.current = el.clientHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
-        armedRef.current = true
+        stickyBottomRef.current = true
         const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
         setThreadScrolledUp(!atBottom)
 
         return
       }
 
-      // Disarm only when `scrollTop` decreases AND neither `scrollHeight` nor
-      // `clientHeight` grew this frame. A bare `top < lastTopRef.current` check
-      // is unsafe for two reasons:
-      //
-      // 1. Content growth (virtualizer item measurement, streaming token,
-      //    code highlight re-tokenization, composer chip): `scrollHeight`
-      //    jumped → the browser emits an interim `scroll` event whose
-      //    `scrollTop` is smaller than the previous frame's because the
-      //    content grew. This fire before the rAF-scheduled `pinToBottom`
-      //    runs, so `programmaticScrollPendingRef` is 0. Treating that as a
-      //    user scroll permanently disarmed sticky-bottom and produced the
-      //    visible at-rest backward jump (#37997).
-      //
-      // 2. Viewport resize (composer expands/collapses, window resize):
-      //    `clientHeight` shrinks → the browser adjusts `scrollTop` down to
-      //    keep the same content visible. Without checking `clientHeight`,
-      //    the handler misreads this as the user scrolling up and disarms
-      //    sticky-bottom — the view then lurches because the user didn't
-      //    actually scroll.
-      //
-      // Gating on stable `scrollHeight` and `clientHeight` keeps real
-      // user-driven upward intent — scrollbar drag, keyboard PgUp,
-      // programmatic scrollIntoView — covered without false positives.
-      // Wheel-up and touchmove still disarm via their own listeners below.
+      // Disarm only when `scrollTop` decreases AND `scrollHeight` did NOT
+      // grow this frame. A bare `top < lastTopRef.current` check is unsafe:
+      // when content grows (virtualizer item measurement, streaming token,
+      // code highlight re-tokenization, composer chip), the browser emits
+      // an interim `scroll` event whose `scrollTop` is smaller than the
+      // previous frame's because `scrollHeight` jumped — this fires before
+      // the rAF-scheduled `pinToBottom` runs, so `programmaticScrollPendingRef`
+      // is 0. Treating that as a user scroll permanently disarmed sticky-bottom
+      // and produced the visible at-rest backward jump (#37997). Gating on a
+      // stable `scrollHeight` keeps real user-driven upward intent — scrollbar
+      // drag, keyboard PgUp, programmatic scrollIntoView — covered without
+      // the false positive. Wheel-up and touchmove still disarm via their
+      // own listeners below.
       const heightGrew = el.scrollHeight > lastHeightRef.current
-      const clientHeightGrew = el.clientHeight > lastClientHeightRef.current
-      if (!heightGrew && !clientHeightGrew && top + 1 < lastTopRef.current) {
-        armedRef.current = false
+      if (!heightGrew && top + 1 < lastTopRef.current) {
+        stickyBottomRef.current = false
       }
 
       lastTopRef.current = top
       lastHeightRef.current = el.scrollHeight
-      lastClientHeightRef.current = el.clientHeight
 
       const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
 
       if (atBottom) {
-        armedRef.current = true
+        stickyBottomRef.current = true
       }
 
       setThreadScrolledUp(!atBottom)
@@ -344,13 +358,13 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     let pinRafScheduled = false
     const schedulePin = () => {
-      if (pinRafScheduled || !armedRef.current) {
+      if (pinRafScheduled || !stickyBottomRef.current) {
         return
       }
       pinRafScheduled = true
       requestAnimationFrame(() => {
         pinRafScheduled = false
-        if (armedRef.current) {
+        if (stickyBottomRef.current) {
           pinToBottom()
         }
       })
@@ -403,10 +417,10 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     if (!enabled) {
       return
     }
-    if (groupCount > prevGroupCountForLayoutRef.current && armedRef.current) {
+    if (groupCount > prevGroupCountForLayoutRef.current && stickyBottomRef.current) {
       pinToBottom()
       requestAnimationFrame(() => {
-        if (armedRef.current) {
+        if (stickyBottomRef.current) {
           pinToBottom()
         }
       })

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -8,6 +8,7 @@ import { setThreadScrolledUp } from '@/store/thread-scroll'
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
+const POST_RUN_BOTTOM_LOCK_MS = 1_200
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -438,6 +439,46 @@ function useThreadScrollAnchor({
     }
     prevGroupCountForLayoutRef.current = groupCount
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
+
+  // Completion swaps streaming placeholders/plain code for final rendered DOM
+  // (notably Shiki-highlighted code). Keep following the bottom briefly after
+  // `isRunning` flips false so that final measurement pass cannot strand the
+  // viewport near the top of a large code block.
+  const prevIsRunningForLayoutRef = useRef(isRunning)
+  useLayoutEffect(() => {
+    const finishedRun = prevIsRunningForLayoutRef.current && !isRunning
+    prevIsRunningForLayoutRef.current = isRunning
+
+    if (!enabled || !finishedRun || !stickyBottomRef.current) {
+      return undefined
+    }
+
+    const lockUntil = performance.now() + POST_RUN_BOTTOM_LOCK_MS
+    let lockRaf: number | null = null
+
+    const lockFrame = () => {
+      lockRaf = null
+
+      if (!stickyBottomRef.current) {
+        return
+      }
+
+      pinToBottom()
+
+      if (performance.now() < lockUntil) {
+        lockRaf = requestAnimationFrame(lockFrame)
+      }
+    }
+
+    pinToBottom()
+    lockRaf = requestAnimationFrame(lockFrame)
+
+    return () => {
+      if (lockRaf !== null) {
+        cancelAnimationFrame(lockRaf)
+      }
+    }
+  }, [enabled, isRunning, pinToBottom, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -13,6 +13,7 @@ import { useStore } from '@nanostores/react'
 import { IconPlayerStopFilled } from '@tabler/icons-react'
 import {
   type ClipboardEvent,
+  type ComponentProps,
   type FC,
   type FocusEvent,
   type FormEvent,
@@ -48,14 +49,13 @@ import { detectTrigger, textBeforeCaret, type TriggerState } from '@/app/chat/co
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import { extractDroppedFiles, HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
-import { DirectiveContent } from '@/components/assistant-ui/directive-text'
-import { UserMessageText } from '@/components/assistant-ui/user-message-text'
-import { hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
-import { MarkdownText } from '@/components/assistant-ui/markdown-text'
+import { DirectiveContent, hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
+import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { VirtualizedThread } from '@/components/assistant-ui/thread-virtualizer'
 import { HoistedTodoPanel, todosFromMessageContent } from '@/components/assistant-ui/todo-tool'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool-fallback'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { UserMessageText } from '@/components/assistant-ui/user-message-text'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { DisclosureRow } from '@/components/chat/disclosure-row'
@@ -446,17 +446,19 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
 
 const ReasoningTextPart: FC<{ text: string; status?: { type: string } }> = ({ text, status }) => {
   const displayText = text.trimStart()
+  const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  const isRunning = status?.type === 'running' || messageRunning
 
   return (
-    <div
-      className={cn(
-        'whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground/85',
-        status?.type === 'running' && 'shimmer text-muted-foreground/55'
+    <MarkdownTextContent
+      containerClassName={cn(
+        'text-xs leading-relaxed text-muted-foreground/85',
+        isRunning && 'shimmer text-muted-foreground/55'
       )}
-      data-slot="aui_reasoning-text"
-    >
-      {displayText}
-    </div>
+      containerProps={{ 'data-slot': 'aui_reasoning-text' } as ComponentProps<'div'>}
+      isRunning={isRunning}
+      text={displayText}
+    />
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -221,6 +221,7 @@ const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> 
   const messageStatus = useAuiState(s => s.message.status?.type)
   const isPlaceholder = messageStatus === 'running' && content.length === 0
   const interruptedOnly = useMemo(() => isInterruptedOnlyMessage(messageText), [messageText])
+  const enterRef = useEnterAnimation(messageStatus === 'running', `assistant-message:${messageId}`)
 
   if (isPlaceholder) {
     return null
@@ -231,6 +232,8 @@ const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> 
       className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
       data-role="assistant"
       data-slot="aui_assistant-message-root"
+      data-streaming={messageStatus === 'running' ? 'true' : undefined}
+      ref={enterRef}
     >
       <div
         className={cn(

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -64,7 +64,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   const label = cleanLanguage && cleanLanguage !== 'unknown' ? cleanLanguage : ''
 
   return (
-    <CodeCard>
+    <CodeCard data-streaming={defer ? 'true' : undefined}>
       <CodeCardHeader>
         <CodeCardTitle>
           <CodeCardIcon name={codiconForLanguage(label)} />

--- a/apps/desktop/src/lib/use-enter-animation.ts
+++ b/apps/desktop/src/lib/use-enter-animation.ts
@@ -81,10 +81,10 @@ export function useEnterAnimation(enabled: boolean, animationKey?: string): (el:
 
     el.animate(
       [
-        { opacity: 0, transform: 'translateY(0.5rem)' },
+        { opacity: 0, transform: 'translateY(0.375rem)' },
         { opacity: 1, transform: 'translateY(0)' }
       ],
-      { duration: 220, easing: 'linear', fill: 'both' }
+      { duration: 180, easing: 'cubic-bezier(0.16, 1, 0.3, 1)', fill: 'both' }
     )
 
     if (key) {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -916,6 +916,32 @@ canvas {
   margin-block: 0 !important;
 }
 
+[data-slot='aui_assistant-message-content'] .aui-md [data-slot='code-card'] {
+  position: relative;
+  transition:
+    border-color 180ms ease-out,
+    box-shadow 180ms ease-out,
+    background-color 180ms ease-out;
+}
+
+[data-slot='aui_assistant-message-content'] .aui-md [data-slot='code-card'][data-streaming='true'] {
+  animation:
+    code-card-stream-enter 180ms cubic-bezier(0.16, 1, 0.3, 1) both,
+    code-card-stream-glow 1.8s ease-in-out 180ms infinite alternate;
+  border-color: color-mix(in srgb, var(--dt-ring) 24%, var(--ui-stroke-tertiary));
+  box-shadow:
+    0 0 0 0.0625rem color-mix(in srgb, var(--dt-ring) 10%, transparent),
+    0 0.625rem 1.75rem color-mix(in srgb, var(--dt-ring) 8%, transparent);
+}
+
+[data-slot='aui_assistant-message-content']
+  .aui-md
+  [data-slot='code-card'][data-streaming='true']
+  [data-slot='code-card-body'] {
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, black calc(100% - 1.5rem), rgb(0 0 0 / 64%) 100%);
+  mask-image: linear-gradient(to bottom, black 0%, black calc(100% - 1.5rem), rgb(0 0 0 / 64%) 100%);
+}
+
 [data-slot='aui_assistant-message-content'] .aui-md :not(pre) > code {
   border: 0.0625rem solid var(--ui-inline-code-border);
   background: var(--ui-inline-code-background);
@@ -1037,4 +1063,38 @@ canvas {
 .thinking-preview {
   -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 28%, black 100%);
   mask-image: linear-gradient(to bottom, transparent 0%, black 28%, black 100%);
+}
+
+@keyframes code-card-stream-enter {
+  from {
+    opacity: 0.74;
+    transform: translateY(0.375rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes code-card-stream-glow {
+  from {
+    border-color: color-mix(in srgb, var(--dt-ring) 18%, var(--ui-stroke-tertiary));
+    box-shadow:
+      0 0 0 0.0625rem color-mix(in srgb, var(--dt-ring) 6%, transparent),
+      0 0.5rem 1.5rem color-mix(in srgb, var(--dt-ring) 5%, transparent);
+  }
+
+  to {
+    border-color: color-mix(in srgb, var(--dt-ring) 32%, var(--ui-stroke-tertiary));
+    box-shadow:
+      0 0 0 0.0625rem color-mix(in srgb, var(--dt-ring) 12%, transparent),
+      0 0.75rem 2rem color-mix(in srgb, var(--dt-ring) 10%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot='aui_assistant-message-content'] .aui-md [data-slot='code-card'][data-streaming='true'] {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

Two fixes for the Hermes Desktop composer:

### 1. IME composition Enter treated as message submission

**Bug:** When using Korean/Japanese/Chinese IME, pressing Enter to finalise composed (preedit) text fired `submitDraft()` because `handleEditorKeyDown` did not check `event.nativeEvent.isComposing`.

**Fix:** Added early return when `isComposing` is true at the top of `handleEditorKeyDown`. The `assistant-ui` hidden textarea handler already guards this correctly; the custom `contentEditable` handler was missing it.

**Repro:** Type in Korean IME, press Enter to confirm composition → message splits mid-word.

### 2. Viewport resize disarms scroll sticky-bottom anchor

**Bug:** When the composer expands/collapses (multi-line input) or the window resizes, the thread viewport height changes via `--thread-viewport-height`. The browser adjusts `scrollTop` to compensate, and the `onScroll` handler misread this `scrollTop` decrease as a user scroll-up, disarming `armedRef` and causing the view to jump.

**Fix:** Added `lastClientHeightRef` tracking. The disarm condition now requires ALL THREE to be true:
- `scrollHeight` did not grow this frame
- `clientHeight` did not grow this frame  
- `scrollTop` decreased

**Repro:** Type a long message (composer expands) or resize the window while scrolled to bottom → chat view jumps.

---

### Files changed
- `apps/desktop/src/app/chat/composer/index.tsx` — +6 lines (IME guard)
- `apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx` — +31/-14 lines (clientHeight tracking)

### Verification
- `tsc -b` passes cleanly
- `npm run build` succeeds
- Both fixes verified in the compiled bundle via string search