### PR TITLE
fix(gateway): inherit busy_text_mode from busy_input_mode when not configured

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1849,7 +1849,7 @@ class GatewayRunner:
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
-        self._busy_text_mode = self._load_busy_text_mode()
+        self._busy_text_mode = self._load_busy_text_mode(self._busy_input_mode)
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
@@ -3191,15 +3191,25 @@ class GatewayRunner:
         return "interrupt"
 
     @staticmethod
-    def _load_busy_text_mode() -> str:
-        """Load normal busy TEXT follow-up behavior from config/env."""
+    def _load_busy_text_mode(busy_input_mode: str = "queue") -> str:
+        """Load normal busy TEXT follow-up behavior from config/env.
+
+        When ``busy_text_mode`` is not explicitly configured, inherit from
+        *busy_input_mode* so that ``busy_input_mode: interrupt`` applies to
+        text follow-ups as well (pre-v2026.5.23 behaviour).  Explicit
+        ``busy_text_mode`` in config/env always wins.
+        """
         mode = os.getenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "").strip().lower()
         if not mode:
             cfg = _load_gateway_runtime_config()
             mode = str(cfg_get(cfg, "display", "busy_text_mode", default="") or "").strip().lower()
         if mode == "interrupt":
             return "interrupt"
-        return "queue"
+        if mode == "queue":
+            return "queue"
+        # Not explicitly configured — inherit from busy_input_mode so that
+        # busy_input_mode: interrupt also interrupts text follow-ups (#38390).
+        return busy_input_mode
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -120,18 +120,27 @@ def test_load_busy_text_mode_defaults_to_queue_and_allows_interrupt(tmp_path, mo
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
 
+    # When not explicitly configured, busy_text_mode inherits from busy_input_mode.
+    # Default busy_input_mode is "interrupt", so busy_text_mode should also be "interrupt".
+    assert gateway_run.GatewayRunner._load_busy_text_mode("interrupt") == "interrupt"
+    # When busy_input_mode is "queue", busy_text_mode inherits "queue".
+    assert gateway_run.GatewayRunner._load_busy_text_mode("queue") == "queue"
+    # Fallback when no argument is given (backward compat).
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
 
+    # Explicit config always wins regardless of busy_input_mode.
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_text_mode: interrupt\n", encoding="utf-8"
     )
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_text_mode("queue") == "interrupt"
 
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue")
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+    assert gateway_run.GatewayRunner._load_busy_text_mode("interrupt") == "queue"
 
+    # Bogus value falls back to busy_input_mode inheritance.
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+    assert gateway_run.GatewayRunner._load_busy_text_mode("interrupt") == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_text_mode("queue") == "queue"
 
 
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where `busy_input_mode: interrupt` stopped working for text follow-ups. When `busy_text_mode` is not explicitly configured, it now inherits from `busy_input_mode` instead of silently defaulting to `"queue"`.

## Related Issue

Fixes #38390

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: `_load_busy_text_mode()` now accepts a `busy_input_mode` fallback parameter. When neither env var nor config explicitly sets `busy_text_mode`, the mode inherits from `busy_input_mode` instead of defaulting to `"queue"`. Updated call site to pass `self._busy_input_mode`.
- `tests/gateway/test_restart_drain.py`: Updated test to verify inheritance behavior — `busy_text_mode` inherits `"interrupt"` from `busy_input_mode` when not configured, while explicit `"queue"` config still overrides.

## How to Test

1. Set `display.busy_input_mode: interrupt` in `config.yaml` (do NOT set `busy_text_mode`)
2. Start the gateway and begin a long-running task
3. Send a text message while the agent is running
4. Verify the agent is interrupted (⚡ "Interrupting current task" message appears)
5. Run `pytest tests/gateway/test_restart_drain.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_config_env_bridge_authority.py -xvs` — all tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `GatewayRunner._load_busy_text_mode()` (called from `__init__`, flows into `_handle_active_session_busy_message` busy-text-mode guard)
- Blast radius: LOW — only affects the default value when `busy_text_mode` is not configured; explicit config/env values are unchanged
- Related patterns: `busy_input_mode`/`busy_text_mode` separation introduced in `7abd62719`; `_handle_active_session_busy_message` at line 3391 checks `busy_text_mode` before deciding to handle or fall through
