### PR TITLE
fix(skills): document xurl X Article ingestion

### DIFF
--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -192,6 +192,15 @@ xurl search "from:elonmusk" -n 20
 xurl search "#buildinpublic lang:en" -n 15
 ```
 
+For X Articles, use raw API mode instead of the `read` shortcut. `xurl read`
+expects a post ID or post URL; do not put `read` before a `/2/tweets/...`
+endpoint. Request the `article` tweet field and ingest `data.article.plain_text`
+from the JSON response:
+
+```bash
+xurl --app APP_NAME '/2/tweets/2057909493250539891?expansions=author_id,attachments.media_keys,referenced_tweets.id&tweet.fields=created_at,lang,public_metrics,context_annotations,entities,possibly_sensitive,conversation_id,in_reply_to_user_id,referenced_tweets,article'
+```
+
 ### Users, Timeline, Mentions
 
 ```bash

--- a/tests/skills/test_xurl_article_ingestion_docs.py
+++ b/tests/skills/test_xurl_article_ingestion_docs.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO_ROOT / "skills" / "social-media" / "xurl" / "SKILL.md"
+DOC_MD = (
+    REPO_ROOT
+    / "website"
+    / "docs"
+    / "user-guide"
+    / "skills"
+    / "bundled"
+    / "social-media"
+    / "social-media-xurl.md"
+)
+
+
+def test_xurl_article_ingestion_uses_raw_api_mode():
+    skill_text = SKILL_MD.read_text(encoding="utf-8")
+    docs_text = DOC_MD.read_text(encoding="utf-8")
+
+    for text in (skill_text, docs_text):
+        assert "For X Articles, use raw API mode" in text
+        assert "`xurl read`" in text
+        assert "do not put `read` before a `/2/tweets/...`" in text
+        assert "tweet.fields=created_at,lang,public_metrics" in text
+        assert "referenced_tweets,article" in text
+        assert "data.article.plain_text" in text
+        assert "read '/2/tweets/" not in text

--- a/website/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
+++ b/website/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
@@ -206,6 +206,15 @@ xurl search "from:elonmusk" -n 20
 xurl search "#buildinpublic lang:en" -n 15
 ```
 
+For X Articles, use raw API mode instead of the `read` shortcut. `xurl read`
+expects a post ID or post URL; do not put `read` before a `/2/tweets/...`
+endpoint. Request the `article` tweet field and ingest `data.article.plain_text`
+from the JSON response:
+
+```bash
+xurl --app APP_NAME '/2/tweets/2057909493250539891?expansions=author_id,attachments.media_keys,referenced_tweets.id&tweet.fields=created_at,lang,public_metrics,context_annotations,entities,possibly_sensitive,conversation_id,in_reply_to_user_id,referenced_tweets,article'
+```
+
 ### Users, Timeline, Mentions
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Documents the correct xurl workflow for ingesting X Articles. The existing skill guidance covered `xurl read POST_ID` and raw API mode separately, but did not spell out that X Article body extraction needs raw `/2/tweets/...` API mode with the `article` tweet field and `data.article.plain_text` from the response.

This prevents agents from mixing the `read` shortcut with a raw endpoint path, which can return an empty JSON object for article ingestion workflows.

## Related Issue

No GitHub issue. Filed from a Discord support report about the xurl skill's article ingestion command returning `{}` for `https://x.com/bookwormengr/article/2057909493250539891`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/social-media/xurl/SKILL.md` with an X Article ingestion note that uses raw API mode instead of `xurl read`.
- Updated `website/docs/user-guide/skills/bundled/social-media/social-media-xurl.md` with the same generated-docs guidance.
- Added `tests/skills/test_xurl_article_ingestion_docs.py` to pin the article ingestion guidance in both the source skill and docs page.

## How to Test

1. Read the xurl skill's Reading & Search section.
2. Confirm X Articles use `xurl --app APP_NAME '/2/tweets/...tweet.fields=...,article'` without `read` before the raw endpoint.
3. Confirm the guidance tells agents to ingest `data.article.plain_text`.

Local validation run:

- `git diff --check` -> passed
- `python3 -m py_compile tests/skills/test_xurl_article_ingestion_docs.py` -> passed
- direct invocation of `test_xurl_article_ingestion_uses_raw_api_mode()` -> passed

I did not run the full pytest suite locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux shell, docs/text validation only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this updates an existing bundled skill.

## Screenshots / Logs

N/A.
