### PR TITLE
fix(desktop): remove early returns blocking mic restart after TTS playback

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -349,9 +349,6 @@ export function useVoiceConversation({
           consumePendingResponse()
           resetSpeechBuffer()
           pendingStartRef.current = true
-          setStatus('idle')
-
-          return
         }
       }
 
@@ -359,9 +356,6 @@ export function useVoiceConversation({
         awaitingSpokenResponseRef.current = false
         resetSpeechBuffer()
         pendingStartRef.current = true
-        setStatus('idle')
-
-        return
       }
     }
 


### PR DESCRIPTION
## Summary
Removes two early returns in the voice conversation effect loop that prevented the microphone from restarting after TTS playback completes.

## Root Cause
The effect loop in `useVoiceConversation` required two separate React effect executions to transition from 'finished speaking' ? 'start listening', but the second execution was never triggered because no React state changed between them:

1. `speak()` finally block set `status` to `'idle'` ? effect fired
2. Effect detected response complete, reset all flags, set `pendingStartRef = true`, called `setStatus('idle')`
3. Early `return` prevented reaching `startListening()` at the bottom of the effect
4. `setStatus('idle')` was a no-op (React 18 bails out when value is unchanged) ? no re-render ? effect never fired again
5. Mic stayed dead until some unrelated re-render happened (~10s delay)

## Fix
Remove the early returns (and redundant `setStatus('idle')` calls) so the code falls through to the existing `startListening()` guard, which already checks `busy` and `status` before starting the mic.

References #38386