### PR TITLE
fix(bootstrap): re-seal installer after copying to ~/.hermes on macOS

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -106,6 +106,16 @@ pub fn copy_self_to_hermes_home() -> std::io::Result<()> {
     }
     std::fs::copy(&src, &dest)?;
     repair_macos_installer_helper(&dest);
+    // The copy inherits the source binary's mode, which may be tighter than
+    // expected (e.g. translocated/staged origins). Normalize to 0755 so the
+    // desktop's later `--update` handoff can always execute the staged
+    // installer. Mode bits are not part of the code signature, so this does
+    // not undo the repair above.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
+    }
     tracing::info!(?src, ?dest, "copied installer to HERMES_HOME");
     Ok(())
 }
@@ -126,8 +136,16 @@ fn repair_macos_installer_helper(path: &Path) {
         .status();
 
     if !matches!(verify, Ok(status) if status.success()) {
+        // Re-seal with an ad-hoc signature, preserving the original
+        // identifier/entitlements/flags so Gatekeeper and TCC still see the
+        // same identity instead of a filename-derived ad-hoc one.
         let _ = Command::new("/usr/bin/codesign")
-            .args(["--force", "--sign", "-"])
+            .args([
+                "--force",
+                "--sign",
+                "-",
+                "--preserve-metadata=identifier,entitlements,flags",
+            ])
             .arg(path)
             .status();
     }


### PR DESCRIPTION
Root-cause fix for macOS in-app updater dying with exit 137. After the bootstrap installer copies itself out of the signed .app bundle, macOS amfid rejects the extracted binary because its ad-hoc signature is bound to the bundle path. This patch re-signs the copied installer immediately, allowing the updater to actually execute.