### PR TITLE
fix(gateway): intercept freeform text replies to multi-choice clarify prompts #38475

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7470,14 +7470,24 @@ class GatewayRunner:
                 _update_prompts.pop(_quick_key, None)
 
         # Intercept messages that are responses to a pending clarify
-        # request that is awaiting free-form text (either an open-ended
-        # clarify with no choices, or one where the user picked the
-        # "Other" button).  The first non-empty user message in the
-        # session resolves the clarify and unblocks the agent thread —
-        # we do NOT route it to the agent as a new turn.
+        # request.  Covers two cases (see GitHub issue #38475):
+        #
+        #  1. Open-ended clarify (no choices) or "Other" button clicked:
+        #     ``awaiting_text`` is True — next message is captured as the
+        #     free-form response.
+        #
+        #  2. Multi-choice clarify with choices: ``awaiting_text`` is
+        #     False, but any typed non-command text should be treated as
+        #     the user's custom "Other" answer.  Numeric replies map to
+        #     the corresponding choice; exact choice text maps to that
+        #     choice; everything else resolves as free-form text.
+        #
+        # In both cases the first non-empty user message in the session
+        # resolves the clarify and unblocks the agent thread — we do NOT
+        # route it to the agent as a new turn.
         try:
             from tools import clarify_gateway as _clarify_mod
-            _pending_clarify = _clarify_mod.get_pending_for_session(_quick_key)
+            _pending_clarify = _clarify_mod.get_any_pending_for_session(_quick_key)
         except Exception:
             _pending_clarify = None
         if _pending_clarify is not None:
@@ -7487,8 +7497,28 @@ class GatewayRunner:
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
+                # For multi-choice clarifies, try to map the typed text
+                # to a choice before falling through to free-form.
+                _clarify_response = _raw_clarify_reply
+                if (
+                    _pending_clarify.choices
+                    and not _pending_clarify.awaiting_text
+                ):
+                    # Numeric reply → map to choice text (1-indexed)
+                    try:
+                        _choice_idx = int(_raw_clarify_reply) - 1
+                        if 0 <= _choice_idx < len(_pending_clarify.choices):
+                            _clarify_response = _pending_clarify.choices[_choice_idx]
+                    except (ValueError, TypeError):
+                        # Not a number — check for exact choice match
+                        _lower_reply = _raw_clarify_reply.lower()
+                        for _choice in _pending_clarify.choices:
+                            if _lower_reply == _choice.lower():
+                                _clarify_response = _choice
+                                break
+                        # else: free-form text, use as-is
                 _resolved = _clarify_mod.resolve_gateway_clarify(
-                    _pending_clarify.clarify_id, _raw_clarify_reply,
+                    _pending_clarify.clarify_id, _clarify_response,
                 )
                 if _resolved:
                     logger.info(

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -224,3 +224,57 @@ class TestGatewayTextIntercept:
         
         # Clean up
         cm.clear_session("sk-tf")
+
+
+class TestGetAnyPendingForSession:
+    """Tests for get_any_pending_for_session (GitHub issue #38475).
+
+    Unlike get_pending_for_session, this returns entries regardless of
+    whether they are in awaiting_text mode — so freeform typed replies to
+    multi-choice clarify prompts are captured instead of dropped.
+    """
+
+    def setup_method(self):
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+
+    def test_returns_awaiting_text_entry(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("c1", "sk", "Free form?", None)
+        assert cm.get_any_pending_for_session("sk") is not None
+
+    def test_returns_multi_choice_entry(self):
+        """Multi-choice clarify (awaiting_text=False) should be found."""
+        from tools import clarify_gateway as cm
+
+        cm.register("c2", "sk", "Pick", ["A", "B"])
+        entry = cm.get_any_pending_for_session("sk")
+        assert entry is not None
+        assert entry.clarify_id == "c2"
+        assert entry.awaiting_text is False
+
+    def test_returns_none_when_no_pending(self):
+        from tools import clarify_gateway as cm
+
+        assert cm.get_any_pending_for_session("empty") is None
+
+    def test_returns_oldest_multi_choice(self):
+        """FIFO ordering — oldest pending entry returned first."""
+        from tools import clarify_gateway as cm
+
+        cm.register("older", "sk", "Q1?", ["A"])
+        cm.register("newer", "sk", "Q2?", ["B"])
+        entry = cm.get_any_pending_for_session("sk")
+        assert entry is not None
+        assert entry.clarify_id == "older"
+
+    def test_get_pending_vs_any_pending_divergence(self):
+        """get_pending_for_session skips multi-choice; get_any finds it."""
+        from tools import clarify_gateway as cm
+
+        cm.register("c-div", "sk-div", "Pick", ["X", "Y"])
+        assert cm.get_pending_for_session("sk-div") is None
+        assert cm.get_any_pending_for_session("sk-div") is not None

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -180,6 +180,26 @@ def get_pending_for_session(session_key: str) -> Optional[_ClarifyEntry]:
         return None
 
 
+def get_any_pending_for_session(session_key: str) -> Optional[_ClarifyEntry]:
+    """Return the OLDEST pending clarify entry for a session, or None.
+
+    Unlike :func:`get_pending_for_session`, this returns entries regardless
+    of whether they are in ``awaiting_text`` mode.  Used by the gateway
+    text-fallback intercept so that freeform typed replies to multi-choice
+    clarify prompts are captured as the user's custom "Other" answer
+    rather than being silently dropped.
+
+    See GitHub issue #38475.
+    """
+    with _lock:
+        ids = _session_index.get(session_key) or []
+        for cid in ids:
+            entry = _entries.get(cid)
+            if entry is not None:
+                return entry
+        return None
+
+
 def mark_awaiting_text(clarify_id: str) -> bool:
     """Flip an entry into text-capture mode (user picked the 'Other' button).
 


### PR DESCRIPTION
## Summary

When a clarify prompt with multiple choices is pending, typed freeform replies were silently dropped because  only returned entries in  mode. This made the chat feel wedged — the user kept sending normal text, but the agent remained blocked on the clarify prompt.

Fixes #38475

## Changes

- ****: Add  that returns pending clarify entries regardless of  mode
- ****: Update the text-fallback intercept to use the new function, with smart choice mapping:
  - Numeric replies → map to the corresponding choice text (1-indexed)
  - Exact choice text (case-insensitive) → resolve with that choice
  - Any other non-command text → resolve as freeform Other answer
- ****: Add 5 tests covering  behavior

## Root cause

 filtered by , which is only  for open-ended clarifies or when the user clicked the Other button. For multi-choice clarifies (where  is set),  starts as , so the text intercept never fired — typed messages fell through to normal dispatch while the clarify remained pending.