### PR TITLE
fix(gateway): clear stale platform fatal errors on startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4299,7 +4299,9 @@ class GatewayRunner:
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            write_runtime_status(
+                gateway_state="starting", exit_reason=None, reset_platforms=True,
+            )
         except Exception:
             pass
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -511,11 +511,20 @@ def write_runtime_status(
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    reset_platforms: bool = False,
 ) -> None:
-    """Persist gateway runtime health information for diagnostics/status."""
+    """Persist gateway runtime health information for diagnostics/status.
+
+    When *reset_platforms* is ``True``, the ``platforms`` dict is wiped
+    before applying any per-platform updates.  This prevents stale fatal
+    errors from a previous gateway run (e.g. a token-conflict lock) from
+    persisting into a fresh startup.
+    """
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    if reset_platforms:
+        payload["platforms"] = {}
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -358,6 +358,85 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_write_runtime_status_reset_platforms_clears_stale_fatal_errors(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: stale fatal errors from a previous run must not
+        survive a fresh gateway startup (issue #38423).
+
+        When two profiles share the same Telegram bot token and one
+        profile's gateway exits with a lock conflict, the ``platforms``
+        dict in ``gateway_state.json`` retains the ``fatal`` state.
+        On the next startup the gateway must wipe those entries so the
+        dashboard does not show phantom errors.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # Simulate a previous run that recorded a fatal lock conflict.
+        status.write_runtime_status(
+            gateway_state="startup_failed",
+            exit_reason="telegram conflict",
+            platform="telegram",
+            platform_state="fatal",
+            error_code="telegram_lock",
+            error_message="Telegram bot token already in use (PID 12345).",
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["telegram"]["state"] == "fatal"
+        assert "already in use" in payload["platforms"]["telegram"]["error_message"]
+
+        # Fresh startup with reset_platforms=True must wipe old platform errors.
+        status.write_runtime_status(
+            gateway_state="starting", exit_reason=None, reset_platforms=True,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"] == {}
+
+    def test_write_runtime_status_reset_platforms_preserves_new_updates(
+        self, tmp_path, monkeypatch
+    ):
+        """When reset_platforms=True is combined with a per-platform update,
+        the reset happens first, then the new platform entry is written."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # Old stale error from a previous run.
+        status.write_runtime_status(
+            platform="telegram",
+            platform_state="fatal",
+            error_code="telegram_lock",
+            error_message="stale error",
+        )
+        # Also a stale discord error.
+        status.write_runtime_status(
+            platform="discord",
+            platform_state="fatal",
+            error_code="discord_timeout",
+            error_message="stale discord error",
+        )
+
+        # Fresh startup: reset platforms, then write a new telegram connected entry.
+        status.write_runtime_status(
+            gateway_state="starting",
+            exit_reason=None,
+            reset_platforms=True,
+            platform="telegram",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        # Telegram is now connected (new entry after reset).
+        assert payload["platforms"]["telegram"]["state"] == "connected"
+        assert payload["platforms"]["telegram"]["error_message"] is None
+        # Discord stale error was wiped by reset and not re-added.
+        assert "discord" not in payload["platforms"]
+
 
 class TestTerminatePid:
     def test_force_uses_taskkill_on_windows(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Clears stale platform fatal errors from `gateway_state.json` on fresh gateway startup, preventing the dashboard from showing phantom errors (e.g. "Telegram bot token already in use") after a token conflict is resolved and the gateway restarts.

## Related Issue

Fixes #38423

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py`: Added `reset_platforms` parameter to `write_runtime_status()`. When `True`, the `platforms` dict is wiped before applying any per-platform updates, preventing stale fatal errors from a previous run from persisting.
- `gateway/run.py`: The gateway startup path now passes `reset_platforms=True` when writing the initial `gateway_state="starting"` status, ensuring old platform error states are cleared on fresh startup.
- `tests/gateway/test_status.py`: Added two regression tests:
  - `test_write_runtime_status_reset_platforms_clears_stale_fatal_errors`: Verifies that stale fatal errors are wiped on startup.
  - `test_write_runtime_status_reset_platforms_preserves_new_updates`: Verifies that reset happens before new platform entries are written, so a newly-connected platform is recorded correctly while stale errors from other platforms are cleared.

## How to Test

1. Simulate a token conflict: start two gateway instances sharing the same Telegram bot token. The second instance should record a `fatal` error in `gateway_state.json`.
2. Kill the first instance and restart the second. Before this fix, the dashboard would still show the stale "token already in use" error. After this fix, the `platforms` dict is cleared on startup, and the dashboard shows a clean state.
3. Run the regression tests: `pytest tests/gateway/test_status.py::TestGatewayRuntimeStatus -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/status.py:write_runtime_status` (callers: 12+ across gateway/run.py, gateway/platforms/base.py, hermes_cli/web_server.py)
- Blast radius: LOW — new parameter is `False` by default, existing callers unaffected
- Related patterns: `_set_fatal_error` → `_write_runtime_status_safe` → `write_runtime_status` chain in `gateway/platforms/base.py`
