### PR TITLE
fix(banner): measure update-check distance against 'upstream' when present

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -144,11 +144,37 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _detect_canonical_remote(repo_dir: Path) -> str:
+    """Return ``'upstream'`` if that remote is configured, else ``'origin'``.
+
+    Mirrors the fork-aware convention used by ``cmd_update`` so the
+    update-check banner measures distance to the canonical source rather
+    than to the user's own fork. See issue #26172.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "upstream"],
+            capture_output=True, text=True, timeout=2,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return "upstream"
+    except Exception:
+        pass
+    return "origin"
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
+    """Count commits behind the canonical remote's ``main`` branch.
+
+    Prefers the ``upstream`` remote when present (typical fork layout) so
+    the count measures distance to the canonical source; falls back to
+    ``origin`` otherwise.
+    """
+    remote = _detect_canonical_remote(repo_dir)
     try:
         subprocess.run(
-            ["git", "fetch", "origin", "--quiet"],
+            ["git", "fetch", remote, "--quiet"],
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
@@ -157,7 +183,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
 
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            ["git", "rev-list", "--count", f"HEAD..{remote}/main"],
             capture_output=True, text=True, timeout=5,
             cwd=str(repo_dir),
         )
@@ -215,7 +241,8 @@ def check_for_updates() -> Optional[int]:
 
     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
     it to upstream main via ``git ls-remote``. Otherwise look for a local
-    git checkout and count commits behind ``origin/main``.
+    git checkout and count commits behind the canonical remote's main
+    (``upstream`` if configured, ``origin`` otherwise).
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if

--- a/tests/hermes_cli/test_banner_upstream_remote.py
+++ b/tests/hermes_cli/test_banner_upstream_remote.py
@@ -1,0 +1,109 @@
+"""Regression: the update check must measure against the canonical remote.
+
+Without the fix, ``_check_via_local_git`` hard-codes ``origin`` for both
+``git fetch`` and the ``rev-list`` reference. For users on a fork (where
+``origin`` is their own clone), this measures "behind" against the
+fork's main rather than the canonical source — the fork is normally
+0–3 commits ahead of local, so the "Update available: N commits behind"
+banner was permanently misleading.
+
+See: ``hermes_cli/banner.py:_check_via_local_git``,
+``hermes_cli/banner.py:_detect_canonical_remote``.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+from hermes_cli import banner
+
+
+def _init_repo_with_remotes(path, remotes: dict[str, str]) -> None:
+    """Create a fresh git repo with the given remotes (name → url)."""
+    path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    for name, url in remotes.items():
+        subprocess.run(
+            ["git", "remote", "add", name, url],
+            cwd=path, check=True,
+        )
+
+
+class TestDetectCanonicalRemote:
+    """The update check should measure against the canonical remote, not a fork."""
+
+    def test_returns_upstream_when_present(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo_with_remotes(repo, {
+            "origin": "https://github.com/me/fork.git",
+            "upstream": "https://github.com/NousResearch/hermes-agent.git",
+        })
+        assert banner._detect_canonical_remote(repo) == "upstream"
+
+    def test_falls_back_to_origin_when_no_upstream(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo_with_remotes(repo, {
+            "origin": "https://github.com/NousResearch/hermes-agent.git",
+        })
+        assert banner._detect_canonical_remote(repo) == "origin"
+
+    def test_returns_origin_when_not_a_git_repo(self, tmp_path):
+        """A directory with no .git must not crash; default to 'origin'."""
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        assert banner._detect_canonical_remote(plain) == "origin"
+
+    def test_returns_upstream_when_only_upstream(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo_with_remotes(repo, {
+            "upstream": "https://github.com/NousResearch/hermes-agent.git",
+        })
+        assert banner._detect_canonical_remote(repo) == "upstream"
+
+
+class TestCheckViaLocalGitUsesCanonicalRemote:
+    """_check_via_local_git must fetch+rev-list the canonical remote.
+
+    These tests pin the *contract* between _check_via_local_git and
+    _detect_canonical_remote: the former must use whatever remote name
+    the latter returns. The detector itself is covered by
+    TestDetectCanonicalRemote above.
+    """
+
+    def test_fetches_upstream_when_canonical_is_upstream(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo_with_remotes(repo, {
+            "origin": "https://github.com/me/fork.git",
+            "upstream": "https://github.com/NousResearch/hermes-agent.git",
+        })
+
+        with patch.object(banner, "_detect_canonical_remote", return_value="upstream"), \
+             patch.object(banner.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="0\n", stderr="",
+            )
+            banner._check_via_local_git(repo)
+
+        calls = [" ".join(str(c) for c in c.args[0]) for c in mock_run.call_args_list]
+        assert any("fetch" in c and "upstream" in c for c in calls), calls
+        assert any("rev-list" in c and "upstream/main" in c for c in calls), calls
+        # No fetch/rev-list against origin in this scenario.
+        assert not any("fetch" in c and " origin" in c for c in calls), calls
+        assert not any("rev-list" in c and "origin/main" in c for c in calls), calls
+
+    def test_falls_back_to_origin_when_canonical_is_origin(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo_with_remotes(repo, {
+            "origin": "https://github.com/NousResearch/hermes-agent.git",
+        })
+
+        with patch.object(banner, "_detect_canonical_remote", return_value="origin"), \
+             patch.object(banner.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="0\n", stderr="",
+            )
+            banner._check_via_local_git(repo)
+
+        calls = [" ".join(str(c) for c in c.args[0]) for c in mock_run.call_args_list]
+        assert any("fetch" in c and " origin" in c for c in calls), calls
+        assert any("rev-list" in c and "origin/main" in c for c in calls), calls
+        assert not any("upstream" in c for c in calls), calls


### PR DESCRIPTION
## Summary

`hermes_cli/banner.py:_check_via_local_git()` was hard-coded to use `origin` for both the `git fetch` and the `rev-list` reference. For users on a fork (where `origin` points to their own clone), this measured "behind" against their own fork's main rather than the canonical source — the fork is normally 0–3 commits ahead of local, so the "Update available: N commits behind" message was permanently misleading.

## Fix

Add a `_detect_canonical_remote()` helper that returns `upstream` when that remote is configured, else `origin`, and use it in `_check_via_local_git`. The fork-aware convention mirrors what `cmd_update` already does (`_has_upstream_remote`, `_sync_with_upstream_if_needed`) so the update-check banner and the `hermes update` flow now agree on what "behind" means for fork users.

The detection is purely a `git remote get-url upstream` existence check, matching the rest of the codebase; we don't try to validate the URL against `OFFICIAL_REPO_URLS` because if a user named a remote `upstream` they presumably did so with intent.

## Repro

```bash
# On a fork: origin = my fork, upstream = NousResearch/hermes-agent
git remote add upstream https://github.com/NousResearch/hermes-agent.git
# HEAD is 1 behind upstream/main, 3 behind origin/main (fork)

./hermes --version
# BEFORE fix: "Update available: 3 commits behind"   (measured to fork)
# AFTER  fix: "Update available: 1 commit behind"    (measured to upstream)
```

## Test plan

- [x] `tests/hermes_cli/test_cmd_update.py` (25 cases) still passes
- [x] Unit tests for `_detect_canonical_remote`:
  - only `origin` → returns `origin`
  - `origin` + `upstream` → returns `upstream`
  - no git dir → returns `origin` (fallback)
  - only `upstream` → returns `upstream`
- [x] Manual: with `origin`=fork / `upstream`=canonical, `hermes --version` reports the distance to `upstream/main`, not `origin/main`.