### PR TITLE
fix(conversation): count tokens from length-truncated responses

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3512,6 +3512,35 @@ def run_conversation(
             continue
 
         if restart_with_length_continuation:
+            # Track token usage from the truncated response before continuing.
+            # Without this, tokens consumed by length-truncated responses are
+            # never counted, causing underreported usage in /insights and
+            # session DB (issue #38458).
+            if response is not None and hasattr(response, 'usage') and response.usage:
+                _length_usage = normalize_usage(
+                    response.usage,
+                    provider=agent.provider,
+                    api_mode=agent.api_mode,
+                )
+                agent.session_prompt_tokens += _length_usage.prompt_tokens
+                agent.session_completion_tokens += _length_usage.output_tokens
+                agent.session_total_tokens += _length_usage.total_tokens
+                agent.session_api_calls += 1
+                agent.session_input_tokens += _length_usage.input_tokens
+                agent.session_output_tokens += _length_usage.output_tokens
+                agent.session_cache_read_tokens += _length_usage.cache_read_tokens
+                agent.session_cache_write_tokens += _length_usage.cache_write_tokens
+                agent.session_reasoning_tokens += _length_usage.reasoning_tokens
+                _length_cost = estimate_usage_cost(
+                    agent.model,
+                    _length_usage,
+                    provider=agent.provider,
+                    base_url=agent.base_url,
+                    api_key=getattr(agent, "api_key", ""),
+                )
+                if _length_cost.amount_usd is not None:
+                    agent.session_estimated_cost_usd += float(_length_cost.amount_usd)
+
             # Progressively boost the output token budget on each retry.
             # Retry 1 → 2× base, retry 2 → 3× base, capped at 32 768.
             # Applies to all providers via _ephemeral_max_output_tokens.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4041,6 +4041,41 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_length_continuation_counts_truncated_tokens(self, agent):
+        """Tokens from length-truncated responses must be counted (issue #38458)."""
+        self._setup_agent(agent)
+        trunc_usage = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "total_tokens": 1500,
+        }
+        cont_usage = {
+            "prompt_tokens": 1200,
+            "completion_tokens": 300,
+            "total_tokens": 1500,
+        }
+        first = _mock_response(
+            content="Part 1 ", finish_reason="length", usage=trunc_usage
+        )
+        second = _mock_response(
+            content="Part 2", finish_reason="stop", usage=cont_usage
+        )
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        # Both the truncated AND the continuation response tokens must be counted
+        assert agent.session_prompt_tokens == 2200  # 1000 + 1200
+        assert agent.session_completion_tokens == 800  # 500 + 300
+        assert agent.session_total_tokens == 3000  # 1500 + 1500
+        assert agent.session_api_calls == 2  # both calls counted
+
     def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
         """Continuation retries must not shrink a higher provider default cap."""
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Fixes token accounting for length-truncated responses. When `finish_reason == "length"` triggers a continuation retry, the tokens consumed by the truncated API call were never tracked — causing underreported usage in `/insights` and the session DB.

## Related Issue

Fixes #38458

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py`: Track token usage (prompt, completion, total, cache, reasoning) and estimated cost from the truncated response in the `restart_with_length_continuation` handler, before boosting the output cap and continuing the loop.
- `tests/run_agent/test_run_agent.py`: Add `test_length_continuation_counts_truncated_tokens` — verifies that both the truncated and continuation response tokens are counted in session totals.

## How to Test

1. Ask the model to produce a response that exceeds `max_output_tokens` (triggers `finish_reason="length"`)
2. After the continuation retry completes, check `/insights` — token counts should include both the truncated and continuation calls
3. Run `pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_length_continuation_counts_truncated_tokens -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/conversation_loop.py:run_conversation` — the `restart_with_length_continuation` handler (line ~3514)
- Callers: `AIAgent.run_conversation()` → called by CLI, gateway, batch_runner, cron
- Blast radius: LOW — only affects token accounting in the length-continuation path; no behavioral change to the retry/continuation logic itself
- Related patterns: existing token tracking at line ~1879 (normal path) and line ~1712 (thinking-exhausted path); this fills the gap in the third early-exit path
