### PR TITLE
fix(cli): ignore Desktop bootstrap marker to fix update stash loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ scripts/out/
 # stores the published notes. They are not a build artifact and must never be
 # committed to the repo root. See the hermes-release skill.
 RELEASE_v*.md
+
+# Desktop app bootstrap marker (created by apps/desktop/electron/main.cjs)
+# Causes 'hermes update' to needlessly stash local changes
+.hermes-bootstrap-complete


### PR DESCRIPTION
Fixes #38529

Added `.hermes-bootstrap-complete` to `.gitignore` to prevent the Desktop app's runtime marker from triggering untracked-file autostash loops during `hermes update`.