### PR TITLE
fix(auxiliary): repair TypeError that silently disabled configured fallback_chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3051,12 +3051,16 @@ def _resolve_single_provider(
 
     Uses the existing provider resolution infrastructure where possible.
     """
-    # Reuse resolve_provider_client which handles provider→client mapping
+    # Reuse resolve_provider_client which handles provider→client mapping.
+    # NOTE: its parameters are named explicit_base_url / explicit_api_key —
+    # passing base_url= / api_key= raises TypeError, which the bare except in
+    # _try_configured_fallback_chain swallows, silently disabling every
+    # configured fallback_chain entry.
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,8 @@ from agent.auxiliary_client import (
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
+    _try_configured_fallback_chain,
+    _resolve_single_provider,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
@@ -1602,6 +1604,49 @@ class TestCallLlmPaymentFallback:
             )
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
+
+
+class TestConfiguredFallbackChainResolution:
+    """fallback_chain entries must reach a real client through resolve_provider_client.
+
+    Regression: ``_resolve_single_provider`` called ``resolve_provider_client``
+    with ``base_url=`` / ``api_key=`` — kwargs that don't exist in its
+    signature (the parameters are ``explicit_base_url`` / ``explicit_api_key``).
+    Every fallback_chain entry raised TypeError, which the bare ``except`` in
+    ``_try_configured_fallback_chain`` swallowed, so configured chains never
+    resolved a client.  ``autospec=True`` enforces the real signature so a
+    kwarg-name regression fails loudly instead of being masked by a
+    permissive MagicMock.
+    """
+
+    def test_resolve_single_provider_matches_resolver_signature(self):
+        sentinel = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   autospec=True,
+                   return_value=(sentinel, "some-model")) as rpc:
+            client = _resolve_single_provider(
+                "openrouter", model="some-model",
+                base_url="https://example.test/v1", api_key="sk-test")
+        assert client is sentinel
+        _, kwargs = rpc.call_args
+        assert kwargs["explicit_base_url"] == "https://example.test/v1"
+        assert kwargs["explicit_api_key"] == "sk-test"
+
+    def test_configured_chain_resolves_entry_end_to_end(self):
+        sentinel = MagicMock()
+        chain_cfg = {"fallback_chain": [
+            {"provider": "openrouter", "model": "meta-llama/llama-3.3-70b"},
+        ]}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value=chain_cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   autospec=True,
+                   return_value=(sentinel, "meta-llama/llama-3.3-70b")):
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "glm", reason="payment error")
+        assert client is sentinel
+        assert model == "meta-llama/llama-3.3-70b"
+        assert label == "fallback_chain[0](openrouter)"
 
 
 class TestAuxiliaryFallbackLayering:


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError` that has silently disabled the per-task `auxiliary.<task>.fallback_chain` feature since it shipped.

`_resolve_single_provider` (called for every `fallback_chain` entry) invokes `resolve_provider_client` with `base_url=` / `api_key=` keyword arguments — but the resolver's parameters are named `explicit_base_url` / `explicit_api_key`. The call raises `TypeError: resolve_provider_client() got an unexpected keyword argument 'base_url'` on **every** entry, and the bare `except Exception` in `_try_configured_fallback_chain` swallows it. Net effect: user-configured fallback chains never resolve a client, and auxiliary calls always skip straight to the main-agent-model fallback as if no chain were configured.

Existing tests didn't catch this because they patch `_try_configured_fallback_chain` itself (testing the layering around it, not its internals).

Reproduction on current `main`:

```python
from agent.auxiliary_client import resolve_provider_client
resolve_provider_client(provider="openrouter", model="x", base_url=None, api_key=None)
# TypeError: resolve_provider_client() got an unexpected keyword argument 'base_url'
```

After the fix, a configured chain entry resolves and serves a live completion (verified end-to-end against a real provider: simulated 402 on the `compression` task -> `fallback_chain[0]` resolved -> completion returned).

## Related Issue

No existing issue found; happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_resolve_single_provider`: pass `explicit_base_url=` / `explicit_api_key=` (the resolver's actual parameter names) instead of `base_url=` / `api_key=`; comment documents the failure mode.
- `tests/agent/test_auxiliary_client.py` — new `TestConfiguredFallbackChainResolution` with two regression tests that patch `resolve_provider_client` with `autospec=True`, so the mock enforces the real signature and any future kwarg drift fails loudly instead of being masked by a permissive `MagicMock`. Both tests fail on current `main` and pass with the fix.

## Testing

```
pytest tests/agent/test_auxiliary_client.py -q
205 passed
```

Verified the new tests are red without the source change (2 failed) and green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
