### PR TITLE
fix(bluebubbles): ignore update echoes before dedup

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -31,7 +31,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
 )
-from gateway.platforms.helpers import strip_markdown
+from gateway.platforms.helpers import MessageDeduplicator, strip_markdown
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +150,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Suppress true webhook replays for the same inbound message. Status
+        # `updated-message` echoes are filtered before this cache so an update
+        # that arrives before the richer `new-message` cannot steal routing.
+        self._dedup = MessageDeduplicator(max_size=2000, ttl_seconds=300)
 
     # ------------------------------------------------------------------
     # API helpers
@@ -921,6 +925,34 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or ""
         )
 
+        message_id = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+            payload.get("messageGuid"),
+        )
+
+        # BlueBubbles emits `updated-message` for receipt/status changes for an
+        # already-delivered inbound message. The adapter does not implement true
+        # edit/retraction semantics yet (`SUPPORTS_MESSAGE_EDITING = False`), so
+        # treating update echoes as fresh conversational input creates duplicate
+        # replies. Importantly, skip before GUID dedup: if an update echo arrives
+        # first with only a sender/chatIdentifier, it must not cause the later
+        # `new-message` carrying the group chat GUID to be dropped.
+        if event_type == "updated-message":
+            logger.debug(
+                "[bluebubbles] ignoring updated-message webhook for message %s",
+                _redact(message_id or ""),
+            )
+            return web.Response(text="ok")
+
+        if message_id and self._dedup.is_duplicate(message_id):
+            logger.info(
+                "[bluebubbles] ignoring duplicate inbound message %s",
+                _redact(message_id),
+            )
+            return web.Response(text="ok")
+
         # --- Inbound attachment handling ---
         attachments = record.get("attachments") or []
         media_urls: List[str] = []
@@ -964,17 +996,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             payload.get("chat_guid"),
             payload.get("guid"),
         )
-        # Fallback: BlueBubbles v1.9+ webhook payloads omit top-level chatGuid;
-        # the chat GUID is nested under data.chats[0].guid instead.
-        if not chat_guid:
-            _chats = record.get("chats") or []
-            if _chats and isinstance(_chats[0], dict):
-                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        # Fallback: BlueBubbles v1.9+ webhook payloads often omit top-level
+        # chatGuid/chatIdentifier. The chat identity is nested under
+        # data.chats[0]; for group chats the stable routing GUID may appear as
+        # the private-api "[auth-key]" (for example: any;+;<group-id>).
+        _chats = record.get("chats") or []
+        _first_chat = _chats[0] if _chats and isinstance(_chats[0], dict) else {}
+        if not chat_guid and _first_chat:
+            chat_guid = self._value(
+                _first_chat.get("guid"),
+                _first_chat.get("chatGuid"),
+                _first_chat.get("[auth-key]"),
+            )
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),
             payload.get("chatIdentifier"),
             payload.get("identifier"),
+            _first_chat.get("chatIdentifier"),
+            _first_chat.get("identifier"),
+            _first_chat.get("displayName"),
         )
         sender = (
             self._value(
@@ -994,7 +1035,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.json_response({"error": "missing message fields"}, status=400)
 
         session_chat_id = chat_guid or chat_identifier
-        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        is_group = (
+            bool(record.get("isGroup"))
+            or (";+;" in (chat_guid or ""))
+            or any(
+                isinstance(chat, dict) and int(chat.get("style") or 0) >= 43
+                for chat in _chats
+            )
+        )
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug(
@@ -1015,11 +1063,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_id,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -10,6 +10,7 @@ from gateway.config import Platform, PlatformConfig
 def _make_adapter(monkeypatch, **extra):
     monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
     monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    monkeypatch.delenv("BLUEBUBBLES_MENTION_PATTERNS", raising=False)
     from gateway.platforms.bluebubbles import BlueBubblesAdapter
 
     cfg = PlatformConfig(
@@ -261,6 +262,196 @@ class TestBlueBubblesMentionGating:
 
         assert response.status == 200
         assert [event.text for event in handled] == ["hello from a dm"]
+
+    @pytest.mark.asyncio
+    async def test_group_auth_key_payload_without_mention_is_skipped(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-auth-key-1",
+                "text": "casual family chatter",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chats": [
+                    {
+                        "[auth-key]": "any;+;family-group",
+                        "style": 43,
+                        "chatIdentifier": "family-group",
+                        "displayName": "Family",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_group_auth_key_payload_with_mention_uses_group_source(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-auth-key-2",
+                "text": "Hermes summarize this",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chats": [
+                    {
+                        "[auth-key]": "any;+;family-group",
+                        "style": 43,
+                        "chatIdentifier": "family-group",
+                        "displayName": "Family",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "summarize this"
+        assert event.source.chat_id == "any;+;family-group"
+        assert event.source.chat_id_alt == "family-group"
+        assert event.source.chat_type == "group"
+
+    @pytest.mark.asyncio
+    async def test_updated_message_then_new_message_uses_group_source_once(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        updated_first = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "same-message-guid",
+                "text": "Hermes diag 20-8",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chatIdentifier": "+155****0100",
+            },
+        }))
+        new_second = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "same-message-guid",
+                "text": "Hermes diag 20-8",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chats": [
+                    {
+                        "[auth-key]": "any;+;family-group",
+                        "style": 43,
+                        "chatIdentifier": "family-group",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert updated_first.status == 200
+        assert new_second.status == 200
+        assert len(handled) == 1
+        assert handled[0].text == "diag 20-8"
+        assert handled[0].source.chat_id == "any;+;family-group"
+        assert handled[0].source.chat_type == "group"
+
+    @pytest.mark.asyncio
+    async def test_new_message_then_updated_message_does_not_duplicate(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "message-guid-1",
+                "text": "yes",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chatGuid": "any;-;+155****0100",
+                "chatIdentifier": "+155****0100",
+            },
+        }))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "message-guid-1",
+                "text": "yes",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "chatIdentifier": "+155****0100",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert len(handled) == 1
+        assert handled[0].source.chat_id == "any;-;+155****0100"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_new_message_same_guid_is_skipped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "replayed-message-guid",
+                "text": "hello",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert [event.text for event in handled] == ["hello"]
 
 
 class TestBlueBubblesWebhookParsing:


### PR DESCRIPTION
## Summary

- ignore BlueBubbles `updated-message` webhook echoes before GUID dedup or session routing
- add bounded GUID replay dedup for true duplicate `new-message` deliveries
- parse nested `data.chats[0]["[auth-key]"]` group GUIDs and nested chat identifiers
- treat BlueBubbles group `style >= 43` as group evidence for mention gating
- add regression coverage for both event orders: `updated-message` first and `new-message` first

## Why this PR instead of #30996

#30996 is directionally right for exact GUID dedup, but it dedups before chat resolution and uses first-seen semantics. That suppresses duplicate replies, but if BlueBubbles delivers the sparse `updated-message` first and the richer `new-message` second, the adapter can keep the wrong DM-like route and drop the later group route.

This PR fixes that ordering hole by acknowledging `updated-message` echoes before they touch the dedup cache. The later `new-message` remains eligible for normal parsing, including the nested group `[auth-key]` route.

## Related

- Fixes #30708
- Fixes #38339
- Supersedes / complements #30996
- Builds on the payload-shape fix from #38342

## Test plan

```text
/Users/amosclaw/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_bluebubbles.py -o addopts= -q
61 passed in 0.68s

git diff --check
/Users/amosclaw/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py
```
