### PR TITLE
feat: add 1Password secrets backend

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -6,8 +6,10 @@ default sources are non-destructive: they only set values for env vars
 that aren't already present, so .env and shell exports continue to win.
 
 Currently shipped:
-
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+  - ``onepassword`` — 1Password CLI (`op`) secret references.  See
+    ``agent.secret_sources.onepassword`` for the integration and
+    ``hermes_cli.onepassword_secrets_cli`` for the user-facing commands.
 """

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -1,0 +1,258 @@
+"""1Password CLI (`op`) secret-source integration.
+
+Hermes can resolve 1Password secret references at process startup and inject
+those values into ``os.environ`` so secrets do not have to live in plaintext in
+``~/.hermes/.env``.
+
+Design summary
+--------------
+
+* Authentication uses a 1Password Service Account token stored in the env var
+  named by ``secrets.onepassword.service_account_token_env`` (default:
+  ``OP_SERVICE_ACCOUNT_TOKEN``). This is the one bootstrap secret.
+* The config maps environment variable names to 1Password secret references,
+  e.g. ``TELEGRAM_BOT_TOKEN: op://Hermes/TELEGRAM_BOT_TOKEN/password``.
+* Fetching is subprocess-driven through ``op read <secret-ref>`` so Hermes does
+  not need a heavyweight SDK dependency.
+* Failures never block Hermes startup. The caller receives a FetchResult with a
+  short error/warning and Hermes continues with whatever credentials were
+  already present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_OP_RUN_TIMEOUT = 20
+_CacheKey = Tuple[str, str]  # (token_fingerprint, stable mapping json)
+_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+
+
+@dataclass
+class _CachedFetch:
+    secrets: Dict[str, str]
+    warnings: List[str]
+    fetched_at: float
+
+    def is_fresh(self, ttl_seconds: float) -> bool:
+        if ttl_seconds <= 0:
+            return False
+        return (time.time() - self.fetched_at) < ttl_seconds
+
+
+@dataclass
+class FetchResult:
+    """Outcome of a single 1Password pull."""
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: List[str] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def find_op() -> Optional[Path]:
+    """Return the 1Password CLI path, if available on PATH."""
+    found = shutil.which("op")
+    return Path(found) if found else None
+
+
+def _token_fingerprint(token: str) -> str:
+    """SHA-256 prefix used as a cache key — never logged, never displayed."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _mapping_key(mapping: Dict[str, str]) -> str:
+    return json.dumps(mapping, sort_keys=True, separators=(",", ":"))
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _normalize_mapping(mapping: object) -> Tuple[Dict[str, str], List[str]]:
+    warnings: List[str] = []
+    normalized: Dict[str, str] = {}
+    if not isinstance(mapping, dict):
+        return {}, ["secrets.onepassword.mapping must be a mapping of ENV_VAR to op:// reference"]
+
+    for raw_key, raw_ref in mapping.items():
+        key = str(raw_key).strip()
+        ref = str(raw_ref).strip()
+        if not _is_valid_env_name(key):
+            warnings.append(f"Skipping mapping {key!r}: not a valid env-var name")
+            continue
+        if not ref.startswith("op://"):
+            warnings.append(f"Skipping {key}: secret reference must start with op://")
+            continue
+        normalized[key] = ref
+    return normalized, warnings
+
+
+def fetch_onepassword_secrets(
+    *,
+    service_account_token: str,
+    mapping: Dict[str, str],
+    binary: Optional[Path] = None,
+    cache_ttl_seconds: float = 300,
+    use_cache: bool = True,
+) -> Tuple[Dict[str, str], List[str]]:
+    """Resolve configured 1Password secret references.
+
+    Returns ``(secrets_dict, warnings_list)``. Raises ``RuntimeError`` for fatal
+    setup/auth/CLI problems. Caller controls whether the values are applied to
+    the process environment.
+    """
+    if not service_account_token:
+        raise RuntimeError("1Password service account token is empty")
+
+    normalized, warnings = _normalize_mapping(mapping)
+    if not normalized:
+        return {}, warnings or ["No valid 1Password secret mappings configured"]
+
+    cache_key = (_token_fingerprint(service_account_token), _mapping_key(normalized))
+    if use_cache:
+        cached = _CACHE.get(cache_key)
+        if cached and cached.is_fresh(cache_ttl_seconds):
+            return cached.secrets, list(cached.warnings)
+
+    op_bin = binary or find_op()
+    if op_bin is None:
+        raise RuntimeError(
+            "op binary not available — install 1Password CLI (`brew install --cask "
+            "1password-cli`) and re-run `hermes secrets onepassword status`."
+        )
+
+    secrets: Dict[str, str] = {}
+    run_warnings: List[str] = list(warnings)
+    for key, ref in normalized.items():
+        value = _run_op_read(op_bin, service_account_token, ref, env_name=key)
+        secrets[key] = value
+
+    _CACHE[cache_key] = _CachedFetch(
+        secrets=secrets,
+        warnings=run_warnings,
+        fetched_at=time.time(),
+    )
+    return secrets, run_warnings
+
+
+def _run_op_read(
+    op_bin: Path,
+    service_account_token: str,
+    ref: str,
+    *,
+    env_name: Optional[str] = None,
+) -> str:
+    target = env_name or "secret reference"
+    env = os.environ.copy()
+    env["OP_SERVICE_ACCOUNT_TOKEN"] = service_account_token
+    env.setdefault("NO_COLOR", "1")
+    try:
+        proc = subprocess.run(  # noqa: S603 — op path is trusted
+            [str(op_bin), "read", ref],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=_OP_RUN_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"op timed out after {_OP_RUN_TIMEOUT}s reading {target}") from exc
+    except OSError as exc:
+        raise RuntimeError(f"failed to invoke op: {exc}") from exc
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
+        raise RuntimeError(f"op read failed for {target}: {err[:240]}")
+
+    return (proc.stdout or "").rstrip("\r\n")
+
+
+def apply_onepassword_secrets(
+    *,
+    enabled: bool,
+    service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+    mapping: Optional[Dict[str, str]] = None,
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+) -> FetchResult:
+    """Pull 1Password references and set them on ``os.environ`` defensively."""
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    token = os.environ.get(service_account_token_env, "").strip()
+    if not token:
+        result.error = (
+            f"secrets.onepassword.enabled is true but {service_account_token_env} "
+            "is not set. Store your 1Password Service Account token in .env."
+        )
+        return result
+
+    normalized, warnings = _normalize_mapping(mapping or {})
+    result.warnings.extend(warnings)
+    if not normalized:
+        result.error = (
+            "secrets.onepassword.mapping is empty. Add ENV_VAR: op://... references "
+            "or run `hermes secrets onepassword setup --map ENV=op://...`."
+        )
+        return result
+
+    binary = find_op()
+    result.binary_path = binary
+    if binary is None:
+        result.error = (
+            "op binary not available. Install 1Password CLI with "
+            "`brew install --cask 1password-cli`."
+        )
+        return result
+
+    try:
+        secrets, fetch_warnings = fetch_onepassword_secrets(
+            service_account_token=token,
+            mapping=normalized,
+            binary=binary,
+            cache_ttl_seconds=cache_ttl_seconds,
+        )
+    except RuntimeError as exc:
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(fetch_warnings)
+
+    for key, value in secrets.items():
+        if key == service_account_token_env:
+            result.skipped.append(key)
+            continue
+        if not override_existing and os.environ.get(key):
+            result.skipped.append(key)
+            continue
+        os.environ[key] = value
+        result.applied.append(key)
+
+    return result
+
+
+def _reset_cache_for_tests() -> None:
+    _CACHE.clear()

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -78,9 +78,10 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
+    if source == "onepassword":
+        return " (from 1Password)"
     # Generic fallback — future-proofing for additional secret sources
-    # (e.g. 1Password, HashiCorp Vault) without having to update every
-    # call site.
+    # (e.g. Vault) without having to update every call site.
     return f" (from {source})"
 
 
@@ -275,52 +276,77 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
 
     bw_cfg = (cfg or {}).get("bitwarden") or {}
-    if not bw_cfg.get("enabled"):
-        return
+    if bw_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.bitwarden import apply_bitwarden_secrets
+        except ImportError:
+            apply_bitwarden_secrets = None  # type: ignore[assignment]
 
-    try:
-        from agent.secret_sources.bitwarden import apply_bitwarden_secrets
-    except ImportError:
-        return
+        if apply_bitwarden_secrets is not None:
+            try:
+                result = apply_bitwarden_secrets(
+                    enabled=True,
+                    access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
+                    project_id=bw_cfg.get("project_id", ""),
+                    override_existing=bool(bw_cfg.get("override_existing", False)),
+                    cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+                    auto_install=bool(bw_cfg.get("auto_install", True)),
+                    server_url=str(bw_cfg.get("server_url", "") or "").strip(),
+                    home_path=home_path,
+                )
+            except Exception as exc:  # noqa: BLE001 — never block startup
+                print(f"  Bitwarden Secrets Manager: {exc}", file=sys.stderr)
+            else:
+                _report_external_secret_result(
+                    label="Bitwarden Secrets Manager",
+                    source="bitwarden",
+                    result=result,
+                )
 
-    result = apply_bitwarden_secrets(
-        enabled=True,
-        access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
-        project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
-        server_url=str(bw_cfg.get("server_url", "") or "").strip(),
-        home_path=home_path,
-    )
+    op_cfg = (cfg or {}).get("onepassword") or {}
+    if op_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.onepassword import apply_onepassword_secrets
+        except ImportError:
+            apply_onepassword_secrets = None  # type: ignore[assignment]
 
+        if apply_onepassword_secrets is not None:
+            try:
+                result = apply_onepassword_secrets(
+                    enabled=True,
+                    service_account_token_env=op_cfg.get(
+                        "service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN"
+                    ),
+                    mapping=op_cfg.get("mapping") or {},
+                    override_existing=bool(op_cfg.get("override_existing", False)),
+                    cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+                )
+            except Exception as exc:  # noqa: BLE001 — never block startup
+                print(f"  1Password: {exc}", file=sys.stderr)
+            else:
+                _report_external_secret_result(
+                    label="1Password",
+                    source="onepassword",
+                    result=result,
+                )
+
+
+def _report_external_secret_result(*, label: str, source: str, result) -> None:
+    """Print a concise status line and remember source metadata."""
     if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
         _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
         for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
+            _SECRET_SOURCES[name] = source
         print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
+            f"  {label}: applied {len(result.applied)} "
             f"secret{'s' if len(result.applied) != 1 else ''} "
             f"({', '.join(sorted(result.applied))})",
             file=sys.stderr,
         )
     if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
+        print(f"  {label}: {result.error}", file=sys.stderr)
     for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+        print(f"  {label}: {warn}", file=sys.stderr)
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11219,16 +11219,15 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
-    # secrets command — external secret managers (currently: Bitwarden)
+    # secrets command — external secret managers
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden, 1Password)",
         description=(
             "Pull API keys from an external secret manager at process startup "
-            "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "instead of storing them in ~/.hermes/.env. Supports Bitwarden "
+            "Secrets Manager and 1Password CLI secret references."
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")
@@ -11238,16 +11237,26 @@ def main():
         aliases=["bw"],
         help="Bitwarden Secrets Manager integration",
     )
+    secrets_op = secrets_subparsers.add_parser(
+        "onepassword",
+        aliases=["op", "1password"],
+        help="1Password CLI secret-reference integration",
+    )
 
-    # Lazy import — only pays for itself when this subcommand is actually used.
+    # Lazy imports — only pay for these when the subcommand is used.
     from hermes_cli import secrets_cli as _secrets_cli
+    from hermes_cli import onepassword_secrets_cli as _onepassword_secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
+    _onepassword_secrets_cli.register_cli(secrets_op)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        op_sub = getattr(args, "secrets_op_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("onepassword", "op", "1password") and op_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -1,0 +1,290 @@
+"""CLI handlers for ``hermes secrets onepassword ...``."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from agent.secret_sources import onepassword as opsec
+from hermes_cli.config import get_env_path, load_config, save_config, save_env_value
+from hermes_cli.secret_prompt import masked_secret_prompt
+
+
+def register_cli(parent_parser: argparse.ArgumentParser) -> None:
+    sub = parent_parser.add_subparsers(dest="secrets_op_command")
+
+    setup = sub.add_parser(
+        "setup",
+        help="Configure 1Password CLI secret references",
+    )
+    setup.add_argument(
+        "--service-account-token",
+        help="Provide the 1Password service account token non-interactively",
+    )
+    setup.add_argument(
+        "--token-env",
+        default=None,
+        help="Env var holding the service account token (default: OP_SERVICE_ACCOUNT_TOKEN)",
+    )
+    setup.add_argument(
+        "--map",
+        action="append",
+        default=[],
+        type=_parse_mapping,
+        metavar="ENV_VAR=op://vault/item/field",
+        help="Add/update a secret reference mapping. Repeatable.",
+    )
+    setup.add_argument(
+        "--skip-test",
+        action="store_true",
+        help="Save config without validating refs with `op read` first",
+    )
+    setup.add_argument(
+        "--no-enable",
+        action="store_true",
+        help="Save config but leave secrets.onepassword.enabled false",
+    )
+    setup.set_defaults(func=cmd_setup)
+
+    status = sub.add_parser("status", help="Show config + op binary status")
+    status.set_defaults(func=cmd_status)
+
+    sync = sub.add_parser("sync", help="Resolve references now and report what changed")
+    sync.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually export the secrets into the current process env (default: dry-run)",
+    )
+    sync.set_defaults(func=cmd_sync)
+
+    disable = sub.add_parser("disable", help="Turn off the 1Password integration")
+    disable.set_defaults(func=cmd_disable)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    console = Console()
+    console.print(
+        Panel.fit(
+            "[bold]1Password secrets setup[/bold]\n\n"
+            "Uses 1Password CLI secret references, e.g.\n"
+            "  [cyan]op://Hermes/TELEGRAM_BOT_TOKEN/password[/cyan]\n\n"
+            "For unattended gateway use, use a 1Password Service Account token.",
+            border_style="cyan",
+        )
+    )
+
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    token_env = args.token_env or op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+
+    token = (args.service_account_token or "").strip()
+    if not token and not os.environ.get(token_env):
+        token = masked_secret_prompt(f"  Paste service account token ({token_env}): ").strip()
+    if token:
+        save_env_value(token_env, token)
+        os.environ[token_env] = token
+        console.print(f"  [green]✓[/green] stored token in {get_env_path()} as {token_env}")
+    elif os.environ.get(token_env):
+        console.print(f"  [green]✓[/green] using existing {token_env} from environment/.env")
+    else:
+        console.print(f"  [red]{token_env} is not set.[/red]")
+        return 1
+
+    mapping = dict(op_cfg.get("mapping") or {})
+    for key, ref in args.map:
+        mapping[key] = ref
+
+    if not mapping:
+        console.print(
+            "  [yellow]No mappings configured yet. Add them with "
+            "--map ENV_VAR=op://Vault/Item/password.[/yellow]"
+        )
+        console.print("  [yellow]Saved disabled config so startup stays quiet.[/yellow]")
+
+    op_cfg["service_account_token_env"] = token_env
+    op_cfg["mapping"] = mapping
+    op_cfg.setdefault("override_existing", True)
+    op_cfg.setdefault("cache_ttl_seconds", 300)
+    op_cfg["enabled"] = bool(mapping) and not bool(args.no_enable)
+
+    if op_cfg["enabled"] and not bool(args.skip_test):
+        console.print("\n[bold]Test fetch[/bold]")
+        try:
+            secrets, warnings = opsec.fetch_onepassword_secrets(
+                service_account_token=os.environ[token_env],
+                mapping=mapping,
+                cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+                use_cache=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"  [red]✗ Fetch failed: {exc}[/red]")
+            console.print("  Config was not enabled. Fix the refs or re-run with --skip-test.")
+            return 1
+
+        for warning in warnings:
+            console.print(f"  [yellow]warning:[/yellow] {warning}")
+        if not secrets:
+            console.print("  [red]✗ No secrets resolved.[/red]")
+            console.print("  Config was not enabled. Add at least one valid --map entry.")
+            return 1
+        console.print(f"  [green]✓[/green] resolved {len(secrets)} secret(s)")
+
+    save_config(cfg)
+
+    console.print("\n[green]✓ 1Password config saved.[/green]")
+    _print_mapping(console, mapping)
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+    enabled = bool(op_cfg.get("enabled"))
+    token_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    token_set = bool(os.environ.get(token_env))
+    mapping = op_cfg.get("mapping") or {}
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled", _yn(enabled))
+    table.add_row("Token env var", token_env)
+    table.add_row("Token in env", _yn(token_set))
+    table.add_row("Mappings", str(len(mapping)))
+    table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", False))))
+    table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
+
+    binary = opsec.find_op()
+    if binary:
+        table.add_row("op binary", f"{binary} ({_op_version(binary)})")
+    else:
+        table.add_row("op binary", "[yellow]not installed[/yellow]")
+
+    console.print(Panel(table, title="1Password", border_style="cyan"))
+    if mapping:
+        _print_mapping(console, mapping)
+    else:
+        console.print("\n  Add mappings with [cyan]hermes secrets onepassword setup --map ENV=op://...[/cyan]")
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+    if not op_cfg.get("enabled"):
+        console.print("[yellow]1Password integration is disabled. Run setup first.[/yellow]")
+        return 1
+
+    token_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        console.print(f"[red]{token_env} is not set.[/red]")
+        return 1
+
+    mapping = op_cfg.get("mapping") or {}
+    try:
+        secrets, warnings = opsec.fetch_onepassword_secrets(
+            service_account_token=token,
+            mapping=mapping,
+            use_cache=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Fetch failed: {exc}[/red]")
+        return 1
+
+    if not secrets:
+        console.print("[yellow]No secrets resolved.[/yellow]")
+        for w in warnings:
+            console.print(f"[yellow]warning:[/yellow] {w}")
+        return 0
+
+    override = bool(op_cfg.get("override_existing", False)) or args.apply
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    applied = 0
+    for key in sorted(secrets):
+        if key == token_env:
+            table.add_row(key, "[dim]skip (bootstrap token)[/dim]")
+            continue
+        already = bool(os.environ.get(key))
+        if already and not override:
+            table.add_row(key, "[dim]skip (already set)[/dim]")
+            continue
+        if args.apply:
+            os.environ[key] = secrets[key]
+            applied += 1
+            table.add_row(key, "[green]exported[/green]" + (" (overrode)" if already else ""))
+        else:
+            table.add_row(key, "[green]would export[/green]" + (" (overrides)" if already else ""))
+
+    console.print(table)
+    for w in warnings:
+        console.print(f"[yellow]warning:[/yellow] {w}")
+    if args.apply:
+        console.print(f"\n  [green]Exported {applied} secret(s) into current process.[/green]")
+    else:
+        console.print("\n  Dry-run. Hermes applies these automatically on next process startup.")
+    return 0
+
+
+def cmd_disable(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["enabled"] = False
+    save_config(cfg)
+    console.print("[green]Disabled.[/green] 1Password secrets will not be pulled on next startup.")
+    return 0
+
+
+def _parse_mapping(entry: str) -> tuple[str, str]:
+    if "=" not in entry:
+        raise argparse.ArgumentTypeError("mapping must be ENV_VAR=op://Vault/Item/field")
+    key, ref = entry.split("=", 1)
+    key = key.strip()
+    ref = ref.strip()
+    if not key or not ref:
+        raise argparse.ArgumentTypeError("mapping must be ENV_VAR=op://Vault/Item/field")
+    if not opsec._is_valid_env_name(key):  # type: ignore[attr-defined]
+        raise argparse.ArgumentTypeError(f"invalid environment variable name: {key}")
+    if not ref.startswith("op://"):
+        raise argparse.ArgumentTypeError("1Password reference must start with op://")
+    return key, ref
+
+
+def _print_mapping(console: Console, mapping: Dict[str, str]) -> None:
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Env var", style="cyan")
+    table.add_column("1Password reference")
+    for key, ref in sorted(mapping.items()):
+        table.add_row(str(key), str(ref))
+    console.print(table)
+
+
+def _op_version(binary: Path) -> str:
+    try:
+        res = subprocess.run(
+            [str(binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if res.returncode == 0:
+            return (res.stdout or res.stderr).strip().splitlines()[0]
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "version unknown"
+
+
+def _yn(value: bool) -> str:
+    return "[green]yes[/green]" if value else "[dim]no[/dim]"

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -53,6 +53,14 @@ def test_format_secret_source_suffix_bitwarden_uses_proper_name():
     )
 
 
+def test_format_secret_source_suffix_onepassword_uses_proper_name():
+    env_loader._SECRET_SOURCES["ANTHROPIC_API_KEY"] = "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
+        == " (from 1Password)"
+    )
+
+
 def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
@@ -119,6 +127,72 @@ def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch)
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
+
+
+def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monkeypatch):
+    """1Password applied keys are tracked for UI suffixes."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    mapping:\n"
+        "      ANTHROPIC_API_KEY: op://Hermes/Anthropic/password\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.onepassword import FetchResult
+
+    fake_result = FetchResult(
+        secrets={"ANTHROPIC_API_KEY": "sk-ant-test"},
+        applied=["ANTHROPIC_API_KEY"],
+    )
+
+    def _fake_apply(**_kwargs):
+        return fake_result
+
+    import agent.secret_sources.onepassword as op_module
+
+    monkeypatch.setattr(op_module, "apply_onepassword_secrets", _fake_apply)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
+        == " (from 1Password)"
+    )
+
+
+def test_apply_external_secret_sources_never_blocks_on_onepassword_exception(
+    tmp_path, monkeypatch, capsys
+):
+    """A buggy/failed backend must not prevent Hermes startup."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    mapping:\n"
+        "      API_KEY: op://Hermes/API/password\n",
+        encoding="utf-8",
+    )
+
+    def _explode(**_kwargs):
+        raise RuntimeError("synthetic op failure")
+
+    import agent.secret_sources.onepassword as op_module
+
+    monkeypatch.setattr(op_module, "apply_onepassword_secrets", _explode)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    assert "1Password: synthetic op failure" in captured.err
 
 
 def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypatch):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -1,0 +1,213 @@
+"""Hermetic tests for the 1Password secret-source integration.
+
+No real 1Password account, Service Account token, or network access is used.
+The `op` CLI subprocess is mocked in every fetch/apply test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import onepassword as opsec  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    opsec._reset_cache_for_tests()
+    yield
+    opsec._reset_cache_for_tests()
+
+
+def test_normalize_mapping_rejects_invalid_entries():
+    mapping, warnings = opsec._normalize_mapping(
+        {
+            "VALID_KEY": "op://Hermes/Valid/password",
+            "1BAD": "op://Hermes/Bad/password",
+            "NOT_OP": "secret-value",
+        }
+    )
+
+    assert mapping == {"VALID_KEY": "op://Hermes/Valid/password"}
+    assert len(warnings) == 2
+
+
+def test_fetch_happy_path_uses_op_read_and_token_env(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    mapping = {
+        "OPENAI_API_KEY": "op://Hermes/OpenAI/password",
+        "ANTHROPIC_API_KEY": "op://Hermes/Anthropic/password",
+    }
+    values = {
+        "op://Hermes/OpenAI/password": "sk-openai-test",
+        "op://Hermes/Anthropic/password": "sk-anthropic-test\n",
+    }
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs["env"].copy()))
+        assert cmd[0] == str(fake_binary)
+        assert cmd[1] == "read"
+        assert kwargs["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "ops_test_token"
+        return mock.Mock(returncode=0, stdout=values[cmd[2]], stderr="")
+
+    monkeypatch.setattr(opsec.subprocess, "run", fake_run)
+
+    secrets, warnings = opsec.fetch_onepassword_secrets(
+        service_account_token="ops_test_token",
+        mapping=mapping,
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    assert secrets == {
+        "OPENAI_API_KEY": "sk-openai-test",
+        "ANTHROPIC_API_KEY": "sk-anthropic-test",
+    }
+    assert warnings == []
+    assert [call[0][2] for call in calls] == list(mapping.values())
+
+
+def test_fetch_op_failure_surfaces_reference_not_secret(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    monkeypatch.setattr(
+        opsec.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="permission denied"),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        opsec.fetch_onepassword_secrets(
+            service_account_token="ops_test_token",
+            mapping={"API_KEY": "op://Hermes/API/password"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+    msg = str(excinfo.value)
+    assert "op read failed for API_KEY" in msg
+    assert "op://Hermes/API/password" not in msg
+    assert "permission denied" in msg
+    assert "ops_test_token" not in msg
+
+
+def test_fetch_timeout(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="op", timeout=20)
+
+    monkeypatch.setattr(opsec.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        opsec.fetch_onepassword_secrets(
+            service_account_token="ops_test_token",
+            mapping={"API_KEY": "op://Hermes/API/password"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+
+def test_fetch_cache_hits(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    call_count = {"n": 0}
+
+    def fake_run(*a, **kw):
+        call_count["n"] += 1
+        return mock.Mock(returncode=0, stdout="secret-value", stderr="")
+
+    monkeypatch.setattr(opsec.subprocess, "run", fake_run)
+
+    kwargs = {
+        "service_account_token": "ops_test_token",
+        "mapping": {"API_KEY": "op://Hermes/API/password"},
+        "binary": fake_binary,
+        "cache_ttl_seconds": 60,
+    }
+    opsec.fetch_onepassword_secrets(**kwargs)
+    opsec.fetch_onepassword_secrets(**kwargs)
+
+    assert call_count["n"] == 1
+
+
+def test_apply_missing_token_does_not_raise(monkeypatch):
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+
+    result = opsec.apply_onepassword_secrets(
+        enabled=True,
+        mapping={"API_KEY": "op://Hermes/API/password"},
+    )
+
+    assert not result.ok
+    assert result.error is not None
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in result.error
+    assert not result.applied
+
+
+def test_apply_does_not_override_existing(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_test_token")
+    monkeypatch.setenv("API_KEY", "existing")
+    monkeypatch.setattr(opsec, "find_op", lambda: fake_binary)
+    monkeypatch.setattr(
+        opsec.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="from-1password", stderr=""),
+    )
+
+    result = opsec.apply_onepassword_secrets(
+        enabled=True,
+        mapping={"API_KEY": "op://Hermes/API/password"},
+        override_existing=False,
+    )
+
+    assert result.ok
+    assert "API_KEY" in result.skipped
+    assert os.environ["API_KEY"] == "existing"
+
+
+def test_apply_override_existing_and_skip_bootstrap(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_original")
+    monkeypatch.setenv("API_KEY", "stale")
+    monkeypatch.setattr(opsec, "find_op", lambda: fake_binary)
+
+    def fake_run(cmd, **kwargs):
+        ref = cmd[2]
+        if ref.endswith("/token"):
+            return mock.Mock(returncode=0, stdout="ops_replacement", stderr="")
+        return mock.Mock(returncode=0, stdout="fresh", stderr="")
+
+    monkeypatch.setattr(opsec.subprocess, "run", fake_run)
+
+    result = opsec.apply_onepassword_secrets(
+        enabled=True,
+        mapping={
+            "API_KEY": "op://Hermes/API/password",
+            "OP_SERVICE_ACCOUNT_TOKEN": "op://Hermes/Bootstrap/token",
+        },
+        override_existing=True,
+    )
+
+    assert result.ok
+    assert os.environ["API_KEY"] == "fresh"
+    assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "ops_original"
+    assert "API_KEY" in result.applied
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in result.skipped

--- a/tests/test_onepassword_secrets_cli.py
+++ b/tests/test_onepassword_secrets_cli.py
@@ -1,0 +1,135 @@
+"""CLI tests for ``hermes secrets onepassword``.
+
+These keep the user-facing setup flow boring: bad flags should be argparse
+errors, setup should not enable an unusable integration, and enabled configs
+must pass a fetch test first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli import onepassword_secrets_cli as cli  # noqa: E402
+
+
+def _setup_args(**overrides):
+    defaults = {
+        "service_account_token": "ops_test_token",
+        "token_env": None,
+        "map": [],
+        "no_enable": False,
+        "skip_test": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_setup_map_argparse_validation_does_not_traceback(capsys):
+    parser = argparse.ArgumentParser(prog="onepassword")
+    cli.register_cli(parser)
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["setup", "--map", "not-a-mapping"])
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert "mapping must be ENV_VAR=op://Vault/Item/field" in captured.err
+
+
+def test_setup_with_no_mappings_saves_disabled_config(monkeypatch):
+    cfg = {}
+    saved = []
+
+    monkeypatch.setattr(cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(cli, "save_config", lambda c: saved.append(c.copy()))
+    monkeypatch.setattr(cli, "save_env_value", lambda *a, **k: None)
+    fetch = mock.Mock()
+    monkeypatch.setattr(cli.opsec, "fetch_onepassword_secrets", fetch)
+
+    rc = cli.cmd_setup(_setup_args())
+
+    assert rc == 0
+    assert saved
+    op_cfg = saved[-1]["secrets"]["onepassword"]
+    assert op_cfg["enabled"] is False
+    assert op_cfg["mapping"] == {}
+    fetch.assert_not_called()
+
+
+def test_setup_fetch_failure_does_not_save_enabled_config(monkeypatch):
+    cfg = {}
+    saved = []
+
+    monkeypatch.setattr(cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(cli, "save_config", lambda c: saved.append(c.copy()))
+    monkeypatch.setattr(cli, "save_env_value", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli.opsec,
+        "fetch_onepassword_secrets",
+        mock.Mock(side_effect=RuntimeError("op read failed for API_KEY: permission denied")),
+    )
+
+    rc = cli.cmd_setup(
+        _setup_args(map=[("API_KEY", "op://Hermes/API/password")])
+    )
+
+    assert rc == 1
+    assert saved == []
+
+
+def test_setup_validates_fetch_before_enabling(monkeypatch):
+    cfg = {}
+    saved = []
+    fetch = mock.Mock(return_value=({"API_KEY": "secret-value"}, []))
+
+    monkeypatch.setattr(cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(cli, "save_config", lambda c: saved.append(c.copy()))
+    monkeypatch.setattr(cli, "save_env_value", lambda *a, **k: None)
+    monkeypatch.setattr(cli.opsec, "fetch_onepassword_secrets", fetch)
+
+    rc = cli.cmd_setup(
+        _setup_args(map=[("API_KEY", "op://Hermes/API/password")])
+    )
+
+    assert rc == 0
+    fetch.assert_called_once_with(
+        service_account_token="ops_test_token",
+        mapping={"API_KEY": "op://Hermes/API/password"},
+        cache_ttl_seconds=300.0,
+        use_cache=False,
+    )
+    op_cfg = saved[-1]["secrets"]["onepassword"]
+    assert op_cfg["enabled"] is True
+    assert op_cfg["mapping"] == {"API_KEY": "op://Hermes/API/password"}
+
+
+def test_setup_skip_test_saves_without_fetch(monkeypatch):
+    cfg = {}
+    saved = []
+    fetch = mock.Mock()
+
+    monkeypatch.setattr(cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(cli, "save_config", lambda c: saved.append(c.copy()))
+    monkeypatch.setattr(cli, "save_env_value", lambda *a, **k: None)
+    monkeypatch.setattr(cli.opsec, "fetch_onepassword_secrets", fetch)
+
+    rc = cli.cmd_setup(
+        _setup_args(
+            map=[("API_KEY", "op://Hermes/API/password")],
+            skip_test=True,
+        )
+    )
+
+    assert rc == 0
+    fetch.assert_not_called()
+    assert saved[-1]["secrets"]["onepassword"]["enabled"] is True

--- a/website/docs/user-guide/secrets/index.md
+++ b/website/docs/user-guide/secrets/index.md
@@ -5,5 +5,6 @@ Hermes can pull API keys from external secret managers at process startup instea
 Supported:
 
 - [Bitwarden Secrets Manager](./bitwarden) — `bws` CLI, lazy-installed, free tier works.
+- [1Password](./onepassword) — `op` CLI secret references using `OP_SERVICE_ACCOUNT_TOKEN`.
 
-More backends (Vault, AWS Secrets Manager, 1Password CLI) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.
+More backends (Vault, AWS Secrets Manager, etc.) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -1,0 +1,73 @@
+# 1Password secret references
+
+Pull API keys from [1Password](https://1password.com/) at process startup using the 1Password CLI (`op`) instead of storing each key in plaintext inside `~/.hermes/.env`.
+
+Hermes uses 1Password **secret references** such as `op://Vault/Item/password` and maps each reference to an environment variable name.
+
+## How it works
+
+1. You create a 1Password Service Account and give it read access to the vault/items Hermes needs.
+2. Hermes stores that single bootstrap token in `~/.hermes/.env` as `OP_SERVICE_ACCOUNT_TOKEN` (or another env var name you configure).
+3. `~/.hermes/config.yaml` maps environment variables to 1Password references.
+4. Every time `hermes` starts, after `.env` loads, Hermes calls `op read <reference>` for each mapping and sets the values into `os.environ`.
+
+Failures never block startup. If `op` is missing, the token is absent, or a reference cannot be read, Hermes prints a short warning and continues with whatever credentials were already available from `.env` or the shell.
+
+## Setup
+
+Install the 1Password CLI yourself first. On macOS:
+
+```bash
+brew install --cask 1password-cli
+```
+
+Then configure Hermes:
+
+```bash
+hermes secrets onepassword setup \
+  --map OPENAI_API_KEY=op://Hermes/OpenAI/password \
+  --map ANTHROPIC_API_KEY=op://Hermes/Anthropic/password
+```
+
+The setup command can prompt for a service account token and stores it in `~/.hermes/.env`. For gateways/services, make sure the token is stored in `~/.hermes/.env`, not only exported in your current shell. For non-interactive setup, pass `--service-account-token "$OP_SERVICE_ACCOUNT_TOKEN"`, but do not put tokens in shell history unless your environment is safe.
+
+## CLI
+
+- `hermes secrets onepassword setup`: configure the token env var and add/update mappings.
+- `hermes secrets onepassword setup --skip-test`: save config without validating `op read` first.
+- `hermes secrets onepassword status`: show whether the integration is enabled, token presence, mapping count, and `op` binary status.
+- `hermes secrets onepassword sync`: dry-run resolve references and show what would be exported.
+- `hermes secrets onepassword sync --apply`: resolve references and export into the current Hermes process.
+- `hermes secrets onepassword disable`: set `secrets.onepassword.enabled: false`.
+
+Aliases: `hermes secrets op ...` and `hermes secrets 1password ...`.
+
+## Configuration
+
+Example `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
+    mapping:
+      OPENAI_API_KEY: op://Hermes/OpenAI/password
+      ANTHROPIC_API_KEY: op://Hermes/Anthropic/password
+    cache_ttl_seconds: 300
+    override_existing: true
+```
+
+- `enabled`: master switch. When false, 1Password is never contacted.
+- `service_account_token_env`: env var holding the Service Account token. Default: `OP_SERVICE_ACCOUNT_TOKEN`.
+- `mapping`: env-var name to `op://...` secret reference.
+- `cache_ttl_seconds`: how long resolved values are cached in-process. Set `0` to disable caching.
+- `override_existing`: when true, 1Password values overwrite existing env values. When false, `.env` / shell exports win.
+
+## Security notes
+
+- The bootstrap token is sensitive. Anyone with it can read the vault items granted to the service account.
+- Hermes never logs secret values. Status output names env vars and references only.
+- Startup/setup errors name env vars, not full `op://Vault/Item/field` references, because vault/item names can be sensitive in logs.
+- Hermes will not overwrite the bootstrap token env var from 1Password, even if you map it by mistake.
+- Keep access narrow: grant the service account read access only to the vault/items Hermes needs.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/secrets/index',
             'user-guide/secrets/bitwarden',
+            'user-guide/secrets/onepassword',
           ],
         },
         'user-guide/sessions',


### PR DESCRIPTION
## Summary
- add a 1Password secret-source backend using the `op` CLI and `OP_SERVICE_ACCOUNT_TOKEN`
- support `secrets.onepassword.mapping` so env vars can resolve from `op://...` secret references at startup
- add `hermes secrets onepassword` / `op` / `1password` CLI commands for setup, status, sync, and disable
- document the 1Password setup path alongside Bitwarden

## Behavior
- resolves mapped 1Password references into `os.environ` during `load_hermes_dotenv()`
- never logs secret values; only env var names and references are shown
- failures are non-fatal so Hermes startup continues with existing env/config
- tracks secret origin as `onepassword` for UI suffixes

## Test Plan
- [x] `python -m pytest tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py tests/test_onepassword_secrets.py -q`
- [x] `python -m py_compile agent/secret_sources/onepassword.py hermes_cli/onepassword_secrets_cli.py hermes_cli/env_loader.py hermes_cli/main.py`
