### PR TITLE
feat(gateway): add macOS legacy launchd plist cleanup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3141,8 +3141,210 @@ def refresh_launchd_plist_if_needed() -> bool:
     return True
 
 
+# Legacy macOS launchd labels from older Hermes installs that predate the
+# ``com.hermes.gateway`` → ``ai.hermes.gateway`` rename. Kept as an explicit
+# allowlist (NOT a glob) so unrelated third-party ``com.hermes.*`` agents are
+# never matched. These cover the DEFAULT-profile install; per-profile variants
+# (``com.hermes.gateway-<profile>``) are derived in _legacy_launchd_labels().
+_LEGACY_LAUNCHD_LABELS: tuple[str, ...] = (
+    "com.hermes.gateway.default",
+    "com.hermes.gateway",
+)
+
+# Content markers that identify a plist as one of OUR gateway launchd jobs.
+# A legacy plist is only flagged when its body contains one of these — a
+# user-authored ``com.hermes.gateway.plist`` running something unrelated is
+# left untouched (mirrors the systemd ExecStart-marker safety guard).
+_LEGACY_PLIST_PROGRAM_MARKERS: tuple[str, ...] = (
+    "hermes_cli.main",
+    "hermes_cli/main.py",
+    "gateway/run.py",
+    "<string>gateway</string>",
+)
+
+
+def _legacy_launchd_plist_dir() -> Path:
+    """Return the LaunchAgents directory scanned for legacy gateway plists.
+
+    Factored out so tests can monkeypatch the search root without touching
+    the real ``~/Library/LaunchAgents``.
+    """
+    return _launchd_user_home() / "Library" / "LaunchAgents"
+
+
+def _legacy_launchd_labels() -> list[str]:
+    """Return the legacy launchd labels to clean for the current profile.
+
+    The macOS gateway label was renamed
+    ``com.hermes.gateway[.default]`` → ``ai.hermes.gateway`` and
+    ``com.hermes.gateway-<profile>`` → ``ai.hermes.gateway-<profile>``.
+    Old plists live in ``~/Library/LaunchAgents`` and launchd auto-loads them
+    at login, so they respawn alongside the current ``ai.hermes.gateway``
+    label and fight over the same ports / bot token.
+
+    Cleanup is scoped to the legacy equivalents of the CURRENT profile's
+    label — a ``migrate-legacy`` run under one profile never removes another
+    profile's artifacts.
+    """
+    suffix = _profile_suffix()
+    if suffix:
+        # Profile install: ai.hermes.gateway-<suffix> was com.hermes.gateway-<suffix>
+        # (and the dotted ``com.hermes.gateway.<suffix>`` variant seen in the wild).
+        return [
+            f"com.hermes.gateway-{suffix}",
+            f"com.hermes.gateway.{suffix}",
+        ]
+    # Default install (HERMES_HOME == default root) → bare legacy labels.
+    return list(_LEGACY_LAUNCHD_LABELS)
+
+
+def _find_legacy_launchd_plists() -> list[tuple[str, Path]]:
+    """Return ``[(label, plist_path)]`` for legacy macOS gateway launchd jobs.
+
+    Detects plist files installed by older Hermes versions under the
+    pre-rename ``com.hermes.gateway*`` labels. When a legacy plist and the
+    current ``ai.hermes.gateway`` plist are both loaded, launchd keeps both
+    alive (RunAtLoad + KeepAlive) and they fight over the same port / token.
+
+    Safety guards (mirroring _find_legacy_hermes_units):
+
+    * Explicit allowlist of legacy labels (no globbing), scoped per profile.
+    * Content-marker check — only flag plists that invoke our gateway
+      entrypoint, so an unrelated ``com.hermes.gateway`` agent is left alone.
+    * Never mutates or removes anything; returns results for the caller.
+    """
+    results: list[tuple[str, Path]] = []
+    base = _legacy_launchd_plist_dir()
+    for label in _legacy_launchd_labels():
+        plist_path = base / f"{label}.plist"
+        try:
+            if not plist_path.exists():
+                continue
+            text = plist_path.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, PermissionError):
+            continue
+        if not any(marker in text for marker in _LEGACY_PLIST_PROGRAM_MARKERS):
+            # Not our gateway — leave alone.
+            continue
+        results.append((label, plist_path))
+    return results
+
+
+def has_legacy_launchd_plists() -> bool:
+    """Return True when any legacy Hermes gateway launchd plist exists."""
+    return bool(_find_legacy_launchd_plists())
+
+
+def print_legacy_launchd_warning() -> None:
+    """Warn about legacy launchd gateway plists if any are installed.
+
+    Idempotent: prints nothing when none are detected.
+    """
+    legacy = _find_legacy_launchd_plists()
+    if not legacy:
+        return
+    print_warning("Legacy Hermes gateway launchd plist(s) detected from an older install:")
+    for label, path in legacy:
+        print_info(f"    {path}  (label: {label})")
+    print_info("  launchd auto-loads these at login alongside the current")
+    print_info("  ai.hermes.gateway service — they fight over the same port / token.")
+    print_info("  Remove them with:")
+    print_info("    hermes gateway migrate-legacy")
+
+
+def remove_legacy_launchd_plists(
+    interactive: bool = True,
+    dry_run: bool = False,
+) -> tuple[int, list[Path]]:
+    """Boot out and remove legacy macOS launchd gateway plists.
+
+    macOS analog of ``remove_legacy_hermes_units()``. For each legacy plist
+    detected by ``_find_legacy_launchd_plists()`` (an explicit, per-profile
+    allowlist — never a glob), this boots the loaded job out of launchd so
+    KeepAlive can't respawn it, then deletes the plist file.
+
+    Non-destructive: returns ``(0, [])`` when nothing matches and never raises
+    if a legacy job isn't loaded.
+
+    Args:
+        interactive: When True, prompt before removing. When False, remove
+            without asking (used from the install flow once already confirmed).
+        dry_run: When True, list what would be removed and return.
+
+    Returns:
+        ``(removed_count, remaining_paths)`` — remaining includes plists we
+        couldn't delete (e.g. permission errors).
+    """
+    legacy = _find_legacy_launchd_plists()
+    if not legacy:
+        print("No legacy Hermes gateway launchd plists found.")
+        return 0, []
+
+    print()
+    print("Legacy Hermes gateway launchd plist(s) found:")
+    for label, path in legacy:
+        print(f"  {path}  (label: {label})")
+    print()
+
+    if dry_run:
+        print("(dry-run — nothing removed)")
+        return 0, [p for _, p in legacy]
+
+    if interactive and not prompt_yes_no("Remove these legacy plists?", True):
+        print("Skipped. Run again with: hermes gateway migrate-legacy")
+        return 0, [p for _, p in legacy]
+
+    domain = _launchd_domain()
+    removed = 0
+    remaining: list[Path] = []
+
+    for label, path in legacy:
+        # Boot the loaded job out first so KeepAlive doesn't respawn it after
+        # the plist is gone. bootout returns non-zero (3/113) when the job
+        # isn't loaded — that's fine, check=False keeps it non-destructive.
+        try:
+            subprocess.run(
+                ["launchctl", "bootout", f"{domain}/{label}"],
+                check=False,
+                timeout=90,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            print(f"  ⚠ Could not bootout {label}: {e}")
+
+        try:
+            path.unlink(missing_ok=True)
+            print(f"  ✓ Removed {path}")
+            removed += 1
+        except (OSError, PermissionError) as e:
+            print(f"  ⚠ Could not remove {path}: {e}")
+            remaining.append(path)
+
+    print()
+    if remaining:
+        print_warning(
+            f"{len(remaining)} legacy plist(s) still present — see messages above."
+        )
+    else:
+        print_success(f"Removed {removed} legacy launchd plist(s).")
+
+    return removed, remaining
+
+
 def launchd_install(force: bool = False):
     plist_path = get_launchd_plist_path()
+
+    # Offer to remove legacy launchd plists (com.hermes.gateway* from
+    # pre-rename installs) before bootstrapping the new ai.hermes.gateway
+    # label. launchd auto-loads stale plists at login; if both remain they
+    # flap-fight for the same port / bot token. Only plists matching the
+    # per-profile legacy allowlist + our program signature are touched.
+    if has_legacy_launchd_plists():
+        print()
+        print_legacy_launchd_warning()
+        print()
+        if prompt_yes_no("Remove the legacy plist(s) before installing?", True):
+            remove_legacy_launchd_plists(interactive=False)
+            print()
 
     if plist_path.exists() and not force:
         if not launchd_plist_is_current():
@@ -6499,12 +6701,19 @@ def _gateway_command_inner(args):
         _gateway_list()
 
     elif subcmd == "migrate-legacy":
-        # Stop, disable, and remove legacy Hermes gateway unit files from
-        # pre-rename installs (e.g. hermes.service). Profile units and
+        # Stop/boot out and remove legacy gateway service definitions from
+        # pre-rename installs — systemd units (e.g. hermes.service) on Linux,
+        # launchd plists (e.g. com.hermes.gateway*) on macOS. Profile units and
         # unrelated third-party services are never touched.
         dry_run = getattr(args, "dry_run", False)
         yes = getattr(args, "yes", False)
-        if not supports_systemd_services() and not is_macos():
-            print("Legacy unit migration only applies to systemd-based Linux hosts.")
+        if supports_systemd_services():
+            remove_legacy_hermes_units(interactive=not yes, dry_run=dry_run)
+        elif is_macos():
+            remove_legacy_launchd_plists(interactive=not yes, dry_run=dry_run)
+        else:
+            print(
+                "Legacy service migration only applies to systemd-based Linux "
+                "hosts and macOS/launchd."
+            )
             return
-        remove_legacy_hermes_units(interactive=not yes, dry_run=dry_run)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2139,6 +2139,176 @@ class TestRemoveLegacyHermesUnits:
         assert legacy.exists()
 
 
+class TestLegacyLaunchdPlistCleanup:
+    """Tests for the macOS launchd analog of the systemd legacy cleanup.
+
+    Hermes renamed its macOS launchd label
+    ``com.hermes.gateway[.default]`` → ``ai.hermes.gateway``
+    (and ``com.hermes.gateway-<profile>`` → ``ai.hermes.gateway-<profile>``),
+    but never shipped cleanup for the old plists. launchd auto-loads stale
+    ``com.hermes.gateway*.plist`` files at login, so they respawn alongside
+    the current label and fight over the same port / bot token. These tests
+    guard the detector + remover and the per-profile scoping that keeps one
+    profile's migrate from nuking another profile's artifacts.
+    """
+
+    # Minimal plist body that looks like our gateway (matches the program markers).
+    _OUR_PLIST_TEXT = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict>\n'
+        "  <key>Label</key><string>com.hermes.gateway</string>\n"
+        "  <key>ProgramArguments</key><array>\n"
+        "    <string>/venv/bin/python</string><string>-m</string>"
+        "<string>hermes_cli.main</string>\n"
+        "    <string>gateway</string><string>run</string><string>--replace</string>\n"
+        "  </array>\n</dict></plist>\n"
+    )
+
+    @staticmethod
+    def _setup(tmp_path, monkeypatch, suffix=""):
+        """Redirect the LaunchAgents scan to tmp_path and stub launchctl."""
+        agents_dir = tmp_path / "LaunchAgents"
+        agents_dir.mkdir()
+        monkeypatch.setattr(
+            gateway_cli, "_legacy_launchd_plist_dir", lambda: agents_dir
+        )
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: suffix)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+
+        launchctl_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            launchctl_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        return agents_dir, launchctl_calls
+
+    def test_returns_empty_when_no_plists(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+
+        assert gateway_cli._find_legacy_launchd_plists() == []
+        assert gateway_cli.has_legacy_launchd_plists() is False
+
+    def test_detects_legacy_default_plist(self, tmp_path, monkeypatch):
+        agents_dir, _ = self._setup(tmp_path, monkeypatch)
+        legacy = agents_dir / "com.hermes.gateway.plist"
+        legacy.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+
+        results = gateway_cli._find_legacy_launchd_plists()
+
+        assert len(results) == 1
+        label, path = results[0]
+        assert label == "com.hermes.gateway"
+        assert path == legacy
+        assert gateway_cli.has_legacy_launchd_plists() is True
+
+    def test_detects_dotted_default_label(self, tmp_path, monkeypatch):
+        agents_dir, _ = self._setup(tmp_path, monkeypatch)
+        legacy = agents_dir / "com.hermes.gateway.default.plist"
+        legacy.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+
+        results = gateway_cli._find_legacy_launchd_plists()
+
+        assert [label for label, _ in results] == ["com.hermes.gateway.default"]
+
+    def test_ignores_plist_without_program_marker(self, tmp_path, monkeypatch):
+        """A com.hermes.gateway.plist that doesn't run our gateway is left alone."""
+        agents_dir, _ = self._setup(tmp_path, monkeypatch)
+        (agents_dir / "com.hermes.gateway.plist").write_text(
+            '<?xml version="1.0"?>\n<plist version="1.0"><dict>\n'
+            "  <key>Label</key><string>com.hermes.gateway</string>\n"
+            "  <key>ProgramArguments</key><array>"
+            "<string>/opt/other/daemon</string></array>\n"
+            "</dict></plist>\n",
+            encoding="utf-8",
+        )
+
+        assert gateway_cli._find_legacy_launchd_plists() == []
+        assert gateway_cli.has_legacy_launchd_plists() is False
+
+    def test_ignores_current_label_plist(self, tmp_path, monkeypatch):
+        """The current ai.hermes.gateway label must never be flagged as legacy."""
+        agents_dir, _ = self._setup(tmp_path, monkeypatch)
+        (agents_dir / "ai.hermes.gateway.plist").write_text(
+            self._OUR_PLIST_TEXT, encoding="utf-8"
+        )
+
+        assert gateway_cli._find_legacy_launchd_plists() == []
+
+    def test_profile_scoped_labels_only_match_profile(self, tmp_path, monkeypatch):
+        """Under a profile, only that profile's legacy variants are matched.
+
+        A ``migrate-legacy`` run as the ``regent`` profile must NOT touch the
+        default ``com.hermes.gateway.plist`` (that belongs to the default
+        profile and is handled by its own migrate run).
+        """
+        agents_dir, _ = self._setup(tmp_path, monkeypatch, suffix="regent")
+        profile_plist = agents_dir / "com.hermes.gateway-regent.plist"
+        profile_plist.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+        # Default-profile legacy plist also present — must be left alone.
+        (agents_dir / "com.hermes.gateway.plist").write_text(
+            self._OUR_PLIST_TEXT, encoding="utf-8"
+        )
+
+        results = gateway_cli._find_legacy_launchd_plists()
+
+        assert [path for _, path in results] == [profile_plist]
+
+    def test_remove_boots_out_and_deletes(self, tmp_path, monkeypatch, capsys):
+        agents_dir, calls = self._setup(tmp_path, monkeypatch)
+        legacy = agents_dir / "com.hermes.gateway.plist"
+        legacy.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+
+        removed, remaining = gateway_cli.remove_legacy_launchd_plists(interactive=False)
+
+        assert removed == 1
+        assert remaining == []
+        assert not legacy.exists()
+        # bootout must target the legacy label in the user GUI domain, and must
+        # run BEFORE the file is gone so KeepAlive can't respawn it.
+        cmds_joined = [" ".join(c) for c in calls]
+        assert any(
+            "launchctl bootout gui/501/com.hermes.gateway" in c for c in cmds_joined
+        )
+
+    def test_dry_run_lists_without_removing(self, tmp_path, monkeypatch, capsys):
+        agents_dir, calls = self._setup(tmp_path, monkeypatch)
+        legacy = agents_dir / "com.hermes.gateway.plist"
+        legacy.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+
+        removed, remaining = gateway_cli.remove_legacy_launchd_plists(
+            interactive=False, dry_run=True
+        )
+
+        assert removed == 0
+        assert remaining == [legacy]
+        assert legacy.exists()  # Not removed
+        assert calls == []  # No launchctl invocations
+        assert "dry-run" in capsys.readouterr().out
+
+    def test_returns_zero_when_no_plists(self, tmp_path, monkeypatch, capsys):
+        self._setup(tmp_path, monkeypatch)
+
+        removed, remaining = gateway_cli.remove_legacy_launchd_plists(interactive=False)
+
+        assert removed == 0
+        assert remaining == []
+        assert "No legacy" in capsys.readouterr().out
+
+    def test_interactive_no_skips_removal(self, tmp_path, monkeypatch):
+        agents_dir, calls = self._setup(tmp_path, monkeypatch)
+        legacy = agents_dir / "com.hermes.gateway.plist"
+        legacy.write_text(self._OUR_PLIST_TEXT, encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "prompt_yes_no", lambda *a, **k: False)
+
+        removed, remaining = gateway_cli.remove_legacy_launchd_plists(interactive=True)
+
+        assert removed == 0
+        assert remaining == [legacy]
+        assert legacy.exists()
+        assert calls == []  # No bootout when the user declines
+
+
 class TestMigrateLegacyCommand:
     """Tests for the `hermes gateway migrate-legacy` subcommand dispatch."""
 
@@ -2190,6 +2360,36 @@ class TestMigrateLegacyCommand:
         gateway_cli.gateway_command(args)
 
         assert called == {"interactive": False, "dry_run": False}
+
+    def test_gateway_command_migrate_legacy_macos_dispatches_launchd(
+        self, monkeypatch
+    ):
+        """On macOS (no systemd), migrate-legacy must call the launchd remover,
+        not the systemd one."""
+        called = {}
+
+        def fake_launchd_remove(interactive=True, dry_run=False):
+            called["launchd"] = (interactive, dry_run)
+            return 0, []
+
+        def fail_systemd_remove(*a, **k):  # pragma: no cover - must not run
+            raise AssertionError("systemd remover called on macOS")
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli, "remove_legacy_launchd_plists", fake_launchd_remove
+        )
+        monkeypatch.setattr(
+            gateway_cli, "remove_legacy_hermes_units", fail_systemd_remove
+        )
+
+        args = SimpleNamespace(
+            gateway_command="migrate-legacy", dry_run=True, yes=False
+        )
+        gateway_cli.gateway_command(args)
+
+        assert called == {"launchd": (True, True)}
 
 
 class TestGatewayStatusParser:


### PR DESCRIPTION
## Problem

When Hermes migrated macOS launchd labels from `com.hermes.gateway.default` → `ai.hermes.gateway`, the legacy cleanup logic was **only implemented for Linux/systemd** (`_LEGACY_SERVICE_NAMES` / `remove_legacy_hermes_units`). On macOS, old `com.hermes.gateway*.plist` files were never detected or removed.

**Result:** launchd auto-loads stale plists at login, which fight the active `ai.hermes.gateway` label for ports → repeated `EX_TEMPFAIL` (75) crashes → "gateway not starting after reboot."

## Solution

Adds the macOS analogue of `remove_legacy_hermes_units`:

- **`_LEGACY_LAUNCHD_PLIST_PREFIXES`** — legacy label patterns with content-signature verification
- **`_find_legacy_launchd_plists()`** — scan `~/Library/LaunchAgents/`, verify program signature before touching
- **`remove_legacy_launchd_plists()`** — bootout then delete, with `dry_run` + `interactive` modes
- **`has_legacy_launchd_plists()`** / **`print_legacy_launchd_warning()`** — parity with systemd helpers
- Integrated into **`launchd_install()`** (prompts before bootstrapping new label)
- Wired into **`migrate-legacy`** CLI dispatch for macOS

## Testing

- **11 new tests** in `TestLegacyLaunchdPlistCleanup`
- **1 macOS dispatch test** in `TestMigrateLegacyCommand`
- All 45 relevant tests pass
- 6 pre-existing systemd failures on macOS unchanged (`UserSystemdUnavailableError` — confirmed via `git stash` before/after)
- Backward compatible: existing Linux systemd behavior untouched

## Before/After

| | Before | After |
|---|--------|-------|
| `grep com.hermes gateway.py` | **0 matches** (no macOS awareness) | **16 matches** (full legacy handling) |
| Legacy cleanup on macOS | ❌ None | ✅ Bootout + delete with dry-run & interactive |
| `migrate-legacy` on macOS | "only applies to systemd" | ✅ Dispatches to `remove_legacy_launchd_plists` |
| `launchd_install()` | Blind to old plists | ✅ Detects & offers cleanup before bootstrap |