### PR TITLE
fix: include error message in gateway transient error log

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -208,10 +208,11 @@ def _gateway_loop_exception_handler(
             except Exception:
                 task_name = repr(task)
         logger.warning(
-            "Gateway swallowed transient network error from %s: %s: %s",
+            "Gateway swallowed transient network error from %s: %s: %s (%s)",
             task_name or "<unknown task>",
             type(exc).__name__,
             exc,
+            message,
             exc_info=(type(exc), exc, exc.__traceback__),
         )
         return


### PR DESCRIPTION
## Summary

In `_gateway_loop_exception_handler`, the `message` variable is extracted from the asyncio exception context but never included in the warning log output. This makes transient network error diagnostics less informative than intended.

## Changes

- Added `message` to the `logger.warning` format string so the context message is now logged alongside the task name, exception type, and exception value

## Testing

- All 14 tests in `tests/gateway/test_loop_exception_handler.py` pass
- `py_compile` passes