### PR TITLE
fix: auxiliary tasks use main_runtime model on hot-switch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3343,7 +3343,8 @@ def resolve_provider_client(
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
     if not model:
-        model = _get_aux_model_for_provider(provider) or _read_main_model() or model
+        rt_model = (main_runtime or {}).get("model", "").strip() if isinstance(main_runtime, dict) else ""
+        model = _get_aux_model_for_provider(provider) or (rt_model or None) or _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:
         """Decide if a plain OpenAI client should be wrapped for Responses API.


### PR DESCRIPTION
## Bug

When user switches model at runtime via `/model` (e.g. `deepseek-v4-pro` → `glm-5.1`), auxiliary tasks like `title_generation` still read the **static** `config.yaml` model via `_read_main_model()`, causing a 400 error when the stale model name is sent to the new provider endpoint.

## Root Cause

`resolve_provider_client()` (L3345-3346) resolves the model string **before** dispatching to `_resolve_auto()`, ignoring the `main_runtime` dict that carries the runtime model.

```python
# Before — ignores main_runtime
if not model:
    model = _get_aux_model_for_provider(provider) or _read_main_model() or model

# After — checks main_runtime.model first
if not model:
    rt_model = (main_runtime or {}).get("model", "").strip() if isinstance(main_runtime, dict) else ""
    model = _get_aux_model_for_provider(provider) or (rt_model or None) or _read_main_model() or model
```

## Log Evidence

Session `20260603_234432_e5b997`, model hot-switched from `deepseek-v4-pro` to `glm-5.1` via Z.AI:

```
23:56:57.897  Auxiliary auto-detect: using main provider zai (glm-5.1)       ← _resolve_auto correct
23:56:57.908  Auxiliary title_generation: using auto (deepseek-v4-pro)       ← stale config value
23:56:58.275  Title generation failed: Error code: 400 - 模型不存在           ← Z.AI rejects deepseek model
```

The main session correctly routes to `glm-5.1`, but `resolve_provider_client` reads `config.yaml → model.default: deepseek-v4-pro` because it bypasses `main_runtime`.

## Fix Priority

`main_runtime.model` is inserted between `_get_aux_model_for_provider` and `_read_main_model`:
1. Provider-specific aux model config (highest priority, unchanged)
2. **Runtime model from `/model` switch (new)**
3. Static `config.yaml` model (lowest priority, unchanged)

## Testing

- Verified import and function body contains the patch
- Domain-digger and graph-reasoning plugins confirmed NOT involved (they initialize ~1s after the title_generation call)
