### PR TITLE
feat(providers): add Inception as a named provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,14 @@
 # ARCEE_BASE_URL=                                 # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Inception)
+# =============================================================================
+# Inception provides access to the Mercury family of diffusion LLMs (mercury-2)
+# Get an Inception key at: https://platform.inceptionlabs.ai/
+# INCEPTION_API_KEY=
+# INCEPTION_BASE_URL=                             # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (MiniMax)
 # =============================================================================
 # MiniMax provides access to MiniMax models (global endpoint)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -336,6 +336,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek-chat",
         "deepseek-reasoner",
     ],
+    "inception": [
+        "mercury-2",
+    ],
     "xiaomi": [
         "mimo-v2.5-pro",
         "mimo-v2.5",
@@ -919,6 +922,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
+    ProviderEntry("inception",      "Inception",                "Inception (direct Inception API)"),
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V3, R1, coder, direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI Grok (Direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu direct API)"),

--- a/plugins/model-providers/inception/__init__.py
+++ b/plugins/model-providers/inception/__init__.py
@@ -1,0 +1,48 @@
+"""Inception provider profile.
+
+Inception (https://www.inceptionlabs.ai/) serves the Mercury family of
+diffusion LLMs behind an OpenAI-compatible API at
+``https://api.inceptionlabs.ai/v1``. Standard ``/v1/chat/completions`` —
+so the default ``chat_completions`` transport applies and no
+``HERMES_OVERLAYS`` entry is needed.
+
+We deliberately surface only ``mercury-2`` in the picker (the live
+``/v1/models`` endpoint may list additional models), so ``fetch_models``
+is pinned to that single id.
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class InceptionProfile(ProviderProfile):
+    """Inception — direct Inception API, only mercury-2 surfaced."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        # Pin the picker to mercury-2 regardless of what the live catalog
+        # returns. Returning the curated list (rather than None) keeps the
+        # picker fast and deterministic without a network round-trip.
+        return ["mercury-2"]
+
+
+inception = InceptionProfile(
+    name="inception",
+    aliases=("inception-labs", "inceptionlabs"),
+    display_name="Inception",
+    description="Inception (direct Inception API)",
+    signup_url="https://platform.inceptionlabs.ai/",
+    env_vars=("INCEPTION_API_KEY", "INCEPTION_BASE_URL"),
+    base_url="https://api.inceptionlabs.ai/v1",
+    auth_type="api_key",
+    default_aux_model="mercury-2",
+    fallback_models=("mercury-2",),
+)
+
+register_provider(inception)

--- a/plugins/model-providers/inception/plugin.yaml
+++ b/plugins/model-providers/inception/plugin.yaml
@@ -1,0 +1,5 @@
+name: inception-provider
+kind: model-provider
+version: 1.0.0
+description: Inception (direct Inception API) — Mercury diffusion LLMs
+author: Inception Labs

--- a/tests/hermes_cli/test_inception_provider.py
+++ b/tests/hermes_cli/test_inception_provider.py
@@ -1,0 +1,174 @@
+"""Tests for Inception provider support — standard direct, OpenAI-compatible
+API provider wired purely through its ``ProviderProfile`` plugin.
+
+Inception serves the Mercury family of diffusion LLMs at
+``https://api.inceptionlabs.ai/v1`` over the OpenAI ``chat/completions`` API,
+so it needs no ``HERMES_OVERLAYS`` entry, URL→provider mapping, or
+prefix-strip rule — the profile auto-wires the registry, picker, and runtime
+credential resolution. These tests assert that auto-wiring, plus the curated
+``mercury-2``-only catalog and the picker ordering (right before DeepSeek).
+"""
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+_OTHER_PROVIDER_KEYS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "DASHSCOPE_API_KEY",
+    "XAI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+    "KILOCODE_API_KEY", "HF_TOKEN", "GLM_API_KEY", "ZAI_API_KEY",
+    "XIAOMI_API_KEY", "TOKENHUB_API_KEY", "ARCEEAI_API_KEY",
+    "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+)
+
+
+# =============================================================================
+# Provider profile (the single source of truth)
+# =============================================================================
+
+
+class TestInceptionProfile:
+    def test_registered(self):
+        from providers import get_provider_profile
+        assert get_provider_profile("inception") is not None
+
+    def test_profile_fields(self):
+        from providers import get_provider_profile
+        p = get_provider_profile("inception")
+        assert p.name == "inception"
+        assert p.display_name == "Inception"
+        assert p.base_url == "https://api.inceptionlabs.ai/v1"
+        assert p.auth_type == "api_key"
+        assert "INCEPTION_API_KEY" in p.env_vars
+        assert "INCEPTION_BASE_URL" in p.env_vars
+
+    @pytest.mark.parametrize("alias", ["inception-labs", "inceptionlabs"])
+    def test_profile_alias_resolves(self, alias):
+        from providers import get_provider_profile
+        assert get_provider_profile(alias).name == "inception"
+
+    def test_fetch_models_pinned_to_mercury_2(self):
+        """fetch_models is deliberately pinned: only mercury-2 is surfaced,
+        regardless of what the live /v1/models endpoint returns."""
+        from providers import get_provider_profile
+        p = get_provider_profile("inception")
+        assert p.fetch_models(api_key="anything") == ["mercury-2"]
+        assert p.fallback_models == ("mercury-2",)
+
+
+# =============================================================================
+# Provider registry (auth.py — auto-extended from the api-key profile)
+# =============================================================================
+
+
+class TestInceptionProviderRegistry:
+    def test_registered(self):
+        assert "inception" in PROVIDER_REGISTRY
+
+    def test_name(self):
+        assert PROVIDER_REGISTRY["inception"].name == "Inception"
+
+    def test_auth_type(self):
+        assert PROVIDER_REGISTRY["inception"].auth_type == "api_key"
+
+    def test_inference_base_url(self):
+        assert (
+            PROVIDER_REGISTRY["inception"].inference_base_url
+            == "https://api.inceptionlabs.ai/v1"
+        )
+
+    def test_api_key_env_vars(self):
+        assert PROVIDER_REGISTRY["inception"].api_key_env_vars == ("INCEPTION_API_KEY",)
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["inception"].base_url_env_var == "INCEPTION_BASE_URL"
+
+
+# =============================================================================
+# Aliases (auth resolution)
+# =============================================================================
+
+
+class TestInceptionAliases:
+    @pytest.mark.parametrize("alias", ["inception", "inception-labs", "inceptionlabs"])
+    def test_alias_resolves(self, alias, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS + ("OPENROUTER_API_KEY",):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("INCEPTION_API_KEY", "inc-test-12345")
+        assert resolve_provider(alias) == "inception"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestInceptionCredentials:
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("INCEPTION_API_KEY", "inc-test")
+        assert get_api_key_provider_status("inception")["configured"]
+
+    def test_status_not_configured(self, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS + ("OPENROUTER_API_KEY", "INCEPTION_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        assert not get_api_key_provider_status("inception")["configured"]
+
+    def test_openrouter_key_does_not_make_inception_configured(self, monkeypatch):
+        """OpenRouter users should NOT see inception as configured."""
+        monkeypatch.delenv("INCEPTION_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        assert not get_api_key_provider_status("inception")["configured"]
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("INCEPTION_API_KEY", "inc-direct-key")
+        monkeypatch.delenv("INCEPTION_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("inception")
+        assert creds["api_key"] == "inc-direct-key"
+        assert creds["base_url"] == "https://api.inceptionlabs.ai/v1"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("INCEPTION_API_KEY", "inc-x")
+        monkeypatch.setenv("INCEPTION_BASE_URL", "https://staging.inceptionlabs.ai/v1")
+        creds = resolve_api_key_provider_credentials("inception")
+        assert creds["base_url"] == "https://staging.inceptionlabs.ai/v1"
+
+
+# =============================================================================
+# Model catalog + picker
+# =============================================================================
+
+
+class TestInceptionModelCatalog:
+    def test_static_model_list(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert _PROVIDER_MODELS["inception"] == ["mercury-2"]
+
+    def test_provider_model_ids(self):
+        from hermes_cli.models import provider_model_ids
+        assert provider_model_ids("inception") == ["mercury-2"]
+
+    def test_canonical_provider_entry(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "inception")
+        assert entry.label == "Inception"
+        assert entry.tui_desc == "Inception (direct Inception API)"
+
+    def test_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["inception"] == "Inception"
+
+    def test_ordered_immediately_before_deepseek(self):
+        """The picker lists Inception right after the Google providers and
+        immediately before DeepSeek (explicit placement, not auto-appended)."""
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert slugs[slugs.index("inception") + 1] == "deepseek"
+        assert slugs[slugs.index("inception") - 1] == "google-gemini-cli"


### PR DESCRIPTION
  ## What does this PR do?

  Adds **Inception** (inceptionlabs.ai) as a selectable provider in `hermes model`,
  served over its OpenAI-compatible API. It's wired through a `ProviderProfile`
  plugin, so the model picker, auth/API-key resolution, the `doctor` health check,
  the env-var wizard, and the runtime client all auto-discover it — no
  `HERMES_OVERLAYS` entry is required, since Inception speaks standard
  `/v1/chat/completions`. The profile's `fetch_models()` returns `mercury-2`, so
  the curated catalog used by `/model` and the dashboard picker surfaces that model.

  ## Related Issue

  N/A — small additive provider integration.

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `plugins/model-providers/inception/__init__.py` (new) — `ProviderProfile`:
    `base_url=https://api.inceptionlabs.ai/v1`, env vars `INCEPTION_API_KEY` /
    `INCEPTION_BASE_URL`, `auth_type=api_key`; `fetch_models()` returns `mercury-2`.
  - `plugins/model-providers/inception/plugin.yaml` (new) — plugin manifest.
  - `hermes_cli/models.py` — `CANONICAL_PROVIDERS` entry (listed directly before
    DeepSeek) and `_PROVIDER_MODELS["inception"] = ["mercury-2"]`.
  - `.env.example` — documents `INCEPTION_API_KEY` / `INCEPTION_BASE_URL`.
  - `tests/hermes_cli/test_inception_provider.py` (new) — 24 tests.

  ## How to Test

  1. `export INCEPTION_API_KEY=<your key>`
  2. `hermes model` → select **Inception** → pick `mercury-2`.
  3. `hermes -z "hello"` for a live completion, or `hermes doctor` for a no-cost
     `/v1/models` connectivity check.
  4. Tests: `scripts/run_tests.sh tests/hermes_cli/test_inception_provider.py` (24 pass).

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(providers):`)
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this feature (no unrelated commits)
  - [x] I've run the test suite and the relevant tests pass
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: Linux (Ubuntu)

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (`.env.example` for the new env vars)
  - [x] `cli-config.yaml.example` — N/A (no new config keys; provider auto-discovered)
  - [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
  - [x] Cross-platform impact considered — N/A (pure Python, no OS-specific code)
  - [x] Tool descriptions/schemas — N/A

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

