### PR TITLE
fix(line): classify image messages as photos

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -968,7 +968,7 @@ class LineAdapter(BasePlatformAdapter):
 
         event_obj = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT if msg_type == "text" else MessageType.IMAGE,
+            message_type=MessageType.TEXT if msg_type == "text" else MessageType.PHOTO,
             source=source_obj,
             raw_message=event,
             message_id=message_id,


### PR DESCRIPTION
## What does this PR do?

Fixes LINE inbound image messages being classified with the nonexistent `MessageType.IMAGE` enum value. Hermes' shared gateway enum uses `MessageType.PHOTO`, and downstream media/photo handling checks for `PHOTO`, so LINE image messages could fail before being routed as image messages.

## Related Issue

Fixes #38235

## Type of Change

- [x] Bug fix

## Changes Made

- `plugins/platforms/line/adapter.py`: classify non-text LINE inbound messages from `_handle_message_event()` as `MessageType.PHOTO` instead of `MessageType.IMAGE`.

## Real behavior proof

Behavior addressed: a LINE webhook image event now produces a Hermes `MessageEvent` with `message_type=photo`, while preserving the downloaded media path and media type.

Real environment tested: local Hermes source checkout on macOS, using the repository's existing Python 3.11 virtualenv from `/Users/allahyar/Documents/fastino-tasks/hermes-agent/.venv`, against this PR branch.

Exact command rerun after rebasing this branch:

```bash
/Users/allahyar/Documents/fastino-tasks/hermes-agent/.venv/bin/python - <<'PY'
import asyncio
from gateway.config import PlatformConfig
from gateway.platforms.base import MessageType
from plugins.platforms.line.adapter import LineAdapter

async def main():
    adapter = LineAdapter(PlatformConfig(enabled=True, extra={"channel_access_token": "tok", "channel_secret": "sec"}))
    captured = []

    async def fake_download(message_id, msg_type):
        print(f"download_called={message_id}:{msg_type}")
        return "/tmp/line-image-proof.jpg"

    async def fake_handle(event):
        captured.append(event)

    adapter._download_media = fake_download
    adapter.handle_message = fake_handle
    await adapter._handle_message_event({
        "replyToken": "reply-token",
        "source": {"type": "user", "userId": "U123"},
        "message": {"type": "image", "id": "img-1"},
    })
    event = captured[0]
    print(f"message_type={event.message_type.value}")
    print(f"is_photo={event.message_type is MessageType.PHOTO}")
    print(f"text={event.text}")
    print(f"media_urls={event.media_urls}")
    print(f"media_types={event.media_types}")

asyncio.run(main())
PY
```

Evidence after fix:

```text
download_called=img-1:image
message_type=photo
is_photo=True
text=[image]
media_urls=['/tmp/line-image-proof.jpg']
media_types=['image']
```

Before source evidence:

```text
message_type=MessageType.TEXT if msg_type == "text" else MessageType.IMAGE,
```

Observed result after fix: the LINE image event is converted into a `MessageEvent` using the shared `PHOTO` enum value, so it can follow the gateway's existing photo/media handling path.

What was not tested: a live LINE webhook with real channel credentials. The focused probe exercises the adapter's inbound image event path directly.

## Verification

```bash
/Users/allahyar/Documents/fastino-tasks/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_line_plugin.py -q -o addopts=
```

```text
73 passed in 0.42s
```

```bash
git diff --check
```

passed with no output.

## Notes

No new committed regression test is included in this PR; the change is a one-line enum correction and the direct runtime probe above covers the reported image-message behavior.
