### PR TITLE
fix(session_search): add session diversity to CJK LIKE fallback

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2911,16 +2911,24 @@ class SessionDB:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
                 like_sql = f"""
-                    SELECT m.id, m.session_id, m.role,
-                           substr(m.content,
-                                  max(1, instr(m.content, ?) - 40),
-                                  120) AS snippet,
-                           m.content, m.timestamp, m.tool_name,
-                           s.source, s.model, s.started_at AS session_started
-                    FROM messages m
-                    JOIN sessions s ON s.id = m.session_id
-                    WHERE {' AND '.join(like_where)}
-                    ORDER BY m.timestamp DESC
+                    SELECT id, session_id, role, snippet, content, timestamp,
+                           tool_name, source, model, session_started
+                    FROM (
+                        SELECT m.id, m.session_id, m.role,
+                               substr(m.content,
+                                      max(1, instr(m.content, ?) - 40),
+                                      120) AS snippet,
+                               m.content, m.timestamp, m.tool_name,
+                               s.source, s.model, s.started_at AS session_started,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY s.id ORDER BY m.timestamp DESC
+                               ) AS rn
+                        FROM messages m
+                        JOIN sessions s ON s.id = m.session_id
+                        WHERE {' AND '.join(like_where)}
+                    )
+                    WHERE rn <= 5
+                    ORDER BY timestamp DESC
                     LIMIT ? OFFSET ?
                 """
                 like_params.extend([limit, offset])


### PR DESCRIPTION
## What does this PR do?

Short CJK tokens (<3 chars, common in Chinese 2-char words like \u5199\u5165/\u94fe\u8def)
fall to the LIKE path, which orders by timestamp DESC \u2014 pushing all results
into the current/active session and hiding older matching sessions.

This wraps the LIKE query with ROW_NUMBER() OVER (PARTITION BY s.id) to keep
up to 5 messages per session, ensuring results span multiple sessions.

## Related issues

- #11511 \u2014 Original CJK FTS5 issue
- #14829 \u2014 CJK characters silently dropped  
- #20494 \u2014 Short CJK OR queries routing bug
- #20499 \u2014 Fix for short CJK OR query routing