### PR TITLE
fix(kanban): gate goal_mode task completion with auxiliary judge

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -589,11 +589,56 @@ def test_complete_retry_with_corrected_created_cards_succeeds(worker_env):
     }))
     assert ok.get("ok") is True
 
+
+def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
+    """Goal-mode tasks must pass the auxiliary judge before completion.
+    Regression for #38367: workers bypassing the judge via early kanban_complete."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    # Set up isolated HERMES_HOME
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
     conn = kb.connect()
     try:
-        assert kb.get_task(conn, worker_env).status == "done"
+        goal_task_id = kb.create_task(
+            conn, title="goal-mode-test", assignee="test-worker",
+            body="Must achieve X with verified evidence.", goal_mode=True
+        )
+        kb.claim_task(conn, goal_task_id)
     finally:
         conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+
+    # Mock the judge to reject the completion
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
+        return "continue", "missing verification evidence", False
+
+    monkeypatch.setattr("hermes_cli.goals.judge_goal", mock_judge_goal)
+
+    # Attempt to complete should be rejected
+    out = kt._handle_complete({"summary": "I did some stuff but not X"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "Goal completion rejected by judge" in d["error"]
+    assert "missing verification evidence" in d["error"]
+    assert "create continuation tasks" in d["error"]
+
+    # Verify the task is NOT completed in the DB
+    conn2 = kb.connect()
+    try:
+        task = kb.get_task(conn2, goal_task_id)
+        assert task.status == "running"  # Should still be running, not done
+    finally:
+        conn2.close()
 
 
 def test_block_happy_path(worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -622,7 +622,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
         return "continue", "missing verification evidence", False
 
-    monkeypatch.setattr("hermes_cli.goals.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
 
     # Attempt to complete should be rejected
     out = kt._handle_complete({"summary": "I did some stuff but not X"})

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -618,11 +618,13 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
 
-    # Mock the judge to reject the completion
+    # Mock the judge to reject the completion. The gate only runs when a
+    # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
         return "continue", "missing verification evidence", False
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
 
     # Attempt to complete should be rejected
     out = kt._handle_complete({"summary": "I did some stuff but not X"})
@@ -630,13 +632,63 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     assert "error" in d
     assert "Goal completion rejected by judge" in d["error"]
     assert "missing verification evidence" in d["error"]
-    assert "create continuation tasks" in d["error"]
+    assert f"parents=[{goal_task_id}]" in d["error"]
 
     # Verify the task is NOT completed in the DB
     conn2 = kb.connect()
     try:
         task = kb.get_task(conn2, goal_task_id)
         assert task.status == "running"  # Should still be running, not done
+    finally:
+        conn2.close()
+
+
+def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path):
+    """Fail-open: an unreachable judge must not wedge a goal_mode worker.
+
+    judge_goal returns a "continue" verdict when no auxiliary model is
+    configured, which is indistinguishable from a real "not done" judgment.
+    The gate probes availability first, so completion proceeds rather than
+    being rejected forever when no judge can be reached."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        goal_task_id = kb.create_task(
+            conn, title="goal-mode-test", assignee="test-worker",
+            body="Must achieve X with verified evidence.", goal_mode=True
+        )
+        kb.claim_task(conn, goal_task_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+
+    # No judge reachable. judge_goal must not even be consulted; if it were,
+    # this stub would reject — so reaching "done" proves the probe short-circuit.
+    def fail_if_called(goal, last_response, *, timeout=30.0, subgoals=None):
+        raise AssertionError("judge_goal must not run when no judge is available")
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", fail_if_called)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: False)
+
+    out = kt._handle_complete({"summary": "done enough"})
+    d = json.loads(out)
+    assert d.get("ok") is True
+
+    conn2 = kb.connect()
+    try:
+        assert kb.get_task(conn2, goal_task_id).status == "done"
     finally:
         conn2.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -33,6 +33,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
@@ -558,26 +559,28 @@ def _handle_complete(args: dict, **kw) -> str:
             # calling kanban_complete before acceptance criteria are met.
             task = kb.get_task(conn, tid)
             if task and task.goal_mode:
+                verdict = "done"
+                reason = ""
                 try:
-                    from hermes_cli.goals import judge_goal
                     verdict, reason, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )
-                    if verdict != "done":
-                        return tool_error(
-                            f"Goal completion rejected by judge: {reason}. "
-                            f"To proceed, either: (1) provide explicit acceptance "
-                            f"evidence in your summary matching the task's criteria, "
-                            f"or (2) create continuation tasks with parent={tid} "
-                            f"and keep this task alive."
-                        )
                 except Exception as judge_exc:
                     # Fail-open to avoid wedging the worker if the judge
                     # is temporarily unavailable or misconfigured.
                     logger.warning(
                         "goal judge check failed, allowing completion: %s",
                         judge_exc,
+                        exc_info=True,
+                    )
+                if verdict != "done":
+                    return tool_error(
+                        f"Goal completion rejected by judge: {reason}. "
+                        f"To proceed, either: (1) provide explicit acceptance "
+                        f"evidence in your summary matching the task's criteria, "
+                        f"or (2) create continuation tasks with parent={tid} "
+                        f"and keep this task alive."
                     )
 
             try:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -553,6 +553,33 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            # Goal-mode pre-completion judge gate (Issue #38367).
+            # Prevent workers from bypassing the auxiliary judge by
+            # calling kanban_complete before acceptance criteria are met.
+            task = kb.get_task(conn, tid)
+            if task and task.goal_mode:
+                try:
+                    from hermes_cli.goals import judge_goal
+                    verdict, reason, _ = judge_goal(
+                        goal=f"{task.title}\n\n{task.body or ''}".strip(),
+                        last_response=(summary or result or "").strip(),
+                    )
+                    if verdict != "done":
+                        return tool_error(
+                            f"Goal completion rejected by judge: {reason}. "
+                            f"To proceed, either: (1) provide explicit acceptance "
+                            f"evidence in your summary matching the task's criteria, "
+                            f"or (2) create continuation tasks with parent={tid} "
+                            f"and keep this task alive."
+                        )
+                except Exception as judge_exc:
+                    # Fail-open to avoid wedging the worker if the judge
+                    # is temporarily unavailable or misconfigured.
+                    logger.warning(
+                        "goal judge check failed, allowing completion: %s",
+                        judge_exc,
+                    )
+
             try:
                 ok = kb.complete_task(
                     conn, tid,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -177,6 +177,27 @@ def _connect(board: Optional[str] = None):
     return kb, kb.connect(board=board)
 
 
+def _goal_judge_available() -> bool:
+    """True when an auxiliary client is configured for the goal judge.
+
+    ``judge_goal`` is fail-open at the source: when no auxiliary model can
+    be reached it returns a ``"continue"`` verdict that is indistinguishable
+    from a real "not done yet" judgment. The completion gate must not treat
+    that as a rejection, or an unconfigured/degraded auxiliary model would
+    wedge every ``goal_mode`` worker (it could never close its own task).
+
+    So we probe availability first and only enforce the gate when a judge is
+    actually reachable. This mirrors the same client lookup ``judge_goal``
+    performs internally.
+    """
+    try:
+        from agent.auxiliary_client import get_text_auxiliary_client
+        client, model = get_text_auxiliary_client("goal_judge")
+    except Exception:
+        return False
+    return client is not None and bool(model)
+
+
 # ---------------------------------------------------------------------------
 # Runtime-activity → board-heartbeat bridge (#31752)
 # ---------------------------------------------------------------------------
@@ -557,8 +578,10 @@ def _handle_complete(args: dict, **kw) -> str:
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
             # calling kanban_complete before acceptance criteria are met.
+            # Only enforce when a judge is actually reachable — see
+            # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
-            if task and task.goal_mode:
+            if task and task.goal_mode and _goal_judge_available():
                 verdict = "done"
                 reason = ""
                 try:
@@ -567,8 +590,8 @@ def _handle_complete(args: dict, **kw) -> str:
                         last_response=(summary or result or "").strip(),
                     )
                 except Exception as judge_exc:
-                    # Fail-open to avoid wedging the worker if the judge
-                    # is temporarily unavailable or misconfigured.
+                    # Defensive: judge_goal swallows its own errors, but if
+                    # it ever raises, fail open rather than wedge the worker.
                     logger.warning(
                         "goal judge check failed, allowing completion: %s",
                         judge_exc,
@@ -579,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                         f"Goal completion rejected by judge: {reason}. "
                         f"To proceed, either: (1) provide explicit acceptance "
                         f"evidence in your summary matching the task's criteria, "
-                        f"or (2) create continuation tasks with parent={tid} "
+                        f"or (2) create continuation tasks with parents=[{tid}] "
                         f"and keep this task alive."
                     )
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bypass vulnerability in the kanban `goal_mode` workflow where a worker agent could prematurely call `kanban_complete` before the acceptance criteria were actually met.

Previously, calling `kanban_complete` would immediately transition the task to `done` in the database, causing the goal loop to exit without ever invoking the auxiliary judge. This PR introduces a pre-completion judge gate in the `kanban_complete` tool handler. If a task has `goal_mode=True`, the handler now synchronously invokes the `judge_goal` function against the task's title/body and the proposed completion summary. If the verdict is not `"done"`, the completion is rejected with actionable guidance for the agent.

This approach keeps `kanban_db.py` as a pure, model-agnostic SQLite wrapper while intercepting the bypass exactly at the agent tool-call boundary, aligning with Hermes' separation of concerns.

## Related Issue

Fixes #38367

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/kanban_tools.py`**: Added a pre-completion judge gate in `_handle_complete`. If `task.goal_mode` is true, it calls `judge_goal` before allowing `kb.complete_task`. Includes a fail-open `try/except` block to prevent wedging the worker if the judge is temporarily unavailable.
- **`tests/tools/test_kanban_tools.py`**: Added `test_complete_goal_mode_rejected_by_judge` to verify that a `goal_mode` task completion is rejected when the mocked judge returns `"continue"`, and that the task status remains `"running"` in the database.

## How to Test

1. Create a kanban task with `goal_mode=True` and a body containing explicit terminal outcome criteria.
2. Dispatch a worker to this task.
3. Have the worker call `kanban_complete` with a summary that does *not* satisfy the criteria.
4. **Expected Result**: The tool call returns an error: `"Goal completion rejected by judge..."`. The task remains in the `"running"` state, and the goal loop continues.
5. Run the test suite: `scripts/run_tests.sh tests/tools/test_kanban_tools.py -- -k test_complete_goal_mode_rejected_by_judge` (should pass).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `scripts/run_tests.sh` and all related tests pass
- [x] I've added tests for my changes