### PR TITLE
fix(skills): report retired bundled-skill leftovers before manifest cleanup

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -404,9 +404,63 @@ class TestSyncSkills:
             result = sync_skills(quiet=True)
 
         assert "removed-skill" in result["cleaned"]
+        assert result["retired_official"] == []
+        assert result["user_modified_retired_official"] == []
         with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
             manifest = _read_manifest()
         assert "removed-skill" not in manifest
+
+    def test_removed_bundled_skill_left_on_disk_is_reported_retired_when_unmodified(self, tmp_path):
+        """A bundled skill removed upstream but unchanged locally becomes a retired local orphan.
+
+        Sync must remove it from the active bundled manifest without deleting the
+        on-disk copy. Reporting it separately lets callers distinguish an
+        unmodified retired upstream skill from a user-authored/agent-authored
+        skill without promoting it to agent-created provenance.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        retired = skills_dir / "retired-skill"
+        retired.mkdir(parents=True)
+        (retired / "SKILL.md").write_text("---\nname: retired-skill\n---\n# Retired\n")
+        origin_hash = _dir_hash(retired)
+        manifest_file.write_text(f"retired-skill:{origin_hash}\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert result["cleaned"] == ["retired-skill"]
+        assert result["retired_official"] == ["retired-skill"]
+        assert result["user_modified_retired_official"] == []
+        assert (retired / "SKILL.md").exists()
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            assert "retired-skill" not in _read_manifest()
+
+    def test_removed_bundled_skill_left_on_disk_is_reported_user_modified_when_changed(self, tmp_path):
+        """Modified retired official skills are preserved and reported separately."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        retired = skills_dir / "retired-skill"
+        retired.mkdir(parents=True)
+        (retired / "SKILL.md").write_text("---\nname: retired-skill\n---\n# Original\n")
+        origin_hash = _dir_hash(retired)
+        manifest_file.write_text(f"retired-skill:{origin_hash}\n")
+        (retired / "SKILL.md").write_text("---\nname: retired-skill\n---\n# User custom\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert result["cleaned"] == ["retired-skill"]
+        assert result["retired_official"] == []
+        assert result["user_modified_retired_official"] == ["retired-skill"]
+        actual = (retired / "SKILL.md").read_text()
+        assert actual == "---\nname: retired-skill\n---\n# User custom\n"
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            assert "retired-skill" not in _read_manifest()
 
     def test_does_not_overwrite_existing_unmanifested_skill(self, tmp_path):
         """New skill whose name collides with user-created skill = skipped."""
@@ -618,7 +672,8 @@ class TestSyncSkills:
             result = sync_skills(quiet=True)
         assert result == {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "suppressed": [], "total_bundled": 0,
+            "user_modified": [], "cleaned": [], "retired_official": [],
+            "user_modified_retired_official": [], "suppressed": [], "total_bundled": 0,
             "optional_provenance_backfilled": [],
         }
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -234,6 +234,29 @@ def _skill_file_list(skill_dir: Path) -> List[str]:
     return files
 
 
+def _find_active_skill_dir_by_name(skill_name: str) -> Path | None:
+    """Find an installed skill directory by frontmatter name.
+
+    Manifest entries are keyed by skill name, not install path. When upstream
+    removes a bundled skill we may still have an on-disk copy in the user's
+    skills tree; this helper lets sync classify that leftover without deleting
+    it or pretending it was agent-created.
+    """
+    if not skill_name or not SKILLS_DIR.exists():
+        return None
+    for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        if is_excluded_skill_path(skill_md):
+            continue
+        try:
+            skill_md.relative_to(SKILLS_DIR)
+        except ValueError:
+            continue
+        candidate = skill_md.parent
+        if _read_skill_name(skill_md, candidate.name) == skill_name:
+            return candidate
+    return None
+
+
 def _content_hash(directory: Path) -> str:
     """Return the same hash style the skills hub lock uses, falling back locally."""
     try:
@@ -457,7 +480,10 @@ def sync_skills(quiet: bool = False) -> dict:
 
     Returns:
         dict with keys: copied (list), updated (list), skipped (int),
-                        user_modified (list), cleaned (list), total_bundled (int)
+                        user_modified (list), cleaned (list),
+                        retired_official (list),
+                        user_modified_retired_official (list),
+                        total_bundled (int)
     """
     # Opt-out: a profile (named or the default ~/.hermes) that wrote the
     # .no-bundled-skills marker gets zero bundled-skill seeding. Returning the
@@ -469,7 +495,8 @@ def sync_skills(quiet: bool = False) -> dict:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "total_bundled": 0,
+            "user_modified": [], "cleaned": [], "retired_official": [],
+            "user_modified_retired_official": [], "total_bundled": 0,
             "optional_provenance_backfilled": [], "skipped_opt_out": True,
         }
 
@@ -477,7 +504,8 @@ def sync_skills(quiet: bool = False) -> dict:
     if not bundled_dir.exists():
         return {
             "copied": [], "updated": [], "skipped": 0,
-            "user_modified": [], "cleaned": [], "suppressed": [], "total_bundled": 0,
+            "user_modified": [], "cleaned": [], "retired_official": [],
+            "user_modified_retired_official": [], "suppressed": [], "total_bundled": 0,
             "optional_provenance_backfilled": [],
         }
 
@@ -596,9 +624,22 @@ def sync_skills(quiet: bool = False) -> dict:
             # ── In manifest but not on disk — user deleted it ──
             skipped += 1
 
-    # Clean stale manifest entries (skills removed from bundled dir)
+    # Clean stale manifest entries (skills removed from bundled dir). Keep any
+    # leftover on-disk skill directory intact, but classify it before dropping
+    # the origin hash so callers can distinguish an unchanged retired official
+    # skill from one the user modified. Do not mark either bucket as
+    # agent-created; curator management remains opt-in via usage provenance.
     cleaned = sorted(set(manifest.keys()) - bundled_names)
+    retired_official: List[str] = []
+    user_modified_retired_official: List[str] = []
     for name in cleaned:
+        origin_hash = manifest.get(name, "")
+        active_dir = _find_active_skill_dir_by_name(name)
+        if active_dir is not None and origin_hash:
+            if _dir_hash(active_dir) == origin_hash:
+                retired_official.append(name)
+            else:
+                user_modified_retired_official.append(name)
         del manifest[name]
 
     # Also copy DESCRIPTION.md files for categories (if not already present)
@@ -621,6 +662,8 @@ def sync_skills(quiet: bool = False) -> dict:
         "skipped": skipped,
         "user_modified": user_modified,
         "cleaned": cleaned,
+        "retired_official": retired_official,
+        "user_modified_retired_official": user_modified_retired_official,
         "suppressed": suppressed_skipped,
         "total_bundled": len(bundled_skills),
         "optional_provenance_backfilled": optional_provenance_backfilled,


### PR DESCRIPTION
## Summary
- report local copies of bundled skills that were removed from upstream as `retired_official` when unchanged
- report the same leftovers as `user_modified_retired_official` when the local copy diverged
- preserve the on-disk skill directory and remove only the stale bundled manifest entry
- keep this as a short-lived update/sync signal, not a Curator policy change

## Why
When a bundled skill disappears from upstream, `sync_skills()` drops its stale `.bundled_manifest` entry. If a matching local copy remains on disk, follow-up tooling can no longer tell whether it is a retired upstream skill, a user-modified retired upstream skill, or an unrelated local/user-owned skill.

Surfacing that distinction gives `hermes update`, future repair UX, dashboard flows, and Curator-adjacent tooling a cleaner provenance signal for explaining drift and offering keep/reset/repair/prune choices.

This does **not** prevent Curator pruning. It preserves provenance at the moment a bundled skill is retired upstream, so future Curator/update/repair UX can distinguish unchanged retired official leftovers from user-modified or user-owned local skills before the manifest information is discarded.

A current example is #43221, which moved `godmode` and `obliteratus` from bundled skills to `optional-skills`. After that kind of update, stale bundled manifest entries are the last cheap place to know that any remaining local directories are former official/bundled skills rather than arbitrary local skills.

## Non-goals
- This PR does not block background review or `skill_manage` from editing bundled skills.
- This PR does not change the `curator.prune_builtins` default or pruning policy.
- This PR does not archive, delete, or restore retired leftovers.
- This PR does not add durable Curator provenance by itself; it only preserves/report the transition signal before manifest cleanup, so a future UX can decide what to persist.

## Test Plan
- `./venv/bin/python -m pytest tests/tools/test_skills_sync.py -q -o 'addopts=' --tb=short`
- `./venv/bin/python -m pytest tests/tools/test_skills_sync.py tests/agent/test_curator.py -q -o 'addopts=' --tb=short`
- `python3 -m py_compile tools/skills_sync.py tests/tools/test_skills_sync.py`
