### PR TITLE
Add MiniMax highspeed variants and StepFun step-3.7-flash model entries

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -290,6 +290,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "stepfun": [
+        "step-3.7-flash",
         "step-3.5-flash",
         "step-3.5-flash-2603",
     ],
@@ -303,20 +304,30 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "minimax-oauth": [
         "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
+        "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
+        "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
     ],
     "minimax-cn": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "anthropic": [


### PR DESCRIPTION
## Summary

Update `_PROVIDER_MODELS` in `hermes_cli/models.py` to include latest model variants discovered via API and documented releases.

### Changes

| Provider | Change | Details |
|----------|--------|---------|
| `minimax-cn` | +3 models | M2.7-highspeed, M2.5-highspeed, M2.1-highspeed (confirmed via `GET /v1/models`) |
| `minimax-oauth` | +4 models | M2.5, M2.5-highspeed, M2.1, M2.1-highspeed |
| `minimax` (global) | +3 models | M2.7-highspeed, M2.5-highspeed, M2.1-highspeed |
| `stepfun` | +1 model | `step-3.7-flash` (released 2026-05-29, latest production Agent model) |

### Verified as latest (no changes needed)
- `moonshot` / `kimi-coding`: kimi-k2.6 confirmed latest
- `tencent-tokenhub`: hy3-preview confirmed latest  
- `xiaomi`: mimo-v2.5 series confirmed latest open-source release
- `zai` (智谱AI): glm-5.1 confirmed latest

### Test plan
- [x] Smoke test `MiniMax-M2.7-highspeed` reachable via minimaxi.com API
- [x] File parses cleanly (`ast.parse`)
