### PR TITLE
fix(desktop): persist boot-failure overlay during retry loops

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -1,12 +1,18 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { AlertTriangle, FileText, Loader2, RefreshCw, Wrench } from '@/lib/icons'
+import { AlertTriangle, FileText, Loader2, Monitor, RefreshCw, Wrench } from '@/lib/icons'
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
 
 type BusyAction = 'local' | 'repair' | 'retry' | null
+
+// After this many boot-failure events within the window, the overlay
+// refuses to auto-dismiss and shows escalated recovery options (including
+// a direct gateway-settings button) even while boot.running is true.
+const ESCALATE_AFTER_FAILURES = 2
+const FAILURE_WINDOW_MS = 30_000
 
 // Recovery surface for a hard boot failure (gateway never came up, backend
 // exited during startup, bootstrap latched, …). Without this the app shell
@@ -25,8 +31,35 @@ export function BootFailureOverlay() {
   // higher z-index regardless of onboarding state.
   const suppressed = onboarding.flow.status !== 'idle' && onboarding.flow.status !== 'error'
 
+  // Track failure timestamps to detect persistent retry loops. After
+  // ESCALATE_AFTER_FAILURES failures within FAILURE_WINDOW_MS, the overlay
+  // stays visible even while boot.running is true so the user can switch
+  // gateway settings without the overlay disappearing between retries.
+  const failureTimestamps = useRef<number[]>([])
+  const [escalated, setEscalated] = useState(false)
+
   useEffect(() => {
-    if (!visible) {
+    if (!visible) return
+    const now = Date.now()
+    failureTimestamps.current = failureTimestamps.current.filter(ts => now - ts < FAILURE_WINDOW_MS)
+    failureTimestamps.current.push(now)
+    if (failureTimestamps.current.length >= ESCALATE_AFTER_FAILURES) {
+      setEscalated(true)
+    }
+  }, [visible])
+
+  // Clear escalation when boot succeeds
+  useEffect(() => {
+    if (boot.phase === 'renderer.ready' && !boot.error) {
+      setEscalated(false)
+      failureTimestamps.current = []
+    }
+  }, [boot.phase, boot.error])
+
+  const effectiveVisible = visible || (escalated && Boolean(boot.error))
+
+  useEffect(() => {
+    if (!effectiveVisible) {
       return
     }
 
@@ -36,7 +69,7 @@ export function BootFailureOverlay() {
       .catch(() => undefined)
   }, [visible])
 
-  if (!visible || suppressed) {
+  if (!effectiveVisible || suppressed) {
     return null
   }
 
@@ -92,9 +125,9 @@ export function BootFailureOverlay() {
                 {busy === 'repair' ? <Loader2 className="size-4 animate-spin" /> : <Wrench className="size-4" />}
                 Repair install
               </Button>
-              <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant="outline">
-                {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : null}
-                Use local gateway
+              <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant={escalated ? 'default' : 'outline'}>
+                {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : <Monitor className="size-4" />}
+                Switch to local gateway
               </Button>
               <Button onClick={openLogs} variant="ghost">
                 <FileText className="size-4" />
@@ -102,7 +135,9 @@ export function BootFailureOverlay() {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Repair re-runs the installer and can take a few minutes on a fresh machine.
+              {escalated
+                ? 'Multiple connection attempts failed. Check your remote gateway URL and token, or switch to local mode.'
+                : 'Repair re-runs the installer and can take a few minutes on a fresh machine.'}
             </p>
           </div>
 


### PR DESCRIPTION
After 2 rapid boot failures the overlay now stays visible even while boot.running is true, letting the user click 'Switch to local gateway' instead of being trapped in an unstoppable retry cycle.

- Track failure timestamps; escalate after ESCALATE_AFTER_FAILURES (2) within FAILURE_WINDOW_MS (30s)
- Promoted 'Switch to local gateway' button when escalated
- Helpful hint suggests checking remote URL/token on repeated failures
- Auto-clears escalation on successful boot

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

