### PR TITLE
fix(docker): bake hindsight-client into the image (#38128)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,10 +157,17 @@ RUN npm install --prefer-offline --no-audit && \
 # so Docker users can use these providers without requiring runtime
 # lazy-install access to PyPI (often blocked in containerized envs).
 #
+# The hindsight memory provider's client (hindsight-client) is baked in
+# for the same reason: it lazy-installs into /opt/hermes/.venv at first
+# use, which lives inside the (immutable) image layer rather than the
+# mounted /opt/data volume, so it is lost on every container recreate /
+# image update and recall/retain then fails with
+# `ModuleNotFoundError: No module named 'hindsight_client'` (#38128).
+#
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -172,6 +172,23 @@ def test_dockerfile_preinstalls_gateway_messaging_dependencies(dockerfile_text):
     )
 
 
+def test_dockerfile_preinstalls_hindsight_memory_dependency(dockerfile_text):
+    sync_steps = [
+        step for step in _run_steps(dockerfile_text)
+        if "uv sync" in step and "--no-install-project" in step
+    ]
+
+    assert sync_steps, "Dockerfile must install Python dependencies with uv sync"
+    assert any("--extra hindsight" in step for step in sync_steps), (
+        "Published Docker images must preload the [hindsight] extra so the "
+        "native Hindsight memory provider's client (hindsight-client) is baked "
+        "into /opt/hermes/.venv. It lazy-installs into the image layer (not the "
+        "mounted /opt/data volume), so without baking it in recall/retain fails "
+        "with `ModuleNotFoundError: No module named 'hindsight_client'` after "
+        "every container recreate / image update (#38128)."
+    )
+
+
 def test_dockerfile_builds_tui_assets(dockerfile_text):
     assert any(
         "ui-tui" in step and "npm" in step and "run build" in step


### PR DESCRIPTION
## Summary

Fixes #38128. The native **Hindsight** memory provider's Python client (`hindsight-client`) is not baked into the published Docker image — it lazy-installs into `/opt/hermes/.venv` at first use (`tools/lazy_deps.py`: `memory.hindsight`). That venv lives inside the **immutable image layer**, not the mounted `/opt/data` volume, so the dependency is wiped on every container recreate / image update.

After an update the profile config still points at Hindsight (it persists under `/opt/data`) and the Hindsight server is healthy, but recall/retain fails with:

```
ModuleNotFoundError: No module named 'hindsight_client'
Failed to search memory: No module named 'hindsight_client'
```

The reporter's manual workaround (`uv pip install hindsight-client` inside the running container) doesn't survive the next recreate, and pip-install-into-`.venv` isn't an officially supported durable Docker workflow.

## Impact case

A Docker user who has set up the native Hindsight memory provider in `local_external` mode loses all memory recall/retain the **first time they pull a new image or recreate the container** — a routine, expected operation. It's not an exotic config: it's the documented way to run self-hosted Hindsight in Docker, and the failure is silent (server healthy, config present, but every recall throws). This is the same class of air-gapped / PyPI-blocked-container failure as the Anthropic-in-Docker bug (#30394 → #30504), just for a memory provider instead of an inference provider.

## Fix

Add `--extra hindsight` to the image's `uv sync` line — the exact pattern already used for `--extra anthropic --extra bedrock --extra azure-identity` (#30504) and `--extra messaging` (#24698). Baking the optional dependency into the build layer makes it survive container recreate.

No pin-drift: the `[hindsight]` extra in `pyproject.toml` (`hindsight-client==0.6.1`) already matches `tools/lazy_deps.py` (`memory.hindsight`) and `uv.lock`, so this is a pure additive `--extra` with **no lockfile churn**. Per the 2026-05-12 `[all]` policy, the extra correctly stays out of `[all]` (memory providers are opt-in) and is only baked into the Docker surface.

## Verification

- **End-to-end install path** (the real mechanism, not just the Dockerfile text): ran the exact image command against the committed lockfile —
  `uv sync --frozen --no-install-project --extra hindsight` → installs `hindsight-client 0.6.1`, and `python -c 'import hindsight_client'` succeeds. This is precisely the resolution the build layer performs.
- **Regression guard**: added `test_dockerfile_preinstalls_hindsight_memory_dependency` (mirrors `test_dockerfile_preinstalls_gateway_messaging_dependencies`) so a future Dockerfile cleanup can't silently drop the extra. Mutation-tested: removing `--extra hindsight` from the Dockerfile makes the test fail with the cited `ModuleNotFoundError` rationale; restoring it passes. Full test file (8 tests) green via `scripts/run_tests.sh`.

## Image-size note

`hindsight-client` is a thin pure-Python HTTP client; the size delta is negligible (single-digit MB, no boto3-class transitives).

Closes #38128