### PR TITLE
feat(kanban): clickable task card ID with one-click copy to clipboard

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -397,10 +397,14 @@
   // standard `drop` event and our `hermes-kanban:drop` event.
   // -------------------------------------------------------------------------
 
+  function isNoDragOrigin(target) {
+    return Boolean(target && target.closest && target.closest("[data-kanban-no-drag]"));
+  }
+
   function attachTouchDrag(el, taskId) {
     if (!el) return;
     function onDown(e) {
-      if (e.pointerType !== "touch") return;
+      if (e.pointerType !== "touch" || isNoDragOrigin(e.target)) return;
       e.preventDefault();
       const proxy = el.cloneNode(true);
       proxy.classList.add("hermes-kanban-touch-proxy");
@@ -2607,6 +2611,7 @@
     const t = props.task;
     const cardRef = useRef(null);
     const [idCopied, setIdCopied] = useState(false);
+    const copyFeedbackTimeoutRef = useRef(null);
 
     const copyTaskId = function () {
       const fallback = function () { window.prompt("Copy:", t.id); };
@@ -2614,8 +2619,11 @@
         const p = navigator.clipboard && navigator.clipboard.writeText(t.id);
         if (p && p.then) {
           p.then(function () {
+            if (copyFeedbackTimeoutRef.current) {
+              clearTimeout(copyFeedbackTimeoutRef.current);
+            }
             setIdCopied(true);
-            setTimeout(function () { setIdCopied(false); }, 2000);
+            copyFeedbackTimeoutRef.current = setTimeout(function () { setIdCopied(false); }, 2000);
           }).catch(fallback);
         } else {
           fallback();
@@ -2634,10 +2642,22 @@
     };
 
     useEffect(function () {
+      return function () {
+        if (copyFeedbackTimeoutRef.current) {
+          clearTimeout(copyFeedbackTimeoutRef.current);
+        }
+      };
+    }, []);
+
+    useEffect(function () {
       return attachTouchDrag(cardRef.current, t.id);
     }, [t.id]);
 
     const handleDragStart = function (e) {
+      if (isNoDragOrigin(e.target)) {
+        e.preventDefault();
+        return;
+      }
       e.dataTransfer.setData(MIME_TASK, t.id);
       e.dataTransfer.effectAllowed = "move";
       const selectedCards = document.querySelectorAll(".hermes-kanban-card--selected");
@@ -2727,6 +2747,7 @@
                 copyTaskId();
               },
               title: "Click to copy task ID",
+              "data-kanban-no-drag": true,
               role: "button",
               tabIndex: 0,
               "aria-label": `Copy task ID ${t.id}`,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2606,6 +2606,32 @@
     const { t: i18n } = useI18n();
     const t = props.task;
     const cardRef = useRef(null);
+    const [idCopied, setIdCopied] = useState(false);
+
+    const copyTaskId = function () {
+      const fallback = function () { window.prompt("Copy:", t.id); };
+      try {
+        const p = navigator.clipboard && navigator.clipboard.writeText(t.id);
+        if (p && p.then) {
+          p.then(function () {
+            setIdCopied(true);
+            setTimeout(function () { setIdCopied(false); }, 2000);
+          }).catch(fallback);
+        } else {
+          fallback();
+        }
+      } catch (_e) {
+        fallback();
+      }
+    };
+
+    const handleIdKeyDown = function (e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        copyTaskId();
+      }
+    };
 
     useEffect(function () {
       return attachTouchDrag(cardRef.current, t.id);
@@ -2691,8 +2717,26 @@
                 "aria-label": `Select task ${t.id}`,
               }),
             ),
-            h("span", { className: "hermes-kanban-card-id",
-                        title: `Task id: ${t.id}. Use this id with kanban_show, /kanban show, or hermes kanban show.` }, t.id),
+            h("span", {
+              className: cn(
+                "hermes-kanban-card-id-clickable",
+                idCopied ? "hermes-kanban-card-id-clickable--copied" : "",
+              ),
+              onClick: function (e) {
+                e.stopPropagation();
+                copyTaskId();
+              },
+              title: "Click to copy task ID",
+              role: "button",
+              tabIndex: 0,
+              "aria-label": `Copy task ID ${t.id}`,
+              onMouseDown: function (e) { e.stopPropagation(); },
+              onKeyDown: handleIdKeyDown,
+            },
+              h("span", { className: "hermes-kanban-card-id" }, t.id),
+              " ",
+              idCopied ? "Copied" : "Copy ID",
+            ),
             t.warnings && t.warnings.count > 0
               ? h("span", {
                   className: cn(

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2610,6 +2610,7 @@
     const { t: i18n } = useI18n();
     const t = props.task;
     const cardRef = useRef(null);
+    const pointerOriginIsNoDragRef = useRef(false);
     const [idCopied, setIdCopied] = useState(false);
     const copyFeedbackTimeoutRef = useRef(null);
 
@@ -2653,8 +2654,15 @@
       return attachTouchDrag(cardRef.current, t.id);
     }, [t.id]);
 
+    const handlePointerDownCapture = function (e) {
+      // Native desktop dragstart may retarget to the draggable card even when
+      // the pointer began on a descendant control. Capture the original
+      // pointer target before the browser starts its drag sequence.
+      pointerOriginIsNoDragRef.current = isNoDragOrigin(e.target);
+    };
+
     const handleDragStart = function (e) {
-      if (isNoDragOrigin(e.target)) {
+      if (pointerOriginIsNoDragRef.current || isNoDragOrigin(e.target)) {
         e.preventDefault();
         return;
       }
@@ -2718,6 +2726,7 @@
       role: "button",
       "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.status}`,
       onDragStart: handleDragStart,
+      onPointerDownCapture: handlePointerDownCapture,
       onClick: handleClick,
       onKeyDown: handleKeyDown,
     },

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -265,6 +265,26 @@
   letter-spacing: 0.03em;
 }
 
+.hermes-kanban-card-id-clickable {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  color: var(--color-muted-foreground);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  font-size: 0.65rem;
+  transition: border-color 0.12s ease, color 0.15s ease, background-color 0.15s ease;
+  user-select: none;
+}
+.hermes-kanban-card-id-clickable:hover {
+  border-color: color-mix(in srgb, var(--color-ring) 30%, transparent);
+}
+.hermes-kanban-card-id-clickable--copied {
+  color: var(--color-foreground);
+}
+
 .hermes-kanban-card-title {
   font-size: 0.85rem;
   font-weight: 500;

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import subprocess
 import sys
 import time
@@ -2362,6 +2363,55 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_task_id_copy_control_has_stateful_keyboard_behavior():
+    """Task IDs must copy through one keyboard-safe, stateful control."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "const [idCopied, setIdCopied] = useState(false);" in js
+    assert "const copyTaskId = function () {" in js
+    assert "navigator.clipboard && navigator.clipboard.writeText(t.id)" in js
+    assert 'window.prompt("Copy:", t.id)' in js
+    assert re.search(
+        r"const handleIdKeyDown = function \(e\) \{\s*"
+        r"if \(e\.key === \"Enter\" \|\| e\.key === \" \"\) \{\s*"
+        r"e\.preventDefault\(\);\s*"
+        r"e\.stopPropagation\(\);\s*"
+        r"copyTaskId\(\);\s*"
+        r"\}\s*\};",
+        js,
+    )
+    assert re.search(
+        r"onClick: function \(e\) \{\s*"
+        r"e\.stopPropagation\(\);\s*"
+        r"copyTaskId\(\);\s*"
+        r"\},",
+        js,
+    )
+    assert (
+        'title: "Click to copy task ID",\n'
+        '              role: "button",\n'
+        '              tabIndex: 0,\n'
+        '              "aria-label": `Copy task ID ${t.id}`,'
+    ) in js
+    assert "onMouseDown: function (e) { e.stopPropagation(); }," in js
+
+
+def test_dashboard_task_id_copy_control_uses_fallback_and_feedback_styles():
+    """The copy control must expose copied feedback with dashboard-local CSS."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert 'window.prompt("Copy:", t.id)' in js
+    assert '"hermes-kanban-card-id-clickable"' in js
+    assert '"hermes-kanban-card-id-clickable--copied"' in js
+    assert 'idCopied ? "Copied" : "Copy ID"' in js
+    assert ".hermes-kanban-card-id-clickable {" in css
+    assert ".hermes-kanban-card-id-clickable:hover {" in css
+    assert ".hermes-kanban-card-id-clickable--copied {" in css
 
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2391,8 +2391,7 @@ def test_dashboard_task_id_copy_control_has_stateful_keyboard_behavior():
         js,
     )
     assert (
-        'title: "Click to copy task ID",\n'
-        '              role: "button",\n'
+        'role: "button",\n'
         '              tabIndex: 0,\n'
         '              "aria-label": `Copy task ID ${t.id}`,'
     ) in js
@@ -2412,6 +2411,54 @@ def test_dashboard_task_id_copy_control_uses_fallback_and_feedback_styles():
     assert ".hermes-kanban-card-id-clickable {" in css
     assert ".hermes-kanban-card-id-clickable:hover {" in css
     assert ".hermes-kanban-card-id-clickable--copied {" in css
+
+
+def test_dashboard_task_id_copy_control_never_starts_parent_drag():
+    """Copying an ID must not activate the card's touch or HTML drag handlers."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert '"data-kanban-no-drag": true,' in js
+    assert re.search(
+        r"function isNoDragOrigin\(target\) \{.*?"
+        r"target\.closest\(\"\[data-kanban-no-drag\]\"\)",
+        js,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"function onDown\(e\) \{\s*"
+        r"if \(e\.pointerType !== \"touch\" \|\| isNoDragOrigin\(e\.target\)\) return;",
+        js,
+    )
+    assert re.search(
+        r"const handleDragStart = function \(e\) \{\s*"
+        r"if \(isNoDragOrigin\(e\.target\)\) \{\s*"
+        r"e\.preventDefault\(\);\s*return;",
+        js,
+    )
+
+
+def test_dashboard_task_id_copy_feedback_uses_one_lifecycle_bound_timer():
+    """A later copy must replace, and unmount must clear, the feedback timer."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "const copyFeedbackTimeoutRef = useRef(null);" in js
+    assert re.search(
+        r"if \(copyFeedbackTimeoutRef\.current\) \{\s*"
+        r"clearTimeout\(copyFeedbackTimeoutRef\.current\);\s*"
+        r"\}",
+        js,
+    )
+    assert "copyFeedbackTimeoutRef.current = setTimeout(function () { setIdCopied(false); }, 2000);" in js
+    assert re.search(
+        r"useEffect\(function \(\) \{\s*"
+        r"return function \(\) \{\s*"
+        r"if \(copyFeedbackTimeoutRef\.current\) \{\s*"
+        r"clearTimeout\(copyFeedbackTimeoutRef\.current\);",
+        js,
+        re.DOTALL,
+    )
 
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2431,11 +2431,82 @@ def test_dashboard_task_id_copy_control_never_starts_parent_drag():
         js,
     )
     assert re.search(
+        r"const handlePointerDownCapture = function \(e\) \{.*?"
+        r"pointerOriginIsNoDragRef\.current = isNoDragOrigin\(e\.target\);",
+        js,
+        re.DOTALL,
+    )
+    assert re.search(
         r"const handleDragStart = function \(e\) \{\s*"
-        r"if \(isNoDragOrigin\(e\.target\)\) \{\s*"
+        r"if \(pointerOriginIsNoDragRef\.current \|\| isNoDragOrigin\(e\.target\)\) \{\s*"
         r"e\.preventDefault\(\);\s*return;",
         js,
     )
+    assert "onPointerDownCapture: handlePointerDownCapture," in js
+
+
+def test_dashboard_task_id_copy_control_blocks_native_drag_from_child_pointer_origin():
+    """A desktop dragstart retargeted to the card must still respect the ID control.
+
+    Native desktop drag events can report the draggable parent as ``dragstart``'s
+    target even though the pointer began on a descendant.  Exercise the bundle's
+    real card handlers in that event order instead of only matching source text.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    script = r'''
+const fs = require("fs");
+const vm = require("vm");
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { runScripts: "outside-only" });
+const { window } = dom;
+const h = (type, props, ...children) => ({ type, props: props || {}, children });
+window.__HERMES_PLUGIN_SDK__ = {
+  React: { createElement: h, Component: class {} },
+  components: { Card: "Card", CardContent: "CardContent", Badge: "Badge", Button: "Button", Input: "Input", Label: "Label", Select: "Select", SelectOption: "SelectOption" },
+  hooks: {
+    useState: (initial) => [initial, () => {}],
+    useEffect: () => {},
+    useCallback: (fn) => fn,
+    useMemo: (fn) => fn(),
+    useRef: (initial) => ({ current: initial }),
+  },
+  utils: { cn: (...classes) => classes.filter(Boolean).join(" "), timeAgo: () => "" },
+};
+window.__HERMES_PLUGINS__ = { register: () => {} };
+let source = fs.readFileSync(process.argv[1], "utf8");
+source = source.replace("function TaskCard(props) {", "window.__captureTaskCard = function TaskCard(props) {");
+vm.runInContext(source, dom.getInternalVMContext());
+const card = window.__captureTaskCard({
+  task: { id: "task-1", title: "Task", status: "ready" },
+  selected: false,
+  failed: false,
+  draggingSource: false,
+  toggleSelected: () => {},
+});
+const copyControl = window.document.createElement("span");
+copyControl.setAttribute("data-kanban-no-drag", "true");
+if (typeof card.props.onPointerDownCapture !== "function") {
+  throw new Error("TaskCard must record the original pointer target before native dragstart retargeting");
+}
+card.props.onPointerDownCapture({ target: copyControl });
+let prevented = false;
+card.props.onDragStart({
+  target: window.document.createElement("div"),
+  preventDefault: () => { prevented = true; },
+  dataTransfer: { setData: () => { throw new Error("copy control must not start a drag"); } },
+});
+if (!prevented) throw new Error("dragstart from a copy-control pointer origin was not prevented");
+'''
+
+    result = subprocess.run(
+        ["node", "-e", script, str(bundle)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_dashboard_task_id_copy_feedback_uses_one_lifecycle_bound_timer():


### PR DESCRIPTION
## Summary

Makes the task card ID clickable for one-click copy. Instead of selecting
the ID text manually, users can now click `t_xxx Copy ID` on any card
to copy the ID to clipboard.

> <img src="https://github.com/user-attachments/assets/0e34fb39-c101-4ead-8828-2d3889de47cd" alt="Copy Bottom" width="400">


## Changes

- **TaskCard**: replaced plain ID `<span>` with a clickable element
  showing `t_xxx Copy ID`. Click copies ID, shows "Copied" for 2 s.
  Keyboard accessible (Enter/Space). Prevents card shrink via
  `onMouseDown: stopPropagation`.
- **CSS**: added `.hermes-kanban-card-id-clickable` with hover border
  highlight and `--copied` state (foreground colour).

## Risk

Minimal — pure UI change, no data layer or API changes.