### PR TITLE
fix(gateway): decode schtasks output with locale encoding on Windows (#38172)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -29,6 +29,7 @@ Design notes
 from __future__ import annotations
 
 import ctypes
+import locale
 import os
 import re
 import shlex
@@ -50,6 +51,20 @@ _ACCESS_DENIED_PATTERN = re.compile(r"(access is denied|acceso denegado)", re.IG
 
 _TASK_NAME_DEFAULT = "Hermes_Gateway"
 _TASK_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+
+
+def _schtasks_encoding() -> str:
+    """Best-effort console encoding for decoding ``schtasks.exe`` output.
+
+    On localized Windows (e.g. Chinese), ``schtasks`` emits text in the OEM/ANSI
+    code page rather than UTF-8. Decoding with the wrong codec raised
+    ``UnicodeDecodeError`` inside ``subprocess``' reader threads. Prefer the
+    locale's preferred encoding and fall back to UTF-8.
+    """
+    try:
+        return locale.getpreferredencoding(False) or "utf-8"
+    except Exception:
+        return "utf-8"
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +127,12 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             [schtasks, *args],
             capture_output=True,
             text=True,
+            # Localized Windows emits schtasks output in the console code page,
+            # not UTF-8. Decode with the locale encoding and replace undecodable
+            # bytes so a non-UTF-8 status line never surfaces a UnicodeDecodeError
+            # traceback from subprocess' reader threads (issue #38172).
+            encoding=_schtasks_encoding(),
+            errors="replace",
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -29,6 +29,49 @@ def test_schtasks_fallback_does_not_hide_unknown_errors():
     assert gateway_windows._should_fall_back(1, "ERROR: The system cannot find the file specified.") is False
 
 
+def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
+    """A broken/empty locale must not leave us without a decoder (issue #38172)."""
+
+    monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", lambda *a, **k: "")
+    assert gateway_windows._schtasks_encoding() == "utf-8"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("locale exploded")
+
+    monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", _boom)
+    assert gateway_windows._schtasks_encoding() == "utf-8"
+
+
+def test_exec_schtasks_decodes_with_replace_errors(monkeypatch):
+    """schtasks output must be decoded with errors='replace' so localized
+    (non-UTF-8) bytes never surface a UnicodeDecodeError traceback (#38172)."""
+
+    captured: dict[str, object] = {}
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows.shutil, "which", lambda name: r"C:\\Windows\\System32\\schtasks.exe")
+    monkeypatch.setattr(gateway_windows.subprocess, "run", fake_run)
+
+    code, out, err = gateway_windows._exec_schtasks(["/Query", "/TN", "Hermes_Gateway"])
+
+    assert (code, out, err) == (0, "ok", "")
+    assert captured["errors"] == "replace", "schtasks output must decode with errors='replace'"
+    assert isinstance(captured["encoding"], str) and captured["encoding"], (
+        "an explicit non-empty encoding must be passed to subprocess.run"
+    )
+    assert captured["text"] is True
+
+
 def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, tmp_path):
     """Avoid uv's venv pythonw launcher because it respawns console python.exe."""
 


### PR DESCRIPTION
## Summary
`hermes gateway status`/`restart` on non-English Windows no longer spams `UnicodeDecodeError` tracebacks before the (correct) status output.

Root cause: `_exec_schtasks()` ran `schtasks.exe` with `text=True` and no explicit `encoding`, so the subprocess reader thread decoded output as UTF-8. On localized Windows (cp936/cp932/etc.) `schtasks` emits OEM-codepage bytes, which choke the UTF-8 decoder.

## Changes
- `hermes_cli/gateway_windows.py`: new `_schtasks_encoding()` helper (`locale.getpreferredencoding(False)`, falls back to `utf-8`); wired into the single `text=True` capture site in `_exec_schtasks` with `errors="replace"`.
- `tests/hermes_cli/test_gateway_windows.py`: covers the encoding fallback and that `errors="replace"` + an explicit encoding are passed.

## Validation
| | Before | After |
|---|---|---|
| cp936 schtasks output | UnicodeDecodeError traceback in reader thread | decoded with locale codepage, `errors="replace"` |
| broken/empty locale | n/a | falls back to `utf-8` |
| targeted tests | — | 31 passed |

Salvage of #38186 by @xxxigm — both commits cherry-picked onto current main with authorship preserved. Closes #38172.

## Infographic

![schtasks locale-safe decoding](https://v3b.fal.media/files/b/0a9cd4de/phfS1yKpp__nle3RNiQ7q_nLGRWNw3.png)
