### PR TITLE
fix(tools): honor explicit composite toolsets for platform-restricted defaults

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1290,8 +1290,28 @@ def _get_platform_tools(
         # keep that toolset enabled on first install.  Skip this dodge for
         # platform-restricted toolsets — those are always opt-in even on
         # their own platform (e.g. `discord` + `discord` should stay OFF).
-        if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
+        #
+        # However, when the user has *explicitly* listed toolsets for this
+        # platform in platform_toolsets (even via composite names like
+        # "hermes-discord"), respect their opt-in by also removing
+        # platform-restricted toolsets from default_off.  Without this,
+        # composites fall through to the else-branch (non-explicit-config
+        # path) and the restriction silently strips discord / discord_admin
+        # despite the user's config.  (#35527)
+        if platform in default_off and (
+            platform not in _TOOLSET_PLATFORM_RESTRICTIONS
+            or platform in platform_toolsets
+        ):
             default_off.remove(platform)
+        # When the user explicitly configured this platform's toolsets,
+        # also remove any platform-restricted toolsets (e.g. discord_admin)
+        # from default_off — otherwise they're silently stripped even though
+        # the composite includes them.
+        if platform in platform_toolsets:
+            default_off -= {
+                ts for ts, restricted in _TOOLSET_PLATFORM_RESTRICTIONS.items()
+                if platform in restricted
+            }
         # Home Assistant is already runtime-gated by its check_fn (requires
         # HASS_TOKEN to register any tools). When a user has configured
         # HASS_TOKEN, they've explicitly opted in — don't also strip it via

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1269,6 +1269,31 @@ def test_discord_toolsets_user_enabled_are_honored():
     assert "discord_admin" not in enabled
 
 
+def test_discord_composite_toolset_honors_explicit_config():
+    """Regression: platform_toolsets.discord = ['hermes-discord'] must not
+    silently drop discord / discord_admin due to _TOOLSET_PLATFORM_RESTRICTIONS.
+
+    The composite name "hermes-discord" is not in CONFIGURABLE_TOOLSETS, so it
+    enters the else-branch (non-explicit-config path).  The platform restriction
+    previously blocked the default_off carve-out, stripping the toolsets even
+    though the user explicitly listed them.  (#35527)
+    """
+    config = {"platform_toolsets": {"discord": ["hermes-discord"]}}
+    enabled = _get_platform_tools(config, "discord")
+    assert "discord" in enabled, "discord toolset missing with explicit hermes-discord composite"
+    assert "discord_admin" in enabled, "discord_admin toolset missing with explicit hermes-discord composite"
+
+
+def test_discord_composite_not_auto_enabled_without_config():
+    """discord / discord_admin must stay OFF when no platform_toolsets entry
+    exists (default install).  The platform restriction keeps them opt-in."""
+    enabled = _get_platform_tools({}, "discord")
+    # On a fresh install without explicit config, discord should NOT be
+    # auto-enabled — it's a restricted platform toolset.
+    assert "discord" not in enabled
+    assert "discord_admin" not in enabled
+
+
 def test_save_platform_tools_strips_restricted_toolsets():
     """Hand-edited or all-platforms checklist with `discord` selected for
     Telegram must be stripped at save time."""


### PR DESCRIPTION
## Summary
`platform_toolsets.discord: [hermes-discord]` (the bare composite name) now correctly enables the `discord` / `discord_admin` toolsets instead of silently dropping them.

Root cause: the composite name `hermes-discord` isn't in `CONFIGURABLE_TOOLSETS`, so resolution falls into the non-explicit-config else-branch. There, `_DEFAULT_OFF_TOOLSETS` stripped `discord`/`discord_admin` because the platform restriction (`platform in _TOOLSET_PLATFORM_RESTRICTIONS`) blocked the carve-out — even though the user had explicitly listed the composite. The recovery pass couldn't rescue them either, since both are in `CONFIGURABLE_TOOLSETS` (hence in the `skip` set).

## Changes
- `hermes_cli/tools_config.py`: in the else-branch, when the user has an explicit `platform_toolsets` entry for the platform (including composite names), also remove platform-restricted toolsets from `default_off`. Guarded by `platform in platform_toolsets`, so fresh installs keep discord opt-in.
- `tests/hermes_cli/test_tools_config.py`: regression test for the composite case + negative test asserting fresh-install opt-in is preserved.

## Validation
E2E matrix against `_get_platform_tools()`:

| config | discord | discord_admin |
|---|---|---|
| fresh install (no config) | OFF | OFF |
| `[hermes-discord]` (the fix) | **ON** | **ON** |
| `[discord, discord_admin]` | ON | ON |
| `[]` (deselect-all) | OFF | OFF |
| telegram `[hermes-discord]` (leak check) | OFF | OFF |

`pytest tests/hermes_cli/test_tools_config.py -k discord` → 7 passed.

Salvaged from #35536 by @liuhao1024 (authorship preserved via cherry-pick). Fixes #35527.

## Infographic

![discord-toolset-rescue](https://v3b.fal.media/files/b/0a9cdef9/jUbI8gkEhntsN7y0kc-wR_Vhy1BxeK.png)
