### PR TITLE
feat(launchd): merge ~/.toolenv variables into generated plist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2863,6 +2863,42 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
+    # ── ~/.toolenv support ──────────────────────────────────────────────────
+    # launchd does not source shell init files (~/.zshrc, ~/.toolenv, etc.).
+    # Detect ~/.toolenv and merge exported variables into the plist so that
+    # API keys, tokens, and other user-level environment is available to the
+    # gateway process without manual plist editing.
+    toolenv_path = Path.home() / ".toolenv"
+    toolenv_vars: dict[str, str] = {}
+    if toolenv_path.is_file():
+        try:
+            text = toolenv_path.read_text(encoding="utf-8", errors="replace")
+            for line in text.splitlines():
+                line = line.strip()
+                # Match lines like: export FOO="bar"   or   export FOO=bar
+                if line.startswith("export "):
+                    rest = line[7:].strip()
+                    if "=" in rest:
+                        key, _, val = rest.partition("=")
+                        # Strip surrounding quotes
+                        val = val.strip().strip("'\"")
+                        if key.isidentifier():
+                            # Skip PATH (already explicitly set), HERMES_HOME,
+                            # VIRTUAL_ENV (managed by Hermes itself)
+                            if key not in ("PATH", "HERMES_HOME", "VIRTUAL_ENV"):
+                                # Expand $HOME since launchd doesn't go through a shell
+                                val = val.replace("$HOME", str(Path.home()))
+                                toolenv_vars[key] = val
+        except Exception:
+            pass  # Best-effort; don't crash plist generation over a read error
+
+    # Render toolenv variables as plist XML entries
+    toolenv_xml = ""
+    for key in sorted(toolenv_vars):
+        escaped_val = toolenv_vars[key].replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        toolenv_xml += f"        <key>{key}</key>\n"
+        toolenv_xml += f"        <string>{escaped_val}</string>\n"
+
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
         f"<string>{python_path}</string>",
@@ -2902,6 +2938,7 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+{toolenv_xml}
     </dict>
     
     <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary

launchd does not source shell init files (`~/.zshrc`, `~/.toolenv`, etc.), so API keys, tokens, and other user-level environment variables configured in `~/.toolenv` are invisible to the gateway process when started via launchctl.

This PR detects `~/.toolenv` during plist generation and merges all exported variables (except `PATH`, `VIRTUAL_ENV`, `HERMES_HOME` which Hermes already manages) into the plist's `EnvironmentVariables` dict.

`$HOME` is expanded to the real home directory path because launchd does not interpret shell variable references.

## Changes

- `hermes_cli/gateway.py`: In `generate_launchd_plist()`, after building the PATH, read `~/.toolenv`, parse `export KEY=VALUE` lines, and inject them as XML key/value entries in the plist.
- Filters out keys that Hermes already handles (`PATH`, `VIRTUAL_ENV`, `HERMES_HOME`).
- Expands `$HOME` references to the actual home path.
- Gracefully handles missing/invalid `.toolenv` (best-effort, silent fail).

## Testing

- Verified `generate_launchd_plist()` produces valid XML with toolenv variables merged.
- Verified on macOS 15 (Sequoia) that the gateway starts successfully via launchd with `FREELMAPI_API_KEY`, `MCP_API_KEY`, etc. available to the process.
- No regressions: when `~/.toolenv` does not exist, behavior is identical to before (no toolenv entries in plist).
