### PR TITLE
fix(banner): invalidate update-check cache when local HEAD moves

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -225,11 +225,29 @@ def check_for_updates() -> Optional[int]:
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check. The version guard matters for pip installs:
-    # `check_via_pypi()` compares against VERSION, so a `pip install --upgrade`
-    # changes VERSION but leaves rev unchanged (both None), and without this
-    # the stale "behind" count would survive the upgrade for up to 6h. See #34491.
+    # Resolve repo_dir + local_head up front so the cache key can invalidate
+    # when the local checkout's HEAD moves (e.g. after a successful
+    # `git pull`/rebase). Without this guard the cache survives for up to 6h
+    # and prints a stale "behind" count even though the local checkout is
+    # now caught up.
+    repo_dir: Optional[Path] = None
+    local_head: Optional[str] = None
+    if not embedded_rev:
+        # Prefer the running code's location over the profile-scoped path.
+        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
+        # Path(__file__) always resolves to the actual installed checkout.
+        repo_dir = Path(__file__).parent.parent.resolve()
+        if not (repo_dir / ".git").exists():
+            repo_dir = hermes_home / "hermes-agent"
+        if (repo_dir / ".git").exists():
+            local_head = _git_short_hash(repo_dir, "HEAD")
+
+    # Read cache — invalidate if the embedded rev, installed version, OR
+    # local HEAD has changed since the last check. The version guard matters
+    # for pip installs: `check_via_pypi()` compares against VERSION, so a
+    # `pip install --upgrade` changes VERSION but leaves rev unchanged (both
+    # None), and without this the stale "behind" count would survive the
+    # upgrade for up to 6h. See #34491.
     now = time.time()
     try:
         if cache_file.exists():
@@ -238,6 +256,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("head") == local_head
             ):
                 return cached.get("behind")
     except Exception:
@@ -245,21 +264,20 @@ def check_for_updates() -> Optional[int]:
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
+    elif repo_dir is not None and (repo_dir / ".git").exists():
+        behind = _check_via_local_git(repo_dir)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            behind = check_via_pypi()
-        else:
-            behind = _check_via_local_git(repo_dir)
+        behind = check_via_pypi()
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
+            json.dumps({
+                "ts": now,
+                "behind": behind,
+                "rev": embedded_rev,
+                "ver": VERSION,
+                "head": local_head,
+            })
         )
     except Exception:
         pass


### PR DESCRIPTION
## Summary

`hermes_cli/banner.py:check_for_updates()` writes a 6h cache file at `~/.hermes/.update_check` and keys it on `(HERMES_REVISION, VERSION, ts)`. None of those change after a successful `git pull`/rebase, so the cache survives for up to 6 hours and `hermes --version` keeps reporting the pre-pull "Update available: N commits behind" even when the local checkout is now caught up.

## Fix

Add the local short HEAD hash to both the cache write and the read-invalidation condition. For pip installs (no local HEAD) the value is `None` and the cache key collapses back to the original `(rev, ver)` pair, preserving the #34491 fix.

While moving the HEAD resolution out of the cache block, also flattened the embedded-rev / git / pypi dispatch into a single `if/elif/else` so `repo_dir` is resolved once at the top.

## Repro

```bash
# 1. fall behind upstream by 38 commits
git checkout ecac659d7    # 38 commits behind origin/main
./hermes --version        # writes cache: behind=38, head=ecac659d7

# 2. catch up
git pull --rebase origin main   # HEAD now efccb7001
./hermes --version        # BEFORE fix: still says "38 commits behind"
                          # AFTER  fix: writes cache: behind=0, head=efccb7001
```

The repro's "Update available: 38 commits behind" survives up to 6h today; with this patch it disappears the moment HEAD moves.

## Test plan

- [ ] Existing `tests/hermes_cli/test_cmd_update.py` (25 cases) still passes — verified locally.
- [ ] Manual: with cache primed at `behind=N, head=H1`, run a no-op commit, run `hermes --version`, confirm cache file is rewritten (`ts` advanced, `head` updated to H2).
- [ ] Manual: with no local git checkout (pip install), confirm `head` is `null` in the cache and invalidation still works via `rev`/`ver` changes only.