### PR TITLE
feat: add Concentrate AI as a model provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -274,6 +274,7 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "concentrate": "qwen3.6-35b",
 }
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -67,6 +67,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    "concentrate",
 })
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -335,6 +335,8 @@ def _resolve_runtime_from_pool_entry(
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
+    elif provider == "concentrate":
+        api_mode = "codex_responses"
     elif provider == "xai":
         api_mode = "codex_responses"
     elif provider == "nous":
@@ -1618,7 +1620,7 @@ def resolve_runtime_provider(
         api_mode = "chat_completions"
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
-        elif provider == "xai":
+        elif provider in {"xai", "concentrate"}:
             api_mode = "codex_responses"
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()

--- a/plugins/model-providers/concentrate/__init__.py
+++ b/plugins/model-providers/concentrate/__init__.py
@@ -1,0 +1,76 @@
+"""Concentrate AI provider profile.
+
+Concentrate exposes an OpenAI Responses-compatible endpoint that routes to
+many underlying model authors (Anthropic, Google, OpenAI, Meta, Mistral, …)
+behind a single API key, with Zero Data Retention available for supported models.
+
+API reference: https://concentrate.ai/docs/api-reference/endpoint/create-response
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+
+class ConcentrateProfile(ProviderProfile):
+    """Concentrate AI — Responses API gateway with ZDR support."""
+
+    auth_type = "api_key"
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch models from Concentrate catalog.
+
+        The Concentrate /v1/models endpoint returns a raw list of objects with
+        a ``slug`` field (not the OpenAI ``{"data": [{"id": ...}]}`` shape).
+        No auth required for the catalog endpoint.
+        """
+        url = self.models_url
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            if not isinstance(data, list):
+                return None
+            return [m["slug"] for m in data if isinstance(m, dict) and "slug" in m]
+        except Exception as exc:
+            logger.debug("fetch_models(concentrate): %s", exc)
+            return None
+
+
+concentrate = ConcentrateProfile(
+    name="concentrate",
+    aliases=("concentrateai", "concentrate-ai"),
+    api_mode="codex_responses",
+    display_name="Concentrate AI",
+    description="Concentrate AI — unified gateway, Zero Data Retention for supported models",
+    signup_url="https://concentrate.ai",
+    env_vars=("CONCENTRATE_API_KEY",),
+    base_url="https://api.concentrate.ai/v1",
+    models_url="https://api.concentrate.ai/v1/models",
+    fallback_models=(
+        "claude-sonnet-4-6",
+        "claude-opus-4-5",
+        "gpt-4o",
+        "gemini-2.5-flash",
+        "meta-llama/llama-3.3-70b-instruct",
+        "deepseek-r1",
+        "mistral-large",
+    ),
+)
+
+register_provider(concentrate)

--- a/plugins/model-providers/concentrate/plugin.yaml
+++ b/plugins/model-providers/concentrate/plugin.yaml
@@ -1,0 +1,5 @@
+name: concentrate-provider
+kind: model-provider
+version: 1.0.0
+description: Concentrate AI — multi-model gateway with Zero Data Retention
+author: Concentrate AI

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2705,3 +2705,27 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def test_concentrate_provider_resolves_codex_responses(monkeypatch):
+    """Concentrate must resolve to api_mode=codex_responses, not fall through
+    to _resolve_openrouter_runtime which would mislabel it as 'openrouter'."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "concentrate")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "concentrate"})
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "sk-cn-test",
+            "base_url": "https://api.concentrate.ai/v1",
+            "source": "env",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="concentrate")
+
+    assert resolved["provider"] == "concentrate"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.concentrate.ai/v1"
+    assert resolved["api_key"] == "sk-cn-test"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -34,6 +34,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `KIMI_API_KEY` | Kimi / Moonshot AI API key ([moonshot.ai](https://platform.moonshot.ai)) |
 | `KIMI_BASE_URL` | Override Kimi base URL (default: `https://api.moonshot.ai/v1`) |
 | `KIMI_CN_API_KEY` | Kimi / Moonshot China API key ([moonshot.cn](https://platform.moonshot.cn)) |
+| `CONCENTRATE_API_KEY` | Concentrate AI API key — unified gateway with Zero Data Retention ([concentrate.ai](https://concentrate.ai)) |
+| `CONCENTRATE_BASE_URL` | Override Concentrate base URL (default: `https://api.concentrate.ai/v1`) |
 | `ARCEEAI_API_KEY` | Arcee AI API key ([chat.arcee.ai](https://chat.arcee.ai/)) |
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |


### PR DESCRIPTION
## Summary

[Concentrate AI](https://concentrate.ai) is a unified LLM gateway that routes to Anthropic, Google, OpenAI, Meta, Mistral and others behind a single API key. It exposes an OpenAI Responses-compatible endpoint at `https://api.concentrate.ai/v1/responses`.

Notable: Concentrate offers **Zero Data Retention (ZDR)** for certified models — prompts and outputs never touch the underlying provider on the user's behalf. This is the differentiator vs. OpenRouter for privacy-conscious deployments.

## Changes

**`plugins/model-providers/concentrate/`** (new plugin, 2 files)
- Registers `ConcentrateProfile` — a `ProviderProfile` subclass with `api_mode=\"codex_responses\"` and a custom `fetch_models` that handles Concentrate's `slug`-keyed catalog format (vs. the standard OpenAI `id`-keyed shape)
- Live catalog fetch returns 133 models, no auth required
- `env_vars = (\"CONCENTRATE_API_KEY\",)`

**`hermes_cli/runtime_provider.py`** (2 lines)
- Adds `concentrate` to the provider dispatch chain so `api_mode` resolves to `codex_responses` rather than falling through to the `chat_completions` default

## Usage

```bash
export CONCENTRATE_API_KEY=sk-cn-v1-...
hermes config set model.provider concentrate
hermes config set model.default claude-sonnet-4-6
```

Or set `CONCENTRATE_API_KEY` and select Concentrate from `hermes model` / the dashboard model picker.

Sign up: https://concentrate.ai
API docs: https://concentrate.ai/docs/api-reference/endpoint/create-response