### PR TITLE
fix(cron): show real next scheduled run time after manual trigger #38281

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -854,6 +854,10 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    # Compute the real next scheduled time for display, so the user sees the
+    # correct future fire time instead of the internal "now" value used to
+    # force immediate execution.  See issue #38281.
+    real_next_run = compute_next_run(job["schedule"])
     return update_job(
         job["id"],
         {
@@ -862,6 +866,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "paused_at": None,
             "paused_reason": None,
             "next_run_at": _hermes_now().isoformat(),
+            "_next_scheduled_run_at": real_next_run,
         },
     )
 
@@ -926,6 +931,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
 
+                # Clear the forced-trigger display override now that the real
+                # next_run_at has been recomputed.  See issue #38281.
+                job.pop("_next_scheduled_run_at", None)
+
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
                 # compute — e.g. 'croniter' missing from the runtime env).
@@ -984,6 +993,8 @@ def advance_next_run(job_id: str) -> bool:
                 new_next = compute_next_run(job["schedule"], now)
                 if new_next and new_next != job.get("next_run_at"):
                     job["next_run_at"] = new_next
+                    # Clear forced-trigger display override (issue #38281).
+                    job.pop("_next_scheduled_run_at", None)
                     save_jobs(jobs)
                     return True
                 return False

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -60,7 +60,7 @@ def cron_list(show_all: bool = False):
         name = job.get("name", "(unnamed)")
         schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
-        next_run = job.get("next_run_at", "?")
+        next_run = job.get("_next_scheduled_run_at") or job.get("next_run_at", "?")
 
         repeat_info = job.get("repeat", {})
         repeat_times = repeat_info.get("times")
@@ -155,7 +155,7 @@ def cron_status():
 
     jobs = list_jobs(include_disabled=False)
     if jobs:
-        next_runs = [j.get("next_run_at") for j in jobs if j.get("next_run_at")]
+        next_runs = [j.get("_next_scheduled_run_at") or j.get("next_run_at") for j in jobs if j.get("_next_scheduled_run_at") or j.get("next_run_at")]
         print(f"  {len(jobs)} active job(s)")
         if next_runs:
             print(f"  Next run: {min(next_runs)}")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -308,7 +308,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
-        "next_run_at": job.get("next_run_at"),
+        "next_run_at": job.get("_next_scheduled_run_at") or job.get("next_run_at"),
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "last_delivery_error": job.get("last_delivery_error"),


### PR DESCRIPTION
## Problem

After manually triggering a recurring cron job (`hermes cron run`), the 'Next run' field showed the internal forced-tick timestamp (`~now`) instead of the real next scheduled fire time. This made it look like the recurring schedule was lost/overwritten.

The value is transient — once the forced tick executes, `next_run_at` is recomputed by croniter back to the correct time. But during the window the user-facing output (CLI and chat agent) is misleading.

## Root Cause

`trigger_job()` intentionally sets `next_run_at = now` so the scheduler picks up the job on the next tick — correct as a mechanism, but this same internal field is what gets surfaced as the user-facing "next scheduled run".

## Fix

1. **`trigger_job()`** now computes the real next scheduled time via `compute_next_run()` and stores it in a transient `_next_scheduled_run_at` field on the job dict.
2. **`_format_job()`** (tool output) prefers `_next_scheduled_run_at` over `next_run_at` when present.
3. **CLI display** (`cron_list`, `cron_status`) also prefers the new field.
4. **`mark_job_run()`** and **`advance_next_run()`** clear the override after recomputing the real `next_run_at`.

The internal `next_run_at = now` mechanism is preserved — only the display is corrected.

## Testing

All 388 existing cron tests pass. The fix is minimal and backward-compatible — the `_next_scheduled_run_at` field is only set during the trigger→execution window and cleared afterward.