### PR TITLE
fix(agent): preserve budget_exhausted exit reason from max_iterations overwrite

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4461,7 +4461,8 @@ def run_conversation(
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        if _turn_exit_reason == "unknown":
+            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
             "— asking model to summarise"


### PR DESCRIPTION
## Summary
- Preserve the specific `budget_exhausted` turn exit reason when the post-loop exhaustion handler runs.
- Only replace `_turn_exit_reason` with `max_iterations_reached(...)` when it is still the initial `unknown` placeholder.

## Related issue
Fixes #38162

## Testing
- Post-rebase branch proof:
  - `uv run pytest tests/run_agent/test_run_agent.py tests/run_agent/test_turn_completion_explainer.py -x -v --timeout=120`
  - Result: `378 passed in 91.17s`

## Notes
- Diff is limited to `agent/conversation_loop.py`.
- No new regression test directly exercises the exact `budget_exhausted` overwrite branch, but the change is minimal and relevant existing exit-reason tests pass.
