### PR TITLE
fix(gateway): deliver ics files as attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1539,6 +1539,7 @@ def _log_safe_path(path: str) -> str:
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
+    ".ics": "text/calendar",
     ".md": "text/markdown",
     ".txt": "text/plain",
     ".csv": "text/csv",
@@ -1644,7 +1645,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".m2a", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".ics", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Geospatial / GIS (#24032)

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -102,6 +102,36 @@ def extract_media_tags_broken(result_messages):
     return media_tags, has_voice_directive
 
 
+class TestMediaDeliveryExtensions:
+    """Tests for the shared outbound media-delivery allowlist."""
+
+    def test_ics_media_tag_is_extracted_for_document_delivery(self):
+        """Calendar invites should upload instead of rendering MEDIA: text."""
+        from gateway.platforms.base import BasePlatformAdapter
+
+        media, cleaned = BasePlatformAdapter.extract_media(
+            "Here is the calendar invite.\nMEDIA:/tmp/event.ics"
+        )
+
+        assert media == [("/tmp/event.ics", False)]
+        assert "MEDIA:" not in cleaned
+        assert "event.ics" not in cleaned
+
+    def test_ics_bare_path_is_allowed_for_document_delivery(self, tmp_path):
+        """Bare local .ics paths should use the same delivery allowlist."""
+        from gateway.platforms.base import BasePlatformAdapter
+
+        invite_path = tmp_path / "event.ics"
+        invite_path.write_text("BEGIN:VCALENDAR\nEND:VCALENDAR\n")
+
+        files, cleaned = BasePlatformAdapter.extract_local_files(
+            f"The invite is at {invite_path}"
+        )
+
+        assert files == [str(invite_path)]
+        assert "event.ics" not in cleaned
+
+
 class TestMediaExtraction:
     """Tests for MEDIA tag extraction from tool results."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes `.ics` calendar invite delivery through the shared gateway media
extraction path.

Before this change, a response like `MEDIA:/tmp/event.ics` could remain visible
as literal text instead of being extracted and uploaded as a native document
attachment, because `.ics` was missing from the gateway document MIME map and
outbound media-delivery extension allowlist.

This is gateway-wide rather than Signal-specific: `BasePlatformAdapter.extract_media()`
runs before platform-specific dispatch, and non-image media is then routed
through `send_document()`.

## Related Issue

N/A — no issue was filed. Related prior closed PR: #33454.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — adds `.ics` to `SUPPORTED_DOCUMENT_TYPES` as
  `text/calendar`.
- `gateway/platforms/base.py` — adds `.ics` to `MEDIA_DELIVERY_EXTS` so calendar
  files are extracted for document delivery.
- `tests/gateway/test_media_extraction.py` — adds regression coverage for both
  explicit `MEDIA:/.../event.ics` tags and bare local `.ics` paths.

## How to Test

1. Create a local `.ics` file.
2. Have an agent response include `MEDIA:/path/to/event.ics`.
3. Verify the gateway extracts the file and sends it as a document attachment
   instead of leaving the `MEDIA:` tag as visible text.

Verification run on this branch:

- `python3 -m pytest tests/gateway/test_media_extraction.py -q` → 11 passed
- `python3 scripts/check-windows-footguns.py gateway/platforms/base.py tests/gateway/test_media_extraction.py` → clean
- `git diff --check main..HEAD` → clean

I also attempted the full suite with `python3 -m pytest tests/ -q`; it did not
complete in this checkout, timing out after 600s with failures outside the
targeted gateway extraction tests before reaching 40%.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — regression tests cover the shared extraction behavior.
