### PR TITLE
fix(gateway): drop is_container() gate from s6 detection to fix restart crash-loop

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -86,7 +86,8 @@ def detect_service_manager() -> ServiceManagerKind:
     """Detect which service manager is available in this environment.
 
     Returns:
-        "s6" — inside a container when /init is s6-svscan (Phase 2+)
+        "s6" — s6-svscan is PID 1 (s6-overlay image; Docker, Podman, or a
+               Fly Firecracker microVM)
         "windows" — native Windows host
         "launchd" — macOS host
         "systemd" — Linux host with a working user/system bus
@@ -100,14 +101,20 @@ def detect_service_manager() -> ServiceManagerKind:
     # Imports deferred so importing this module doesn't drag in the
     # whole gateway dependency graph for callers that only need the
     # Protocol type or validate_profile_name().
-    from hermes_constants import is_container
     from hermes_cli.gateway import (
         is_macos,
         is_windows,
         supports_systemd_services,
     )
 
-    if is_container() and _s6_running():
+    # Gate on _s6_running() alone (PID 1 comm == s6-svscan AND /run/s6/basedir),
+    # NOT is_container(): the latter only detects Docker/Podman/lxc, so it is
+    # False on Fly's Firecracker microVMs even though s6-overlay is PID 1 there.
+    # That false negative made the whole s6 dispatch path inert on Fly, so
+    # `hermes gateway start/stop/restart` fell through to host code that spawns
+    # a foreground gateway competing with the supervised one. _s6_running() is
+    # already an s6-overlay-specific signal, so the container gate was redundant.
+    if _s6_running():
         return "s6"
     if is_windows():
         return "windows"

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -86,8 +86,8 @@ def detect_service_manager() -> ServiceManagerKind:
     """Detect which service manager is available in this environment.
 
     Returns:
-        "s6" — s6-svscan is PID 1 (s6-overlay image; Docker, Podman, or a
-               Fly Firecracker microVM)
+        "s6" — s6-svscan is PID 1 (s6-overlay image, regardless of how
+               it's run: container runtime, microVM, etc.)
         "windows" — native Windows host
         "launchd" — macOS host
         "systemd" — Linux host with a working user/system bus
@@ -107,13 +107,6 @@ def detect_service_manager() -> ServiceManagerKind:
         supports_systemd_services,
     )
 
-    # Gate on _s6_running() alone (PID 1 comm == s6-svscan AND /run/s6/basedir),
-    # NOT is_container(): the latter only detects Docker/Podman/lxc, so it is
-    # False on Fly's Firecracker microVMs even though s6-overlay is PID 1 there.
-    # That false negative made the whole s6 dispatch path inert on Fly, so
-    # `hermes gateway start/stop/restart` fell through to host code that spawns
-    # a foreground gateway competing with the supervised one. _s6_running() is
-    # already an s6-overlay-specific signal, so the container gate was redundant.
     if _s6_running():
         return "s6"
     if is_windows():

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -69,6 +69,20 @@ def test_detect_service_manager_returns_known_value() -> None:
     assert result in ("systemd", "launchd", "windows", "s6", "none")
 
 
+def test_detect_service_manager_s6_keys_off_s6_running_not_is_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: Fly runs s6-overlay as PID 1 in a Firecracker microVM, which
+    is not a Docker/Podman container. Gating s6 detection on is_container() made
+    the dispatch path inert on Fly, so `hermes gateway restart` spawned a
+    foreground gateway that fought the supervised one. Detection must key off
+    s6 being PID 1 (`_s6_running`) alone."""
+    monkeypatch.setattr(
+        "hermes_cli.service_manager._s6_running", lambda: True,
+    )
+    assert detect_service_manager() == "s6"
+
+
 # ---------------------------------------------------------------------------
 # _s6_running — must work for unprivileged users, not just root
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -72,14 +72,13 @@ def test_detect_service_manager_returns_known_value() -> None:
 def test_detect_service_manager_s6_keys_off_s6_running_not_is_container(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression: Fly runs s6-overlay as PID 1 in a Firecracker microVM, which
-    is not a Docker/Podman container. Gating s6 detection on is_container() made
-    the dispatch path inert on Fly, so `hermes gateway restart` spawned a
-    foreground gateway that fought the supervised one. Detection must key off
-    s6 being PID 1 (`_s6_running`) alone."""
+    """s6 detection must key off s6 being PID 1 alone, not container markers:
+    s6-overlay images can run outside Docker/Podman (e.g. microVMs), where
+    is_container() is False but the gateway is still s6-supervised."""
     monkeypatch.setattr(
         "hermes_cli.service_manager._s6_running", lambda: True,
     )
+    monkeypatch.setattr("hermes_constants._container_detected", False)  # defeat cache
     assert detect_service_manager() == "s6"
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway crash-loop triggered by `hermes gateway restart` (e.g. the dashboard **Restart** button) when s6-overlay is PID 1 but the environment is not a Docker/Podman/lxc container.

s6 detection was gated on `is_container() and _s6_running()`, but `is_container()` only checks Docker/Podman/lxc markers. Where those are absent, the s6 dispatch path went inert and `restart` fell through to the host path, spawning a foreground gateway that grabbed the lock, while the s6-supervised slot crash-looped every ~7s with `Gateway already running (PID …)`.

Fix: detect s6 via `_s6_running()` alone. It already checks `/proc/1/comm == "s6-svscan"` and `/run/s6/basedir`, which is the exact condition that matters; the `is_container()` gate was redundant. Hosts on systemd/launchd/Windows are unaffected.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/service_manager.py`: `detect_service_manager()` returns `"s6"` based on `_s6_running()` alone, dropping the `is_container()` gate.
- `tests/hermes_cli/test_service_manager.py`: regression test asserting `"s6"` is detected when `_s6_running()` is true without container markers.

## How to Test

1. `pytest tests/hermes_cli/test_service_manager.py -q` passes.
2. Before the fix, with s6-overlay as PID 1 outside a container: `hermes gateway restart` spawns a foreground gateway holding the lock, and the s6 slot loops with `Gateway already running (PID …)`.
3. With the fix, `restart` dispatches to s6 and the supervised slot restarts cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS 15 (unit tests); verified on a live deployment with s6-overlay as PID 1 outside a container

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `detect_service_manager()` docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `/proc/1/comm` doesn't exist there, so detection is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Crash-loop before the fix (repeats every ~7s):

```
⚕ Hermes Gateway Starting...
❌ Gateway already running (PID 206).
Use 'hermes gateway restart' to replace it,
or 'hermes gateway stop' to kill it first.
```
