### PR TITLE
fix(agent): track tokens on truncated responses and refund api_call_count on retry exhaustion

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -520,6 +520,91 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     return sp
 
 
+def _track_response_token_usage(agent: Any, response: Any) -> None:
+    """Record token usage from an API response on the agent's session counters.
+
+    This is intentionally safe to call on *every* API response, including
+    truncated ones (finish_reason='length') and failed retries.  When the
+    response carries no ``usage`` attribute the call is a no-op.
+
+    Fixes: https://github.com/NousResearch/hermes-agent/issues/38458
+    """
+    if not hasattr(response, "usage") or not response.usage:
+        return
+    try:
+        canonical_usage = normalize_usage(
+            response.usage,
+            provider=getattr(agent, "provider", None),
+            api_mode=getattr(agent, "api_mode", None),
+        )
+        prompt_tokens = canonical_usage.prompt_tokens
+        completion_tokens = canonical_usage.output_tokens
+        total_tokens = canonical_usage.total_tokens
+
+        agent.session_prompt_tokens += prompt_tokens
+        agent.session_completion_tokens += completion_tokens
+        agent.session_total_tokens += total_tokens
+        agent.session_api_calls += 1
+        agent.session_input_tokens += canonical_usage.input_tokens
+        agent.session_output_tokens += canonical_usage.output_tokens
+        agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
+        agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+        agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+        cost_result = estimate_usage_cost(
+            agent.model,
+            canonical_usage,
+            provider=agent.provider,
+            base_url=agent.base_url,
+            api_key=getattr(agent, "api_key", ""),
+        )
+        if cost_result.amount_usd is not None:
+            agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+        agent.session_cost_status = cost_result.status
+        agent.session_cost_source = cost_result.source
+
+        # Persist to session DB so /insights and analytics stay accurate.
+        if getattr(agent, "_session_db", None) and agent.session_id:
+            try:
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                agent._session_db.update_token_counts(
+                    agent.session_id,
+                    input_tokens=canonical_usage.input_tokens,
+                    output_tokens=canonical_usage.output_tokens,
+                    cache_read_tokens=canonical_usage.cache_read_tokens,
+                    cache_write_tokens=canonical_usage.cache_write_tokens,
+                    reasoning_tokens=canonical_usage.reasoning_tokens,
+                    estimated_cost_usd=float(cost_result.amount_usd)
+                    if cost_result.amount_usd is not None else None,
+                    cost_status=cost_result.status,
+                    cost_source=cost_result.source,
+                    billing_provider=agent.provider,
+                    billing_base_url=agent.base_url,
+                    billing_mode="subscription_included"
+                    if cost_result.status == "included" else None,
+                    model=agent.model,
+                    api_call_count=1,
+                )
+            except Exception as e:
+                logger.debug(
+                    "Token persistence failed (session=%s, tokens=%d): %s",
+                    agent.session_id, total_tokens, e,
+                )
+
+        # Keep the context compressor in sync so compression decisions
+        # after a truncated early-exit use real token counts, not stale
+        # ones from the previous turn.  Mirrors the update_from_response
+        # call in the canonical accounting block (~L1994).
+        _compressor = getattr(agent, "context_compressor", None)
+        if _compressor is not None and prompt_tokens:
+            _compressor.last_prompt_tokens = prompt_tokens
+
+    except Exception:
+        # Never let usage tracking crash the conversation loop.
+        logger.debug("_track_response_token_usage failed", exc_info=True)
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -1564,6 +1649,15 @@ def run_conversation(
                         agent._flush_status_buffer()
                         agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                         logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
+                        # Refund the optimistic increment from line ~889 — this
+                        # turn never produced a successful response so it should
+                        # not count against the budget or api_call_count.
+                        api_call_count -= 1
+                        agent._api_call_count = api_call_count
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Invalid API response after {max_retries} retries: {_failure_hint}"
                         return {
@@ -1838,6 +1932,8 @@ def run_conversation(
                             "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
                             "→ Or switch to a larger/non-reasoning model with `/model`"
                         )
+                        # Record tokens consumed by this truncated response.
+                        _track_response_token_usage(agent, response)
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
                         return {
@@ -1946,9 +2042,14 @@ def run_conversation(
                                 messages.append(continue_msg)
                                 agent._session_messages = messages
                                 _retry.restart_with_length_continuation = True
+                                # Record tokens consumed by this truncated response
+                                # before requesting a continuation.
+                                _track_response_token_usage(agent, response)
                                 break
 
                             partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            # Record tokens consumed by this final truncated response.
+                            _track_response_token_usage(agent, response)
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -1997,6 +2098,8 @@ def run_conversation(
                                 # Don't append the broken response to messages;
                                 # just re-run the same API call from the current
                                 # message state, giving the model another chance.
+                                # Record tokens consumed by this truncated attempt.
+                                _track_response_token_usage(agent, response)
                                 continue
                             agent._flush_status_buffer()
                             if _is_stub_stall:
@@ -2009,6 +2112,8 @@ def run_conversation(
                                     f"{agent.log_prefix}⚠️  Truncated tool call response detected again — refusing to execute incomplete tool arguments.",
                                     force=True,
                                 )
+                            # Record tokens consumed by the truncated tool call.
+                            _track_response_token_usage(agent, response)
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             _final_response = (
@@ -2031,6 +2136,8 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn")
                         rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
 
+                        # Record tokens consumed by the truncated response.
+                        _track_response_token_usage(agent, response)
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
 
@@ -2046,6 +2153,8 @@ def run_conversation(
                         # First message was truncated - mark as failed
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ First response truncated - cannot recover", force=True)
+                        # Record tokens consumed by the truncated response.
+                        _track_response_token_usage(agent, response)
                         agent._persist_session(messages, conversation_history)
                         return {
                             "final_response": "First response truncated due to output length limit",
@@ -4100,6 +4209,15 @@ def run_conversation(
                         agent._dump_api_request_debug(
                             api_kwargs, reason="max_retries_exhausted", error=api_error,
                         )
+                    # Refund the optimistic increment from line ~889 — all
+                    # retries and fallbacks are exhausted without a successful
+                    # response, so this call must not count against the budget.
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
+                    try:
+                        agent.iteration_budget.refund()
+                    except Exception:
+                        pass
                     agent._persist_session(messages, conversation_history)
                     if classified.reason == FailoverReason.billing:
                         _final_response = f"Billing or credits exhausted: {_final_summary}"
@@ -4275,6 +4393,12 @@ def run_conversation(
         if response is None:
             _turn_exit_reason = "all_retries_exhausted_no_response"
             print(f"{agent.log_prefix}❌ All API retries exhausted with no successful response.")
+            api_call_count -= 1
+            agent._api_call_count = api_call_count
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
             agent._persist_session(messages, conversation_history)
             break
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5820,6 +5820,92 @@ class TestRetryExhaustion:
         assert "UnboundLocalError" not in result.get("error", "")
         assert "bad messages" in result["error"]
 
+    def test_length_truncation_tracks_token_usage(self, agent):
+        """Token counters must accumulate across both halves of a length-continuation.
+
+        Regression for https://github.com/NousResearch/hermes-agent/issues/38458 —
+        when finish_reason='length' the early-exit path previously skipped token
+        accounting, leaving session_prompt_tokens/session_completion_tokens at zero
+        and breaking analytics and cost tracking.
+        """
+        self._setup_agent(agent)
+
+        # First call: truncated at 'length'
+        first = _mock_response(
+            content="Part 1 ",
+            finish_reason="length",
+            usage={"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        )
+        # Second call: normal completion
+        second = _mock_response(
+            content="Part 2",
+            finish_reason="stop",
+            usage={"prompt_tokens": 160, "completion_tokens": 30, "total_tokens": 190},
+        )
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Part 1 Part 2"
+
+        # Token accounting from the truncated leg must not be silently dropped.
+        # The first call's prompt_tokens (100) must appear in the session total.
+        assert agent.session_prompt_tokens >= 100, (
+            f"session_prompt_tokens={agent.session_prompt_tokens} — "
+            "truncated-leg tokens were not tracked"
+        )
+        assert agent.session_completion_tokens >= 50, (
+            f"session_completion_tokens={agent.session_completion_tokens} — "
+            "truncated-leg tokens were not tracked"
+        )
+
+    def test_retry_exhaustion_refunds_api_call_count(self, agent):
+        """api_call_count must be refunded when all API retries are exhausted.
+
+        Regression for https://github.com/NousResearch/hermes-agent/issues/38445 —
+        the optimistic api_call_count += 1 at the start of each turn was not
+        rolled back when every retry+fallback failed, inflating the reported
+        count and consuming iteration budget for a turn that never succeeded.
+        """
+        self._setup_agent(agent)
+        # Force every API call to fail with a generic error so max_retries
+        # are exhausted and the generic-exception terminal return is reached.
+        agent.client.chat.completions.create.side_effect = RuntimeError("network down")
+        from agent import conversation_loop as _conv_loop
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", self._make_fast_time_mock()),
+            patch.object(_conv_loop, "time", self._make_fast_time_mock()),
+            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+        ):
+            initial_budget = agent.iteration_budget.remaining
+            result = agent.run_conversation("hello")
+
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+
+        # The api_call_count in the result must be 0 (refunded back from the
+        # optimistic +1) because no successful response was ever produced.
+        assert result.get("api_calls", -1) == 0, (
+            f"api_calls={result.get('api_calls')} — expected 0 after refund "
+            "(one turn attempted but never succeeded)"
+        )
+
+        # The iteration budget must also have been refunded — remaining should
+        # equal the initial value (or differ by at most 0 if refund was called).
+        assert agent.iteration_budget.remaining >= initial_budget - 0, (
+            f"iteration_budget.remaining={agent.iteration_budget.remaining} "
+            f"but started at {initial_budget} — budget was not refunded"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Conversation history mutation


### PR DESCRIPTION
Fixes #38445
Fixes #38458

### 1. Fix #38458: Missing Token Tracking on Truncation
When the API model hits context or output length constraints (`finish_reason == "length"`), the loop exits early and skips the usual end-of-turn token tracking, leading to analytics and API cost tracking dropping critical data.
- Added `_track_response_token_usage(self, response)` to centralize token tracking and cost extraction.
- Hooked this up before triggering the different truncated flow returns.

### 2. Fix #38445: API Call Count Inflation on Failure
When `run_conversation` fails all API retries, the `api_call_count` variable remained incremented without actually producing a successful turn.
- Deducted `1` from `agent._api_call_count` when all retries are exhausted.
- Called `agent.iteration_budget.refund()` alongside the rollbacks.