### PR TITLE
feat(desktop): add themes and zoom controls

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -26,6 +26,7 @@ const { execFileSync, spawn } = require('node:child_process')
 const { isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { createZoomController } = require('./zoom-controller.cjs')
 const {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -190,6 +191,7 @@ const BOOTSTRAP_MARKER_SCHEMA_VERSION = 1
 
 const DESKTOP_CONNECTION_CONFIG_PATH = path.join(app.getPath('userData'), 'connection.json')
 const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
+const DESKTOP_ZOOM_CONFIG_PATH = path.join(app.getPath('userData'), 'zoom.json')
 // Branch we track for self-update. The GUI work has merged to main, so this
 // tracks main. User can also override at runtime via
 // hermesDesktop.updates.setBranch().
@@ -445,6 +447,12 @@ let previewShortcutActive = false
 let desktopLogBuffer = ''
 let desktopLogFlushTimer = null
 let desktopLogFlushPromise = Promise.resolve()
+const zoomController = createZoomController({
+  configPath: DESKTOP_ZOOM_CONFIG_PATH,
+  fs,
+  getWindow: () => mainWindow,
+  onChanged: payload => sendZoomChanged(payload)
+})
 let bootProgressState = {
   error: null,
   fakeMode: BOOT_FAKE_MODE,
@@ -2520,6 +2528,13 @@ function sendWindowStateChanged(nextIsFullscreen) {
   webContents.send('hermes:window-state-changed', state)
 }
 
+function sendZoomChanged(payload = zoomController.getState()) {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  const { webContents } = mainWindow
+  if (!webContents || webContents.isDestroyed()) return
+  webContents.send('hermes:zoom:changed', payload)
+}
+
 function buildApplicationMenu() {
   const template = []
   const checkForUpdatesItem = {
@@ -2582,9 +2597,21 @@ function buildApplicationMenu() {
       { role: 'forceReload' },
       { role: 'toggleDevTools' },
       { type: 'separator' },
-      { role: 'resetZoom' },
-      { role: 'zoomIn' },
-      { role: 'zoomOut' },
+      {
+        accelerator: 'CommandOrControl+0',
+        click: () => zoomController.reset(),
+        label: 'Actual Size'
+      },
+      {
+        accelerator: 'CommandOrControl+=',
+        click: () => zoomController.adjust(1),
+        label: 'Zoom In'
+      },
+      {
+        accelerator: 'CommandOrControl+-',
+        click: () => zoomController.adjust(-1),
+        label: 'Zoom Out'
+      },
       { type: 'separator' },
       { role: 'togglefullscreen' }
     ]
@@ -2640,6 +2667,12 @@ function installPreviewShortcut(window) {
 
     event.preventDefault()
     sendClosePreviewRequested()
+  })
+}
+
+function installZoomShortcut(window) {
+  window.webContents.on('before-input-event', (event, input) => {
+    zoomController.handleBeforeInput(event, input)
   })
 }
 
@@ -3207,6 +3240,7 @@ function createWindow() {
 
   installPreviewShortcut(mainWindow)
   installDevToolsShortcut(mainWindow)
+  installZoomShortcut(mainWindow)
   installContextMenu(mainWindow)
   mainWindow.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
@@ -3228,14 +3262,21 @@ function createWindow() {
     mainWindow.loadURL(pathToFileURL(resolveRendererIndex()).toString())
   }
 
+  zoomController.load()
+
   mainWindow.webContents.once('did-finish-load', () => {
     broadcastBootProgress()
     sendWindowStateChanged()
+    sendZoomChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))
   })
 }
 
 ipcMain.handle('hermes:connection', async () => startHermes())
+ipcMain.handle('hermes:zoom:get', async () => zoomController.getState())
+ipcMain.handle('hermes:zoom:set', async (_event, factor) => zoomController.setFactor(factor))
+ipcMain.handle('hermes:zoom:adjust', async (_event, direction) => zoomController.adjust(direction))
+ipcMain.handle('hermes:zoom:reset', async () => zoomController.reset())
 ipcMain.handle('hermes:bootstrap:reset', async () => {
   // Renderer's "Reload and retry" path. Clear the latched failure and
   // reset connection state so the next startHermes() call restarts the

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -3,6 +3,17 @@ const { contextBridge, ipcRenderer, webUtils } = require('electron')
 contextBridge.exposeInMainWorld('hermesDesktop', {
   getConnection: () => ipcRenderer.invoke('hermes:connection'),
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),
+  zoom: {
+    get: () => ipcRenderer.invoke('hermes:zoom:get'),
+    set: factor => ipcRenderer.invoke('hermes:zoom:set', factor),
+    adjust: direction => ipcRenderer.invoke('hermes:zoom:adjust', direction),
+    reset: () => ipcRenderer.invoke('hermes:zoom:reset'),
+    onChanged: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:zoom:changed', listener)
+      return () => ipcRenderer.removeListener('hermes:zoom:changed', listener)
+    }
+  },
   getConnectionConfig: () => ipcRenderer.invoke('hermes:connection-config:get'),
   saveConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:save', payload),
   applyConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:apply', payload),

--- a/apps/desktop/electron/zoom-controller.cjs
+++ b/apps/desktop/electron/zoom-controller.cjs
@@ -1,0 +1,140 @@
+'use strict'
+
+const DEFAULT_ZOOM_FACTOR = 1
+const ZOOM_FACTORS = Object.freeze([0.5, 0.67, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2])
+const MIN_ZOOM_FACTOR = ZOOM_FACTORS[0]
+const MAX_ZOOM_FACTOR = ZOOM_FACTORS[ZOOM_FACTORS.length - 1]
+
+function normalizeZoomFactor(value) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return DEFAULT_ZOOM_FACTOR
+  return Math.round(parsed * 100) / 100
+}
+
+function clampZoomFactor(value) {
+  const normalized = normalizeZoomFactor(value)
+  if (normalized < MIN_ZOOM_FACTOR) return MIN_ZOOM_FACTOR
+  if (normalized > MAX_ZOOM_FACTOR) return MAX_ZOOM_FACTOR
+  return normalized
+}
+
+function getZoomPercent(value) {
+  return Math.round(clampZoomFactor(value) * 100)
+}
+
+function getNextZoomFactor(current, direction) {
+  const factor = clampZoomFactor(current)
+  const step = direction >= 0 ? 1 : -1
+
+  if (step > 0) {
+    return ZOOM_FACTORS.find(next => next > factor + 0.001) ?? MAX_ZOOM_FACTOR
+  }
+
+  for (let index = ZOOM_FACTORS.length - 1; index >= 0; index -= 1) {
+    if (ZOOM_FACTORS[index] < factor - 0.001) {
+      return ZOOM_FACTORS[index]
+    }
+  }
+
+  return MIN_ZOOM_FACTOR
+}
+
+function isZoomAccelerator(input) {
+  if (!input || input.alt || (!input.control && !input.meta)) {
+    return null
+  }
+
+  const key = String(input.key || '').toLowerCase()
+  const code = String(input.code || '')
+
+  if (key === '+' || key === '=' || code === 'Equal' || code === 'NumpadAdd') {
+    return 'in'
+  }
+
+  if (key === '-' || key === '_' || code === 'Minus' || code === 'NumpadSubtract') {
+    return 'out'
+  }
+
+  if (key === '0' || code === 'Digit0' || code === 'Numpad0') {
+    return 'reset'
+  }
+
+  return null
+}
+
+function createZoomController({ fs, configPath, getWindow, onChanged } = {}) {
+  let factor = DEFAULT_ZOOM_FACTOR
+
+  const readPersistedFactor = () => {
+    if (!fs || !configPath) return DEFAULT_ZOOM_FACTOR
+
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+      return clampZoomFactor(parsed?.factor)
+    } catch {
+      return DEFAULT_ZOOM_FACTOR
+    }
+  }
+
+  const persistFactor = next => {
+    if (!fs || !configPath) return
+
+    try {
+      fs.mkdirSync(require('node:path').dirname(configPath), { recursive: true })
+      fs.writeFileSync(configPath, `${JSON.stringify({ factor: next }, null, 2)}\n`)
+    } catch {
+      // Zoom should still work for this session if persistence fails.
+    }
+  }
+
+  const applyToWindow = targetWindow => {
+    const win = targetWindow || getWindow?.()
+    const webContents = win?.webContents
+    if (!webContents || webContents.isDestroyed?.()) return
+    webContents.setZoomFactor(factor)
+  }
+
+  const emitChanged = () => {
+    const payload = { factor, percent: getZoomPercent(factor) }
+    onChanged?.(payload)
+    return payload
+  }
+
+  const setFactor = (value, { persist = true } = {}) => {
+    factor = clampZoomFactor(value)
+    applyToWindow()
+    if (persist) persistFactor(factor)
+    return emitChanged()
+  }
+
+  const reset = () => setFactor(DEFAULT_ZOOM_FACTOR)
+  const adjust = direction => setFactor(getNextZoomFactor(factor, direction))
+  const getState = () => ({ factor, percent: getZoomPercent(factor) })
+  const load = () => setFactor(readPersistedFactor(), { persist: false })
+
+  const handleBeforeInput = (event, input) => {
+    const action = isZoomAccelerator(input)
+    if (!action) return false
+
+    event?.preventDefault?.()
+    if (action === 'in') adjust(1)
+    if (action === 'out') adjust(-1)
+    if (action === 'reset') reset()
+    return true
+  }
+
+  return { adjust, applyToWindow, getState, handleBeforeInput, load, reset, setFactor }
+}
+
+module.exports = {
+  DEFAULT_ZOOM_FACTOR,
+  MAX_ZOOM_FACTOR,
+  MIN_ZOOM_FACTOR,
+  ZOOM_FACTORS,
+  clampZoomFactor,
+  createZoomController,
+  getNextZoomFactor,
+  getZoomPercent,
+  isZoomAccelerator,
+  normalizeZoomFactor
+}

--- a/apps/desktop/electron/zoom-controller.test.cjs
+++ b/apps/desktop/electron/zoom-controller.test.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  ZOOM_FACTORS,
+  clampZoomFactor,
+  getNextZoomFactor,
+  getZoomPercent,
+  isZoomAccelerator,
+  normalizeZoomFactor
+} = require('./zoom-controller.cjs')
+
+test('normalizes zoom factors to the supported range and precision', () => {
+  assert.equal(clampZoomFactor(0.1), ZOOM_FACTORS[0])
+  assert.equal(clampZoomFactor(9), ZOOM_FACTORS.at(-1))
+  assert.equal(normalizeZoomFactor(1.234), 1.23)
+  assert.equal(normalizeZoomFactor('bad'), 1)
+  assert.equal(getZoomPercent(1.25), 125)
+})
+
+test('steps zoom through modern desktop zoom stops', () => {
+  assert.equal(getNextZoomFactor(1, 1), 1.1)
+  assert.equal(getNextZoomFactor(1.1, 1), 1.25)
+  assert.equal(getNextZoomFactor(1.25, -1), 1.1)
+  assert.equal(getNextZoomFactor(1.24, 1), 1.25)
+  assert.equal(getNextZoomFactor(2, 1), 2)
+  assert.equal(getNextZoomFactor(0.5, -1), 0.5)
+})
+
+test('recognizes browser-style zoom accelerators', () => {
+  assert.equal(isZoomAccelerator({ control: true, meta: false, alt: false, key: '+', code: 'Equal' }), 'in')
+  assert.equal(isZoomAccelerator({ control: true, meta: false, alt: false, key: '=', code: 'Equal' }), 'in')
+  assert.equal(isZoomAccelerator({ control: true, meta: false, alt: false, key: '-', code: 'Minus' }), 'out')
+  assert.equal(isZoomAccelerator({ control: true, meta: false, alt: false, key: '0', code: 'Digit0' }), 'reset')
+  assert.equal(isZoomAccelerator({ control: false, meta: true, alt: false, key: '+', code: 'Equal' }), 'in')
+  assert.equal(isZoomAccelerator({ control: true, meta: false, alt: true, key: '+', code: 'Equal' }), null)
+  assert.equal(isZoomAccelerator({ control: false, meta: false, alt: false, key: '+', code: 'Equal' }), null)
+})

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -46,6 +46,7 @@ import {
   setSessionsTotal
 } from '../store/session'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '../store/updates'
+import { initializeZoom, zoomIn, zoomOut } from '../store/zoom'
 
 import { ChatView } from './chat'
 import { useComposerActions } from './chat/hooks/use-composer-actions'
@@ -90,6 +91,8 @@ const MessagingView = lazy(async () => ({ default: (await import('./messaging'))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
+
+const ZOOM_WHEEL_MIN_INTERVAL_MS = 80
 
 export function DesktopController() {
   const queryClient = useQueryClient()
@@ -157,6 +160,70 @@ export function DesktopController() {
   useEffect(() => {
     window.hermesDesktop?.setPreviewShortcutActive?.(Boolean(chatOpen && (filePreviewTarget || previewTarget)))
   }, [chatOpen, filePreviewTarget, previewTarget])
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined
+    void initializeZoom().then(result => {
+      unsubscribe = typeof result === 'object' && 'unsubscribe' in result ? result.unsubscribe : undefined
+    })
+
+    return () => unsubscribe?.()
+  }, [])
+
+  useEffect(() => {
+    let lastZoomAt = 0
+    let pendingDirection: -1 | 1 | null = null
+    let pendingTimer: ReturnType<typeof window.setTimeout> | undefined
+
+    const clearPendingTimer = () => {
+      if (pendingTimer) {
+        window.clearTimeout(pendingTimer)
+        pendingTimer = undefined
+      }
+    }
+
+    const applyWheelZoom = (direction: -1 | 1) => {
+      lastZoomAt = Date.now()
+      void (direction > 0 ? zoomIn() : zoomOut())
+    }
+
+    const onWheel = (event: WheelEvent) => {
+      if (!window.hermesDesktop?.zoom || event.altKey || !(event.ctrlKey || event.metaKey) || event.deltaY === 0) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      const direction: -1 | 1 = event.deltaY < 0 ? 1 : -1
+      const now = Date.now()
+      const elapsed = now - lastZoomAt
+
+      if (elapsed >= ZOOM_WHEEL_MIN_INTERVAL_MS) {
+        clearPendingTimer()
+        pendingDirection = null
+        applyWheelZoom(direction)
+        return
+      }
+
+      pendingDirection = direction
+      clearPendingTimer()
+      pendingTimer = window.setTimeout(() => {
+        if (pendingDirection) {
+          applyWheelZoom(pendingDirection)
+          pendingDirection = null
+        }
+        pendingTimer = undefined
+      }, ZOOM_WHEEL_MIN_INTERVAL_MS - elapsed)
+    }
+
+    window.addEventListener('wheel', onWheel, { capture: true, passive: false })
+
+    return () => {
+      clearPendingTimer()
+      window.removeEventListener('wheel', onWheel, { capture: true })
+    }
+  }, [])
 
   useEffect(() => {
     startUpdatePoller()

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -16,6 +16,7 @@ import { Volume2, VolumeX } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import { $fileBrowserOpen, $sidebarOpen, toggleFileBrowserOpen, toggleSidebarOpen } from '@/store/layout'
+import { $zoomState, resetZoom, zoomIn, zoomOut } from '@/store/zoom'
 
 import { PROFILES_ROUTE } from '../routes'
 
@@ -169,11 +170,69 @@ export function TitlebarControls({
         {visibleSystemToolsBeforeSettings.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
+        <ZoomMenuButton />
         <ProfilesMenuButton navigate={navigate} />
         {settingsTool && <TitlebarToolButton navigate={navigate} tool={settingsTool} />}
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
       </div>
     </>
+  )
+}
+
+function ZoomMenuButton() {
+  const zoomState = useStore($zoomState)
+
+  const handleZoomIn = () => {
+    triggerHaptic('tap')
+    void zoomIn()
+  }
+
+  const handleZoomOut = () => {
+    triggerHaptic('tap')
+    void zoomOut()
+  }
+
+  const handleReset = () => {
+    triggerHaptic('tap')
+    void resetZoom()
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={`Zoom ${zoomState.percent}%`}
+          className={cn(titlebarButtonClass, 'min-w-12 bg-transparent px-2 text-xs font-medium tabular-nums select-none')}
+          onPointerDown={event => event.stopPropagation()}
+          title="UI zoom (Ctrl/Cmd +, Ctrl/Cmd -, Ctrl/Cmd 0)"
+          type="button"
+        >
+          {zoomState.percent}%
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48" sideOffset={8}>
+        <DropdownMenuLabel>
+          <div className="text-sm font-medium text-foreground">UI Zoom</div>
+          <div className="mt-1 text-xs font-normal leading-4 text-muted-foreground">Scales the whole desktop interface.</div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={handleZoomOut}>
+          <span className="w-4 text-center text-base leading-none">−</span>
+          <span>Zoom Out</span>
+          <span className="ml-auto text-xs text-muted-foreground">Ctrl−</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleReset}>
+          <Codicon name="debug-restart" size="1rem" />
+          <span>Reset Zoom</span>
+          <span className="ml-auto text-xs text-muted-foreground">Ctrl0</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleZoomIn}>
+          <span className="w-4 text-center text-base leading-none">+</span>
+          <span>Zoom In</span>
+          <span className="ml-auto text-xs text-muted-foreground">Ctrl+</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -5,6 +5,13 @@ declare global {
     hermesDesktop: {
       getConnection: () => Promise<HermesConnection>
       getBootProgress: () => Promise<DesktopBootProgress>
+      zoom?: {
+        get: () => Promise<DesktopZoomState>
+        set: (factor: number) => Promise<DesktopZoomState>
+        adjust: (direction: number) => Promise<DesktopZoomState>
+        reset: () => Promise<DesktopZoomState>
+        onChanged: (callback: (payload: DesktopZoomState) => void) => () => void
+      }
       getConnectionConfig: () => Promise<DesktopConnectionConfig>
       saveConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>
       applyConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>
@@ -129,6 +136,11 @@ export interface DesktopUpdateProgress {
   percent: number | null
   error: string | null
   at: number
+}
+
+export interface DesktopZoomState {
+  factor: number
+  percent: number
 }
 
 export interface HermesConnection {

--- a/apps/desktop/src/store/zoom.ts
+++ b/apps/desktop/src/store/zoom.ts
@@ -1,0 +1,46 @@
+import { atom } from 'nanostores'
+
+export interface DesktopZoomState {
+  factor: number
+  percent: number
+}
+
+const DEFAULT_ZOOM_STATE: DesktopZoomState = { factor: 1, percent: 100 }
+
+export const $zoomState = atom<DesktopZoomState>(DEFAULT_ZOOM_STATE)
+
+const applyZoomState = (state: DesktopZoomState | null | undefined) => {
+  if (!state || typeof state.factor !== 'number' || typeof state.percent !== 'number') {
+    return DEFAULT_ZOOM_STATE
+  }
+
+  const next = { factor: state.factor, percent: state.percent }
+  $zoomState.set(next)
+  return next
+}
+
+export async function initializeZoom() {
+  const api = window.hermesDesktop?.zoom
+  if (!api) return DEFAULT_ZOOM_STATE
+
+  const unsubscribe = api.onChanged?.(applyZoomState)
+  const current = await api.get().catch(() => DEFAULT_ZOOM_STATE)
+  applyZoomState(current)
+
+  return { ...$zoomState.get(), unsubscribe }
+}
+
+export async function zoomIn() {
+  const next = await window.hermesDesktop?.zoom?.adjust(1)
+  return applyZoomState(next)
+}
+
+export async function zoomOut() {
+  const next = await window.hermesDesktop?.zoom?.adjust(-1)
+  return applyZoomState(next)
+}
+
+export async function resetZoom() {
+  const next = await window.hermesDesktop?.zoom?.reset()
+  return applyZoomState(next)
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -348,6 +348,77 @@
     --ui-selection-background: color-mix(in srgb, #ffd24a 38%, transparent);
   }
 
+  :root[data-hermes-theme='dark-glass'] {
+    --theme-mix-chrome: 58%;
+    --theme-mix-sidebar: 70%;
+    --theme-mix-card: 20%;
+    --theme-mix-elevated: 28%;
+    --theme-mix-bubble: 34%;
+    --theme-fill-primary-accent-mix: 22%;
+    --theme-fill-secondary-accent-mix: 15%;
+    --theme-fill-tertiary-accent-mix: 10%;
+    --theme-stroke-primary-accent-mix: 36%;
+    --theme-stroke-secondary-accent-mix: 22%;
+    --theme-control-hover-accent-mix: 12%;
+    --theme-control-active-accent-mix: 18%;
+    --radius-scalar: 0.82;
+    --shadow-header:
+      inset 0 -0.0625rem 0 color-mix(in srgb, #ffffff 8%, transparent),
+      0 0.75rem 2rem -1.25rem color-mix(in srgb, #000 55%, transparent);
+    --shadow-md:
+      inset 0 0.0625rem 0 color-mix(in srgb, #ffffff 14%, transparent),
+      0 0 0 0.0625rem color-mix(in srgb, var(--dt-midground) 12%, transparent),
+      0 1.25rem 3rem -1.5rem color-mix(in srgb, #000 70%, transparent);
+    --shadow-composer:
+      inset 0 0.0625rem 0 color-mix(in srgb, #ffffff 16%, transparent),
+      0 0.5rem 1.75rem color-mix(in srgb, #000 26%, transparent);
+  }
+
+  :root[data-hermes-theme='dark-glass'] body {
+    background:
+      radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--dt-midground) 18%, transparent), transparent 32rem),
+      radial-gradient(circle at 88% 8%, color-mix(in srgb, #8fb6ff 10%, transparent), transparent 28rem),
+      var(--ui-chat-surface-background);
+  }
+
+  :root[data-hermes-theme='dark-glass'] :is([data-slot='dropdown-menu-content'], [data-slot='select-content'], [data-slot='dialog-content']),
+  :root[data-hermes-theme='dark-glass'] [data-slot='composer-surface'] {
+    background: color-mix(in srgb, var(--ui-bg-elevated) 76%, transparent) !important;
+    backdrop-filter: blur(1.125rem) saturate(1.24);
+    -webkit-backdrop-filter: blur(1.125rem) saturate(1.24);
+  }
+
+  :root[data-hermes-theme='veritas'] {
+    --theme-mix-chrome: 66%;
+    --theme-mix-sidebar: 82%;
+    --theme-mix-card: 30%;
+    --theme-mix-elevated: 38%;
+    --theme-mix-bubble: 42%;
+    --theme-fill-primary-accent-mix: 18%;
+    --theme-fill-secondary-accent-mix: 16%;
+    --theme-fill-tertiary-accent-mix: 10%;
+    --theme-stroke-primary-accent-mix: 32%;
+    --theme-stroke-secondary-accent-mix: 20%;
+    --theme-row-active-accent-mix: 12%;
+    --composer-ring-strength: 1.45;
+    --warm-glow: color-mix(in srgb, #f6d365 34%, color-mix(in srgb, var(--dt-midground) 12%, transparent));
+    --ui-selection-background: color-mix(in srgb, #f6d365 34%, color-mix(in srgb, var(--dt-midground) 18%, transparent));
+  }
+
+  :root[data-hermes-theme='veritas'] body {
+    background:
+      radial-gradient(circle at 10% 0%, color-mix(in srgb, #8b5cf6 20%, transparent), transparent 30rem),
+      radial-gradient(circle at 86% 12%, color-mix(in srgb, #2dd4bf 14%, transparent), transparent 26rem),
+      radial-gradient(circle at 64% 96%, color-mix(in srgb, #f6d365 8%, transparent), transparent 24rem),
+      var(--ui-chat-surface-background);
+  }
+
+  :root[data-hermes-theme='veritas'] .arc-border {
+    --arc-c1: #f6d365;
+    --arc-c2: var(--dt-midground);
+    --arc-duration: 3.7s;
+  }
+
   * {
     box-sizing: border-box;
     border-color: var(--dt-border);

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -151,13 +151,39 @@ function renderedModeFor(colors: DesktopThemeColors, mode: 'light' | 'dark'): 'l
 // Per-mode mix knobs. Light/dark fallbacks live in styles.css `:root` /
 // `:root.dark`; setting them inline keeps active-skin overrides surviving
 // the boot-time paint.
-const mixesFor = (isDark: boolean): Record<string, string> => ({
-  '--theme-mix-chrome': isDark ? '74%' : '92%',
-  '--theme-mix-sidebar': '100%',
-  '--theme-mix-card': isDark ? '38%' : '22%',
-  '--theme-mix-elevated': isDark ? '46%' : '28%',
-  '--theme-mix-bubble': isDark ? '46%' : '0%'
-})
+const mixesFor = (isDark: boolean, skinName: string): Record<string, string> => {
+  const base = {
+    '--theme-mix-chrome': isDark ? '74%' : '92%',
+    '--theme-mix-sidebar': '100%',
+    '--theme-mix-card': isDark ? '38%' : '22%',
+    '--theme-mix-elevated': isDark ? '46%' : '28%',
+    '--theme-mix-bubble': isDark ? '46%' : '0%'
+  }
+
+  if (isDark && skinName === 'dark-glass') {
+    return {
+      ...base,
+      '--theme-mix-chrome': '58%',
+      '--theme-mix-sidebar': '70%',
+      '--theme-mix-card': '20%',
+      '--theme-mix-elevated': '28%',
+      '--theme-mix-bubble': '34%'
+    }
+  }
+
+  if (isDark && skinName === 'veritas') {
+    return {
+      ...base,
+      '--theme-mix-chrome': '66%',
+      '--theme-mix-sidebar': '82%',
+      '--theme-mix-card': '30%',
+      '--theme-mix-elevated': '38%',
+      '--theme-mix-bubble': '42%'
+    }
+  }
+
+  return base
+}
 
 function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
   if (typeof document === 'undefined') {
@@ -212,7 +238,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--noise-opacity-mul': isDark ? 'calc(0.04 / 0.21)' : 'calc(0.34 / 0.21)'
   }
 
-  for (const [k, v] of Object.entries({ ...seeds, ...mixesFor(isDark), ...palette })) {
+  for (const [k, v] of Object.entries({ ...seeds, ...mixesFor(isDark, skinName), ...palette })) {
     root.style.setProperty(k, v)
   }
 

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -15,6 +15,9 @@ export const DEFAULT_TYPOGRAPHY: DesktopThemeTypography = { fontSans: SYSTEM_SAN
 const NOUS_BLUE = '#0053FD'
 const PSYCHE_BLUE = '#1540B1'
 const PSYCHE_WARM = '#FFE6CB'
+const VERITAS_VIOLET = '#8B5CF6'
+const VERITAS_CYAN = '#2DD4BF'
+const VERITAS_GOLD = '#F6D365'
 
 const nousTint = (pct: number) => `color-mix(in srgb, ${NOUS_BLUE} ${pct}%, #FFFFFF)`
 const nousTintTransparent = (pct: number) => `color-mix(in srgb, ${NOUS_BLUE} ${pct}%, transparent)`
@@ -269,8 +272,88 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+/** Translucent charcoal glass with cold blue/cyan highlights. */
+export const darkGlassTheme: DesktopTheme = {
+  name: 'dark-glass',
+  label: 'Dark Glass',
+  description: 'Translucent charcoal glass with cool blue highlights',
+  colors: {
+    background: '#070A12',
+    foreground: '#EEF7FF',
+    card: '#111827',
+    cardForeground: '#EEF7FF',
+    muted: '#172033',
+    mutedForeground: '#8FA5BC',
+    popover: '#111A29',
+    popoverForeground: '#F3FAFF',
+    primary: '#BFE7FF',
+    primaryForeground: '#06101C',
+    secondary: '#17253A',
+    secondaryForeground: '#C7DAEA',
+    accent: '#10283D',
+    accentForeground: '#DDF4FF',
+    border: '#29415B',
+    input: '#24364E',
+    ring: '#68D8FF',
+    midground: '#68D8FF',
+    composerRing: '#68D8FF',
+    destructive: '#FF5E7A',
+    destructiveForeground: '#FFF7F8',
+    sidebarBackground: '#080D17',
+    sidebarBorder: '#20344D',
+    userBubble: '#102D45',
+    userBubbleBorder: '#2E5D7D'
+  },
+  typography: {
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap'
+  }
+}
+
+/** Veritas — calm intelligence: obsidian, violet, cyan, and a small gold spark. */
+export const veritasTheme: DesktopTheme = {
+  name: 'veritas',
+  label: 'Veritas',
+  description: 'Obsidian violet/cyan with a restrained gold spark',
+  colors: {
+    background: '#090915',
+    foreground: '#F2F0FF',
+    card: '#121124',
+    cardForeground: '#F2F0FF',
+    muted: '#1A1830',
+    mutedForeground: '#9B96BD',
+    popover: '#15132B',
+    popoverForeground: '#F7F4FF',
+    primary: VERITAS_GOLD,
+    primaryForeground: '#171108',
+    secondary: '#201B3A',
+    secondaryForeground: '#DAD4F7',
+    accent: '#181F38',
+    accentForeground: '#E9E5FF',
+    border: '#322C54',
+    input: '#2B2747',
+    ring: VERITAS_VIOLET,
+    midground: VERITAS_CYAN,
+    midgroundForeground: '#041716',
+    composerRing: VERITAS_CYAN,
+    destructive: '#E35B72',
+    destructiveForeground: '#FFF5F7',
+    sidebarBackground: '#070713',
+    sidebarBorder: '#292346',
+    userBubble: '#171F3B',
+    userBubbleBorder: '#2B4F62'
+  },
+  typography: {
+    fontSans: `Inter, ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
+  'dark-glass': darkGlassTheme,
+  veritas: veritasTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,


### PR DESCRIPTION
## Summary
- add persistent Desktop app zoom backed by Electron `webContents.setZoomFactor`
- add browser/IDE-style zoom shortcuts, application menu entries, titlebar zoom dropdown, and Ctrl/Cmd + wheel scroll zoom
- add Dark Glass and Veritas built-in theme presets with per-theme mix overrides

## Test Plan
- `node --check electron/main.cjs`
- `node --check electron/preload.cjs`
- `node --check electron/zoom-controller.cjs`
- `node --test electron/zoom-controller.test.cjs`
- `npm run type-check`
- `npm run build`
- `npx electron-builder --dir --config.directories.output=release-scroll-zoom`
