### PR TITLE
fix(security): block write_file/patch on Gemini OAuth store (read/write parity)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -46,6 +46,17 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level Anthropic PKCE credential store remains sensitive even
             # when a profile is active; default/non-profile sessions still read it.
             str(hermes_root / ".anthropic_oauth.json"),
+            # Active profile Gemini (google-gemini-cli) OAuth credential store.
+            # The read side has been guarded since #17656, but the write side
+            # was left open, so a prompt-injected write_file/patch could
+            # overwrite the refresh/access tokens that get_valid_access_token()
+            # reads back (agent/google_oauth.py) — silently hijacking or
+            # bricking the Gemini session. Closes that read/write parity gap.
+            str(hermes_home / "auth" / "google_oauth.json"),
+            # Top-level Gemini OAuth store stays sensitive under a profile too;
+            # default/non-profile sessions still read it (same root-widening as
+            # .env and .anthropic_oauth.json above, #15981).
+            str(hermes_root / "auth" / "google_oauth.json"),
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -63,6 +63,7 @@ class TestIsWriteDenied:
             "config.yaml",
             "webhook_subscriptions.json",
             ".anthropic_oauth.json",
+            "auth/google_oauth.json",
             "mcp-tokens/token1.json",
             "mcp-tokens/subdir/token2.json",
             "pairing/telegram-approved.json",
@@ -108,15 +109,22 @@ class TestIsWriteDenied:
 
     @pytest.mark.parametrize(
         "name",
-        ["auth.json", "config.yaml", "webhook_subscriptions.json", ".anthropic_oauth.json"],
+        [
+            "auth.json",
+            "config.yaml",
+            "webhook_subscriptions.json",
+            ".anthropic_oauth.json",
+            "auth/google_oauth.json",
+        ],
     )
     def test_control_files_and_oauth_protected_in_profile_mode(self, tmp_path, monkeypatch, name):
         """Under a profile, BOTH <profile>/X and <root>/X must be denied (#15981 shape).
 
         Without the root-level pass, a profile-mode session leaves the
         global ~/.hermes/{auth.json,config.yaml,webhook_subscriptions.json,
-        .anthropic_oauth.json} writable — the same gap PR #15981 fixed
-        for .env.
+        .anthropic_oauth.json,auth/google_oauth.json} writable — the same gap
+        PR #15981 fixed for .env. The Gemini OAuth store (auth/google_oauth.json)
+        was read-guarded since #17656 but left write-open until this parity fix.
         """
         # Simulate a profile-mode HERMES_HOME layout:
         #   <root>/profiles/coder/{auth.json,config.yaml,...}


### PR DESCRIPTION

### What
Add `auth/google_oauth.json` (Gemini / google-gemini-cli OAuth store) to the write deny list in `agent/file_safety.py`, at both the active-profile `HERMES_HOME` and the global root.

### Why
The store is **read**-guarded since #17656, but the **write** side was never added. A prompt-injected `write_file`/`patch`/`move`/`delete` could overwrite the refresh+access tokens that `get_valid_access_token()` reads back (`agent/google_oauth.py`) — hijacking or bricking the Gemini session. Every other credential store in the read guard (`auth.json`, `.anthropic_oauth.json`, `.env`, `webhook_subscriptions.json`, `mcp-tokens/`) is already write-denied; `google_oauth.json` was the lone exception. Same root-widening as #15981.

> Defense-in-depth, **not** a security boundary — the terminal tool runs as the same OS user and can still reach the file (`file_safety.py` docstring; SECURITY.md §2.4/§3.2). Regular hardening PR, not the advisory channel.

### Tests
```bash
scripts/run_tests.sh tests/tools/test_file_operations.py::TestIsWriteDenied
```
- Added `auth/google_oauth.json` to the basic + profile-mode deny parametrize.
- Red/green verified: both new cases **fail** without the fix, **pass** with it.

```
TestIsWriteDenied ........................ 33 passed
file_safety write-deny suites ............ 132 passed, 1 skipped
```

