### PR TITLE
fix(uv): never gut the venv in place when rebuilding on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /venv/
+/venv.old/
 /_pycache/
 *.pyc*
 __pycache__/

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7834,7 +7834,10 @@ def _update_via_zip(args):
     # may point to a Python without FTS5.  Rebuild it so the new managed
     # uv provides a fresh interpreter with FTS5 guaranteed.
     if fresh_bootstrap and uv_bin:
-        rebuild_venv(uv_bin, PROJECT_ROOT / "venv")
+        if not rebuild_venv(uv_bin, PROJECT_ROOT / "venv"):
+            raise RuntimeError(
+                "venv rebuild failed; aborting update before dependency install"
+            )
 
     pip_cmd = [sys.executable, "-m", "pip"]
     if not uv_bin:
@@ -10036,7 +10039,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # may point to a Python without FTS5.  Rebuild it so the new managed
         # uv provides a fresh interpreter with FTS5 guaranteed.
         if fresh_bootstrap and uv_bin:
-            rebuild_venv(uv_bin, PROJECT_ROOT / "venv")
+            if not rebuild_venv(uv_bin, PROJECT_ROOT / "venv"):
+                raise RuntimeError(
+                    "venv rebuild failed; aborting update before dependency install"
+                )
 
         pip_cmd = [sys.executable, "-m", "pip"]
         if not uv_bin:

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -105,18 +105,45 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
     old venv may point to a Python without FTS5, so we rebuild it with a
     fresh interpreter from the current managed uv.  Returns ``True`` on
     success.
+
+    The old venv is moved aside *atomically* before recreating, never deleted
+    in place.  On Windows a still-running ``hermes.exe`` (gateway/desktop) holds
+    ``venv\\Scripts\\python.exe`` open; ``shutil.rmtree(ignore_errors=True)``
+    would delete everything it *can* (site-packages, certifi's cert bundle) and
+    silently leave a half-gutted venv that the following ``uv venv`` then refuses
+    to overwrite ("directory already exists") — bricking the install with no
+    recovery (every later HTTPS call dies with ``FileNotFoundError`` for the
+    missing cert bundle).  ``os.replace`` instead fails fast and cleanly when the
+    venv is in use, leaving it untouched; and if the rebuild itself fails we move
+    the old venv back so we never leave Hermes with no venv at all.
     """
+    backup: Optional[Path] = None
     if venv_dir.exists():
         print(f"  → Rebuilding venv (old Python may lack FTS5)...")
-        shutil.rmtree(venv_dir, ignore_errors=True)
+        backup = venv_dir.with_name(venv_dir.name + ".old")
+        shutil.rmtree(backup, ignore_errors=True)  # clear any stale backup
+        try:
+            # Atomic move — fails (without partial deletion) if a process still
+            # holds files inside the venv, which is exactly the Windows file-lock
+            # case that previously bricked the install.
+            os.replace(venv_dir, backup)
+        except OSError as exc:
+            logger.warning("venv rebuild aborted — venv in use: %s", exc)
+            print(
+                "  ✗ venv rebuild aborted — the venv is in use; stop the "
+                f"gateway/desktop and retry ({exc})"
+            )
+            return False
 
     result = subprocess.run(
-        [uv_bin, "venv", str(venv_dir), "--python", python_version],
+        [uv_bin, "venv", str(venv_dir), "--python", python_version, "--clear"],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode == 0:
+        if backup is not None:
+            shutil.rmtree(backup, ignore_errors=True)
         venv_python = venv_dir / ("Scripts" if platform.system() == "Windows" else "bin") / "python"
         py_ver = subprocess.run(
             [str(venv_python), "--version"],
@@ -127,6 +154,14 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
         print(f"  ✓ venv rebuilt ({py_ver})")
         return True
     else:
+        # Rebuild failed — restore the old venv so we never leave Hermes with no
+        # venv (the bricked-install failure mode this function exists to avoid).
+        if backup is not None and not venv_dir.exists():
+            try:
+                os.replace(backup, venv_dir)
+                print("  ↩ Restored previous venv after failed rebuild.")
+            except OSError:
+                pass
         logger.warning("venv rebuild failed: %s", result.stderr)
         print(f"  ✗ venv rebuild failed: {result.stderr.strip()}")
         return False

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -142,9 +142,24 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
         check=False,
     )
     if result.returncode == 0:
+        venv_python = venv_dir / ("Scripts" if platform.system() == "Windows" else "bin") / "python"
+        # uv can exit 0 yet leave no usable interpreter (e.g. a half-written
+        # venv). Don't report success on a venv that has no python — and restore
+        # the moved-aside copy so the caller can abort without losing a working
+        # environment.
+        if not venv_python.exists():
+            logger.warning("venv rebuild reported success but %s is missing", venv_python)
+            print(f"  ✗ venv rebuild failed: Python interpreter missing at {venv_python}")
+            if backup is not None:
+                shutil.rmtree(venv_dir, ignore_errors=True)
+                try:
+                    os.replace(backup, venv_dir)
+                    print("  ↩ Restored previous venv.")
+                except OSError:
+                    pass
+            return False
         if backup is not None:
             shutil.rmtree(backup, ignore_errors=True)
-        venv_python = venv_dir / ("Scripts" if platform.system() == "Windows" else "bin") / "python"
         py_ver = subprocess.run(
             [str(venv_python), "--version"],
             capture_output=True,

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -108,6 +108,27 @@ class TestEnsureUv:
 # ---------------------------------------------------------------------------
 
 class TestRebuildVenv:
+    def test_venv_backup_dir_is_gitignored(self):
+        """The moved-aside backup (``venv.old``) must be gitignored.
+
+        ``hermes update`` runs ``git stash push --include-untracked`` before
+        pulling. ``rebuild_venv`` moves the live venv aside to ``venv.old``
+        (it is not deleted in place), so if that directory is untracked the
+        autostash sweeps a whole moved-aside venv every update. The existing
+        ``/venv/`` entry is anchored and does not cover ``venv.old``, so the
+        backup needs its own ignore entry.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        patterns = {
+            line.strip().strip("/")
+            for line in (repo_root / ".gitignore").read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+        assert "venv.old" in patterns, (
+            "venv.old must be in .gitignore so `hermes update`'s "
+            "`git stash --include-untracked` does not sweep the moved-aside venv"
+        )
+
     def test_removes_old_venv_and_creates_new(self, tmp_path):
         venv_dir = tmp_path / "venv"
         venv_dir.mkdir()

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -114,25 +114,78 @@ class TestRebuildVenv:
         (venv_dir / "old_file").write_text("stale")
 
         uv_bin = str(tmp_path / "bin" / "uv")
+        seen_cmds = []
 
         def fake_run(cmd, **kwargs):
+            seen_cmds.append(cmd)
             m = MagicMock(returncode=0)
             if cmd[1] == "venv":
-                # Simulate uv creating the venv dir
+                # Simulate uv creating a fresh venv dir (uv removes the old one
+                # too, but here it has already been moved aside to <name>.old).
                 venv_dir.mkdir(exist_ok=True)
-                bin_dir = venv_dir / "bin"
-                bin_dir.mkdir(parents=True, exist_ok=True)
-                (bin_dir / "python").write_text("#!/bin/sh\necho Python 3.11.0")
+                for sub in ("bin", "Scripts"):
+                    bin_dir = venv_dir / sub
+                    bin_dir.mkdir(parents=True, exist_ok=True)
+                    (bin_dir / "python").write_text("#!/bin/sh\necho Python 3.11.0")
             elif "--version" in cmd:
                 m.stdout = "Python 3.11.0"
             return m
 
-        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
-             patch("hermes_cli.managed_uv.shutil.rmtree") as mock_rmtree:
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run):
             from hermes_cli.managed_uv import rebuild_venv
             result = rebuild_venv(uv_bin, venv_dir)
             assert result is True
-            mock_rmtree.assert_called_once_with(venv_dir, ignore_errors=True)
+            # Fresh venv exists, old contents gone, backup cleaned up.
+            assert venv_dir.exists()
+            assert not (venv_dir / "old_file").exists()
+            assert not (tmp_path / "venv.old").exists()
+            # uv venv was invoked with --clear so a leftover partial dir can't
+            # wedge the rebuild.
+            venv_cmd = next(c for c in seen_cmds if c[1] == "venv")
+            assert "--clear" in venv_cmd
+
+    def test_aborts_without_deleting_when_venv_in_use(self, tmp_path):
+        """Regression: a venv in use (Windows file lock) must be left intact.
+
+        Previously rebuild_venv ran ``shutil.rmtree(ignore_errors=True)`` which
+        deleted what it could (site-packages, certifi) and left a gutted venv,
+        bricking the install.  Now the move-aside fails fast and the existing
+        venv is untouched, with no ``uv venv`` attempted.
+        """
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        marker = venv_dir / "site-packages-marker"
+        marker.write_text("do not delete me")
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch("hermes_cli.managed_uv.os.replace", side_effect=OSError("in use")), \
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is False
+            # No rebuild attempted, existing venv fully intact.
+            mock_run.assert_not_called()
+            assert marker.exists()
+            assert marker.read_text() == "do not delete me"
+
+    def test_restores_old_venv_when_rebuild_fails(self, tmp_path):
+        """If ``uv venv`` fails, the moved-aside venv is restored, not lost."""
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        (venv_dir / "marker").write_text("original")
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch(
+            "hermes_cli.managed_uv.subprocess.run",
+            return_value=MagicMock(returncode=1, stderr="boom"),
+        ):
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is False
+            # Old venv restored; no orphaned backup left behind.
+            assert (venv_dir / "marker").exists()
+            assert (venv_dir / "marker").read_text() == "original"
+            assert not (tmp_path / "venv.old").exists()
 
     def test_rebuild_failure_returns_false(self, tmp_path):
         venv_dir = tmp_path / "venv"

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -198,6 +198,21 @@ class TestRebuildVenv:
             result = rebuild_venv(uv_bin, venv_dir)
             assert result is False
 
+    def test_rebuild_success_without_python_returns_false(self, tmp_path):
+        """uv can exit 0 yet leave no interpreter; that must not count as success
+        (guard adapted from #38511)."""
+        venv_dir = tmp_path / "venv"
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
+             patch("hermes_cli.managed_uv.shutil.rmtree"):
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is False
+            # Returned before the `python --version` probe ran.
+            assert mock_run.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # update_managed_uv

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -423,6 +423,41 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
+def test_cmd_update_aborts_when_fresh_managed_uv_rebuild_fails(monkeypatch, tmp_path):
+    """A failed fresh managed-uv venv rebuild must not continue into pip install
+    (guard adapted from #38511)."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(cmd)
+        # Tolerant matching: the update flow's exact git invocations vary by
+        # checkout, so key off the verb. Branch detection must return a real name
+        # and rev-list a parseable count, or the flow aborts early before it ever
+        # reaches the venv rebuild this test exercises.
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "git":
+            if "rev-parse" in cmd:
+                return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+            if "rev-list" in cmd:
+                return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+            if "pull" in cmd:
+                return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with patch("hermes_cli.managed_uv.ensure_uv", return_value=("/usr/bin/uv", True)), \
+         patch("hermes_cli.managed_uv.rebuild_venv", return_value=False), \
+         pytest.raises(RuntimeError, match="venv rebuild failed"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    install_cmds = [c for c in recorded if "pip" in c and "install" in c]
+    assert install_cmds == []
+
+
 def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
     """Termux update path should target .[termux-all] when requested."""
     calls = []

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -101,6 +101,10 @@ $ hermes update
 
 Close the listed processes and re-run. If you're sure the concurrent process won't interfere (rare — usually only useful when an antivirus shim is mis-attributed), pass `--force` to skip the check. In that case the updater will still retry the `.exe` rename with exponential backoff and, on stubborn locks, schedule the replacement for next reboot via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` so the update can complete.
 
+:::note venv rebuild under `--force`
+`--force` only skips the *concurrency check* — it never bricks the install. When the venv itself has to be rebuilt during an update (e.g. the first update after a managed-uv change) while a `hermes.exe` still holds the venv's `python.exe` open, the old venv is moved aside atomically (`os.replace`) and a fresh one is built in its place; the already-running processes keep using the moved-aside copy until they next restart. If the venv genuinely can't be moved (still locked), the rebuild aborts cleanly and leaves your existing venv **intact** rather than half-deleting it. Earlier builds deleted the venv in place here, so a `--force` update with the gateway/desktop running could gut it (missing `pyvenv.cfg`/`site-packages`, then `FileNotFoundError` on every request) with no recovery.
+:::
+
 Expected output looks like:
 
 ```


### PR DESCRIPTION
## What does this PR do?

On Windows, a normal `hermes update` can **brick its own install** by gutting the venv it is rebuilding.

`hermes_cli/managed_uv.py:rebuild_venv()` deletes the old venv in place and then recreates it:

```python
if venv_dir.exists():
    shutil.rmtree(venv_dir, ignore_errors=True)      # (1)
result = subprocess.run([uv_bin, "venv", str(venv_dir), "--python", python_version])  # (2)
```

When any `hermes.exe` (gateway/desktop) is running â€” including the updater's own
interpreter â€” it holds `venv\Scripts\python.exe` open. Then (1) deletes
everything it *can* (`site-packages`, including `certifi/cacert.pem`) but
silently fails on the locked `python.exe`, leaving a **half-gutted venv** with no
`pyvenv.cfg`. (2) then aborts with *"A directory already exists"*, so the venv is
never recreated. The result is a venv that still loads but whose every outbound
HTTPS call dies with `FileNotFoundError` (missing `cacert.pem`), and the CLI
reports `No virtual environment found` / `ModuleNotFoundError: hermes_cli`. No
automatic recovery â€” the venv must be rebuilt by hand. (This is issue #37881; we
hit it in production on Windows 11.)

This fixes the **root cause**: never destroy a venv that is in use. Move the old
venv aside *atomically* with `os.replace`, which fails fast and cleanly when the
venv is locked â€” leaving the working venv fully intact â€” instead of deleting it
piecemeal. Also pass `--clear`, and restore the moved-aside venv if the rebuild
itself fails.

> **Relationship to #37895 and #38051 (alternative approach).** Both of those add
> `--clear` to `uv venv` while keeping `shutil.rmtree(ignore_errors=True)`. In the
> real lock scenario `--clear` is insufficient: the running interpreter *is* the
> venv's `python.exe`, so `uv venv --clear` cannot delete it either, and the
> `rmtree` has already gutted `site-packages`. Moving the directory aside first
> (`os.replace`) is what actually prevents the brick â€” it bails out *before* any
> deletion when the venv is in use, and tells the user to stop the gateway. This
> PR includes that fix; happy to fold it into whichever PR the maintainers prefer.

## Related Issue

Fixes #37881

## Type of Change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/managed_uv.py` â€” `rebuild_venv()`: move the existing venv aside with
  `os.replace` (abort without deletion if it's in use), pass `--clear` to
  `uv venv`, and restore the old venv if the rebuild fails. Updated docstring.
- `tests/hermes_cli/test_managed_uv.py` â€” regression tests (below).

## How to Test

1. On Windows, with a Hermes gateway/desktop running (so `venv\Scripts\python.exe`
   is locked), run `hermes update`. On `main` this bricks the venv
   (`pyvenv.cfg` gone, later HTTPS calls raise `FileNotFoundError`).
2. With this patch, `rebuild_venv` aborts cleanly with *"venv is in use; stop the
   gateway/desktop and retry"* and the existing venv is left fully intact.
3. Unit: `pytest tests/hermes_cli/test_managed_uv.py -k RebuildVenv` â€” see new
   tests proving an in-use venv is never deleted and a failed rebuild is restored.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(uv): ...`)
- [x] I searched for existing PRs â€” found #37895 and #38051; this is intentionally a more complete alternative (see note above), not a blind duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass â€” ran `TestRebuildVenv` (all pass on Windows/Py3.12); did **not** run the full suite. Note: 6 pre-existing tests in `test_managed_uv.py` (`TestResolveUv`/`TestEnsureUv`/`TestUpdateManagedUv`/`TestInstallUvInternals`) fail on Windows independent of this change (POSIX `chmod`/`os.access(X_OK)` assumptions)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on `rebuild_venv`)
- [x] `cli-config.yaml.example` â€” N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` â€” N/A
- [x] I've considered cross-platform impact â€” `os.replace` is correct on POSIX too; behavior there is unchanged (move-aside then recreate)
- [x] tool descriptions/schemas â€” N/A

## Logs

Production failure signature that this prevents:

```
WARNING hermes_cli.managed_uv: venv rebuild failed: A directory already exists at: ...\venv
ERROR  agent.conversation_loop: API call failed after 3 retries. [Errno 2] No such file or directory
       | provider=custom base_url=http://127.0.0.1:8001/v1 model=qwen3.6-27b-gptq
```
