### PR TITLE
feat(desktop): YOLO toggle in the status bar (per-session, TUI parity)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -526,6 +526,7 @@ export function DesktopController() {
     modelMenuContent,
     openAgents,
     openCommandCenterSection,
+    requestGateway,
     statusSnapshot,
     toggleCommandCenter
   })

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -525,6 +525,7 @@ export function DesktopController() {
     inferenceStatus,
     modelMenuContent,
     openAgents,
+    freshDraftReady,
     openCommandCenterSection,
     requestGateway,
     statusSnapshot,

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -35,11 +35,7 @@ const RIGHT_SIDEBAR_TABS: readonly RightSidebarTab[] = [
   { id: 'terminal', label: 'Terminal', icon: 'terminal' }
 ]
 
-export function RightSidebarPane({
-  onActivateFile,
-  onActivateFolder,
-  onChangeCwd
-}: RightSidebarPaneProps) {
+export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd }: RightSidebarPaneProps) {
   const activeTab = useStore($rightSidebarTab)
   const terminalTakeover = useStore($terminalTakeover)
   const currentBranch = useStore($currentBranch).trim()
@@ -53,8 +49,17 @@ export function RightSidebarPane({
         .pop() ?? currentCwd)
     : 'No folder selected'
 
-  const { collapseAll, collapseNonce, data, loadChildren, openState, refreshRoot, rootError, rootLoading, setNodeOpen } =
-    useProjectTree(currentCwd)
+  const {
+    collapseAll,
+    collapseNonce,
+    data,
+    loadChildren,
+    openState,
+    refreshRoot,
+    rootError,
+    rootLoading,
+    setNodeOpen
+  } = useProjectTree(currentCwd)
 
   const canCollapse = Object.values(openState).some(Boolean)
   const effectiveTab: RightSidebarTabId = terminalTakeover ? 'files' : activeTab
@@ -86,14 +91,12 @@ export function RightSidebarPane({
     }
   }
 
-  const tabs = terminalTakeover
-    ? RIGHT_SIDEBAR_TABS.filter(tab => tab.id !== 'terminal')
-    : RIGHT_SIDEBAR_TABS
+  const tabs = terminalTakeover ? RIGHT_SIDEBAR_TABS.filter(tab => tab.id !== 'terminal') : RIGHT_SIDEBAR_TABS
 
   return (
     <aside
       aria-label="Right sidebar"
-      className="before:pointer-events-none relative flex h-full w-full min-w-0 flex-col overflow-hidden border-l border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) pt-(--titlebar-height) text-(--ui-text-tertiary) shadow-[inset_0.0625rem_0_0_color-mix(in_srgb,white_18%,transparent)] before:absolute before:inset-x-0 before:top-(--titlebar-height) before:z-1 before:h-px before:bg-(--ui-stroke-tertiary)"
+      className="before:pointer-events-none relative flex h-full w-full min-w-0 flex-col overflow-hidden border-l border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) pt-(--titlebar-height) text-(--ui-text-tertiary) shadow-[inset_0.0625rem_0_0_color-mix(in_srgb,white_18%,transparent)]"
     >
       <RightSidebarChrome activeTab={effectiveTab} branch={currentBranch} tabs={tabs} />
 
@@ -135,7 +138,7 @@ function RightSidebarChrome({
 }) {
   return (
     <header className="shrink-0 bg-transparent text-[0.75rem]">
-      <div className="flex items-center gap-2 border-b border-(--ui-stroke-tertiary) px-2.5 py-1">
+      <div className="flex items-center gap-2 px-2.5 py-1">
         <nav aria-label="Right sidebar panels" className="flex min-w-0 items-center gap-1">
           {tabs.map(tab => (
             <button

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -29,7 +29,8 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setYoloActive
 } from '@/store/session'
 import { clearSessionSubagents, pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { recordToolDiff } from '@/store/tool-diffs'
@@ -653,6 +654,10 @@ export function useMessageStream({
 
           if (typeof payload?.fast === 'boolean') {
             setCurrentFastMode(payload.fast)
+          }
+
+          if (typeof payload?.yolo === 'boolean') {
+            setYoloActive(payload.yolo)
           }
 
           if (runningChanged && sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -29,8 +29,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
-  setTurnStartedAt,
-  setYoloActive
+  setTurnStartedAt
 } from '@/store/session'
 import { clearSessionSubagents, pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { recordToolDiff } from '@/store/tool-diffs'
@@ -654,10 +653,6 @@ export function useMessageStream({
 
           if (typeof payload?.fast === 'boolean') {
             setCurrentFastMode(payload.fast)
-          }
-
-          if (typeof payload?.yolo === 'boolean') {
-            setYoloActive(payload.yolo)
           }
 
           if (runningChanged && sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/desktop-slash-commands'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { setSessionYolo } from '@/lib/yolo-session'
 import {
   $composerAttachments,
   addComposerAttachment,
@@ -28,7 +29,15 @@ import {
 } from '@/store/composer'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { $busy, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import {
+  $busy,
+  $messages,
+  $yoloActive,
+  setAwaitingResponse,
+  setBusy,
+  setMessages,
+  setYoloActive
+} from '@/store/session'
 
 import type { ClientSessionState, ImageAttachResponse, SlashExecResponse } from '../../types'
 
@@ -396,6 +405,30 @@ export function usePromptActions({
 
         if (normalizedName === 'branch' || normalizedName === 'fork') {
           await branchCurrentSession()
+
+          return
+        }
+
+        // /yolo maps to the status-bar YOLO control rather than a gateway slash.
+        // With an active session it flips that session; without one it just arms
+        // the sticky preference for the next session.
+        if (normalizedName === 'yolo') {
+          const sid = sessionHint || activeSessionIdRef.current
+          const next = !$yoloActive.get()
+
+          if (!sid) {
+            setYoloActive(next)
+            notify({ kind: 'success', message: next ? 'YOLO armed for the next session' : 'YOLO off' })
+
+            return
+          }
+
+          try {
+            const active = await setSessionYolo(requestGateway, sid, next)
+            appendSessionTextMessage(sid, 'system', `YOLO ${active ? 'on' : 'off'} for this session`)
+          } catch {
+            notify({ kind: 'error', title: 'YOLO', message: 'Could not toggle YOLO' })
+          }
 
           return
         }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -409,16 +409,16 @@ export function usePromptActions({
           return
         }
 
-        // /yolo maps to the status-bar YOLO control rather than a gateway slash.
-        // With an active session it flips that session; without one it just arms
-        // the sticky preference for the next session.
+        // /yolo maps to the status-bar YOLO control — a per-session approval
+        // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm
+        // it locally; the session-create path applies it on the first message.
         if (normalizedName === 'yolo') {
           const sid = sessionHint || activeSessionIdRef.current
           const next = !$yoloActive.get()
 
           if (!sid) {
             setYoloActive(next)
-            notify({ kind: 'success', message: next ? 'YOLO armed for the next session' : 'YOLO off' })
+            notify({ kind: 'success', message: next ? 'YOLO armed for this chat' : 'YOLO off' })
 
             return
           }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -16,6 +16,7 @@ import {
   $currentCwd,
   $messages,
   $sessions,
+  $yoloActive,
   getRememberedWorkspaceCwd,
   sessionPinId,
   setActiveSessionId,
@@ -37,9 +38,7 @@ import {
   setSessions,
   setSessionsTotal,
   setSessionStartedAt,
-  setTurnStartedAt,
-  $yoloActive,
-  setYoloActive
+  setTurnStartedAt
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, UsageStats } from '@/types/hermes'
@@ -250,10 +249,6 @@ function applyRuntimeInfo(
   if (typeof info.fast === 'boolean') {
     setCurrentFastMode(info.fast)
   }
-
-  // Always sync YOLO on resume/create so switching sessions can't leave a stale
-  // "on" indicator (the gateway clears per-session yolo on some resume paths).
-  setYoloActive(info.yolo === true)
 
   if (info.usage) {
     setCurrentUsage(current => ({ ...current, ...info.usage }))
@@ -528,6 +523,12 @@ export function useSessionActions({
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
         const runtimeInfo = applyRuntimeInfo(resumed.info)
+
+        // Sticky YOLO: the gateway clears per-session yolo on resume, so re-apply
+        // the user's persisted preference onto the resumed session.
+        if ($yoloActive.get() && resumed.info?.yolo !== true) {
+          void setSessionYolo(requestGateway, resumed.session_id, true).catch(() => undefined)
+        }
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -36,7 +36,8 @@ import {
   setSessions,
   setSessionsTotal,
   setSessionStartedAt,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setYoloActive
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, UsageStats } from '@/types/hermes'
@@ -247,6 +248,10 @@ function applyRuntimeInfo(
   if (typeof info.fast === 'boolean') {
     setCurrentFastMode(info.fast)
   }
+
+  // Always sync YOLO on resume/create so switching sessions can't leave a stale
+  // "on" indicator (the gateway clears per-session yolo on some resume paths).
+  setYoloActive(info.yolo === true)
 
   if (info.usage) {
     setCurrentUsage(current => ({ ...current, ...info.usage }))

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -6,6 +6,7 @@ import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
+import { setSessionYolo } from '@/lib/yolo-session'
 import { clearComposerAttachments, clearComposerDraft } from '@/store/composer'
 import { clearQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -37,6 +38,7 @@ import {
   setSessionsTotal,
   setSessionStartedAt,
   setTurnStartedAt,
+  $yoloActive,
   setYoloActive
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
@@ -348,10 +350,17 @@ export function useSessionActions({
       setActiveSessionId(created.session_id)
       setSelectedStoredSessionId(stored)
       setSessionStartedAt(Date.now())
+      const yoloArmed = $yoloActive.get()
       const runtimeInfo = applyRuntimeInfo(created.info)
 
       if (runtimeInfo) {
         updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
+      }
+
+      // User may have armed YOLO on the new-chat draft before the runtime session
+      // existed — apply explicitly (toggle would be wrong if the server starts off).
+      if (yoloArmed) {
+        await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
       }
 
       return created.session_id

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -38,7 +38,8 @@ import {
   setSessions,
   setSessionsTotal,
   setSessionStartedAt,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setYoloActive
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, UsageStats } from '@/types/hermes'
@@ -250,6 +251,10 @@ function applyRuntimeInfo(
     setCurrentFastMode(info.fast)
   }
 
+  if (typeof info.yolo === 'boolean') {
+    setYoloActive(info.yolo)
+  }
+
   if (info.usage) {
     setCurrentUsage(current => ({ ...current, ...info.usage }))
   }
@@ -352,8 +357,8 @@ export function useSessionActions({
         updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
       }
 
-      // User may have armed YOLO on the new-chat draft before the runtime session
-      // existed — apply explicitly (toggle would be wrong if the server starts off).
+      // User may have armed YOLO on the new-chat draft before the runtime
+      // session existed — apply it to the freshly created session.
       if (yoloArmed) {
         await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
       }
@@ -523,12 +528,6 @@ export function useSessionActions({
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
         const runtimeInfo = applyRuntimeInfo(resumed.info)
-
-        // Sticky YOLO: the gateway clears per-session yolo on resume, so re-apply
-        // the user's persisted preference onto the resumed session.
-        if ($yoloActive.get() && resumed.info?.yolo !== true) {
-          void setSessionYolo(requestGateway, resumed.session_id, true).catch(() => undefined)
-        }
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -8,8 +8,8 @@ import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Spar
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
-import { setSessionYolo } from '@/lib/yolo-session'
 import { cn } from '@/lib/utils'
+import { setSessionYolo } from '@/lib/yolo-session'
 import { $desktopActionTasks } from '@/store/activity'
 import { $previewServerRestartStatus } from '@/store/preview'
 import {
@@ -308,17 +308,9 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
-        className: cn(
-          'w-8 justify-center px-2',
-          yoloActive && 'bg-[#f4e381] hover:bg-[#f4e381]',
-          yoloActive && !activeSessionId && 'ring-1 ring-inset ring-amber-700/15'
-        ),
+        className: cn('px-1', yoloActive && 'bg-(--chrome-action-hover)'),
         hidden: !showYoloToggle,
-        icon: (
-          <Zap
-            className={cn('size-3.5 shrink-0', yoloActive ? 'text-amber-950' : 'opacity-70')}
-          />
-        ),
+        icon: <Zap className={cn('size-3.5 shrink-0', yoloActive || 'opacity-70')} />,
         id: 'yolo',
         onSelect: () => void toggleYolo(),
         title: yoloActive
@@ -348,16 +340,12 @@ export function useStatusbarItems({
               menuAlign: 'end' as const,
               menuClassName: 'w-64',
               menuContent: modelMenuContent,
-              title: currentProvider
-                ? `Model · ${currentProvider}: ${currentModel || 'none'}`
-                : 'Switch model',
+              title: currentProvider ? `Model · ${currentProvider}: ${currentModel || 'none'}` : 'Switch model',
               variant: 'menu' as const
             }
           : {
               onSelect: () => setModelPickerOpen(true),
-              title: currentProvider
-                ? `${currentProvider} · ${currentModel || 'no model'}`
-                : 'Open model picker',
+              title: currentProvider ? `${currentProvider} · ${currentModel || 'no model'}` : 'Open model picker',
               variant: 'action' as const
             })
       },
@@ -372,8 +360,6 @@ export function useStatusbarItems({
       currentModel,
       currentProvider,
       currentReasoningEffort,
-      freshDraftReady,
-      gatewayState,
       modelMenuContent,
       sessionStartedAt,
       showYoloToggle,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
-import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Sparkles, Zap } from '@/lib/icons'
+import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Sparkles, Zap, ZapFilled } from '@/lib/icons'
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
@@ -310,7 +310,7 @@ export function useStatusbarItems({
       {
         className: cn('px-1', yoloActive && 'bg-(--chrome-action-hover)'),
         hidden: !showYoloToggle,
-        icon: <Zap className={cn('size-3.5 shrink-0', yoloActive || 'opacity-70')} />,
+        icon: yoloActive ? <ZapFilled className="size-3.5 shrink-0" /> : <Zap className="size-3.5 shrink-0 opacity-70" />,
         id: 'yolo',
         onSelect: () => void toggleYolo(),
         title: yoloActive

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -256,26 +256,9 @@ export function useStatusbarItems({
         title: 'Open cron jobs',
         to: CRON_ROUTE,
         variant: 'action'
-      },
-      {
-        // Gray (inherits tertiary text) when off, amber/yellow when on — amber
-        // is the app's existing "heads-up" colour and tracks dark/light theme.
-        className: yoloActive
-          ? 'text-amber-600 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-300'
-          : undefined,
-        hidden: !activeSessionId,
-        icon: <Zap className="size-3" />,
-        id: 'yolo',
-        label: 'YOLO',
-        onSelect: () => void toggleYolo(),
-        title: yoloActive
-          ? 'YOLO on — auto-approving commands this session. Click to turn off.'
-          : 'YOLO off — click to auto-approve commands this session.',
-        variant: 'action'
       }
     ],
     [
-      activeSessionId,
       agentsOpen,
       bgFailed,
       bgRunning,
@@ -287,9 +270,7 @@ export function useStatusbarItems({
       inferenceStatus?.reason,
       openAgents,
       subagentsRunning,
-      toggleCommandCenter,
-      toggleYolo,
-      yoloActive
+      toggleCommandCenter
     ]
   )
 
@@ -319,6 +300,22 @@ export function useStatusbarItems({
         label: 'Session',
         title: 'Runtime session elapsed',
         variant: 'text'
+      },
+      {
+        // Gray (inherits tertiary text) when off, amber/yellow when on — amber
+        // is the app's existing "heads-up" colour and tracks dark/light theme.
+        className: yoloActive
+          ? 'text-amber-600 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-300'
+          : undefined,
+        hidden: !activeSessionId,
+        icon: <Zap className="size-3" />,
+        id: 'yolo',
+        label: 'YOLO',
+        onSelect: () => void toggleYolo(),
+        title: yoloActive
+          ? 'YOLO on — auto-approving commands this session. Click to turn off.'
+          : 'YOLO off — click to auto-approve commands this session.',
+        variant: 'action'
       },
       {
         id: 'model-summary',
@@ -354,6 +351,7 @@ export function useStatusbarItems({
       versionItem
     ],
     [
+      activeSessionId,
       busy,
       contextBar,
       contextUsage,
@@ -363,8 +361,10 @@ export function useStatusbarItems({
       currentReasoningEffort,
       modelMenuContent,
       sessionStartedAt,
+      toggleYolo,
       turnStartedAt,
-      versionItem
+      versionItem,
+      yoloActive
     ]
   )
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -309,23 +309,17 @@ export function useStatusbarItems({
       },
       {
         className: cn(
-          yoloActive &&
-            '!text-(--ui-text-primary) bg-amber-500/10 hover:!text-(--ui-text-primary) hover:bg-amber-500/16 dark:bg-amber-400/12 dark:hover:bg-amber-400/18',
-          yoloActive &&
-            !activeSessionId &&
-            'ring-1 ring-inset ring-amber-500/30 dark:ring-amber-400/25'
+          'w-8 justify-center px-2',
+          yoloActive && 'bg-[#f4e381] hover:bg-[#f4e381]',
+          yoloActive && !activeSessionId && 'ring-1 ring-inset ring-amber-700/15'
         ),
         hidden: !showYoloToggle,
         icon: (
           <Zap
-            className={cn(
-              'size-3 shrink-0',
-              yoloActive ? 'text-amber-900 dark:text-amber-100' : 'opacity-70'
-            )}
+            className={cn('size-3.5 shrink-0', yoloActive ? 'text-amber-950' : 'opacity-70')}
           />
         ),
         id: 'yolo',
-        label: 'YOLO',
         onSelect: () => void toggleYolo(),
         title: yoloActive
           ? activeSessionId

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -88,8 +88,9 @@ export function useStatusbarItems({
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
 
-  // Per-session approval bypass. On a new-chat draft (no runtime session yet),
-  // arm locally; `createBackendSessionForSend` applies it after session.create.
+  // Per-session approval bypass (same scope as the TUI's Shift+Tab). On a
+  // new-chat draft (no runtime session yet) we arm locally; the session-create
+  // path applies it once the backend session exists.
   const toggleYolo = useCallback(async () => {
     const next = !$yoloActive.get()
     const sid = $activeSessionId.get()
@@ -314,12 +315,8 @@ export function useStatusbarItems({
         id: 'yolo',
         onSelect: () => void toggleYolo(),
         title: yoloActive
-          ? activeSessionId
-            ? 'YOLO on — auto-approving dangerous commands this session. Click to turn off.'
-            : 'YOLO armed for the next session — will apply when you send the first message.'
-          : activeSessionId
-            ? 'YOLO off — click to auto-approve dangerous commands this session.'
-            : 'YOLO off — click to enable for the next session.',
+          ? 'YOLO on — auto-approving dangerous commands. Click to turn off.'
+          : 'YOLO off — click to auto-approve dangerous commands.',
         variant: 'action'
       },
       {
@@ -352,7 +349,6 @@ export function useStatusbarItems({
       versionItem
     ],
     [
-      activeSessionId,
       busy,
       contextBar,
       contextUsage,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -8,6 +8,7 @@ import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Spar
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import { setSessionYolo } from '@/lib/yolo-session'
 import { cn } from '@/lib/utils'
 import { $desktopActionTasks } from '@/store/activity'
 import { $previewServerRestartStatus } from '@/store/preview'
@@ -44,10 +45,14 @@ interface StatusbarItemsOptions {
   modelMenuContent?: ReactNode
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void
+  freshDraftReady: boolean
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   statusSnapshot: StatusResponse | null
   toggleCommandCenter: () => void
 }
+
+const YOLO_ON_CLASS =
+  'bg-amber-500/15 text-foreground hover:bg-amber-500/25 dark:bg-amber-500/20 dark:hover:bg-amber-500/30'
 
 export function useStatusbarItems({
   agentsOpen,
@@ -60,6 +65,7 @@ export function useStatusbarItems({
   modelMenuContent,
   openAgents,
   openCommandCenterSection,
+  freshDraftReady,
   requestGateway,
   statusSnapshot,
   toggleCommandCenter
@@ -85,23 +91,26 @@ export function useStatusbarItems({
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
 
-  // Flip per-session approval bypass via the same `config.set yolo` RPC the TUI
-  // uses, then recolour from the gateway's reported value. The gateway has no
-  // `value` arg for yolo — sending the key alone toggles it.
+  // Per-session approval bypass. On a new-chat draft (no runtime session yet),
+  // arm locally; `createBackendSessionForSend` applies it after session.create.
   const toggleYolo = useCallback(async () => {
+    const next = !$yoloActive.get()
     const sid = $activeSessionId.get()
+
+    setYoloActive(next)
 
     if (!sid) {
       return
     }
 
     try {
-      const result = await requestGateway<{ value?: string }>('config.set', { key: 'yolo', session_id: sid })
-      setYoloActive(result?.value === '1')
+      await setSessionYolo(requestGateway, sid, next)
     } catch {
-      // Leave the indicator as-is if the toggle RPC fails.
+      setYoloActive(!next)
     }
   }, [requestGateway])
+
+  const showYoloToggle = gatewayState === 'open' && (!!activeSessionId || freshDraftReady)
 
   const gatewayMenuContent = useMemo(
     () => (
@@ -302,19 +311,19 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
-        // Gray (inherits tertiary text) when off, amber/yellow when on — amber
-        // is the app's existing "heads-up" colour and tracks dark/light theme.
-        className: yoloActive
-          ? 'text-amber-600 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-300'
-          : undefined,
-        hidden: !activeSessionId,
+        className: yoloActive ? YOLO_ON_CLASS : undefined,
+        hidden: !showYoloToggle,
         icon: <Zap className="size-3" />,
         id: 'yolo',
         label: 'YOLO',
         onSelect: () => void toggleYolo(),
         title: yoloActive
-          ? 'YOLO on — auto-approving commands this session. Click to turn off.'
-          : 'YOLO off — click to auto-approve commands this session.',
+          ? activeSessionId
+            ? 'YOLO on — auto-approving dangerous commands this session. Click to turn off.'
+            : 'YOLO armed for the next session — will apply when you send the first message.'
+          : activeSessionId
+            ? 'YOLO off — click to auto-approve dangerous commands this session.'
+            : 'YOLO off — click to enable for the next session.',
         variant: 'action'
       },
       {
@@ -359,8 +368,11 @@ export function useStatusbarItems({
       currentModel,
       currentProvider,
       currentReasoningEffort,
+      freshDraftReady,
+      gatewayState,
       modelMenuContent,
       sessionStartedAt,
+      showYoloToggle,
       toggleYolo,
       turnStartedAt,
       versionItem,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,10 +1,10 @@
 import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
-import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Sparkles } from '@/lib/icons'
+import { Activity, AlertCircle, ChevronDown, Clock, Command, Hash, Loader2, Sparkles, Zap } from '@/lib/icons'
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils'
 import { $desktopActionTasks } from '@/store/activity'
 import { $previewServerRestartStatus } from '@/store/preview'
 import {
+  $activeSessionId,
   $busy,
   $currentFastMode,
   $currentModel,
@@ -21,7 +22,9 @@ import {
   $sessionStartedAt,
   $turnStartedAt,
   $workingSessionIds,
-  setModelPickerOpen
+  $yoloActive,
+  setModelPickerOpen,
+  setYoloActive
 } from '@/store/session'
 import { $subagentsBySession, activeSubagentCount } from '@/store/subagents'
 import { $desktopVersion, $updateApply, $updateStatus, setUpdateOverlayOpen } from '@/store/updates'
@@ -41,6 +44,7 @@ interface StatusbarItemsOptions {
   modelMenuContent?: ReactNode
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   statusSnapshot: StatusResponse | null
   toggleCommandCenter: () => void
 }
@@ -56,9 +60,12 @@ export function useStatusbarItems({
   modelMenuContent,
   openAgents,
   openCommandCenterSection,
+  requestGateway,
   statusSnapshot,
   toggleCommandCenter
 }: StatusbarItemsOptions) {
+  const activeSessionId = useStore($activeSessionId)
+  const yoloActive = useStore($yoloActive)
   const busy = useStore($busy)
   const currentFastMode = useStore($currentFastMode)
   const currentModel = useStore($currentModel)
@@ -77,6 +84,24 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+
+  // Flip per-session approval bypass via the same `config.set yolo` RPC the TUI
+  // uses, then recolour from the gateway's reported value. The gateway has no
+  // `value` arg for yolo — sending the key alone toggles it.
+  const toggleYolo = useCallback(async () => {
+    const sid = $activeSessionId.get()
+
+    if (!sid) {
+      return
+    }
+
+    try {
+      const result = await requestGateway<{ value?: string }>('config.set', { key: 'yolo', session_id: sid })
+      setYoloActive(result?.value === '1')
+    } catch {
+      // Leave the indicator as-is if the toggle RPC fails.
+    }
+  }, [requestGateway])
 
   const gatewayMenuContent = useMemo(
     () => (
@@ -231,9 +256,26 @@ export function useStatusbarItems({
         title: 'Open cron jobs',
         to: CRON_ROUTE,
         variant: 'action'
+      },
+      {
+        // Gray (inherits tertiary text) when off, amber/yellow when on — amber
+        // is the app's existing "heads-up" colour and tracks dark/light theme.
+        className: yoloActive
+          ? 'text-amber-600 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-300'
+          : undefined,
+        hidden: !activeSessionId,
+        icon: <Zap className="size-3" />,
+        id: 'yolo',
+        label: 'YOLO',
+        onSelect: () => void toggleYolo(),
+        title: yoloActive
+          ? 'YOLO on — auto-approving commands this session. Click to turn off.'
+          : 'YOLO off — click to auto-approve commands this session.',
+        variant: 'action'
       }
     ],
     [
+      activeSessionId,
       agentsOpen,
       bgFailed,
       bgRunning,
@@ -245,7 +287,9 @@ export function useStatusbarItems({
       inferenceStatus?.reason,
       openAgents,
       subagentsRunning,
-      toggleCommandCenter
+      toggleCommandCenter,
+      toggleYolo,
+      yoloActive
     ]
   )
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -51,9 +51,6 @@ interface StatusbarItemsOptions {
   toggleCommandCenter: () => void
 }
 
-const YOLO_ON_CLASS =
-  'bg-amber-500/15 text-foreground hover:bg-amber-500/25 dark:bg-amber-500/20 dark:hover:bg-amber-500/30'
-
 export function useStatusbarItems({
   agentsOpen,
   commandCenterOpen,
@@ -311,9 +308,22 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
-        className: yoloActive ? YOLO_ON_CLASS : undefined,
+        className: cn(
+          yoloActive &&
+            '!text-(--ui-text-primary) bg-amber-500/10 hover:!text-(--ui-text-primary) hover:bg-amber-500/16 dark:bg-amber-400/12 dark:hover:bg-amber-400/18',
+          yoloActive &&
+            !activeSessionId &&
+            'ring-1 ring-inset ring-amber-500/30 dark:ring-amber-400/25'
+        ),
         hidden: !showYoloToggle,
-        icon: <Zap className="size-3" />,
+        icon: (
+          <Zap
+            className={cn(
+              'size-3 shrink-0',
+              yoloActive ? 'text-amber-900 dark:text-amber-100' : 'opacity-70'
+            )}
+          />
+        ),
         id: 'yolo',
         label: 'YOLO',
         onSelect: () => void toggleYolo(),

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -44,6 +44,7 @@ export type GatewayEventPayload = {
   reasoning_effort?: string
   service_tier?: string
   fast?: boolean
+  yolo?: boolean
   running?: boolean
   cwd?: string
   branch?: string

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -15,6 +15,8 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/branch')).toBe(true)
     expect(isDesktopSlashSuggestion('/skin')).toBe(true)
     expect(isDesktopSlashSuggestion('/usage')).toBe(true)
+    expect(isDesktopSlashSuggestion('/yolo')).toBe(true)
+    expect(isDesktopSlashCommand('/yolo')).toBe(true)
   })
 
   it('lets explicitly typed extension commands run without suggesting them', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -41,7 +41,8 @@ const DESKTOP_COMMAND_META = [
   ['/stop', 'Stop running background processes'],
   ['/title', 'Rename the current session'],
   ['/undo', 'Remove the last user/assistant exchange'],
-  ['/usage', 'Show token usage for this session']
+  ['/usage', 'Show token usage for this session'],
+  ['/yolo', 'Toggle YOLO — auto-approve dangerous commands']
 ] as const
 
 const DESKTOP_COMMANDS: ReadonlySet<string> = new Set(DESKTOP_COMMAND_META.map(([command]) => command))
@@ -114,8 +115,7 @@ const ADVANCED_COMMANDS = new Set([
   '/reasoning',
   '/reload-mcp',
   '/reload-skills',
-  '/voice',
-  '/yolo'
+  '/voice'
 ])
 
 const BLOCKED_COMMANDS = new Set([

--- a/apps/desktop/src/lib/icons.ts
+++ b/apps/desktop/src/lib/icons.ts
@@ -93,7 +93,8 @@ import {
   IconTool as Wrench,
   IconX as X,
   IconX as XIcon,
-  IconBolt as Zap
+  IconBolt as Zap,
+  IconBoltFilled as ZapFilled
 } from '@tabler/icons-react'
 
 export {
@@ -191,7 +192,8 @@ export {
   Wrench,
   X,
   XIcon,
-  Zap
+  Zap,
+  ZapFilled
 }
 
 export type { Icon as IconComponent } from '@tabler/icons-react'

--- a/apps/desktop/src/lib/yolo-session.ts
+++ b/apps/desktop/src/lib/yolo-session.ts
@@ -1,0 +1,23 @@
+import { setYoloActive } from '@/store/session'
+
+export type GatewayRequester = <T = unknown>(
+  method: string,
+  params?: Record<string, unknown>
+) => Promise<T>
+
+/** Apply per-session YOLO (approval bypass) via gateway `config.set`. */
+export async function setSessionYolo(
+  requestGateway: GatewayRequester,
+  sessionId: string,
+  enabled: boolean
+): Promise<boolean> {
+  const result = await requestGateway<{ value?: string }>('config.set', {
+    key: 'yolo',
+    session_id: sessionId,
+    value: enabled ? '1' : '0'
+  })
+  const active = result?.value === '1'
+  setYoloActive(active)
+
+  return active
+}

--- a/apps/desktop/src/lib/yolo-session.ts
+++ b/apps/desktop/src/lib/yolo-session.ts
@@ -5,7 +5,11 @@ export type GatewayRequester = <T = unknown>(
   params?: Record<string, unknown>
 ) => Promise<T>
 
-/** Apply per-session YOLO (approval bypass) via gateway `config.set`. */
+/**
+ * Toggle per-session YOLO (approval bypass) via gateway `config.set` — the same
+ * session-scoped flag as the TUI's Shift+Tab. It does NOT touch the global
+ * `approvals.mode` config, so CLI / TUI / cron behavior is unaffected.
+ */
 export async function setSessionYolo(
   requestGateway: GatewayRequester,
   sessionId: string,
@@ -16,7 +20,9 @@ export async function setSessionYolo(
     session_id: sessionId,
     value: enabled ? '1' : '0'
   })
+
   const active = result?.value === '1'
+
   setYoloActive(active)
 
   return active

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -3,12 +3,13 @@ import { atom } from 'nanostores'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { persistString, storedString } from '@/lib/storage'
+import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+const YOLO_STICKY_KEY = 'hermes.desktop.yolo-sticky'
 
 export const getRememberedWorkspaceCwd = (): string => storedString(WORKSPACE_CWD_KEY)?.trim() || ''
 
@@ -88,10 +89,12 @@ export const $currentProvider = atom('')
 export const $currentReasoningEffort = atom('')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(false)
-// Per-session YOLO (approval-bypass) state, mirrored from the gateway so the
-// status-bar toggle can colour itself. Not persisted — it follows the live
-// runtime session and resets when there's no active session.
-export const $yoloActive = atom(false)
+// Sticky YOLO (approval-bypass) preference. This is the user's *desired* state,
+// persisted across restarts — when on, every new/resumed session is forced into
+// YOLO (see use-session-actions). It is intentionally NOT overwritten by the
+// gateway's per-session state, so turning it on once keeps it on until the user
+// turns it off.
+export const $yoloActive = atom(storedBoolean(YOLO_STICKY_KEY, false))
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $currentBranch = atom('')
 export const $currentUsage = atom<UsageStats>({
@@ -126,7 +129,10 @@ export const setCurrentProvider = (next: Updater<string>) => updateAtom($current
 export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($currentReasoningEffort, next)
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
-export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
+export const setYoloActive = (next: Updater<boolean>) => {
+  updateAtom($yoloActive, next)
+  persistBoolean(YOLO_STICKY_KEY, $yoloActive.get())
+}
 
 export const setCurrentCwd = (next: Updater<string>) => {
   updateAtom($currentCwd, next)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -88,6 +88,10 @@ export const $currentProvider = atom('')
 export const $currentReasoningEffort = atom('')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(false)
+// Per-session YOLO (approval-bypass) state, mirrored from the gateway so the
+// status-bar toggle can colour itself. Not persisted — it follows the live
+// runtime session and resets when there's no active session.
+export const $yoloActive = atom(false)
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $currentBranch = atom('')
 export const $currentUsage = atom<UsageStats>({
@@ -122,6 +126,7 @@ export const setCurrentProvider = (next: Updater<string>) => updateAtom($current
 export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($currentReasoningEffort, next)
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
+export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
 
 export const setCurrentCwd = (next: Updater<string>) => {
   updateAtom($currentCwd, next)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -3,13 +3,12 @@ import { atom } from 'nanostores'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
+import { persistString, storedString } from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
-const YOLO_STICKY_KEY = 'hermes.desktop.yolo-sticky'
 
 export const getRememberedWorkspaceCwd = (): string => storedString(WORKSPACE_CWD_KEY)?.trim() || ''
 
@@ -89,12 +88,10 @@ export const $currentProvider = atom('')
 export const $currentReasoningEffort = atom('')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(false)
-// Sticky YOLO (approval-bypass) preference. This is the user's *desired* state,
-// persisted across restarts — when on, every new/resumed session is forced into
-// YOLO (see use-session-actions). It is intentionally NOT overwritten by the
-// gateway's per-session state, so turning it on once keeps it on until the user
-// turns it off.
-export const $yoloActive = atom(storedBoolean(YOLO_STICKY_KEY, false))
+// Effective approval-bypass state mirrored from the gateway (session.info).
+// Persistence lives in the backend config (approvals.mode), so this is a plain
+// reflection of the truth the gateway reports rather than its own store.
+export const $yoloActive = atom(false)
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $currentBranch = atom('')
 export const $currentUsage = atom<UsageStats>({
@@ -129,10 +126,7 @@ export const setCurrentProvider = (next: Updater<string>) => updateAtom($current
 export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($currentReasoningEffort, next)
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
-export const setYoloActive = (next: Updater<boolean>) => {
-  updateAtom($yoloActive, next)
-  persistBoolean(YOLO_STICKY_KEY, $yoloActive.get())
-}
+export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
 
 export const setCurrentCwd = (next: Updater<string>) => {
   updateAtom($currentCwd, next)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -321,6 +321,7 @@ export interface SessionRuntimeInfo {
   tools?: Record<string, string[]>
   usage?: Partial<UsageStats>
   version?: string
+  yolo?: boolean
 }
 
 export interface UsageStats {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1582,16 +1582,23 @@ def _session_info(agent, session: dict | None = None) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
-    # Per-session YOLO only — what `config.set yolo` toggles. Do not mirror
-    # HERMES_YOLO_MODE here; that is process-scoped and would lie to the desktop
-    # status bar while approvals.mode stays manual.
+    # Effective approval-bypass state — the same three sources that
+    # check_all_command_guards() ORs together: persistent config
+    # (approvals.mode=off), the process-scoped --yolo env, and the
+    # per-session flag. Reporting only the per-session flag here would lie to
+    # the desktop status bar (it would show YOLO "off" while approvals.mode=off
+    # silently auto-approves every dangerous command).
     yolo = False
     try:
-        session_key = (session or {}).get("session_key")
-        if session_key:
-            from tools.approval import is_session_yolo_enabled
+        from tools.approval import (
+            _YOLO_MODE_FROZEN,
+            _get_approval_mode,
+            is_session_yolo_enabled,
+        )
 
-            yolo = bool(is_session_yolo_enabled(session_key))
+        session_key = (session or {}).get("session_key")
+        session_yolo = bool(is_session_yolo_enabled(session_key)) if session_key else False
+        yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or _get_approval_mode() == "off"
     except Exception:
         yolo = False
     info: dict = {
@@ -5035,6 +5042,9 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"key": key, "value": nv})
 
     if key == "yolo":
+        # Per-session approval bypass — same scope as the TUI's Shift+Tab. This
+        # toggles ONLY this session's _session_yolo flag; it never writes the
+        # global approvals.mode, so it cannot change CLI / TUI / cron behavior.
         try:
             if session:
                 from tools.approval import (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1582,11 +1582,27 @@ def _session_info(agent, session: dict | None = None) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
+    # Surface YOLO (approval-bypass) state so clients (desktop status bar, TUI)
+    # can hydrate their indicator on session start/resume. Mirror exactly what
+    # `config.set yolo` reports: the session-scoped flag when we have a session,
+    # else the process-level HERMES_YOLO_MODE env toggle.
+    yolo = False
+    try:
+        session_key = (session or {}).get("session_key")
+        if session_key:
+            from tools.approval import is_session_yolo_enabled
+
+            yolo = bool(is_session_yolo_enabled(session_key))
+        if not yolo:
+            yolo = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
+    except Exception:
+        yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
+        "yolo": yolo,
         "tools": {},
         "skills": {},
         "cwd": cwd,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1582,10 +1582,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
-    # Surface YOLO (approval-bypass) state so clients (desktop status bar, TUI)
-    # can hydrate their indicator on session start/resume. Mirror exactly what
-    # `config.set yolo` reports: the session-scoped flag when we have a session,
-    # else the process-level HERMES_YOLO_MODE env toggle.
+    # Per-session YOLO only — what `config.set yolo` toggles. Do not mirror
+    # HERMES_YOLO_MODE here; that is process-scoped and would lie to the desktop
+    # status bar while approvals.mode stays manual.
     yolo = False
     try:
         session_key = (session or {}).get("session_key")
@@ -1593,8 +1592,6 @@ def _session_info(agent, session: dict | None = None) -> dict:
             from tools.approval import is_session_yolo_enabled
 
             yolo = bool(is_session_yolo_enabled(session_key))
-        if not yolo:
-            yolo = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
     except Exception:
         yolo = False
     info: dict = {
@@ -5046,13 +5043,28 @@ def _(rid, params: dict) -> dict:
                     is_session_yolo_enabled,
                 )
 
-                current = is_session_yolo_enabled(session["session_key"])
-                if current:
+                raw = str(value or "").strip().lower()
+                if raw in {"1", "on", "true", "yes"}:
+                    enable_session_yolo(session["session_key"])
+                    nv = "1"
+                elif raw in {"0", "off", "false", "no"}:
                     disable_session_yolo(session["session_key"])
                     nv = "0"
                 else:
-                    enable_session_yolo(session["session_key"])
-                    nv = "1"
+                    current = is_session_yolo_enabled(session["session_key"])
+                    if current:
+                        disable_session_yolo(session["session_key"])
+                        nv = "0"
+                    else:
+                        enable_session_yolo(session["session_key"])
+                        nv = "1"
+                agent = session.get("agent")
+                if agent is not None:
+                    _emit(
+                        "session.info",
+                        params.get("session_id", ""),
+                        _session_info(agent, session),
+                    )
             else:
                 current = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
                 if current:


### PR DESCRIPTION
## Summary
- Adds a clickable **YOLO** control to the desktop status bar (right group, just before the model selector): an icon-only **lightning bolt** — outline/dimmed when off, **filled** on a `#f4e381` fill when on.
- It toggles **per-session** approval bypass via the existing `config.set yolo` gateway RPC — the exact same session-scoped flag as the TUI's **Shift+Tab** / `/yolo`. It does **not** write the global `approvals.mode`, so it can never change CLI / TUI / cron behavior.
- `/yolo` now works in the desktop too: it maps to this control (and is listed in the slash palette) instead of returning "not available".
- On a brand-new chat draft (no runtime session yet) the toggle arms locally; the session-create path applies it once the backend session exists.

## Honest status display
The bolt previously only reflected the per-session flag, so it lied when a global policy already auto-approved commands (e.g. `approvals.mode: off` in `config.yaml`). Now:
- Gateway `_session_info` reports the **effective** bypass state — the same condition the approval guard ORs together: per-session yolo **OR** `approvals.mode == "off"` **OR** `HERMES_YOLO_MODE`.
- The desktop `$yoloActive` atom is a plain reflection of that, hydrated from `session.info` events and `applyRuntimeInfo` on session create/resume. Persistence lives in the backend (config / per-session), not in the client.

## Files
- `tui_gateway/server.py` — `_session_info` reports effective yolo; `config.set yolo` stays per-session-scoped
- `apps/desktop/src/store/session.ts` — `$yoloActive` atom + `setYoloActive`
- `apps/desktop/src/types/hermes.ts`, `src/lib/chat-messages.ts` — `yolo?: boolean` on runtime-info / event payloads
- `apps/desktop/src/app/session/hooks/use-message-stream.ts`, `use-session-actions.ts` — hydrate the atom + arm-on-create
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts` — `/yolo` handler
- `apps/desktop/src/lib/desktop-slash-commands.ts` (+ test) — make `/yolo` discoverable and routable
- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx` — the clickable bolt + toggle
- `apps/desktop/src/app/desktop-controller.tsx` — pass `freshDraftReady` / `requestGateway` into the hook
- `apps/desktop/src/lib/yolo-session.ts` — `setSessionYolo` helper
- `apps/desktop/src/lib/icons.ts` — `Zap` (outline) + `ZapFilled`

## Test plan
- [x] `npm run type-check` (apps/desktop) passes
- [x] `eslint` on changed files introduces no new errors (one pre-existing `perfectionist` import-sort error in `use-session-actions.ts` confirmed present on `main`)
- [x] `vitest` desktop slash-command suite passes
- [x] `tests/test_tui_gateway_server.py` passes (the lone `test_browser_manage_connect_default_local_reports_launch_hint` failure is environment-dependent — local machine has Chrome installed — and unrelated)
- [ ] Manual: start a session, click the bolt → fills, dangerous commands auto-approve; click again → outline. With `approvals.mode: off` in config, the bolt correctly shows on. `/yolo` toggles the same state.