### PR TITLE
fix(desktop): upload remote image attachments

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -4,6 +4,12 @@ import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
 import {
+  fileToDataUrl,
+  type ImageUploadPayload,
+  imageUploadPayloadFromFile,
+  imageUploadPayloadFromPath
+} from '@/lib/image-upload'
+import {
   addComposerAttachment,
   type ComposerAttachment,
   removeComposerAttachment,
@@ -11,7 +17,7 @@ import {
 } from '@/store/composer'
 import { notify, notifyError } from '@/store/notifications'
 
-import type { ImageDetachResponse } from '../../types'
+import type { ImageAttachResponse, ImageDetachResponse } from '../../types'
 
 const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|webp|bmp|tiff?|svg|ico)$/i
 
@@ -276,35 +282,102 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
     [currentCwd]
   )
 
-  const attachImagePath = useCallback(async (filePath: string) => {
-    if (!filePath) {
+  const shouldUploadImageToGateway = useCallback(async () => {
+    if (!activeSessionId) {
       return false
     }
 
-    const baseAttachment: ComposerAttachment = {
-      id: attachmentId('image', filePath),
-      kind: 'image',
-      label: pathLabel(filePath),
-      detail: filePath,
-      path: filePath
-    }
-
-    attachToMain(baseAttachment)
-
     try {
-      const previewUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
+      const connection = await window.hermesDesktop?.getConnection()
 
-      if (previewUrl) {
-        addComposerAttachment({ ...baseAttachment, previewUrl })
+      return connection?.mode === 'remote'
+    } catch {
+      return false
+    }
+  }, [activeSessionId])
+
+  const uploadImageToGateway = useCallback(
+    async (payload: ImageUploadPayload, previewUrl?: string) => {
+      if (!activeSessionId) {
+        return false
       }
 
-      return true
-    } catch (err) {
-      notifyError(err, 'Image preview failed')
+      const result = await requestGateway<ImageAttachResponse>('image.upload', {
+        session_id: activeSessionId,
+        ...payload
+      })
+
+      if (!result.attached || !result.path) {
+        notify({ kind: 'error', title: 'Image attach', message: result.message || 'Failed to upload image.' })
+
+        return false
+      }
+
+      attachToMain({
+        id: attachmentId('image', result.path),
+        kind: 'image',
+        label: pathLabel(result.path),
+        detail: result.path,
+        path: result.path,
+        previewUrl,
+        attachedSessionId: activeSessionId
+      })
 
       return true
-    }
-  }, [])
+    },
+    [activeSessionId, requestGateway]
+  )
+
+  const attachImagePath = useCallback(
+    async (filePath: string, options: { uploadToGateway?: boolean } = {}) => {
+      if (!filePath) {
+        return false
+      }
+
+      if (options.uploadToGateway && (await shouldUploadImageToGateway())) {
+        try {
+          const previewUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
+
+          if (!previewUrl) {
+            notify({ kind: 'error', title: 'Image attach', message: 'Failed to read image.' })
+
+            return false
+          }
+
+          return uploadImageToGateway(imageUploadPayloadFromPath(filePath, previewUrl), previewUrl)
+        } catch (err) {
+          notifyError(err, 'Image upload failed')
+
+          return false
+        }
+      }
+
+      const baseAttachment: ComposerAttachment = {
+        id: attachmentId('image', filePath),
+        kind: 'image',
+        label: pathLabel(filePath),
+        detail: filePath,
+        path: filePath
+      }
+
+      attachToMain(baseAttachment)
+
+      try {
+        const previewUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
+
+        if (previewUrl) {
+          addComposerAttachment({ ...baseAttachment, previewUrl })
+        }
+
+        return true
+      } catch (err) {
+        notifyError(err, 'Image preview failed')
+
+        return true
+      }
+    },
+    [shouldUploadImageToGateway, uploadImageToGateway]
+  )
 
   const attachImageBlob = useCallback(
     async (blob: Blob) => {
@@ -317,6 +390,13 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
       }
 
       try {
+        if (await shouldUploadImageToGateway()) {
+          const file = blob as File
+          const previewUrl = await fileToDataUrl(file)
+
+          return uploadImageToGateway(await imageUploadPayloadFromFile(file), previewUrl)
+        }
+
         const buffer = await blob.arrayBuffer()
         const data = new Uint8Array(buffer)
         const savedPath = await window.hermesDesktop?.saveImageBuffer(data, blobExtension(blob))
@@ -334,7 +414,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         return false
       }
     },
-    [attachImagePath]
+    [attachImagePath, shouldUploadImageToGateway, uploadImageToGateway]
   )
 
   const pickImages = useCallback(async () => {
@@ -354,7 +434,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
     }
 
     for (const path of paths) {
-      await attachImagePath(path)
+      await attachImagePath(path, { uploadToGateway: true })
     }
   }, [attachImagePath, currentCwd])
 
@@ -372,7 +452,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         return
       }
 
-      await attachImagePath(path)
+      await attachImagePath(path, { uploadToGateway: true })
     } catch (err) {
       notifyError(err, 'Clipboard paste failed')
     }
@@ -456,6 +536,18 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {
+          if (await shouldUploadImageToGateway()) {
+            if (await attachImageBlob(file)) {
+              attached = true
+
+              continue
+            }
+
+            lastFailure = `Could not attach ${file.name || 'image'}`
+
+            continue
+          }
+
           if ((filePath && (await attachImagePath(filePath))) || (await attachImageBlob(file))) {
             attached = true
 
@@ -482,7 +574,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
 
       return attached
     },
-    [attachContextFilePath, attachContextFolderPath, attachImageBlob, attachImagePath]
+    [attachContextFilePath, attachContextFolderPath, attachImageBlob, attachImagePath, shouldUploadImageToGateway]
   )
 
   const removeAttachment = useCallback(

--- a/apps/desktop/src/lib/image-upload.test.ts
+++ b/apps/desktop/src/lib/image-upload.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { arrayBufferToBase64, imageUploadPayloadFromFile, imageUploadPayloadFromPath } from './image-upload'
+
+describe('image upload helpers', () => {
+  it('encodes binary data as base64 without leaking file paths', async () => {
+    const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'C:\\Users\\alice\\Screenshot 2026.png', {
+      type: 'image/png'
+    })
+
+    const payload = await imageUploadPayloadFromFile(file)
+
+    expect(payload).toEqual({
+      data_base64: 'iVBORw==',
+      filename: 'Screenshot 2026.png',
+      mime_type: 'image/png'
+    })
+    expect(Object.values(payload).join(' ')).not.toContain('Users')
+  })
+
+  it('extracts base64 payloads from data URLs read from local paths', () => {
+    const payload = imageUploadPayloadFromPath('/Users/alice/Desktop/private.png', 'data:image/png;base64,iVBORw==')
+
+    expect(payload).toEqual({
+      data_base64: 'iVBORw==',
+      filename: 'private.png',
+      mime_type: 'image/png'
+    })
+    expect(Object.values(payload).join(' ')).not.toContain('/Users/alice')
+  })
+
+  it('encodes array buffers in chunks', () => {
+    expect(arrayBufferToBase64(new Uint8Array([0, 1, 2, 253, 254, 255]).buffer)).toBe('AAEC/f7/')
+  })
+})

--- a/apps/desktop/src/lib/image-upload.ts
+++ b/apps/desktop/src/lib/image-upload.ts
@@ -1,0 +1,55 @@
+export interface ImageUploadPayload {
+  data_base64: string
+  filename: string
+  mime_type: string
+}
+
+const DATA_URL_RE = /^data:([^;,]+)?(?:;[^,]*)?;base64,(.*)$/s
+const CHUNK_SIZE = 0x8000
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || 'image'
+}
+
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+
+  for (let offset = 0; offset < bytes.length; offset += CHUNK_SIZE) {
+    const chunk = bytes.subarray(offset, offset + CHUNK_SIZE)
+    binary += String.fromCharCode(...chunk)
+  }
+
+  return btoa(binary)
+}
+
+export async function imageUploadPayloadFromFile(file: File): Promise<ImageUploadPayload> {
+  return {
+    data_base64: arrayBufferToBase64(await file.arrayBuffer()),
+    filename: basename(file.name || 'image'),
+    mime_type: file.type || 'application/octet-stream'
+  }
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => resolve(String(reader.result || '')))
+    reader.addEventListener('error', () => reject(reader.error || new Error('Failed to read image')))
+    reader.readAsDataURL(file)
+  })
+}
+
+export function imageUploadPayloadFromPath(filePath: string, dataUrl: string): ImageUploadPayload {
+  const match = dataUrl.match(DATA_URL_RE)
+
+  if (!match) {
+    throw new Error('Expected image data URL')
+  }
+
+  return {
+    data_base64: match[2] || '',
+    filename: basename(filePath),
+    mime_type: match[1] || 'application/octet-stream'
+  }
+}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import sys
@@ -2499,6 +2500,99 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     assert resp["result"]["path"] == str(screenshot)
     assert resp["result"]["remainder"] == ""
     assert len(server._sessions["sid"]["attached_images"]) == 1
+
+
+def test_image_upload_writes_image_under_gateway_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["sid"] = _session()
+
+    payload = base64.b64encode(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00"
+    ).decode("ascii")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.upload",
+            "params": {
+                "session_id": "sid",
+                "data_base64": payload,
+                "filename": r"C:\Users\alice\Desktop\Screenshot 2026-06-03 at 10.22.11 AM.png",
+                "mime_type": "image/png",
+            },
+        }
+    )
+
+    uploaded_path = Path(resp["result"]["path"])
+    assert resp["result"]["attached"] is True
+    assert uploaded_path.parent == tmp_path / "images"
+    assert uploaded_path.name.endswith("Screenshot_2026-06-03_at_10.22.11_AM.png")
+    assert "Users" not in uploaded_path.name
+    assert uploaded_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    assert server._sessions["sid"]["attached_images"] == [str(uploaded_path)]
+
+
+def test_image_upload_rejects_non_image_bytes(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["sid"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.upload",
+            "params": {
+                "session_id": "sid",
+                "data_base64": base64.b64encode(b"not an image").decode("ascii"),
+                "filename": "not-image.png",
+                "mime_type": "image/png",
+            },
+        }
+    )
+
+    assert resp["error"]["message"] == "invalid image data"
+    assert server._sessions["sid"]["attached_images"] == []
+
+
+def test_image_upload_rejects_svg(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["sid"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.upload",
+            "params": {
+                "session_id": "sid",
+                "data_base64": base64.b64encode(b"<svg><script /></svg>").decode("ascii"),
+                "filename": "diagram.svg",
+                "mime_type": "image/svg+xml",
+            },
+        }
+    )
+
+    assert resp["error"]["message"] == "invalid image data"
+    assert server._sessions["sid"]["attached_images"] == []
+
+
+def test_image_upload_rejects_oversized_encoded_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["sid"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.upload",
+            "params": {
+                "session_id": "sid",
+                "data_base64": "A" * (((server._IMAGE_UPLOAD_MAX_BYTES + 2) // 3) * 4 + 1),
+                "filename": "huge.png",
+                "mime_type": "image/png",
+            },
+        }
+    )
+
+    assert resp["error"]["message"] == "image too large"
+    assert server._sessions["sid"]["attached_images"] == []
 
 
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1,4 +1,6 @@
 import atexit
+import base64
+import binascii
 import concurrent.futures
 import contextvars
 import copy
@@ -7,6 +9,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -28,6 +31,28 @@ from tui_gateway.transport import (
 )
 
 logger = logging.getLogger(__name__)
+
+_IMAGE_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
+_IMAGE_UPLOAD_MIME_EXTENSIONS = {
+    "image/bmp": ".bmp",
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/tiff": ".tiff",
+    "image/webp": ".webp",
+    "image/x-icon": ".ico",
+}
+_IMAGE_UPLOAD_EXTENSIONS = {
+    ".bmp",
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
 
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
@@ -426,6 +451,79 @@ def _image_meta(path: Path) -> dict:
     except Exception:
         pass
     return meta
+
+
+def _uploaded_image_basename(filename: str) -> str:
+    return re.split(r"[/\\]+", filename or "image")[-1] or "image"
+
+
+def _safe_uploaded_image_name(filename: str, ext: str) -> str:
+    stem = Path(_uploaded_image_basename(filename)).stem or "image"
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", stem).strip("._-") or "image"
+    return f"{safe[:80]}{ext}"
+
+
+def _upload_image_extension(filename: str, mime_type: str) -> str | None:
+    ext = Path(_uploaded_image_basename(filename)).suffix.lower()
+    if ext in _IMAGE_UPLOAD_EXTENSIONS:
+        return ext
+    mime = (mime_type or "").split(";", 1)[0].strip().lower()
+    return _IMAGE_UPLOAD_MIME_EXTENSIONS.get(mime)
+
+
+def _decode_uploaded_image(data_base64: str) -> bytes:
+    raw = data_base64.split(",", 1)[1] if data_base64.startswith("data:") and "," in data_base64 else data_base64
+    if not raw:
+        raise ValueError("image data required")
+    if len(raw) > ((_IMAGE_UPLOAD_MAX_BYTES + 2) // 3) * 4:
+        raise ValueError("image too large")
+    try:
+        data = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("invalid image data") from exc
+    if not data:
+        raise ValueError("image data required")
+    if len(data) > _IMAGE_UPLOAD_MAX_BYTES:
+        raise ValueError("image too large")
+    return data
+
+
+def _verified_uploaded_image_extension(data: bytes, filename: str, mime_type: str) -> str:
+    requested = _upload_image_extension(filename, mime_type)
+    signatures = [
+        (b"\x89PNG\r\n\x1a\n", ".png"),
+        (b"\xff\xd8\xff", ".jpg"),
+        (b"GIF87a", ".gif"),
+        (b"GIF89a", ".gif"),
+        (b"BM", ".bmp"),
+        (b"II*\x00", ".tiff"),
+        (b"MM\x00*", ".tiff"),
+        (b"\x00\x00\x01\x00", ".ico"),
+    ]
+    detected = next((ext for magic, ext in signatures if data.startswith(magic)), None)
+    if detected is None and data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        detected = ".webp"
+    if detected is None:
+        raise ValueError("invalid image data")
+    if requested in {".jpeg", ".jpg"} and detected == ".jpg":
+        return requested
+    if requested in {".tif", ".tiff"} and detected == ".tiff":
+        return requested
+    if requested and requested == detected:
+        return requested
+    return detected
+
+
+def _save_uploaded_image(session: dict, data: bytes, filename: str, mime_type: str) -> Path:
+    ext = _verified_uploaded_image_extension(data, filename, mime_type)
+
+    session["image_counter"] = session.get("image_counter", 0) + 1
+    img_dir = _hermes_home / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = _safe_uploaded_image_name(filename, ext)
+    img_path = img_dir / f"upload_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{session['image_counter']}_{safe_name}"
+    img_path.write_bytes(data)
+    return img_path
 
 
 def _ok(rid, result: dict) -> dict:
@@ -4558,6 +4656,36 @@ def _(rid, params: dict) -> dict:
             **_image_meta(img_path),
         },
     )
+
+
+@method("image.upload")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    data_base64 = str(params.get("data_base64", "") or "").strip()
+    filename = str(params.get("filename", "image") or "image")
+    mime_type = str(params.get("mime_type", "") or "")
+
+    try:
+        data = _decode_uploaded_image(data_base64)
+        image_path = _save_uploaded_image(session, data, filename, mime_type)
+        session.setdefault("attached_images", []).append(str(image_path))
+        return _ok(
+            rid,
+            {
+                "attached": True,
+                "path": str(image_path),
+                "count": len(session["attached_images"]),
+                "text": f"[User attached image: {image_path.name}]",
+                **_image_meta(image_path),
+            },
+        )
+    except ValueError as exc:
+        return _err(rid, 4016, str(exc))
+    except Exception as exc:
+        return _err(rid, 5027, str(exc))
 
 
 @method("image.attach")


### PR DESCRIPTION
## Summary
- Upload remote Desktop image attachments as bytes before attaching them to a session
- Store uploaded images under the gateway-side Hermes images directory and use the returned server-side path
- Strip local path components from upload filenames and reject invalid, oversized, or SVG/non-image uploads

## Test Plan
- `npm run test:ui -- src/lib/image-upload.test.ts`
- `npm run type-check`
- `npm run build`
- `npx eslint src/app/chat/hooks/use-composer-actions.ts src/lib/image-upload.ts src/lib/image-upload.test.ts`
- `python -m pytest -o addopts='' tests/test_tui_gateway_server.py::test_image_upload_writes_image_under_gateway_home tests/test_tui_gateway_server.py::test_image_upload_rejects_non_image_bytes tests/test_tui_gateway_server.py::test_image_upload_rejects_svg tests/test_tui_gateway_server.py::test_image_upload_rejects_oversized_encoded_payload tests/test_tui_gateway_server.py::test_image_attach_appends_local_image tests/test_tui_gateway_server.py::test_image_attach_accepts_unquoted_screenshot_path_with_spaces -q`

## Notes
This keeps path-only in-app refs on the existing path attachment flow, while File-backed OS drops, picker images, and clipboard images upload bytes in remote Desktop mode.
