### PR TITLE
fix(desktop): disable provider key validation in launch setup

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -56,8 +56,6 @@ interface ApiKeyOption {
   short?: string
 }
 
-const MIN_KEY_LENGTH = 8
-
 const API_KEY_OPTIONS: ApiKeyOption[] = [
   {
     id: 'openrouter',
@@ -418,7 +416,9 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
   const [error, setError] = useState<null | string>(null)
 
   const isLocal = option.envKey === 'OPENAI_BASE_URL'
-  const canSave = value.trim().length >= (isLocal ? 1 : MIN_KEY_LENGTH)
+  // Only require a non-empty value — no length/format validation, so a short
+  // or unusual key can't block the user from continuing.
+  const canSave = value.trim().length >= 1
 
   const submit = async () => {
     if (!canSave || saving) {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -9,8 +9,7 @@ import {
   setEnvVar,
   setModelAssignment,
   startOAuthLogin,
-  submitOAuthCode,
-  validateProviderCredential
+  submitOAuthCode
 } from '@/hermes'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { notify, notifyError } from '@/store/notifications'
@@ -253,12 +252,16 @@ async function completeWithModelConfirm(
   ctx: OnboardingContext,
   providerLabel: string,
   preferredSlugs: string[],
-  onFail: (reason: null | string) => void
+  onFail: (reason: null | string) => void,
+  // When true, a failing runtime check no longer blocks progression — the
+  // user is allowed through onboarding regardless. Used by the API-key path,
+  // where we intentionally don't validate the key (it blocked too many users).
+  ignoreRuntimeGate = false
 ) {
   await ctx.requestGateway('reload.env').catch(() => undefined)
   const runtime = await checkRuntime(ctx)
 
-  if (!runtime.ready) {
+  if (!runtime.ready && !ignoreRuntimeGate) {
     onFail(runtime.reason)
 
     return
@@ -616,23 +619,13 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
     return { ok: false, message: 'Enter a value first.' }
   }
 
-  // Live-probe the credential BEFORE persisting so a mistyped key never lands
-  // in .env. A rejected key (reachable && !ok) hard-blocks; an unreachable
-  // probe (offline / provider down) falls through and saves with the usual
-  // runtime check, so we don't strand offline users.
-  try {
-    const probe = await validateProviderCredential(envKey, trimmed)
-    if (!probe.ok && probe.reachable) {
-      return { ok: false, message: probe.message || `That ${label} key was rejected.` }
-    }
-  } catch {
-    // Validation endpoint unavailable — don't block; fall through to save.
-  }
-
+  // No key validation here on purpose: we previously live-probed the key and
+  // hard-blocked on a runtime check after saving, which rejected too many
+  // legitimate users (corporate proxies, regional blocks, flaky/rate-limited
+  // provider probes, self-hosted endpoints). We now save the value as-is and
+  // let the user proceed; an actually-bad key surfaces later at chat time.
   try {
     await setEnvVar(envKey, trimmed)
-    let stillFailing = false
-    let runtimeFailure: null | string = null
     // For API-key flows we don't have a definitive provider id (the
     // user picked which API key they're entering, but the corresponding
     // backend slug — e.g. OPENROUTER_API_KEY → "openrouter" — is the
@@ -640,19 +633,8 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
     // fetchProviderDefaultModel falls back to the first authenticated
     // provider returned by /api/model/options if none match.
     const slugCandidates = [envKey.replace(/_API_KEY$/, '').toLowerCase(), label.toLowerCase()]
-    await completeWithModelConfirm(ctx, label, slugCandidates, reason => {
-      stillFailing = true
-      runtimeFailure = reason
-    })
-
-    if (stillFailing) {
-      const failureDetail = (runtimeFailure ?? '').trim()
-
-      return {
-        ok: false,
-        message: failureDetail || `Saved, but Hermes still cannot reach ${label}. Double-check the value.`
-      }
-    }
+    // ignoreRuntimeGate=true: never block onboarding on the runtime check.
+    await completeWithModelConfirm(ctx, label, slugCandidates, () => undefined, true)
 
     return { ok: true }
   } catch (error) {


### PR DESCRIPTION
## Summary
The launch/onboarding provider setup screen was blocking too many legitimate users. It enforced three gates before letting someone through:

1. A **live credential probe** (`POST /api/providers/validate`) that hard-blocked on `reachable && !ok` → "That API key was rejected."
2. A **post-save runtime check** (`setup.runtime_check`) that returned an error → "Saved, but Hermes still cannot reach X."
3. An **8-character minimum** on the key before the **Connect** button enabled.

These fire false negatives for corporate proxies, region-blocked endpoints, rate-limited/flaky provider probes, and self-hosted/base-URL setups. This PR removes all three from the API-key entry path: we now only require a **non-empty** value, save it as-is, and let the user continue. A genuinely bad key surfaces later at chat time rather than wedging onboarding.

## Changes
- `apps/desktop/src/store/onboarding.ts`
  - `saveOnboardingApiKey`: drop the `validateProviderCredential` live probe and the runtime-check hard-block; just persist the value and proceed.
  - `completeWithModelConfirm`: add an opt-in `ignoreRuntimeGate` param (default `false`, so **OAuth flows keep their runtime gate**); the API-key path passes `true`.
  - Remove the now-unused `validateProviderCredential` import.
- `apps/desktop/src/components/desktop-onboarding-overlay.tsx`
  - `ApiKeyForm`: `canSave` now only requires a non-empty trimmed value; remove the unused `MIN_KEY_LENGTH` constant.

## Scope / non-goals
- OAuth onboarding still runs its runtime check (unchanged).
- The backend `POST /api/providers/validate` endpoint is left in place (no longer called from onboarding); not removed to avoid touching the dashboard server surface.
- `refreshOnboarding`'s "is a provider configured?" detection is unchanged — it still decides whether onboarding appears at all.

## Test plan
- [x] `npm run type-check` (apps/desktop) passes
- [x] `eslint` on changed files: no new errors (a few pre-existing `padding-line-between-statements` warnings remain, outside the edited ranges)
- [x] `vitest`: `onboarding.test.ts`, `runtime-readiness.test.ts`, `provider-setup-errors.test.ts` pass
- [ ] Manual: enter a short / made-up / proxied key → **Connect** is enabled, saves, and onboarding completes without a rejection