### PR TITLE
fix(discord): suppress terminal bot chatter

### DIFF
--- a/gateway/platforms/bot_terminal_filter.py
+++ b/gateway/platforms/bot_terminal_filter.py
@@ -1,0 +1,115 @@
+"""Deterministic terminal bot-message suppression for platform adapters.
+
+When a platform's allow-bots policy permits bot-authored messages to reach
+agent dispatch, bot-to-bot loops can form: agent A sends an ACK/final, agent B's
+gateway dispatches it, B's agent replies with its own ACK/final, and so on.
+Prompt doctrine alone is not a sufficient loop brake.
+
+This module classifies bot-authored message text as terminal/no-work chatter
+(suppress) versus actionable handoff/request (preserve), using fixed regexes
+only — no LLM classification. Callers remain responsible for gating on
+``is_bot`` and the platform's enable toggle.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+__all__ = [
+    "should_suppress_terminal_bot_message",
+    "message_requests_no_visible_ack",
+    "terminal_bot_suppression_enabled",
+    "SUPPRESS_TERMINAL_BOT_MESSAGES_ENV",
+]
+
+SUPPRESS_TERMINAL_BOT_MESSAGES_ENV = "DISCORD_SUPPRESS_TERMINAL_BOT_MESSAGES"
+
+_FALSY = {"false", "0", "no", "off"}
+
+_ACTIONABLE_PATTERNS = [
+    re.compile(r"\bkind\s*[:=]\s*request\b", re.IGNORECASE),
+    re.compile(r"\brequires[\s_-]?ack\b", re.IGNORECASE),
+    re.compile(r"\bhandoff\b", re.IGNORECASE),
+    re.compile(r"\boperator[\s_-]?gated\b", re.IGNORECASE),
+]
+
+_NO_VISIBLE_ACK_PATTERN = re.compile(
+    r"\back[\s_-]?policy\s*[:=]\s*none\b", re.IGNORECASE
+)
+_KIND_PATTERN = re.compile(r"\bkind\s*[:=]\s*([a-z0-9_-]+)\b", re.IGNORECASE)
+_TRANSPORT_RECEIPT_KINDS = {"transport_receipt", "transport-receipt", "receipt"}
+
+_TERMINAL_PATTERNS = [
+    re.compile(r"\bkind\s*[:=]\s*ack\b", re.IGNORECASE),
+    re.compile(r"\bkind\s*[:=]\s*final\b", re.IGNORECASE),
+    re.compile(r"\bkind\s*[:=]\s*status\b", re.IGNORECASE),
+    re.compile(r"\b(?:done|complete|completed)\b\.?", re.IGNORECASE),
+    re.compile(r"\back(?:s|ed|nowledged)?\b", re.IGNORECASE),
+    re.compile(r"\backs?\b\s+do\s+not\s+require\s+\backs?\b", re.IGNORECASE),
+    re.compile(r"\bno[\s_-]?ack\b", re.IGNORECASE),
+    re.compile(r"\bno[\s_-]?op\b", re.IGNORECASE),
+    re.compile(r"\bstanding[\s_-]?down\b", re.IGNORECASE),
+    re.compile(r"\bclosed\b", re.IGNORECASE),
+    re.compile(r"\bno\s+further\s+action\b", re.IGNORECASE),
+]
+
+
+def terminal_bot_suppression_enabled(env: "os._Environ[str] | None" = None) -> bool:
+    """Return whether terminal bot-message suppression is enabled.
+
+    Auditable and default-enabled: only an explicit falsy value disables it.
+    """
+
+    environ = os.environ if env is None else env
+    raw = environ.get(SUPPRESS_TERMINAL_BOT_MESSAGES_ENV, "").strip().lower()
+    if raw in _FALSY:
+        return False
+    return True
+
+
+def message_requests_no_visible_ack(text: str) -> bool:
+    """Return True when *text* declares no visible ACK/final is wanted."""
+
+    if not text or not text.strip():
+        return False
+    if re.search(r"\brequires[\s_-]?ack\b", text, re.IGNORECASE):
+        return False
+    return bool(_NO_VISIBLE_ACK_PATTERN.search(text))
+
+
+def should_suppress_terminal_bot_message(text: str) -> bool:
+    """Classify bot-authored *text* as terminal/no-work chatter.
+
+    Returns ``True`` when the message should be dropped before agent dispatch.
+    Pure function: callers gate on ``is_bot`` and on
+    :func:`terminal_bot_suppression_enabled` themselves.
+    """
+
+    if not text or not text.strip():
+        return False
+
+    # Transport receipts with ack_policy:none are deliberately non-actionable
+    # acknowledgements of delivery. Suppress only when the top-level structured
+    # kind is a receipt. Do not scan every embedded/code-quoted kind token: a
+    # transport_test instruction may quote the receipt text the recipient should
+    # send, and suppressing the instruction would swallow real work.
+    first_kind = _KIND_PATTERN.search(text)
+    if (
+        message_requests_no_visible_ack(text)
+        and first_kind is not None
+        and first_kind.group(1).lower() in _TRANSPORT_RECEIPT_KINDS
+    ):
+        return True
+
+    # Actionable markers win: preserve genuine handoffs/requests even if the
+    # message also contains terminal-looking words.
+    for pattern in _ACTIONABLE_PATTERNS:
+        if pattern.search(text):
+            return False
+
+    for pattern in _TERMINAL_PATTERNS:
+        if pattern.search(text):
+            return True
+
+    return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9715,6 +9715,26 @@ class GatewayRunner:
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
+            # Transport-only bot handoffs can ask for no visible final ACK.
+            # Preserve transcript/tool side effects above, but do not emit the
+            # model's closing "Done"/"Acknowledged" response back to Discord.
+            try:
+                _inbound_adapter = self.adapters.get(source.platform)
+                if (
+                    _inbound_adapter is not None
+                    and hasattr(_inbound_adapter, "_event_requests_no_visible_ack")
+                    and _inbound_adapter._event_requests_no_visible_ack(event)
+                ):
+                    logger.info(
+                        "Suppressing visible final response for ack_policy:none event: platform=%s chat=%s message_id=%s",
+                        _platform_name,
+                        source.chat_id or "unknown",
+                        event.message_id or "?",
+                    )
+                    return None
+            except Exception as _no_ack_err:
+                logger.debug("ack_policy:none final-response gate failed: %s", _no_ack_err)
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -51,6 +51,11 @@ from gateway.config import Platform, PlatformConfig
 import re
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
+from gateway.platforms.bot_terminal_filter import (
+    message_requests_no_visible_ack,
+    should_suppress_terminal_bot_message,
+    terminal_bot_suppression_enabled,
+)
 from utils import atomic_json_write
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -788,6 +793,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     elif allow_bots == "mentions":
                         if not self._client.user or self._client.user not in message.mentions:
                             return
+                    if adapter_self._should_suppress_bot_message(message.content or ""):
+                        logger.info(
+                            "Discord: suppressed terminal bot message id=%s from %s (%s)",
+                            getattr(message, "id", "?"),
+                            getattr(message.author, "display_name", None)
+                            or getattr(message.author, "name", "unknown"),
+                            "DISCORD_SUPPRESS_TERMINAL_BOT_MESSAGES",
+                        )
+                        return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
                 else:
@@ -4365,6 +4379,18 @@ class DiscordAdapter(BasePlatformAdapter):
         if parent_name:
             return f"{parent_name} / {thread_name}"
         return thread_name
+
+    def _should_suppress_bot_message(self, text: str) -> bool:
+        """Return True if bot-authored text is terminal/no-work chatter to drop."""
+
+        if not terminal_bot_suppression_enabled():
+            return False
+        return should_suppress_terminal_bot_message(text)
+
+    def _event_requests_no_visible_ack(self, event: MessageEvent) -> bool:
+        """Return True when an inbound event asks for no visible final/ACK."""
+
+        return message_requests_no_visible_ack(event.text or "")
 
     # ------------------------------------------------------------------
     # Attachment download helpers

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -2,7 +2,12 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from gateway.platforms.bot_terminal_filter import (
+    should_suppress_terminal_bot_message,
+    terminal_bot_suppression_enabled,
+)
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -99,7 +104,8 @@ class TestDiscordBotFilter(unittest.TestCase):
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
-        default = os.getenv("DISCORD_ALLOW_BOTS", "none")
+        with patch.dict(os.environ, {}, clear=True):
+            default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
     def test_case_insensitive(self):
@@ -110,6 +116,54 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "All"))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
+
+
+class TestDiscordTerminalBotMessageClassifier(unittest.TestCase):
+    """Test deterministic suppression of non-actionable bot chatter."""
+
+    def test_terminal_chatter_suppressed(self):
+        for text in [
+            "Done.",
+            "Acknowledged.",
+            "kind: ack correlation: abc123",
+            "kind: final\nstatus: closed",
+            "No further action.",
+        ]:
+            with self.subTest(text=text):
+                self.assertTrue(should_suppress_terminal_bot_message(text))
+
+    def test_actionable_markers_preserved(self):
+        for text in [
+            "kind: request requires_ack: yes please inspect logs",
+            "handoff: please continue the RCA",
+            "operator-gated: credential needed",
+        ]:
+            with self.subTest(text=text):
+                self.assertFalse(should_suppress_terminal_bot_message(text))
+
+    def test_transport_receipt_no_ack_suppressed(self):
+        for text in [
+            "kind: transport_receipt ack_policy: none correlation: abc123",
+            "<@bot> kind: transport_receipt ack-policy=none correlation=abc123",
+            "kind=receipt ack_policy=none correlation=abc123",
+        ]:
+            with self.subTest(text=text):
+                self.assertTrue(should_suppress_terminal_bot_message(text))
+
+    def test_transport_test_with_embedded_receipt_instruction_preserved(self):
+        text = (
+            "<@wintermute> kind: transport_test ack_policy: none correlation: abc123\n\n"
+            "Perform exactly one visible Discord action: send one message in #galiana "
+            "containing only this text:\n"
+            "`<@galiana> kind: transport_receipt ack_policy: none correlation: abc123`"
+        )
+        self.assertFalse(should_suppress_terminal_bot_message(text))
+
+    def test_suppression_default_enabled_explicit_false_disables(self):
+        self.assertTrue(terminal_bot_suppression_enabled({}))
+        self.assertFalse(
+            terminal_bot_suppression_enabled({"DISCORD_SUPPRESS_TERMINAL_BOT_MESSAGES": "false"})
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a deterministic classifier for non-actionable bot-authored ACK/final/status chatter when DISCORD_ALLOW_BOTS permits bot messages
- suppress ack_policy:none transport receipts before model dispatch while preserving transport_test instructions that quote receipt payloads
- suppress visible final responses for transport-only inbound events that request ack_policy:none

## Test plan
- python -m pytest tests/gateway/test_discord_bot_filter.py -q -o 'addopts='
- python -m py_compile gateway/platforms/bot_terminal_filter.py plugins/platforms/discord/adapter.py gateway/run.py

## Live validation
Validated in a two-bot Discord probe with Galiana/Wintermute: one instruction in the target channel, one transport_receipt in the response channel, no visible Done/Acknowledged echo, and gateway logs showing deterministic suppression/final-response gating.