### PR TITLE
[codex] add website maintenance mode

### DIFF
--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,0 +1,79 @@
+import Head from '@docusaurus/Head';
+import type {ReactNode} from 'react';
+
+type RootProps = {
+  children: ReactNode;
+};
+
+function MaintenancePage() {
+  return (
+    <>
+      <Head>
+        <meta name="robots" content="noindex,nofollow" />
+        <title>Maintenance | Hermes Agent</title>
+      </Head>
+      <main
+        style={{
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          padding: '2rem',
+          background: '#07070d',
+          color: '#e8e4dc',
+          fontFamily:
+            'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+          textAlign: 'center',
+        }}
+      >
+        <section style={{maxWidth: '38rem'}}>
+          <img
+            src="/docs/img/logo.png"
+            alt="Hermes Agent"
+            style={{
+              width: '4rem',
+              height: '4rem',
+              marginBottom: '1.5rem',
+            }}
+          />
+          <p
+            style={{
+              margin: '0 0 0.75rem',
+              color: '#FFD700',
+              fontSize: '0.82rem',
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Maintenance
+          </p>
+          <h1
+            style={{
+              margin: '0 0 1rem',
+              fontSize: 'clamp(2rem, 4vw, 3.5rem)',
+              lineHeight: 1.05,
+            }}
+          >
+            Nous Hermes is in maintenance mode
+          </h1>
+          <p
+            style={{
+              margin: 0,
+              color: '#b7b1a7',
+              fontSize: '1.05rem',
+              lineHeight: 1.7,
+            }}
+          >
+            We are sorting out a few Hermes things and will bring the site back
+            once the docs are ready.
+          </p>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default function Root({children}: RootProps) {
+  void children;
+  return <MaintenancePage />;
+}

--- a/website/tests/maintenance-mode.test.mjs
+++ b/website/tests/maintenance-mode.test.mjs
@@ -1,0 +1,12 @@
+import {readFileSync} from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const rootTheme = readFileSync(new URL('../src/theme/Root.tsx', import.meta.url), 'utf8');
+
+test('site root renders maintenance mode', () => {
+  assert.match(rootTheme, /Nous Hermes is in maintenance mode/);
+  assert.match(rootTheme, /noindex,nofollow/);
+  assert.match(rootTheme, /children/);
+  assert.match(rootTheme, /return <MaintenancePage \/>/);
+});


### PR DESCRIPTION
## Summary
- Add a Docusaurus theme root that renders a noindex maintenance page for the docs site.
- Add a focused Node test asserting the maintenance page markers stay present.

## Validation
- `node --test tests/maintenance-mode.test.mjs` passed on the clean branch.
- `npm run build` passed on the clean branch. Existing unresolved Markdown link warnings were emitted by Docusaurus.
- Secret-pattern scan on added files found no matches.
- `npm run typecheck` currently fails on current `origin/main` in `src/components/UserStoriesCollage/index.tsx` with `TS2503: Cannot find namespace JSX`.
