### PR TITLE
 fix(security): deny writes to read-blocked HERMES_HOME credential stores

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -25,6 +25,27 @@ def _hermes_root_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+# Credential / secret stores under a Hermes home dir (and the global Hermes
+# root) that the agent must never read *or* write through file tools.
+# ``get_read_block_error`` enforces the read block; ``is_write_denied`` enforces
+# the write block. Sharing one list guarantees the invariant "every credential
+# file hidden from reads is also protected from overwrites" — a
+# read-blocked-but-writable file (the prior state of ``auth.lock``,
+# ``auth/google_oauth.json`` and ``cache/bws_cache.json``) still let a
+# prompt-injected ``write_file`` corrupt the OAuth token store, the Bitwarden
+# secret cache, or the auth lock. Names are relative to a Hermes home dir;
+# nested entries use ``os.path.join`` so the separator is correct per platform.
+CREDENTIAL_FILE_NAMES: tuple[str, ...] = (
+    "auth.json",
+    "auth.lock",
+    ".anthropic_oauth.json",
+    ".env",
+    "webhook_subscriptions.json",
+    os.path.join("auth", "google_oauth.json"),
+    os.path.join("cache", "bws_cache.json"),
+)
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
@@ -104,12 +125,18 @@ def is_write_denied(path: str) -> bool:
         if resolved.startswith(prefix):
             return True
 
-    # Hermes control-plane files: block both the ACTIVE profile's view
-    # (hermes_home) AND the global root view. Without the root pass, a
+    # Hermes control-plane + credential files: block both the ACTIVE profile's
+    # view (hermes_home) AND the global root view. Without the root pass, a
     # profile-mode session leaves <root>/auth.json + <root>/config.yaml
     # writable — letting a prompt-injected write_file overwrite the global
     # files that every profile inherits from (same shape as #15981).
-    control_file_names = ("auth.json", "config.yaml", "webhook_subscriptions.json")
+    #
+    # Every credential file blocked from *reading* (CREDENTIAL_FILE_NAMES) is
+    # blocked from *writing* here too, so a file too sensitive to read can never
+    # be silently overwritten. ``config.yaml`` is the one extra: write-denied to
+    # protect the profile, but intentionally still readable (see
+    # get_read_block_error / test_config_yaml_not_blocked).
+    denied_file_names = ("config.yaml",) + CREDENTIAL_FILE_NAMES
     mcp_tokens_dir_name = "mcp-tokens"
 
     hermes_dirs = []
@@ -122,7 +149,7 @@ def is_write_denied(path: str) -> bool:
             continue
 
     for base_real in hermes_dirs:
-        for name in control_file_names:
+        for name in denied_file_names:
             try:
                 if resolved == os.path.realpath(os.path.join(base_real, name)):
                     return True
@@ -241,21 +268,13 @@ def get_read_block_error(path: str) -> Optional[str]:
             )
 
     # Credential / secret stores. Exact-file matches under either
-    # HERMES_HOME or <root>.
-    credential_file_names = (
-        "auth.json",
-        "auth.lock",
-        ".anthropic_oauth.json",
-        ".env",
-        "webhook_subscriptions.json",
-        os.path.join("auth", "google_oauth.json"),
-        # Bitwarden Secrets Manager disk cache: stores plaintext secret values
-        # to avoid re-fetching across back-to-back CLI invocations. The file
-        # was introduced by #31968 but not added to this guard.
-        os.path.join("cache", "bws_cache.json"),
-    )
+    # HERMES_HOME or <root>. Shared with is_write_denied via
+    # CREDENTIAL_FILE_NAMES so a file hidden from reads is always protected
+    # from overwrites too. (Bitwarden's cache/bws_cache.json stores plaintext
+    # secret values — added in #31968; the Gemini auth/google_oauth.json holds
+    # OAuth refresh/access tokens.)
     for hd in hermes_dirs:
-        for name in credential_file_names:
+        for name in CREDENTIAL_FILE_NAMES:
             try:
                 blocked = (hd / name).resolve()
             except Exception:

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -116,6 +116,62 @@ class TestWriteDenyPrefixes:
             assert _is_write_denied(target) is True
 
 
+class TestCredentialStoreWriteParity:
+    """Every HERMES_HOME credential store blocked from *reading* must also be
+    blocked from *writing*.
+
+    Regression: ``auth.lock``, ``auth/google_oauth.json`` and
+    ``cache/bws_cache.json`` were read-blocked (``get_read_block_error``) but
+    writable, so a prompt-injected ``write_file`` could overwrite the Gemini
+    OAuth token store / Bitwarden secret cache, or clobber the auth lock the
+    agent never legitimately writes. The fix shares one ``CREDENTIAL_FILE_NAMES``
+    list between the read and write guards.
+    """
+
+    def test_auth_lock_write_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "auth.lock")
+        assert _is_write_denied(path) is True
+
+    def test_google_oauth_token_write_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "auth" / "google_oauth.json")
+        assert _is_write_denied(path) is True
+
+    def test_bitwarden_cache_write_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "cache" / "bws_cache.json")
+        assert _is_write_denied(path) is True
+
+    def test_every_read_blocked_credential_is_write_denied(self):
+        """Invariant: ``CREDENTIAL_FILE_NAMES`` (the read block) is a subset of
+        the write deny list. Adding a new credential store to the read block
+        automatically protects it from overwrites — this contract is what keeps
+        the two guards from drifting apart again."""
+        from hermes_constants import get_hermes_home
+        from agent.file_safety import CREDENTIAL_FILE_NAMES
+
+        home = get_hermes_home()
+        for name in CREDENTIAL_FILE_NAMES:
+            path = str(home / name)
+            assert _is_write_denied(path) is True, (
+                f"{name} is read-blocked but still writable"
+            )
+
+    def test_root_credential_write_denied_under_profile(self, tmp_path, monkeypatch):
+        """Under a profile, the global ``<root>/auth.lock`` (and other root
+        credential stores every profile inherits) stays write-denied — same
+        widening as the root ``.env`` case (#15981)."""
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (root / "auth.lock").write_text(" ")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        assert _is_write_denied(str(root / "auth.lock")) is True
+
+
 class TestWriteAllowed:
     def test_tmp_file(self):
         assert _is_write_denied("/tmp/safe_file.txt") is False


### PR DESCRIPTION

### What & why
`get_read_block_error` hides several HERMES_HOME credential stores from the
agent, but `is_write_denied` did **not** block writing three of them — so a
prompt-injected `write_file` could still overwrite real secrets:

| File | Read-blocked | Write-blocked (before) |
|------|:---:|:---:|
| `auth/google_oauth.json` (Gemini OAuth tokens) | ✅ | ❌ |
| `cache/bws_cache.json` (Bitwarden plaintext secrets) | ✅ | ❌ |
| `auth.lock` (auth.json advisory lock) | ✅ | ❌ |

This closes the read/write asymmetry by enforcing the invariant **"every
credential file hidden from reads is also protected from overwrites."** The read
and write guards now share a single `CREDENTIAL_FILE_NAMES` list, so any future
credential added to the read block is automatically write-protected too — the
lists can't drift apart again. `config.yaml` stays write-denied but
intentionally readable. Internal writers (`auth.py`, `google_oauth.py`,
`bitwarden.py`) write directly and don't pass through this guard, so no runtime
flow changes.

### Changes
- `agent/file_safety.py` — lift `CREDENTIAL_FILE_NAMES` to a shared module
  constant; `is_write_denied` now denies `("config.yaml",) + CREDENTIAL_FILE_NAMES`.
- `tests/tools/test_write_deny.py` — `TestCredentialStoreWriteParity`: per-file
  regression tests, root-widening-under-profile test, and a contract test
  asserting `CREDENTIAL_FILE_NAMES ⊆ write-denied`.

### Testing
`scripts/run_tests.sh tests/tools/test_write_deny.py tests/agent/test_file_safety_credentials.py -q`
→ 44 passed, 1 skipped (Windows symlink test). Broader file-safety + write-path
suites: no regressions. `scripts/check-windows-footguns.py`: clean.
