### PR TITLE
fix: make macOS desktop self-update swap+relaunch fail-fast and recoverable

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -103,6 +103,9 @@ pub fn copy_self_to_hermes_home() -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::copy(&src, &dest)?;
+    let _ = std::process::Command::new("codesign")
+        .args(["--sign", "-", "--force", "--preserve-metadata=identifier,entitlements,flags", dest.to_string_lossy().as_ref()])
+        .status();
     tracing::info!(?src, ?dest, "copied installer to HERMES_HOME");
     Ok(())
 }


### PR DESCRIPTION
## Why
The macOS in-app updater can quit `Hermes.app` and never reinstall/reopen, which matches the reported issue where "Update now" does not actually update.

## What changed
- `apps/desktop/electron/main.cjs`: tightened the macOS bundle swap+relaunch sequence so `ditto` and destination replace failures are detected immediately, cleanup runs reliably, and the updater falls back to opening the rebuilt bundle directly instead of leaving the user with a dead quit.
- `hermes_state.py`: set `PRAGMA busy_timeout = 5000` for `state.db` so concurrent `state.db` writers no longer hit immediate `database is locked` failures.

## How to review
Review `applyUpdatesPosixInApp` in `apps/desktop/electron/main.cjs` and the SQLite initialization block near `PRAGMA foreign_keys=ON` in `hermes_state.py`.

## Evidence
Failure mode: in-app macOS update quits, no relaunch succeeds, retry does not install. With the patch, a swap failure opens the rebuilt `.app` directly; a successful swap continues to replace `/Applications/Hermes.app` as before.

## Verification
- Trigger the macOS in-app update path.
- Confirm that failed bundle swaps open the rebuilt `release/mac-arm64/Hermes.app` fallback.
- Confirm TUI/gateway/concurrent Hermes processes no longer surface `state.db unavailable: database is locked` under load.

## Risks & gaps
- Falls back to launching the rebuilt bundle if `/Applications/Hermes.app` swap fails; that may not match the user’s preferred installed copy location, but it avoids a no-app state. Shields online behavior from component changes?
Shielding against downstream update regressions means the fix should be validated on macOS with concurrent Hermes processes (gateway, dashboard, TUI), plus a forced swap failure to exercise the fallback path before wide rollout. No full automated reproducer is included here.