### PR TITLE
fix(tools): wrap coroutines in create_task() in _run_async() to fix aiohttp timeout error

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -123,7 +123,8 @@ def _run_async(coro):
             loop_ready.set()
             try:
                 asyncio.set_event_loop(worker_loop)
-                return worker_loop.run_until_complete(coro)
+                tool_task = worker_loop.create_task(coro)
+                return worker_loop.run_until_complete(tool_task)
             finally:
                 try:
                     # Cancel anything still pending (e.g. task cancelled
@@ -167,10 +168,12 @@ def _run_async(coro):
     # lifetime — preventing "Event loop is closed" on GC cleanup.
     if threading.current_thread() is not threading.main_thread():
         worker_loop = _get_worker_loop()
-        return worker_loop.run_until_complete(coro)
+        tool_task = worker_loop.create_task(coro)
+        return worker_loop.run_until_complete(tool_task)
 
     tool_loop = _get_tool_loop()
-    return tool_loop.run_until_complete(coro)
+    tool_task = tool_loop.create_task(coro)
+    return tool_loop.run_until_complete(tool_task)
 
 
 # =============================================================================


### PR DESCRIPTION
Wrap the coroutine in `loop.create_task()` before passing it to `run_until_complete()` in all three code paths of `_run_async()`. This ensures `asyncio.current_task()` returns a valid task, which aiohttp's `TimerContext.__enter__()` requires on Python 3.11+.

Without this, when aiohttp creates a TimerContext during an HTTP request, it calls `asyncio.current_task()` which returns `None` because `run_until_complete()` schedules the coroutine at the event loop's top level without creating an asyncio `Task`. This raises:

```
RuntimeError: Timeout context manager should be used inside a task
```

Affects any synchronous tool handler that bridges to async via `_run_async()` and uses aiohttp with `ClientTimeout` — including `send_message` for Mattermost, Matrix, Email, SMS, Bluebubbles, QQbot, HomeAssistant, DingTalk, Feishu, WeCom, and Yuanbao platforms.

The Weixin adapter previously worked around this per-platform (#29037) by disabling aiohttp's ClientTimeout and using `asyncio.wait_for()` instead. This fix addresses the root cause, resolving it for all platforms at once.

Fixes #37005