### PR TITLE
fix(bluebubbles): parse nested auth-key group webhooks

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -964,17 +964,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             payload.get("chat_guid"),
             payload.get("guid"),
         )
-        # Fallback: BlueBubbles v1.9+ webhook payloads omit top-level chatGuid;
-        # the chat GUID is nested under data.chats[0].guid instead.
-        if not chat_guid:
-            _chats = record.get("chats") or []
-            if _chats and isinstance(_chats[0], dict):
-                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        # Fallback: BlueBubbles v1.9+ webhook payloads often omit top-level
+        # chatGuid/chatIdentifier. The chat identity is nested under
+        # data.chats[0]; for group chats the stable routing GUID may appear as
+        # the private-api "[auth-key]" (for example: any;+;<group-id>).
+        _chats = record.get("chats") or []
+        _first_chat = _chats[0] if _chats and isinstance(_chats[0], dict) else {}
+        if not chat_guid and _first_chat:
+            chat_guid = self._value(
+                _first_chat.get("guid"),
+                _first_chat.get("chatGuid"),
+                _first_chat.get("[auth-key]"),
+            )
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),
             payload.get("chatIdentifier"),
             payload.get("identifier"),
+            _first_chat.get("chatIdentifier"),
+            _first_chat.get("identifier"),
+            _first_chat.get("displayName"),
         )
         sender = (
             self._value(
@@ -994,7 +1003,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.json_response({"error": "missing message fields"}, status=400)
 
         session_chat_id = chat_guid or chat_identifier
-        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        is_group = (
+            bool(record.get("isGroup"))
+            or (";+;" in (chat_guid or ""))
+            or any(
+                isinstance(chat, dict) and int(chat.get("style") or 0) >= 43
+                for chat in _chats
+            )
+        )
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug(

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -10,6 +10,7 @@ from gateway.config import Platform, PlatformConfig
 def _make_adapter(monkeypatch, **extra):
     monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
     monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    monkeypatch.delenv("BLUEBUBBLES_MENTION_PATTERNS", raising=False)
     from gateway.platforms.bluebubbles import BlueBubblesAdapter
 
     cfg = PlatformConfig(
@@ -261,6 +262,81 @@ class TestBlueBubblesMentionGating:
 
         assert response.status == 200
         assert [event.text for event in handled] == ["hello from a dm"]
+
+    @pytest.mark.asyncio
+    async def test_group_auth_key_payload_without_mention_is_skipped(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-auth-key-1",
+                "text": "casual family chatter",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chats": [
+                    {
+                        "[auth-key]": "any;+;family-group",
+                        "style": 43,
+                        "chatIdentifier": "family-group",
+                        "displayName": "Family",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_group_auth_key_payload_with_mention_uses_group_source(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-auth-key-2",
+                "text": "Hermes summarize this",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chats": [
+                    {
+                        "[auth-key]": "any;+;family-group",
+                        "style": 43,
+                        "chatIdentifier": "family-group",
+                        "displayName": "Family",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "summarize this"
+        assert event.source.chat_id == "any;+;family-group"
+        assert event.source.chat_id_alt == "family-group"
+        assert event.source.chat_type == "group"
 
 
 class TestBlueBubblesWebhookParsing:


### PR DESCRIPTION
## Summary

- handle BlueBubbles group webhook payloads whose stable chat GUID is nested under `data.chats[0]["[auth-key]"]`
- use nested `chatIdentifier` / `identifier` / `displayName` as fallback chat identifiers
- treat BlueBubbles `style >= 43` as group evidence for mention gating
- add regression tests that replay the sanitized payload through `_handle_webhook()`
- isolate BlueBubbles tests from ambient `BLUEBUBBLES_MENTION_PATTERNS` env

## Why

This covers a payload shape not handled by the existing `chats[0].guid` fallback from #8514 / #9806. Without it, Hermes can lose group chat identity and treat a group webhook as a DM.

Fixes #38339.

## Test plan

```text
/Users/amosclaw/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_bluebubbles.py -o addopts= -q
58 passed in 0.51s

git diff --check
```
