### PR TITLE
fix(tui): eliminate TOCTOU race between goal followup and concurrent turn

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4574,24 +4574,22 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 pass
             _clear_session_context(session_tokens)
             with session["history_lock"]:
-                session["running"] = False
+                if not goal_followup:
+                    # Only release the turn guard when there is no followup
+                    # to chain.  When a goal continuation exists we keep
+                    # running=True so no other thread (notification poller,
+                    # concurrent prompt.submit) can steal the turn during the
+                    # gap between this finally and the followup dispatch below.
+                    session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
             _emit("session.info", sid, _session_info(agent, session))
 
-        # Chain a goal-continuation turn if the judge said so. We do
-        # this AFTER the finally releases session["running"], so the
-        # nested _run_prompt_submit doesn't deadlock on the busy
-        # guard. A real user prompt that races us wins because
-        # prompt.submit sets running=True under the history_lock and
-        # we check that guard before re-firing.
+        # Chain a goal-continuation turn if the judge said so.  Because the
+        # finally block above intentionally kept running=True when a followup
+        # exists, there is no TOCTOU window — no other thread can sneak in
+        # and start a concurrent turn on this session.
         if goal_followup:
-            with session["history_lock"]:
-                if session.get("running"):
-                    # User already sent something — their turn wins,
-                    # the judge will re-run on the next turn anyway.
-                    return
-                session["running"] = True
             try:
                 _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, goal_followup)


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition between goal followup continuation and concurrent turn submission that could lead to two agent turns running on the same session simultaneously.

### Root Cause
When a turn finished and a goal followup existed, the `finally` block set `session["running"] = False` (under `history_lock`), then the goal followup code re-acquired the lock and set `session["running"] = True`. Between these two lock acquisitions, a notification poller daemon thread or a concurrent `prompt.submit` RPC could:

1. Acquire `history_lock`
2. See `running = False`
3. Set `running = True`
4. Call `_run_prompt_submit`

Then the goal followup code would also:
1. Acquire `history_lock`  
2. See `running = True` (set by the other thread) → return

While this lock correctly prevents TWO concurrent `_run_prompt_submit` calls in theory, the code relied on callers correctly checking `running` before calling `_run_prompt_submit`. If any code path missed this check (or the timing was unlucky), concurrent turns would result in interleaved history writes and corrupted conversation state.

### Fix
Instead of releasing and re-acquiring the turn guard, **keep `running = True`** across the `finally` → goal-followup boundary. Only set `running = False` in the `finally` block when there is **no** goal followup to chain. This eliminates the TOCTOU window entirely — there is never a moment where `running` is False while a goal followup is pending.

### Verification
- All 183 TUI tests pass: `tests/tui_gateway/` + `tests/hermes_cli/test_tui_*.py` + `tests/cli/test_tui_*.py`
- All 11 goal command tests pass: `tests/tui_gateway/test_goal_command.py`