### PR TITLE
Add MiniMax highspeed variants and StepFun step-3.7-flash

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -290,6 +290,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "stepfun": [
+        "step-3.7-flash",
+        "step-3.7-flash-2506",
         "step-3.5-flash",
         "step-3.5-flash-2603",
     ],
@@ -311,12 +313,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
+        "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
+        "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
     ],
     "minimax-cn": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "anthropic": [


### PR DESCRIPTION
## Summary

Update provider model lists with latest MiniMax highspeed variants and StepFun newest model:

### Changes
- **minimax-cn**: add M2.7-highspeed, M2.5-highspeed, M2.1-highspeed
- **minimax-oauth**: add M2.5, M2.5-highspeed, M2.1, M2.1-highspeed
- **stepfun**: add step-3.7-flash, step-3.7-flash-2506

### Already present (from prior commit)
- step-3.7-flash in display names list
- M2.7-highspeed in minimax-oauth