### PR TITLE
feat(providers): add Nebius Token Factory as an OpenAI-compatible provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,6 +48,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
+    "nebius",
     "qwen-oauth",
     "xiaomi",
     "arcee",
@@ -67,6 +68,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    "nebius-token-factory", "token-factory", "tokenfactory", "nebius-ai-studio",
 })
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -142,6 +142,7 @@ class ProviderInfo:
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
     "novita": "novita-ai",
+    "nebius": "nebius",
     "anthropic": "anthropic",
     "openai": "openai",
     "openai-codex": "openai",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5972,7 +5972,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         )
         if model_list:
             print(f"  Found {len(model_list)} model(s) from Ollama Cloud")
-    elif provider_id == "novita":
+    elif provider_id in ("novita", "nebius"):
         from hermes_cli.models import fetch_api_models
 
         api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -487,6 +487,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    # Nebius Token Factory model IDs are HuggingFace-style and case-sensitive —
+    # keep the exact casing the API expects.
+    "nebius": [
+        "moonshotai/Kimi-K2.5",
+        "zai-org/GLM-5",
+        "deepseek-ai/DeepSeek-V3.2",
+        "Qwen/Qwen3-235B-A22B-Instruct-2507",
+        "openai/gpt-oss-120b",
+        "MiniMaxAI/MiniMax-M2.5",
+        "meta-llama/Llama-3.3-70B-Instruct",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -905,6 +916,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
+    ProviderEntry("nebius",         "Nebius Token Factory",     "Nebius Token Factory (OpenAI-compatible API for open-weight LLMs)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
@@ -1117,6 +1129,10 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "novita-ai": "novita",
     "novitaai": "novita",
+    "nebius-token-factory": "nebius",
+    "token-factory": "nebius",
+    "tokenfactory": "nebius",
+    "nebius-ai-studio": "nebius",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
     "tencent": "tencent-tokenhub",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -167,6 +167,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="NOVITA_BASE_URL",
     ),
+    # Nebius Token Factory — OpenAI-compatible; base_url comes from models.dev.
+    "nebius": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_env_var="NEBIUS_BASE_URL",
+    ),
     "xai": HermesOverlay(
         transport="codex_responses",
         base_url_override="https://api.x.ai/v1",
@@ -323,6 +329,12 @@ ALIASES: Dict[str, str] = {
     # novita
     "novita-ai": "novita",
     "novitaai": "novita",
+
+    # nebius (Token Factory)
+    "nebius-token-factory": "nebius",
+    "token-factory": "nebius",
+    "tokenfactory": "nebius",
+    "nebius-ai-studio": "nebius",
 
     # xiaomi
     "mimo": "xiaomi",

--- a/plugins/model-providers/nebius/__init__.py
+++ b/plugins/model-providers/nebius/__init__.py
@@ -1,0 +1,33 @@
+"""Nebius Token Factory provider profile.
+
+Nebius Token Factory exposes an OpenAI-compatible inference API, so it routes
+through the standard ``openai_chat`` transport — no bespoke client needed.
+Docs: https://docs.tokenfactory.nebius.com/quickstart
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+nebius = ProviderProfile(
+    name="nebius",
+    aliases=("nebius-token-factory", "token-factory", "tokenfactory", "nebius-ai-studio"),
+    display_name="Nebius Token Factory",
+    description="Nebius Token Factory — OpenAI-compatible API for open-weight LLMs",
+    signup_url="https://tokenfactory.nebius.com/",
+    env_vars=("NEBIUS_API_KEY", "NEBIUS_BASE_URL"),
+    base_url="https://api.tokenfactory.nebius.com/v1",
+    auth_type="api_key",
+    default_aux_model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+    fallback_models=(
+        "moonshotai/Kimi-K2.5",
+        "zai-org/GLM-5",
+        "deepseek-ai/DeepSeek-V3.2",
+        "Qwen/Qwen3-235B-A22B-Instruct-2507",
+        "openai/gpt-oss-120b",
+        "MiniMaxAI/MiniMax-M2.5",
+        "meta-llama/Llama-3.3-70B-Instruct",
+    ),
+)
+
+register_provider(nebius)

--- a/plugins/model-providers/nebius/plugin.yaml
+++ b/plugins/model-providers/nebius/plugin.yaml
@@ -1,0 +1,5 @@
+name: nebius-provider
+kind: model-provider
+version: 1.0.0
+description: Nebius Token Factory OpenAI-compatible API for open-weight LLMs
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1225,6 +1225,102 @@ class TestNovitaProvider:
 
 
 # =============================================================================
+# Nebius Token Factory provider tests (added by feat/add-nebius-provider)
+# =============================================================================
+
+class TestNebiusProvider:
+    """Tests for Nebius Token Factory — an OpenAI-compatible LLM platform."""
+
+    def test_nebius_profile_loads(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("nebius")
+        assert profile is not None
+        assert profile.name == "nebius"
+        assert profile.display_name == "Nebius Token Factory"
+        assert profile.base_url == "https://api.tokenfactory.nebius.com/v1"
+        assert "NEBIUS_API_KEY" in profile.env_vars
+
+    def test_nebius_aliases(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("nebius")
+        assert "nebius-token-factory" in profile.aliases
+        assert "tokenfactory" in profile.aliases
+
+    def test_nebius_alias_resolves(self):
+        assert resolve_provider("nebius-token-factory") == "nebius"
+        assert resolve_provider("token-factory") == "nebius"
+        assert resolve_provider("tokenfactory") == "nebius"
+        assert resolve_provider("nebius-ai-studio") == "nebius"
+
+    def test_nebius_in_provider_registry(self):
+        """Auto-registration from ProviderProfile should expose Nebius."""
+        assert "nebius" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["nebius"]
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.id == "nebius"
+        assert pconfig.inference_base_url == "https://api.tokenfactory.nebius.com/v1"
+        assert pconfig.api_key_env_vars == ("NEBIUS_API_KEY",)
+        assert pconfig.base_url_env_var == "NEBIUS_BASE_URL"
+
+    def test_nebius_aliases_in_registry(self):
+        assert "nebius-token-factory" in PROVIDER_REGISTRY
+        assert "tokenfactory" in PROVIDER_REGISTRY
+
+    def test_main_provider_models_has_nebius(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        assert "nebius" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["nebius"]) >= 1
+
+    def test_models_py_has_nebius(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "nebius" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["nebius"]) >= 1
+
+    def test_nebius_model_lists_match(self):
+        """Model lists in main.py and models.py should be identical."""
+        from hermes_cli.main import _PROVIDER_MODELS as main_models
+        from hermes_cli.models import _PROVIDER_MODELS as models_models
+        assert main_models["nebius"] == models_models["nebius"]
+
+    def test_nebius_models_use_org_name_format(self):
+        """Nebius models should use org/name format (HuggingFace-style)."""
+        from hermes_cli.models import _PROVIDER_MODELS
+        for model in _PROVIDER_MODELS["nebius"]:
+            assert "/" in model, f"Nebius model {model!r} missing org/ prefix"
+
+    def test_nebius_aliases_in_models_py(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("nebius-token-factory") == "nebius"
+        assert _PROVIDER_ALIASES.get("tokenfactory") == "nebius"
+
+    def test_nebius_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert "nebius" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["nebius"] == "Nebius Token Factory"
+
+    def test_nebius_in_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "nebius" in _PROVIDER_PREFIXES
+
+    def test_nebius_url_to_provider(self):
+        """Reverse hostname map is auto-derived from the provider profile."""
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("api.tokenfactory.nebius.com") == "nebius"
+
+    def test_nebius_in_models_dev_mapping(self):
+        """Nebius must be in PROVIDER_TO_MODELS_DEV (no identity fallback)."""
+        from agent.models_dev import PROVIDER_TO_MODELS_DEV
+        assert PROVIDER_TO_MODELS_DEV.get("nebius") == "nebius"
+
+    def test_nebius_overlay_transport(self):
+        """Overlay should route Nebius through the OpenAI chat transport."""
+        from hermes_cli.providers import HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["nebius"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_env_var == "NEBIUS_BASE_URL"
+
+
+# =============================================================================
 # MiniMax OAuth provider tests (added by feat/minimax-oauth-provider)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Adds **Nebius Token Factory** as a model provider. It exposes an OpenAI-compatible inference API, so it routes through the standard `openai_chat` transport, wired in with full parity to the existing Novita integration.

Docs: https://docs.tokenfactory.nebius.com/. Catalog: listed on models.dev under `nebius`.

## What's included

- **`plugins/model-providers/nebius/`**: `ProviderProfile` (`base_url=https://api.tokenfactory.nebius.com/v1`, `NEBIUS_API_KEY`, aliases, curated agentic models, cheap aux model) plus `plugin.yaml` manifest.
- **`agent/models_dev.py`**: `PROVIDER_TO_MODELS_DEV["nebius"] = "nebius"` so the live models.dev catalog, pricing, and context lookups resolve. `_get_provider_models()` uses `.get(provider)` with no identity fallback, so the entry is required even though the id matches.
- **`hermes_cli/providers.py`**: `HermesOverlay` (`openai_chat`, `NEBIUS_BASE_URL`) plus aliases.
- **`hermes_cli/models.py`**: curated picker models, `ProviderEntry`, aliases.
- **`hermes_cli/main.py`**: probe Nebius `/models` live during setup (added to the Novita live-fetch branch; the generic path leads with models.dev).
- **`agent/model_metadata.py`**: provider-prefix entries (the reverse hostname map auto-derives from the profile).
- **Tests**: `TestNebiusProvider` mirroring the Novita suite (15 tests).

Model IDs use exact HuggingFace-style casing (Nebius IDs are case-sensitive), pulled from the live models.dev catalog.

## Testing

- `tests/hermes_cli/test_api_key_providers.py`: 180 passed (15 new). `tests/providers/`: 94 passed.
- Verified end-to-end against the live Nebius API: `/models` returns 33 models, and a real chat completion through the full hermes agent path succeeds:
  ```
  $ python3 -m hermes_cli.main --provider nebius -m meta-llama/Llama-3.3-70B-Instruct --yolo -z "..."
  hermes-to-nebius OK
  ```