### PR TITLE
fix: preserve Mattermost thread context for prompts

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -266,6 +266,70 @@ class MattermostAdapter(BasePlatformAdapter):
             return data["root_id"]
         return post_id
 
+    @staticmethod
+    def _clip_thread_text(text: str, limit: int) -> str:
+        """Bound Mattermost thread context before injecting it into the agent."""
+        cleaned = (text or "").strip()
+        if len(cleaned) <= limit:
+            return cleaned
+        return cleaned[: max(0, limit - 1)].rstrip() + "…"
+
+    async def _build_thread_context(
+        self,
+        root_id: str,
+        current_post_id: str,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Fetch a compact Mattermost thread-root context block.
+
+        Mattermost WebSocket events for replies only contain the new reply and
+        its root_id.  Without fetching the root post, prompts like "diagnose
+        this failure" arrive with no failure artifact even though the alert is
+        visible directly above the reply in the Mattermost UI.
+        """
+        if not root_id:
+            return None, None
+
+        try:
+            thread = await self._api_get(f"posts/{root_id}/thread")
+        except Exception as exc:  # noqa: BLE001 - context is best-effort
+            logger.debug("Mattermost: failed to fetch thread %s: %s", root_id, exc)
+            return None, None
+
+        posts = thread.get("posts") if isinstance(thread, dict) else None
+        if not isinstance(posts, dict) or not posts:
+            return None, None
+
+        order = thread.get("order") if isinstance(thread, dict) else None
+        if not isinstance(order, list) or not order:
+            order = list(posts.keys())
+
+        root_post = posts.get(root_id) or {}
+        root_text = self._clip_thread_text(root_post.get("message", ""), 1800)
+        if not root_text:
+            return None, None
+
+        lines = ["[Mattermost thread context]", f"Thread root:\n{root_text}"]
+
+        prior_reply_ids = [
+            str(pid) for pid in order
+            if str(pid) not in {str(root_id), str(current_post_id)}
+            and isinstance(posts.get(str(pid)), dict)
+            and (posts.get(str(pid), {}).get("message") or "").strip()
+        ]
+        if prior_reply_ids:
+            lines.append("Recent earlier replies:")
+            for pid in prior_reply_ids[-5:]:
+                reply_text = self._clip_thread_text(
+                    posts.get(pid, {}).get("message", ""),
+                    600,
+                )
+                if reply_text:
+                    lines.append(f"- {reply_text}")
+
+        context = "\n\n".join(lines)
+        context = self._clip_thread_text(context, 4000)
+        return context, root_text
+
     async def send(
         self,
         chat_id: str,
@@ -276,6 +340,16 @@ class MattermostAdapter(BasePlatformAdapter):
         """Send a message (or multiple chunks) to a channel."""
         if not content:
             return SendResult(success=True)
+
+        # Gateway-level helpers (typing, clarify prompts, final delivery, etc.)
+        # carry thread routing in metadata.  Normal final responses also pass a
+        # reply_to anchor, but default/fallback helpers such as send_clarify()
+        # may not.  Preserve the same Mattermost thread root when reply_mode is
+        # enabled instead of leaking those prompts into the parent channel.
+        if not reply_to and metadata and self._reply_mode == "thread":
+            meta_thread_id = metadata.get("thread_id")
+            if meta_thread_id:
+                reply_to = str(meta_thread_id)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
@@ -788,6 +862,13 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Thread support: if the post is in a thread, use root_id.
         thread_id = post.get("root_id") or None
+        thread_context = None
+        reply_to_text = None
+        if thread_id:
+            thread_context, reply_to_text = await self._build_thread_context(
+                thread_id,
+                post_id,
+            )
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -849,6 +930,7 @@ class MattermostAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name,
             thread_id=thread_id,
+            message_id=post_id,
         )
 
         # Per-channel ephemeral prompt
@@ -865,7 +947,10 @@ class MattermostAdapter(BasePlatformAdapter):
             message_id=post_id,
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
+            reply_to_message_id=thread_id if reply_to_text else None,
+            reply_to_text=reply_to_text,
             channel_prompt=_channel_prompt,
+            channel_context=thread_context,
         )
 
         await self.handle_message(msg_event)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -253,6 +253,46 @@ class TestMattermostSend:
 
         assert result.success is False
 
+    @pytest.mark.asyncio
+    async def test_send_clarify_uses_mattermost_thread_metadata(self):
+        """Clarify prompts in a Mattermost thread should be posted under that thread."""
+        from tools.clarify_gateway import clear_session
+
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "clarify_post"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.json = AsyncMock(return_value={"id": "root_failure", "root_id": ""})
+        mock_get_resp.text = AsyncMock(return_value="")
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._session.get = MagicMock(return_value=mock_get_resp)
+
+        try:
+            result = await self.adapter.send_clarify(
+                chat_id="chan_456",
+                question="Need failure artifact?",
+                choices=["Paste logs"],
+                clarify_id="clarify123",
+                session_key="session123",
+                metadata={"thread_id": "root_failure"},
+            )
+        finally:
+            clear_session("session123")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_failure"
+
 
 # ---------------------------------------------------------------------------
 # WebSocket event parsing
@@ -389,6 +429,57 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_injects_root_post_context(self):
+        """A thread mention should include the Mattermost root post as agent context."""
+        post_data = {
+            "id": "post_reply",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id can you diagnose this failure?",
+            "root_id": "root_failure",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+        self.adapter._api_get = AsyncMock(return_value={
+            "order": ["root_failure", "older_reply", "post_reply"],
+            "posts": {
+                "root_failure": {
+                    "id": "root_failure",
+                    "user_id": "bot_user_id",
+                    "message": (
+                        "⚠️ Hermes nightly maintenance FAILURE\n"
+                        "Hermes update rc: 1\n"
+                        "Log: /home/adityargadgil/.local/state/hermes-maintenance/update-20260603T090001Z.log"
+                    ),
+                },
+                "older_reply": {
+                    "id": "older_reply",
+                    "user_id": "user_456",
+                    "message": "Earlier diagnostic hint",
+                    "root_id": "root_failure",
+                },
+                "post_reply": post_data,
+            },
+        })
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "root_failure"
+        assert msg_event.reply_to_message_id == "root_failure"
+        assert "Hermes nightly maintenance FAILURE" in msg_event.reply_to_text
+        assert "Hermes nightly maintenance FAILURE" in msg_event.channel_context
+        assert "update-20260603T090001Z.log" in msg_event.channel_context
+        assert "Earlier diagnostic hint" in msg_event.channel_context
 
     @pytest.mark.asyncio
     async def test_invalid_post_json_ignored(self):


### PR DESCRIPTION
## Summary
- Fetch Mattermost thread root context for threaded replies so prompts like "diagnose this failure" include the alert/root post the user is replying to.
- Preserve Mattermost thread anchoring for clarify/default helper sends by using `metadata.thread_id` when `reply_to` is absent.
- Add regression coverage for both thread-root context injection and clarify prompts staying in-thread.

## Test plan
- `python -m pytest tests/gateway/test_mattermost.py tests/gateway/test_send_multiple_images.py -q -o 'addopts='`

## Operational note
This fixes a bug observed in threaded Mattermost maintenance-alert replies: the WebSocket event carried the `root_id`, but Hermes did not inject the root alert into agent context, and clarify fallback prompts could post top-level.
