### PR TITLE
fix: use dark backgrounds for TUI diff highlights in dark theme

### DIFF
--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -291,8 +291,8 @@ export const DARK_THEME: Theme = {
     statusCritical: '#FF6B6B',
     selectionBg: '#3a3a55',
 
-    diffAdded: 'rgb(220,255,220)',
-    diffRemoved: 'rgb(255,220,220)',
+    diffAdded: 'rgb(30,70,30)',
+    diffRemoved: 'rgb(70,30,30)',
     diffAddedWord: 'rgb(36,138,61)',
     diffRemovedWord: 'rgb(207,34,46)',
     shellDollar: '#4dabf7'


### PR DESCRIPTION
## Summary

The TUI dark theme uses near-white background colors (`rgb(220,255,220)` and `rgb(255,220,220)`) for diff added/removed highlights. These are appropriate for light terminal backgrounds but create jarring bright rectangles on dark terminals.

## Changes

- Changed dark theme `diffAdded` from `rgb(220,255,220)` to `rgb(30,70,30)` (dark green background)
- Changed dark theme `diffRemoved` from `rgb(255,220,220)` to `rgb(70,30,30)` (dark red background)
- Foreground text colors (`diffAddedWord`, `diffRemovedWord`) are already appropriate for dark backgrounds and remain unchanged
- Light theme is unaffected

## Verification

- Manual verification: old light-colored values removed from dark theme, new dark values in place
- Light theme diff colors (`rgb(200,240,200)` and `rgb(240,200,200)`) are unchanged
- All consumers in `markdown.tsx` read from `t.color.*` — no code changes needed beyond the theme definition

Closes #38359