### PR TITLE
fix(mem0): read agent-attributed memories

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -211,8 +211,20 @@ class Mem0MemoryProvider(MemoryProvider):
         self._rerank = self._config.get("rerank", True)
 
     def _read_filters(self) -> Dict[str, Any]:
-        """Filters for search/get_all — scoped to user only for cross-session recall."""
-        return {"user_id": self._user_id}
+        """Filters for search/get_all, including agent-tagged memories.
+
+        Writes include both user_id and agent_id for attribution. Mem0 Platform
+        treats records with agent_id as entity-scoped, so a plain
+        {"user_id": ...} read can miss memories saved by the same user through
+        an agent. Include the current agent-scoped shape in an OR filter while
+        keeping the plain user filter for older un-attributed records.
+        """
+        return {
+            "OR": [
+                {"user_id": self._user_id},
+                {"user_id": self._user_id, "agent_id": self._agent_id},
+            ]
+        }
 
     def _write_filters(self) -> Dict[str, Any]:
         """Filters for add — scoped to user + agent for attribution."""

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -59,7 +59,12 @@ class TestMem0FiltersV2:
         assert client.captured_search["query"] == "hello"
         assert client.captured_search["top_k"] == 3
         assert client.captured_search["rerank"] is False
-        assert client.captured_search["filters"] == {"user_id": "u123"}
+        assert client.captured_search["filters"] == {
+            "OR": [
+                {"user_id": "u123"},
+                {"user_id": "u123", "agent_id": "hermes"},
+            ]
+        }
         # Must NOT have bare user_id kwarg
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
@@ -69,7 +74,12 @@ class TestMem0FiltersV2:
 
         provider.handle_tool_call("mem0_profile", {})
 
-        assert client.captured_get_all["filters"] == {"user_id": "u123"}
+        assert client.captured_get_all["filters"] == {
+            "OR": [
+                {"user_id": "u123"},
+                {"user_id": "u123", "agent_id": "hermes"},
+            ]
+        }
         assert "user_id" not in {k for k in client.captured_get_all if k != "filters"}
 
     def test_prefetch_uses_filters(self, monkeypatch):
@@ -80,7 +90,12 @@ class TestMem0FiltersV2:
         provider._prefetch_thread.join(timeout=2)
 
         assert client.captured_search["query"] == "hello"
-        assert client.captured_search["filters"] == {"user_id": "u123"}
+        assert client.captured_search["filters"] == {
+            "OR": [
+                {"user_id": "u123"},
+                {"user_id": "u123", "agent_id": "hermes"},
+            ]
+        }
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
     def test_sync_turn_uses_write_filters(self, monkeypatch):
@@ -107,12 +122,29 @@ class TestMem0FiltersV2:
         assert call["agent_id"] == "hermes"
         assert call["infer"] is False
 
-    def test_read_filters_no_agent_id(self):
-        """Read filters should use user_id only — cross-session recall across agents."""
+    def test_read_filters_include_unattributed_and_agent_scoped_memories(self):
+        """Read filters should cover old user-only rows and agent-attributed rows."""
         provider = Mem0MemoryProvider()
         provider._user_id = "u123"
         provider._agent_id = "hermes"
-        assert provider._read_filters() == {"user_id": "u123"}
+        assert provider._read_filters() == {
+            "OR": [
+                {"user_id": "u123"},
+                {"user_id": "u123", "agent_id": "hermes"},
+            ]
+        }
+
+    def test_read_filters_use_configured_agent_id(self):
+        """Read filters should use the active agent id, not a hard-coded name."""
+        provider = Mem0MemoryProvider()
+        provider._user_id = "u123"
+        provider._agent_id = "gideon"
+        assert provider._read_filters() == {
+            "OR": [
+                {"user_id": "u123"},
+                {"user_id": "u123", "agent_id": "gideon"},
+            ]
+        }
 
     def test_write_filters_include_agent_id(self):
         """Write filters should include agent_id for attribution."""


### PR DESCRIPTION
## What does this PR do?

Fixes the Mem0 provider read filter so profile, search, and prefetch include memories saved with agent attribution.

The provider already writes with `user_id` and `agent_id`. Reads used only `user_id`, which can miss records on Mem0 Platform once they are stored under an agent scope. This keeps the user-only read path for older records and adds the active agent-scoped shape to the filter.

## Related Issue

Fixes #38424

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/mem0/__init__.py`
  - Changed `_read_filters()` to return an OR filter covering both user-only and active agent-attributed memories.
- `tests/plugins/memory/test_mem0_v2.py`
  - Updated search, profile, and prefetch filter assertions.
  - Added coverage that the configured `agent_id` is used instead of a hard-coded value.

## How to Test

1. Run `python3 -m pytest tests/plugins/memory/test_mem0_v2.py -q`.
2. Run `ruff check plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v2.py`.
3. Run `python scripts/run_tests_parallel.py --slice 1/6`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A