### PR TITLE
fix: restore immediate Telegram typing indicator

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -80,6 +80,8 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
+    _reply_anchor_for_event,
+    _thread_metadata_for_source,
 )
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
@@ -5824,10 +5826,31 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
+        """Show immediate Telegram activity when message processing begins.
+
+        BasePlatformAdapter also runs a continuous typing refresh loop, but it is
+        scheduled as a background task. Fire one scoped chat-action here so
+        Telegram clients show the "typing" bubble immediately in the current
+        topic/thread, then optionally add the in-progress reaction when enabled.
+        """
+        chat_id = getattr(event.source, "chat_id", None)
+        if chat_id:
+            try:
+                metadata = _thread_metadata_for_source(
+                    event.source,
+                    _reply_anchor_for_event(event),
+                )
+                await self.send_typing(chat_id, metadata=metadata)
+            except Exception:
+                # Typing is best-effort and must never block the agent.
+                logger.debug(
+                    "[%s] Failed to send processing-start typing indicator",
+                    self.name,
+                    exc_info=True,
+                )
+
         if not self._reactions_enabled():
             return
-        chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
             await self._set_reaction(chat_id, message_id, "\U0001f440")

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -18,10 +18,15 @@ def _make_adapter(**extra_env):
     adapter.config = PlatformConfig(enabled=True, token="fake-token")
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
+    adapter._bot.send_chat_action = AsyncMock()
     return adapter
 
 
-def _make_event(chat_id: str = "123", message_id: str = "456") -> MessageEvent:
+def _make_event(
+    chat_id: str = "123",
+    message_id: str = "456",
+    thread_id: str | None = None,
+) -> MessageEvent:
     return MessageEvent(
         text="hello",
         message_type=MessageType.TEXT,
@@ -31,6 +36,7 @@ def _make_event(chat_id: str = "123", message_id: str = "456") -> MessageEvent:
             chat_type="private",
             user_id="42",
             user_name="TestUser",
+            thread_id=thread_id,
         ),
         message_id=message_id,
     )
@@ -123,6 +129,23 @@ async def test_set_reaction_handles_api_error_gracefully(monkeypatch):
 
 
 # ── on_processing_start ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_processing_start_sends_immediate_typing_in_thread(monkeypatch):
+    """Processing start should immediately scope typing to the Telegram thread."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    event = _make_event(chat_id="-100123", thread_id="1")
+
+    await adapter.on_processing_start(event)
+
+    adapter._bot.send_chat_action.assert_awaited_once_with(
+        chat_id=-100123,
+        action="typing",
+        message_thread_id=1,
+    )
+    adapter._bot.set_message_reaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Send a scoped Telegram `typing` chat action immediately when processing starts.
- Preserve existing continuous typing refresh behavior and reaction handling.
- Add a regression test for topic/thread-scoped processing-start typing.

## Test Plan
- `python -m pytest tests/gateway/test_telegram_reactions.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_telegram_thread_fallback.py::test_send_typing_preserves_general_topic_thread_id tests/gateway/test_telegram_thread_fallback.py::test_send_typing_does_not_fall_back_to_root_for_dm_topic tests/gateway/test_telegram_thread_fallback.py::test_send_typing_falls_back_without_thread_on_bad_request -q -o 'addopts='`

## Notes
- Full `test_telegram_thread_fallback.py` currently has unrelated fixture failures around mocked supergroup chat-type classification; targeted typing-thread tests pass.
