### PR TITLE
fix(agent): refund api_call_count when all retries are exhausted

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5265,6 +5265,13 @@ def run_conversation(
                             "execute_code with Python's open() for large "
                             "files, or to write in smaller sections."
                         )
+                    # ``api_call_count`` is bumped before the request so attempt
+                    # numbering is available to logs/hooks during retries. Every
+                    # retry failed, so no call succeeded this iteration — drop it
+                    # before the count is reported and persisted (#38445).
+                    if api_call_count > 0:
+                        api_call_count -= 1
+                        agent._api_call_count = api_call_count
                     return {
                         "final_response": _final_response,
                         "messages": messages,

--- a/tests/run_agent/test_38445_api_call_count_refund.py
+++ b/tests/run_agent/test_38445_api_call_count_refund.py
@@ -1,0 +1,64 @@
+"""Regression guard for #38445: ``api_calls`` must not count a failed call.
+
+``run_conversation`` bumps ``api_call_count`` before issuing the request so
+attempt numbering is available to logs and hooks during retries. When every
+retry fails the loop returns through the max-retries-exhausted path, which
+reports ``api_calls`` as-is — so a turn where no call ever succeeded is
+logged, displayed and persisted with a count one too high.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _build_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1/",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = set()
+    agent.api_max_retries = 2
+    return agent
+
+
+def test_exhausted_retries_do_not_count_an_api_call():
+    """No call succeeded, so the reported count must stay at zero."""
+    agent = _build_agent()
+    agent.client = MagicMock()
+    # Every attempt fails — a plain connection error is retryable, so the loop
+    # burns its retries and exits through the max-retries-exhausted return.
+    agent.client.chat.completions.create.side_effect = Exception("Connection error.")
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("time.sleep", return_value=None),
+    ):
+        result = agent.run_conversation("do the thing")
+
+    assert result["failed"] is True
+    assert "API call failed after" in result["final_response"]
+    assert result["api_calls"] == 0, (
+        f"Expected 0 successful API calls, got {result['api_calls']}. "
+        "The optimistic pre-call increment was not refunded, so a turn "
+        "where nothing succeeded reports one successful call."
+    )
+    assert agent._api_call_count == 0, (
+        "agent._api_call_count must stay in sync with the refunded value"
+    )


### PR DESCRIPTION
## What does this PR do?

**Rewritten and rebased on current `main`, and cut down to the reported bug.** The original branch carried a general `_refund_api_call` helper covering every terminal path in `run_conversation` (~140 lines). This version fixes only what #38445 reports: the max-retries-exhausted return.

`run_conversation` bumps `api_call_count` before issuing the request so attempt numbering is available to logs and hooks during retries (`agent/conversation_loop.py`, `api_call_count += 1` then `agent._touch_activity(f"starting API call #{api_call_count}")`). When every retry fails, the loop returns through the max-retries-exhausted path and reports `"api_calls": api_call_count` unchanged — so a turn where **no call ever succeeded** is logged, displayed and persisted with a count one too high. That is exactly the issue's "1 bigger than the correct value".

`main` already refunds on two neighbouring paths — the Ollama runtime-context error and the compaction restart — but not on retry exhaustion, so the reported case is still live.

## Related Issue

Fixes #38445

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_loop.py` — refund the optimistic increment immediately before the max-retries-exhausted return, keeping `agent._api_call_count` in sync. Guarded by `if api_call_count > 0` so it can never go negative.
- `tests/run_agent/test_38445_api_call_count_refund.py` — regression test driving the real `run_conversation` path.

Production diff is **+7 lines**.

## How to Test

The test builds a real `AIAgent`, makes every attempt fail, and drives `run_conversation` end to end. On unmodified `main` the loop genuinely exhausts its retries and the assertion fails:

```
WARNING  agent.conversation_loop: API call failed (attempt 1/3) … summary=Connection error.
WARNING  agent.conversation_loop: API call failed (attempt 2/3) … summary=Connection error.
WARNING  agent.conversation_loop: API call failed (attempt 3/3) … summary=Connection error.
ERROR    agent.conversation_loop:5224 API call failed after 3 retries. Connection error. | provider= model= msgs=2 tokens=~24

>       assert result["api_calls"] == 0, (
            f"Expected 0 successful API calls, got {result['api_calls']}. "
============================== 1 failed in 0.99s ===============================
```

With the fix:

```
scripts/run_tests.sh tests/run_agent/test_38445_api_call_count_refund.py
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 1.4s (16 workers) ===
```

No regressions across the agent suites:

```
scripts/run_tests.sh tests/run_agent/ tests/agent/
=== 1 file with test failures (1 test failed) ===
  tests/agent/test_credential_pool_routing.py  (1 test failed)
```

That one failure is `test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`, which **fails identically on unmodified `main`** — re-verified on this base by checking out clean `origin/main` in the same worktree and running the same file (`1 failed, 14 passed` both ways). `ruff check` is clean on both changed files; `ruff format` reports `agent/conversation_loop.py` as needing reformatting on **unmodified `main`** too, in code this PR does not touch, so it is not reformatted here.

Honest limits: the refund is applied to the retry-exhaustion path only. `run_conversation` has 26 return sites that report `"api_calls": api_call_count`; most are successful paths where the count is correct, and only this one refunds. The clearest remaining siblings — where no call succeeded either — are the interrupt-during-error-handling returns and the non-retryable "Billing or credits exhausted" returns. They are out of scope for #38445 and would want their own issue rather than a broad helper landing unreviewed, especially given this PR's `sweeper:blast-broad` label. The original version of this PR attempted the general fix — happy to restore that shape if a maintainer prefers it.

## Note on #39115

#39115 (@lEWFkRAD) targeted the same issue and was closed on 2026-06-04 with no comment. Credit to them for filing it; if that PR was closed for a reason that also applies here, I'm glad to close this one too.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the note on #39115
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass (one pre-existing failure documented above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing surface change
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — arithmetic only
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Included inline under **How to Test** above.

