### PR TITLE
feat(feishu): render Markdown tables as native card table component

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4326,14 +4326,14 @@ class FeishuAdapter(BasePlatformAdapter):
             return None
 
         header_line = lines[0]
-        headers = [re.sub(r"\[(.+?)\]\(.+?\)", r"\1", cell.strip()) for cell in header_line.strip().strip("|").split("|")]
+        headers = [cell.strip() for cell in header_line.strip().strip("|").split("|")]
 
         columns = []
         for idx, header in enumerate(headers):
             col_name = f"col{idx}"
             col_def: dict = {
                 "name": col_name,
-                "data_type": "text",
+                "data_type": "markdown",
                 "vertical_align": "top",
                 "width": "auto",
             }
@@ -4349,11 +4349,6 @@ class FeishuAdapter(BasePlatformAdapter):
             for idx in range(len(columns)):
                 col_name = columns[idx]["name"]
                 cell_value = cells[idx] if idx < len(cells) else ""
-                # Clean markdown formatting for cleaner display
-                cell_value = re.sub(r"\*\*(.+?)\*\*", r"\1", cell_value)
-                cell_value = re.sub(r"\*(.+?)\*", r"\1", cell_value)
-                cell_value = re.sub(r"~~(.+?)~~", r"\1", cell_value)
-                cell_value = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", cell_value)
                 row[col_name] = cell_value
             rows.append(row)
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -162,7 +162,13 @@ _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
-_POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_POST_CONTENT_INVALID_RE = re.compile(
+    r"content format of the (post|interactive) type is incorrect"
+    r"|invalid card"
+    r"|failed to create card content"
+    r"|card contains images",
+    re.IGNORECASE,
+)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1792,9 +1798,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type not in {"post", "interactive"} or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid %s payload rejected by API; falling back to plain text", msg_type)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1803,11 +1809,11 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type in {"post", "interactive"}
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] %s payload rejected by API response; falling back to plain text", msg_type)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1841,8 +1847,8 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and msg_type in {"post", "interactive"} and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                logger.warning("[Feishu] Invalid %s update payload rejected by API; falling back to plain text", msg_type)
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -4307,17 +4313,142 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _parse_markdown_table(lines: list[str]) -> Optional[dict]:
+        """Convert a list of consecutive markdown table lines into a Feishu
+        JSON 2.0 ``table`` component dict, or *None* if the block is not a
+        valid table (e.g. no separator row).
+
+        Feishu table component docs:
+        https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/table
+        """
+        if len(lines) < 2:
+            return None
+
+        header_line = lines[0]
+        headers = [re.sub(r"\[(.+?)\]\(.+?\)", r"\1", cell.strip()) for cell in header_line.strip().strip("|").split("|")]
+
+        columns = []
+        for idx, header in enumerate(headers):
+            col_name = f"col{idx}"
+            col_def: dict = {
+                "name": col_name,
+                "data_type": "text",
+                "vertical_align": "top",
+                "width": "auto",
+            }
+            if header:
+                col_def["display_name"] = header
+            columns.append(col_def)
+
+        # Skip separator row at index 1
+        rows = []
+        for table_line in lines[2:]:
+            cells = [cell.strip() for cell in table_line.strip().strip("|").split("|")]
+            row: dict = {}
+            for idx in range(len(columns)):
+                col_name = columns[idx]["name"]
+                cell_value = cells[idx] if idx < len(cells) else ""
+                # Clean markdown formatting for cleaner display
+                cell_value = re.sub(r"\*\*(.+?)\*\*", r"\1", cell_value)
+                cell_value = re.sub(r"\*(.+?)\*", r"\1", cell_value)
+                cell_value = re.sub(r"~~(.+?)~~", r"\1", cell_value)
+                cell_value = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", cell_value)
+                row[col_name] = cell_value
+            rows.append(row)
+
+        if not rows and not headers:
+            return None
+
+        return {
+            "tag": "table",
+            "columns": columns,
+            "rows": rows,
+            "header_style": {
+                "text_align": "left",
+                "text_size": "normal",
+                "background_style": "grey",
+                "bold": True,
+                "lines": 1,
+            },
+            "row_height": "auto",
+            "page_size": 50,
+        }
+
+    @staticmethod
+    def _split_content_and_tables(content: str) -> list:
+        """Split *content* into a sequence of Feishu card elements.
+
+        Returns a list where each element is either:
+        - ``{"tag": "markdown", "content": "..."}`` — a text block
+        - ``{"tag": "table", ...}``                  — a parsed table component
+
+        The function walks line-by-line, collects consecutive non-table lines
+        into markdown elements and converts table blocks into Feishu JSON 2.0
+        ``table`` components.
+        """
+        elements: list[dict] = []
+        lines = content.split("\n")
+        i = 0
+        n = len(lines)
+
+        while i < n:
+            line = lines[i]
+
+            # Detect potential table start: line begins with |
+            if "|" in line and line.strip().startswith("|"):
+                # Confirm it is a real table by checking the next line (separator)
+                if i + 1 < n and "|" in lines[i + 1] and lines[i + 1].strip().startswith("|"):
+                    # Collect all consecutive table lines
+                    table_lines: list[str] = []
+                    while i < n and "|" in lines[i] and lines[i].strip().startswith("|"):
+                        table_lines.append(lines[i])
+                        i += 1
+                    table_component = FeishuAdapter._parse_markdown_table(table_lines)
+                    if table_component is not None:
+                        elements.append(table_component)
+                    else:
+                        # Fallback: emit as markdown text
+                        elements.append({"tag": "markdown", "content": "\n".join(table_lines)})
+                else:
+                    # Single | line without separator — treat as normal text
+                    i += 1
+                    continue
+            else:
+                # Collect consecutive non-table lines into a markdown element
+                text_lines: list[str] = [line]
+                i += 1
+                while i < n:
+                    next_line = lines[i]
+                    if "|" in next_line and next_line.strip().startswith("|"):
+                        # Peek ahead to see if it starts a real table
+                        if i + 1 < n and "|" in lines[i + 1] and lines[i + 1].strip().startswith("|"):
+                            break
+                    text_lines.append(next_line)
+                    i += 1
+                text = "\n".join(text_lines)
+                if text.strip():
+                    elements.append({"tag": "markdown", "content": text})
+
+        return elements
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        """Build outbound Feishu message payload.
+
+        Uses interactive card (JSON 2.0) for all messages so that markdown
+        tables are rendered as native ``table`` components instead of being
+        dumped as raw ``| |`` text that Feishu cannot render.
+
+        Non-table text is placed in ``markdown`` elements which support bold,
+        italic, strikethrough, links, code blocks, lists, and dividers.
+        """
+        elements = self._split_content_and_tables(content)
+        card = {
+            "schema": "2.0",
+            "config": {"wide_screen_mode": True},
+            "body": {"elements": elements},
+        }
+        return "interactive", json.dumps(card, ensure_ascii=False)
 
     async def _send_uploaded_file_message(
         self,
@@ -4599,7 +4730,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type in {"post", "interactive"} and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -367,14 +367,12 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
-        self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
-        )
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["schema"], "2.0")
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_edit_message_falls_back_to_text_when_post_update_is_rejected(self):
+    def test_edit_message_falls_back_to_text_when_interactive_update_is_rejected(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -385,7 +383,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             def update(self, request):
                 captured["calls"].append(request)
                 if len(captured["calls"]) == 1:
-                    return SimpleNamespace(success=lambda: False, code=230001, msg="content format of the post type is incorrect")
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="invalid card")
                 return SimpleNamespace(success=lambda: True)
 
         adapter._client = SimpleNamespace(
@@ -409,7 +407,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2538,7 +2536,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_inline_markdown(self):
+    def test_send_uses_interactive_card_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2573,10 +2571,13 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+        self.assertEqual(payload["schema"], "2.0")
+        elements = payload["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("**粗体**", elements[0]["content"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
@@ -2624,22 +2625,14 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
-        )
+        self.assertEqual(payload["schema"], "2.0")
+        elements = payload["body"]["elements"]
+        # Content with code blocks is now a single markdown element in the card
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("```json", elements[0]["content"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -2707,7 +2700,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_falls_back_to_text_when_post_payload_is_rejected(self):
+    def test_send_falls_back_to_text_when_interactive_payload_is_rejected(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2718,7 +2711,7 @@ class TestAdapterBehavior(unittest.TestCase):
             def create(self, request):
                 captured["calls"].append(request)
                 if len(captured["calls"]) == 1:
-                    raise RuntimeError("content format of the post type is incorrect")
+                    raise RuntimeError("invalid card")
                 return SimpleNamespace(
                     success=lambda: True,
                     data=SimpleNamespace(message_id="om_plain"),
@@ -2744,7 +2737,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2752,7 +2745,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_falls_back_to_text_when_post_response_is_unsuccessful(self):
+    def test_send_falls_back_to_text_when_interactive_response_is_unsuccessful(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2763,7 +2756,7 @@ class TestAdapterBehavior(unittest.TestCase):
             def create(self, request):
                 captured["calls"].append(request)
                 if len(captured["calls"]) == 1:
-                    return SimpleNamespace(success=lambda: False, code=230001, msg="content format of the post type is incorrect")
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="invalid card")
                 return SimpleNamespace(
                     success=lambda: True,
                     data=SimpleNamespace(message_id="om_plain_response"),
@@ -2789,7 +2782,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2832,13 +2825,13 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
-        )
+        self.assertEqual(payload["schema"], "2.0")
+        elements = payload["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("1. 第一项", elements[0]["content"])
 
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## Summary

Markdown tables in Feishu messages currently display as raw pipe-separated text because Feishu's `post` message type does not support table rendering.

This PR switches outbound messages to use Feishu interactive cards (JSON schema 2.0) with the native `table` component, while keeping non-table content as `markdown` elements within the same card.

## Changes

**`gateway/platforms/feishu.py`**
- New `_parse_markdown_table()`: parses `| col | col |` lines into Feishu table component JSON (`columns`, `rows`, `header_style`)
- New `_split_content_and_tables()`: line-by-line scanner that groups consecutive table lines and converts them, collecting non-table lines into markdown elements
- Rewritten `_build_outbound_payload()`: always returns `interactive` msg_type with schema 2.0 card structure, mixing markdown + table elements
- Expanded `_POST_CONTENT_INVALID_RE` regex to match additional Feishu card error messages
- Updated fallback logic in `send_message`, `edit_message`, `_feishu_send_with_retry` to handle `interactive` alongside `post`

**`tests/gateway/test_feishu.py`**
- Updated 7 tests to assert `interactive` card structure with `schema: "2.0"` and `body.elements` instead of `post` type

## Test Results

All 205 Feishu adapter tests pass.

## Before / After

**Before:** Table messages show as raw `| | |` plain text
**After:** Tables render natively as Feishu card table component with headers and cell borders
