### PR TITLE
fix(tui): persist project workspaces for auto-detected cwd

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1016,8 +1016,8 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
 
 
 def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
-    """Without an explicit workspace, cwd is left null so the session groups
-    under "No workspace" rather than the gateway's launch directory."""
+    """Generic non-project cwd is left null so the session groups under
+    "No workspace" rather than a desktop/gateway launch directory."""
     created = []
 
     class _FakeDB:
@@ -1026,6 +1026,46 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
+
+    assert created == [{"key": "k1", "source": "tui", "model": "test-model", "cwd": None}]
+
+
+def test_ensure_session_db_row_persists_auto_detected_project_cwd(monkeypatch, tmp_path):
+    """A non-explicit cwd below a project marker is persisted as a workspace."""
+    project = tmp_path / "project"
+    nested = project / "src" / "pkg"
+    nested.mkdir(parents=True)
+    (project / ".git").mkdir()
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, source=None, model=None, cwd=None):
+            created.append({"key": key, "source": source, "model": model, "cwd": cwd})
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    server._ensure_session_db_row({"session_key": "k1", "cwd": str(nested)})
+
+    assert created == [
+        {"key": "k1", "source": "tui", "model": "test-model", "cwd": str(nested)}
+    ]
+
+
+def test_ensure_session_db_row_does_not_persist_home_launch_cwd(monkeypatch, tmp_path):
+    """Even if home contains project-like files, it remains a generic launch cwd."""
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, source=None, model=None, cwd=None):
+            created.append({"key": key, "source": source, "model": model, "cwd": cwd})
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server.Path, "home", lambda: tmp_path)
+    (tmp_path / ".git").mkdir()
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -689,6 +689,54 @@ def _session_cwd(session: dict | None) -> str:
     return _completion_cwd()
 
 
+_PROJECT_CWD_MARKERS = (
+    ".git",
+    ".hg",
+    ".svn",
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    "Gemfile",
+    "composer.json",
+)
+
+
+def _is_project_cwd(cwd: str) -> bool:
+    """Return True when cwd looks like a real project/workspace directory.
+
+    Desktop may launch the gateway from a generic directory such as the user's
+    home; persisting that would group unrelated sessions under the home
+    directory. Persist only directories that are either a repository/project
+    root or below one, so sessions opened from ``~/src/app`` show up under that
+    workspace.
+    """
+    try:
+        path = Path(cwd).expanduser().resolve()
+    except Exception:
+        return False
+    if not path.is_dir():
+        return False
+    try:
+        if path == Path.home().resolve():
+            return False
+    except Exception:
+        pass
+    for parent in (path, *path.parents):
+        if any((parent / marker).exists() for marker in _PROJECT_CWD_MARKERS):
+            return True
+    return False
+
+
+def _session_persisted_cwd(session: dict | None) -> str | None:
+    if not session:
+        return None
+    cwd = _session_cwd(session)
+    if session.get("explicit_cwd") or _is_project_cwd(cwd):
+        return cwd
+    return None
+
+
 def _register_session_cwd(session: dict | None) -> None:
     if not session:
         return
@@ -710,12 +758,10 @@ def _ensure_session_db_row(session: dict) -> None:
     Uses INSERT OR IGNORE under the hood, so re-calls (and the AIAgent's own
     lazy create) are no-ops.
 
-    Only an *explicitly chosen* workspace is persisted as the session's cwd.
-    The agent still runs in the auto-detected directory (session["cwd"]), but
-    we don't stamp that onto the row — otherwise every session the user never
-    picked a folder for gets grouped under whatever directory the desktop
-    happened to launch in (e.g. "desktop"). Leaving it null groups them under
-    "No workspace", which is the desired default.
+    Persist an explicitly chosen workspace, or an auto-detected cwd that looks
+    like a real project/workspace. Generic launch directories such as the
+    user's home stay null so they group under "No workspace" instead of
+    swallowing unrelated sessions under the home directory.
     """
     key = session.get("session_key")
     if not key:
@@ -728,7 +774,7 @@ def _ensure_session_db_row(session: dict) -> None:
             key,
             source="tui",
             model=_resolve_model(),
-            cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
+            cwd=_session_persisted_cwd(session),
         )
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)


### PR DESCRIPTION
## Summary
- Persist Desktop/TUI session cwd when the auto-detected cwd is a real project/workspace directory.
- Keep generic home/non-project launch cwd as `null`, so unrelated sessions do not get grouped under the home directory.
- Add regression tests for explicit cwd, project cwd, and home cwd behaviour.

## Author
Authored by Hermes Agent.

## Why
Desktop/TUI could run tools from the correct project cwd while the workspace list still grouped the session under `No workspace` or the user's home. The session row only persisted `cwd` when `explicit_cwd` was set, so auto-detected project cwd was lost.

## Validation
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` failed locally because no virtualenv was found in the clean worktree (`.venv` or `venv`).
- `python -m py_compile tui_gateway/server.py`
- `python -m pytest tests/test_tui_gateway_server.py -q` — 201 passed, 1 warning
