### PR TITLE
feat(desktop): surface dangerous-command approval prompts

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import { ApprovalOverlay } from '@/components/approval-overlay'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { DesktopOnboardingOverlay } from '@/components/desktop-onboarding-overlay'
@@ -561,6 +562,7 @@ export function DesktopController() {
       <UpdatesOverlay />
       <GatewayConnectingOverlay />
       <BootFailureOverlay />
+      <ApprovalOverlay />
 
       {settingsOpen && (
         <Suspense fallback={null}>

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -16,6 +16,7 @@ import {
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { setApprovalRequest } from '@/store/approval'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -809,6 +810,26 @@ export function useMessageStream({
             question,
             choices: Array.isArray(payload?.choices) ? payload!.choices!.filter(c => typeof c === 'string') : null,
             sessionId: sessionId ?? null
+          })
+        }
+      } else if (event.type === 'approval.request') {
+        if (!isActiveEvent) {
+          return
+        }
+
+        // Surface the dangerous-command approval modal. The Python side blocks
+        // in tools/approval.py:_await_gateway_decision on `approval.respond`;
+        // silence denies on timeout, so without this a desktop-only user never
+        // sees the gate and every dangerous command times out. Emitted from
+        // tui_gateway/server.py:578 (register_gateway_notify → approval.request).
+        const command = typeof payload?.command === 'string' ? payload.command : ''
+        const description = typeof payload?.description === 'string' ? payload.description : ''
+
+        if (command) {
+          setApprovalRequest({
+            command,
+            description: description || 'dangerous command',
+            sessionId: explicitSid || sessionId || null
           })
         }
       } else if (event.type === 'error') {

--- a/apps/desktop/src/components/approval-overlay.test.tsx
+++ b/apps/desktop/src/components/approval-overlay.test.tsx
@@ -1,0 +1,84 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApprovalOverlay } from '@/components/approval-overlay'
+import type { HermesGateway } from '@/hermes'
+import { $approvalRequest, setApprovalRequest } from '@/store/approval'
+import { setGateway } from '@/store/gateway'
+
+const request = vi.fn()
+
+function mockGateway(): void {
+  setGateway({ request } as unknown as HermesGateway)
+}
+
+function open(command = 'rm -rf /tmp/old', sessionId: string | null = 'sess-1'): void {
+  act(() => {
+    setApprovalRequest({ command, description: 'recursive delete', sessionId })
+  })
+}
+
+beforeEach(() => {
+  request.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  cleanup()
+  act(() => {
+    $approvalRequest.set(null)
+  })
+  setGateway(null)
+  vi.clearAllMocks()
+})
+
+describe('ApprovalOverlay', () => {
+  it('renders nothing when there is no pending approval', () => {
+    const { container } = render(<ApprovalOverlay />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('surfaces the command and description once a request arrives', () => {
+    render(<ApprovalOverlay />)
+    open()
+
+    expect(screen.getByText('recursive delete')).toBeTruthy()
+    expect(screen.getByText('rm -rf /tmp/old')).toBeTruthy()
+  })
+
+  it('sends approval.respond with the chosen action and clears the request', async () => {
+    mockGateway()
+    render(<ApprovalOverlay />)
+    open()
+
+    fireEvent.click(screen.getByText('Approve once'))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+    )
+    await waitFor(() => expect($approvalRequest.get()).toBeNull())
+  })
+
+  it('denies on Escape as the safe default', async () => {
+    mockGateway()
+    render(<ApprovalOverlay />)
+    open()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'sess-1' })
+    )
+  })
+
+  it('does not dispatch when the gateway is disconnected', () => {
+    render(<ApprovalOverlay />)
+    open()
+
+    fireEvent.click(screen.getByText('Always allow'))
+
+    expect(request).not.toHaveBeenCalled()
+    // Request stays open so the user can retry once the gateway reconnects.
+    expect($approvalRequest.get()).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/components/approval-overlay.tsx
+++ b/apps/desktop/src/components/approval-overlay.tsx
@@ -1,0 +1,139 @@
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { triggerHaptic } from '@/lib/haptics'
+import { AlertTriangle, Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { $approvalRequest, type ApprovalChoice, clearApprovalRequest } from '@/store/approval'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+
+// Order mirrors the TUI overlay (1 once → 2 session → 3 always → 4 deny). Deny
+// is rendered last and styled destructive so it reads as the safe way out.
+const CHOICES: { choice: ApprovalChoice; label: string; variant: 'default' | 'destructive' | 'outline' }[] = [
+  { choice: 'once', label: 'Approve once', variant: 'default' },
+  { choice: 'session', label: 'Approve for session', variant: 'outline' },
+  { choice: 'always', label: 'Always allow', variant: 'outline' },
+  { choice: 'deny', label: 'Deny', variant: 'destructive' }
+]
+
+// Top-level modal for dangerous-command approvals. Unlike clarify (an inline
+// tool card), approval is an interception of the terminal tool, so it has no
+// message part to render against — it lives as a controller-level overlay
+// driven purely by the `approval.request` gateway event. The Python agent is
+// blocked on `approval.respond` until a choice lands (silence denies on
+// timeout), which is why a desktop-only user was hanging on every gate.
+export function ApprovalOverlay() {
+  const request = useStore($approvalRequest)
+  const gateway = useStore($gateway)
+  const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
+
+  const respond = useCallback(
+    async (choice: ApprovalChoice) => {
+      if (!request || submitting) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
+
+        return
+      }
+
+      setSubmitting(choice)
+
+      try {
+        await gateway.request<{ ok?: boolean }>('approval.respond', {
+          choice,
+          session_id: request.sessionId ?? ''
+        })
+        triggerHaptic('submit')
+        clearApprovalRequest(request.sessionId ?? undefined)
+      } catch (error) {
+        notifyError(error, 'Could not send approval response')
+        setSubmitting(null)
+      }
+    },
+    [gateway, request, submitting]
+  )
+
+  // Escape denies — same safe default as the TUI (escape → 'deny'). Only wired
+  // while a request is open so it never shadows other Escape handlers.
+  useEffect(() => {
+    if (!request) {
+      return
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        void respond('deny')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [request, respond])
+
+  if (!request) {
+    return null
+  }
+
+  const busy = submitting !== null
+
+  return (
+    <div
+      aria-modal="true"
+      className="fixed inset-0 z-[1300] grid place-items-center bg-black/55 p-6 backdrop-blur-sm"
+      role="alertdialog"
+    >
+      <div
+        className={cn(
+          'grid w-full max-w-lg gap-4 rounded-2xl border border-border/70 bg-card px-5 py-5 text-sm shadow-2xl',
+          'shadow-[0_24px_60px_-20px_rgba(0,0,0,0.55)]'
+        )}
+        data-slot="approval-overlay"
+      >
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden
+            className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg bg-destructive/12 text-destructive ring-1 ring-inset ring-destructive/25"
+          >
+            <AlertTriangle className="size-4" />
+          </span>
+          <div className="grid flex-1 gap-1">
+            <span className="text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground/85">
+              Dangerous command — approval required
+            </span>
+            <span className="whitespace-pre-wrap leading-snug text-foreground">{request.description}</span>
+          </div>
+        </div>
+
+        <pre className="max-h-48 overflow-auto rounded-lg border border-border/70 bg-background/70 px-3 py-2.5 font-mono text-[0.8125rem] leading-relaxed text-foreground/95 wrap-anywhere whitespace-pre-wrap">
+          {request.command}
+        </pre>
+
+        <div className="grid gap-1.5 sm:grid-cols-2">
+          {CHOICES.map(({ choice, label, variant }) => (
+            <Button
+              className="justify-center"
+              disabled={busy}
+              key={choice}
+              onClick={() => void respond(choice)}
+              type="button"
+              variant={variant}
+            >
+              {submitting === choice ? <Loader2 className="size-3.5 animate-spin" /> : label}
+            </Button>
+          ))}
+        </div>
+
+        <span className="text-[0.6875rem] text-muted-foreground/85">
+          Esc denies. “Always allow” adds this command to the permanent allowlist on the agent host.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -54,6 +54,9 @@ export type GatewayEventPayload = {
   request_id?: string
   question?: string
   choices?: string[] | null
+  // approval.request
+  command?: string
+  description?: string
 }
 
 export function textPart(text: string): ChatMessagePart {

--- a/apps/desktop/src/store/approval.test.ts
+++ b/apps/desktop/src/store/approval.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $approvalRequest, clearApprovalRequest, setApprovalRequest } from './approval'
+
+afterEach(() => {
+  $approvalRequest.set(null)
+})
+
+describe('approval store', () => {
+  it('stores the latest approval request', () => {
+    setApprovalRequest({ command: 'rm -rf old', description: 'recursive delete', sessionId: 'sess-1' })
+
+    expect($approvalRequest.get()).toEqual({
+      command: 'rm -rf old',
+      description: 'recursive delete',
+      sessionId: 'sess-1'
+    })
+  })
+
+  it('clears unconditionally when no sessionId is supplied', () => {
+    setApprovalRequest({ command: 'a', description: 'b', sessionId: 'sess-1' })
+    clearApprovalRequest()
+
+    expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('only clears when the sessionId matches, guarding against a stale race', () => {
+    setApprovalRequest({ command: 'a', description: 'b', sessionId: 'sess-1' })
+
+    clearApprovalRequest('sess-2')
+    expect($approvalRequest.get()).not.toBeNull()
+
+    clearApprovalRequest('sess-1')
+    expect($approvalRequest.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/approval.ts
+++ b/apps/desktop/src/store/approval.ts
@@ -1,0 +1,42 @@
+import { atom } from 'nanostores'
+
+// The four choices the backend accepts for `approval.respond` (see
+// tools/approval.py:resolve_gateway_approval and the TUI's approvalAction:
+// 1→once, 2→session, 3→always, 4/escape→deny).
+export type ApprovalChoice = 'always' | 'deny' | 'once' | 'session'
+
+export interface ApprovalRequest {
+  command: string
+  description: string
+  sessionId: string | null
+}
+
+// Holds the most recent in-flight dangerous-command approval. The
+// ApprovalOverlay reads this to render the modal and to know which
+// session_id to echo back over `approval.respond`. The Python agent thread
+// is blocked in tools/approval.py:_await_gateway_decision until a choice
+// arrives — silence denies on timeout — so without surfacing this, a desktop
+// user never sees the gate and every dangerous command times out.
+// Backend emits it via tui_gateway/server.py:578
+// (register_gateway_notify → _emit('approval.request', sid, {command, description})).
+export const $approvalRequest = atom<ApprovalRequest | null>(null)
+
+export function setApprovalRequest(request: ApprovalRequest): void {
+  $approvalRequest.set(request)
+}
+
+export function clearApprovalRequest(sessionId?: string): void {
+  const current = $approvalRequest.get()
+
+  if (!current) {
+    return
+  }
+
+  // Guard against a stale clear racing a newer request for a different
+  // session (e.g. two sessions each hitting a gate in quick succession).
+  if (sessionId && current.sessionId !== sessionId) {
+    return
+  }
+
+  $approvalRequest.set(null)
+}


### PR DESCRIPTION
## Summary

The Electron desktop app never handled the gateway `approval.request` event, so a **desktop-only** user never saw the dangerous-command approval gate. Every dangerous command silently rode the approval timeout to an automatic deny (or hung, depending on mode), with no way for the user to approve from the GUI.

The backend approval contract was already complete; only the desktop UI layer was missing. This PR adds it, mirroring the existing `clarify.request` pattern.

## Background / root cause

- `tools/approval.py` detects dangerous terminal commands and, in gateway sessions, blocks the agent thread in `_await_gateway_decision` until `approval.respond` arrives (silence denies on timeout).
- `tui_gateway/server.py` already registers the notifier that emits the event: `register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))`, and exposes the `approval.respond` RPC which resolves on the session's `session_key`.
- The TUI handles this fully. The desktop renderer (`apps/desktop`) received gateway events through `use-message-stream.ts` and handled `clarify.request`, tool output, session info, etc., but **had no `approval.request` handling at all** — so the modal never rendered and the response was never sent.

## What changed

- **`src/store/approval.ts`** (new): a `$approvalRequest` nanostores atom with `set`/`clear`, mirroring `store/clarify.ts`.
- **`src/components/approval-overlay.tsx`** (new): a controller-level modal. Unlike clarify (an inline tool card), approval is an interception of the terminal tool, so it has no message part to render against and lives as a top-level overlay. Shows the command + description, offers `Approve once` / `Approve for session` / `Always allow` / `Deny`, and sends `approval.respond { choice, session_id }`. Escape denies (same safe default as the TUI's `approvalAction`).
- **`src/lib/chat-messages.ts`**: added `command` / `description` to `GatewayEventPayload`.
- **`src/app/session/hooks/use-message-stream.ts`**: new `approval.request` handler beside the existing `clarify.request` one.
- **`src/app/desktop-controller.tsx`**: mount `<ApprovalOverlay />` alongside the other overlays.
- **Tests**: `store/approval.test.ts` and `components/approval-overlay.test.tsx` (8 assertions) pin the param shape (`{ choice, session_id }`), the four choice strings, the disconnected-gateway path, and Escape-denies.

## How it works (contract)

- Event in: `approval.request` with `{ session_id, payload: { command, description } }` (no `request_id`, unlike clarify — approval resolves on `session_key`).
- Response out: `approval.respond` with `{ choice, session_id }`, choices `once | session | always | deny`, matching the TUI client (`ui-tui/src/app/useMainApp.ts`, `useInputHandlers.ts`) and the backend's `resolve_gateway_approval`.

## Testing

- `tsc -b` clean, `vite build` succeeds.
- `vitest run` for the two new files: 8/8 pass.
- Verified live end to end: with `approvals.mode: manual`, a dangerous command from desktop chat surfaces the modal; choosing `Approve once` unblocks the agent.

## Known limitations / follow-ups

1. The store is a single atom, but the backend supports a FIFO queue of pending approvals per session (`_gateway_queues[session_key]`). In the common one-command-at-a-time case this is invisible; under parallel/subagent approvals the displayed command and the FIFO-resolved one could diverge. A clean fix needs the backend to emit a per-approval id (it currently emits none), so this is gated on a backend contract change rather than a desktop-only fix.
2. The handler early-returns on non-active sessions (mirrors the clarify handler), so a dangerous command from a background session is not surfaced and rides the timeout to a deny. Deny-by-default on background is arguably the safe choice, but noting it.
