### PR TITLE
fix(feishu): preserve command text in resolved approval card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1921,6 +1921,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "command_preview": cmd_preview,
                 }
             return result
         except Exception as exc:
@@ -1996,22 +1997,28 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_approval_card(*, choice: str, user_name: str, command_preview: str = "") -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+        elements = [
+            {
+                "tag": "markdown",
+                "content": f"{icon} **{label}** by {user_name}",
+            },
+        ]
+        if command_preview:
+            elements.insert(1, {
+                "tag": "markdown",
+                "content": f"**命令内容：**\n```\n{command_preview}\n```",
+            })
         return {
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": elements,
         }
 
     @staticmethod
@@ -2620,7 +2627,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            cmd_preview = state.get("command_preview", "")
+            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name, command_preview=cmd_preview)
             response.card = card
         return response
 


### PR DESCRIPTION
## Problem

When a user approves or denies an exec approval via the Feishu interactive card callback, the replacement card only showed the approval result (e.g. ✅ Approved by username) without the original command text. This made it impossible to see what was approved after the fact.

## Solution

- Store command_preview in _approval_state when sending the approval card
- Pass command_preview to _build_resolved_approval_card in the callback handler
- Render the command text in a code block below the approval result