### PR TITLE
fix: surface WhatsApp quote-reply text for agent context

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1381,6 +1381,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                reply_to_message_id=data.get("quotedMessageId"),
+                reply_to_text=data.get("quotedText"),
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -146,6 +146,19 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+// Extract a text snippet from a quoted (replied-to) message so the gateway
+// can inject reply context into the agent prompt.
+function getQuotedText(contextInfo) {
+  const quoted = contextInfo?.quotedMessage;
+  if (!quoted || typeof quoted !== 'object') return null;
+  if (quoted.conversation) return quoted.conversation;
+  if (quoted.extendedTextMessage?.text) return quoted.extendedTextMessage.text;
+  if (quoted.imageMessage) return quoted.imageMessage.caption || '[image]';
+  if (quoted.videoMessage) return quoted.videoMessage.caption || '[video]';
+  if (quoted.documentMessage) return quoted.documentMessage.caption || quoted.documentMessage.fileName || '[document]';
+  return null;
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -321,6 +334,7 @@ async function startSocket() {
       const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
       const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
       const hasQuotedMessage = !!contextInfo?.quotedMessage;
+      const quotedText = getQuotedText(contextInfo);
 
       // Extract message body
       let body = '';
@@ -436,6 +450,7 @@ async function startSocket() {
         quotedParticipant,
         quotedRemoteJid,
         hasQuotedMessage,
+        quotedText,
         botIds,
         timestamp: msg.messageTimestamp,
       };


### PR DESCRIPTION
Bridge now extracts quotedText from contextInfo.quotedMessage and whatsapp.py maps it to MessageEvent reply_to fields, enabling the gateway's existing reply-context injection for WhatsApp quote-replies.