### PR TITLE
fix(kanban): keep workers out of inherited TUI mode

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6614,6 +6614,14 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
+    # Kanban workers are always headless ``chat -q`` CLI runs.  If the
+    # dispatcher lives inside a TUI/dashboard process, inherited TUI launch
+    # variables (especially HERMES_TUI=1) would make the child try to start the
+    # Node TUI and crash on hosts where the dispatcher PATH has node but not
+    # npm.  Strip TUI-only state before adding worker-specific env below.
+    for key in list(env):
+        if key == "HERMES_TUI" or key.startswith("HERMES_TUI_"):
+            env.pop(key, None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1559,6 +1559,51 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawna
         assert kb.get_task(conn, t).claim_lock is None
 
 
+def test_default_spawn_forces_cli_mode_when_dispatcher_inherits_tui_env(
+    kanban_home, tmp_path, monkeypatch
+):
+    """Kanban workers are headless CLI runs, even if the dispatcher was
+    started from a TUI/dashboard process that has TUI-only env vars.
+
+    Regresses the failure where workers inherited ``HERMES_TUI=1``, launched
+    the TUI instead of ``chat -q``, then crashed with "npm not found" in
+    environments whose dispatcher PATH includes node but not npm.
+    """
+    captured = {}
+
+    class FakePopen:
+        pid = 4242
+
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env", {})
+            captured["cwd"] = kwargs.get("cwd")
+
+    monkeypatch.setenv("HERMES_TUI", "1")
+    monkeypatch.setenv("HERMES_TUI_QUERY", "stale dashboard prompt")
+    monkeypatch.setenv("HERMES_TUI_GATEWAY_URL", "ws://dashboard.invalid/api/ws")
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="spawn", assignee="default")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+
+    pid = kb._default_spawn(task, str(workspace), board="default")
+
+    assert pid == 4242
+    assert captured["cwd"] == str(workspace)
+    assert "--tui" not in captured["cmd"]
+    assert captured["cmd"][-3:] == ["chat", "-q", f"work kanban task {tid}"]
+    assert "HERMES_TUI" not in captured["env"]
+    assert "HERMES_TUI_QUERY" not in captured["env"]
+    assert "HERMES_TUI_GATEWAY_URL" not in captured["env"]
+    assert captured["env"]["HERMES_KANBAN_TASK"] == tid
+
+
 def test_dispatch_max_spawn_counts_existing_running_tasks(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## What does this PR do?

Prevents headless kanban worker subprocesses from accidentally inheriting TUI launch state from a dispatcher running under the TUI or dashboard. Inherited `HERMES_TUI=1` / `HERMES_TUI_*` variables can make the `hermes ... chat -q` worker enter TUI startup instead of the intended quiet CLI worker path, which can crash before the worker reports `kanban_complete` or `kanban_block`.

This keeps the existing worker launch command and strips only TUI hand-off environment variables before adding the kanban worker-specific environment.

## Related Issue

Related: #32057 proposes the same production fix. This PR rebases the fix on current `main` and adds a more explicit regression test for the TUI/dashboard inherited-env case.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: remove `HERMES_TUI` and all `HERMES_TUI_*` variables from the environment copied into `_default_spawn()` worker subprocesses.
- `tests/hermes_cli/test_kanban_db.py`: add regression coverage proving a dispatcher with inherited TUI env still spawns `chat -q` with TUI-only env removed.

## How to Test

1. Run the targeted regression test:
   ```bash
   python -m pytest tests/hermes_cli/test_kanban_db.py::test_default_spawn_forces_cli_mode_when_dispatcher_inherits_tui_env -q
   ```
2. Expected result:
   ```text
   1 passed
   ```

Tested locally on Linux 6.12.90 / NixOS using the repository dev virtualenv:

```bash
python -m pytest tests/hermes_cli/test_kanban_db.py::test_default_spawn_forces_cli_mode_when_dispatcher_inherits_tui_env -q
# 1 passed in 0.62s
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found related #32057)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.12.90 / NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
