### PR TITLE
fix(tui): exclude skill commands from autocomplete dropdown

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1859,6 +1859,31 @@ def test_complete_slash_includes_tui_details_command():
     assert any(item["text"] == "/details" for item in resp["result"]["items"])
 
 
+def test_complete_slash_excludes_skill_commands():
+    """Skill commands must NOT appear in TUI autocomplete.
+
+    ``slash.exec`` rejects skill commands (they must go through
+    ``command.dispatch``), so offering them in the completion dropdown
+    creates a dead-end UX.  Regression test for #38461.
+    """
+    fake_skills = {
+        "/mam": {"name": "mam", "description": "My Anime List"},
+        "/xyztest": {"name": "xyztest", "description": "Test skill"},
+    }
+    with patch(
+        "agent.skill_commands.get_skill_commands",
+        return_value=fake_skills,
+    ):
+        resp = server.handle_request(
+            {"id": "1", "method": "complete.slash", "params": {"text": "/ma"}}
+        )
+
+    items = resp.get("result", {}).get("items", [])
+    assert not any(it["text"] == "mam" for it in items), (
+        "Skill command 'mam' must not appear in TUI autocomplete"
+    )
+
+
 def test_complete_slash_includes_tui_mouse_command():
     resp = server.handle_request(
         {"id": "1", "method": "complete.slash", "params": {"text": "/mou"}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6595,11 +6595,14 @@ def _(rid, params: dict) -> dict:
         from prompt_toolkit.document import Document
         from prompt_toolkit.formatted_text import to_plain_text
 
-        from agent.skill_commands import get_skill_commands
         from agent.skill_bundles import get_skill_bundles
 
+        # Skill commands are intentionally excluded from TUI autocomplete.
+        # ``slash.exec`` rejects skill commands (they must go through
+        # ``command.dispatch``), so showing them in the completion dropdown
+        # creates a dead-end UX: the user selects a suggestion only to hit an
+        # error on submit.  Users can still type skill commands manually.
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands(),
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         doc = Document(text, len(text))


### PR DESCRIPTION
## What does this PR do?

Excludes skill commands from the TUI slash-command autocomplete dropdown. Previously, typing `/` in the TUI would suggest skill commands (e.g. `/mam`), but submitting them would fail with a "skill command: use command.dispatch" error — a confusing dead-end UX.

## Related Issue

Fixes #38461

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Remove `skill_commands_provider` from the `SlashCommandCompleter` instantiation in the `complete.slash` handler. Skill commands are intentionally excluded because `slash.exec` rejects them (they must go through `command.dispatch`). Users can still type skill commands manually.
- `tests/test_tui_gateway_server.py`: Add `test_complete_slash_excludes_skill_commands` — mocks `get_skill_commands` with a known skill and verifies it does not appear in autocomplete results.

## How to Test

1. Run the new regression test: `pytest tests/test_tui_gateway_server.py::test_complete_slash_excludes_skill_commands -xvs`
2. Run all autocomplete tests: `pytest tests/test_tui_gateway_server.py -k "complete_slash" -xvs`
3. Verify skill commands still work when typed manually in the TUI (they go through `command.dispatch` fallback)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `tui_gateway/server.py` (complete.slash handler, line 6598), `hermes_cli/commands.py` (SlashCommandCompleter, line 1186)
- Blast radius: LOW — change is scoped to TUI autocomplete only; CLI autocomplete unaffected (CLI passes its own `skill_commands_provider` separately)
- Related patterns: `slash.exec` skill command rejection (line 6924), `command.dispatch` skill handling (line 5885), TUI `createSlashHandler.ts` fallback (line 89)
