### PR TITLE
fix(cli): scope web UI npm install to --workspace web

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6929,7 +6929,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     r1 = _run_npm_install_deterministic(
         npm,
         _workspace_root(web_dir),
-        extra_args=("--silent",),
+        extra_args=("--silent", "--workspace", "web"),
     )
     if r1.returncode != 0:
         _say(


### PR DESCRIPTION
## Summary

Fixes #38358. `hermes_cli/main.py::_build_web_ui()` was invoking `_run_npm_install_deterministic()` without scoping it to the `web` workspace. On repos with additional workspaces (notably `apps/desktop`, which pulls in Electron via devDependencies), npm tries to resolve every workspace, fetches the ~200MB Electron binary, and the install step fails — surfacing as:

```
→ Building web UI...
⚠ Web UI npm install failed (hermes web will not be available)
```

during the CLI self-upgrade flow on Windows.

## Root Cause

`_build_web_ui()` (around line 6929):

```python
r1 = _run_npm_install_deterministic(
    npm,
    _workspace_root(web_dir),
    extra_args=("--silent",),
)
```

The peer call site `_update_node_dependencies()` step 2 already scopes the workspaced install with `"--workspace", "web"`; this path was inconsistent.

## Fix

Add `"--workspace", "web"` to `extra_args` so npm only installs the web workspace deps, matching the pattern used elsewhere in the same module. One-line change.

## Testing

```
pytest tests/ -k 'web_ui or build_web'
# 16 passed, 2 skipped
```

## Risk

Minimal. The change tightens npm's workspace scope to the exact directory we are about to build, which is the documented intent. Single-workspace repos are unaffected because `--workspace web` is still valid when `web` is the only workspace.
