### PR TITLE
feat(tools): add selector support to browser_click and browser_type

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -222,7 +222,7 @@ class TestCamofoxInteractions:
         camofox_navigate("https://x.com", task_id="t4")
 
         mock_post.return_value = _mock_response(json_data={"ok": True, "url": "https://x.com"})
-        result = json.loads(camofox_click("@e5", task_id="t4"))
+        result = json.loads(camofox_click("@e5", "t4"))
         assert result["success"] is True
         assert result["clicked"] == "e5"
 
@@ -233,10 +233,50 @@ class TestCamofoxInteractions:
         camofox_navigate("https://x.com", task_id="t5")
 
         mock_post.return_value = _mock_response(json_data={"ok": True})
-        result = json.loads(camofox_type("@e3", "hello world", task_id="t5"))
+        result = json.loads(camofox_type("@e3", "hello world", "t5"))
         assert result["success"] is True
         # Normal text is left readable.
         assert result["typed"] == "hello world"
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_click_with_selector(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab_selector_click", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id="t_selector_click")
+
+        mock_post.return_value = _mock_response(json_data={"ok": True, "url": "https://x.com"})
+        result = json.loads(camofox_click(selector="button.submit", task_id="t_selector_click"))
+
+        assert result["success"] is True
+        assert result["clicked"] == "button.submit"
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["selector"] == "button.submit"
+        assert "ref" not in payload
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_type_with_selector(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab_selector_type", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id="t_selector_type")
+
+        mock_post.return_value = _mock_response(json_data={"ok": True})
+        result = json.loads(camofox_type(text="hello", selector="input.username", task_id="t_selector_type"))
+
+        assert result["success"] is True
+        assert result["element"] == "input.username"
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["selector"] == "input.username"
+        assert payload["text"] == "hello"
+        assert "ref" not in payload
+
+    def test_selector_target_validation(self):
+        for result in (
+            camofox_click(),
+            camofox_click("@e1", selector="button.submit"),
+            camofox_type(text="hello"),
+            camofox_type("@e1", "hello", selector="input.username"),
+        ):
+            assert json.loads(result)["success"] is False
 
     @patch("tools.browser_camofox.requests.post")
     def test_type_redacts_api_key(self, mock_post, monkeypatch):
@@ -455,5 +495,3 @@ class TestBrowserToolRouting:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         from tools.browser_tool import check_browser_requirements
         assert check_browser_requirements() is True
-
-

--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -85,6 +85,62 @@ def test_guard_inactive_does_not_block_or_probe(monkeypatch):
     assert calls == [("task-1", "click", ["@e1"])]
 
 
+def test_selector_routes_to_agent_browser(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+
+    def fake_run(task_id, command, args):
+        calls.append((task_id, command, args))
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    click = json.loads(browser_tool.browser_click(selector="button.submit", task_id="click-task"))
+    typed = json.loads(browser_tool.browser_type(selector="input.username", text="hello", task_id="type-task"))
+
+    assert click == {"success": True, "clicked": "button.submit"}
+    assert typed["success"] is True
+    assert typed["element"] == "input.username"
+    assert calls == [
+        ("click-task", "click", ["button.submit"]),
+        ("type-task", "fill", ["input.username", "hello"]),
+    ]
+
+
+def test_click_and_type_preserve_positional_task_id(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
+
+    def fake_run(task_id, command, args):
+        calls.append((task_id, command, args))
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", fake_run)
+
+    click = json.loads(browser_tool.browser_click("@e1", "click-task"))
+    typed = json.loads(browser_tool.browser_type("@e2", "hello", "type-task"))
+
+    assert click == {"success": True, "clicked": "@e1"}
+    assert typed["success"] is True
+    assert typed["element"] == "@e2"
+    assert calls == [
+        ("click-task", "click", ["@e1"]),
+        ("type-task", "fill", ["@e2", "hello"]),
+    ]
+
+
+def test_selector_target_validation():
+    for result in (
+        browser_tool.browser_click(),
+        browser_tool.browser_click("@e1", selector="button.submit"),
+        browser_tool.browser_type(text="hello"),
+        browser_tool.browser_type("@e1", "hello", selector="input.username"),
+    ):
+        assert json.loads(result)["success"] is False
+
+
 def test_camofox_short_circuits_before_guard(monkeypatch):
     """Camofox mode returns from the dedicated camofox_* path BEFORE reaching the
     private-page guard, so the guard's helpers must never be consulted. Guards the
@@ -99,7 +155,7 @@ def test_camofox_short_circuits_before_guard(monkeypatch):
 
     import tools.browser_camofox as camofox
 
-    monkeypatch.setattr(camofox, "camofox_click", lambda ref, task_id: '{"success": true, "camofox": true}')
+    monkeypatch.setattr(camofox, "camofox_click", lambda ref, task_id, selector=None: '{"success": true, "camofox": true}')
 
     out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -646,8 +646,17 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         return tool_error(str(e), success=False)
 
 
-def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
-    """Click an element by ref via Camofox."""
+def camofox_click(
+    ref: Optional[str] = None,
+    task_id: Optional[str] = None,
+    selector: Optional[str] = None,
+) -> str:
+    """Click an element by ref or CSS selector via Camofox."""
+    if not ref and not selector:
+        return tool_error("Either 'ref' or 'selector' must be provided.", success=False)
+    if ref and selector:
+        return tool_error("Parameters 'ref' and 'selector' are mutually exclusive.", success=False)
+
     try:
         session = _get_session(task_id)
         if not session["tab_id"]:
@@ -657,24 +666,40 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         if blocked:
             return blocked
 
-        # Strip @ prefix if present (our tool convention)
-        clean_ref = ref.lstrip("@")
+        body = {"userId": session["user_id"]}
+        if ref:
+            # Strip @ prefix if present (our tool convention)
+            target = ref.lstrip("@")
+            body["ref"] = target
+        else:
+            target = selector
+            body["selector"] = target
 
         data = _post(
             f"/tabs/{session['tab_id']}/click",
-            {"userId": session["user_id"], "ref": clean_ref},
+            body,
         )
         return json.dumps({
             "success": True,
-            "clicked": clean_ref,
+            "clicked": target,
             "url": data.get("url", ""),
         })
     except Exception as e:
         return tool_error(str(e), success=False)
 
 
-def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
-    """Type text into an element by ref via Camofox."""
+def camofox_type(
+    ref: Optional[str] = None,
+    text: str = "",
+    task_id: Optional[str] = None,
+    selector: Optional[str] = None,
+) -> str:
+    """Type text into an element by ref or CSS selector via Camofox."""
+    if not ref and not selector:
+        return tool_error("Either 'ref' or 'selector' must be provided.", success=False)
+    if ref and selector:
+        return tool_error("Parameters 'ref' and 'selector' are mutually exclusive.", success=False)
+
     try:
         session = _get_session(task_id)
         if not session["tab_id"]:
@@ -684,11 +709,18 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         if blocked:
             return blocked
 
-        clean_ref = ref.lstrip("@")
+        body = {"userId": session["user_id"], "text": text}
+        if ref:
+            # Strip @ prefix if present (our tool convention)
+            target = ref.lstrip("@")
+            body["ref"] = target
+        else:
+            target = selector
+            body["selector"] = target
 
         _post(
             f"/tabs/{session['tab_id']}/type",
-            {"userId": session["user_id"], "ref": clean_ref, "text": text},
+            body,
         )
         from agent.display import (
             redact_browser_typed_text_for_display,
@@ -704,7 +736,7 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             # tool progress or chat history.  The raw text is still typed into
             # the page; only the returned display value is redacted.
             "typed": display_text,
-            "element": clean_ref,
+            "element": target,
         }
         response = redact_browser_typed_text_for_display(response, text)
         return json.dumps(response)
@@ -944,6 +976,5 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1891,34 +1891,42 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_click",
-        "description": "Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first.",
+        "description": "Click an element by its ref ID from the snapshot (e.g., '@e5') or a CSS selector (e.g., 'button.submit'). Specify exactly one target. Requires browser_navigate and browser_snapshot to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
                 "ref": {
                     "type": "string",
-                    "description": "The element reference from the snapshot (e.g., '@e5', '@e12')"
+                    "description": "The element reference from the snapshot (e.g., '@e5', '@e12'). Mutually exclusive with selector."
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector of the element to click (e.g., 'button.submit'). Mutually exclusive with ref."
                 }
             },
-            "required": ["ref"]
+            "required": []
         }
     },
     {
         "name": "browser_type",
-        "description": "Type text into an input field identified by its ref ID. Clears the field first, then types the new text. Requires browser_navigate and browser_snapshot to be called first.",
+        "description": "Type text into an input field identified by its ref ID or a CSS selector. Clears the field first, then types the new text. Specify exactly one target. Requires browser_navigate and browser_snapshot to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
                 "ref": {
                     "type": "string",
-                    "description": "The element reference from the snapshot (e.g., '@e3')"
+                    "description": "The element reference from the snapshot (e.g., '@e3'). Mutually exclusive with selector."
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector of the element to type into (e.g., 'input.username'). Mutually exclusive with ref."
                 },
                 "text": {
                     "type": "string",
                     "description": "The text to type into the field"
                 }
             },
-            "required": ["ref", "text"]
+            "required": ["text"]
         }
     },
     {
@@ -3128,73 +3136,104 @@ def browser_snapshot(
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_click(ref: str, task_id: Optional[str] = None) -> str:
+def browser_click(
+    ref: Optional[str] = None,
+    task_id: Optional[str] = None,
+    selector: Optional[str] = None,
+) -> str:
     """
     Click on an element.
 
     Args:
-        ref: Element reference (e.g., "@e5")
+        ref: Element reference (e.g., "@e5"). Mutually exclusive with selector.
         task_id: Task identifier for session isolation
+        selector: CSS selector of the element to click (e.g., "button.submit").
+            Mutually exclusive with ref.
 
     Returns:
         JSON string with click result
     """
+    if not ref and not selector:
+        return json.dumps({"success": False, "error": "Either 'ref' or 'selector' must be provided."}, ensure_ascii=False)
+    if ref and selector:
+        return json.dumps({"success": False, "error": "Parameters 'ref' and 'selector' are mutually exclusive."}, ensure_ascii=False)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
-        return camofox_click(ref, task_id)
+        return camofox_click(ref, task_id, selector=selector)
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "click")
     if blocked is not None:
         return blocked
 
-    # Ensure ref starts with @
-    if not ref.startswith("@"):
-        ref = f"@{ref}"
+    if ref:
+        # Ensure ref starts with @
+        if not ref.startswith("@"):
+            ref = f"@{ref}"
+        target = ref
+    else:
+        target = selector
 
-    result = _run_browser_command(effective_task_id, "click", [ref])
+    result = _run_browser_command(effective_task_id, "click", [target])
 
     if result.get("success"):
         response = {
             "success": True,
-            "clicked": ref
+            "clicked": target
         }
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
     else:
         response = {
             "success": False,
-            "error": result.get("error", f"Failed to click {ref}")
+            "error": result.get("error", f"Failed to click {target}")
         }
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+def browser_type(
+    ref: Optional[str] = None,
+    text: str = "",
+    task_id: Optional[str] = None,
+    selector: Optional[str] = None,
+) -> str:
     """
     Type text into an input field.
 
     Args:
-        ref: Element reference (e.g., "@e3")
+        ref: Element reference (e.g., "@e3"). Mutually exclusive with selector.
         text: Text to type
         task_id: Task identifier for session isolation
+        selector: CSS selector of the element to type into (e.g., "input.username").
+            Mutually exclusive with ref.
 
     Returns:
         JSON string with type result
     """
+    if not ref and not selector:
+        return json.dumps({"success": False, "error": "Either 'ref' or 'selector' must be provided."}, ensure_ascii=False)
+    if ref and selector:
+        return json.dumps({"success": False, "error": "Parameters 'ref' and 'selector' are mutually exclusive."}, ensure_ascii=False)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
-        return camofox_type(ref, text, task_id)
+        return camofox_type(ref, text, task_id, selector=selector)
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "type")
     if blocked is not None:
         return blocked
 
-    # Ensure ref starts with @
-    if not ref.startswith("@"):
-        ref = f"@{ref}"
+    if ref:
+        # Ensure ref starts with @
+        if not ref.startswith("@"):
+            ref = f"@{ref}"
+        target = ref
+    else:
+        target = selector
 
     # Use fill command (clears then types)
-    result = _run_browser_command(effective_task_id, "fill", [ref, text])
+    result = _run_browser_command(effective_task_id, "fill", [target, text])
 
     from agent.display import (
         redact_browser_typed_text_for_display,
@@ -3211,7 +3250,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             # text passes through unchanged.  The raw value was already sent
             # to the browser command above.
             "typed": display_text,
-            "element": ref
+            "element": target
         }
         response = _copy_fallback_warning(response, result)
         response = redact_browser_typed_text_for_display(response, text)
@@ -3219,7 +3258,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     else:
         response = {
             "success": False,
-            "error": result.get("error", f"Failed to type into {ref}")
+            "error": result.get("error", f"Failed to type into {target}")
         }
         response = _copy_fallback_warning(response, result)
         response = redact_browser_typed_text_for_display(response, text)
@@ -4882,7 +4921,11 @@ registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_click(
+        ref=args.get("ref"),
+        task_id=kw.get("task_id"),
+        selector=args.get("selector"),
+    ),
     check_fn=check_browser_requirements,
     emoji="👆",
 )
@@ -4890,7 +4933,12 @@ registry.register(
     name="browser_type",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_type"],
-    handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_type(
+        ref=args.get("ref"),
+        text=args.get("text", ""),
+        task_id=kw.get("task_id"),
+        selector=args.get("selector"),
+    ),
     check_fn=check_browser_requirements,
     emoji="⌨️",
 )

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -447,18 +447,20 @@ Snapshots over 15,000 characters are automatically truncated or summarized by an
 
 ### `browser_click`
 
-Click an element identified by its ref ID from the snapshot.
+Click an element identified by its ref ID from the snapshot or by a CSS selector.
 
 ```
 Click @e5 to press the "Sign In" button
+Click button.submit using a CSS selector
 ```
 
 ### `browser_type`
 
-Type text into an input field. Clears the field first, then types the new text.
+Type text into an input field by ref ID or CSS selector. Clears the field first, then types the new text.
 
 ```
 Type "hermes agent" into the search field @e3
+Type "hermes agent" into input.search using a CSS selector
 ```
 
 ### `browser_scroll`


### PR DESCRIPTION
## What does this PR do?

This PR adds an optional selector parameter to the browser_click and browser_type tools. This allows the agent to interact with elements via CSS selectors (e.g., button.submit) in addition to the existing accessibility tree ref IDs. This is particularly useful for interacting with elements that are not properly exposed to the accessibility tree but are available in the DOM.



## Related Issue

#38462 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- tools/browser_tool.py: Updated browser_click and browser_type schemas and function signatures to include the optional selector parameter. Added logic to ensure ref and selector are mutually exclusive.
- tools/browser_camofox.py: Updated Camofox handlers to pass the selector field to the underlying Camofox REST API.
- tests/tools/test_browser_camofox.py: Added comprehensive test cases for the new selector-based interactions and associated error handling.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the new unit tests specifically:
`scripts/run_tests.sh tests/tools/test_browser_camofox.py`
2. Verify no regressions in the broader browser toolset:
`scripts/run_tests.sh tests/tools/`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

### Test Results:

```sh
   1 Discovered 241 test files (5947 tests) under ['tests/tools']; running with -j 24
   2 === Summary: 241 files, 5880 tests passed, 0 failed (100% complete) in 104.7s ===
```

