### PR TITLE
fix(gateway/feishu): support encrypted webhook payloads and Schema 2.0 URL verification

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -87,6 +87,7 @@ except ImportError:
 
 try:
     import lark_oapi as lark
+    from lark_oapi.core.utils.decryptor import AESCipher
     from lark_oapi.api.application.v6 import GetApplicationRequest
     from lark_oapi.api.im.v1 import (
         CreateFileRequest,
@@ -117,6 +118,7 @@ try:
     FEISHU_AVAILABLE = True
 except ImportError:
     FEISHU_AVAILABLE = False
+    AESCipher = None  # type: ignore[assignment]
     lark = None  # type: ignore[assignment]
     CallBackCard = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
@@ -1382,6 +1384,7 @@ def check_feishu_requirements() -> bool:
         from lark_oapi.core import AccessTokenType, HttpMethod
         from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
         from lark_oapi.core.model import BaseRequest
+        from lark_oapi.core.utils.decryptor import AESCipher
         from lark_oapi.event.callback.model.p2_card_action_trigger import (
             CallBackCard, P2CardActionTriggerResponse,
         )
@@ -1409,6 +1412,7 @@ def check_feishu_requirements() -> bool:
             "FEISHU_DOMAIN": FEISHU_DOMAIN,
             "LARK_DOMAIN": LARK_DOMAIN,
             "BaseRequest": BaseRequest,
+            "AESCipher": AESCipher,
             "CallBackCard": CallBackCard,
             "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
             "EventDispatcherHandler": EventDispatcherHandler,
@@ -3508,6 +3512,62 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
+        signature_verified = False
+        unsigned_encrypted_payload = False
+
+        # URL-verification requests are the documented exception to signature
+        # verification: when encryption is enabled, Feishu sends only an
+        # encrypted envelope and expects the decrypted challenge within one
+        # second. Normal encrypted events must authenticate the raw envelope
+        # before decryption.
+        if payload.get("encrypt"):
+            if not self._encrypt_key:
+                logger.error("[Feishu] Encrypted webhook payload received but FEISHU_ENCRYPT_KEY is not set")
+                self._record_webhook_anomaly(remote_ip, "400-encrypted")
+                return web.json_response(
+                    {"code": 400, "msg": "encrypted webhook payloads are not supported"},
+                    status=400,
+                )
+            signature_headers_present = any(
+                str(headers.get(name, "") or "")
+                for name in (
+                    "x-lark-request-timestamp",
+                    "x-lark-request-nonce",
+                    "x-lark-signature",
+                )
+            )
+            if signature_headers_present:
+                if not self._is_webhook_signature_valid(headers, body_bytes):
+                    logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
+                    self._record_webhook_anomaly(remote_ip, "401-sig")
+                    return web.Response(status=401, text="Invalid signature")
+                signature_verified = True
+            else:
+                unsigned_encrypted_payload = True
+            if AESCipher is None:
+                logger.error("[Feishu] Encrypted webhook payload received but lark_oapi is not installed")
+                self._record_webhook_anomaly(remote_ip, "500-no-lark-oapi")
+                return web.json_response(
+                    {
+                        "code": 500,
+                        "msg": "encrypted webhook payloads are not supported (missing dependency)",
+                    },
+                    status=500,
+                )
+            try:
+                cipher = AESCipher(self._encrypt_key)
+                decrypted = cipher.decrypt_str(payload["encrypt"])
+                payload = json.loads(decrypted)
+            except Exception as e:
+                logger.warning("[Feishu] Failed to decrypt webhook payload: %s", e)
+                if unsigned_encrypted_payload:
+                    self._record_webhook_anomaly(remote_ip, "401-sig")
+                    return web.json_response(
+                        {"code": 401, "msg": "invalid signature"}, status=401
+                    )
+                self._record_webhook_anomaly(remote_ip, "400-decrypt")
+                return web.json_response({"code": 400, "msg": "failed to decrypt payload"}, status=400)
+
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3525,19 +3585,35 @@ class FeishuAdapter(BasePlatformAdapter):
         # challenge requests. Validate the token (above) before reflecting the
         # challenge so an unauthenticated remote request cannot prove endpoint
         # control by getting attacker-supplied challenge data echoed back.
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
+        is_v1_url_verification = payload.get("type") == "url_verification"
+        is_v2_url_verification = (
+            str((payload.get("header") or {}).get("event_type") or "")
+            == "url_verification"
+        )
+        if is_v1_url_verification or is_v2_url_verification:
+            challenge = (
+                payload.get("challenge", "")
+                if is_v1_url_verification
+                else (payload.get("event") or {}).get("challenge", "")
+            )
+            return web.json_response({"challenge": challenge})
+
+        if unsigned_encrypted_payload:
+            logger.warning("[Feishu] Webhook rejected: missing signature from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "401-sig")
+            return web.json_response(
+                {"code": 401, "msg": "invalid signature"}, status=401
+            )
 
         # Timing-safe signature verification (only enforced when encrypt_key is set).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
+        if (
+            self._encrypt_key
+            and not signature_verified
+            and not self._is_webhook_signature_valid(headers, body_bytes)
+        ):
             logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
             self._record_webhook_anomaly(remote_ip, "401-sig")
             return web.Response(status=401, text="Invalid signature")
-
-        if payload.get("encrypt"):
-            logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
-            self._record_webhook_anomaly(remote_ip, "400-encrypted")
-            return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
 
         self._clear_webhook_anomaly(remote_ip)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -108,6 +108,7 @@ HttpMethod = None  # type: ignore[assignment]
 FEISHU_DOMAIN = None  # type: ignore[assignment]
 LARK_DOMAIN = None  # type: ignore[assignment]
 BaseRequest = None  # type: ignore[assignment]
+AESCipher = None  # type: ignore[assignment]
 CallBackCard = None  # type: ignore[assignment]
 P2CardActionTriggerResponse = None  # type: ignore[assignment]
 EventDispatcherHandler = None  # type: ignore[assignment]
@@ -1408,6 +1409,7 @@ def _load_lark_oapi() -> bool:
             from lark_oapi.core import AccessTokenType, HttpMethod
             from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
             from lark_oapi.core.model import BaseRequest
+            from lark_oapi.core.utils.decryptor import AESCipher
             from lark_oapi.event.callback.model.p2_card_action_trigger import (
                 CallBackCard, P2CardActionTriggerResponse,
             )
@@ -1438,6 +1440,7 @@ def _load_lark_oapi() -> bool:
             "FEISHU_DOMAIN": FEISHU_DOMAIN,
             "LARK_DOMAIN": LARK_DOMAIN,
             "BaseRequest": BaseRequest,
+            "AESCipher": AESCipher,
             "CallBackCard": CallBackCard,
             "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
             "EventDispatcherHandler": EventDispatcherHandler,
@@ -3605,6 +3608,62 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
+        signature_verified = False
+        unsigned_encrypted_payload = False
+
+        # URL-verification requests are the documented exception to signature
+        # verification: when encryption is enabled, Feishu sends only an
+        # encrypted envelope and expects the decrypted challenge within one
+        # second. Normal encrypted events must authenticate the raw envelope
+        # before decryption.
+        if payload.get("encrypt"):
+            if not self._encrypt_key:
+                logger.error("[Feishu] Encrypted webhook payload received but FEISHU_ENCRYPT_KEY is not set")
+                self._record_webhook_anomaly(remote_ip, "400-encrypted")
+                return web.json_response(
+                    {"code": 400, "msg": "encrypted webhook payloads are not supported"},
+                    status=400,
+                )
+            signature_headers_present = any(
+                str(headers.get(name, "") or "")
+                for name in (
+                    "x-lark-request-timestamp",
+                    "x-lark-request-nonce",
+                    "x-lark-signature",
+                )
+            )
+            if signature_headers_present:
+                if not self._is_webhook_signature_valid(headers, body_bytes):
+                    logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
+                    self._record_webhook_anomaly(remote_ip, "401-sig")
+                    return web.Response(status=401, text="Invalid signature")
+                signature_verified = True
+            else:
+                unsigned_encrypted_payload = True
+            if AESCipher is None:
+                logger.error("[Feishu] Encrypted webhook payload received but lark_oapi is not installed")
+                self._record_webhook_anomaly(remote_ip, "500-no-lark-oapi")
+                return web.json_response(
+                    {
+                        "code": 500,
+                        "msg": "encrypted webhook payloads are not supported (missing dependency)",
+                    },
+                    status=500,
+                )
+            try:
+                cipher = AESCipher(self._encrypt_key)
+                decrypted = cipher.decrypt_str(payload["encrypt"])
+                payload = json.loads(decrypted)
+            except Exception as e:
+                logger.warning("[Feishu] Failed to decrypt webhook payload: %s", e)
+                if unsigned_encrypted_payload:
+                    self._record_webhook_anomaly(remote_ip, "401-sig")
+                    return web.json_response(
+                        {"code": 401, "msg": "invalid signature"}, status=401
+                    )
+                self._record_webhook_anomaly(remote_ip, "400-decrypt")
+                return web.json_response({"code": 400, "msg": "failed to decrypt payload"}, status=400)
+
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3622,19 +3681,35 @@ class FeishuAdapter(BasePlatformAdapter):
         # challenge requests. Validate the token (above) before reflecting the
         # challenge so an unauthenticated remote request cannot prove endpoint
         # control by getting attacker-supplied challenge data echoed back.
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
+        is_v1_url_verification = payload.get("type") == "url_verification"
+        is_v2_url_verification = (
+            str((payload.get("header") or {}).get("event_type") or "")
+            == "url_verification"
+        )
+        if is_v1_url_verification or is_v2_url_verification:
+            challenge = (
+                payload.get("challenge", "")
+                if is_v1_url_verification
+                else (payload.get("event") or {}).get("challenge", "")
+            )
+            return web.json_response({"challenge": challenge})
+
+        if unsigned_encrypted_payload:
+            logger.warning("[Feishu] Webhook rejected: missing signature from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "401-sig")
+            return web.json_response(
+                {"code": 401, "msg": "invalid signature"}, status=401
+            )
 
         # Timing-safe signature verification (only enforced when encrypt_key is set).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
+        if (
+            self._encrypt_key
+            and not signature_verified
+            and not self._is_webhook_signature_valid(headers, body_bytes)
+        ):
             logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
             self._record_webhook_anomaly(remote_ip, "401-sig")
             return web.Response(status=401, text="Invalid signature")
-
-        if payload.get("encrypt"):
-            logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
-            self._record_webhook_anomaly(remote_ip, "400-encrypted")
-            return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
 
         self._clear_webhook_anomaly(remote_ip)
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3278,6 +3278,20 @@ class TestWebhookSecurity(unittest.TestCase):
         with patch.dict(os.environ, {"FEISHU_APP_ID": "cli", "FEISHU_APP_SECRET": "sec", "FEISHU_ENCRYPT_KEY": encrypt_key}, clear=True):
             return FeishuAdapter(PlatformConfig())
 
+    @staticmethod
+    def _send_webhook(
+        adapter: "FeishuAdapter",
+        body: bytes,
+        headers: dict[str, str] | None = None,
+    ):
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=len(body),
+            headers=headers or {"Content-Type": "application/json"},
+            content=_FakeRequestContent(body),
+        )
+        return asyncio.run(adapter._handle_webhook_request(request))
+
     def test_signature_valid_passes(self):
         import hashlib
 
@@ -3303,6 +3317,91 @@ class TestWebhookSecurity(unittest.TestCase):
     def test_signature_missing_headers_rejected(self):
         adapter = self._make_adapter("test_secret")
         self.assertFalse(adapter._is_webhook_signature_valid({}, b'{}'))
+
+    def test_signed_encrypted_event_is_decrypted_and_dispatched(self):
+        import hashlib
+
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        timestamp = "1700000000"
+        nonce = "abc123"
+        signature = hashlib.sha256(
+            f"{timestamp}{nonce}test_secret{body.decode()}".encode()
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-request-nonce": nonce,
+            "x-lark-signature": signature,
+        }
+        decrypted = json.dumps(
+            {"header": {"event_type": "im.message.receive_v1"}, "event": {}}
+        )
+        cipher = Mock()
+        cipher.decrypt_str.return_value = decrypted
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ) as cipher_class, patch.object(adapter, "_on_message_event") as on_message:
+            response = self._send_webhook(adapter, body, headers)
+
+        self.assertEqual(response.status, 200)
+        cipher_class.assert_called_once_with("test_secret")
+        cipher.decrypt_str.assert_called_once_with("ciphertext")
+        on_message.assert_called_once()
+
+    def test_encrypted_event_rejects_bad_signature_without_decrypting(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "x-lark-request-timestamp": "1700000000",
+            "x-lark-request-nonce": "abc123",
+            "x-lark-signature": "invalid",
+        }
+
+        with patch("plugins.platforms.feishu.adapter.AESCipher") as cipher_class:
+            response = self._send_webhook(adapter, body, headers)
+
+        self.assertEqual(response.status, 401)
+        cipher_class.assert_not_called()
+
+    def test_unsigned_encrypted_url_verification_is_decrypted(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps(
+            {
+                "type": "url_verification",
+                "challenge": "unsigned_encrypted_challenge",
+            }
+        )
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ):
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"unsigned_encrypted_challenge", response.body)
+        cipher.decrypt_str.assert_called_once_with("ciphertext")
+
+    def test_unsigned_encrypted_event_is_not_dispatched(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps(
+            {"header": {"event_type": "im.message.receive_v1"}, "event": {}}
+        )
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ), patch.object(adapter, "_on_message_event") as on_message:
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 401)
+        self.assertIn(b"invalid signature", response.body)
+        on_message.assert_not_called()
 
     def test_rate_limit_allows_requests_within_window(self):
         adapter = self._make_adapter()
@@ -3445,6 +3544,24 @@ class TestWebhookSecurity(unittest.TestCase):
         response = asyncio.run(adapter._handle_webhook_request(request))
         self.assertEqual(response.status, 200)
         self.assertIn(b"test_challenge_token", response.body)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_webhook_schema_v2_url_verification_returns_nested_challenge(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps(
+            {
+                "schema": "2.0",
+                "header": {"event_type": "url_verification"},
+                "event": {"challenge": "schema_v2_challenge"},
+            }
+        ).encode()
+        response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"schema_v2_challenge", response.body)
 
 
 class TestDedupTTL(unittest.TestCase):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1524,6 +1524,20 @@ class TestWebhookSecurity(unittest.TestCase):
         with patch.dict(os.environ, {"FEISHU_APP_ID": "cli", "FEISHU_APP_SECRET": "sec", "FEISHU_ENCRYPT_KEY": encrypt_key}, clear=True):
             return FeishuAdapter(PlatformConfig())
 
+    @staticmethod
+    def _send_webhook(
+        adapter: "FeishuAdapter",
+        body: bytes,
+        headers: dict[str, str] | None = None,
+    ):
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=len(body),
+            headers=headers or {"Content-Type": "application/json"},
+            content=_FakeRequestContent(body),
+        )
+        return asyncio.run(adapter._handle_webhook_request(request))
+
     def test_signature_valid_passes(self):
         import hashlib
 
@@ -1537,6 +1551,90 @@ class TestWebhookSecurity(unittest.TestCase):
         headers = {"x-lark-request-timestamp": timestamp, "x-lark-request-nonce": nonce, "x-lark-signature": sig}
         self.assertTrue(adapter._is_webhook_signature_valid(headers, body))
 
+    def test_signed_encrypted_event_is_decrypted_and_dispatched(self):
+        import hashlib
+
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        timestamp = "1700000000"
+        nonce = "abc123"
+        signature = hashlib.sha256(
+            f"{timestamp}{nonce}test_secret{body.decode()}".encode()
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-request-nonce": nonce,
+            "x-lark-signature": signature,
+        }
+        decrypted = json.dumps(
+            {"header": {"event_type": "im.message.receive_v1"}, "event": {}}
+        )
+        cipher = Mock()
+        cipher.decrypt_str.return_value = decrypted
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ) as cipher_class, patch.object(adapter, "_on_message_event") as on_message:
+            response = self._send_webhook(adapter, body, headers)
+
+        self.assertEqual(response.status, 200)
+        cipher_class.assert_called_once_with("test_secret")
+        cipher.decrypt_str.assert_called_once_with("ciphertext")
+        on_message.assert_called_once()
+
+    def test_encrypted_event_rejects_bad_signature_without_decrypting(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "x-lark-request-timestamp": "1700000000",
+            "x-lark-request-nonce": "abc123",
+            "x-lark-signature": "invalid",
+        }
+
+        with patch("plugins.platforms.feishu.adapter.AESCipher") as cipher_class:
+            response = self._send_webhook(adapter, body, headers)
+
+        self.assertEqual(response.status, 401)
+        cipher_class.assert_not_called()
+
+    def test_unsigned_encrypted_url_verification_is_decrypted(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps(
+            {
+                "type": "url_verification",
+                "challenge": "unsigned_encrypted_challenge",
+            }
+        )
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ):
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"unsigned_encrypted_challenge", response.body)
+        cipher.decrypt_str.assert_called_once_with("ciphertext")
+
+    def test_unsigned_encrypted_event_is_not_dispatched(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps(
+            {"header": {"event_type": "im.message.receive_v1"}, "event": {}}
+        )
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ), patch.object(adapter, "_on_message_event") as on_message:
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 401)
+        self.assertIn(b"invalid signature", response.body)
+        on_message.assert_not_called()
 
     def test_rate_limit_resets_after_window_expires(self):
         from plugins.platforms.feishu.adapter import _FEISHU_WEBHOOK_RATE_LIMIT_MAX, _FEISHU_WEBHOOK_RATE_WINDOW_SECONDS
@@ -1609,6 +1707,23 @@ class TestWebhookSecurity(unittest.TestCase):
         self.assertEqual(adapter._verification_token, "token_from_extra")
         self.assertEqual(adapter._encrypt_key, "encrypt_from_extra")
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_webhook_schema_v2_url_verification_returns_nested_challenge(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps(
+            {
+                "schema": "2.0",
+                "header": {"event_type": "url_verification"},
+                "event": {"challenge": "schema_v2_challenge"},
+            }
+        ).encode()
+        response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"schema_v2_challenge", response.body)
 
 class TestDedupTTL(unittest.TestCase):
     """Tests for TTL-aware deduplication."""


### PR DESCRIPTION
Fixes #13254

## Problem

1. Encrypted webhook payloads rejected — Feishu with Encrypt Key sends {"encrypt": "..."}, Hermes returns 400.
2. Schema 2.0 URL verification fails — Feishu sends event_type in header and challenge in event, but Hermes only checks payload.type.

## Why this fix

- Feishu docs confirm webhook encryption uses AES-256-CBC via Encrypt Key
- Schema 2.0 docs confirm event_type moved to header.event_type
- Original decrypt logic (if any) was placed after signature check, making it unreachable

## Changes

- Decrypt encrypted payloads using lark-oapi.AESCipher before token/signature checks
- Support header.event_type for URL verification detection (Schema 2.0)
- Extract challenge from event.challenge for Schema 2.0 format
- Backward compatible with Schema 1.0 (payload.type / payload.challenge)

## Verification

- [x] Feishu event subscription verified with encryption enabled
- [x] Schema 2.0 URL verification (header.event_type)
- [x] Schema 1.0 backward compatibility (payload.type)
- [x] Regular message events after decryption