### PR TITLE
Add bundled OpenClaw operational skill

### DIFF
--- a/skills/autonomous-ai-agents/openclaw/SKILL.md
+++ b/skills/autonomous-ai-agents/openclaw/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: openclaw
+description: "Configure and recover OpenClaw agent installations."
+version: 1.0.0
+author: Joey Cera + Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [OpenClaw, configuration, agents, skills, gateway]
+    homepage: https://github.com/openclaw/openclaw
+    related_skills: [hermes-agent]
+---
+
+# OpenClaw Skill
+
+Use this skill when Hermes needs to inspect, configure, restart, or recover an OpenClaw installation. Prefer OpenClaw's CLI and official documentation over direct file edits, and keep Hermes-owned state under `~/.hermes` separate from OpenClaw-owned state under `~/.openclaw`.
+
+This skill is operational only. For full migration, defer to the official Hermes OpenClaw migration docs; do not improvise migration steps from this skill.
+
+## When to Use
+
+- The user asks Hermes to configure OpenClaw agents, skills, models, channels, gateway, or workspace paths.
+- OpenClaw is stopped, sleeping, misconfigured, or needs a restart after config updates.
+- A Hermes workflow needs to check whether OpenClaw can run, route messages, or load a skill.
+- The user asks how Hermes and OpenClaw should coexist without overwriting each other's state.
+- Do not use this for OpenClaw source-code changes unless the user explicitly asks to work in the OpenClaw repository.
+
+## Prerequisites
+
+- Use official OpenClaw docs only: start from `https://docs.openclaw.ai/llms.txt`, then fetch the specific docs page you need.
+- Confirm the installed CLI before making changes:
+
+```bash
+openclaw --version
+openclaw config file
+```
+
+- Default paths; verify the active install with `openclaw config file`:
+  - Config: `~/.openclaw/openclaw.json`
+  - Workspace: `~/.openclaw/workspace`
+  - Workspace skills: `~/.openclaw/workspace/skills/<skill>/SKILL.md`
+  - Shared skills: `~/.openclaw/skills/<skill>/SKILL.md`
+- If `openclaw` is missing, use the official install or update docs. Do not invent install commands.
+
+## How to Run
+
+Start read-only. Capture the exact command output before proposing any change.
+
+```bash
+openclaw status
+openclaw doctor
+openclaw gateway status
+openclaw config validate
+openclaw agents list
+openclaw skills list
+```
+
+Use `openclaw config get` for targeted reads:
+
+```bash
+openclaw config get agents.defaults.workspace
+openclaw config get agents.defaults.skills
+openclaw config get agents.list --json
+```
+
+For config mutations, prefer CLI writes with dry-run preview:
+
+```bash
+openclaw config set agents.defaults.heartbeat.every "2h" --dry-run
+openclaw config patch --file ./openclaw.patch.json5 --dry-run
+openclaw config validate --json
+```
+
+If `openclaw config --help` does not show `patch` on an older install, use the documented batch setter instead:
+
+```bash
+openclaw config set --batch-file ./openclaw-config-set.batch.json --dry-run
+```
+
+Apply only after the dry run matches the requested change:
+
+```bash
+openclaw config patch --file ./openclaw.patch.json5
+openclaw gateway restart
+openclaw status
+```
+
+## Quick Reference
+
+| Task | Command |
+| --- | --- |
+| Show active config path | `openclaw config file` |
+| Validate config | `openclaw config validate --json` |
+| Run health checks | `openclaw doctor` |
+| Check gateway | `openclaw gateway status` |
+| Restart gateway | `openclaw gateway restart` |
+| Inspect agents | `openclaw agents list` |
+| Inspect skills | `openclaw skills list` |
+| Check skill readiness | `openclaw skills check` |
+| Install a skill | `openclaw skills install <slug-or-path>` |
+| Migrate from OpenClaw | See the official Hermes OpenClaw migration docs |
+
+## Procedure
+
+1. Identify the OpenClaw home, config file, workspace, and gateway status.
+2. Read the relevant official docs page when the requested config surface is unfamiliar or version-sensitive.
+3. Inspect current values with `openclaw config get`, `openclaw agents list`, and `openclaw skills list`.
+4. For agent and skill visibility, distinguish skill location from agent allowlists:
+   - `agents.defaults.skills` sets the inherited default allowlist.
+   - `agents.list[].skills` replaces the default for that agent.
+   - Empty `skills: []` means no skills for that agent.
+5. For config edits, create the smallest `openclaw.patch.json5`, batch `config set` file, or single `config set` command that changes only the requested keys.
+6. Run a dry run, validate config, then apply.
+7. Restart only the component that needs it. Prefer `openclaw gateway restart` after gateway, channel, agent, or skill-load changes.
+8. Verify with `openclaw status`, `openclaw doctor`, and the narrow command that proves the requested state.
+
+## Pitfalls
+
+- Do not edit `~/.openclaw/openclaw.json` by hand when `openclaw config patch` or `openclaw config set` can make the same change with validation.
+- Do not merge `agents.defaults.skills` with `agents.list[].skills`; a non-empty per-agent list is final.
+- Do not treat a same-named skill in two locations as two active skills. OpenClaw loads by precedence, and the highest-precedence copy wins.
+- Do not copy Hermes `config.yaml` or `.env` directly into OpenClaw. Use migration commands when moving state between systems.
+- Do not print secret values. Use OpenClaw SecretRef config commands or local environment files.
+- Do not add unverified command flags. If a command is not in official docs or `openclaw --help`, point to the docs instead of inventing syntax.
+
+## Verification
+
+After changes, report the exact commands used and the resulting state:
+
+```bash
+openclaw config validate --json
+openclaw skills check
+openclaw doctor
+openclaw status
+```
+
+For cross-agent coexistence, also verify Hermes separately:
+
+```bash
+hermes status --all
+hermes doctor
+```

--- a/tests/skills/test_openclaw_skill.py
+++ b/tests/skills/test_openclaw_skill.py
@@ -1,0 +1,86 @@
+"""Smoke tests for the bundled OpenClaw operational skill."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "autonomous-ai-agents" / "openclaw"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    match = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(match.group(1))
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_frontmatter_hardline_shape(frontmatter: dict) -> None:
+    assert frontmatter["name"] == "openclaw"
+    assert frontmatter["license"]
+    assert set(frontmatter["platforms"]) >= {"linux", "macos"}
+
+    description = frontmatter["description"]
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_metadata_points_to_official_source(frontmatter: dict) -> None:
+    hermes = frontmatter["metadata"]["hermes"]
+    assert hermes["homepage"] == "https://github.com/openclaw/openclaw"
+    assert "OpenClaw" in hermes["tags"]
+    assert "hermes-agent" in hermes["related_skills"]
+
+
+def test_official_docs_referenced(skill_text: str) -> None:
+    assert "docs.openclaw.ai" in skill_text
+    assert "official Hermes OpenClaw migration docs" in skill_text
+
+
+def test_no_migration_apply_recipes(skill_text: str) -> None:
+    blocked_fragments = [
+        "hermes claw migrate",
+        "openclaw migrate apply",
+        "--include-secrets",
+    ]
+
+    for fragment in blocked_fragments:
+        assert fragment not in skill_text
+
+
+def test_openclaw_cli_flow_uses_documented_surfaces(skill_text: str) -> None:
+    required_fragments = [
+        "openclaw config file",
+        "openclaw config validate --json",
+        "openclaw config patch --file ./openclaw.patch.json5 --dry-run",
+        "openclaw config set --batch-file ./openclaw-config-set.batch.json --dry-run",
+        "openclaw gateway status",
+        "openclaw skills check",
+    ]
+
+    for fragment in required_fragments:
+        assert fragment in skill_text
+
+
+def test_modern_sections_present(skill_text: str) -> None:
+    for heading in [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]:
+        assert heading in skill_text

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -29,6 +29,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`claude-code`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code) | Delegate coding to Claude Code CLI (features, PRs). | `autonomous-ai-agents/claude-code` |
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents/codex` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Configure, extend, or contribute to Hermes Agent. | `autonomous-ai-agents/hermes-agent` |
+| [`openclaw`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-openclaw) | Configure and recover OpenClaw agent installations. | `autonomous-ai-agents/openclaw` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents/opencode` |
 
 ## creative

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-openclaw.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-openclaw.md
@@ -1,0 +1,160 @@
+---
+title: "OpenClaw: Configure and recover OpenClaw agent installations"
+sidebar_label: "OpenClaw"
+description: "Configure and recover OpenClaw agent installations"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# OpenClaw
+
+Configure and recover OpenClaw agent installations.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/autonomous-ai-agents/openclaw` |
+| Version | `1.0.0` |
+| Author | Joey Cera + Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `OpenClaw`, `configuration`, `agents`, `skills`, `gateway` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# OpenClaw Skill
+
+Use this skill when Hermes needs to inspect, configure, restart, or recover an OpenClaw installation. Prefer OpenClaw's CLI and official documentation over direct file edits, and keep Hermes-owned state under `~/.hermes` separate from OpenClaw-owned state under `~/.openclaw`.
+
+This skill is operational only. For full migration, defer to the official Hermes OpenClaw migration docs; do not improvise migration steps from this skill.
+
+## When to Use
+
+- The user asks Hermes to configure OpenClaw agents, skills, models, channels, gateway, or workspace paths.
+- OpenClaw is stopped, sleeping, misconfigured, or needs a restart after config updates.
+- A Hermes workflow needs to check whether OpenClaw can run, route messages, or load a skill.
+- The user asks how Hermes and OpenClaw should coexist without overwriting each other's state.
+- Do not use this for OpenClaw source-code changes unless the user explicitly asks to work in the OpenClaw repository.
+
+## Prerequisites
+
+- Use official OpenClaw docs only: start from `https://docs.openclaw.ai/llms.txt`, then fetch the specific docs page you need.
+- Confirm the installed CLI before making changes:
+
+```bash
+openclaw --version
+openclaw config file
+```
+
+- Default paths; verify the active install with `openclaw config file`:
+  - Config: `~/.openclaw/openclaw.json`
+  - Workspace: `~/.openclaw/workspace`
+  - Workspace skills: `~/.openclaw/workspace/skills/<skill>/SKILL.md`
+  - Shared skills: `~/.openclaw/skills/<skill>/SKILL.md`
+- If `openclaw` is missing, use the official install or update docs. Do not invent install commands.
+
+## How to Run
+
+Start read-only. Capture the exact command output before proposing any change.
+
+```bash
+openclaw status
+openclaw doctor
+openclaw gateway status
+openclaw config validate
+openclaw agents list
+openclaw skills list
+```
+
+Use `openclaw config get` for targeted reads:
+
+```bash
+openclaw config get agents.defaults.workspace
+openclaw config get agents.defaults.skills
+openclaw config get agents.list --json
+```
+
+For config mutations, prefer CLI writes with dry-run preview:
+
+```bash
+openclaw config set agents.defaults.heartbeat.every "2h" --dry-run
+openclaw config patch --file ./openclaw.patch.json5 --dry-run
+openclaw config validate --json
+```
+
+If `openclaw config --help` does not show `patch` on an older install, use the documented batch setter instead:
+
+```bash
+openclaw config set --batch-file ./openclaw-config-set.batch.json --dry-run
+```
+
+Apply only after the dry run matches the requested change:
+
+```bash
+openclaw config patch --file ./openclaw.patch.json5
+openclaw gateway restart
+openclaw status
+```
+
+## Quick Reference
+
+| Task | Command |
+| --- | --- |
+| Show active config path | `openclaw config file` |
+| Validate config | `openclaw config validate --json` |
+| Run health checks | `openclaw doctor` |
+| Check gateway | `openclaw gateway status` |
+| Restart gateway | `openclaw gateway restart` |
+| Inspect agents | `openclaw agents list` |
+| Inspect skills | `openclaw skills list` |
+| Check skill readiness | `openclaw skills check` |
+| Install a skill | `openclaw skills install <slug-or-path>` |
+| Migrate from OpenClaw | See the official Hermes OpenClaw migration docs |
+
+## Procedure
+
+1. Identify the OpenClaw home, config file, workspace, and gateway status.
+2. Read the relevant official docs page when the requested config surface is unfamiliar or version-sensitive.
+3. Inspect current values with `openclaw config get`, `openclaw agents list`, and `openclaw skills list`.
+4. For agent and skill visibility, distinguish skill location from agent allowlists:
+   - `agents.defaults.skills` sets the inherited default allowlist.
+   - `agents.list[].skills` replaces the default for that agent.
+   - Empty `skills: []` means no skills for that agent.
+5. For config edits, create the smallest `openclaw.patch.json5`, batch `config set` file, or single `config set` command that changes only the requested keys.
+6. Run a dry run, validate config, then apply.
+7. Restart only the component that needs it. Prefer `openclaw gateway restart` after gateway, channel, agent, or skill-load changes.
+8. Verify with `openclaw status`, `openclaw doctor`, and the narrow command that proves the requested state.
+
+## Pitfalls
+
+- Do not edit `~/.openclaw/openclaw.json` by hand when `openclaw config patch` or `openclaw config set` can make the same change with validation.
+- Do not merge `agents.defaults.skills` with `agents.list[].skills`; a non-empty per-agent list is final.
+- Do not treat a same-named skill in two locations as two active skills. OpenClaw loads by precedence, and the highest-precedence copy wins.
+- Do not copy Hermes `config.yaml` or `.env` directly into OpenClaw. Use migration commands when moving state between systems.
+- Do not print secret values. Use OpenClaw SecretRef config commands or local environment files.
+- Do not add unverified command flags. If a command is not in official docs or `openclaw --help`, point to the docs instead of inventing syntax.
+
+## Verification
+
+After changes, report the exact commands used and the resulting state:
+
+```bash
+openclaw config validate --json
+openclaw skills check
+openclaw doctor
+openclaw status
+```
+
+For cross-agent coexistence, also verify Hermes separately:
+
+```bash
+hermes status --all
+hermes doctor
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -156,6 +156,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent',
+                    'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-openclaw',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode',
                   ],
                 },


### PR DESCRIPTION
## Summary

- Adds a bundled `openclaw` skill under `autonomous-ai-agents`.
- Documents the official OpenClaw CLI flow for inspecting, configuring, restarting, and verifying OpenClaw installs.
- Adds a focused skill smoke test plus docs catalog and sidebar entries.
- Keeps scope to operational configuration and recovery. Full migration stays delegated to the existing Hermes OpenClaw migration docs.
- No runtime code changes.

## Why

Hermes already has migration coverage for OpenClaw state, but it does not have a lightweight operational skill for keeping an OpenClaw install healthy after setup. This skill gives Hermes a narrow path: inspect first, use official OpenClaw docs, preview config changes with dry run commands, restart only the affected component, and verify with `doctor`, `status`, and skill checks.

The skill also handles version drift cleanly: current OpenClaw docs and source expose `openclaw config patch`; older local installs can fall back to `openclaw config set --batch-file ... --dry-run` after checking `openclaw config --help`.

## Real behavior proof

- **Behavior or issue addressed**: Hermes now includes a bundled OpenClaw operational skill so a Hermes agent can inspect, configure, restart, and verify OpenClaw using documented OpenClaw CLI flows.
- **Real environment tested**: macOS 26.5 local setup with OpenClaw 2026.4.27 installed at `/usr/local/bin/openclaw` and Hermes Agent v0.11.0 installed at `/Users/husky/.local/bin/hermes`. OpenClaw gateway and Hermes gateway were both running locally.
- **Exact steps or command run after this patch**: Ran the focused Hermes skill pytest, verified current OpenClaw source/docs expose `config patch`, then exercised the OpenClaw CLI surfaces referenced by the skill on the local setup: `openclaw --version`, `openclaw status`, `openclaw doctor`, `openclaw config file`, `openclaw config validate`, `openclaw gateway status`, `openclaw skills list`, `openclaw skills check`, `openclaw agents list --help`, and `openclaw config get agents.list --json`.
- **Evidence after fix**: Redacted terminal output from the real local setup:

```text
$ openclaw --version
OpenClaw 2026.4.27 (cbc2ba0)

$ openclaw status
Gateway: local ws://127.0.0.1:18789 reachable
Gateway service: LaunchAgent installed, loaded, running
Agents: 1 configured; main active
Sessions: 3 active

$ openclaw doctor
Doctor complete
No channel security warnings detected
Skills status, plugin loading, agents, and session store sections rendered successfully

$ openclaw config file
~/.openclaw/openclaw.json

$ openclaw config validate
Config valid: ~/.openclaw/openclaw.json

$ openclaw gateway status
Runtime: running
Probe target: ws://127.0.0.1:18789
Connectivity probe: ok
Capability: admin-capable

$ openclaw skills check
Total: 65
Eligible: 23
Disabled: 0
Blocked by allowlist: 0
Missing requirements: 42

$ openclaw agents list --help
Usage: openclaw agents list [options]
Options include --bindings and --json

$ openclaw config get agents.list --json
[{"id":"main","default":true,"identity":{"name":"Patsy"},"tools":{}}]
```

- **Observed result after fix**: The OpenClaw operational commands used by the new skill are available on a real OpenClaw install, the gateway/config/skills/agents surfaces respond, and the skill includes a fallback for older installs where `openclaw config --help` does not yet expose `patch`.
- **What was not tested**: No known gaps for the skill/content change. Full OpenClaw migration remains covered by the existing Hermes migration path and is intentionally out of scope for this operational skill.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c /dev/null -o cache_dir=/tmp/hermes-pytest-cache tests/skills/test_openclaw_skill.py -q` (7 passed)
- `git diff --check` (passed)
- Changed-file conflict marker scan (passed)
- Current OpenClaw source/docs check: `config patch` is present in `src/cli/config-cli.ts` and `docs/cli/config.md`
- Local OpenClaw smoke checks passed on this machine: `openclaw --version`, `openclaw status`, `openclaw doctor`, `openclaw config file`, `openclaw config validate`, `openclaw gateway status`, `openclaw skills list`, `openclaw skills check`, `openclaw agents list --help`, and `openclaw config get agents.list --json`