### PR TITLE
docs(desktop): point Chat section to remote-backend + dashboard doc

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -57,6 +57,8 @@ The center of the app. You get:
 - **Drag-and-drop files** anywhere in the chat area to attach them to your next message.
 - **A right-hand preview rail** — render web pages, files, and tool outputs side by side while you keep chatting.
 
+Chatting against a Hermes instance on another machine instead of the bundled local backend? See [Connecting to a remote backend](#connecting-to-a-remote-backend) below — and for the full picture of how the remote-hosted dashboard connection works (the `/api/ws` chat socket, the `--tui` requirement, session-token pinning, and WebSocket close-code triage), see [Web Dashboard → Connecting Hermes Desktop to a remote backend](./features/web-dashboard.md#connecting-hermes-desktop-to-a-remote-backend).
+
 ### File browser
 
 Explore and preview the working directory without leaving the app — useful for following along as the agent reads, writes, and edits files. Set the initial project directory with `hermes desktop --cwd <path>` (or the `HERMES_DESKTOP_CWD` environment variable).


### PR DESCRIPTION
## Summary
Adds a signpost from the Desktop app's Chat section to the remote-backend documentation, so a reader on the Chat page knows the remote-hosted Hermes connection is fully documented.

The Desktop Chat section described chat-only and gave no hint that connecting to a Hermes instance on another machine is covered elsewhere. This adds a one-line pointer to the in-page remote-backend section and to the deeper Web Dashboard doc (which covers the `/api/ws` chat socket, the `--tui` requirement, session-token pinning, and WebSocket close-code triage).

## Changes
- `website/docs/user-guide/desktop.md`: one cross-link line in the **Chat** section pointing to `#connecting-to-a-remote-backend` (in-page) and to `web-dashboard.md#connecting-hermes-desktop-to-a-remote-backend` (the deep doc added in #38534).

## Validation
| | Before | After |
|---|---|---|
| Desktop Chat → remote info | no signpost | links to in-page section + dashboard deep doc |

Docs-only. Both anchor targets verified to resolve (in-page `#connecting-to-a-remote-backend`, cross-page dashboard anchor from #38534).

## Infographic

![desktop-chat-remote-docs-pointer](https://v3b.fal.media/files/b/0a9cdf46/iaf32n3nX2ZnXjjGiBggc_N6nMHmIn.png)
