### PR TITLE
fix(telegram): make album media_group debounce configurable via env

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -347,6 +347,9 @@ class TelegramAdapter(BasePlatformAdapter):
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
+    # Default album (media_group) debounce, in seconds. Per-instance value is
+    # resolved in ``__init__`` and may be overridden via the
+    # ``HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS`` environment variable.
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
@@ -412,6 +415,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        # Album (media_group) debounce. Telegram delivers each album photo as a
+        # separate update; we reset this timer on each arrival and flush once it
+        # elapses. The 0.8s default is too short for slow/large uploads, where a
+        # later photo can arrive after the timer fires — splitting one album into
+        # several turns. Overridable via HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS;
+        # falls back to the class default on a missing/invalid value.
+        try:
+            self.MEDIA_GROUP_WAIT_SECONDS = float(
+                os.getenv("HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS", "")
+                or self.MEDIA_GROUP_WAIT_SECONDS
+            )
+        except (TypeError, ValueError):
+            pass  # keep the class-level default
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -892,3 +892,30 @@ class TestSendVideo:
 
         call_kwargs = connected_adapter._bot.send_video.call_args[1]
         assert call_kwargs["message_thread_id"] == 789
+
+
+# ---------------------------------------------------------------------------
+# TestMediaGroupWaitConfig — HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS override
+# ---------------------------------------------------------------------------
+
+class TestMediaGroupWaitConfig:
+    """The album debounce window is overridable via env, defaulting to 0.8s."""
+
+    def _make_adapter(self):
+        return TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS", raising=False)
+        assert self._make_adapter().MEDIA_GROUP_WAIT_SECONDS == 0.8
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS", "3.0")
+        assert self._make_adapter().MEDIA_GROUP_WAIT_SECONDS == 3.0
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS", "not-a-number")
+        assert self._make_adapter().MEDIA_GROUP_WAIT_SECONDS == 0.8
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS", "")
+        assert self._make_adapter().MEDIA_GROUP_WAIT_SECONDS == 0.8


### PR DESCRIPTION
## What does this PR do?

Telegram delivers each photo in an album as a **separate update** sharing a `media_group_id`. `TelegramAdapter` debounces these into a single `MessageEvent` by resetting a timer on each arrival and flushing once it elapses (`_handle_media_group` → `_flush_media_group_event`). That window was hard-coded to `MEDIA_GROUP_WAIT_SECONDS = 0.8`.

For **slow or large uploads**, a later photo in the same album can arrive *after* the 0.8s timer has already fired. The album is then flushed in fragments, and each fragment becomes its own agent turn. This is especially costly for skills that delegate per inbound message — e.g. a "save these photos to my notes" skill ends up invoking the downstream tool **once per photo** instead of once for the whole album.

This PR makes the window configurable via `HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS`, mirroring the existing `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`. The default stays `0.8`, and an invalid/empty value falls back to the class default, so **behaviour is unchanged unless the operator opts in**.

## Related Issue

<!-- No tracking issue; small, self-contained adapter config fix. -->
N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`
  - Documented `MEDIA_GROUP_WAIT_SECONDS` as the default and resolved a per-instance value in `__init__` from `HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS`, with a fallback to the class default on a missing/invalid value (same pattern as the neighbouring `_media_batch_delay_seconds`).
- `tests/gateway/test_telegram_documents.py`
  - Added `TestMediaGroupWaitConfig` covering default, override, and invalid/empty fallback.

## How to Test

1. Set `HERMES_TELEGRAM_MEDIA_GROUP_WAIT_SECONDS=3.0` in the gateway environment and restart the gateway.
2. Send a 3–5 photo album over a slow connection (or large images). Previously the album split into multiple turns (`Image routing: ... Pre-analyzing 1 image` per fragment); with a longer window it is delivered as a single `MessageEvent` (`Pre-analyzing N image(s)`).
3. Unit tests: `pytest tests/gateway/test_telegram_documents.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected module only: `tests/gateway/test_telegram_documents.py` (45 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (Darwin 24.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/inline comments) — env var is documented inline next to the code
- [x] N/A — `cli-config.yaml.example`: this is an env-var override, not a config.yaml key
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — pure `os.getenv` + `float()`, no platform-specific behaviour
- [x] N/A — no tool behaviour change

## Screenshots / Logs

Gateway log showing the split (before): each fragment triggers its own turn

```
Image routing: text (mode=text). Pre-analyzing 1 image(s) via vision_analyze.
... (later photo arrives after the 0.8s flush) ...
Image routing: text (mode=text). Pre-analyzing 1 image(s) via vision_analyze.
```

With a longer window the same album is delivered once:

```
Image routing: text (mode=text). Pre-analyzing 4 image(s) via vision_analyze.
```
