### PR TITLE
FGD-127 add Telegram no-action pre-dispatch suppression

### DIFF
--- a/plugins/telegram_no_action_suppression/__init__.py
+++ b/plugins/telegram_no_action_suppression/__init__.py
@@ -1,0 +1,123 @@
+"""Telegram group no-action suppression.
+
+This plugin is intentionally narrow:
+- It only applies to Telegram non-DM contexts.
+- It skips obvious casual/no-action group chatter before agent dispatch.
+- It preserves explicit Jimmy/action/dev/approval/blocker/correction signals.
+- It does not inspect secrets, logs, env, auth, or runtime configuration.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+
+_REASON = "telegram-group-casual-no-action"
+
+_EXPLICIT_HEADERS = (
+    "JIMMY:",
+    "REQUEST:",
+    "ACTION:",
+    "REVIEW:",
+    "APPROVAL:",
+    "BLOCKER:",
+    "ROUTE:",
+    "CODEX READ-ONLY:",
+    "TIMMY:",
+    "BEBE:",
+    "DECISION:",
+    "GATE:",
+    "ESCALATION:",
+    "CLOSEOUT:",
+    "QUESTION FOR JIMMY:",
+)
+
+_PRESERVE_KEYWORDS = (
+    "approval",
+    "approve",
+    "auto-approve",
+    "read-only",
+    "readonly",
+    "codex",
+    "timmy",
+    "bebe",
+    "blocker",
+    "blocked",
+    "review",
+    "correction",
+    "correct",
+    "gate",
+    "escalat",
+    "closeout",
+    "decision",
+    "route",
+    "implement",
+    "implementation",
+    "evidence",
+    "qa",
+    "test",
+)
+
+
+def _platform_name(platform: Any) -> str:
+    value = getattr(platform, "value", platform)
+    return str(value or "").strip().lower()
+
+
+def _is_telegram_group_context(source: Any) -> bool:
+    if source is None:
+        return False
+
+    if _platform_name(getattr(source, "platform", None)) != "telegram":
+        return False
+
+    chat_type = str(getattr(source, "chat_type", "") or "").strip().lower()
+
+    if chat_type in {"dm", "private"}:
+        return False
+
+    return chat_type in {"group", "supergroup", "channel", "thread"}
+
+
+def _has_preserve_signal(text: str) -> bool:
+    stripped = (text or "").strip()
+    if not stripped:
+        return True
+
+    upper = stripped.upper()
+    lower = stripped.lower()
+
+    if any(header in upper for header in _EXPLICIT_HEADERS):
+        return True
+
+    # Preserve any direct natural-language address to Jimmy.
+    if re.search(r"\bjimmy\b", lower):
+        return True
+
+    # Preserve questions rather than risking false-positive suppression.
+    if "?" in stripped:
+        return True
+
+    if any(keyword in lower for keyword in _PRESERVE_KEYWORDS):
+        return True
+
+    return False
+
+
+def _on_pre_gateway_dispatch(event: Any, **_: Any) -> Optional[dict[str, str]]:
+    source = getattr(event, "source", None)
+
+    if not _is_telegram_group_context(source):
+        return None
+
+    text = str(getattr(event, "text", "") or "").strip()
+
+    if _has_preserve_signal(text):
+        return None
+
+    return {"action": "skip", "reason": _REASON}
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)

--- a/plugins/telegram_no_action_suppression/plugin.yaml
+++ b/plugins/telegram_no_action_suppression/plugin.yaml
@@ -1,0 +1,7 @@
+name: telegram_no_action_suppression
+version: 0.1.0
+description: "Suppress obvious casual/no-action Telegram group chatter before Hermes agent dispatch."
+author: FGD GHO
+kind: standalone
+hooks:
+  - pre_gateway_dispatch

--- a/tests/gateway/test_telegram_no_action_suppression.py
+++ b/tests/gateway/test_telegram_no_action_suppression.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from plugins.telegram_no_action_suppression import _on_pre_gateway_dispatch
+
+
+def _event(text: str, *, chat_type: str = "group", platform=Platform.TELEGRAM):
+    return SimpleNamespace(
+        text=text,
+        source=SimpleNamespace(
+            platform=platform,
+            chat_id="chat-1",
+            chat_name="TCC Social Media",
+            chat_type=chat_type,
+            user_id="user-1",
+            user_name="tester",
+            thread_id=None,
+            is_bot=False,
+        ),
+    )
+
+
+def test_casual_telegram_group_message_is_skipped():
+    result = _on_pre_gateway_dispatch(
+        _event("Christine - This has been set up but the agents are not built out enough to use yet.")
+    )
+
+    assert result == {
+        "action": "skip",
+        "reason": "telegram-group-casual-no-action",
+    }
+
+
+def test_explicit_jimmy_header_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("JIMMY: please review this")) is None
+
+
+def test_question_for_jimmy_header_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("QUESTION FOR JIMMY: what is next?")) is None
+
+
+def test_direct_natural_language_jimmy_reference_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("Jimmy can you check this?")) is None
+
+
+def test_dm_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("hello", chat_type="dm")) is None
+
+
+def test_dev_approval_message_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("Codex read-only approval request for FGD-127")) is None
+
+
+def test_blocker_message_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("BLOCKER: branch state is unclear")) is None
+
+
+def test_correction_message_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("Correction required before closeout")) is None
+
+
+def test_non_telegram_group_message_is_allowed():
+    assert _on_pre_gateway_dispatch(_event("casual message", platform=Platform.DISCORD)) is None


### PR DESCRIPTION
Implements a narrow pre_gateway_dispatch plugin that suppresses obvious casual/no-action Telegram group messages before Jimmy/model dispatch.

Validation:
- ./venv/bin/python -m pytest tests/gateway/test_telegram_no_action_suppression.py -q
- 9 passed

Scope:
- Adds plugin: plugins/telegram_no_action_suppression/
- Adds tests: tests/gateway/test_telegram_no_action_suppression.py
- Does not change global empty-output handling
- Does not edit SOUL.md or SKILL.md
- Does not restart Hermes or run live Telegram QA