### PR TITLE
fix: send explicit stop-typing RPC in Signal adapter

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1385,6 +1385,24 @@ class SignalAdapter(BasePlatformAdapter):
                 await task
             except asyncio.CancelledError:
                 pass
+        # Send explicit stop-typing signal so the recipient's indicator
+        # disappears immediately instead of waiting for Signal's built-in
+        # timeout (~5 s).
+        try:
+            params: Dict[str, Any] = {"account": self.account}
+            if chat_id.startswith("group:"):
+                params["groupId"] = chat_id[6:]
+            else:
+                params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params["stop"] = True
+            await self._rpc(
+                "sendTyping",
+                params,
+                rpc_id="typing-stop",
+                log_failures=False,
+            )
+        except Exception:
+            pass
         # Reset per-chat typing backoff state so the next agent turn starts
         # fresh rather than inheriting a cooldown from a prior conversation.
         self._typing_failures.pop(chat_id, None)


### PR DESCRIPTION
## Summary

The Signal adapter's `_stop_typing_indicator` method cancels the internal typing asyncio task and resets backoff state, but never sends an explicit `sendTyping` RPC with `stop=true` to signal-cli. As a result, the typing indicator on the recipient's device lingers until Signal's built-in timeout (~5s) expires.

## Changes

- Added a best-effort `sendTyping` RPC call with `stop=true` in `_stop_typing_indicator`, wrapped in `try/except Exception` for graceful degradation
- The stop signal is sent before clearing backoff state, matching the pattern used by the Matrix adapter (`set_typing` with `timeout=0`)

## Testing

- All 171 existing Signal adapter tests pass (including 7 typing-specific tests)
- `py_compile` passes
- No new dependencies or API changes

Closes #38303