### PR TITLE
fix(mem0): include agent-attributed memories in read filter (closes #38424)

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -211,8 +211,19 @@ class Mem0MemoryProvider(MemoryProvider):
         self._rerank = self._config.get("rerank", True)
 
     def _read_filters(self) -> Dict[str, Any]:
-        """Filters for search/get_all — scoped to user only for cross-session recall."""
-        return {"user_id": self._user_id}
+        """Filters for search/get_all — OR of user-only and user+agent scopes.
+
+        The write filter includes ``agent_id`` for attribution, so the read
+        filter must explicitly cover both:
+        - older memories stored without ``agent_id`` (user-only scope)
+        - newer memories stored with both ``user_id`` and ``agent_id``
+        """
+        return {
+            "OR": [
+                {"user_id": self._user_id},
+                {"user_id": self._user_id, "agent_id": self._agent_id},
+            ]
+        }
 
     def _write_filters(self) -> Dict[str, Any]:
         """Filters for add — scoped to user + agent for attribution."""

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -59,7 +59,9 @@ class TestMem0FiltersV2:
         assert client.captured_search["query"] == "hello"
         assert client.captured_search["top_k"] == 3
         assert client.captured_search["rerank"] is False
-        assert client.captured_search["filters"] == {"user_id": "u123"}
+        assert client.captured_search["filters"] == {
+            "OR": [{"user_id": "u123"}, {"user_id": "u123", "agent_id": "hermes"}]
+        }
         # Must NOT have bare user_id kwarg
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
@@ -69,7 +71,9 @@ class TestMem0FiltersV2:
 
         provider.handle_tool_call("mem0_profile", {})
 
-        assert client.captured_get_all["filters"] == {"user_id": "u123"}
+        assert client.captured_get_all["filters"] == {
+            "OR": [{"user_id": "u123"}, {"user_id": "u123", "agent_id": "hermes"}]
+        }
         assert "user_id" not in {k for k in client.captured_get_all if k != "filters"}
 
     def test_prefetch_uses_filters(self, monkeypatch):
@@ -80,7 +84,9 @@ class TestMem0FiltersV2:
         provider._prefetch_thread.join(timeout=2)
 
         assert client.captured_search["query"] == "hello"
-        assert client.captured_search["filters"] == {"user_id": "u123"}
+        assert client.captured_search["filters"] == {
+            "OR": [{"user_id": "u123"}, {"user_id": "u123", "agent_id": "hermes"}]
+        }
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
     def test_sync_turn_uses_write_filters(self, monkeypatch):
@@ -107,12 +113,14 @@ class TestMem0FiltersV2:
         assert call["agent_id"] == "hermes"
         assert call["infer"] is False
 
-    def test_read_filters_no_agent_id(self):
-        """Read filters should use user_id only — cross-session recall across agents."""
+    def test_read_filters_include_agent_id_in_or(self):
+        """Read filters should use OR to match both user-only and user+agent-attributed memories."""
         provider = Mem0MemoryProvider()
         provider._user_id = "u123"
         provider._agent_id = "hermes"
-        assert provider._read_filters() == {"user_id": "u123"}
+        assert provider._read_filters() == {
+            "OR": [{"user_id": "u123"}, {"user_id": "u123", "agent_id": "hermes"}]
+        }
 
     def test_write_filters_include_agent_id(self):
         """Write filters should include agent_id for attribution."""


### PR DESCRIPTION
## Summary

The Mem0 provider writes memories with both `user_id` and `agent_id` (see `_write_filters`), but `_read_filters` only queried by `user_id`. The Mem0 Platform API matches filters strictly, so agent-attributed memories were invisible to `mem0_profile`, `mem0_search`, and prefetch.

## Fix

Changed `_read_filters()` to use an `OR` filter that matches both:
- older user-only memories (no `agent_id`)
- newer memories saved with both `user_id` and `agent_id`

### Before
```python
def _read_filters(self):
    return {"user_id": self._user_id}
```

### After
```python
def _read_filters(self):
    return {
        "OR": [
            {"user_id": self._user_id},
            {"user_id": self._user_id, "agent_id": self._agent_id},
        ]
    }
```

## Verification

- ✅ All 16 mem0 tests pass
- ✅ All 168 memory plugin tests pass with no regressions

Closes #38424

## Notes

- This is a **doc**-type auto-fix PR generated by the auto-fixer engine.
- The fix is minimal and focused — only `_read_filters()` and the corresponding test assertions changed.
- The OR filter format matches the Mem0 Platform API's documented filter syntax.