### PR TITLE
fix: clear stale session env in subprocesses

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -85,6 +85,29 @@ _VAR_MAP = {
 }
 
 
+def session_context_env_overlay(strip_unset: bool = False) -> list[tuple[str, str | None]]:
+    """Return session env overlay actions derived from ContextVars.
+
+    Each item is ``(name, value)``. A string value means set/export that exact
+    value. ``None`` means remove/unset the variable and is only emitted when
+    ``strip_unset`` is true and the ContextVar is still ``_UNSET``.
+
+    This gives all subprocess/shell bridges one shared interpretation of the
+    session ContextVars: explicit empty values clear stale state, while gateway
+    callers can also make ``_UNSET`` authoritative and strip process-global
+    values that may belong to another concurrent session.
+    """
+    overlay: list[tuple[str, str | None]] = []
+    for var_name, var in _VAR_MAP.items():
+        value = var.get()
+        if value is _UNSET:
+            if strip_unset:
+                overlay.append((var_name, None))
+            continue
+        overlay.append((var_name, "" if value is None else str(value)))
+    return overlay
+
+
 def set_current_session_id(session_id: str) -> None:
     """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ``.
 

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -89,6 +89,85 @@ class TestWrapCommand:
 
         assert "exit 126" in wrapped
 
+    def test_session_context_overlay_runs_after_snapshot_source(self):
+        """Explicit empty session vars must override stale snapshot values."""
+        from gateway.session_context import (
+            _UNSET,
+            _VAR_MAP,
+            clear_session_vars,
+            set_session_vars,
+        )
+
+        tokens = set_session_vars(
+            platform="mattermost",
+            chat_id="trading_channel",
+            thread_id="",
+            session_key="mattermost:trading",
+            message_id="trading_top_post",
+        )
+        try:
+            env = _TestableEnv()
+            env._snapshot_ready = True
+            wrapped = env._wrap_command("echo hello", "/tmp")
+        finally:
+            clear_session_vars(tokens)
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+        lines = wrapped.splitlines()
+        source_idx = next(i for i, line in enumerate(lines) if line.startswith("source "))
+        thread_idx = lines.index("export HERMES_SESSION_THREAD_ID=''")
+        eval_idx = lines.index("eval 'echo hello'")
+
+        assert source_idx < thread_idx < eval_idx
+        assert "export HERMES_SESSION_CHAT_ID=trading_channel" in lines
+        assert "export HERMES_SESSION_KEY=mattermost:trading" in lines
+
+    def test_gateway_unset_session_context_clears_stale_snapshot_values(self, monkeypatch):
+        """Under the gateway, _UNSET session ContextVars must not inherit stale snapshot state."""
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        saved = {var: var.get() for var in _VAR_MAP.values()}
+        try:
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+            env = _TestableEnv()
+            env._snapshot_ready = True
+            wrapped = env._wrap_command("echo hello", "/tmp")
+        finally:
+            for var, value in saved.items():
+                var.set(value)
+
+        lines = wrapped.splitlines()
+        source_idx = next(i for i, line in enumerate(lines) if line.startswith("source "))
+        unset_idx = lines.index("unset HERMES_SESSION_KEY")
+        eval_idx = lines.index("eval 'echo hello'")
+        dump_idx = next(i for i, line in enumerate(lines) if line.startswith("export -p >"))
+
+        assert source_idx < unset_idx < eval_idx < dump_idx
+        assert "export HERMES_SESSION_KEY" not in lines
+
+    def test_unset_session_context_preserves_cli_snapshot_fallback(self, monkeypatch):
+        """Outside the gateway, _UNSET preserves the existing CLI/cron env fallback."""
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        saved = {var: var.get() for var in _VAR_MAP.values()}
+        try:
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+            env = _TestableEnv()
+            env._snapshot_ready = True
+            wrapped = env._wrap_command("echo hello", "/tmp")
+        finally:
+            for var, value in saved.items():
+                var.set(value)
+
+        assert "unset HERMES_SESSION_KEY" not in wrapped.splitlines()
+
 
 class TestExtractCwdFromOutput:
     def test_happy_path(self):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -404,6 +404,7 @@ class TestSanePathIncludesHomebrew:
         launchd_env = {"PATH": "/usr/local/bin:/usr/bin:/bin"}
         with patch.dict(os.environ, launchd_env, clear=True):
             result = _make_run_env({})
+
         path_entries = result["PATH"].split(":")
         assert "/opt/homebrew/bin" in path_entries
         assert "/opt/homebrew/sbin" in path_entries
@@ -471,3 +472,228 @@ class TestSanePathIncludesHomebrew:
             result = _make_run_env({})
         assert result["Path"] == windows_env["Path"]
         assert "PATH" not in result
+
+class TestSessionEnvBridge:
+    @staticmethod
+    def _reset_session_context_vars():
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        saved = {var: var.get() for var in _VAR_MAP.values()}
+        for var in _VAR_MAP.values():
+            var.set(_UNSET)
+        return saved
+
+    @staticmethod
+    def _restore_session_context_vars(saved):
+        for var, value in saved.items():
+            var.set(value)
+
+    def test_make_run_env_explicit_empty_context_clears_stale_process_env(self):
+        """Explicit empty ContextVars must not inherit stale process env values."""
+        from gateway.session_context import (
+            _UNSET,
+            _VAR_MAP,
+            clear_session_vars,
+            set_session_vars,
+        )
+        from tools.environments.local import _make_run_env
+
+        stale_env = {
+            "PATH": "/usr/bin:/bin",
+            "HERMES_SESSION_PLATFORM": "mattermost",
+            "HERMES_SESSION_CHAT_ID": "ekum_fantasy_channel",
+            "HERMES_SESSION_THREAD_ID": "ekum_fantasy_thread",
+            "HERMES_SESSION_MESSAGE_ID": "ekum_fantasy_post",
+        }
+        tokens = set_session_vars(
+            platform="mattermost",
+            chat_id="trading_channel",
+            thread_id="",
+            session_key="mattermost:trading",
+            message_id="trading_top_post",
+        )
+        try:
+            with patch.dict(os.environ, stale_env, clear=True):
+                result = _make_run_env({})
+        finally:
+            clear_session_vars(tokens)
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+        assert result["HERMES_SESSION_PLATFORM"] == "mattermost"
+        assert result["HERMES_SESSION_CHAT_ID"] == "trading_channel"
+        assert result["HERMES_SESSION_THREAD_ID"] == ""
+        assert result["HERMES_SESSION_MESSAGE_ID"] == "trading_top_post"
+        assert result["HERMES_SESSION_KEY"] == "mattermost:trading"
+
+    def test_make_run_env_gateway_unset_context_strips_foreign_session_env(self):
+        """Foreground env must not leak a foreign process-global session under the gateway."""
+        from tools.environments.local import _make_run_env
+
+        saved = self._reset_session_context_vars()
+        try:
+            stale_env = {
+                "PATH": "/usr/bin:/bin",
+                "_HERMES_GATEWAY": "1",
+                "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN:X",
+                "HERMES_SESSION_THREAD_ID": "FOREIGN_THREAD",
+            }
+            with patch.dict(os.environ, stale_env, clear=True):
+                result = _make_run_env({})
+        finally:
+            self._restore_session_context_vars(saved)
+
+        assert "HERMES_SESSION_KEY" not in result
+        assert "HERMES_SESSION_THREAD_ID" not in result
+
+    def test_make_run_env_gateway_partial_unset_strips_only_unset_session_vars(self):
+        """A partially-bound gateway context keeps bound values and strips only _UNSET vars."""
+        from gateway.session_context import _UNSET, _VAR_MAP, clear_session_vars, set_session_vars
+        from tools.environments.local import _make_run_env
+
+        tokens = set_session_vars(
+            platform="discord",
+            chat_id="CORRECT_CHAT",
+            thread_id="CORRECT_THREAD",
+            session_key="agent:main:discord:group:CORRECT_CHAT:1",
+        )
+        try:
+            _VAR_MAP["HERMES_SESSION_THREAD_ID"].set(_UNSET)
+            with patch.dict(os.environ, {
+                "PATH": "/usr/bin:/bin",
+                "_HERMES_GATEWAY": "1",
+                "HERMES_SESSION_CHAT_ID": "FOREIGN_CHAT",
+                "HERMES_SESSION_THREAD_ID": "FOREIGN_THREAD",
+                "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN:X",
+            }, clear=True):
+                result = _make_run_env({})
+        finally:
+            clear_session_vars(tokens)
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+        assert result["HERMES_SESSION_CHAT_ID"] == "CORRECT_CHAT"
+        assert result["HERMES_SESSION_KEY"] == "agent:main:discord:group:CORRECT_CHAT:1"
+        assert "HERMES_SESSION_THREAD_ID" not in result
+
+    def test_make_run_env_thread_without_copied_context_does_not_inherit_foreign_gateway_env(self):
+        """Regression for fresh worker threads whose ContextVars are _UNSET."""
+        from gateway.session_context import _UNSET, _VAR_MAP, clear_session_vars, set_session_vars
+        from tools.environments.local import _make_run_env
+
+        observed = []
+        tokens = set_session_vars(
+            platform="discord",
+            chat_id="CORRECT_CHAT",
+            session_key="agent:main:discord:group:CORRECT_CHAT:1",
+        )
+        try:
+            with patch.dict(os.environ, {
+                "PATH": "/usr/bin:/bin",
+                "_HERMES_GATEWAY": "1",
+                "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN:X",
+                "HERMES_SESSION_THREAD_ID": "FOREIGN_THREAD",
+            }, clear=True):
+                def worker():
+                    observed.append(_make_run_env({}))
+
+                t = threading.Thread(target=worker)
+                t.start()
+                t.join(timeout=5)
+                assert not t.is_alive()
+        finally:
+            clear_session_vars(tokens)
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+        assert len(observed) == 1
+        assert "HERMES_SESSION_KEY" not in observed[0]
+        assert "HERMES_SESSION_THREAD_ID" not in observed[0]
+
+    def test_make_run_env_unset_context_preserves_cli_env_fallback(self):
+        """Outside the gateway, CLI/cron still inherit HERMES_SESSION_* from os.environ."""
+        from tools.environments.local import _make_run_env
+
+        saved = self._reset_session_context_vars()
+        try:
+            cli_env = {
+                "PATH": "/usr/bin:/bin",
+                "HERMES_SESSION_KEY": "cli:session:kept",
+            }
+            with patch.dict(os.environ, cli_env, clear=True):
+                result = _make_run_env({})
+        finally:
+            self._restore_session_context_vars(saved)
+
+        assert result["HERMES_SESSION_KEY"] == "cli:session:kept"
+
+    def test_sanitize_subprocess_env_explicit_empty_context_clears_stale_env(self):
+        """Background subprocess env must use the same session overlay as foreground."""
+        from gateway.session_context import (
+            _UNSET,
+            _VAR_MAP,
+            clear_session_vars,
+            set_session_vars,
+        )
+        from tools.environments.local import _sanitize_subprocess_env
+
+        stale_env = {
+            "PATH": "/usr/bin:/bin",
+            "HERMES_SESSION_PLATFORM": "mattermost",
+            "HERMES_SESSION_CHAT_ID": "ekum_fantasy_channel",
+            "HERMES_SESSION_THREAD_ID": "ekum_fantasy_thread",
+            "HERMES_SESSION_MESSAGE_ID": "ekum_fantasy_post",
+        }
+        tokens = set_session_vars(
+            platform="mattermost",
+            chat_id="trading_channel",
+            thread_id="",
+            session_key="mattermost:trading",
+            message_id="trading_top_post",
+        )
+        try:
+            result = _sanitize_subprocess_env(stale_env)
+        finally:
+            clear_session_vars(tokens)
+            for var in _VAR_MAP.values():
+                var.set(_UNSET)
+
+        assert result["HERMES_SESSION_PLATFORM"] == "mattermost"
+        assert result["HERMES_SESSION_CHAT_ID"] == "trading_channel"
+        assert result["HERMES_SESSION_THREAD_ID"] == ""
+        assert result["HERMES_SESSION_MESSAGE_ID"] == "trading_top_post"
+        assert result["HERMES_SESSION_KEY"] == "mattermost:trading"
+
+    def test_sanitize_subprocess_env_gateway_unset_context_strips_foreign_session_env(self):
+        """Background env must use the same gateway _UNSET strip policy as foreground."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        saved = self._reset_session_context_vars()
+        try:
+            with patch.dict(os.environ, {"_HERMES_GATEWAY": "1"}, clear=True):
+                result = _sanitize_subprocess_env({
+                    "PATH": "/usr/bin:/bin",
+                    "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN:X",
+                    "HERMES_SESSION_THREAD_ID": "FOREIGN_THREAD",
+                })
+        finally:
+            self._restore_session_context_vars(saved)
+
+        assert "HERMES_SESSION_KEY" not in result
+        assert "HERMES_SESSION_THREAD_ID" not in result
+
+    def test_sanitize_subprocess_env_unset_context_preserves_cli_env_fallback(self):
+        """Background CLI/cron subprocesses keep explicit process env fallback values."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        saved = self._reset_session_context_vars()
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                result = _sanitize_subprocess_env({
+                    "PATH": "/usr/bin:/bin",
+                    "HERMES_SESSION_KEY": "cli:session:kept",
+                })
+        finally:
+            self._restore_session_context_vars(saved)
+
+        assert result["HERMES_SESSION_KEY"] == "cli:session:kept"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -414,6 +414,31 @@ class BaseEnvironment(ABC):
             return f"$HOME/{shlex.quote(cwd[2:])}"
         return shlex.quote(cwd)
 
+    @staticmethod
+    def _session_context_env_exports() -> list[str]:
+        """Return shell exports for explicitly-bound gateway session context.
+
+        Command shells source a persistent snapshot before running user code.
+        If the current gateway turn deliberately has an empty value (for
+        example a top-level Mattermost post with no thread id), that empty
+        value must overwrite any older value saved in the snapshot. Under the
+        gateway, an unset ContextVar must also clear a possibly-foreign
+        process-global/snapshot value from another concurrent session.
+        """
+        try:
+            from gateway.session_context import session_context_env_overlay
+        except ImportError:
+            return []
+
+        under_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
+        exports: list[str] = []
+        for var_name, value in session_context_env_overlay(strip_unset=under_gateway):
+            if value is None:
+                exports.append(f"unset {var_name}")
+                continue
+            exports.append(f"export {var_name}={shlex.quote(value)}")
+        return exports
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -438,6 +463,8 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+
+        parts.extend(self._session_context_env_exports())
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -203,6 +203,27 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _inject_session_context_env(env: dict) -> None:
+    """Bridge explicitly-bound gateway session ContextVars into subprocess env.
+
+    An explicitly empty value is meaningful: it clears any stale session value
+    inherited from os.environ or a previous shell snapshot. Under the gateway,
+    an unset ContextVar is also meaningful: do not inherit a process-global
+    value that may have been written by a different concurrent session.
+    """
+    try:
+        from gateway.session_context import session_context_env_overlay
+    except ImportError:
+        return
+
+    under_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
+    for var_name, value in session_context_env_overlay(strip_unset=under_gateway):
+        if value is None:
+            env.pop(var_name, None)
+            continue
+        env[var_name] = value
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -226,6 +247,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     _inject_context_hermes_home(sanitized)
+    _inject_session_context_env(sanitized)
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(sanitized)
@@ -387,16 +409,8 @@ def _make_run_env(env: dict) -> dict:
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(run_env)
 
-    # Inject ContextVar-based session vars into subprocess env.
-    # ContextVars don't propagate to child processes, so we bridge them here.
-    try:
-        from gateway.session_context import _UNSET, _VAR_MAP
-        for var_name, var in _VAR_MAP.items():
-            value = var.get()
-            if value is not _UNSET and value:
-                run_env[var_name] = value
-    except Exception:
-        pass
+    # ContextVars don't propagate to child processes, so bridge them here.
+    _inject_session_context_env(run_env)
 
     return run_env
 


### PR DESCRIPTION
## Summary

- bridge explicitly-bound gateway session ContextVars into foreground and background subprocess envs even when the current value is empty
- overlay session vars after sourcing the persistent shell snapshot so stale `HERMES_SESSION_*` values cannot leak into the command
- add regressions for foreground env construction, background env sanitization, and snapshot ordering

## Tests

- `python -m pytest tests/tools/test_local_env_blocklist.py::TestSessionEnvBridge::test_sanitize_subprocess_env_explicit_empty_context_clears_stale_env tests/tools/test_local_env_blocklist.py::TestSessionEnvBridge::test_make_run_env_explicit_empty_context_clears_stale_process_env tests/tools/test_base_environment.py::TestWrapCommand::test_session_context_overlay_runs_after_snapshot_source -q -o 'addopts='`
- `./scripts/run_tests.sh tests/tools/test_base_environment.py tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py tests/tools/test_process_registry.py tests/tools/test_terminal_tool.py tests/tools/test_init_session_cwd_respect.py tests/tools/test_local_shell_init.py tests/tools/test_local_env_cwd_recovery.py tests/test_subprocess_home_isolation.py tests/gateway/test_session_env.py`
- `python -m py_compile tools/environments/base.py tools/environments/local.py tests/tools/test_base_environment.py tests/tools/test_local_env_blocklist.py`
- `ruff check tools/environments/base.py tools/environments/local.py tests/tools/test_base_environment.py tests/tools/test_local_env_blocklist.py`
- `git diff --check`
- manual smoke: `LocalEnvironment` foreground and `ProcessRegistry.spawn_local()` background commands both saw the current chat id and an empty thread id over stale inherited `HERMES_SESSION_*` values
