### PR TITLE
fix(gateway): inherit busy_text_mode from busy_input_mode when not configured

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3192,14 +3192,31 @@ class GatewayRunner:
 
     @staticmethod
     def _load_busy_text_mode() -> str:
-        """Load normal busy TEXT follow-up behavior from config/env."""
+        """Load normal busy TEXT follow-up behavior from config/env.
+
+        When ``display.busy_text_mode`` is not explicitly configured,
+        inherits from ``display.busy_input_mode`` so that a single
+        ``busy_input_mode: interrupt`` setting covers all message types —
+        not just non-text.  Without this fallback, ``busy_text_mode``
+        silently defaults to ``queue`` even when the user has set
+        ``busy_input_mode: interrupt``, causing text messages to be queued
+        instead of interrupting (see #38390).
+        """
         mode = os.getenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "").strip().lower()
         if not mode:
             cfg = _load_gateway_runtime_config()
             mode = str(cfg_get(cfg, "display", "busy_text_mode", default="") or "").strip().lower()
         if mode == "interrupt":
             return "interrupt"
-        return "queue"
+        if mode == "queue":
+            return "queue"
+        if mode == "steer":
+            return "steer"
+        # busy_text_mode not explicitly configured — inherit from
+        # busy_input_mode so that ``display.busy_input_mode: interrupt``
+        # also interrupts text messages, not just non-text (images/files).
+        # See #38390.
+        return GatewayRunner._load_busy_input_mode()
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -116,22 +116,53 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 
 
-def test_load_busy_text_mode_defaults_to_queue_and_allows_interrupt(tmp_path, monkeypatch):
+def test_load_busy_text_mode_inherits_from_busy_input_mode_when_unset(tmp_path, monkeypatch):
+    """When busy_text_mode is not configured, it should inherit from
+    busy_input_mode so that a single ``busy_input_mode: interrupt`` covers
+    all message types (#38390)."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+    # Default busy_input_mode is "interrupt", so busy_text_mode inherits that.
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
 
+    # Explicit busy_text_mode: interrupt still works.
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_text_mode: interrupt\n", encoding="utf-8"
     )
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
 
+    # Explicit busy_text_mode: queue overrides the inheritance.
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_text_mode: queue\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+
+    # When busy_text_mode is not set but busy_input_mode is queue,
+    # busy_text_mode inherits queue.
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_input_mode: queue\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+
+    # When busy_text_mode is not set but busy_input_mode is steer,
+    # busy_text_mode inherits steer.
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_input_mode: steer\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "steer"
+
+    # Env var overrides everything.
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue")
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
 
+    # Unknown env values fall through to busy_input_mode inheritance.
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
+    # busy_input_mode is steer (from config above), so inherits that.
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "steer"
 
 
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(


### PR DESCRIPTION
## Summary

When `display.busy_text_mode` is not explicitly configured, it now inherits from `display.busy_input_mode` instead of silently defaulting to `queue`.

## Problem

In `_load_busy_text_mode()`, when `display.busy_text_mode` was not set, the method always returned `"queue"` regardless of the user's `display.busy_input_mode` setting. This caused the guard in `_handle_active_session_busy_message` (line 3391-3396) to fire for TEXT messages, returning `False` and letting the adapter queue the message without interrupting — even when the user explicitly configured `busy_input_mode: interrupt`.

## Root Cause

`_load_busy_text_mode()` had a hard default of `"queue"` and no fallback to `_load_busy_input_mode()`. The two settings were designed to be independent (text vs non-text), but the lack of inheritance meant a single `busy_input_mode: interrupt` setting didn't cover text messages.

## Fix

`_load_busy_text_mode()` now falls through to `_load_busy_input_mode()` when `busy_text_mode` is not explicitly configured. This means:
- `busy_input_mode: interrupt` + `busy_text_mode: (unset)` → text messages interrupt ✓
- `busy_text_mode: queue` explicitly set → still overrides to queue behavior ✓
- Unknown values fall through to busy_input_mode inheritance ✓

## Testing

- Updated existing test `test_load_busy_text_mode_defaults_to_queue_and_allows_interrupt` → renamed to `test_load_busy_text_mode_inherits_from_busy_input_mode_when_unset` with comprehensive coverage
- All 17 `test_restart_drain` tests pass
- All 17 `test_subagent_protection_30170` tests pass
- All 49 CLI busy input mode tests pass

Closes #38390