### PR TITLE
fix(mcp): preserve embedded resource tool content

### DIFF
--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -18,6 +18,35 @@ class _FakeContentBlock:
         self.type = block_type
 
 
+class _FakeTextResourceContents:
+    """Minimal TextResourceContents stand-in."""
+
+    def __init__(self, uri: str, mimeType: str, text: str, meta=None):
+        self.uri = uri
+        self.mimeType = mimeType
+        self.text = text
+        self._meta = meta
+
+
+class _FakeBlobResourceContents:
+    """Minimal BlobResourceContents stand-in."""
+
+    def __init__(self, uri: str, mimeType: str, blob: str, meta=None):
+        self.uri = uri
+        self.mimeType = mimeType
+        self.blob = blob
+        self._meta = meta
+
+
+class _FakeEmbeddedResourceBlock:
+    """Minimal EmbeddedResource stand-in."""
+
+    def __init__(self, resource, meta=None):
+        self.type = "resource"
+        self.resource = resource
+        self._meta = meta
+
+
 class _FakeCallToolResult:
     """Minimal CallToolResult stand-in.
 
@@ -141,3 +170,73 @@ class TestStructuredContentPreservation:
         raw = handler({})
         data = json.loads(raw)
         assert data["result"] == payload
+
+    def test_embedded_resource_content_is_preserved(self, _patch_mcp_server):
+        """MCP Apps / mcp-ui resources must survive tool result serialization."""
+        session = _patch_mcp_server
+        html = "<html><body><button>Ask Lisa</button></body></html>"
+        resource = _FakeTextResourceContents(
+            uri="ui://lisa-spike/card.html",
+            mimeType="text/html;profile=mcp-app",
+            text=html,
+            meta={"ui": {"visibility": ["model", "app"]}},
+        )
+        block_meta = {"ui": {"resourceUri": "ui://lisa-spike/card.html"}}
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[
+                    _FakeContentBlock("Rendered card"),
+                    _FakeEmbeddedResourceBlock(resource, meta=block_meta),
+                ],
+                structuredContent={"answer": 42},
+            )
+        )
+
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+
+        assert data["result"][0] == "Rendered card"
+        resource_payload = data["result"][1]
+        assert resource_payload == {
+            "type": "resource",
+            "resource": {
+                "uri": "ui://lisa-spike/card.html",
+                "mimeType": "text/html;profile=mcp-app",
+                "text": html,
+                "_meta": {"ui": {"visibility": ["model", "app"]}},
+            },
+            "_meta": block_meta,
+        }
+        assert data["structuredContent"] == {"answer": 42}
+
+    def test_blob_embedded_resource_content_is_preserved(self, _patch_mcp_server):
+        """Binary MCP resources should keep their base64 blob payload."""
+        session = _patch_mcp_server
+        resource = _FakeBlobResourceContents(
+            uri="ui://lisa-spike/image.bin",
+            mimeType="application/octet-stream",
+            blob="AAECAw==",
+        )
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[_FakeEmbeddedResourceBlock(resource)],
+            )
+        )
+
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+
+        assert data == {
+            "result": [
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "ui://lisa-spike/image.bin",
+                        "mimeType": "application/octet-stream",
+                        "blob": "AAECAw==",
+                    },
+                }
+            ]
+        }

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2583,6 +2583,46 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
     return server
 
 
+def _serialize_mcp_resource_block(block) -> Optional[dict]:
+    """Serialize MCP EmbeddedResource/ResourceLink content blocks.
+
+    Text/image blocks already have compact legacy representations. Resource
+    blocks need their structured shape preserved so MCP Apps / mcp-ui hosts can
+    render ``ui://`` resources instead of losing them during text flattening.
+    """
+    block_type = getattr(block, "type", None)
+    resource = getattr(block, "resource", None)
+    if block_type == "resource" and resource is not None:
+        resource_payload = {}
+        if hasattr(resource, "uri"):
+            resource_payload["uri"] = str(resource.uri)
+        if getattr(resource, "mimeType", None):
+            resource_payload["mimeType"] = resource.mimeType
+        if hasattr(resource, "text"):
+            resource_payload["text"] = resource.text
+        if hasattr(resource, "blob"):
+            resource_payload["blob"] = resource.blob
+        if getattr(resource, "_meta", None) is not None:
+            resource_payload["_meta"] = resource._meta
+
+        payload = {"type": "resource", "resource": resource_payload}
+        if getattr(block, "_meta", None) is not None:
+            payload["_meta"] = block._meta
+        return payload
+
+    if block_type == "resource_link" and hasattr(block, "uri"):
+        payload = {"type": "resource_link", "uri": str(block.uri)}
+        for attr in ("name", "title", "description", "mimeType", "size"):
+            value = getattr(block, attr, None)
+            if value is not None:
+                payload[attr] = value
+        if getattr(block, "_meta", None) is not None:
+            payload["_meta"] = block._meta
+        return payload
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Handler / check-fn factories
 # ---------------------------------------------------------------------------
@@ -2655,7 +2695,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # both too stale to cherry-pick. #10848's approach (integrate with
             # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
             # the two — plugs into existing infrastructure.
-            parts: List[str] = []
+            parts: List[object] = []
+            has_structured_parts = False
             for block in (result.content or []):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
@@ -2663,7 +2704,17 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)
-            text_result = "\n".join(parts) if parts else ""
+                    continue
+                resource_payload = _serialize_mcp_resource_block(block)
+                if resource_payload:
+                    parts.append(resource_payload)
+                    has_structured_parts = True
+            if not parts:
+                text_result = ""
+            elif has_structured_parts:
+                text_result = parts
+            else:
+                text_result = "\n".join(str(part) for part in parts)
 
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent


### PR DESCRIPTION
## Summary
- Preserve MCP `EmbeddedResource` tool-result content instead of dropping it during text flattening
- Serialize resource blocks with `uri`, `mimeType`, `text`/`blob`, and `_meta` so MCP Apps / mcp-ui hosts can render returned resources
- Keep legacy text-only and image MEDIA-tag behavior unchanged; only switch `result` to a list when structured resource parts are present
- Add regression coverage for text and blob embedded resources alongside existing structuredContent behavior

## Test Plan
- `python -m pytest tests/tools/test_mcp_structured_content.py::TestStructuredContentPreservation::test_embedded_resource_content_is_preserved -q -o 'addopts='`
- `python -m pytest tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_image_content.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_image_content.py tests/tools/test_mcp_tool.py -q -o 'addopts='`
- Manual SDK smoke with `mcp.types.CallToolResult`, `TextContent`, `EmbeddedResource`, and `TextResourceContents` confirming `SDK_EMBEDDED_RESOURCE_OK`
