### PR TITLE
fix: stop BlueBubbles typing before final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3096,6 +3096,17 @@ class BasePlatformAdapter(ABC):
                     pass
             self._typing_paused.discard(chat_id)
 
+    def stop_typing_before_final_delivery(self) -> bool:
+        """Whether to stop typing before the first final response send.
+
+        Most platforms expire typing indicators quickly or clear them when a
+        message arrives. Some adapters (notably BlueBubbles/iMessage) can
+        render a late keep-alive pulse after the final reply, so they need the
+        keep-typing loop stopped before delivery and then stopped again during
+        normal cleanup.
+        """
+        return False
+
     def pause_typing_for_chat(self, chat_id: str) -> None:
         """Pause typing indicator for a chat (e.g. during approval waits).
 
@@ -4033,6 +4044,28 @@ class BasePlatformAdapter(ABC):
                 # typing task is already cancelled; if the parent task is also
                 # cancelling, let this message-processing task unwind now.
                 pass
+
+        _typing_stopped_before_delivery = False
+
+        async def _stop_typing_before_delivery_once() -> None:
+            """Stop typing before the first visible final delivery if needed."""
+            nonlocal _typing_stopped_before_delivery
+            if _typing_stopped_before_delivery:
+                return
+            if not self.stop_typing_before_final_delivery():
+                return
+            _typing_stopped_before_delivery = True
+            logger.debug(
+                "[%s] Stopping typing before final delivery to %s",
+                self.name,
+                event.source.chat_id,
+            )
+            await _stop_typing_task()
+            try:
+                if hasattr(self, "stop_typing"):
+                    await self.stop_typing(event.source.chat_id)
+            except Exception:
+                pass
         
         try:
             await self._run_processing_hook("on_processing_start", event)
@@ -4153,6 +4186,7 @@ class BasePlatformAdapter(ABC):
                 _tts_caption_delivered = False
                 if _tts_path and Path(_tts_path).exists():
                     try:
+                        await _stop_typing_before_delivery_once()
                         telegram_tts_caption = None
                         if (
                             self.platform == Platform.TELEGRAM
@@ -4178,6 +4212,7 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                    await _stop_typing_before_delivery_once()
                     _reply_anchor = _reply_anchor_for_event(event)
                     # Mark final response messages for notification delivery.
                     # Platform adapters that support per-message notification
@@ -4221,6 +4256,7 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
+                        await _stop_typing_before_delivery_once()
                         await self.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=images,
@@ -4262,6 +4298,7 @@ class BasePlatformAdapter(ABC):
 
                 if _image_paths:
                     try:
+                        await _stop_typing_before_delivery_once()
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
                         await self.send_multiple_images(
                             chat_id=event.source.chat_id,
@@ -4276,6 +4313,7 @@ class BasePlatformAdapter(ABC):
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        await _stop_typing_before_delivery_once()
                         ext = Path(media_path).suffix.lower()
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
                             media_result = await self.send_voice(
@@ -4306,6 +4344,7 @@ class BasePlatformAdapter(ABC):
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        await _stop_typing_before_delivery_once()
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
                             await self.send_video(

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -114,6 +114,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
 
+    def stop_typing_before_final_delivery(self) -> bool:
+        """Stop iMessage typing before sending the final reply.
+
+        BlueBubbles/IMCore can process a late "start typing" pulse after a
+        cancel signal. Stopping the refresh loop before the reply, then letting
+        base cleanup stop it again after delivery, keeps the indicator aligned
+        with actual agent processing instead of lingering after the response.
+        """
+        return True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
         extra = config.extra or {}
@@ -685,30 +695,45 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        # /server/info can report helper_connected=false during gateway startup
+        # and never refresh. The typing endpoint is the source of truth; if the
+        # Private API is enabled, try it and log endpoint failures.
+        if not self._private_api_enabled or not self.client:
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
             if guid:
                 encoded = quote(guid, safe="")
-                await self.client.post(
+                res = await self.client.post(
                     self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
                 )
-        except Exception:
-            pass
+                res.raise_for_status()
+                logger.debug("[bluebubbles] typing start chat=%s", _redact(guid))
+        except Exception as exc:
+            logger.debug(
+                "[bluebubbles] send_typing failed for %s: %s",
+                _redact(chat_id or ""),
+                exc,
+            )
 
     async def stop_typing(self, chat_id: str) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not self._private_api_enabled or not self.client:
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
             if guid:
                 encoded = quote(guid, safe="")
-                await self.client.delete(
+                res = await self.client.delete(
                     self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
                 )
-        except Exception:
-            pass
+                res.raise_for_status()
+                logger.debug("[bluebubbles] typing stop chat=%s", _redact(guid))
+        except Exception as exc:
+            logger.debug(
+                "[bluebubbles] stop_typing failed for %s: %s",
+                _redact(chat_id or ""),
+                exc,
+            )
 
     # ------------------------------------------------------------------
     # Read receipts

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -5,11 +5,13 @@ import json
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
 
 
 def _make_adapter(monkeypatch, **extra):
     monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
     monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+    monkeypatch.delenv("BLUEBUBBLES_MENTION_PATTERNS", raising=False)
     from gateway.platforms.bluebubbles import BlueBubblesAdapter
 
     cfg = PlatformConfig(
@@ -76,6 +78,80 @@ class TestBlueBubblesHelpers:
     def test_supports_message_editing_is_false(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         assert adapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_stops_typing_before_final_delivery(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.stop_typing_before_final_delivery() is True
+
+    @pytest.mark.asyncio
+    async def test_typing_uses_endpoint_even_when_helper_cache_is_false(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        calls = []
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+        class _Client:
+            async def post(self, url, timeout=None):
+                calls.append(("post", url, timeout))
+                return _Response()
+
+            async def delete(self, url, timeout=None):
+                calls.append(("delete", url, timeout))
+                return _Response()
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        monkeypatch.setattr(adapter, "client", _Client())
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+
+        await adapter.send_typing("user@example.com")
+        await adapter.stop_typing("user@example.com")
+
+        assert [call[0] for call in calls] == ["post", "delete"]
+
+    @pytest.mark.asyncio
+    async def test_final_response_stops_typing_before_send(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        events = []
+
+        async def fake_send_typing(chat_id, metadata=None):
+            events.append("typing-start")
+
+        async def fake_stop_typing(chat_id):
+            events.append("typing-stop")
+
+        async def fake_send(chat_id, content, reply_to=None, metadata=None):
+            events.append("send")
+            return SendResult(success=True, message_id="sent-1")
+
+        async def fake_handler(event):
+            await asyncio.sleep(0.01)
+            return "done"
+
+        monkeypatch.setattr(adapter, "send_typing", fake_send_typing)
+        monkeypatch.setattr(adapter, "stop_typing", fake_stop_typing)
+        monkeypatch.setattr(adapter, "send", fake_send)
+        adapter._message_handler = fake_handler
+
+        source = adapter.build_source(
+            chat_id="iMessage;-;user@example.com",
+            chat_type="dm",
+            user_id="user@example.com",
+        )
+        event = MessageEvent(text="hello", source=source)
+
+        await adapter._process_message_background(event, "test-session")
+
+        assert "send" in events
+        send_index = events.index("send")
+        assert "typing-start" in events[:send_index]
+        assert "typing-stop" in events[:send_index]
+        assert "typing-start" not in events[send_index + 1:]
 
     def test_truncate_message_omits_pagination_suffixes(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)


### PR DESCRIPTION
## Summary
- add an adapter hook for platforms that need typing stopped before the first final response send
- opt BlueBubbles into that hook so the keep-typing loop is cancelled before text/media delivery, then normal cleanup still stops typing after delivery
- let BlueBubbles typing start/stop call the endpoint whenever Private API is enabled instead of trusting a potentially stale helper_connected cache, and log endpoint failures at debug level

Fixes #31534.

## Tests
- `python -m pytest tests/gateway/test_bluebubbles.py -q -o 'addopts='`\n- `python -m pytest tests/gateway/test_google_chat.py tests/gateway/test_pending_drain_race.py tests/gateway/test_pending_drain_no_recursion.py -q -o 'addopts='`