### PR TITLE
fix(desktop): avoid idle chat history re-renders

### DIFF
--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -1,0 +1,159 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
+import {
+  $activeSessionId,
+  $awaitingResponse,
+  $busy,
+  $contextSuggestions,
+  $currentCwd,
+  $currentModel,
+  $currentProvider,
+  $freshDraftReady,
+  $gatewayState,
+  $introPersonality,
+  $introSeed,
+  $messages,
+  $selectedStoredSessionId,
+  $sessions
+} from '@/store/session'
+
+import { ChatView } from './index'
+
+const threadRenderCount = vi.hoisted(() => ({ current: 0 }))
+
+vi.mock('@/components/assistant-ui/thread', async () => {
+  const React = await import('react')
+
+  return {
+    Thread: () => {
+      threadRenderCount.current += 1
+
+      return React.createElement('div', { 'data-testid': 'thread' })
+    }
+  }
+})
+
+vi.mock('@/components/Backdrop', async () => {
+  const React = await import('react')
+
+  return { Backdrop: () => React.createElement('div', { 'data-testid': 'backdrop' }) }
+})
+vi.mock('@/components/notifications', () => ({ NotificationStack: () => null }))
+vi.mock('./chat-drop-overlay', () => ({ ChatDropOverlay: () => null }))
+vi.mock('./composer', () => ({ ChatBar: () => null, ChatBarFallback: () => null }))
+vi.mock('./hooks/use-file-drop-zone', () => ({
+  useFileDropZone: () => ({ dragActive: false, dropHandlers: {} })
+}))
+vi.mock('./sidebar/session-actions-menu', async () => {
+  const React = await import('react')
+
+  return {
+    SessionActionsMenu: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'session-actions-menu' }, children)
+  }
+})
+
+function assistantMessage(id: string, text: string): ChatMessage {
+  return {
+    id,
+    parts: [assistantTextPart(text)],
+    role: 'assistant'
+  }
+}
+
+describe('ChatView render isolation', () => {
+  beforeEach(() => {
+    threadRenderCount.current = 0
+    $activeSessionId.set('runtime-1')
+    $awaitingResponse.set(false)
+    $busy.set(false)
+    $contextSuggestions.set([])
+    $currentCwd.set('/work')
+    $currentModel.set('test-model')
+    $currentProvider.set('test-provider')
+    $freshDraftReady.set(false)
+    $gatewayState.set('closed')
+    $introPersonality.set('')
+    $introSeed.set(0)
+    $messages.set([assistantMessage('assistant-1', 'Stable historical answer')])
+    $selectedStoredSessionId.set('stored-1')
+    $sessions.set([{ id: 'stored-1', message_count: 1, title: 'Stable chat' } as never])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $activeSessionId.set(null)
+    $awaitingResponse.set(false)
+    $busy.set(false)
+    $contextSuggestions.set([])
+    $currentCwd.set('')
+    $currentModel.set('')
+    $currentProvider.set('')
+    $freshDraftReady.set(false)
+    $gatewayState.set('idle')
+    $introPersonality.set('')
+    $introSeed.set(0)
+    $messages.set([])
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+  })
+
+  it('does not re-render chat history when an unrelated parent idle tick updates', () => {
+    const props = {
+      gateway: null,
+      maxVoiceRecordingSeconds: 120,
+      onAddContextRef: vi.fn(),
+      onAddUrl: vi.fn(),
+      onAttachDroppedItems: vi.fn(),
+      onAttachImageBlob: vi.fn(),
+      onBranchInNewChat: vi.fn(),
+      onCancel: vi.fn(),
+      onDeleteSelectedSession: vi.fn(),
+      onEdit: vi.fn(),
+      onPasteClipboardImage: vi.fn(),
+      onPickFiles: vi.fn(),
+      onPickFolders: vi.fn(),
+      onPickImages: vi.fn(),
+      onReload: vi.fn(),
+      onRemoveAttachment: vi.fn(),
+      onSubmit: vi.fn(),
+      onThreadMessagesChange: vi.fn(),
+      onToggleSelectedPin: vi.fn(),
+      onTranscribeAudio: vi.fn()
+    }
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    function ParentTickHarness() {
+      const [tick, setTick] = useState(0)
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/stored-1']}>
+            <button onClick={() => setTick(value => value + 1)} type="button">
+              parent tick {tick}
+            </button>
+            <ChatView {...props} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    }
+
+    render(<ParentTickHarness />)
+
+    expect(screen.getByTestId('thread')).toBeTruthy()
+    expect(threadRenderCount.current).toBe(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /parent tick/i }))
+
+    expect(threadRenderCount.current).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { Suspense, useCallback, useMemo, useRef } from 'react'
+import { Suspense, memo, useCallback, useMemo, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Thread } from '@/components/assistant-ui/thread'
@@ -135,7 +135,7 @@ function ChatHeader({
   )
 }
 
-export function ChatView({
+export const ChatView = memo(function ChatView({
   className,
   gateway,
   onToggleSelectedPin,
@@ -267,18 +267,29 @@ export function ChatView({
     return ExportedMessageRepository.fromBranchableArray(items, { headId })
   }, [messages])
 
-  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
-    messageRepository: runtimeMessageRepository,
-    isRunning: busy,
-    setMessages: onThreadMessagesChange,
-    onNew: async () => {
-      // Submission is handled explicitly by ChatBar.
-      // Keeping this no-op avoids duplicate prompt.submit calls.
-    },
-    onEdit,
-    onCancel: async () => onCancel(),
-    onReload
-  })
+  const handleRuntimeNew = useCallback(async () => {
+    // Submission is handled explicitly by ChatBar.
+    // Keeping this no-op avoids duplicate prompt.submit calls.
+  }, [])
+
+  const handleRuntimeCancel = useCallback(async () => {
+    await onCancel()
+  }, [onCancel])
+
+  const runtimeAdapter = useMemo(
+    () => ({
+      isRunning: busy,
+      messageRepository: runtimeMessageRepository,
+      onCancel: handleRuntimeCancel,
+      onEdit,
+      onNew: handleRuntimeNew,
+      onReload,
+      setMessages: onThreadMessagesChange
+    }),
+    [busy, handleRuntimeCancel, handleRuntimeNew, onEdit, onReload, onThreadMessagesChange, runtimeMessageRepository]
+  )
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>(runtimeAdapter)
 
   // Drop files anywhere in the conversation area, not just on the composer
   // input — appending the same inline `@file:` ref chips the composer drop
@@ -364,4 +375,4 @@ export function ChatView({
       </div>
     </div>
   )
-}
+})

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -426,6 +426,18 @@ export function DesktopController() {
     currentCwd,
     requestGateway
   })
+  const {
+    addContextRefAttachment,
+    addTerminalSelectionAttachment,
+    attachContextFilePath,
+    attachContextFolderPath,
+    attachDroppedItems,
+    attachImageBlob,
+    pasteClipboardImage,
+    pickContextPaths,
+    pickImages,
+    removeAttachment
+  } = composer
 
   const branchInNewChat = useCallback(
     async (messageId?: string) => {
@@ -479,6 +491,40 @@ export function DesktopController() {
       sttEnabled,
       updateSessionState
     })
+
+  const addUrlAttachment = useCallback(
+    (url: string) => addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
+    [addContextRefAttachment]
+  )
+
+  const deleteSelectedSession = useCallback(() => {
+    if (selectedStoredSessionId) {
+      void removeSession(selectedStoredSessionId)
+    }
+  }, [removeSession, selectedStoredSessionId])
+
+  const pasteClipboardImageIntoChat = useCallback(() => {
+    void pasteClipboardImage()
+  }, [pasteClipboardImage])
+
+  const pickFileContext = useCallback(() => {
+    void pickContextPaths('file')
+  }, [pickContextPaths])
+
+  const pickFolderContext = useCallback(() => {
+    void pickContextPaths('folder')
+  }, [pickContextPaths])
+
+  const pickImageAttachments = useCallback(() => {
+    void pickImages()
+  }, [pickImages])
+
+  const removeChatAttachment = useCallback(
+    (id: string) => {
+      void removeAttachment(id)
+    },
+    [removeAttachment]
+  )
 
   useGatewayBoot({
     handleGatewayEvent: handleDesktopGatewayEvent,
@@ -547,7 +593,7 @@ export function DesktopController() {
       <DesktopInstallOverlay />
       {/* One PTY-backed terminal mounted forever; <TerminalSlot /> placeholders
           decide where it shows. Toggling fullscreen never rebuilds the shell. */}
-      <PersistentTerminal cwd={currentCwd} onAddSelectionToChat={composer.addTerminalSelectionAttachment} />
+      <PersistentTerminal cwd={currentCwd} onAddSelectionToChat={addTerminalSelectionAttachment} />
       <DesktopOnboardingOverlay
         enabled={gatewayState === 'open'}
         onCompleted={() => {
@@ -608,24 +654,20 @@ export function DesktopController() {
     <ChatView
       gateway={gatewayRef.current}
       maxVoiceRecordingSeconds={voiceMaxRecordingSeconds}
-      onAddContextRef={composer.addContextRefAttachment}
-      onAddUrl={url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url)}
-      onAttachDroppedItems={composer.attachDroppedItems}
-      onAttachImageBlob={composer.attachImageBlob}
+      onAddContextRef={addContextRefAttachment}
+      onAddUrl={addUrlAttachment}
+      onAttachDroppedItems={attachDroppedItems}
+      onAttachImageBlob={attachImageBlob}
       onBranchInNewChat={branchInNewChat}
       onCancel={cancelRun}
-      onDeleteSelectedSession={() => {
-        if (selectedStoredSessionId) {
-          void removeSession(selectedStoredSessionId)
-        }
-      }}
+      onDeleteSelectedSession={deleteSelectedSession}
       onEdit={editMessage}
-      onPasteClipboardImage={() => void composer.pasteClipboardImage()}
-      onPickFiles={() => void composer.pickContextPaths('file')}
-      onPickFolders={() => void composer.pickContextPaths('folder')}
-      onPickImages={() => void composer.pickImages()}
+      onPasteClipboardImage={pasteClipboardImageIntoChat}
+      onPickFiles={pickFileContext}
+      onPickFolders={pickFolderContext}
+      onPickImages={pickImageAttachments}
       onReload={reloadFromMessage}
-      onRemoveAttachment={id => void composer.removeAttachment(id)}
+      onRemoveAttachment={removeChatAttachment}
       onSubmit={submitText}
       onThreadMessagesChange={handleThreadMessagesChange}
       onToggleSelectedPin={toggleSelectedPin}
@@ -740,8 +782,8 @@ export function DesktopController() {
         width={FILE_BROWSER_DEFAULT_WIDTH}
       >
         <RightSidebarPane
-          onActivateFile={composer.attachContextFilePath}
-          onActivateFolder={composer.attachContextFolderPath}
+          onActivateFile={attachContextFilePath}
+          onActivateFolder={attachContextFolderPath}
           onChangeCwd={changeSessionCwd}
         />
       </Pane>

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -172,7 +172,7 @@ export function useIncrementalExternalStoreRuntime<T extends ThreadMessage>(
 
   useEffect(() => {
     runtime.setAdapter(store as ExternalStoreAdapter)
-  })
+  }, [runtime, store])
 
   const { modelContext } = useRuntimeAdapters() ?? {}
 


### PR DESCRIPTION
## Summary

Desktop's parent controller can re-render while chat is idle, for example from background status polling. Before this change, those parent renders passed fresh callback props into `ChatView`, rebuilt the assistant runtime adapter, and caused the mounted assistant-ui thread/chat history to re-render even when `$messages` had not changed.

This stabilizes the idle chat path by:

- memoizing `ChatView`
- stabilizing `DesktopController` -> `ChatView` callback props
- memoizing the assistant runtime adapter
- only updating the incremental external-store runtime adapter when the adapter object changes
- adding a regression test that a parent idle tick does not re-render mounted chat history

This is intentionally scoped to idle render isolation. It does not change the scroll-anchor logic.

## Test Plan

- `npm run test:ui -- src/app/chat/index.test.tsx`
- `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx`
- `npm run type-check`
