### PR TITLE
feat(feishu): add Card Kit streaming support

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -395,6 +395,12 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # Markdown rendering mode for messages containing tables.
+    # "post" (default): table content falls back to plain text (current behaviour).
+    # "card":  table content is sent as an interactive card (JSON 2.0) with full
+    #          markdown rendering including tables; non-table messages unchanged.
+    markdown_mode: str = "post"
+    card_streaming: bool = False
 
 
 @dataclass
@@ -548,6 +554,41 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _build_interactive_card_payload(
+    content: str,
+    *,
+    note: str = "",
+    header_title: str = "",
+    header_template: str = "",
+) -> str:
+    """Build a Feishu interactive card with markdown body and optional footer.
+
+    Interactive cards support full markdown rendering including tables,
+    which the post type's ``md`` tag does not.  Use JSON 2.0 card structure.
+    Header is only included when *header_title* is provided.  Footer note
+    uses grey markdown text when supplied (following OpenClaw patterns).
+    """
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+    }
+    if header_title:
+        card["header"] = {
+            "template": header_template or "blue",
+            "title": {"tag": "plain_text", "content": header_title},
+        }
+    elements: List[Dict[str, Any]] = [
+        {"tag": "markdown", "content": content},
+    ]
+    if note:
+        elements.append({"tag": "hr"})
+        elements.append({
+            "tag": "markdown",
+            "content": f"<font color='grey'>{note}</font>",
+        })
+    card["elements"] = elements
+    return json.dumps(card, ensure_ascii=False)
+
+
 def _build_markdown_post_payload(content: str) -> str:
     rows = _build_markdown_post_rows(content)
     return json.dumps(
@@ -607,6 +648,232 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 
     _flush_current()
     return rows or [[{"tag": "md", "text": content}]]
+
+
+
+class FeishuCardKitStreamSession:
+    """Card Kit streaming session independent from normal message send/edit.
+
+    The transport follows Feishu Card Kit's lifecycle: create a streaming card
+    entity, send a card reference as an interactive message, update markdown
+    elements by id, then close streaming mode.
+    """
+
+    _token_cache: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        app_secret: str,
+        domain_name: str = "feishu",
+        request_json: Optional[Any] = None,
+        send_card_reference: Optional[Any] = None,
+        note: str = "",
+    ) -> None:
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.domain_name = domain_name or "feishu"
+        self.request_json = request_json or self._default_request_json
+        self.send_card_reference = send_card_reference
+        self.note = note
+        self.card_id: Optional[str] = None
+        self.message_id: Optional[str] = None
+        self.sequence = 0
+        self.sent_text = ""
+        self.closed = False
+
+    @property
+    def api_base(self) -> str:
+        return _ONBOARD_OPEN_URLS.get(self.domain_name, _ONBOARD_OPEN_URLS["feishu"])
+
+    async def _default_request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if aiohttp is None:
+            raise RuntimeError("aiohttp required for Feishu Card Kit streaming")
+        async with aiohttp.ClientSession() as session:
+            async with session.request(
+                method,
+                url,
+                headers=headers,
+                json=json_body,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                try:
+                    return await resp.json()
+                except Exception:
+                    text = await resp.text()
+                    return {"code": resp.status, "msg": text}
+
+    async def _tenant_token(self) -> str:
+        cache_key = f"{self.domain_name}|{self.app_id}"
+        now = time.time()
+        cached = self._token_cache.get(cache_key)
+        if cached and cached.get("expires_at", 0) > now + 60:
+            return str(cached["token"])
+
+        data = await self.request_json(
+            "POST",
+            f"{self.api_base}/open-apis/auth/v3/tenant_access_token/internal",
+            headers={"Content-Type": "application/json"},
+            json_body={"app_id": self.app_id, "app_secret": self.app_secret},
+        )
+        token = data.get("tenant_access_token")
+        if data.get("code") != 0 or not token:
+            raise RuntimeError(f"Feishu Card Kit token error: {data.get('msg', 'unknown')}")
+        self._token_cache[cache_key] = {
+            "token": token,
+            "expires_at": now + int(data.get("expire") or 7200),
+        }
+        return str(token)
+
+    async def _authorized_request(self, method: str, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        token = await self._tenant_token()
+        return await self.request_json(
+            method,
+            f"{self.api_base}/open-apis{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json_body=body,
+        )
+
+    def _next_sequence(self) -> int:
+        self.sequence += 1
+        return self.sequence
+
+    def _summary(self, text: str, max_len: int = 50) -> str:
+        clean = (text or "").replace("\n", " ").strip()
+        return clean if len(clean) <= max_len else clean[: max_len - 3] + "..."
+
+    async def start(
+        self,
+        chat_id: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        elements: List[Dict[str, Any]] = [
+            {"tag": "markdown", "content": "", "element_id": "content"},
+        ]
+        if self.note:
+            elements.extend([
+                {"tag": "hr"},
+                {
+                    "tag": "markdown",
+                    "content": f"<font color='grey'>{self.note}</font>",
+                    "element_id": "note",
+                },
+            ])
+        card_json = {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": "[Generating...]"},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 1},
+                },
+            },
+            "body": {"elements": elements},
+        }
+        data = await self._authorized_request(
+            "POST",
+            "/cardkit/v1/cards",
+            {"type": "card_json", "data": json.dumps(card_json, ensure_ascii=False)},
+        )
+        self.card_id = ((data.get("data") or {}).get("card_id"))
+        if data.get("code") != 0 or not self.card_id:
+            return SendResult(success=False, error=f"Card Kit create failed: {data.get('msg', 'unknown')}")
+        if self.send_card_reference is None:
+            return SendResult(success=False, error="send_card_reference callback not configured")
+        result = await self.send_card_reference(
+            chat_id,
+            self.card_id,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if result.success:
+            self.message_id = result.message_id
+        return result
+
+    async def update(self, text: str) -> bool:
+        if not self.card_id or self.closed:
+            return False
+        if text.startswith(self.sent_text):
+            delta = text[len(self.sent_text):]
+            if not delta:
+                return True
+            seq = self._next_sequence()
+            data = await self._authorized_request(
+                "PUT",
+                f"/cardkit/v1/cards/{self.card_id}/elements/content/content",
+                {"content": delta, "sequence": seq, "uuid": f"s_{self.card_id}_{seq}"},
+            )
+        else:
+            seq = self._next_sequence()
+            data = await self._authorized_request(
+                "PUT",
+                f"/cardkit/v1/cards/{self.card_id}/elements/content",
+                {
+                    "element": json.dumps({"tag": "markdown", "content": text, "element_id": "content"}, ensure_ascii=False),
+                    "sequence": seq,
+                    "uuid": f"r_{self.card_id}_{seq}",
+                },
+            )
+        ok = data.get("code", 0) == 0
+        if ok:
+            self.sent_text = text
+        return ok
+
+    async def update_note(self, note: str) -> bool:
+        if not self.card_id or self.closed or not note:
+            return False
+        seq = self._next_sequence()
+        data = await self._authorized_request(
+            "PUT",
+            f"/cardkit/v1/cards/{self.card_id}/elements/note/content",
+            {
+                "content": f"<font color='grey'>{note}</font>",
+                "sequence": seq,
+                "uuid": f"n_{self.card_id}_{seq}",
+            },
+        )
+        return data.get("code", 0) == 0
+
+    async def close(self, final_text: Optional[str] = None, *, note: str = "") -> bool:
+        if not self.card_id or self.closed:
+            return False
+        if final_text is not None and final_text != self.sent_text:
+            await self.update(final_text)
+        if note:
+            await self.update_note(note)
+        seq = self._next_sequence()
+        data = await self._authorized_request(
+            "PATCH",
+            f"/cardkit/v1/cards/{self.card_id}/settings",
+            {
+                "settings": json.dumps({
+                    "config": {
+                        "streaming_mode": False,
+                        "summary": {"content": self._summary(final_text or self.sent_text)},
+                    }
+                }, ensure_ascii=False),
+                "sequence": seq,
+                "uuid": f"c_{self.card_id}_{seq}",
+            },
+        )
+        self.closed = data.get("code", 0) == 0
+        return self.closed
+
+
 
 
 def parse_feishu_post_payload(
@@ -1409,6 +1676,7 @@ def check_feishu_requirements() -> bool:
 class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
 
+    SUPPORTS_NATIVE_STREAMING = True
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
@@ -1468,6 +1736,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        self._model_picker_state: Dict[str, Dict[str, Any]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1573,6 +1842,8 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            markdown_mode=str(extra.get("markdown_mode", os.getenv("FEISHU_MARKDOWN_MODE", "post"))).strip().lower(),
+            card_streaming=_to_boolean(extra.get("card_streaming", os.getenv("FEISHU_CARD_STREAMING", "false"))),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1605,6 +1876,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._markdown_mode = settings.markdown_mode if settings.markdown_mode in {"post", "card"} else "post"
+        self._card_streaming = bool(settings.card_streaming)
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1765,6 +2038,43 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    def create_stream_session(self, metadata: Optional[Dict[str, Any]] = None) -> Optional[FeishuCardKitStreamSession]:
+        """Create a Card Kit native stream session when enabled.
+
+        GatewayStreamConsumer probes this capability to avoid using normal
+        send/edit_message for Feishu streaming cards.
+        """
+        if not self._card_streaming:
+            return None
+        note = ""
+        if isinstance(metadata, dict):
+            note = str(metadata.get("stream_footer_note") or "")
+        return FeishuCardKitStreamSession(
+            app_id=self._app_id,
+            app_secret=self._app_secret,
+            domain_name=self._domain_name,
+            send_card_reference=self._send_card_kit_reference,
+            note=note,
+        )
+
+    async def _send_card_kit_reference(
+        self,
+        chat_id: str,
+        card_id: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        content = json.dumps({"type": "card", "data": {"card_id": card_id}}, ensure_ascii=False)
+        response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        return self._finalize_send_result(response, "Card Kit send failed")
+
     async def send(
         self,
         chat_id: str,
@@ -1830,13 +2140,48 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Feishu text/post message."""
+        """Edit a previously sent Feishu text/post message.
+
+        When ``finalize=True`` and the content requires an interactive card
+        (markdown_mode=card), we recall the old placeholder and send a fresh
+        card instead, because Feishu's message.update API does not support
+        editing interactive cards.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
+            # Interactive cards cannot be edited via the message update API.
+            if msg_type == "interactive":
+                if finalize:
+                    # Final delivery: recall the placeholder, send a fresh card.
+                    logger.info("[Feishu] Recalling placeholder %s and resending as interactive card", message_id)
+                    try:
+                        from lark_oapi.api.im.v1 import DeleteMessageRequest
+                        del_request = DeleteMessageRequest.builder().message_id(message_id).build()
+                        await asyncio.to_thread(self._client.im.v1.message.delete, del_request)
+                    except Exception as del_err:
+                        logger.warning("[Feishu] Failed to recall message %s: %s", message_id, del_err)
+                    # Send fresh card as a new message
+                    if chat_id.startswith("ou_"):
+                        receive_id_type = "open_id"
+                    else:
+                        receive_id_type = "chat_id"
+                    card_body = self._build_create_message_body(
+                        receive_id=chat_id,
+                        msg_type="interactive",
+                        content=payload,
+                        uuid_value=str(uuid.uuid4()),
+                    )
+                    card_request = self._build_create_message_request(receive_id_type, card_body)
+                    card_response = await asyncio.to_thread(self._client.im.v1.message.create, card_request)
+                    result = self._finalize_send_result(card_response, "card resend failed")
+                    return result
+                logger.debug("[Feishu] Skipping interactive card edit (not supported); using post fallback")
+                msg_type = "post"
+                payload = _build_markdown_post_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
@@ -1994,6 +2339,370 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc))
+
+    _MODEL_PAGE_SIZE = 8
+
+    # =========================================================================
+    # Model picker cards
+    # =========================================================================
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive card for model selection.
+
+        Two-step drill-down via Feishu CallBackCard: provider → model → confirm.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            from hermes_cli.providers import get_label
+        except ImportError:
+            def get_label(slug):
+                return slug
+
+        try:
+            card = self._build_model_picker_providers_card(
+                providers=providers,
+                current_model=current_model,
+                current_provider=current_provider,
+                provider_label=get_label(current_provider),
+            )
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_model_picker failed")
+            if result.success:
+                self._model_picker_state[chat_id] = {
+                    "message_id": result.message_id or "",
+                    "providers": providers,
+                    "session_key": session_key,
+                    "on_model_selected": on_model_selected,
+                    "current_model": current_model,
+                    "current_provider": current_provider,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_model_picker failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_model_picker_providers_card(
+        *,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        provider_label: str,
+    ) -> Dict[str, Any]:
+        """Build provider selection card."""
+        def _btn(label: str, slug: str) -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": "default",
+                "value": {"hermes_model_picker": "provider", "slug": slug},
+            }
+
+        actions = []
+        for p in providers:
+            count = p.get("total_models", len(p.get("models", [])))
+            label = f"✓ {p['name']} ({count})" if p.get("is_current") else f"{p['name']} ({count})"
+            actions.append(_btn(label, p["slug"]))
+
+        actions.append({
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "✗ 取消"},
+            "type": "danger",
+            "value": {"hermes_model_picker": "cancel"},
+        })
+
+        short_model = current_model.split("/")[-1] if "/" in current_model else (current_model or "unknown")
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型配置", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"**当前模型：** `{short_model}`\n**供应商：** {provider_label}\n\n选择一个供应商：",
+                },
+                {
+                    "tag": "action",
+                    "actions": actions,
+                },
+            ],
+        }
+
+    @classmethod
+    def _build_model_picker_models_card(
+        cls,
+        *,
+        provider_name: str,
+        models: list,
+        page: int,
+        provider_slug: str,
+        total_models: int,
+    ) -> Dict[str, Any]:
+        """Build model selection card for a specific provider."""
+        page_size = cls._MODEL_PAGE_SIZE
+        total = len(models)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(0, min(page, total_pages - 1))
+        start = page * page_size
+        end = min(start + page_size, total)
+        page_models = models[start:end]
+
+        def _model_btn(label: str, idx: int) -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": "default",
+                "value": {"hermes_model_picker": "model", "slug": provider_slug, "idx": idx},
+            }
+
+        actions = [_model_btn(m, start + i) for i, m in enumerate(page_models)]
+
+        # Pagination
+        if total_pages > 1:
+            if page > 0:
+                actions.append({
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": "◀ 上一页"},
+                    "type": "default",
+                    "value": {"hermes_model_picker": "page", "slug": provider_slug, "page": page - 1},
+                })
+            actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": f"{page + 1}/{total_pages}"},
+                "type": "default",
+                "value": {"hermes_model_picker": "noop"},
+            })
+            if page < total_pages - 1:
+                actions.append({
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": "下一页 ▶"},
+                    "type": "default",
+                    "value": {"hermes_model_picker": "page", "slug": provider_slug, "page": page + 1},
+                })
+
+        actions.append({
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "◀ 返回供应商"},
+            "type": "default",
+            "value": {"hermes_model_picker": "back"},
+        })
+        actions.append({
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "✗ 取消"},
+            "type": "danger",
+            "value": {"hermes_model_picker": "cancel"},
+        })
+
+        page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
+        extra = f"\n_还有 {total_models - total} 个可用模型 — 直接输入 `/model <名称>`_" if total_models > total else ""
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型配置", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"**供应商：** {provider_name}{page_info}\n选择一个模型：{extra}",
+                },
+                {
+                    "tag": "action",
+                    "actions": actions,
+                },
+            ],
+        }
+
+    @staticmethod
+    def _build_model_picker_confirm_card(content: str) -> Dict[str, Any]:
+        """Build confirmation card after model switch."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ 模型已切换", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": content},
+            ],
+        }
+
+    def _handle_model_picker_card_action(
+        self, *, event: Any, action_value: Dict[str, Any], loop: Any
+    ) -> Any:
+        """Handle model picker card actions synchronously via CallBackCard.
+
+        Returns a P2CardActionTriggerResponse with updated card JSON.
+        """
+        import asyncio
+
+        picker_action = action_value.get("hermes_model_picker") if isinstance(action_value, dict) else None
+        if not picker_action:
+            return None
+
+        context = getattr(event, "context", None)
+        chat_id = str(getattr(context, "open_chat_id", "") or "")
+        state = self._model_picker_state.get(chat_id)
+        if not state:
+            logger.debug("[Feishu] Model picker state not found for chat %s", chat_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        try:
+            from hermes_cli.providers import get_label
+        except ImportError:
+            def get_label(slug):
+                return slug
+
+        new_card = None
+
+        if picker_action == "provider":
+            # Provider selected → show model list
+            slug = action_value.get("slug", "")
+            provider = next((p for p in state["providers"] if p["slug"] == slug), None)
+            if not provider:
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            models = provider.get("models", [])
+            state["selected_provider"] = slug
+            state["selected_provider_name"] = provider.get("name", slug)
+            state["model_list"] = models
+            state["model_page"] = 0
+
+            new_card = self._build_model_picker_models_card(
+                provider_name=provider.get("name", slug),
+                models=models,
+                page=0,
+                provider_slug=slug,
+                total_models=provider.get("total_models", len(models)),
+            )
+
+        elif picker_action == "page":
+            slug = action_value.get("slug", "")
+            page = action_value.get("page", 0)
+            models = state.get("model_list", [])
+            provider_slug = state.get("selected_provider", slug)
+            provider_name = state.get("selected_provider_name", slug)
+            provider = next(
+                (p for p in state["providers"] if p["slug"] == provider_slug), None
+            )
+            state["model_page"] = page
+
+            new_card = self._build_model_picker_models_card(
+                provider_name=provider_name,
+                models=models,
+                page=page,
+                provider_slug=provider_slug,
+                total_models=provider.get("total_models", len(models)) if provider else len(models),
+            )
+
+        elif picker_action == "model":
+            # Model selected → perform switch asynchronously
+            idx = action_value.get("idx", -1)
+            model_list = state.get("model_list", [])
+            if idx < 0 or idx >= len(model_list):
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            model_id = model_list[idx]
+            provider_slug = state.get("selected_provider", "")
+            callback = state.get("on_model_selected")
+
+            if callback:
+                self._submit_on_loop(
+                    loop,
+                    self._async_switch_model(
+                        chat_id=chat_id, model_id=model_id,
+                        provider_slug=provider_slug, callback=callback,
+                    ),
+                )
+
+            new_card = self._build_model_picker_confirm_card(
+                f"正在切换到 **{model_id}** …",
+            )
+            # Clean up state — the async handler will send final result if needed
+            self._model_picker_state.pop(chat_id, None)
+
+        elif picker_action == "back":
+            # Back to provider list
+            try:
+                provider_label = get_label(state["current_provider"])
+            except Exception:
+                provider_label = state["current_provider"]
+
+            new_card = self._build_model_picker_providers_card(
+                providers=state["providers"],
+                current_model=state["current_model"],
+                current_provider=state["current_provider"],
+                provider_label=provider_label,
+            )
+
+        elif picker_action == "cancel":
+            self._model_picker_state.pop(chat_id, None)
+            new_card = self._build_model_picker_confirm_card("模型选择已取消。")
+
+        elif picker_action == "noop":
+            # No-op (page counter button) — return unchanged
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        else:
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if new_card is None:
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = new_card
+            response.card = card
+        return response
+
+    async def _async_switch_model(
+        self, *, chat_id: str, model_id: str, provider_slug: str, callback: Any
+    ) -> None:
+        """Perform the model switch asynchronously and send the result."""
+        try:
+            result_text = await callback(chat_id, model_id, provider_slug)
+        except Exception as exc:
+            logger.error("[Feishu] Model picker async switch failed: %s", exc)
+            result_text = f"❌ 切换模型失败：{exc}"
+
+        try:
+            msg_type, payload = self._build_outbound_payload(self.format_message(result_text))
+            await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type=msg_type,
+                payload=payload,
+                reply_to=None,
+                metadata=None,
+            )
+        except Exception:
+            logger.warning("[Feishu] Failed to send model switch result", exc_info=True)
 
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
@@ -2529,10 +3238,15 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
-                event=event,
-                action_value=action_value,
-                loop=loop,
+                event=event, action_value=action_value, loop=loop,
             )
+
+        # Model picker card actions
+        picker_result = self._handle_model_picker_card_action(
+            event=event, action_value=action_value, loop=loop,
+        )
+        if picker_result is not None:
+            return picker_result
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
@@ -2582,9 +3296,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-            logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning(
+                "[Feishu] Unauthorized approval click by %s (admins=%s, allowed_users=%s)",
+                open_id or "<unknown>",
+                list(self._admins)[:5],
+                list(self._allowed_group_users)[:5],
+            )
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
         callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
@@ -4310,11 +5028,28 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
+        # When markdown_mode is "card", send table content as an interactive
+        # card (JSON 2.0) which supports full markdown including tables.
+        #
+        # IMPORTANT: interactive cards CANNOT be edited via message.update API
+        # (only text/post are supported). This means streaming messages (which
+        # use edit_message) will degrade. The base adapter's _send_with_retry
+        # fallback also calls send(), so we must never return interactive for
+        # fallback content (prefixed with "(Response formatting failed").
+        is_fallback = content.startswith("(Response formatting failed")
+
+        if _MARKDOWN_TABLE_RE.search(content) and not is_fallback:
+            if self._markdown_mode == "card":
+                payload = _build_interactive_card_payload(content)
+                logger.debug("[Feishu] Using interactive card for table content (%d chars)", len(content))
+                return "interactive", payload
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
+            if self._markdown_mode == "card":
+                payload = _build_interactive_card_payload(content)
+                logger.debug("[Feishu] Using interactive card for markdown content (%d chars)", len(content))
+                return "interactive", payload
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
@@ -4392,6 +5127,8 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
+        if msg_type == "interactive":
+            logger.info("[Feishu] Sending interactive card to %s, payload=%s", chat_id, payload[:2000])
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1930,6 +1930,10 @@ class GatewayRunner:
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
         self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+        # Cache for /model picker provider list (TTL 60s).
+        # Key: hash of (current_provider, current_base_url), Value: (providers, timestamp)
+        self._model_picker_cache: Dict[str, tuple] = {}
+        self._model_picker_cache_ttl: float = 60.0
         self._kanban_notifier_profile = self._active_profile_name()
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
@@ -10955,19 +10959,31 @@ class GatewayRunner:
                 adapter is not None
                 and getattr(type(adapter), "send_model_picker", None) is not None
             )
+            logger.info("[/model] adapter=%s has_picker=%s platform=%s", type(adapter).__name__ if adapter else None, has_picker, source.platform)
 
             if has_picker:
-                try:
-                    providers = list_picker_providers(
-                        current_provider=current_provider,
-                        current_base_url=current_base_url,
-                        current_model=current_model,
-                        user_providers=user_provs,
-                        custom_providers=custom_provs,
-                        max_models=50,
-                    )
-                except Exception:
-                    providers = []
+                # Check cache first to avoid repeated provider enumeration.
+                import hashlib, time as _time
+                _cache_key = hashlib.sha256(
+                    f"{current_provider}|{current_base_url}|{current_model}".encode()
+                ).hexdigest()
+                _cached = self._model_picker_cache.get(_cache_key)
+                if _cached is not None and _time.time() - _cached[1] < self._model_picker_cache_ttl:
+                    providers = _cached[0]
+                    logger.info("[/model] cache hit for key=%s age=%.1fs", _cache_key[:12], _time.time() - _cached[1])
+                else:
+                    try:
+                        providers = list_picker_providers(
+                            current_provider=current_provider,
+                            current_base_url=current_base_url,
+                            current_model=current_model,
+                            user_providers=user_provs,
+                            custom_providers=custom_provs,
+                            max_models=50,
+                        )
+                        self._model_picker_cache[_cache_key] = (providers, _time.time())
+                    except Exception:
+                        providers = []
 
                 if providers:
                     # Build a callback closure for when the user picks a model.
@@ -11099,6 +11115,7 @@ class GatewayRunner:
                         on_model_selected=_on_model_selected,
                         metadata=metadata,
                     )
+                    logger.info("[/model] send_model_picker result: success=%s error=%s providers_count=%d", result.success, getattr(result, 'error', None), len(providers))
                     if result.success:
                         return None  # Picker sent — adapter handles the response
 
@@ -17444,6 +17461,21 @@ class GatewayRunner:
             }
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+        if source.platform == Platform.FEISHU:
+            if _status_thread_metadata is None:
+                _status_thread_metadata = {}
+            try:
+                _model_cfg = (user_config or {}).get("model", {}) if isinstance(user_config, dict) else {}
+                _stream_model = str(model or _model_cfg.get("default") or "").strip()
+                _stream_provider = str(_model_cfg.get("provider") or "").strip()
+                _footer_parts = ["Agent: Hermes"]
+                if _stream_model:
+                    _footer_parts.append(f"Model: {_stream_model}")
+                if _stream_provider:
+                    _footer_parts.append(f"Provider: {_stream_provider}")
+                _status_thread_metadata["stream_footer_note"] = " | ".join(_footer_parts)
+            except Exception:
+                _status_thread_metadata["stream_footer_note"] = "Agent: Hermes"
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -182,6 +182,7 @@ class GatewayStreamConsumer:
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
+        self._native_stream_session = None
 
     @property
     def already_sent(self) -> bool:
@@ -261,6 +262,7 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        self._native_stream_session = None
         # #29346: a tool/segment boundary means what we delivered was an interim
         # preamble, not the final answer — clear the flags so a premature setter
         # can't fool the gateway. Safe: got_done returns before any reset, and
@@ -674,7 +676,7 @@ class GatewayStreamConsumer:
         stream finishes — we just need to hide the raw directives from the
         user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
+        if "media:" not in text.lower() and "[[audio_as_voice]]" not in text:
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
@@ -1126,6 +1128,57 @@ class GatewayStreamConsumer:
             self._final_response_sent = True
         return True
 
+    async def _send_or_update_native_stream(
+        self,
+        text: str,
+        *,
+        finalize: bool = False,
+        is_turn_final: bool = True,
+    ) -> Optional[bool]:
+        """Route through an adapter-native stream session.
+
+        Native sessions (e.g. Feishu Card Kit) have a lifecycle distinct from
+        ordinary send/edit_message: start -> update -> close.
+        """
+        try:
+            if self._native_stream_session is None:
+                factory = getattr(self.adapter, "create_stream_session")
+                self._native_stream_session = factory(metadata=self.metadata)
+                if self._native_stream_session is None:
+                    return None
+                result = await self._native_stream_session.start(
+                    self.chat_id,
+                    reply_to=self._initial_reply_to_id,
+                    metadata=self.metadata,
+                )
+                if not getattr(result, "success", False):
+                    self._edit_supported = False
+                    self._fallback_final_send = True
+                    return False
+                self._message_id = getattr(result, "message_id", None)
+                self._message_created_ts = time.monotonic() if self._message_id else None
+                self._already_sent = True
+                self._notify_new_message()
+
+            ok = await self._native_stream_session.update(text)
+            if ok:
+                self._last_sent_text = text
+            if finalize:
+                note = ""
+                if isinstance(self.metadata, dict):
+                    note = str(self.metadata.get("stream_footer_note") or "")
+                closed = await self._native_stream_session.close(text, note=note)
+                if closed and is_turn_final:
+                    self._final_response_sent = True
+                    self._final_content_delivered = True
+                return bool(closed)
+            return bool(ok)
+        except Exception as e:
+            logger.error("Native stream send/update error: %s", e, exc_info=True)
+            self._edit_supported = False
+            self._fallback_final_send = True
+            return False
+
     async def _send_or_edit(
         self, text: str, *, finalize: bool = False, is_turn_final: bool = True,
     ) -> bool:
@@ -1152,6 +1205,11 @@ class GatewayStreamConsumer:
             return True  # cursor-only / whitespace-only update
         if not text.strip():
             return True  # nothing to send is "success"
+        native_stream_factory = getattr(self.adapter, "create_stream_session", None)
+        if getattr(self.adapter, "SUPPORTS_NATIVE_STREAMING", False) is True and callable(native_stream_factory):
+            native_result = await self._send_or_update_native_stream(text, finalize=finalize, is_turn_final=is_turn_final)
+            if native_result is not None:
+                return native_result
         # Guard: do not create a brand-new standalone message when the only
         # visible content is a handful of characters alongside the streaming
         # cursor.  During rapid tool-calling the model often emits 1-2 tokens

--- a/tests/gateway/test_feishu_cardkit_stream.py
+++ b/tests/gateway/test_feishu_cardkit_stream.py
@@ -1,0 +1,135 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.platforms.feishu import FeishuCardKitStreamSession
+
+
+@pytest.mark.asyncio
+async def test_cardkit_stream_lifecycle_creates_appends_updates_note_and_closes():
+    requests = []
+    sent_refs = []
+
+    async def request_json(method, url, *, headers=None, json_body=None):
+        requests.append((method, url, headers or {}, json_body))
+        if url.endswith('/auth/v3/tenant_access_token/internal'):
+            return {"code": 0, "tenant_access_token": "tenant-token", "expire": 7200}
+        if url.endswith('/cardkit/v1/cards') and method == 'POST':
+            card_data = json.loads(json_body["data"])
+            assert card_data["schema"] == "2.0"
+            assert card_data["config"]["streaming_mode"] is True
+            assert card_data["body"]["elements"][0] == {
+                "tag": "markdown",
+                "content": "",
+                "element_id": "content",
+            }
+            assert card_data["body"]["elements"][2]["element_id"] == "note"
+            assert "<font color='grey'>Agent: Hermes" in card_data["body"]["elements"][2]["content"]
+            return {"code": 0, "data": {"card_id": "card-1"}}
+        return {"code": 0, "msg": "ok"}
+
+    async def send_card_reference(chat_id, card_id, *, reply_to=None, metadata=None):
+        sent_refs.append((chat_id, card_id, reply_to, metadata))
+        return SendResult(success=True, message_id="msg-1")
+
+    session = FeishuCardKitStreamSession(
+        app_id="app-id",
+        app_secret="app-secret",
+        domain_name="feishu",
+        request_json=request_json,
+        send_card_reference=send_card_reference,
+        note="Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI | Generating…",
+    )
+
+    start = await session.start("chat-1", reply_to="root-msg", metadata={"thread_id": "topic-1"})
+    assert start.success is True
+    assert start.message_id == "msg-1"
+    assert sent_refs == [("chat-1", "card-1", "root-msg", {"thread_id": "topic-1"})]
+
+    assert await session.update("hello") is True
+    assert await session.update("hello world") is True
+    await session.update_note("Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI")
+    assert await session.close("hello world", note="Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI") is True
+
+    update_calls = [c for c in requests if c[0] == "PUT" and c[1].endswith('/elements/content/content')]
+    assert [c[3]["content"] for c in update_calls] == ["hello", " world"]
+    assert [c[3]["sequence"] for c in update_calls] == [1, 2]
+    assert update_calls[0][3]["uuid"] == "s_card-1_1"
+
+    note_calls = [c for c in requests if c[0] == "PUT" and c[1].endswith('/elements/note/content')]
+    assert note_calls[-1][3]["content"] == "<font color='grey'>Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI</font>"
+
+    close_calls = [c for c in requests if c[0] == "PATCH" and c[1].endswith('/cardkit/v1/cards/card-1/settings')]
+    assert len(close_calls) == 1
+    close_settings = json.loads(close_calls[0][3]["settings"])
+    assert close_settings["config"]["streaming_mode"] is False
+    assert close_settings["config"]["summary"]["content"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_cardkit_stream_replaces_content_when_text_is_not_append_only():
+    requests = []
+
+    async def request_json(method, url, *, headers=None, json_body=None):
+        requests.append((method, url, json_body))
+        if url.endswith('/auth/v3/tenant_access_token/internal'):
+            return {"code": 0, "tenant_access_token": "tenant-token", "expire": 7200}
+        if url.endswith('/cardkit/v1/cards') and method == 'POST':
+            return {"code": 0, "data": {"card_id": "card-2"}}
+        return {"code": 0}
+
+    async def send_card_reference(*args, **kwargs):
+        return SendResult(success=True, message_id="msg-2")
+
+    session = FeishuCardKitStreamSession(
+        app_id="app-id",
+        app_secret="app-secret",
+        domain_name="feishu",
+        request_json=request_json,
+        send_card_reference=send_card_reference,
+    )
+    await session.start("chat")
+    assert await session.update("abcdef") is True
+    assert await session.update("XYZ") is True
+
+    replace_calls = [c for c in requests if c[0] == "PUT" and c[1].endswith('/elements/content')]
+    assert len(replace_calls) == 1
+    element = json.loads(replace_calls[0][2]["element"])
+    assert element == {"tag": "markdown", "content": "XYZ", "element_id": "content"}
+
+
+def test_feishu_adapter_creates_cardkit_stream_session_with_footer_note():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig(enabled=True, extra={
+        "app_id": "app-id",
+        "app_secret": "app-secret",
+        "domain": "feishu",
+        "card_streaming": True,
+    }))
+
+    session = adapter.create_stream_session(metadata={
+        "stream_footer_note": "Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI"
+    })
+
+    assert isinstance(session, FeishuCardKitStreamSession)
+    assert session.app_id == "app-id"
+    assert session.app_secret == "app-secret"
+    assert session.note == "Agent: Hermes | Model: gpt-5.5 | Provider: OpenAI"
+
+
+def test_feishu_adapter_does_not_offer_cardkit_stream_when_disabled():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig(enabled=True, extra={
+        "app_id": "app-id",
+        "app_secret": "app-secret",
+        "domain": "feishu",
+        "card_streaming": False,
+    }))
+
+    assert not hasattr(adapter, "create_stream_session") or adapter.create_stream_session(metadata={}) is None

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -41,6 +41,13 @@ class TestCleanForDisplay:
             result = GatewayStreamConsumer._clean_for_display(text)
             assert "MEDIA:" not in result, f"Failed for wrapper: {wrapper}"
 
+    def test_lowercase_media_tag_stripped(self):
+        """Lowercase media: tags are internal directives too."""
+        text = "Here\nmedia:/tmp/golden_chinchilla-01.jpg"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "media:" not in result
+        assert "Here" in result
+
     def test_audio_as_voice_stripped(self):
         """[[audio_as_voice]] directive is removed."""
         text = "[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg"
@@ -1908,3 +1915,81 @@ class TestUtf16OverflowDetection:
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
 
+
+
+class _NativeStreamSession:
+    def __init__(self):
+        self.started = []
+        self.updated = []
+        self.closed = []
+        self.message_id = "native-msg-1"
+
+    async def start(self, chat_id, *, reply_to=None, metadata=None):
+        self.started.append((chat_id, reply_to, metadata))
+        from gateway.platforms.base import SendResult
+        return SendResult(success=True, message_id=self.message_id)
+
+    async def update(self, text):
+        self.updated.append(text)
+        return True
+
+    async def close(self, final_text=None, *, note=""):
+        self.closed.append((final_text, note))
+        return True
+
+
+class _NativeStreamAdapter:
+    MAX_MESSAGE_LENGTH = 8000
+    SUPPORTS_NATIVE_STREAMING = True
+
+    def __init__(self, session):
+        self.session = session
+        self.send_calls = []
+        self.edit_calls = []
+
+    def truncate_message(self, text, max_length, len_fn=len):
+        return [text]
+
+    def len_for_limit(self, text):
+        return len(text)
+
+    def create_stream_session(self, metadata=None):
+        return self.session
+
+    async def send(self, *args, **kwargs):
+        self.send_calls.append((args, kwargs))
+        from gateway.platforms.base import SendResult
+        return SendResult(success=True, message_id="fallback-msg")
+
+    async def edit_message(self, *args, **kwargs):
+        self.edit_calls.append((args, kwargs))
+        from gateway.platforms.base import SendResult
+        return SendResult(success=True, message_id=kwargs.get("message_id"))
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_uses_adapter_native_stream_session_instead_of_send_edit():
+    session = _NativeStreamSession()
+    adapter = _NativeStreamAdapter(session)
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat-1",
+        config=StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata={"thread_id": "topic-1", "stream_footer_note": "Agent: Hermes | Model: gpt-5.5"},
+        initial_reply_to_id="root-msg",
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("hello")
+    await asyncio.sleep(0.03)
+    consumer.on_delta(" world")
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert session.started == [("chat-1", "root-msg", {"thread_id": "topic-1", "stream_footer_note": "Agent: Hermes | Model: gpt-5.5"})]
+    assert session.updated[-1] == "hello world"
+    assert session.closed == [("hello world", "Agent: Hermes | Model: gpt-5.5")]
+    assert adapter.send_calls == []
+    assert adapter.edit_calls == []
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True


### PR DESCRIPTION
## Summary
- add Feishu Card Kit streaming sessions for create/update/footer/close lifecycle
- route GatewayStreamConsumer through adapter-native streaming when supported
- pass Feishu stream footer metadata with Agent / Model / Provider
- keep normal Feishu card headers empty by default and footer grey when provided
- align streaming media cleanup with the shared MEDIA tag regex

## Test Plan
- `python3 -m py_compile gateway/platforms/feishu.py gateway/stream_consumer.py gateway/run.py`
- `python3 -m pytest tests/gateway/test_feishu_cardkit_stream.py -q`
- `python3 -m pytest tests/gateway/test_stream_consumer.py -q`

## Notes
- `FEISHU_CARD_STREAMING=true` enables Card Kit streaming.
- Falls back to normal send/edit when the adapter does not provide a native session.
