### PR TITLE
Nixos restart trigger

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -860,6 +860,16 @@
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
 
+          restartTriggers = [
+            configFile
+            envFileContent
+            (builtins.toJSON cfg.mcpServers)
+            (builtins.toJSON cfg.extraArgs)
+            "${toString cfg.extraPlugins}"
+            "${toString cfg.extraPythonPackages}"
+            "${toString cfg.extraDependencyGroups}"
+          ];
+
           environment = {
             HOME = cfg.stateDir;
             HERMES_HOME = "${cfg.stateDir}/.hermes";
@@ -922,6 +932,16 @@
             ++ lib.optional (cfg.container.backend == "docker") "docker.service";
           wants = [ "network-online.target" ];
           requires = lib.optional (cfg.container.backend == "docker") "docker.service";
+
+          restartTriggers = [
+            configFile
+            envFileContent
+            (builtins.toJSON cfg.mcpServers)
+            (builtins.toJSON cfg.extraArgs)
+            "${toString cfg.extraPlugins}"
+            "${toString cfg.extraPythonPackages}"
+            "${toString cfg.extraDependencyGroups}"
+          ];
 
           preStart = ''
             # Stable symlinks — container references these, not store paths directly

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -668,16 +668,6 @@
         }];
       }
 
-      # ── Assertions ─────────────────────────────────────────────────────
-      {
-        assertions = let
-          names = map lib.getName cfg.extraPlugins;
-        in [{
-          assertion = (lib.length names) == (lib.length (lib.unique names));
-          message = "services.hermes-agent.extraPlugins: duplicate plugin names detected: ${toString names}. If using fetchFromGitHub, set name = \"plugin-name\" to disambiguate.";
-        }];
-      }
-
       # ── Warnings ──────────────────────────────────────────────────────
       # ── Per-user profile for extraPackages ───────────────────────────
       # Wire extraPackages into the hermes user's per-user profile so the


### PR DESCRIPTION
## What does this PR do?

While running the module on NixOS I noticed that changes to the configuration and environment didn't trigger a restart of the hermes-agent.servcie. This caused the service to keep running with the old environment variables even after a `nixos-rebuild switch`.

This adds a restart trigger to the service that depends on the various configuration options to ensure the cause the service to restart if changed.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `nix/nixosModules.nix`
  - add restart trigger
  - remove duplicate assert

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Deploy using NixOS
2. Change `services.hermes-agent.environment`
3. Run nixos-rebuild switch
4. Observe the `hermes-agent.service` getting stopped and started again

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- N/A I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- N/A I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- N/A I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- N/A I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- N/A I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

