### PR TITLE
fix: recognize iTerm.app and Apple Terminal for Shift+Enter newline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2661,6 +2661,14 @@ def _preserve_ctrl_enter_newline() -> bool:
         return True
     if os.environ.get("TERM_PROGRAM", "").lower() == "ghostty":
         return True
+    # iTerm.app sends bare LF (0x0a) for Shift+Enter while plain Enter
+    # sends CR (0x0d). Without this, Shift+Enter triggers the c-j submit
+    # binding instead of inserting a newline.
+    if os.environ.get("TERM_PROGRAM", "") == "iTerm.app":
+        return True
+    # Apple Terminal also sends bare LF for Shift+Enter.
+    if os.environ.get("TERM_PROGRAM", "") == "Apple_Terminal":
+        return True
     if "microsoft" in os.environ.get("WSL_DISTRO_NAME", "").lower():
         return True
     # WSL detection — env vars can be scrubbed under sudo, also peek /proc.

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -144,6 +144,18 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
+  // iTerm.app on macOS sends \n (LF) for Shift+Enter and \r (CR) for plain
+  // Enter. Without this, Shift+Enter is indistinguishable from Enter and
+  // submits the message instead of inserting a newline.
+  if ((env.TERM_PROGRAM ?? '') === 'iTerm.app') {
+    return true
+  }
+
+  // Apple Terminal also sends \n for Shift+Enter.
+  if ((env.TERM_PROGRAM ?? '') === 'Apple_Terminal') {
+    return true
+  }
+
   return (env.WSL_DISTRO_NAME ?? '').toLowerCase().includes('microsoft')
 }
 


### PR DESCRIPTION
## Problem

On **iTerm.app** and **Apple Terminal** (macOS), pressing **Shift+Enter** sends a bare LF (`0x0a` / `\n` / `Keys.ControlJ`) while plain Enter sends CR (`0x0d`).

Because neither terminal was listed in the `_preserve_ctrl_enter_newline()` / `shouldPreserveCtrlJNewline()` allowlists, the `c-j` key was bound to the **submit** handler. This meant Shift+Enter would **send the message** instead of inserting a newline — making multi-line input impossible without using `\` + Enter.

## Fix

Add `iTerm.app` and `Apple_Terminal` to the terminal allowlist in both:

- **`cli.py`** — `_preserve_ctrl_enter_newline()` (prompt\_toolkit CLI mode)
- **`ui-tui/src/components/textInput.tsx`** — `shouldPreserveCtrlJNewline()` (Ink TUI mode)

When these terminals are detected via `TERM_PROGRAM`, `c-j` is no longer bound to submit, and the existing `handle_ctrl_enter_newline` binding fires correctly to insert a newline.

## Testing

Manually verified on iTerm.app 3.x (macOS):
- Shift+Enter now inserts a newline in both CLI and TUI modes
- Plain Enter still submits the message
- No regression on other terminals (Ghostty, WSL tested via existing code paths)

## Notes

These are the two most common macOS terminal emulators after Ghostty (which was already supported). This should cover the vast majority of macOS users.