### PR TITLE
fix: stabilize gateway launchd HOME and Honcho memory sync

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -114,8 +114,8 @@ class MemoryProvider(ABC):
 
     def sync_turn(
         self,
-        user_content: str,
-        assistant_content: str,
+        user_content: Any,
+        assistant_content: Any,
         *,
         session_id: str = "",
         messages: Optional[List[Dict[str, Any]]] = None,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3011,6 +3011,7 @@ def generate_launchd_plist() -> str:
     # to launchd's WorkingDirectory as to systemd's).
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
+    launchd_home = str(_launchd_user_home())
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
@@ -3077,6 +3078,8 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>HOME</key>
+        <string>{launchd_home}</string>
     </dict>
     
     <key>RunAtLoad</key>

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,58 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+def _content_to_text(content: Any) -> str:
+    """Normalize provider message content into text before memory sync.
+
+    Model providers may pass OpenAI/Anthropic-style content parts instead of a
+    plain string, e.g. ``[{"type": "text", "text": "..."}]``. Honcho memory
+    ingest and ``sanitize_context()`` operate on strings, so convert known text
+    parts and preserve non-text parts as compact placeholders instead of raising.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (int, float, bool)):
+        return str(content)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            text = _content_part_to_text(item)
+            if text:
+                parts.append(text)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        return _content_part_to_text(content) or json.dumps(content, ensure_ascii=False, default=str)
+    return str(content)
+
+
+def _content_part_to_text(part: Any) -> str:
+    if part is None:
+        return ""
+    if isinstance(part, str):
+        return part
+    if not isinstance(part, dict):
+        return str(part)
+
+    text = part.get("text")
+    if isinstance(text, str):
+        return text
+
+    nested = part.get("content")
+    if isinstance(nested, str):
+        return nested
+    if isinstance(nested, list):
+        return _content_to_text(nested)
+
+    part_type = str(part.get("type") or "content_part")
+    if part_type in {"image", "image_url", "input_image"}:
+        return "[image content omitted from memory sync]"
+    if part_type in {"tool_use", "tool_result", "function_call"}:
+        return f"[{part_type} omitted from memory sync]"
+    return json.dumps(part, ensure_ascii=False, default=str)
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1198,7 +1250,14 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(
+        self,
+        user_content: Any,
+        assistant_content: Any,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
         """Record the conversation turn in Honcho (non-blocking).
 
         Messages exceeding the Honcho API limit (default 25k chars) are
@@ -1213,8 +1272,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
-        clean_user_content = sanitize_context(user_content or "").strip()
-        clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        clean_user_content = sanitize_context(_content_to_text(user_content)).strip()
+        clean_assistant_content = sanitize_context(_content_to_text(assistant_content)).strip()
 
         def _sync():
             try:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -65,6 +65,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -88,6 +89,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -499,6 +501,13 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
+    def test_generate_launchd_plist_includes_real_home_for_restart_helper(self):
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>HERMES_HOME</key>" in plist
+        assert "<key>HOME</key>" in plist
+        assert f"<string>{gateway_cli._launchd_user_home()}</string>" in plist
+
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
@@ -740,6 +749,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
@@ -785,6 +795,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_uses_systemd_main_pid_when_pid_file_is_missing(self, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
@@ -844,6 +855,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_reports_start_limit_hit(self, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
@@ -874,6 +886,7 @@ class TestGatewaySystemServiceRouting:
         assert "reset-failed" in out
 
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -4,6 +4,7 @@ import time
 
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from plugins.memory.honcho.session import (
@@ -588,10 +589,50 @@ class TestConcludeToolDispatch:
                 "Visible answer"
             ),
         )
+        assert provider._sync_thread is not None
         provider._sync_thread.join(timeout=1.0)
 
         assert session.add_message.call_args_list[0].args == ("user", "hello")
         assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
+
+    def test_sync_turn_normalizes_content_parts_before_honcho_ingest(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = cast(Any, SimpleNamespace(message_max_chars=25000))
+
+        session = MagicMock()
+        provider._manager.get_or_create.return_value = session
+
+        provider.sync_turn(
+            [
+                {"type": "text", "text": "First user line"},
+                {"type": "image_url", "image_url": {"url": "https://example.invalid/image.png"}},
+            ],
+            [
+                {
+                    "type": "text",
+                    "text": (
+                        "<memory-context>\n"
+                        "hidden context\n"
+                        "</memory-context>\n\n"
+                        "Visible assistant line"
+                    ),
+                }
+            ],
+        )
+        assert provider._sync_thread is not None
+        provider._sync_thread.join(timeout=1.0)
+
+        assert session.add_message.call_args_list[0].args == (
+            "user",
+            "First user line\n[image content omitted from memory sync]",
+        )
+        assert session.add_message.call_args_list[1].args == (
+            "assistant",
+            "Visible assistant line",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related runtime-stability fixes for the messaging gateway on macOS launchd and the Honcho memory provider.

### 1. launchd gateway: inject `HOME` into the generated plist

The gateway's detached restart helper (`hermes gateway restart`) silently dies with `RuntimeError: Could not determine home directory` when the launchd plist's `EnvironmentVariables` lacks `HOME`. Because `KeepAlive = { SuccessfulExit = false }`, launchd does not relaunch a clean exit, so a Telegram `/restart` (or `hermes update`) can stop the gateway and print the startup banner but never relaunch. This adds `HOME` to the generated plist so the detached helper can resolve the Hermes home directory.

### 2. Honcho `sync_turn`: normalize content-part lists before sync

Multimodal / OpenAI-style content-part lists (`content` is a `list[dict]`, not a `str`) reached the Honcho memory sync path and crashed with `expected string or bytes-like object, got 'list'`. This normalizes non-string content into a flat string before `sanitize_context()` and the Honcho write, so memory sync no longer fails on multimodal turns.

## Changes

- `hermes_cli/gateway.py` — add `HOME` to generated launchd plist `EnvironmentVariables`.
- `agent/memory_provider.py` — content normalization touchpoint.
- `plugins/memory/honcho/__init__.py` — normalize content-part lists before `sanitize_context()` / Honcho write.
- `tests/hermes_cli/test_gateway_service.py` — regression coverage for the plist `HOME` field.
- `tests/honcho_plugin/test_session.py` — regression coverage for content-part normalization in `sync_turn()`.

## Testing

```
python -m pytest tests/hermes_cli/test_gateway_service.py tests/honcho_plugin/test_session.py -q
255 passed in 3.79s
```

Cherry-picked cleanly onto current `main` (no conflicts).

## Notes

These were validated in a live production Hermes install (macOS launchd gateway + Telegram + Honcho). The launchd `HOME` fix addresses the missing-`HOME` silent-death variant; a separate update-triggered `bootout`-then-failed-`bootstrap` race exists and is best handled by an external watchdog, which is out of scope for this PR.
