### PR TITLE
fix(web): honor plugin-registered backend availability

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -189,6 +189,44 @@ class TestPerCapabilityBackendSelection:
         # Should fall back to firecrawl since exa isn't configured
         assert web_tools._get_search_backend() == "firecrawl"
 
+    def test_custom_plugin_backend_selected_when_registered(self, monkeypatch):
+        """Unknown backend names should consult plugin-registered providers."""
+        from agent.web_search_provider import WebSearchProvider
+        from agent.web_search_registry import _reset_for_tests, register_provider
+        from tools import web_tools
+
+        class CustomExtractProvider(WebSearchProvider):
+            @property
+            def name(self) -> str:
+                return "custom-extract"
+
+            def is_available(self) -> bool:
+                return True
+
+            def supports_search(self) -> bool:
+                return False
+
+            def supports_extract(self) -> bool:
+                return True
+
+            def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+                return []
+
+        _reset_for_tests()
+        register_provider(CustomExtractProvider())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "backend": "firecrawl",
+            "extract_backend": "custom-extract",
+        })
+
+        try:
+            assert web_tools._is_backend_available("custom-extract") is True
+            assert web_tools._get_extract_backend() == "custom-extract"
+            assert web_tools._is_backend_available("missing-custom") is False
+        finally:
+            _reset_for_tests()
+
     def test_fully_backward_compatible_with_web_backend_only(self, monkeypatch):
         from tools import web_tools
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -218,6 +218,21 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+
+    # User-installed web backend plugins are not known to this static helper.
+    # After plugin discovery, trust the registered provider's own cheap
+    # availability check so custom backends can be selected via
+    # web.search_backend / web.extract_backend without hardcoding every
+    # provider name in core.
+    try:
+        _ensure_web_plugins_loaded()
+        from agent.web_search_registry import get_provider as _wsp_get_provider
+
+        provider = _wsp_get_provider(backend)
+        if provider is not None:
+            return bool(provider.is_available())
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## What does this PR do?

Makes web backend availability checks plugin-aware. Today `_is_backend_available()` only recognizes a hardcoded set of built-in backend names. A third-party web provider can register successfully through `PluginContext.register_web_search_provider()`, but if a user sets `web.search_backend` or `web.extract_backend` to that provider name, `_get_capability_backend()` filters it out before dispatch reaches the provider registry.

This PR keeps the existing fast paths for built-in backends, then falls back to the web provider registry for unknown backend names after plugin discovery. That lets user-installed web backend plugins decide their own availability via `provider.is_available()` instead of requiring every provider name to be hardcoded in core.

## Related Issue

Fixes #31873
Fixes #35970

Related open PRs found before opening this one:
- #31829
- #33902
- #36987

This PR differs by including a focused regression test and using the repository PR template/checklist.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools.py`: for unknown backend names, trigger plugin discovery and consult `agent.web_search_registry.get_provider(backend)`, returning the provider's own `is_available()` result when registered.
- `tests/tools/test_web_providers.py`: add a regression test proving a custom registry-backed extract provider is selected via `web.extract_backend`, while an unregistered custom name still returns unavailable.

## How to Test

1. Configure a user web backend plugin that calls `ctx.register_web_search_provider()` and returns a provider named `custom-extract`.
2. Set `web.extract_backend: custom-extract`.
3. Run `web_extract` and verify it routes to the custom provider instead of falling back to `web.backend` / a built-in backend.

Automated test run:

```bash
/root/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_web_providers.py tests/plugins/web/test_web_search_provider_plugins.py -q
# 66 passed, 1 warning in 5.13s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 / Linux 6.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted tests:

```text
..................................................................       [100%]
=============================== warnings summary ===============================
tests/tools/test_web_providers.py::TestWebSearchUsesSearchBackend::test_search_tool_calls_search_backend
  /root/.hermes/hermes-agent/venv/lib/python3.11/site-packages/discord/player.py:30: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
66 passed, 1 warning in 5.13s
```
