### PR TITLE
perf(tui): improve streaming performance by memoizing useSessionLifecycle return

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -727,7 +727,6 @@ export function useMainApp(gw: GatewayClient) {
     [
       appendMessage,
       bellOnComplete,
-      clearSelection,
       composerActions.setInput,
       gateway,
       panel,

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'node:fs'
 
 import type { ScrollBoxHandle } from '@hermes/ink'
 import { evictInkCaches } from '@hermes/ink'
-import { type RefObject, useCallback } from 'react'
+import { type RefObject, useCallback, useMemo } from 'react'
 
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import { introMsg, toTranscriptMessages } from '../domain/messages.js'
@@ -352,7 +352,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     [sys]
   )
 
-  return {
+  return useMemo(() => ({
     activateLiveSession,
     closeSession,
     guardBusySessionSwitch,
@@ -362,5 +362,14 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     resetVisibleHistory,
     resumeById,
     trimLastExchange: trimTail
-  }
+  }), [
+    activateLiveSession,
+    closeSession,
+    guardBusySessionSwitch,
+    newLiveSession,
+    newSession,
+    resetSession,
+    resetVisibleHistory,
+    resumeById
+  ])
 }


### PR DESCRIPTION
## Summary

Fixes cascading re-render chains that cause unnecessary GC pressure during 60fps streaming.

### Root Cause
`useSessionLifecycle()` returned a new plain object literal on every render. This caused every `useCallback`/`useMemo` that depended on it — `onEvent`, `slash`, `appActions`, `closeLiveSession` — to be recreated every render cycle. During streaming at 60fps, this resulted in:
- Massive GC churn from constantly recreated closures
- Agents nudge firing multiple times (stale closure state reset)
- Unnecessary React reconciliation in the entire component tree

### Fix
1. **`useSessionLifecycle.ts`** — wrap the return value in `useMemo` with the seven stable callbacks as dependencies. The returned object identity is now stable across renders.

2. **`useMainApp.ts`** — remove `clearSelection` from `onEvent`'s `useMemo` dependency array (it was never passed to `createGatewayEventHandler`, causing unnecessary re-creation).

### Verification
- TypeScript compilation: clean (no new errors)
- All 187 TUI tests pass: `tests/tui_gateway/` + `tests/hermes_cli/test_tui_*.py` + `tests/cli/test_tui_*.py`