### PR TITLE
fix(kanban): treat max_runtime_seconds=0 as no limit instead of instant timeout

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2087,6 +2087,11 @@ def create_task(
         )
     if branch_name is not None:
         branch_name = str(branch_name).strip() or None
+    if max_runtime_seconds is not None and int(max_runtime_seconds) <= 0:
+        raise ValueError(
+            "max_runtime_seconds must be a positive integer or None (no limit); "
+            f"got {max_runtime_seconds!r}"
+        )
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
     parents = tuple(p for p in parents if p)
@@ -5127,6 +5132,7 @@ def enforce_max_runtime(
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
+        "  AND t.max_runtime_seconds > 0 "
         "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
         "  AND t.worker_pid IS NOT NULL"
     ).fetchall()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -928,6 +928,62 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
         assert kb.get_task(conn, t).status == "running"
 
 
+def test_max_runtime_zero_is_treated_as_no_limit(kanban_home, monkeypatch):
+    """max_runtime_seconds=0 must not kill the worker.
+
+    A value of 0 was previously treated as a literal upper bound: every
+    non-zero elapsed time triggered an immediate timeout.  After the fix,
+    0 is equivalent to NULL (no cap).
+
+    We insert max_runtime_seconds=0 via SQL to simulate a pre-existing row
+    (``create_task`` now rejects zero at the API boundary).
+    """
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        t = kb.create_task(conn, title="zero-runtime", assignee="a")
+        # Simulate a pre-existing task with max_runtime_seconds=0
+        conn.execute(
+            "UPDATE tasks SET max_runtime_seconds = 0 WHERE id = ?", (t,),
+        )
+        kb.claim_task(conn, t, claimer=f"{host}:w")
+        conn.execute(
+            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+            (999999, t),
+        )
+        run = kb.latest_run(conn, t)
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
+            (999999, run.id),
+        )
+        # Simulate 5 minutes of elapsed time
+        old_started = int(time.time()) - 300
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE id = ?",
+            (old_started, run.id),
+        )
+
+        timed_out = kb.enforce_max_runtime(conn, signal_fn=lambda _pid, _sig: None)
+        assert timed_out == [], "max_runtime_seconds=0 should not trigger timeout"
+        assert kb.get_task(conn, t).status == "running"
+
+
+def test_create_task_rejects_max_runtime_zero(kanban_home):
+    """create_task must reject max_runtime_seconds <= 0."""
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="positive integer"):
+            kb.create_task(conn, title="bad", assignee="a", max_runtime_seconds=0)
+        with pytest.raises(ValueError, match="positive integer"):
+            kb.create_task(conn, title="bad", assignee="a", max_runtime_seconds=-1)
+        # None is fine (no limit)
+        tid = kb.create_task(conn, title="ok", assignee="a", max_runtime_seconds=None)
+        assert tid
+        # Positive is fine
+        tid2 = kb.create_task(conn, title="ok2", assignee="a", max_runtime_seconds=120)
+        assert tid2
+
+
 def test_heartbeat_extends_claim(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")


### PR DESCRIPTION
## What does this PR do?

Treat `max_runtime_seconds=0` as "no limit" in the kanban dispatcher and reject zero/negative values at task creation time. Previously, a value of 0 was treated as a literal upper bound, causing every worker to be killed immediately on the first dispatcher tick.

## Related Issue

Fixes #38366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Add `AND t.max_runtime_seconds > 0` to `enforce_max_runtime()` SQL query so zero-valued rows are skipped (same as NULL). Add validation in `create_task()` to reject `max_runtime_seconds <= 0` with a clear `ValueError`.
- `tests/hermes_cli/test_kanban_db.py`: Add `test_max_runtime_zero_is_treated_as_no_limit` (verifies dispatcher skips zero-valued tasks) and `test_create_task_rejects_max_runtime_zero` (verifies API boundary rejects zero/negative).

## How to Test

1. Run `pytest tests/hermes_cli/test_kanban_db.py -xvs -k "max_runtime_zero or rejects_max_runtime_zero"` — both new tests should pass.
2. Run `pytest tests/hermes_cli/test_kanban_db.py -x` — all 213 kanban DB tests should pass (no regressions).
3. Manual verification: `hermes kanban create --title test --max-runtime-seconds 0` should now raise `ValueError: max_runtime_seconds must be a positive integer or None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_db.py -q` and all 213 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (POSIX signal handling is test-mocked)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `enforce_max_runtime()` in `hermes_cli/kanban_db.py:5101` (callers: 1 — `run_dispatch_tick` at line 5821)
- Analyzed: `create_task()` in `hermes_cli/kanban_db.py:2028` (callers: 4 — kanban_tools.py, kanban_swarm.py, kanban.py CLI, tests)
- Blast radius: LOW — changes are additive (new SQL filter + new validation guard)
- Related patterns: `detect_crashed_workers()` uses similar SQL WHERE clause pattern; validation in `create_task()` follows existing `ValueError` pattern for `title`, `initial_status`, `workspace_kind`
