### PR TITLE
feat(linear): resolve label/assignee names to UUIDs for create & upda…

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jeffrobodie@gmail.com": "lEWFkRAD",
     "prostoandrei9@gmail.com": "vladkvlchk",
     "liliangjya@gmail.com": "truenorth-lj",
     "16943149+nepenth@users.noreply.github.com": "nepenth",

--- a/skills/productivity/linear/SKILL.md
+++ b/skills/productivity/linear/SKILL.md
@@ -49,9 +49,28 @@ python3 "$SCRIPT" list-teams
 python3 "$SCRIPT" get-issue ENG-42
 python3 "$SCRIPT" get-document 38359beef67c      # fetch a doc by slugId from the URL
 python3 "$SCRIPT" raw 'query { viewer { name } }'
+
+# Create/update issues with label and assignee by NAME (resolved to UUIDs for you)
+python3 "$SCRIPT" create-issue --team ENG --title "Fix login bug" --label bug --label p1 --assignee "Jane Doe" --priority 1
+python3 "$SCRIPT" update-issue ENG-42 --label regression,ui --assignee me   # add labels, assign to yourself
+python3 "$SCRIPT" list-labels --team ENG          # discover valid label names
+python3 "$SCRIPT" list-users                      # discover valid assignee names
 ```
 
-All subcommands: `whoami`, `list-teams`, `list-projects`, `list-states`, `list-issues`, `get-issue`, `search-issues`, `create-issue`, `update-issue`, `update-status`, `add-comment`, `list-documents`, `get-document`, `search-documents`, `raw`. Run with `--help` for flags.
+Resolution details:
+- **Case-insensitive, whitespace-trimmed.** Assignees match by name, displayName, full email, or
+  email local-part; `--assignee me` resolves to the authenticated user.
+- **Multiple labels:** repeat `--label` or comma-separate (`--label bug --label p1` or `--label bug,p1`).
+- **`update-issue --label` is additive:** `issueUpdate` overwrites the whole label set, so the command
+  reads the issue's current labels first and appends (deduped) — it never silently drops labels you
+  didn't mention. Labels are team-scoped, so the team is inferred from the issue (or pass `--team`).
+- **Safe on large workspaces:** label/user lookups paginate past the 250-per-page cap, so a name is
+  never falsely reported missing.
+- **Ambiguity is surfaced, not guessed:** if a name matches more than one label/user the command
+  exits with the candidates instead of picking one. Deactivated users are not assignable.
+- On any miss the command exits non-zero and points you at `list-labels` / `list-users`.
+
+All subcommands: `whoami`, `list-teams`, `list-projects`, `list-states`, `list-labels`, `list-users`, `list-issues`, `get-issue`, `search-issues`, `create-issue`, `update-issue`, `update-status`, `add-comment`, `list-documents`, `get-document`, `search-documents`, `raw`. Run with `--help` for flags.
 
 Use the script when: you want a quick answer without crafting GraphQL. Use curl when: you need a query the script doesn't wrap, or you want to compose filters inline.
 

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -9,6 +9,8 @@ Commands:
   list-teams                              List all teams
   list-projects [--team KEY]              List projects (optionally filter by team)
   list-states [--team KEY]                List workflow states
+  list-labels [--team KEY]                List labels (optionally filter by team)
+  list-users                              List workspace members (for --assignee)
   list-issues [filters]                   List issues
     --team KEY                            Filter by team key (e.g. ENG)
     --status NAME                         Filter by workflow state name
@@ -22,10 +24,14 @@ Commands:
     --team KEY                            Required
     --description DESC
     --priority 0-4                        0=none, 1=urgent, 4=low
-    --label NAME
-    --assignee NAME
+    --label NAME                          Repeatable / comma-separated for several
+    --assignee NAME                       Name, email, or 'me'
     --parent IDENTIFIER                   Parent issue ID for sub-issues
-  update-issue <IDENTIFIER> [options]     Update existing issue (same options as create)
+  update-issue <IDENTIFIER> [options]     Update existing issue
+    --title / --description / --priority
+    --label NAME                          Added to existing labels; repeatable / comma-separated
+    --assignee NAME                       Name, email, or 'me'
+    --team KEY                            Scope --label lookup (else inferred from issue)
   update-status <IDENTIFIER> <STATE>      Move issue to workflow state (by state name)
   add-comment <IDENTIFIER> <body>         Add comment to issue
 
@@ -120,15 +126,167 @@ def cmd_list_teams(_args: argparse.Namespace) -> None:
     emit(gql(q).get("teams", {}).get("nodes", []))
 
 
+def _paginate(query: str, path: list[str], variables: dict[str, Any] | None = None,
+              page_size: int = 250) -> list[dict]:
+    """Collect every node from a Relay-style connection, following cursors.
+
+    The query must accept `$first: Int!` and `$after: String` and select, at the
+    given `path`, both `nodes` and `pageInfo { hasNextPage endCursor }`. This is
+    what makes name resolution correct on workspaces larger than one page (250) —
+    a single-page fetch would silently miss labels/users past the cap.
+    """
+    out: list[dict] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        base = dict(variables or {})
+        base["first"] = page_size
+        base["after"] = cursor
+        node: Any = gql(query, base)
+        for key in path:
+            node = (node or {}).get(key, {})
+        out.extend(node.get("nodes", []))
+        info = node.get("pageInfo") or {}
+        cursor = info.get("endCursor")
+        # Stop on last page, a missing cursor, or a repeat (defensive against loops).
+        if not info.get("hasNextPage") or not cursor or cursor in seen_cursors:
+            break
+        seen_cursors.add(cursor)
+    return out
+
+
 def _resolve_team_id(key_or_name: str) -> str | None:
-    """Map a team key (ENG) or name to UUID."""
-    q = "query { teams(first: 100) { nodes { id key name } } }"
-    teams = gql(q).get("teams", {}).get("nodes", [])
-    kl = key_or_name.lower()
-    for t in teams:
+    """Map a team key (ENG) or name to UUID. Team keys/names are unique."""
+    q = """query($first: Int!, $after: String) {
+      teams(first: $first, after: $after) {
+        nodes { id key name } pageInfo { hasNextPage endCursor }
+      }
+    }"""
+    kl = key_or_name.strip().lower()
+    for t in _paginate(q, ["teams"]):
         if t["key"].lower() == kl or t["name"].lower() == kl:
             return t["id"]
     return None
+
+
+def _find_labels(name: str, team_id: str | None = None) -> list[dict]:
+    """Return every label whose name matches (case-insensitive, trimmed).
+
+    When team_id is given we filter server-side to that team; otherwise we search
+    all labels visible to the caller. More than one result means the name is
+    ambiguous (e.g. the same label name in different teams).
+    """
+    if not name or not name.strip():
+        return []
+    target = name.strip().lower()
+    if team_id:
+        # Team.labels is guaranteed to exist; the root labels connection is
+        # `issueLabels` (there is no root `labels`).
+        q = """query($teamId: String!, $first: Int!, $after: String) {
+          team(id: $teamId) {
+            labels(first: $first, after: $after) {
+              nodes { id name } pageInfo { hasNextPage endCursor }
+            }
+          }
+        }"""
+        labels = _paginate(q, ["team", "labels"], {"teamId": team_id})
+    else:
+        q = """query($first: Int!, $after: String) {
+          issueLabels(first: $first, after: $after) {
+            nodes { id name } pageInfo { hasNextPage endCursor }
+          }
+        }"""
+        labels = _paginate(q, ["issueLabels"])
+    return [lbl for lbl in labels if (lbl.get("name") or "").strip().lower() == target]
+
+
+def _find_users(name: str) -> list[dict]:
+    """Return every user matching name, displayName, full email, or email
+    local-part (case-insensitive, trimmed). Each node carries `active` so the
+    caller can refuse to assign deactivated members."""
+    if not name or not name.strip():
+        return []
+    target = name.strip().lower()
+    q = """query($first: Int!, $after: String) {
+      users(first: $first, after: $after) {
+        nodes { id name displayName email active } pageInfo { hasNextPage endCursor }
+      }
+    }"""
+    matches: list[dict] = []
+    for user in _paginate(q, ["users"]):
+        fields = {(user.get("name") or "").lower(), (user.get("displayName") or "").lower()}
+        email = (user.get("email") or "").lower()
+        if target in fields and target:
+            matches.append(user)
+        elif email and (email == target or email.split("@", 1)[0] == target):
+            matches.append(user)
+    return matches
+
+
+def _label_tokens(values: list[str] | None) -> list[str]:
+    """Flatten repeated --label flags and comma-separated values into names."""
+    out: list[str] = []
+    for value in values or []:
+        out.extend(tok.strip() for tok in value.split(",") if tok.strip())
+    return out
+
+
+def _resolve_label_id_or_exit(name: str, team_id: str | None, list_hint: str) -> str:
+    """Resolve one label name to a UUID, or print a precise error and exit.
+
+    Tries the team-scoped lookup first, then falls back to a workspace-wide
+    search. Exits with the candidate list when a name is ambiguous.
+    """
+    matches = _find_labels(name, team_id)
+    if not matches and team_id:
+        matches = _find_labels(name)  # workspace-wide fallback
+    # Collapse exact-duplicate ids (same label seen twice) before counting.
+    unique = {m["id"]: m for m in matches}
+    if not unique:
+        sys.stderr.write(f"Label not found: '{name}'\n")
+        sys.stderr.write(f"Hint: run 'linear_api.py list-labels{list_hint}' to see available labels.\n")
+        sys.exit(1)
+    if len(unique) > 1:
+        sys.stderr.write(f"Label '{name}' is ambiguous — {len(unique)} matches across teams:\n")
+        for m in unique.values():
+            sys.stderr.write(f"  - {m['id']}\n")
+        sys.stderr.write("Hint: pass --team to scope the lookup to one team.\n")
+        sys.exit(1)
+    return next(iter(unique))
+
+
+def _resolve_assignee_id_or_exit(name: str) -> str:
+    """Resolve --assignee (a name, email, or 'me') to a user UUID, or exit.
+
+    Only active users are assignable: if a name matches solely deactivated
+    members, that's an error rather than a silent assignment. Ambiguous names
+    exit with the candidate list.
+    """
+    if name.strip().lower() == "me":
+        viewer = gql("query { viewer { id } }").get("viewer") or {}
+        if not viewer.get("id"):
+            sys.stderr.write("Could not resolve 'me' to the current user.\n")
+            sys.exit(1)
+        return viewer["id"]
+    matches = _find_users(name)
+    active = [u for u in matches if u.get("active")]
+    if matches and not active:
+        sys.stderr.write(f"Assignee '{name}' matches only deactivated user(s).\n")
+        sys.stderr.write("Hint: assign an active member, or reactivate them in Linear.\n")
+        sys.exit(1)
+    unique = {u["id"]: u for u in active}
+    if not unique:
+        sys.stderr.write(f"Assignee not found: '{name}'\n")
+        sys.stderr.write("Hint: run 'linear_api.py list-users' to see available users.\n")
+        sys.exit(1)
+    if len(unique) > 1:
+        sys.stderr.write(f"Assignee '{name}' is ambiguous — {len(unique)} matches:\n")
+        for u in unique.values():
+            label = u.get("email") or u.get("displayName") or u.get("name") or u["id"]
+            sys.stderr.write(f"  - {label}\n")
+        sys.stderr.write("Hint: use a full email address to disambiguate.\n")
+        sys.exit(1)
+    return next(iter(unique))
 
 
 def cmd_list_projects(args: argparse.Namespace) -> None:
@@ -229,7 +387,15 @@ def cmd_create_issue(args: argparse.Namespace) -> None:
         inp["priority"] = args.priority
     if args.parent:
         inp["parentId"] = args.parent
-    # TODO: label + assignee name->id lookup (omitted for v1 brevity)
+    label_ids: list[str] = []
+    for token in _label_tokens(args.label):
+        label_id = _resolve_label_id_or_exit(token, tid, f" --team {args.team}")
+        if label_id not in label_ids:
+            label_ids.append(label_id)
+    if label_ids:
+        inp["labelIds"] = label_ids
+    if args.assignee:
+        inp["assigneeId"] = _resolve_assignee_id_or_exit(args.assignee)
 
     q = """mutation($input: IssueCreateInput!) {
       issueCreate(input: $input) {
@@ -247,6 +413,34 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
         inp["description"] = args.description
     if args.priority is not None:
         inp["priority"] = args.priority
+    if args.label:
+        # issueUpdate REPLACES the whole label set, so fetch the issue's current
+        # labels (and team) up front and append to them — we never silently drop
+        # labels the caller didn't mention. Labels are team-scoped, so resolve
+        # within the issue's team (or an explicit --team), falling back to a
+        # workspace-wide search.
+        issue = gql(
+            "query($id: String!) { issue(id: $id) { team { id } labels { nodes { id } } } }",
+            {"id": args.identifier},
+        ).get("issue")
+        if not issue:
+            sys.stderr.write(f"Issue not found: {args.identifier}\n")
+            sys.exit(1)
+        if args.team:
+            team_id = _resolve_team_id(args.team)
+            if not team_id:
+                sys.stderr.write(f"Team not found: {args.team}\n")
+                sys.exit(1)
+        else:
+            team_id = (issue.get("team") or {}).get("id")
+        label_ids = [lbl["id"] for lbl in (issue.get("labels") or {}).get("nodes", [])]
+        for token in _label_tokens(args.label):
+            label_id = _resolve_label_id_or_exit(token, team_id, " --team <KEY>")
+            if label_id not in label_ids:
+                label_ids.append(label_id)
+        inp["labelIds"] = label_ids
+    if args.assignee:
+        inp["assigneeId"] = _resolve_assignee_id_or_exit(args.assignee)
     if not inp:
         sys.stderr.write("No update fields provided.\n")
         sys.exit(1)
@@ -282,6 +476,38 @@ def cmd_update_status(args: argparse.Namespace) -> None:
       }
     }"""
     emit(gql(q, {"id": args.identifier, "stateId": match["id"]}).get("issueUpdate"))
+
+
+def cmd_list_labels(args: argparse.Namespace) -> None:
+    if args.team:
+        tid = _resolve_team_id(args.team)
+        if not tid:
+            sys.stderr.write(f"Team not found: {args.team}\n")
+            sys.exit(1)
+        q = """query($teamId: String!, $first: Int!, $after: String) {
+          team(id: $teamId) {
+            labels(first: $first, after: $after) {
+              nodes { id name color } pageInfo { hasNextPage endCursor }
+            }
+          }
+        }"""
+        emit(_paginate(q, ["team", "labels"], {"teamId": tid}))
+    else:
+        q = """query($first: Int!, $after: String) {
+          issueLabels(first: $first, after: $after) {
+            nodes { id name color } pageInfo { hasNextPage endCursor }
+          }
+        }"""
+        emit(_paginate(q, ["issueLabels"]))
+
+
+def cmd_list_users(_args: argparse.Namespace) -> None:
+    q = """query($first: Int!, $after: String) {
+      users(first: $first, after: $after) {
+        nodes { id name displayName email active } pageInfo { hasNextPage endCursor }
+      }
+    }"""
+    emit(_paginate(q, ["users"]))
 
 
 def cmd_add_comment(args: argparse.Namespace) -> None:
@@ -370,6 +596,13 @@ def build_parser() -> argparse.ArgumentParser:
     ls.add_argument("--team")
     ls.set_defaults(func=cmd_list_states)
 
+    ll = sub.add_parser("list-labels")
+    ll.add_argument("--team")
+    ll.set_defaults(func=cmd_list_labels)
+
+    lu = sub.add_parser("list-users")
+    lu.set_defaults(func=cmd_list_users)
+
     li = sub.add_parser("list-issues")
     li.add_argument("--team")
     li.add_argument("--status")
@@ -392,8 +625,8 @@ def build_parser() -> argparse.ArgumentParser:
     ci.add_argument("--team", required=True)
     ci.add_argument("--description")
     ci.add_argument("--priority", type=int, choices=[0, 1, 2, 3, 4])
-    ci.add_argument("--label")
-    ci.add_argument("--assignee")
+    ci.add_argument("--label", action="append", help="Label name; repeat or comma-separate for several")
+    ci.add_argument("--assignee", help="Name, email, or 'me'")
     ci.add_argument("--parent")
     ci.set_defaults(func=cmd_create_issue)
 
@@ -402,6 +635,9 @@ def build_parser() -> argparse.ArgumentParser:
     ui.add_argument("--title")
     ui.add_argument("--description")
     ui.add_argument("--priority", type=int, choices=[0, 1, 2, 3, 4])
+    ui.add_argument("--label", action="append", help="Label name to add; repeat or comma-separate for several")
+    ui.add_argument("--assignee", help="Name, email, or 'me'")
+    ui.add_argument("--team", help="Scope --label lookup; inferred from the issue if omitted")
     ui.set_defaults(func=cmd_update_issue)
 
     us = sub.add_parser("update-status")

--- a/tests/skills/test_linear_api.py
+++ b/tests/skills/test_linear_api.py
@@ -1,0 +1,337 @@
+"""Tests for skills/productivity/linear/scripts/linear_api.py.
+
+Covers name->UUID resolution for labels and assignees and its wiring into
+create-issue / update-issue, including the hardening that makes it safe on any
+workspace: cursor pagination past the 250 page cap, ambiguous-name detection,
+additive (non-destructive) label updates, multiple labels per call,
+active-user-only assignment, and the `me` shortcut.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "linear"
+    / "scripts"
+    / "linear_api.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("linear_api_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeGQL:
+    """Stand-in for gql() that routes by query shape and records mutations.
+
+    Connection responses include pageInfo with hasNextPage=False so the
+    paginator terminates after one page (multi-page paging is exercised
+    separately against _paginate directly).
+    """
+
+    def __init__(self):
+        self.teams: list[dict] = []
+        self.labels: list[dict] = []                       # team-scoped results
+        self.workspace_labels: list[dict] | None = None    # defaults to self.labels
+        self.users: list[dict] = []
+        self.issue_team_id: str | None = None
+        self.issue_labels: list[dict] = []
+        self.viewer_id: str | None = None
+        self.calls: list[tuple[str, dict | None]] = []
+        self.mutation_input: dict | None = None
+
+    def __call__(self, query, variables=None):
+        self.calls.append((query, variables))
+        q = " ".join(query.split())
+        if "issueCreate" in q:
+            self.mutation_input = variables["input"]
+            return {"issueCreate": {"success": True, "issue": {"identifier": "ENG-1"}}}
+        if "issueUpdate" in q:
+            self.mutation_input = variables["input"]
+            return {"issueUpdate": {"success": True, "issue": {"identifier": variables["id"]}}}
+        if "viewer" in q:
+            return {"viewer": {"id": self.viewer_id}}
+        if "issue(id:" in q and "team" in q:
+            return {"issue": {
+                "team": {"id": self.issue_team_id},
+                "labels": {"nodes": self.issue_labels},
+            }}
+        if "teams(" in q:
+            return {"teams": {"nodes": self.teams, "pageInfo": {"hasNextPage": False}}}
+        if "team(id:" in q and "labels(" in q:  # team-scoped label query
+            return {"team": {"labels": {"nodes": self.labels, "pageInfo": {"hasNextPage": False}}}}
+        if "issueLabels(" in q:  # workspace-wide label query
+            nodes = self.workspace_labels if self.workspace_labels is not None else self.labels
+            return {"issueLabels": {"nodes": nodes, "pageInfo": {"hasNextPage": False}}}
+        if "users(" in q:
+            return {"users": {"nodes": self.users, "pageInfo": {"hasNextPage": False}}}
+        return {}
+
+
+@pytest.fixture
+def mod(monkeypatch):
+    module = load_module()
+    monkeypatch.setenv("LINEAR_API_KEY", "test-key")
+    return module
+
+
+@pytest.fixture
+def fake(mod, monkeypatch):
+    f = FakeGQL()
+    monkeypatch.setattr(mod, "gql", f)
+    return f
+
+
+def ns(**kw):
+    defaults = dict(
+        identifier=None, title=None, description=None, priority=None,
+        parent=None, label=None, assignee=None, team=None,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def user(uid, name=None, display=None, email=None, active=True):
+    return {"id": uid, "name": name, "displayName": display, "email": email, "active": active}
+
+
+# ---------- _paginate ----------
+
+def test_paginate_follows_cursors(mod, monkeypatch):
+    pages = [
+        {"conn": {"nodes": [{"id": "a"}], "pageInfo": {"hasNextPage": True, "endCursor": "c1"}}},
+        {"conn": {"nodes": [{"id": "b"}], "pageInfo": {"hasNextPage": True, "endCursor": "c2"}}},
+        {"conn": {"nodes": [{"id": "c"}], "pageInfo": {"hasNextPage": False, "endCursor": None}}},
+    ]
+    cursors = []
+
+    def fake_gql(query, variables=None):
+        cursors.append(variables.get("after"))
+        return pages[len(cursors) - 1]
+
+    monkeypatch.setattr(mod, "gql", fake_gql)
+    out = mod._paginate("q", ["conn"])
+    assert [n["id"] for n in out] == ["a", "b", "c"]
+    assert cursors == [None, "c1", "c2"]  # first page sends no cursor, then follows endCursor
+
+
+def test_paginate_stops_on_repeated_cursor(mod, monkeypatch):
+    # Defensive: a server that keeps returning hasNextPage with the same cursor
+    # must not loop forever.
+    def fake_gql(query, variables=None):
+        return {"conn": {"nodes": [{"id": "x"}], "pageInfo": {"hasNextPage": True, "endCursor": "stuck"}}}
+
+    monkeypatch.setattr(mod, "gql", fake_gql)
+    out = mod._paginate("q", ["conn"])
+    assert [n["id"] for n in out] == ["x", "x"]  # one extra page, then bails on repeat
+
+
+# ---------- _label_tokens ----------
+
+def test_label_tokens_flattens_repeats_and_commas(mod):
+    assert mod._label_tokens(["bug", "p1,p2", " spaced "]) == ["bug", "p1", "p2", "spaced"]
+    assert mod._label_tokens(None) == []
+    assert mod._label_tokens([" , "]) == []
+
+
+# ---------- _find_labels ----------
+
+def test_find_labels_exact_and_case_and_trim(mod, fake):
+    fake.labels = [{"id": "l1", "name": "Bug"}, {"id": "l2", "name": "Feature"}]
+    assert [m["id"] for m in mod._find_labels("  bUg ")] == ["l1"]
+
+
+def test_find_labels_blank_or_missing(mod, fake):
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    assert mod._find_labels("") == []
+    assert mod._find_labels("nope") == []
+
+
+def test_find_labels_skips_null_name(mod, fake):
+    fake.labels = [{"id": "l1", "name": None}, {"id": "l2", "name": "Bug"}]
+    assert [m["id"] for m in mod._find_labels("Bug")] == ["l2"]
+
+
+def test_find_labels_team_scoped_passes_team_id(mod, fake):
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    mod._find_labels("Bug", "team-9")
+    assert any(v and v.get("teamId") == "team-9" for _, v in fake.calls)
+
+
+def test_find_labels_returns_all_matches(mod, fake):
+    fake.labels = [{"id": "l1", "name": "Bug"}, {"id": "l2", "name": "bug"}]
+    assert {m["id"] for m in mod._find_labels("bug")} == {"l1", "l2"}
+
+
+# ---------- _find_users ----------
+
+def test_find_users_by_name_display_email_localpart(mod, fake):
+    fake.users = [
+        user("u1", name="John Doe", email="john@x.com"),
+        user("u2", display="Janie", email="jane@acme.com"),
+    ]
+    assert [m["id"] for m in mod._find_users("john doe")] == ["u1"]
+    assert [m["id"] for m in mod._find_users("janie")] == ["u2"]
+    assert [m["id"] for m in mod._find_users("jane@acme.com")] == ["u2"]
+    assert [m["id"] for m in mod._find_users("jane")] == ["u2"]  # email local-part
+
+
+def test_find_users_includes_inactive_and_blank(mod, fake):
+    fake.users = [user("u1", name="Ghost", active=False)]
+    assert [m["id"] for m in mod._find_users("Ghost")] == ["u1"]
+    assert mod._find_users("  ") == []
+
+
+# ---------- create-issue ----------
+
+def test_create_issue_single_label_and_assignee(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    fake.users = [user("u1", name="John Doe", email="j@x.com")]
+    mod.cmd_create_issue(ns(team="ENG", title="x", label=["Bug"], assignee="John Doe"))
+    assert fake.mutation_input["labelIds"] == ["l1"]
+    assert fake.mutation_input["assigneeId"] == "u1"
+
+
+def test_create_issue_multiple_labels_repeated_and_comma(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.labels = [{"id": "l1", "name": "bug"}, {"id": "l2", "name": "p1"}, {"id": "l3", "name": "ui"}]
+    # repeated flag + comma-separated, with a duplicate to prove dedup
+    mod.cmd_create_issue(ns(team="ENG", title="x", label=["bug", "p1,ui", "bug"]))
+    assert fake.mutation_input["labelIds"] == ["l1", "l2", "l3"]
+
+
+def test_create_issue_label_not_found_exits(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.labels = []
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_create_issue(ns(team="ENG", title="x", label=["Ghost"]))
+    assert e.value.code == 1
+
+
+def test_create_issue_ambiguous_label_exits(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.labels = [{"id": "l1", "name": "Bug"}, {"id": "l2", "name": "Bug"}]
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_create_issue(ns(team="ENG", title="x", label=["Bug"]))
+    assert e.value.code == 1
+
+
+def test_create_issue_assignee_me_uses_viewer(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.viewer_id = "me-123"
+    mod.cmd_create_issue(ns(team="ENG", title="x", assignee="me"))
+    assert fake.mutation_input["assigneeId"] == "me-123"
+
+
+def test_create_issue_assignee_inactive_only_exits(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.users = [user("u1", name="Gone", active=False)]
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_create_issue(ns(team="ENG", title="x", assignee="Gone"))
+    assert e.value.code == 1
+
+
+def test_create_issue_ambiguous_assignee_exits(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.users = [user("u1", name="John", active=True), user("u2", display="John", active=True)]
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_create_issue(ns(team="ENG", title="x", assignee="John"))
+    assert e.value.code == 1
+
+
+# ---------- update-issue ----------
+
+def test_update_issue_label_is_additive(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.issue_labels = [{"id": "old-1"}, {"id": "old-2"}]
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    mod.cmd_update_issue(ns(identifier="ENG-42", label=["Bug"]))
+    assert fake.mutation_input["labelIds"] == ["old-1", "old-2", "l1"]
+
+
+def test_update_issue_label_dedup(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.issue_labels = [{"id": "l1"}]
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    mod.cmd_update_issue(ns(identifier="ENG-42", label=["Bug"]))
+    assert fake.mutation_input["labelIds"] == ["l1"]
+
+
+def test_update_issue_multiple_labels_additive(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.issue_labels = [{"id": "old-1"}]
+    fake.labels = [{"id": "l1", "name": "bug"}, {"id": "l2", "name": "p1"}]
+    mod.cmd_update_issue(ns(identifier="ENG-42", label=["bug,p1"]))
+    assert fake.mutation_input["labelIds"] == ["old-1", "l1", "l2"]
+
+
+def test_update_issue_label_workspace_fallback(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.labels = []  # team-scoped miss
+    fake.workspace_labels = [{"id": "l9", "name": "Bug"}]
+    mod.cmd_update_issue(ns(identifier="ENG-42", label=["Bug"]))
+    assert fake.mutation_input["labelIds"] == ["l9"]
+
+
+def test_update_issue_ambiguous_label_exits(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.labels = []
+    fake.workspace_labels = [{"id": "a", "name": "Bug"}, {"id": "b", "name": "Bug"}]
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_update_issue(ns(identifier="ENG-42", label=["Bug"]))
+    assert e.value.code == 1
+
+
+def test_update_issue_label_not_found_exits(mod, fake):
+    fake.issue_team_id = "team-7"
+    fake.labels = []
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_update_issue(ns(identifier="ENG-42", label=["Ghost"]))
+    assert e.value.code == 1
+
+
+def test_update_issue_explicit_team_resolves_label(mod, fake):
+    fake.teams = [{"id": "team-1", "key": "ENG", "name": "Engineering"}]
+    fake.labels = [{"id": "l1", "name": "Bug"}]
+    mod.cmd_update_issue(ns(identifier="ENG-42", label=["Bug"], team="ENG"))
+    assert fake.mutation_input["labelIds"] == ["l1"]
+
+
+def test_update_issue_resolves_assignee(mod, fake):
+    fake.users = [user("u1", name="Jane", email="jane@x.com")]
+    mod.cmd_update_issue(ns(identifier="ENG-42", assignee="Jane"))
+    assert fake.mutation_input["assigneeId"] == "u1"
+
+
+def test_update_issue_assignee_me(mod, fake):
+    fake.viewer_id = "me-9"
+    mod.cmd_update_issue(ns(identifier="ENG-42", assignee="me"))
+    assert fake.mutation_input["assigneeId"] == "me-9"
+
+
+def test_update_issue_assignee_inactive_only_exits(mod, fake):
+    fake.users = [user("u1", name="Gone", active=False)]
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_update_issue(ns(identifier="ENG-42", assignee="Gone"))
+    assert e.value.code == 1
+
+
+def test_update_issue_no_fields_exits(mod, fake):
+    with pytest.raises(SystemExit) as e:
+        mod.cmd_update_issue(ns(identifier="ENG-42"))
+    assert e.value.code == 1


### PR DESCRIPTION
## What does this PR do?

The Linear skill's `linear_api.py` exposed `--label` / `--assignee` on `create-issue` and `update-issue` but never resolved those human-readable names to the UUIDs Linear's GraphQL API requires â€” `create-issue` carried a `# TODO: label + assignee name->id lookup (omitted for v1 brevity)` stub, and `update-issue` had no label/assignee support at all. This PR implements name resolution for both, designed to stay correct on a workspace of any size: it paginates past the 250-per-page cap, surfaces ambiguous names instead of guessing, and makes `update-issue --label` additive so it never silently drops existing labels.

## Related Issue

_No tracking issue â€” this completes the `# TODO` stub in `skills/productivity/linear/scripts/linear_api.py`._
Related: #21143 (an overlapping attempt at the `create-issue` half; this PR is a complete, tested implementation that also covers `update-issue`).

Fixes #

## Type of Change

- [x] âœ¨ New feature (non-breaking change that adds functionality)

## Changes Made

- `skills/productivity/linear/scripts/linear_api.py`
  - Add `_paginate()` (Relay cursor pagination, with a repeated-cursor loop guard).
  - Add `_find_labels()` / `_find_users()` (return all matches so ambiguity is detectable) and `_resolve_label_id_or_exit()` / `_resolve_assignee_id_or_exit()` (resolve or exit with a precise, candidate-listing error).
  - Resolve labels within the issue's/explicit team (`Team.labels`), falling back to the workspace-wide `issueLabels` connection; assignees match name / displayName / full email / email local-part; only **active** users are assignable; `--assignee me` resolves to the viewer.
  - Wire resolution into `create-issue` and `update-issue`; both accept multiple labels (repeat `--label` or comma-separate). `update-issue --label` is **additive** â€” it reads the issue's current labels and appends (deduped), since `issueUpdate` replaces the whole set.
  - Add `list-labels [--team]` and `list-users` subcommands (paginated) so the not-found hints reference real commands.
- `tests/skills/test_linear_api.py` â€” new, 28 cases.
- `skills/productivity/linear/SKILL.md` â€” document name resolution, additive labels, multi-label, `me`, pagination, and ambiguity behavior.
- `scripts/release.py` â€” add the contributor's email to `AUTHOR_MAP` (required by the Contributor Attribution Check), as a separate `chore` commit.

## How to Test

1. `pytest tests/skills/test_linear_api.py -q` â†’ 28 passing. Covers pagination (incl. the cursor-loop guard), label tokenizing, the match-finders, ambiguity, additive/dedup label merges, multi-label, the workspace-wide fallback, `me`, and refusal to assign deactivated users.
2. With `LINEAR_API_KEY` set, exercise the CLI:
   ```bash
   python3 skills/productivity/linear/scripts/linear_api.py create-issue --team ENG --title "Test" --label bug --label p1 --assignee me
   python3 skills/productivity/linear/scripts/linear_api.py update-issue ENG-42 --label regression,ui --assignee jane
   python3 skills/productivity/linear/scripts/linear_api.py list-labels --team ENG
   ```
3. `python -m py_compile skills/productivity/linear/scripts/linear_api.py` â†’ clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(linear): â€¦`, `chore: â€¦`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (found #21143; see Related)
- [x] My PR contains only changes related to this feature â€” plus the required `chore` AUTHOR_MAP attribution commit
- [ ] I've run `pytest tests/ -q` and all tests pass â€” **ran the new module (`tests/skills/test_linear_api.py`, 28 passed) + `py_compile`; the full suite was not run in my Windows dev env**
- [x] I've added tests for my changes
- [x] I've tested on my platform: **Windows 11** (unit tests + `py_compile` + CLI `--help` smoke; not yet exercised against a live Linear workspace â€” no API key in this environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`SKILL.md` + script docstring/`--help`)
- [x] `cli-config.yaml.example` â€” N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` â€” N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact â€” stdlib only (`urllib`, `argparse`); no platform-specific calls
- [x] Tool descriptions/schemas â€” N/A (skill is invoked via the terminal; no Hermes tool schema changed)
