### PR TITLE
feat: add policy approvals with WhatsApp mirror

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,47 @@ from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
+def _build_exec_approval_text(command: str, description: str, approval_id: str = "") -> str:
+    """Build a plain-text approval prompt usable across gateway platforms."""
+    cmd_preview = command[:200] + "..." if len(command) > 200 else command
+    if approval_id:
+        approve = f"/approve {approval_id}"
+        approve_session = f"/approve {approval_id} session"
+        approve_always = f"/approve {approval_id} always"
+        deny = f"/deny {approval_id}"
+    else:
+        approve = "/approve"
+        approve_session = "/approve session"
+        approve_always = "/approve always"
+        deny = "/deny"
+    return (
+        f"⚠️ **Dangerous command requires approval:**\n"
+        f"```\n{cmd_preview}\n```\n"
+        f"Reason: {description}\n\n"
+        f"Reply `{approve}` to execute, `{approve_session}` to approve this pattern "
+        f"for the session, `{approve_always}` to approve permanently, or `{deny}` to cancel."
+    )
+
+
+def _approval_notify_platform() -> str:
+    """Return optional cross-platform approval mirror target from config."""
+    try:
+        from hermes_cli.config import load_config
+        approvals = (load_config().get("approvals", {}) or {})
+    except Exception:
+        return ""
+    notify = approvals.get("notify", {}) or {}
+    if notify is False:
+        return ""
+    if isinstance(notify, str):
+        return notify.strip().lower()
+    if isinstance(notify, dict):
+        if str(notify.get("enabled", "true")).strip().lower() in {"0", "false", "no", "off"}:
+            return ""
+        return str(notify.get("platform", "") or "").strip().lower()
+    return str(approvals.get("notify_platform", "") or "").strip().lower()
+
+
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
 # long-lived gateways (each AIAgent holds LLM clients, tool schemas,
@@ -14708,18 +14749,17 @@ class GatewayRunner:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval_by_id,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.approval_expired")
-            return t("gateway.approve.no_pending")
-
-        # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
-        resolve_all = "all" in args
-        remaining = [a for a in args if a != "all"]
+        # Parse args: support "all", "all session", "all always", "session",
+        # "always", and cross-channel IDs: `/approve Ab3_xYz9`.
+        raw_args = event.get_command_args().strip().split()
+        lowered_args = [a.lower() for a in raw_args]
+        resolve_all = "all" in lowered_args
+        remaining = [a for a in lowered_args if a != "all"]
+        approval_id = next((raw_args[i] for i, a in enumerate(lowered_args)
+                            if a not in {"all", "always", "permanent", "permanently", "session", "ses"}), None)
 
         if any(a in {"always", "permanent", "permanently"} for a in remaining):
             choice = "always"
@@ -14728,7 +14768,15 @@ class GatewayRunner:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        if approval_id:
+            count = resolve_gateway_approval_by_id(approval_id, choice)
+        else:
+            if not has_blocking_approval(session_key):
+                if session_key in self._pending_approvals:
+                    self._pending_approvals.pop(session_key)
+                    return t("gateway.approval_expired")
+                return t("gateway.approve.no_pending")
+            count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -14754,18 +14802,23 @@ class GatewayRunner:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval_by_id,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.deny.stale")
-            return t("gateway.deny.no_pending")
+        raw_args = event.get_command_args().strip().split()
+        lowered_args = [a.lower() for a in raw_args]
+        resolve_all = "all" in lowered_args
+        approval_id = next((raw_args[i] for i, a in enumerate(lowered_args) if a != "all"), None)
 
-        args = event.get_command_args().strip().lower()
-        resolve_all = "all" in args
-
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
+        if approval_id:
+            count = resolve_gateway_approval_by_id(approval_id, "deny")
+        else:
+            if not has_blocking_approval(session_key):
+                if session_key in self._pending_approvals:
+                    self._pending_approvals.pop(session_key)
+                    return t("gateway.deny.stale")
+                return t("gateway.deny.no_pending")
+            count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
         if not count:
             return t("gateway.deny.no_pending")
 
@@ -17927,6 +17980,35 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_id = approval_data.get("approval_id", "")
+
+                def _send_approval_mirror() -> None:
+                    """Mirror approval prompts to the configured out-of-thread platform."""
+                    platform_name = _approval_notify_platform()
+                    if platform_name != "whatsapp":
+                        return
+                    try:
+                        mirror_platform = Platform.WHATSAPP
+                        mirror_adapter = self.adapters.get(mirror_platform)
+                        mirror_home = self.config.get_home_channel(mirror_platform)
+                        if mirror_adapter is None or mirror_home is None or not mirror_home.chat_id:
+                            logger.warning("Approval mirror requested for WhatsApp but no WhatsApp home channel/adapter is available")
+                            return
+                        if source.platform == mirror_platform and str(source.chat_id) == str(mirror_home.chat_id):
+                            return
+                        mirror_msg = _build_exec_approval_text(cmd, desc, approval_id)
+                        mirror_fut = safe_schedule_threadsafe(
+                            mirror_adapter.send(mirror_home.chat_id, mirror_msg),
+                            _loop_for_step,
+                            logger=logger,
+                            log_message="Approval WhatsApp mirror scheduling error",
+                        )
+                        if mirror_fut is not None:
+                            mirror_fut.result(timeout=15)
+                    except Exception as _e:
+                        logger.warning("Failed to mirror approval request to WhatsApp: %s", _e)
+
+                _send_approval_mirror()
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -17960,14 +18042,7 @@ class GatewayRunner:
                         )
 
                 # Fallback: plain text approval prompt
-                cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
-                msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
-                    f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
-                    f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                    f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
-                )
+                msg = _build_exec_approval_text(cmd, desc, approval_id="")
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(
                         _status_adapter.send(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1784,6 +1784,7 @@ DEFAULT_CONFIG = {
     # Approval mode for dangerous commands:
     #   manual — always prompt the user (default)
     #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
+    #   policy — deterministic policy: approve/deny by default, manually prompt matching commands
     #   off    — skip all approval prompts (equivalent to --yolo)
     #
     # cron_mode — what to do when a cron job hits a dangerous command:
@@ -1793,6 +1794,14 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        "policy": {
+            "default": "manual",
+            "require_manual": [],
+        },
+        "notify": {
+            "enabled": False,
+            "platform": "",
+        },
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -58,6 +58,26 @@ def _make_adapter():
 
 
 # ===========================================================================
+# Cross-platform approval prompt text
+# ===========================================================================
+
+def test_plain_approval_prompt_includes_cross_channel_approval_id():
+    from gateway.run import _build_exec_approval_text
+
+    msg = _build_exec_approval_text(
+        "hermes update",
+        "hermes update (restarts gateway, kills running agents)",
+        approval_id="Ab3_xYz9",
+    )
+
+    assert "/approve Ab3_xYz9" in msg
+    assert "/approve Ab3_xYz9 session" in msg
+    assert "/approve Ab3_xYz9 always" in msg
+    assert "/deny Ab3_xYz9" in msg
+    assert "hermes update" in msg
+
+
+# ===========================================================================
 # send_exec_approval — Block Kit buttons
 # ===========================================================================
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1379,6 +1379,142 @@ class TestEtcPatternsUnaffectedByRefactor:
 # =========================================================================
 
 
+class TestPolicyApprovalMode:
+    SESSION_KEY = "test-policy-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+        if hasattr(mod, "_approval_id_index"):
+            mod._approval_id_index.clear()
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        if hasattr(mod, "_approval_id_index"):
+            mod._approval_id_index.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_policy_default_approve_skips_prompt_for_non_lifecycle_danger(self, monkeypatch):
+        from tools import approval as mod
+        monkeypatch.setattr(
+            mod, "_get_approval_config",
+            lambda: {
+                "mode": "policy",
+                "gateway_timeout": 1,
+                "policy": {
+                    "default": "approve",
+                    "require_manual": ["stop/restart hermes gateway", "hermes update"],
+                },
+            },
+        )
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is True
+        assert notified == []
+        assert result.get("policy_approved") is True
+
+    def test_policy_requires_manual_for_hermes_update(self, monkeypatch):
+        from tools import approval as mod
+        monkeypatch.setattr(
+            mod, "_get_approval_config",
+            lambda: {
+                "mode": "policy",
+                "gateway_timeout": 1,
+                "policy": {
+                    "default": "approve",
+                    "require_manual": ["stop/restart hermes gateway", "hermes update"],
+                },
+            },
+        )
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result_holder = {}
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards("hermes update", "local")
+        t = threading.Thread(target=_check)
+        t.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.02)
+
+        assert notified, "policy-gated Hermes update did not request approval"
+        assert notified[0]["approval_id"]
+        assert notified[0]["description"] == "hermes update (restarts gateway, kills running agents)"
+
+        resolved = mod.resolve_gateway_approval_by_id(notified[0]["approval_id"], "once")
+        t.join(timeout=5)
+
+        assert resolved == 1
+        assert result_holder["r"]["approved"] is True
+
+    def test_approval_id_can_be_resolved_from_other_gateway_session(self, monkeypatch):
+        from tools import approval as mod
+        monkeypatch.setattr(mod, "_get_approval_config", lambda: {"mode": "manual", "gateway_timeout": 1})
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result_holder = {}
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards("hermes gateway restart", "local")
+        t = threading.Thread(target=_check)
+        t.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.02)
+
+        other_session = "agent:main:whatsapp:dm:home"
+        assert other_session != self.SESSION_KEY
+        resolved = mod.resolve_gateway_approval_by_id(notified[0]["approval_id"], "once")
+        t.join(timeout=5)
+
+        assert resolved == 1
+        assert result_holder["r"]["approved"] is True
+
+    def test_policy_default_approve_skips_execute_code_prompt(self, monkeypatch):
+        from tools import approval as mod
+        monkeypatch.setattr(
+            mod, "_get_approval_config",
+            lambda: {
+                "mode": "policy",
+                "gateway_timeout": 1,
+                "policy": {"default": "approve", "require_manual": ["hermes update"]},
+            },
+        )
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_execute_code_guard("print('safe')", "local")
+
+        assert result["approved"] is True
+        assert notified == []
+        assert result.get("policy_approved") is True
+
+
 class TestApprovalTimeoutIsNotConsent:
     """The gateway approval contract: silence is not consent (#24912)."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -11,6 +11,7 @@ This module is the single source of truth for the dangerous command system:
 import contextvars
 import logging
 import os
+import secrets
 import re
 import sys
 import threading
@@ -566,16 +567,25 @@ _permanent_approved: set = set()
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result")
+    __slots__ = ("approval_id", "session_key", "event", "data", "result")
 
-    def __init__(self, data: dict):
+    def __init__(self, session_key: str, data: dict):
+        self.approval_id = _new_approval_id()
+        self.session_key = session_key
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.data = dict(data, approval_id=self.approval_id)  # command, description, pattern_keys, …
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_approval_id_index: dict[str, _ApprovalEntry] = {}  # short id → _ApprovalEntry
+
+
+def _new_approval_id() -> str:
+    """Return a short human-copyable id for cross-channel approval replies."""
+    # 8 chars is enough for the tiny live pending set while staying WhatsApp-friendly.
+    return secrets.token_urlsafe(6).replace("-", "_")[:8]
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -599,6 +609,8 @@ def unregister_gateway_notify(session_key: str) -> None:
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            _approval_id_index.pop(entry.approval_id, None)
     for entry in entries:
         entry.event.set()
 
@@ -623,6 +635,8 @@ def resolve_gateway_approval(session_key: str, choice: str,
             queue.clear()
         else:
             targets = [queue.pop(0)]
+        for entry in targets:
+            _approval_id_index.pop(entry.approval_id, None)
         if not queue:
             _gateway_queues.pop(session_key, None)
 
@@ -630,6 +644,31 @@ def resolve_gateway_approval(session_key: str, choice: str,
         entry.result = choice
         entry.event.set()
     return len(targets)
+
+
+def resolve_gateway_approval_by_id(approval_id: str, choice: str) -> int:
+    """Resolve one pending approval by id, regardless of the replying session.
+
+    This lets an approval request mirrored to a second platform (for example
+    WhatsApp) unblock the original Slack/Telegram/etc. agent turn without
+    requiring the user to be watching that original thread.
+    """
+    approval_id = (approval_id or "").strip()
+    if not approval_id:
+        return 0
+    with _lock:
+        entry = _approval_id_index.pop(approval_id, None)
+        if entry is None:
+            return 0
+        queue = _gateway_queues.get(entry.session_key, [])
+        if entry in queue:
+            queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(entry.session_key, None)
+
+    entry.result = choice
+    entry.event.set()
+    return 1
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -675,6 +714,8 @@ def clear_session(session_key: str) -> None:
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            _approval_id_index.pop(entry.approval_id, None)
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
         # immediately so the old run can unwind instead of idling until timeout.
@@ -914,6 +955,36 @@ def _get_approval_timeout() -> int:
         return 60
 
 
+def _get_policy_approval_config() -> dict:
+    """Return normalized policy-mode approval settings."""
+    config = _get_approval_config()
+    policy = config.get("policy", {}) or {}
+    if not isinstance(policy, dict):
+        policy = {}
+    default = str(policy.get("default", config.get("policy_default", "manual"))).lower().strip()
+    if default in {"approve", "allow", "yes", "off"}:
+        default = "approve"
+    elif default in {"deny", "block", "no"}:
+        default = "deny"
+    else:
+        default = "manual"
+    require_manual = policy.get("require_manual", config.get("policy_require_manual", [])) or []
+    if isinstance(require_manual, str):
+        require_manual = [require_manual]
+    require_manual = [str(item).lower().strip() for item in require_manual if str(item).strip()]
+    return {"default": default, "require_manual": require_manual}
+
+
+def _policy_decision_for_warnings(command: str, warnings: list[tuple[str, str, bool]]) -> str:
+    """Return approve/manual/deny for policy mode."""
+    policy = _get_policy_approval_config()
+    haystack = " ".join([command] + [desc for _, desc, _ in warnings]).lower()
+    for needle in policy["require_manual"]:
+        if needle and needle in haystack:
+            return "manual"
+    return policy["default"]
+
+
 def _get_cron_approval_mode() -> str:
     """Read the cron approval mode from config. Returns 'deny' or 'approve'."""
     try:
@@ -1129,15 +1200,18 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
-    entry = _ApprovalEntry(approval_data)
+    entry = _ApprovalEntry(session_key, approval_data)
+    approval_data = entry.data
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
+        _approval_id_index[entry.approval_id] = entry
 
     def _drop_entry() -> None:
         with _lock:
             queue = _gateway_queues.get(session_key, [])
             if entry in queue:
                 queue.remove(entry)
+            _approval_id_index.pop(entry.approval_id, None)
             if not queue:
                 _gateway_queues.pop(session_key, None)
 
@@ -1314,6 +1388,27 @@ def check_all_command_guards(command: str, env_type: str,
     # Nothing to warn about
     if not warnings:
         return {"approved": True, "message": None}
+
+    # --- Phase 2.5: Policy approval (deterministic allow/manual/deny) ---
+    # When approvals.mode=policy, use configured manual-only matchers instead
+    # of prompting for every pattern false-positive. Hardline/runtime/sudo
+    # blocks above remain non-bypassable.
+    if approval_mode == "policy":
+        decision = _policy_decision_for_warnings(command, warnings)
+        combined_desc_for_policy = "; ".join(desc for _, desc, _ in warnings)
+        if decision == "approve":
+            logger.debug("Policy approval: auto-approved '%s' (%s)",
+                         command[:60], combined_desc_for_policy)
+            return {"approved": True, "message": None,
+                    "policy_approved": True,
+                    "description": combined_desc_for_policy}
+        if decision == "deny":
+            return {
+                "approved": False,
+                "message": f"BLOCKED by approval policy: {combined_desc_for_policy}. Do NOT retry.",
+                "policy_denied": True,
+            }
+        # decision == "manual" → fall through to gateway/CLI prompt
 
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
@@ -1574,6 +1669,26 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     # Built only now (past the early-return gates) so the common non-approval
     # paths don't pay to copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"
+
+    # Policy mode: deterministic approval for the whole script. Per-call
+    # terminal() guards still run for shell commands issued from the script.
+    if approval_mode == "policy":
+        decision = _policy_decision_for_warnings(command, [(pattern_key, description, False)])
+        if decision == "approve":
+            logger.debug("Policy approval: auto-approved execute_code for session %s", session_key)
+            return {"approved": True, "message": None,
+                    "policy_approved": True, "description": description}
+        if decision == "deny":
+            return {
+                "approved": False,
+                "message": "BLOCKED by approval policy: execute_code script execution. Do NOT retry.",
+                "policy_denied": True,
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "denied",
+                "user_consent": False,
+            }
+        # decision == "manual" → fall through to manual approval
 
     # Smart mode: ask the aux LLM about the whole script. An APPROVE here only
     # suppresses the redundant whole-script prompt; the per-call terminal()


### PR DESCRIPTION
Adds deterministic policy-mode approvals plus cross-channel approval IDs so approval prompts can be mirrored to WhatsApp and approved from there.\n\nImplemented:\n- approvals.mode: policy with policy.default approve/manual/deny and policy.require_manual matchers\n- short approval IDs resolvable from any gateway session via /approve <id> or /deny <id>\n- optional approvals.notify platform config; currently supports WhatsApp mirror to home channel\n- plain approval prompt includes ID-scoped approve/deny commands\n\nVerification:\n- /root/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_approval.py tests/gateway/test_slack_approval_buttons.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_cron_approval_mode.py tests/tools/test_approval_plugin_hooks.py -q\n- /root/.hermes/hermes-agent/venv/bin/python -m py_compile tools/approval.py gateway/run.py hermes_cli/config.py\n- git diff --check