### PR TITLE
fix(gateway): invalidate cached system prompt on session.cwd.set

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -851,6 +851,104 @@ def _session(agent=None, **extra):
     }
 
 
+def test_session_cwd_set_invalidates_cached_system_prompt(monkeypatch, tmp_path):
+    """A mid-session cwd change must invalidate agent._cached_system_prompt.
+
+    Otherwise the agent's "Current working directory" hint in the system
+    prompt remains stale for the rest of the session even though
+    session["cwd"], terminal_tool overrides, and the session.info event
+    all reflect the new directory.
+    """
+    project_a = tmp_path / "project-a"
+    project_a.mkdir()
+    project_b = tmp_path / "project-b"
+    project_b.mkdir()
+
+    # Build an agent stand-in with a pre-populated cached system prompt.
+    agent = types.SimpleNamespace(_cached_system_prompt="old prompt with cwd: A")
+
+    server._sessions["sid"] = _session(
+        agent=agent,
+        cwd=str(project_a),
+        session_key="session-key",
+    )
+
+    # Stub the DB so _set_session_cwd can persist the new cwd without
+    # touching the real hermes_state.sqlite.
+    class _StubDB:
+        def update_session_cwd(self, sid, cwd):
+            self.last = (sid, cwd)
+
+    stub_db = _StubDB()
+    monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+    # Stub terminal_tool.cleanup_vm (called by _set_session_cwd).
+    monkeypatch.setattr(
+        "tools.terminal_tool.cleanup_vm", lambda _sid: None, raising=False
+    )
+    # Stub register_task_env_overrides (also called by _set_session_cwd and
+    # _register_session_cwd) so the test doesn't reach into real tool state.
+    monkeypatch.setattr(
+        "tools.terminal_tool.register_task_env_overrides",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.cwd.set",
+            "params": {"session_id": "sid", "cwd": str(project_b)},
+        }
+    )
+
+    assert "error" not in resp, resp
+    assert resp["result"]["cwd"] == str(project_b)
+    # The cached prompt was cleared so the next turn rebuilds with the new cwd.
+    assert agent._cached_system_prompt is None
+    # The session's own cwd field was updated.
+    assert server._sessions["sid"]["cwd"] == str(project_b)
+    # The DB was told to persist the new cwd.
+    assert stub_db.last == ("session-key", str(project_b))
+
+
+def test_session_cwd_set_skips_invalidation_when_no_agent(monkeypatch, tmp_path):
+    """Lazy / draft sessions without an AIAgent must not crash on invalidation."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    server._sessions["sid"] = _session(
+        agent=None,
+        cwd=str(project),
+        session_key="session-key",
+    )
+
+    class _StubDB:
+        def update_session_cwd(self, sid, cwd):
+            self.last = (sid, cwd)
+
+    stub_db = _StubDB()
+    monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+    monkeypatch.setattr(
+        "tools.terminal_tool.cleanup_vm", lambda _sid: None, raising=False
+    )
+    monkeypatch.setattr(
+        "tools.terminal_tool.register_task_env_overrides",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.cwd.set",
+            "params": {"session_id": "sid", "cwd": str(project)},
+        }
+    )
+    assert "error" not in resp, resp
+    assert resp["result"]["cwd"] == str(project)
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3013,6 +3013,19 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
+    # The AIAgent caches its system prompt on ``_cached_system_prompt`` for
+    # the lifetime of the session (prefix-cache optimization). Without an
+    # invalidation here, the "Current working directory" line baked into that
+    # cache stays stale and subsequent turns see the previous cwd even though
+    # session["cwd"], terminal_tool overrides, and the session.info event
+    # all already reflect the new directory.
+    if agent is not None:
+        try:
+            from agent.system_prompt import invalidate_system_prompt
+
+            invalidate_system_prompt(agent)
+        except Exception:
+            pass
     info = _session_info(agent, session) if agent is not None else {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),


### PR DESCRIPTION
The AIAgent caches its system prompt on `_cached_system_prompt` for the lifetime of a session (prefix-cache optimization). When `session.cwd.set` updates the session cwd mid-conversation, the cached prompt's "Current working directory" line stays stale, so subsequent turns keep answering from the old cwd even though session["cwd"], terminal_tool overrides, and the session.info event all already reflect the new directory.

After a successful cwd change, drop the cached prompt so the next turn rebuilds it from the live context. The lazy/draft path (no agent yet) is left untouched.

Tests:
- test_session_cwd_set_invalidates_cached_system_prompt verifies the agent's _cached_system_prompt is cleared, session["cwd"] is updated, and the new cwd is persisted to the DB.
- test_session_cwd_set_skips_invalidation_when_no_agent guards the agent=None (lazy) path.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

