### PR TITLE
feat(prompt): broaden Hermes self-knowledge pointer to docs + skill

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -129,9 +129,14 @@ DEFAULT_AGENT_IDENTITY = (
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (
-    "If the user asks about configuring, setting up, or using Hermes Agent "
-    "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "before answering. Docs: https://hermes-agent.nousresearch.com/docs"
+    "You run on Hermes Agent (by Nous Research). When the user needs help with "
+    "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
+    "it — or when you need to understand your own features, tools, or capabilities, "
+    "the documentation at https://hermes-agent.nousresearch.com/docs is your "
+    "authoritative reference and always holds the latest, most up-to-date "
+    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+    "for additional guidance and proven workflows, but treat the docs as the source "
+    "of truth when the two differ."
 )
 
 MEMORY_GUIDANCE = (


### PR DESCRIPTION
## Summary
Every Hermes agent now treats the docs site as a standing source of self-knowledge — not just a reactive lookup when the user explicitly asks about config.

`HERMES_AGENT_HELP_GUIDANCE` (added in #16535, Apr 27) only fired "if the user asks about configuring, setting up, or using Hermes Agent itself." This broadens it: the agent treats https://hermes-agent.nousresearch.com/docs as its authoritative, always-latest reference for any Hermes-related help and for understanding its own features/tools, points to the `hermes-agent` skill for additional guidance/workflows, and treats the docs as the source of truth when the two differ.

## Changes
- `agent/prompt_builder.py`: rewrite the `HERMES_AGENT_HELP_GUIDANCE` constant. Wider trigger (help/extend/troubleshoot + self-understanding, not just config), docs framed as authoritative + latest, skill kept as secondary guidance.

## Cache safety
Static constant in the stable tier (`system_prompt.py:102`, appended unconditionally for every agent). No runtime metadata, no per-turn mutation — upholds the system-prompt HARD INVARIANT, zero prompt-cache impact.

## Validation
E2E via a real offline `AIAgent` (`build_system_prompt_parts`, dummy key/url, no network):

| Check | Result |
|---|---|
| Docs URL in stable tier | PASS |
| "authoritative reference" framing | PASS |
| "most up-to-date" latest framing | PASS |
| `skill_view(name='hermes-agent')` pointer | PASS |
| "source of truth when the two differ" | PASS |

## Infographic

![ui-wireframe](https://v3b.fal.media/files/b/0a9cdf17/0QVucmJ0Z4KjVhH4_bSob_IT1qHshV.png)
