### PR TITLE
fix(security): deny write_file/patch on Bitwarden disk cache

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -104,12 +104,25 @@ def is_write_denied(path: str) -> bool:
         if resolved.startswith(prefix):
             return True
 
-    # Hermes control-plane files: block both the ACTIVE profile's view
-    # (hermes_home) AND the global root view. Without the root pass, a
-    # profile-mode session leaves <root>/auth.json + <root>/config.yaml
+    # Hermes control-plane + credential-store files: block both the ACTIVE
+    # profile's view (hermes_home) AND the global root view. Without the root
+    # pass, a profile-mode session leaves <root>/auth.json + <root>/config.yaml
     # writable — letting a prompt-injected write_file overwrite the global
     # files that every profile inherits from (same shape as #15981).
-    control_file_names = ("auth.json", "config.yaml", "webhook_subscriptions.json")
+    #
+    # cache/bws_cache.json holds plaintext Bitwarden Secrets Manager values
+    # (agent/secret_sources/bitwarden.py) that load_hermes_dotenv() injects
+    # into os.environ on the next run. _read_disk_cache() trusts the file with
+    # no integrity check, so a prompt-injected write_file/patch could poison
+    # cached credentials. get_read_block_error() already blocks reading it;
+    # an unpaired read block leaves the write side open, so deny writes here
+    # too — keep this in sync with credential_file_names in the read guard.
+    control_file_names = (
+        "auth.json",
+        "config.yaml",
+        "webhook_subscriptions.json",
+        os.path.join("cache", "bws_cache.json"),
+    )
     mcp_tokens_dir_name = "mcp-tokens"
 
     hermes_dirs = []

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -76,6 +76,19 @@ def test_google_oauth_json_blocked(fake_home):
     assert "credential store" in err
 
 
+def test_bws_cache_blocked(fake_home):
+    """The Bitwarden Secrets Manager disk cache (cache/bws_cache.json) holds
+    plaintext secret values — blocked from direct reads. Paired with the
+    is_write_denied write deny so the read block isn't left unguarded on the
+    write side (credential integrity)."""
+    from agent.file_safety import get_read_block_error
+
+    cache = _create(fake_home, Path("cache") / "bws_cache.json")
+    err = get_read_block_error(str(cache))
+    assert err is not None
+    assert "credential store" in err
+
+
 def test_arbitrary_hermes_home_file_not_blocked(fake_home):
     """Non-credential files inside HERMES_HOME stay readable."""
     from agent.file_safety import get_read_block_error

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -67,6 +67,44 @@ class TestWriteDenyExactPaths:
 
         assert _is_write_denied(str(global_env)) is True
 
+    def test_hermes_bws_cache(self):
+        """The Bitwarden Secrets Manager disk cache (cache/bws_cache.json)
+        holds plaintext secret values that load_hermes_dotenv() injects into
+        os.environ on the next run. get_read_block_error() already blocks
+        reading it; the write deny must be paired so a prompt-injected
+        write_file/patch cannot poison cached credentials.
+        """
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "cache" / "bws_cache.json")
+        assert _is_write_denied(path) is True
+
+    def test_bws_cache_write_denied_in_profile_and_root(self, tmp_path, monkeypatch):
+        """The BWS disk cache is write-denied both in the active profile and at
+        the global root, mirroring the read guard.
+
+        Under a profile, HERMES_HOME = <root>/profiles/<name>, but
+        <root>/cache/bws_cache.json is inherited by every profile and must
+        also be protected — same shape as the <root>/.env widening (#15981).
+        """
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        from hermes_constants import get_hermes_home, get_default_hermes_root
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        profile_cache = profile_home / "cache" / "bws_cache.json"
+        root_cache = root / "cache" / "bws_cache.json"
+        profile_cache.parent.mkdir(parents=True, exist_ok=True)
+        root_cache.parent.mkdir(parents=True, exist_ok=True)
+        profile_cache.write_text("{}", encoding="utf-8")
+        root_cache.write_text("{}", encoding="utf-8")
+
+        assert _is_write_denied(str(profile_cache)) is True
+        assert _is_write_denied(str(root_cache)) is True
+
     def test_shell_profiles(self):
         home = str(Path.home())
         for name in [".bashrc", ".zshrc", ".profile", ".bash_profile", ".zprofile"]:


### PR DESCRIPTION


### What
`cache/bws_cache.json` was read-blocked but not write-denied in
`agent/file_safety.py`. Added it to the write deny list (active profile +
global root), pairing the existing read guard.

### Why
The cache holds plaintext secret values, is trusted with no integrity check,
and is injected into `os.environ` on the next run
(`agent/secret_sources/bitwarden.py`). An unpaired read block let a
prompt-injected `write_file`/`patch` poison cached credentials. Both tools
route through `is_write_denied`, so this closes both. Defense-in-depth,
consistent with `#15981`.

### Changes
- `agent/file_safety.py` — add `cache/bws_cache.json` to `control_file_names`.
- `tests/tools/test_write_deny.py` — write-deny tests (profile + root).
- `tests/agent/test_file_safety_credentials.py` — read-block test.

### Tests
    $ python -m pytest tests/tools/test_write_deny.py \
        tests/agent/test_file_safety.py \
        tests/agent/test_file_safety_credentials.py \
        tests/agent/test_copilot_acp_client.py
    67 passed, 1 skipped

Repro before: read_block=True, write_denied=False → after: True / True.

