### PR TITLE
fix(installer): restore main build — pass LogStream to emit_log calls from #38296

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -165,6 +165,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     emit_log(
         &app,
         Some("update"),
+        LogStream::Stdout,
         &format!("[update] updating against branch {update_branch}"),
     );
     let child_env = update_child_env(&install_root);
@@ -330,6 +331,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
             emit_log(
                 &app,
                 None,
+                LogStream::Stderr,
                 &format!("[update] could not auto-launch desktop: {err}. Launch Hermes manually."),
             );
         }
@@ -585,6 +587,7 @@ async fn install_macos_app_update(
         emit_log(
             app,
             Some("install"),
+            LogStream::Stdout,
             &format!(
                 "[update] rebuilt app is already the launch target: {}",
                 target_app.display()
@@ -596,6 +599,7 @@ async fn install_macos_app_update(
     emit_log(
         app,
         Some("install"),
+        LogStream::Stdout,
         &format!(
             "[update] installing rebuilt app {} -> {}",
             rebuilt_app.display(),


### PR DESCRIPTION
## Summary

`main` currently **does not compile** the bootstrap installer (`apps/bootstrap-installer/src-tauri`).

PR #38296 (merged as `9632609`) added four `emit_log(...)` calls in `update.rs` using the old **3-arg** signature. Meanwhile #38312 ("stop mislabeling stdout-style progress as stderr", `810e5864d`/`84710995e`) had already changed `emit_log` to take a 4th `stream: LogStream` argument. The two PRs touched different lines, so the merge of #38296 auto-resolved with **no conflict** — leaving `main` with the 4-arg signature *and* 4 stale 3-arg calls:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> src/update.rs:165 / 330 / 585 / 596
```

This is the classic stale-branch-vs-recent-fix skew (the #38296 branch predated the `LogStream` change, so it built green on the branch but breaks on `main`).

## Changes

- `update.rs` — supply the missing `stream` arg to the 4 call sites:
  - `Stdout` for the update/install **progress** lines (updating-against-branch, already-launch-target, installing-rebuilt-app)
  - `Stderr` for the **"could not auto-launch desktop"** failure line

matching the stdout/stderr convention introduced in #38312.

## Test plan

- [x] `cargo check` in `apps/bootstrap-installer/src-tauri` — passes (only pre-existing dead-code warnings)
- [ ] `cargo test` (installer unit tests)
- [ ] Full `tauri build` produces a signed installer dmg

## Note

This PR is intentionally scoped to **only** the build break. A separate report — in-app macOS self-update relaunching the installer ("Hermes Setup") with a blank screen instead of the rebuilt **Hermes** desktop app — is still under investigation and not addressed here.

Made with [Cursor](https://cursor.com)