### PR TITLE
fix(provider): honor Anthropic keys for auto portal provider (#38466)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -73,6 +73,19 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
     return _loopback_hostname(base_url_hostname(bu))
 
 
+def _api_key_provider_has_usable_credentials(provider: str) -> bool:
+    """Return True when an API-key provider has configured usable credentials."""
+    try:
+        if provider == "anthropic":
+            from agent.anthropic_adapter import resolve_anthropic_token
+
+            return has_usable_secret(resolve_anthropic_token())
+        runtime = resolve_api_key_provider_credentials(provider)
+    except Exception:
+        return False
+    return has_usable_secret(runtime.get("api_key"))
+
+
 def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     """Auto-detect api_mode from the resolved base URL.
 
@@ -1271,6 +1284,29 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
+
+    # ── #38466: model-aware provider auto-switch ──────────────────────────
+    # When the active provider is auto-resolved (not explicitly requested)
+    # and target_model belongs to a different provider that has usable
+    # credentials, switch to that provider so direct API keys aren't
+    # overridden by the portal/OAuth provider.
+    if target_model and requested_provider == "auto":
+        try:
+            from hermes_cli.models import detect_provider_for_model
+            detected = detect_provider_for_model(target_model, provider)
+            if detected:
+                detected_provider, _ = detected
+                if detected_provider != provider and detected_provider in PROVIDER_REGISTRY:
+                    if _api_key_provider_has_usable_credentials(detected_provider):
+                        logger.info(
+                            "Auto-switching provider from %s to %s for model %s "
+                            "(configured credentials found)",
+                            provider, detected_provider, target_model,
+                        )
+                        provider = detected_provider
+        except Exception:
+            pass  # Detection is best-effort; fall through on any error
+
     model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2774,6 +2774,9 @@ def test_portal_provider_falls_through_when_no_anthropic_credentials(monkeypatch
         lambda provider: {"provider": provider, "api_key": "", "base_url": "", "source": "default"},
     )
 
+    # Prevent pool from intercepting before the fallthrough path
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
     # Mock nous runtime credentials so fallthrough works
     monkeypatch.setattr(
         rp, "resolve_nous_runtime_credentials",
@@ -2802,6 +2805,9 @@ def test_explicit_provider_prevents_anthropic_auto_switch(monkeypatch):
         lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
     )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    # Prevent pool from intercepting before credential resolution
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
     monkeypatch.setattr(
         rp, "resolve_nous_runtime_credentials",
         lambda timeout_seconds=None: {
@@ -2830,6 +2836,9 @@ def test_portal_with_non_anthropic_model_stays_on_nous(monkeypatch):
         lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
     )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    # Prevent pool from intercepting before credential resolution
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
     monkeypatch.setattr(
         rp, "resolve_nous_runtime_credentials",
         lambda timeout_seconds=None: {

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2705,3 +2705,144 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+# ── #38466: portal provider should not override Anthropic key for Anthropic models ──
+
+
+def test_portal_provider_switches_to_anthropic_for_anthropic_model(monkeypatch):
+    """When active provider is portal/nous but target_model is an Anthropic
+    model, resolve_runtime_provider should detect the mismatch and switch to
+    the anthropic provider with the configured API key."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        target_model="claude-sonnet-4-20250514",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_key"] == "anthropic-key"
+    assert resolved["api_mode"] == "anthropic_messages"
+
+
+def test_portal_provider_switches_to_anthropic_for_configured_anthropic_key(monkeypatch):
+    """Model-aware switching should honor Anthropic's normal token resolver,
+    including configured Claude/Anthropic credentials beyond the portal
+    provider."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: "configured-anthropic-key",
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        target_model="claude-sonnet-4-20250514",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_key"] == "configured-anthropic-key"
+    assert resolved["api_mode"] == "anthropic_messages"
+
+
+def test_portal_provider_falls_through_when_no_anthropic_credentials(monkeypatch):
+    """When active provider is portal/nous and target_model is an Anthropic
+    model but no ANTHROPIC_API_KEY is set, the system should fall through
+    to normal nous credential resolution."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
+    )
+    # No ANTHROPIC_API_KEY set
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr("agent.anthropic_adapter.resolve_anthropic_token", lambda: None)
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {"provider": provider, "api_key": "", "base_url": "", "source": "default"},
+    )
+
+    # Mock nous runtime credentials so fallthrough works
+    monkeypatch.setattr(
+        rp, "resolve_nous_runtime_credentials",
+        lambda timeout_seconds=None: {
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "portal-jwt",
+            "source": "portal",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        target_model="claude-sonnet-4-20250514",
+    )
+
+    assert resolved["provider"] == "nous"
+    assert resolved["api_key"] == "portal-jwt"
+
+
+def test_explicit_provider_prevents_anthropic_auto_switch(monkeypatch):
+    """When the user explicitly requests 'nous' provider (not auto),
+    the explicit choice takes priority even for Anthropic models."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    monkeypatch.setattr(
+        rp, "resolve_nous_runtime_credentials",
+        lambda timeout_seconds=None: {
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "portal-jwt",
+            "source": "portal",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="nous",  # explicit, not auto
+        target_model="claude-sonnet-4-20250514",
+    )
+
+    # Explicit 'nous' request should stay on nous
+    assert resolved["provider"] == "nous"
+    assert resolved["api_key"] == "portal-jwt"
+
+
+def test_portal_with_non_anthropic_model_stays_on_nous(monkeypatch):
+    """When target_model is NOT an Anthropic model (e.g., a nous model),
+    the system should stay on the nous provider."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "nous")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "nous", "base_url": "https://inference-api.nousresearch.com/v1"},
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    monkeypatch.setattr(
+        rp, "resolve_nous_runtime_credentials",
+        lambda timeout_seconds=None: {
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "portal-jwt",
+            "source": "portal",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        target_model="hermes-3-70b",  # a nous model, not anthropic
+    )
+
+    assert resolved["provider"] == "nous"
+    assert resolved["api_key"] == "portal-jwt"


### PR DESCRIPTION
## What changed

Fixes #38466 by making runtime provider resolution model-aware when the active provider was auto-resolved to the Nous Portal (`nous`) but the requested `target_model` belongs to Anthropic.

When `requested_provider == "auto"`, Hermes now:
- detects the target model's provider with `detect_provider_for_model()`;
- verifies the detected provider has usable configured credentials before switching;
- uses Anthropic's normal token resolver for Anthropic models, so configured Claude/Anthropic credentials are honored;
- preserves explicit provider choices such as `--provider nous`.

## Verification

- RED proof from build artifact: `test_portal_provider_switches_to_anthropic_for_anthropic_model` failed on upstream/main with `assert 'openrouter' == 'anthropic'`.
- After reviewer improvement pass and rebase onto current `upstream/main`:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -v -o addopts= --tb=short`
  - Result: `132 passed in 1.53s`
- Branch is exactly one focused commit ahead of upstream: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`.

## Competitor analysis

Open competing PR #38477 addresses the same issue but changes production code only and includes no regression tests. This PR includes production-path regression coverage for:
- portal/nous auto-resolving to Anthropic for Anthropic models;
- configured Anthropic token resolver path;
- no-credential fallthrough;
- explicit provider selection preserving `nous`;
- non-Anthropic model staying on `nous`.

Auto-published by Moonsong via Path B automated pipeline.
