### PR TITLE
fix(browser): pass viewport config to Camofox tab creation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -314,6 +314,11 @@ browser:
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
+  # Camofox browser backend settings (requires camofox-browser npm package)
+  # camofox:
+  #   viewport:
+  #     width: 1920    # 320–3840
+  #     height: 1080   # 240–2160
 
 # =============================================================================
 # Tool Loop Guardrails

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -406,6 +406,87 @@ class TestCamofoxVisionConfig:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Viewport configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxViewportConfig:
+    """Tests for _get_viewport_config and viewport in _ensure_tab."""
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_none_when_not_configured(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox()
+        from tools.browser_camofox import _get_viewport_config
+        assert _get_viewport_config() is None
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_returns_configured_dimensions(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport={"width": 1920, "height": 1080})
+        from tools.browser_camofox import _get_viewport_config
+        result = _get_viewport_config()
+        assert result == {"width": 1920, "height": 1080}
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_rejects_out_of_range_width(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport={"width": 100, "height": 720})
+        from tools.browser_camofox import _get_viewport_config
+        assert _get_viewport_config() is None
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_rejects_out_of_range_height(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport={"width": 1280, "height": 5000})
+        from tools.browser_camofox import _get_viewport_config
+        assert _get_viewport_config() is None
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_rejects_non_dict(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport="1280x720")
+        from tools.browser_camofox import _get_viewport_config
+        assert _get_viewport_config() is None
+
+    @patch("tools.browser_camofox.load_config")
+    def test_viewport_rejects_non_integer_values(self, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport={"width": "1280", "height": "720"})
+        from tools.browser_camofox import _get_viewport_config
+        assert _get_viewport_config() is None
+
+    @patch("tools.browser_camofox.requests.post")
+    @patch("tools.browser_camofox.load_config")
+    def test_ensure_tab_passes_viewport_to_api(self, mock_config, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox(viewport={"width": 1920, "height": 1080})
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab_vp"})
+
+        from tools.browser_camofox import _ensure_tab
+        _ensure_tab("vp_task", "https://example.com")
+
+        call_body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert call_body["viewport"] == {"width": 1920, "height": 1080}
+        assert call_body["userId"]
+        assert call_body["sessionKey"]
+        assert call_body["url"] == "https://example.com"
+
+    @patch("tools.browser_camofox.requests.post")
+    @patch("tools.browser_camofox.load_config")
+    def test_ensure_tab_omits_viewport_when_not_configured(self, mock_config, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_config.return_value = _config_with_camofox()
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab_novp"})
+
+        from tools.browser_camofox import _ensure_tab
+        _ensure_tab("novp_task", "https://example.com")
+
+        call_body = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "viewport" not in call_body
+
+
 class TestBrowserToolRouting:
     """Verify that browser_tool.py delegates to camofox when CAMOFOX_URL is set."""
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -335,19 +335,45 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
         return _adopt_existing_tab(session)
 
 
+def _get_viewport_config() -> Optional[Dict[str, int]]:
+    """Return viewport dimensions from ``browser.camofox.viewport`` config.
+
+    Expected format: ``{width: <int>, height: <int>}``.
+    Returns ``None`` if not configured or invalid.
+    """
+    camofox_cfg = _get_camofox_config()
+    viewport = camofox_cfg.get("viewport")
+    if not isinstance(viewport, dict):
+        return None
+    width = viewport.get("width")
+    height = viewport.get("height")
+    if not isinstance(width, int) or not isinstance(height, int):
+        return None
+    if not (320 <= width <= 3840) or not (240 <= height <= 2160):
+        logger.warning(
+            "camofox viewport out of range (%sx%s), ignoring", width, height,
+        )
+        return None
+    return {"width": width, "height": height}
+
+
 def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
     """Ensure a tab exists for the session, creating one if needed."""
     session = _get_session(task_id)
     if session["tab_id"]:
         return session
     base = get_camofox_url()
+    body: Dict[str, Any] = {
+        "userId": session["user_id"],
+        "sessionKey": session["session_key"],
+        "url": url,
+    }
+    viewport = _get_viewport_config()
+    if viewport:
+        body["viewport"] = viewport
     resp = requests.post(
         f"{base}/tabs",
-        json={
-            "userId": session["user_id"],
-            "sessionKey": session["session_key"],
-            "url": url,
-        },
+        json=body,
         timeout=_DEFAULT_TIMEOUT,
     )
     resp.raise_for_status()


### PR DESCRIPTION
## What does this PR do?

Passes the `viewport` config (`browser.camofox.viewport`) to the Camofox `POST /tabs` endpoint when creating new browser tabs. Without this, screenshots use the Camofox server's default viewport (1280x720) regardless of user configuration, resulting in cropped/zoomed screenshots.

## Related Issue

Fixes #38478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_camofox.py`: Add `_get_viewport_config()` to read and validate `browser.camofox.viewport` from config; pass viewport to `POST /tabs` body when configured and valid (range: 320–3840 × 240–2160)
- `tests/tools/test_browser_camofox.py`: Add 8 tests covering viewport config parsing, range validation, type checking, and API integration
- `cli-config.yaml.example`: Document the `browser.camofox.viewport` config option

## How to Test

1. Configure `browser.camofox.viewport` in `~/.hermes/config.yaml`:
   ```yaml
   browser:
     camofox:
       viewport:
         width: 1920
         height: 1080
   ```
2. Start Camofox and use `browser_navigate` to visit any site
3. Call `browser_screenshot` — the screenshot should be 1920×1080 instead of 1280×720
4. Run `pytest tests/tools/test_browser_camofox.py::TestCamofoxViewportConfig -v` — all 8 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/browser_camofox.py:_ensure_tab`, `tools/browser_camofox.py:_get_viewport_config`
- Blast radius: LOW — only affects Camofox browser tab creation; no impact on CDP or other browser backends
- Related patterns: `_get_camofox_config()` already used for `managed_persistence`, `adopt_existing_tab`, `rewrite_loopback_urls` — viewport follows the same config-driven pattern
