### PR TITLE
fix(discord): stop typing indicator before response delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4034,6 +4034,16 @@ class BasePlatformAdapter(ABC):
                 # cancelling, let this message-processing task unwind now.
                 pass
         
+        async def _stop_typing_now(chat_id: str) -> None:
+            """Stop the persistent typing loop *before* response delivery
+            so Discord's ~10s typing indicator doesn't overlap the reply."""
+            await _stop_typing_task()
+            try:
+                if hasattr(self, "stop_typing"):
+                    await self.stop_typing(chat_id)
+            except Exception:
+                pass
+
         try:
             await self._run_processing_hook("on_processing_start", event)
 
@@ -4069,6 +4079,9 @@ class BasePlatformAdapter(ABC):
                     session_key,
                 )
                 response = None
+            # Stop persistent typing indicator before response delivery so
+            # Discord's ~10s typing bubble doesn't overlap the reply text.
+            await _stop_typing_now(event.source.chat_id)
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:


### PR DESCRIPTION
## Summary
Stop the persistent typing indicator **before** delivering the bot's reply, so the ~10s Discord typing bubble doesn't visually overlap the response text.

## Root Cause
The existing `stop_typing` call lives in the `finally` block of the message-processing pipeline — it fires after the response is already sent over the wire. On Discord this means the "typing..." indicator persists for several seconds into the reply, obscuring the text.

## Fix
Add an inner helper `_stop_typing_now` that is called just before the response dispatch path, before `if not response:` is evaluated. The cleanup-path `stop_typing` in the `finally` block is kept as a safety net for error/cancellation paths.

## Test Plan
- Existing gateway tests pass
- Manual verification: Discord typing bubble now clears before reply appears