### PR TITLE
feat: add contact reminder brief helper

### DIFF
--- a/docs/plans/2026-06-04-contact-reminder-brief.md
+++ b/docs/plans/2026-06-04-contact-reminder-brief.md
@@ -1,0 +1,54 @@
+# Contact Reminder Brief Helper Implementation Plan
+
+> **For Hermes:** Use test-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a small local-first helper that turns a JSON/YAML contact occasion file into a concise Traditional Chinese relationship-reminder brief, with exact `[SILENT]` output when nothing needs attention.
+
+**Architecture:** A standalone script in `scripts/contact_reminder_brief.py` exposes pure functions for loading contacts, computing upcoming annual/one-off occasions, and rendering text. The CLI accepts `--input`, `--today`, `--window-days`, and `--format json|text` so cron jobs can run it deterministically.
+
+**Tech Stack:** Python standard library plus optional PyYAML if installed; pytest tests under `tests/scripts/`.
+
+---
+
+### Task 1: Specify upcoming occasion behavior with failing tests
+
+**Objective:** Capture the core behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_contact_reminder_brief.py`
+- Create later: `scripts/contact_reminder_brief.py`
+
+**Steps:**
+1. Write tests that import the script with `importlib.util.spec_from_file_location()`.
+2. Cover annual birthdays/anniversaries within the window.
+3. Cover exact `[SILENT]` when no item is actionable.
+4. Cover Feb 29 annual dates in non-leap years by observing them on Feb 28.
+5. Run focused tests and confirm they fail because the script does not exist yet.
+
+### Task 2: Implement minimal pure functions and renderer
+
+**Objective:** Pass the focused tests with a small, dependency-light script.
+
+**Files:**
+- Create: `scripts/contact_reminder_brief.py`
+
+**Steps:**
+1. Implement JSON/YAML loading.
+2. Implement `build_brief(records, today, window_days)` returning structured items.
+3. Implement leap-day normalization for annual dates.
+4. Implement Traditional Chinese text rendering with TL;DR and action bullets.
+5. Run focused tests and confirm pass.
+
+### Task 3: Add CLI smoke path and verify
+
+**Objective:** Make the helper useful from cron/shell.
+
+**Files:**
+- Modify: `scripts/contact_reminder_brief.py`
+- Modify: `tests/scripts/test_contact_reminder_brief.py`
+
+**Steps:**
+1. Add `main()` and argparse flags.
+2. Test text output and `[SILENT]` behavior through pure helper or subprocess-safe CLI entrypoint.
+3. Run `scripts/run_tests.sh tests/scripts/test_contact_reminder_brief.py`.
+4. Run a manual sample invocation with a temp JSON file.

--- a/scripts/contact_reminder_brief.py
+++ b/scripts/contact_reminder_brief.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Build a local-first relationship/contact reminder brief.
+
+Input shape accepts either a list of records or a mapping with a ``contacts``
+list. Records can use built-in annual date fields such as ``birthday`` and
+``anniversary`` or an ``occasions`` list for custom events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+ANNUAL_FIELDS = {
+    "birthday": "生日",
+    "anniversary": "紀念日",
+}
+
+
+@dataclass(frozen=True)
+class Occasion:
+    name: str
+    event: str
+    event_label: str
+    date: date
+    days_until: int
+    relationship: str | None = None
+    notes: str | None = None
+    turning_age: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "name": self.name,
+            "event": self.event,
+            "event_label": self.event_label,
+            "date": self.date.isoformat(),
+            "days_until": self.days_until,
+        }
+        if self.relationship:
+            data["relationship"] = self.relationship
+        if self.notes:
+            data["notes"] = self.notes
+        if self.turning_age is not None:
+            data["turning_age"] = self.turning_age
+        return data
+
+
+def _parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def _is_leap_year(year: int) -> bool:
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def _annual_observed_date(source: date, year: int) -> date:
+    if source.month == 2 and source.day == 29 and not _is_leap_year(year):
+        return date(year, 2, 28)
+    return date(year, source.month, source.day)
+
+
+def _next_annual_occurrence(source: date, today: date) -> date:
+    candidate = _annual_observed_date(source, today.year)
+    if candidate < today:
+        candidate = _annual_observed_date(source, today.year + 1)
+    return candidate
+
+
+def _age_on_annual_date(source: date, occurrence: date) -> int:
+    years = occurrence.year - source.year
+    if source.month == 2 and source.day == 29 and occurrence.month == 2 and occurrence.day == 28:
+        return years
+    if (occurrence.month, occurrence.day) < (source.month, source.day):
+        return years - 1
+    return years
+
+
+def load_records(path: str | Path) -> list[dict[str, Any]]:
+    """Load contacts from JSON or YAML without reading any external sources."""
+    source = Path(path)
+    text = source.read_text(encoding="utf-8")
+    if source.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - depends on env packaging
+            raise RuntimeError("PyYAML is required for YAML input") from exc
+        payload = yaml.safe_load(text)
+    else:
+        payload = json.loads(text)
+
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("contacts"), list):
+        records = payload["contacts"]
+    else:
+        raise ValueError("Expected a list of contacts or an object with a contacts list")
+
+    if not all(isinstance(record, dict) for record in records):
+        raise ValueError("Every contact record must be an object")
+    return records
+
+
+def _record_occasions(record: dict[str, Any], today: date, window_days: int) -> list[Occasion]:
+    name = str(record.get("name", "")).strip()
+    if not name:
+        return []
+
+    relationship = str(record.get("relationship", "")).strip() or None
+    notes = str(record.get("notes", "")).strip() or None
+    items: list[Occasion] = []
+
+    for field, label in ANNUAL_FIELDS.items():
+        raw_value = record.get(field)
+        if not raw_value:
+            continue
+        source_date = _parse_date(str(raw_value))
+        occurrence = _next_annual_occurrence(source_date, today)
+        days_until = (occurrence - today).days
+        if 0 <= days_until <= window_days:
+            items.append(
+                Occasion(
+                    name=name,
+                    event=field,
+                    event_label=label,
+                    date=occurrence,
+                    days_until=days_until,
+                    relationship=relationship,
+                    notes=notes,
+                    turning_age=_age_on_annual_date(source_date, occurrence),
+                )
+            )
+
+    for occasion in record.get("occasions", []) or []:
+        if not isinstance(occasion, dict) or not occasion.get("date"):
+            continue
+        label = str(occasion.get("label") or occasion.get("event") or "提醒")
+        raw_event = str(occasion.get("event") or occasion.get("label") or "occasion")
+        source_date = _parse_date(str(occasion["date"]))
+        recurring = bool(occasion.get("annual", False))
+        occurrence = _next_annual_occurrence(source_date, today) if recurring else source_date
+        days_until = (occurrence - today).days
+        if 0 <= days_until <= window_days:
+            items.append(
+                Occasion(
+                    name=name,
+                    event=raw_event,
+                    event_label=label,
+                    date=occurrence,
+                    days_until=days_until,
+                    relationship=relationship,
+                    notes=str(occasion.get("notes") or notes or "").strip() or None,
+                )
+            )
+
+    return items
+
+
+def build_brief(
+    records: list[dict[str, Any]], today: date | None = None, window_days: int = 14
+) -> dict[str, Any]:
+    """Return a structured brief for occasions due within ``window_days``."""
+    today = today or date.today()
+    items: list[Occasion] = []
+    for record in records:
+        items.extend(_record_occasions(record, today, window_days))
+
+    item_dicts = [item.as_dict() for item in sorted(items, key=lambda item: (item.date, item.name))]
+    if not item_dicts:
+        return {"silent": True, "items": []}
+    return {"silent": False, "today": today.isoformat(), "window_days": window_days, "items": item_dicts}
+
+
+def _relative_zh(days_until: int) -> str:
+    if days_until == 0:
+        return "今天"
+    if days_until == 1:
+        return "明天"
+    return f"{days_until} 天後"
+
+
+def render_text(brief: dict[str, Any]) -> str:
+    """Render a Joe-style Traditional Chinese brief."""
+    if brief.get("silent"):
+        return "[SILENT]"
+
+    items = brief.get("items", [])
+    lines = [
+        f"TL;DR：未來 {brief.get('window_days')} 天有 {len(items)} 個關係提醒需要 Joe 看一眼。",
+        "",
+        "- 事實 / 已驗證：",
+    ]
+    for item in items:
+        age = f"，{item['turning_age']} 歲" if item.get("turning_age") is not None else ""
+        relationship = f"（{item['relationship']}）" if item.get("relationship") else ""
+        notes = f"；備註：{item['notes']}" if item.get("notes") else ""
+        lines.append(
+            f"  - {item['name']}{relationship}：{item['event_label']}在 {item['date']}（{_relative_zh(int(item['days_until']))}{age}）{notes}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "- 建議動作：",
+            "  - 若要聯絡真人，只起草內容；由 Joe 手動傳送。",
+            "  - 今天/明天的項目優先處理，避免最後一刻補救。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_today(value: str | None) -> date:
+    if not value:
+        return date.today()
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Path to contacts JSON/YAML")
+    parser.add_argument("--today", help="Override today as YYYY-MM-DD for deterministic runs")
+    parser.add_argument("--window-days", type=int, default=14)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    if args.window_days < 0:
+        parser.error("--window-days must be non-negative")
+
+    brief = build_brief(load_records(args.input), today=_parse_today(args.today), window_days=args.window_days)
+    if args.format == "json":
+        print(json.dumps(brief, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(brief))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_contact_reminder_brief.py
+++ b/tests/scripts/test_contact_reminder_brief.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "_contact_reminder_brief_under_test",
+        Path(__file__).resolve().parents[2] / "scripts" / "contact_reminder_brief.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_brief_returns_due_and_upcoming_annual_occasions():
+    module = _load_module()
+    records = [
+        {
+            "name": "Finn",
+            "relationship": "girlfriend",
+            "birthday": "2000-04-10",
+            "notes": "Likes playful, low-pressure gestures.",
+        },
+        {
+            "name": "Jeremy",
+            "birthday": "1994-05-23",
+        },
+    ]
+
+    brief = module.build_brief(records, today=date(2026, 4, 8), window_days=7)
+
+    assert brief["silent"] is False
+    assert [item["name"] for item in brief["items"]] == ["Finn"]
+    assert brief["items"][0]["event"] == "birthday"
+    assert brief["items"][0]["days_until"] == 2
+    assert brief["items"][0]["turning_age"] == 26
+    rendered = module.render_text(brief)
+    assert "TL;DR" in rendered
+    assert "Finn" in rendered
+    assert "2 天後" in rendered
+    assert "26 歲" in rendered
+    assert "手動傳送" in rendered
+
+
+def test_build_brief_is_silent_when_nothing_is_within_window():
+    module = _load_module()
+    records = [{"name": "Jeremy", "birthday": "1994-05-23"}]
+
+    brief = module.build_brief(records, today=date(2026, 4, 8), window_days=7)
+
+    assert brief == {"silent": True, "items": []}
+    assert module.render_text(brief) == "[SILENT]"
+
+
+def test_feb_29_annual_occasion_is_observed_on_feb_28_in_non_leap_year():
+    module = _load_module()
+    records = [{"name": "Leap Friend", "birthday": "2000-02-29"}]
+
+    brief = module.build_brief(records, today=date(2027, 2, 27), window_days=2)
+
+    assert brief["silent"] is False
+    assert brief["items"][0]["date"] == "2027-02-28"
+    assert brief["items"][0]["days_until"] == 1
+    assert brief["items"][0]["turning_age"] == 27
+
+
+def test_load_records_accepts_json_mapping_with_contacts_key(tmp_path):
+    module = _load_module()
+    path = tmp_path / "contacts.json"
+    path.write_text(
+        json.dumps({"contacts": [{"name": "Finn", "birthday": "2000-04-10"}]}),
+        encoding="utf-8",
+    )
+
+    assert module.load_records(path) == [{"name": "Finn", "birthday": "2000-04-10"}]
+
+
+def test_main_prints_text_brief_for_cli_input(tmp_path, capsys):
+    module = _load_module()
+    path = tmp_path / "contacts.json"
+    path.write_text(
+        json.dumps({"contacts": [{"name": "Finn", "birthday": "2000-04-10"}]}),
+        encoding="utf-8",
+    )
+
+    assert module.main(["--input", str(path), "--today", "2026-04-08", "--window-days", "7"]) == 0
+
+    output = capsys.readouterr().out
+    assert "TL;DR" in output
+    assert "Finn" in output
+    assert "手動傳送" in output
+
+
+def test_main_can_emit_json_brief(tmp_path, capsys):
+    module = _load_module()
+    path = tmp_path / "contacts.json"
+    path.write_text(
+        json.dumps({"contacts": [{"name": "Finn", "birthday": "2000-04-10"}]}),
+        encoding="utf-8",
+    )
+
+    assert module.main([
+        "--input",
+        str(path),
+        "--today",
+        "2026-04-08",
+        "--window-days",
+        "7",
+        "--format",
+        "json",
+    ]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["silent"] is False
+    assert payload["items"][0]["name"] == "Finn"
+
+
+def test_main_rejects_negative_window_days(tmp_path):
+    module = _load_module()
+    path = tmp_path / "contacts.json"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        module.main(["--input", str(path), "--window-days", "-1"])


### PR DESCRIPTION
## Summary
- Adds `scripts/contact_reminder_brief.py`, a local-first JSON/YAML helper for upcoming birthdays, anniversaries, and custom contact occasions.
- Renders Joe-style Traditional Chinese morning briefs with exact `[SILENT]` output when nothing is due.
- Handles annual Feb 29 occasions on Feb 28 in non-leap years and exposes `--today`, `--window-days`, and `--format json|text` for deterministic cron use.
- Includes a small implementation plan under `docs/plans/`.

## Why this helps
- Gives Hermes a reversible, non-network personal relationship reminder primitive without sending messages or interacting with people.
- Keeps the behavior testable and cron-friendly, so future jobs can surface only actionable personal reminders.

## Test Plan
- [x] `scripts/run_tests.sh tests/scripts/test_contact_reminder_brief.py`
- [x] `python -m ruff check scripts/contact_reminder_brief.py tests/scripts/test_contact_reminder_brief.py`
- [x] Manual smoke: `python scripts/contact_reminder_brief.py --input <tmp-json> --today 2026-04-08 --window-days 7`
