### PR TITLE
fix(gateway): restart launchd-managed gateways via service path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1156,6 +1156,29 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _is_macos_launchd_service_process() -> bool:
+    """Return True when this gateway PID is the loaded macOS launchd service."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        from hermes_cli.gateway import get_launchd_label
+        import subprocess
+
+        current_pid = os.getpid()
+        result = subprocess.run(
+            ["launchctl", "list", get_launchd_label()],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return False
+        return bool(re.search(rf'"PID"\s*=\s*{current_pid}\s*;', result.stdout or ""))
+    except Exception as exc:
+        logger.debug("macOS launchd service detection failed: %s", exc)
+        return False
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -10737,13 +10760,16 @@ class GatewayRunner:
         active_agents = self._running_agent_count()
         # When running under a service manager (systemd/launchd) or inside a
         # Docker/Podman container, use the service restart path: exit with
-        # code 75 so the service manager / container restart policy restarts
-        # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # code 75/clean service semantics so the service manager / container
+        # restart policy restarts us. The detached subprocess approach
+        # (setsid + bash) doesn't work under systemd (KillMode=mixed kills
+        # the cgroup), launchd-managed macOS services (clean exit does not
+        # relaunch with KeepAlive.SuccessfulExit=false), or Docker (tini exits
+        # when the gateway dies, taking the detached helper with it).
+        _under_systemd_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _under_launchd_service = _is_macos_launchd_service_process()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_systemd_service or _under_launchd_service or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,7 +1,9 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
 import json
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -77,6 +79,48 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     assert "thread_id" not in data  # no thread → omitted
 
 
+def test_macos_launchd_service_process_false_off_macos(monkeypatch):
+    """launchd detection is inert on non-macOS platforms."""
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+
+    assert gateway_run._is_macos_launchd_service_process() is False
+
+
+def test_macos_launchd_service_process_matches_current_pid(monkeypatch):
+    """macOS launchd detection matches the current PID in launchctl output."""
+    calls = []
+
+    def _fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(returncode=0, stdout='{\n    "PID" = 4242;\n}')
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 4242)
+    monkeypatch.setattr("hermes_cli.gateway.get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assert gateway_run._is_macos_launchd_service_process() is True
+    assert calls == [
+        (
+            ["launchctl", "list", "ai.hermes.gateway"],
+            {"capture_output": True, "text": True, "timeout": 2},
+        )
+    ]
+
+
+def test_macos_launchd_service_process_false_on_launchctl_failure(monkeypatch):
+    """launchctl errors degrade to False instead of blocking /restart."""
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setattr("hermes_cli.gateway.get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout=""),
+    )
+
+    assert gateway_run._is_macos_launchd_service_process() is False
+
+
 @pytest.mark.asyncio
 async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monkeypatch):
     """Under systemd (INVOCATION_ID set), /restart uses via_service=True."""
@@ -99,10 +143,43 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under macOS launchd, /restart must exit through the service restart path."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(
+        gateway_run,
+        "_is_macos_launchd_service_process",
+        lambda: True,
+        raising=False,
+    )
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_service_manager(tmp_path, monkeypatch):
+    """Without a service manager/container, /restart uses detached relaunch."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(
+        gateway_run,
+        "_is_macos_launchd_service_process",
+        lambda: False,
+        raising=False,
+    )
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway `/restart` path when Hermes is running as a macOS `launchd` service.

The existing restart logic already routes systemd-managed and container-managed gateway processes through the service restart path, but launchd-managed macOS gateways were not detected. They fell through to the detached subprocess fallback. For a launchd service with `KeepAlive.SuccessfulExit=false`, that can look like a successful manual stop instead of a service restart, so the gateway may not relaunch and the requester never receives the comeback notification.

This PR adds conservative launchd detection: on macOS only, call `launchctl list <profile label>`, compare the reported `PID` to the current gateway process PID, and degrade to `False` on errors/timeouts. When that check is true, `/restart` uses `request_restart(detached=False, via_service=True)` so launchd handles the relaunch.

## Related Issue

N/A — no exact existing issue found.

Related but distinct items checked before opening:
- #28632 covers non-atomic CLI `hermes gateway restart --all` bootout/bootstrap behavior.
- #35305 / #35460 cover refusing shell-launched duplicate gateway processes under service supervision.

This PR is narrower: it fixes the in-process messaging `/restart` route for a gateway that is already the launchd-managed service process.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Add `_is_macos_launchd_service_process()`.
  - Detect the active profile launchd job by matching `launchctl list <label>` PID to the current process PID.
  - Include launchd-managed service processes in the existing service/container restart branch for `/restart`.
- `tests/gateway/test_restart_notification.py`
  - Cover launchd helper behavior off macOS, on PID match, and on `launchctl` failure.
  - Cover `/restart` routing through `via_service=True` under launchd.
  - Keep the detached fallback covered when no service manager/container is detected.

## How to Test

Local verification on macOS 26.5 arm64:

1. `git diff --cached --check` — clean before commit.
2. Added-line static scan for hardcoded secrets, shell injection, eval/exec, pickle, and simple SQL injection patterns — clean.
3. `python -m py_compile gateway/run.py tests/gateway/test_restart_notification.py` — passed.
4. `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_restart_notification.py` — passed, no footguns found.
5. `scripts/run_tests.sh tests/gateway/test_restart_notification.py` — passed, 31/31.
6. `python -m pytest tests/gateway/test_restart_notification.py -q` — passed, 31/31.
7. `scripts/run_tests.sh tests/gateway` — attempted broader gateway suite: 6057 passed, 4 failed. The same four concrete failures reproduce against clean `upstream/main`, so they are baseline/unrelated to this PR:
   - `tests/gateway/test_background_command.py::TestRunBackgroundTask::test_media_files_routed_by_type` (`/tmp` vs `/private/tmp` path normalization on macOS)
   - `tests/gateway/test_memory_monitor.py::test_periodic_timer_fires` timing-sensitive periodic tick count
   - `tests/gateway/test_gateway_shutdown.py::test_gateway_stop_systemd_service_restart_exits_cleanly` expects exit code 0 while upstream currently sets 75
   - `tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output` diagnostic helper returned `None`

Manual reproduction outline:

1. Install/start the gateway as the macOS launchd job.
2. Send `/restart` through a messaging platform to the running gateway.
3. Confirm the process exits via the service restart path and launchd relaunches it.
4. Confirm the requester receives the restart-complete notification after the gateway comes back.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- focused tests pass; broader gateway suite has unrelated upstream-main baseline failures listed above -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — helper is Darwin-gated and uses `subprocess.run([...])` without shell
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Local log evidence showed `/restart` persisted the notification marker and stopped the gateway, but launchd did not relaunch because the old path exited as a detached/manual restart. The added tests cover the corrected routing decision directly.
