### PR TITLE
feat(slack): native AI Assistant Steps API streaming

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1244,6 +1244,104 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
 
+    # ── Assistant Steps API support ─────────────────────────────────────
+
+    async def set_thread_title(
+        self,
+        chat_id: str,
+        thread_ts: str,
+        title: str,
+    ) -> bool:
+        """Set the title of an assistant thread.
+
+        Uses ``assistant.threads.setTitle`` to give the thread a meaningful
+        name (e.g. "Research: quantum computing" or "Debug: auth flow").
+        Requires the ``assistant:write`` scope.
+
+        Returns True on success, False on failure (silently logged).
+        """
+        if not self._app:
+            return False
+        try:
+            await self._get_client(chat_id).assistant_threads_setTitle(
+                channel_id=chat_id,
+                thread_ts=thread_ts,
+                title=title,
+            )
+            return True
+        except Exception as e:
+            logger.debug("[Slack] assistant.threads.setTitle failed: %s", e)
+            return False
+
+    async def set_suggested_prompts(
+        self,
+        chat_id: str,
+        thread_ts: str,
+        prompts: List[Dict[str, str]],
+        title: Optional[str] = None,
+    ) -> bool:
+        """Set suggested follow-up prompts for an assistant thread.
+
+        Uses ``assistant.threads.setSuggestedPrompts`` to display clickable
+        prompt suggestions below the assistant's response.  Each prompt dict
+        should have ``"title"`` (display text) and ``"message"`` (what gets
+        sent when clicked).
+
+        Requires the ``assistant:write`` scope.
+
+        Returns True on success, False on failure (silently logged).
+        """
+        if not self._app:
+            return False
+        try:
+            kwargs: Dict[str, Any] = {
+                "channel_id": chat_id,
+                "thread_ts": thread_ts,
+                "prompts": prompts,
+            }
+            if title:
+                kwargs["title"] = title
+            await self._get_client(chat_id).assistant_threads_setSuggestedPrompts(
+                **kwargs,
+            )
+            return True
+        except Exception as e:
+            logger.debug("[Slack] assistant.threads.setSuggestedPrompts failed: %s", e)
+            return False
+
+    def create_stream_consumer(
+        self,
+        chat_id: str,
+        thread_ts: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SlackStreamConsumer":
+        """Create a :class:`SlackStreamConsumer` for native Slack streaming.
+
+        This is the entry point for the gateway to obtain a streaming consumer
+        that uses ``chat.startStream`` / ``chat.appendStream`` / ``chat.stopStream``
+        with ``task_update`` chunks instead of the legacy postMessage → edit loop.
+
+        The returned consumer's ``on_delta`` and ``on_tool_progress`` methods
+        can be wired directly as callbacks to ``AIAgent``.
+        """
+        from gateway.platforms.slack_stream import (
+            SlackStreamConsumer,
+            SlackStreamConfig,
+        )
+        client = self._get_client(chat_id)
+        config = SlackStreamConfig(
+            show_thinking=self.config.extra.get("show_thinking_steps", True),
+            set_title=self.config.extra.get("set_thread_title", True),
+            feedback_buttons=self.config.extra.get("feedback_buttons", True),
+        )
+        return SlackStreamConsumer(
+            client=client,
+            channel_id=chat_id,
+            thread_ts=thread_ts,
+            config=config,
+            metadata=metadata,
+        )
+
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.
 

--- a/gateway/platforms/slack_stream.py
+++ b/gateway/platforms/slack_stream.py
@@ -1,7 +1,7 @@
 """Slack AI Assistant streaming consumer — native step indicators via the Steps API.
 
 Uses Slack's ``chat.startStream`` / ``chat.appendStream`` / ``chat.stopStream``
-methods with ``task_update`` chunks to render native collapsible step cards
+methods with ``TaskUpdateChunk`` objects to render native collapsible step cards
 with checkmarks, chevrons, and status indicators — the same UI pattern used
 by Slack's own AI assistants (e.g. Slack AI, Highbeam's Luma).
 
@@ -10,14 +10,28 @@ Architecture
 Instead of the legacy postMessage → chat.update edit loop, this consumer:
 
 1. Calls ``chat.startStream`` with ``task_display_mode="plan"`` to create a
-   streaming message container.  The response includes a ``ts`` for the stream.
-2. Calls ``chat.appendStream`` with ``task_update`` chunks for each tool call:
-   - When a tool starts: ``{type: "task_start", id, name, status: "in_progress"}``
-   - When a tool completes: ``{type: "task_update", id, name, status: "complete", description}``
-   - When a tool fails: ``{type: "task_update", id, name, status: "failed", description}``
-3. Appends ``markdown_text`` chunks as the model streams tokens.
-4. Calls ``chat.stopStream`` to finalize, optionally with Block Kit ``blocks``
-   for the final rendered message (e.g. footer, feedback buttons).
+   streaming message container in **plan mode**.  The response includes a
+   ``ts`` for the stream.
+
+2. Calls ``chat.appendStream`` with ``TaskUpdateChunk`` objects for each step:
+   - When a tool starts:  ``TaskUpdateChunk(id, title, status="in_progress")``
+   - When a tool completes: ``TaskUpdateChunk(id, title, status="complete", details=...)``
+   - When a tool fails:  ``TaskUpdateChunk(id, title, status="failed", details=...)``
+
+3. For the model's text output, emits a **"Response" task step** whose
+   ``output`` field carries the markdown text.  This is required because
+   plan mode streams cannot use ``markdown_text`` — they only accept
+   ``chunks``.  The text is buffered and flushed periodically as incremental
+   updates to the Response step's ``output``.
+
+4. Calls ``chat.stopStream`` to finalize.
+
+.. important::
+   Slack's streaming API enforces **mode isolation**: a stream started with
+   ``task_display_mode="plan"`` can only accept ``chunks`` (not
+   ``markdown_text``), and vice versa.  Attempting to mix them raises
+   ``streaming_mode_mismatch``.  This consumer uses plan mode exclusively
+   and routes all text through ``TaskUpdateChunk.output``.
 
 Thread Safety
 -------------
@@ -68,16 +82,18 @@ class StreamChunk:
 @dataclass
 class SlackStreamConfig:
     """Runtime config for a Slack streaming consumer instance."""
-    # How often to flush accumulated markdown_text (seconds)
-    flush_interval: float = 0.8
+    # How often to flush accumulated text to the Response step (seconds)
+    flush_interval: float = 1.0
     # Maximum characters to buffer before flushing regardless of interval
-    buffer_threshold: int = 800
+    buffer_threshold: int = 1200
     # Whether to include thinking/reasoning as a task step
     show_thinking: bool = True
     # Whether to set thread title on first response
     set_title: bool = True
     # Whether to include feedback buttons on the final message
     feedback_buttons: bool = True
+    # Title for the Response step that carries the LLM text output
+    response_step_title: str = "Response"
 
 
 class SlackStreamConsumer:
@@ -128,13 +144,20 @@ class SlackStreamConsumer:
         # Running counter for task IDs
         self._task_counter: int = 0
 
-        # Buffer for text deltas
+        # Buffer for text deltas — accumulated and flushed to the Response
+        # step's ``output`` field periodically
         self._text_buffer: str = ""
 
         # Track active tasks so we can complete/fail them
         self._active_tasks: Dict[str, str] = {}  # task_id → name
 
-        # Whether we've sent the first appendStream with markdown
+        # Whether we've started the Response step
+        self._response_step_id: Optional[str] = None
+
+        # Total text sent so far (for incremental output updates)
+        self._total_text_sent: int = 0
+
+        # Whether we've sent the first appendStream
         self._started: bool = False
 
     # ── Public sync callbacks (called from agent worker thread) ───────
@@ -154,9 +177,9 @@ class SlackStreamConsumer:
     ) -> None:
         """Thread-safe callback for tool lifecycle events.
 
-        Maps agent tool events to Slack task_update chunks:
-        - ``tool.started``  → ``task_start`` (in_progress)
-        - ``tool.completed`` → ``task_update`` (complete)
+        Maps agent tool events to Slack TaskUpdateChunk steps:
+        - ``tool.started``  → in_progress step
+        - ``tool.completed`` → complete step
         """
         if event_type == "tool.started" and tool_name:
             self._task_counter += 1
@@ -227,7 +250,7 @@ class SlackStreamConsumer:
                 pass
 
             if item is None:
-                # Periodic flush of buffered text
+                # Periodic flush of buffered text to the Response step
                 now = time.monotonic()
                 if self._text_buffer and (now - last_flush) >= self._config.flush_interval:
                     await self._flush_text()
@@ -252,16 +275,16 @@ class SlackStreamConsumer:
 
             elif kind is _TASK_START:
                 _, task_id, task_name, status, desc = item
-                await self._send_task_start(task_id, task_name, status, desc)
+                await self._send_task_step(task_id, task_name, status, desc)
 
             elif kind is _TASK_UPDATE:
                 _, task_id, task_name, status, desc = item
-                await self._send_task_update(task_id, task_name, status, desc)
+                await self._send_task_step(task_id, task_name, status, desc)
 
     # ── Slack API calls ──────────────────────────────────────────────
 
     async def _start_stream(self) -> None:
-        """Initiate a streaming message via chat.startStream."""
+        """Initiate a streaming message via chat.startStream in plan mode."""
         resp = await self._client.chat_startStream(
             channel=self._channel_id,
             thread_ts=self._thread_ts,
@@ -278,112 +301,133 @@ class SlackStreamConsumer:
         )
         self._started = True
 
+    async def _ensure_response_step(self) -> str:
+        """Create the Response step if it doesn't exist yet, return its ID."""
+        if self._response_step_id is not None:
+            return self._response_step_id
+        self._task_counter += 1
+        self._response_step_id = f"response_{self._task_counter}"
+        # Start the Response step as in_progress
+        await self._send_task_step(
+            self._response_step_id,
+            self._config.response_step_title,
+            "in_progress",
+            "",
+        )
+        return self._response_step_id
+
     async def _flush_text(self) -> None:
-        """Flush accumulated text deltas via chat.appendStream."""
+        """Flush accumulated text deltas to the Response step's output field.
+
+        In plan mode, ``markdown_text`` is not allowed — text must be carried
+        inside a ``TaskUpdateChunk.output`` field.  We maintain a "Response"
+        step and update it with the full accumulated text each flush.
+        """
         if not self._text_buffer or not self._stream_ts:
             return
         try:
-            await self._client.chat_appendStream(
-                channel=self._channel_id,
-                ts=self._stream_ts,
-                markdown_text=self._text_buffer,
-            )
-            self._text_buffer = ""
-        except Exception as e:
-            logger.warning("[SlackStream] appendStream text failed: %s", e)
-
-    async def _send_task_start(
-        self, task_id: str, name: str, status: str, description: str,
-    ) -> None:
-        """Send a TaskUpdateChunk to create a new step indicator."""
-        if not self._stream_ts:
-            return
-        try:
-            from slack_sdk.models.messages.chunk import TaskUpdateChunk
-            chunk = TaskUpdateChunk(
-                id=task_id,
-                title=name,
-                status=status,
-                details=description or None,
+            step_id = await self._ensure_response_step()
+            # Build the full output so far
+            full_text = self._text_buffer[:self._total_text_sent + len(self._text_buffer)]
+            # Actually just send what we have — the output field replaces the
+            # previous value for this step ID
+            full_output = self._text_buffer
+            chunk = self._make_task_chunk(
+                step_id,
+                self._config.response_step_title,
+                "in_progress",
+                output=full_output,
             )
             await self._client.chat_appendStream(
                 channel=self._channel_id,
                 ts=self._stream_ts,
                 chunks=[chunk],
             )
-        except ImportError:
-            # Fallback for slack_sdk < 3.35
-            chunk = {
-                "type": "task_start",
+            self._total_text_sent = len(self._text_buffer)
+            # Don't clear the buffer yet — we need the full text for the next
+            # incremental update (Slack replaces the entire output each time)
+        except Exception as e:
+            logger.warning("[SlackStream] flush text to Response step failed: %s", e)
+
+    async def _send_task_step(
+        self, task_id: str, name: str, status: str, description: str,
+    ) -> None:
+        """Send a TaskUpdateChunk for a tool/thinking step."""
+        if not self._stream_ts:
+            return
+        try:
+            chunk = self._make_task_chunk(task_id, name, status, details=description or None)
+            await self._client.chat_appendStream(
+                channel=self._channel_id,
+                ts=self._stream_ts,
+                chunks=[chunk],
+            )
+        except Exception as e:
+            logger.warning("[SlackStream] task step failed for %s: %s", name, e)
+
+    def _make_task_chunk(
+        self,
+        task_id: str,
+        title: str,
+        status: str,
+        details: Optional[str] = None,
+        output: Optional[str] = None,
+    ) -> Any:
+        """Build a TaskUpdateChunk, falling back to a raw dict for old SDKs."""
+        try:
+            from slack_sdk.models.messages.chunk import TaskUpdateChunk
+            kwargs: Dict[str, Any] = {
                 "id": task_id,
-                "name": name,
+                "title": title,
                 "status": status,
             }
-            if description:
-                chunk["description"] = description
-            try:
-                await self._client.chat_appendStream(
-                    channel=self._channel_id,
-                    ts=self._stream_ts,
-                    chunks=[chunk],
-                )
-            except Exception as e:
-                logger.warning("[SlackStream] task_start failed for %s: %s", name, e)
-        except Exception as e:
-            logger.warning("[SlackStream] task_start failed for %s: %s", name, e)
-
-    async def _send_task_update(
-        self, task_id: str, name: str, status: str, description: str,
-    ) -> None:
-        """Send a TaskUpdateChunk to update a step's status."""
-        if not self._stream_ts:
-            return
-        try:
-            from slack_sdk.models.messages.chunk import TaskUpdateChunk
-            chunk = TaskUpdateChunk(
-                id=task_id,
-                title=name,
-                status=status,
-                details=description or None,
-            )
-            await self._client.chat_appendStream(
-                channel=self._channel_id,
-                ts=self._stream_ts,
-                chunks=[chunk],
-            )
+            if details:
+                kwargs["details"] = details
+            if output:
+                kwargs["output"] = output
+            return TaskUpdateChunk(**kwargs)
         except ImportError:
             # Fallback for slack_sdk < 3.35
-            chunk = {
+            chunk: Dict[str, Any] = {
                 "type": "task_update",
                 "id": task_id,
-                "name": name,
+                "name": title,
                 "status": status,
             }
-            if description:
-                chunk["description"] = description
-            try:
-                await self._client.chat_appendStream(
-                    channel=self._channel_id,
-                    ts=self._stream_ts,
-                    chunks=[chunk],
-                )
-            except Exception as e:
-                logger.warning("[SlackStream] task_update failed for %s: %s", name, e)
-        except Exception as e:
-            logger.warning("[SlackStream] task_update failed for %s: %s", name, e)
+            if details:
+                chunk["description"] = details
+            if output:
+                chunk["output"] = output
+            return chunk
 
     async def _finalize(self) -> None:
-        """Flush remaining text and stop the stream."""
-        # Complete any still-active tasks
+        """Flush remaining text, complete active tasks, and stop the stream."""
+        # Complete any still-active tool/thinking tasks
         for task_id, name in list(self._active_tasks.items()):
             try:
-                await self._send_task_update(task_id, name, "complete", "")
+                await self._send_task_step(task_id, name, "complete", "")
             except Exception:
                 pass
 
-        # Flush remaining text
-        if self._text_buffer:
-            await self._flush_text()
+        # Flush remaining text and mark the Response step as complete
+        if self._text_buffer or self._response_step_id:
+            try:
+                step_id = await self._ensure_response_step()
+                full_output = self._text_buffer or ""
+                chunk = self._make_task_chunk(
+                    step_id,
+                    self._config.response_step_title,
+                    "complete",
+                    output=full_output,
+                )
+                await self._client.chat_appendStream(
+                    channel=self._channel_id,
+                    ts=self._stream_ts,
+                    chunks=[chunk],
+                )
+                self._text_buffer = ""
+            except Exception as e:
+                logger.warning("[SlackStream] finalize Response step failed: %s", e)
 
         # Stop the stream
         if self._stream_ts:

--- a/gateway/platforms/slack_stream.py
+++ b/gateway/platforms/slack_stream.py
@@ -1,0 +1,368 @@
+"""Slack AI Assistant streaming consumer — native step indicators via the Steps API.
+
+Uses Slack's ``chat.startStream`` / ``chat.appendStream`` / ``chat.stopStream``
+methods with ``task_update`` chunks to render native collapsible step cards
+with checkmarks, chevrons, and status indicators — the same UI pattern used
+by Slack's own AI assistants (e.g. Slack AI, Highbeam's Luma).
+
+Architecture
+------------
+Instead of the legacy postMessage → chat.update edit loop, this consumer:
+
+1. Calls ``chat.startStream`` with ``task_display_mode="plan"`` to create a
+   streaming message container.  The response includes a ``ts`` for the stream.
+2. Calls ``chat.appendStream`` with ``task_update`` chunks for each tool call:
+   - When a tool starts: ``{type: "task_start", id, name, status: "in_progress"}``
+   - When a tool completes: ``{type: "task_update", id, name, status: "complete", description}``
+   - When a tool fails: ``{type: "task_update", id, name, status: "failed", description}``
+3. Appends ``markdown_text`` chunks as the model streams tokens.
+4. Calls ``chat.stopStream`` to finalize, optionally with Block Kit ``blocks``
+   for the final rendered message (e.g. footer, feedback buttons).
+
+Thread Safety
+-------------
+Like the base ``GatewayStreamConsumer``, all public ``on_*`` methods are
+synchronous and thread-safe (called from the agent's worker thread).  The
+actual Slack API calls happen in an async ``run()`` task on the event loop.
+
+Requirements
+------------
+- Slack app must have the ``assistant:write`` scope.
+- The ``Agents & AI Apps`` feature must be enabled in the Slack app config.
+- The conversation must be in a Slack thread (``thread_ts`` is required for
+  ``chat.startStream``).
+- ``slack_sdk >= 3.35`` (for streaming method support).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("gateway.slack_stream")
+
+# ── Queue sentinels ──────────────────────────────────────────────────────
+
+_DONE = object()        # Stream is complete
+_DELTA = object()       # Text delta from the model
+_TASK_START = object()  # Tool started
+_TASK_UPDATE = object() # Tool completed / failed
+_THINKING = object()    # Thinking/reasoning started or ended
+
+
+@dataclass
+class StreamChunk:
+    """Internal representation of a queued chunk."""
+    kind: str           # "delta" | "task_start" | "task_update" | "thinking" | "done"
+    task_id: str = ""
+    task_name: str = ""
+    status: str = ""    # "in_progress" | "complete" | "failed"
+    description: str = ""
+    text: str = ""
+
+
+@dataclass
+class SlackStreamConfig:
+    """Runtime config for a Slack streaming consumer instance."""
+    # How often to flush accumulated markdown_text (seconds)
+    flush_interval: float = 0.8
+    # Maximum characters to buffer before flushing regardless of interval
+    buffer_threshold: int = 800
+    # Whether to include thinking/reasoning as a task step
+    show_thinking: bool = True
+    # Whether to set thread title on first response
+    set_title: bool = True
+    # Whether to include feedback buttons on the final message
+    feedback_buttons: bool = True
+
+
+class SlackStreamConsumer:
+    """Async consumer that streams AI responses via Slack's native Steps API.
+
+    Usage::
+
+        consumer = SlackStreamConsumer(
+            client=slack_client,
+            channel_id="C01234",
+            thread_ts="1234567890.123456",
+            config=SlackStreamConfig(),
+        )
+        # Pass consumer callbacks to AIAgent
+        agent = AIAgent(
+            ...,
+            stream_delta_callback=consumer.on_delta,
+            tool_progress_callback=consumer.on_tool_progress,
+        )
+        # Start the consumer
+        task = asyncio.create_task(consumer.run())
+        # ... run agent ...
+        consumer.finish()
+        await task
+    """
+
+    def __init__(
+        self,
+        client: Any,              # AsyncWebClient
+        channel_id: str,
+        thread_ts: str,
+        config: Optional[SlackStreamConfig] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        self._client = client
+        self._channel_id = channel_id
+        self._thread_ts = thread_ts
+        self._config = config or SlackStreamConfig()
+        self._metadata = metadata or {}
+
+        # Thread-safe queue — on_delta / on_tool_progress are called from
+        # the agent's worker thread; run() drains from the async loop.
+        self._queue: queue.Queue = queue.Queue()
+
+        # Stream state — set by run() after startStream succeeds
+        self._stream_ts: Optional[str] = None
+
+        # Running counter for task IDs
+        self._task_counter: int = 0
+
+        # Buffer for text deltas
+        self._text_buffer: str = ""
+
+        # Track active tasks so we can complete/fail them
+        self._active_tasks: Dict[str, str] = {}  # task_id → name
+
+        # Whether we've sent the first appendStream with markdown
+        self._started: bool = False
+
+    # ── Public sync callbacks (called from agent worker thread) ───────
+
+    def on_delta(self, text: str) -> None:
+        """Thread-safe callback — called from the agent's worker thread."""
+        if text:
+            self._queue.put((_DELTA, text))
+
+    def on_tool_progress(
+        self,
+        event_type: str,
+        tool_name: str = None,
+        preview: str = None,
+        args: dict = None,
+        **kwargs,
+    ) -> None:
+        """Thread-safe callback for tool lifecycle events.
+
+        Maps agent tool events to Slack task_update chunks:
+        - ``tool.started``  → ``task_start`` (in_progress)
+        - ``tool.completed`` → ``task_update`` (complete)
+        """
+        if event_type == "tool.started" and tool_name:
+            self._task_counter += 1
+            task_id = f"tool_{self._task_counter}"
+            desc = preview or ""
+            if not desc and args:
+                # Build a short description from the first argument
+                first_key = next(iter(args), None)
+                if first_key:
+                    val = str(args[first_key])[:80]
+                    desc = f"{first_key}: {val}"
+            self._queue.put((_TASK_START, task_id, tool_name, "in_progress", desc))
+            self._active_tasks[task_id] = tool_name
+
+        elif event_type == "tool.completed" and tool_name:
+            # Find the matching active task
+            task_id = None
+            for tid, name in list(self._active_tasks.items()):
+                if name == tool_name:
+                    task_id = tid
+                    break
+            if task_id:
+                duration = kwargs.get("duration", 0)
+                desc = f"Done ({duration:.1f}s)" if duration else "Done"
+                self._queue.put((_TASK_UPDATE, task_id, tool_name, "complete", desc))
+                self._active_tasks.pop(task_id, None)
+
+    def on_thinking_start(self) -> None:
+        """Signal that the model is thinking/reasoning."""
+        if self._config.show_thinking:
+            self._task_counter += 1
+            task_id = f"thinking_{self._task_counter}"
+            self._queue.put((_TASK_START, task_id, "Thinking", "in_progress", ""))
+            self._active_tasks[task_id] = "Thinking"
+
+    def on_thinking_end(self) -> None:
+        """Signal that thinking/reasoning is complete."""
+        for task_id, name in list(self._active_tasks.items()):
+            if name == "Thinking":
+                self._queue.put((_TASK_UPDATE, task_id, "Thinking", "complete", ""))
+                self._active_tasks.pop(task_id, None)
+                break
+
+    def finish(self) -> None:
+        """Signal that the stream is complete."""
+        self._queue.put(_DONE)
+
+    # ── Async run loop ───────────────────────────────────────────────
+
+    async def run(self) -> None:
+        """Main async loop — drains the queue and calls Slack streaming APIs."""
+        try:
+            await self._start_stream()
+        except Exception as e:
+            logger.error("[SlackStream] Failed to start stream: %s", e, exc_info=True)
+            return
+
+        last_flush = time.monotonic()
+
+        while True:
+            # Drain queue without blocking the event loop.
+            # queue.Queue is thread-safe but blocking; use a short
+            # loop + async sleep to stay responsive.
+            item = None
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                pass
+
+            if item is None:
+                # Periodic flush of buffered text
+                now = time.monotonic()
+                if self._text_buffer and (now - last_flush) >= self._config.flush_interval:
+                    await self._flush_text()
+                    last_flush = now
+                await asyncio.sleep(0.05)
+                continue
+
+            if item is _DONE:
+                # Finalize any remaining text and active tasks
+                await self._finalize()
+                break
+
+            kind = item[0]
+
+            if kind is _DELTA:
+                self._text_buffer += item[1]
+                now = time.monotonic()
+                if len(self._text_buffer) >= self._config.buffer_threshold or \
+                   (now - last_flush) >= self._config.flush_interval:
+                    await self._flush_text()
+                    last_flush = now
+
+            elif kind is _TASK_START:
+                _, task_id, task_name, status, desc = item
+                await self._send_task_start(task_id, task_name, status, desc)
+
+            elif kind is _TASK_UPDATE:
+                _, task_id, task_name, status, desc = item
+                await self._send_task_update(task_id, task_name, status, desc)
+
+    # ── Slack API calls ──────────────────────────────────────────────
+
+    async def _start_stream(self) -> None:
+        """Initiate a streaming message via chat.startStream."""
+        resp = await self._client.chat_startStream(
+            channel=self._channel_id,
+            thread_ts=self._thread_ts,
+            task_display_mode="plan",
+        )
+        self._stream_ts = resp.get("ts") or resp.get("message", {}).get("ts")
+        if not self._stream_ts:
+            # Some SDK versions nest differently
+            data = resp.data if hasattr(resp, "data") else resp
+            self._stream_ts = data.get("ts") or data.get("message", {}).get("ts")
+        logger.debug(
+            "[SlackStream] Started stream: channel=%s thread=%s stream_ts=%s",
+            self._channel_id, self._thread_ts, self._stream_ts,
+        )
+        self._started = True
+
+    async def _flush_text(self) -> None:
+        """Flush accumulated text deltas via chat.appendStream."""
+        if not self._text_buffer or not self._stream_ts:
+            return
+        try:
+            await self._client.chat_appendStream(
+                channel=self._channel_id,
+                ts=self._stream_ts,
+                markdown_text=self._text_buffer,
+            )
+            self._text_buffer = ""
+        except Exception as e:
+            logger.warning("[SlackStream] appendStream text failed: %s", e)
+
+    async def _send_task_start(
+        self, task_id: str, name: str, status: str, description: str,
+    ) -> None:
+        """Send a task_start chunk to create a new step indicator."""
+        if not self._stream_ts:
+            return
+        chunk = {
+            "type": "task_start",
+            "id": task_id,
+            "name": name,
+            "status": status,
+        }
+        if description:
+            chunk["description"] = description
+        try:
+            await self._client.chat_appendStream(
+                channel=self._channel_id,
+                ts=self._stream_ts,
+                chunks=[chunk],
+            )
+        except Exception as e:
+            logger.warning("[SlackStream] task_start failed for %s: %s", name, e)
+
+    async def _send_task_update(
+        self, task_id: str, name: str, status: str, description: str,
+    ) -> None:
+        """Send a task_update chunk to update a step's status."""
+        if not self._stream_ts:
+            return
+        chunk = {
+            "type": "task_update",
+            "id": task_id,
+            "name": name,
+            "status": status,
+        }
+        if description:
+            chunk["description"] = description
+        try:
+            await self._client.chat_appendStream(
+                channel=self._channel_id,
+                ts=self._stream_ts,
+                chunks=[chunk],
+            )
+        except Exception as e:
+            logger.warning("[SlackStream] task_update failed for %s: %s", name, e)
+
+    async def _finalize(self) -> None:
+        """Flush remaining text and stop the stream."""
+        # Complete any still-active tasks
+        for task_id, name in list(self._active_tasks.items()):
+            try:
+                await self._send_task_update(task_id, name, "complete", "")
+            except Exception:
+                pass
+
+        # Flush remaining text
+        if self._text_buffer:
+            await self._flush_text()
+
+        # Stop the stream
+        if self._stream_ts:
+            try:
+                await self._client.chat_stopStream(
+                    channel=self._channel_id,
+                    ts=self._stream_ts,
+                )
+                logger.debug(
+                    "[SlackStream] Stopped stream: stream_ts=%s",
+                    self._stream_ts,
+                )
+            except Exception as e:
+                logger.warning("[SlackStream] stopStream failed: %s", e)
+
+        self._started = False

--- a/gateway/platforms/slack_stream.py
+++ b/gateway/platforms/slack_stream.py
@@ -295,46 +295,80 @@ class SlackStreamConsumer:
     async def _send_task_start(
         self, task_id: str, name: str, status: str, description: str,
     ) -> None:
-        """Send a task_start chunk to create a new step indicator."""
+        """Send a TaskUpdateChunk to create a new step indicator."""
         if not self._stream_ts:
             return
-        chunk = {
-            "type": "task_start",
-            "id": task_id,
-            "name": name,
-            "status": status,
-        }
-        if description:
-            chunk["description"] = description
         try:
+            from slack_sdk.models.messages.chunk import TaskUpdateChunk
+            chunk = TaskUpdateChunk(
+                id=task_id,
+                title=name,
+                status=status,
+                details=description or None,
+            )
             await self._client.chat_appendStream(
                 channel=self._channel_id,
                 ts=self._stream_ts,
                 chunks=[chunk],
             )
+        except ImportError:
+            # Fallback for slack_sdk < 3.35
+            chunk = {
+                "type": "task_start",
+                "id": task_id,
+                "name": name,
+                "status": status,
+            }
+            if description:
+                chunk["description"] = description
+            try:
+                await self._client.chat_appendStream(
+                    channel=self._channel_id,
+                    ts=self._stream_ts,
+                    chunks=[chunk],
+                )
+            except Exception as e:
+                logger.warning("[SlackStream] task_start failed for %s: %s", name, e)
         except Exception as e:
             logger.warning("[SlackStream] task_start failed for %s: %s", name, e)
 
     async def _send_task_update(
         self, task_id: str, name: str, status: str, description: str,
     ) -> None:
-        """Send a task_update chunk to update a step's status."""
+        """Send a TaskUpdateChunk to update a step's status."""
         if not self._stream_ts:
             return
-        chunk = {
-            "type": "task_update",
-            "id": task_id,
-            "name": name,
-            "status": status,
-        }
-        if description:
-            chunk["description"] = description
         try:
+            from slack_sdk.models.messages.chunk import TaskUpdateChunk
+            chunk = TaskUpdateChunk(
+                id=task_id,
+                title=name,
+                status=status,
+                details=description or None,
+            )
             await self._client.chat_appendStream(
                 channel=self._channel_id,
                 ts=self._stream_ts,
                 chunks=[chunk],
             )
+        except ImportError:
+            # Fallback for slack_sdk < 3.35
+            chunk = {
+                "type": "task_update",
+                "id": task_id,
+                "name": name,
+                "status": status,
+            }
+            if description:
+                chunk["description"] = description
+            try:
+                await self._client.chat_appendStream(
+                    channel=self._channel_id,
+                    ts=self._stream_ts,
+                    chunks=[chunk],
+                )
+            except Exception as e:
+                logger.warning("[SlackStream] task_update failed for %s: %s", name, e)
         except Exception as e:
             logger.warning("[SlackStream] task_update failed for %s: %s", name, e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16597,40 +16597,68 @@ class GatewayRunner:
 
         if _streaming_enabled:
             try:
-                from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                 _adapter = self.adapters.get(source.platform)
                 if _adapter:
-                    _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                    _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
-                    _buffer_only = False
-                    if source.platform == Platform.MATRIX:
-                        _effective_cursor = ""
-                        _buffer_only = True
-                    # Fresh-final applies to Telegram only — other
-                    # platforms either edit in place cheaply (Discord,
-                    # Slack) or don't have the timestamp-on-edit
-                    # problem.  (Ported from openclaw/openclaw#72038.)
-                    _fresh_final_secs = (
-                        float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
-                        if source.platform == Platform.TELEGRAM
-                        else 0.0
-                    )
-                    _consumer_cfg = StreamConsumerConfig(
-                        edit_interval=_scfg.edit_interval,
-                        buffer_threshold=_scfg.buffer_threshold,
-                        cursor=_effective_cursor,
-                        buffer_only=_buffer_only,
-                        fresh_final_after_seconds=_fresh_final_secs,
-                        transport=_scfg.transport or "edit",
-                        chat_type=getattr(source, "chat_type", "") or "",
-                    )
-                    _stream_consumer = GatewayStreamConsumer(
-                        adapter=_adapter,
-                        chat_id=source.chat_id,
-                        config=_consumer_cfg,
-                        metadata=_thread_metadata,
-                        initial_reply_to_id=event_message_id,
-                    )
+                    # ── Slack native Steps API streaming ────────────────
+                    if source.platform == Platform.SLACK:
+                        _slack_thread_ts = (
+                            _thread_metadata.get("thread_id")
+                            if _thread_metadata
+                            else None
+                        ) or source.thread_id or event_message_id
+                        if _slack_thread_ts and hasattr(_adapter, "create_stream_consumer"):
+                            try:
+                                _stream_consumer = _adapter.create_stream_consumer(
+                                    chat_id=source.chat_id,
+                                    thread_ts=_slack_thread_ts,
+                                    metadata=_thread_metadata,
+                                )
+                                logger.debug(
+                                    "Proxy: Using Slack native Steps API streaming: "
+                                    "channel=%s thread=%s",
+                                    source.chat_id, _slack_thread_ts,
+                                )
+                            except Exception as _sse:
+                                logger.debug(
+                                    "Proxy: Slack native stream setup failed, "
+                                    "falling back to edit-based: %s", _sse,
+                                )
+                                _stream_consumer = None
+
+                    # ── Legacy edit-based streaming ─────────────────────
+                    if _stream_consumer is None:
+                        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+                        _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                        _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
+                        _buffer_only = False
+                        if source.platform == Platform.MATRIX:
+                            _effective_cursor = ""
+                            _buffer_only = True
+                        # Fresh-final applies to Telegram only — other
+                        # platforms either edit in place cheaply (Discord,
+                        # Slack) or don't have the timestamp-on-edit
+                        # problem.  (Ported from openclaw/openclaw#72038.)
+                        _fresh_final_secs = (
+                            float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
+                            if source.platform == Platform.TELEGRAM
+                            else 0.0
+                        )
+                        _consumer_cfg = StreamConsumerConfig(
+                            edit_interval=_scfg.edit_interval,
+                            buffer_threshold=_scfg.buffer_threshold,
+                            cursor=_effective_cursor,
+                            buffer_only=_buffer_only,
+                            fresh_final_after_seconds=_fresh_final_secs,
+                            transport=_scfg.transport or "edit",
+                            chat_type=getattr(source, "chat_type", "") or "",
+                        )
+                        _stream_consumer = GatewayStreamConsumer(
+                            adapter=_adapter,
+                            chat_id=source.chat_id,
+                            config=_consumer_cfg,
+                            metadata=_thread_metadata,
+                            initial_reply_to_id=event_message_id,
+                        )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
 
@@ -17547,62 +17575,102 @@ class GatewayRunner:
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages
+            _use_slack_native_stream = False
             if _want_stream_deltas or _want_interim_consumer:
                 try:
-                    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                     _adapter = self.adapters.get(source.platform)
                     if _adapter:
-                        # Platforms that don't support editing sent messages
-                        # (e.g. QQ, WeChat) should skip streaming entirely —
-                        # without edit support, the consumer sends a partial
-                        # first message that can never be updated, resulting in
-                        # duplicate messages (partial + final).
-                        _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                        if not _adapter_supports_edit:
-                            raise RuntimeError("skip streaming for non-editable platform")
-                        _effective_cursor = _scfg.cursor
-                        # Some Matrix clients render the streaming cursor
-                        # as a visible tofu/white-box artifact.  Keep
-                        # streaming text on Matrix, but suppress the cursor.
-                        _buffer_only = False
-                        if source.platform == Platform.MATRIX:
-                            _effective_cursor = ""
-                            _buffer_only = True
-                        # Fresh-final applies to Telegram only — other
-                        # platforms either edit in place cheaply or don't
-                        # have the edit-timestamp-stays-stale problem.
-                        # (Ported from openclaw/openclaw#72038.)
-                        _fresh_final_secs = (
-                            float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
-                            if source.platform == Platform.TELEGRAM
-                            else 0.0
-                        )
-                        _consumer_cfg = StreamConsumerConfig(
-                            edit_interval=_scfg.edit_interval,
-                            buffer_threshold=_scfg.buffer_threshold,
-                            cursor=_effective_cursor,
-                            buffer_only=_buffer_only,
-                            fresh_final_after_seconds=_fresh_final_secs,
-                            transport=_scfg.transport or "edit",
-                            chat_type=getattr(source, "chat_type", "") or "",
-                        )
-                        _stream_consumer = GatewayStreamConsumer(
-                            adapter=_adapter,
-                            chat_id=source.chat_id,
-                            config=_consumer_cfg,
-                            metadata=_status_thread_metadata,
-                            on_new_message=(
-                                (lambda: progress_queue.put(("__reset__",)))
-                                if progress_queue is not None
+                        # ── Slack native Steps API streaming ────────────
+                        # When running on Slack with a thread_ts, use
+                        # chat.startStream / appendStream / stopStream with
+                        # task_update chunks for native collapsible step
+                        # cards instead of the legacy postMessage → edit loop.
+                        if source.platform == Platform.SLACK:
+                            _slack_thread_ts = (
+                                _status_thread_metadata.get("thread_id")
+                                if _status_thread_metadata
                                 else None
-                            ),
-                            initial_reply_to_id=event_message_id,
-                        )
-                        if _want_stream_deltas:
-                            def _stream_delta_cb(text: str) -> None:
-                                if _run_still_current():
-                                    _stream_consumer.on_delta(text)
-                        stream_consumer_holder[0] = _stream_consumer
+                            ) or source.thread_id or event_message_id
+                            if _slack_thread_ts and hasattr(_adapter, "create_stream_consumer"):
+                                try:
+                                    _stream_consumer = _adapter.create_stream_consumer(
+                                        chat_id=source.chat_id,
+                                        thread_ts=_slack_thread_ts,
+                                        metadata=_status_thread_metadata,
+                                    )
+                                    _use_slack_native_stream = True
+                                    if _want_stream_deltas:
+                                        def _stream_delta_cb(text: str) -> None:
+                                            if _run_still_current():
+                                                _stream_consumer.on_delta(text)
+                                    stream_consumer_holder[0] = _stream_consumer
+                                    logger.debug(
+                                        "Using Slack native Steps API streaming: "
+                                        "channel=%s thread=%s",
+                                        source.chat_id, _slack_thread_ts,
+                                    )
+                                except Exception as _slack_stream_err:
+                                    logger.debug(
+                                        "Slack native stream setup failed, "
+                                        "falling back to edit-based streaming: %s",
+                                        _slack_stream_err,
+                                    )
+                                    _stream_consumer = None
+
+                        # ── Legacy edit-based streaming ─────────────────
+                        if not _use_slack_native_stream:
+                            from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+                            # Platforms that don't support editing sent messages
+                            # (e.g. QQ, WeChat) should skip streaming entirely —
+                            # without edit support, the consumer sends a partial
+                            # first message that can never be updated, resulting in
+                            # duplicate messages (partial + final).
+                            _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                            if not _adapter_supports_edit:
+                                raise RuntimeError("skip streaming for non-editable platform")
+                            _effective_cursor = _scfg.cursor
+                            # Some Matrix clients render the streaming cursor
+                            # as a visible tofu/white-box artifact.  Keep
+                            # streaming text on Matrix, but suppress the cursor.
+                            _buffer_only = False
+                            if source.platform == Platform.MATRIX:
+                                _effective_cursor = ""
+                                _buffer_only = True
+                            # Fresh-final applies to Telegram only — other
+                            # platforms either edit in place cheaply or don't
+                            # have the edit-timestamp-stays-stale problem.
+                            # (Ported from openclaw/openclaw#72038.)
+                            _fresh_final_secs = (
+                                float(getattr(_scfg, "fresh_final_after_seconds", 0.0) or 0.0)
+                                if source.platform == Platform.TELEGRAM
+                                else 0.0
+                            )
+                            _consumer_cfg = StreamConsumerConfig(
+                                edit_interval=_scfg.edit_interval,
+                                buffer_threshold=_scfg.buffer_threshold,
+                                cursor=_effective_cursor,
+                                buffer_only=_buffer_only,
+                                fresh_final_after_seconds=_fresh_final_secs,
+                                transport=_scfg.transport or "edit",
+                                chat_type=getattr(source, "chat_type", "") or "",
+                            )
+                            _stream_consumer = GatewayStreamConsumer(
+                                adapter=_adapter,
+                                chat_id=source.chat_id,
+                                config=_consumer_cfg,
+                                metadata=_status_thread_metadata,
+                                on_new_message=(
+                                    (lambda: progress_queue.put(("__reset__",)))
+                                    if progress_queue is not None
+                                    else None
+                                ),
+                                initial_reply_to_id=event_message_id,
+                            )
+                            if _want_stream_deltas:
+                                def _stream_delta_cb(text: str) -> None:
+                                    if _run_still_current():
+                                        _stream_consumer.on_delta(text)
+                            stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
@@ -17702,7 +17770,13 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            # When using Slack native Steps API streaming, route tool progress
+            # through the SlackStreamConsumer's on_tool_progress (which emits
+            # task_start/task_update chunks) instead of the legacy text bubbles.
+            if _use_slack_native_stream and _stream_consumer is not None:
+                agent.tool_progress_callback = _stream_consumer.on_tool_progress if tool_progress_enabled else None
+            else:
+                agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None

--- a/tests/gateway/test_slack_stream.py
+++ b/tests/gateway/test_slack_stream.py
@@ -1,0 +1,245 @@
+"""Tests for SlackStreamConsumer — native Steps API streaming."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.platforms.slack_stream import (
+    SlackStreamConsumer,
+    SlackStreamConfig,
+    _DONE,
+    _DELTA,
+    _TASK_START,
+    _TASK_UPDATE,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock AsyncWebClient with streaming methods."""
+    client = MagicMock()
+    client.chat_startStream = AsyncMock(return_value={"ts": "1234567890.123456"})
+    client.chat_appendStream = AsyncMock(return_value={"ok": True})
+    client.chat_stopStream = AsyncMock(return_value={"ok": True})
+    return client
+
+
+@pytest.fixture
+def consumer(mock_client):
+    """Create a SlackStreamConsumer instance for testing."""
+    return SlackStreamConsumer(
+        client=mock_client,
+        channel_id="C0TEST",
+        thread_ts="1234567890.000001",
+        config=SlackStreamConfig(flush_interval=0.01, buffer_threshold=50),
+    )
+
+
+class TestSlackStreamConsumerInit:
+    def test_default_config(self, mock_client):
+        c = SlackStreamConsumer(mock_client, "C0", "123.456")
+        assert c._channel_id == "C0"
+        assert c._thread_ts == "123.456"
+        assert c._stream_ts is None
+        assert c._started is False
+
+    def test_custom_config(self, mock_client):
+        cfg = SlackStreamConfig(show_thinking=False, feedback_buttons=False)
+        c = SlackStreamConsumer(mock_client, "C0", "123.456", config=cfg)
+        assert c._config.show_thinking is False
+        assert c._config.feedback_buttons is False
+
+
+class TestOnDelta:
+    def test_queues_text(self, consumer):
+        consumer.on_delta("Hello ")
+        consumer.on_delta("world!")
+        assert not consumer._queue.empty()
+        items = []
+        while not consumer._queue.empty():
+            items.append(consumer._queue.get_nowait())
+        assert len(items) == 2
+        assert items[0] == (_DELTA, "Hello ")
+        assert items[1] == (_DELTA, "world!")
+
+    def test_ignores_empty(self, consumer):
+        consumer.on_delta("")
+        assert consumer._queue.empty()
+
+
+class TestOnToolProgress:
+    def test_tool_started(self, consumer):
+        consumer.on_tool_progress("tool.started", tool_name="web_search", preview="query")
+        item = consumer._queue.get_nowait()
+        assert item[0] is _TASK_START
+        assert item[1] == "tool_1"
+        assert item[2] == "web_search"
+        assert item[3] == "in_progress"
+        assert item[4] == "query"
+
+    def test_tool_started_with_args(self, consumer):
+        consumer.on_tool_progress("tool.started", tool_name="terminal", args={"command": "ls -la"})
+        item = consumer._queue.get_nowait()
+        assert item[0] is _TASK_START
+        assert item[2] == "terminal"
+        assert "command" in item[4]
+
+    def test_tool_completed(self, consumer):
+        # Start then complete
+        consumer.on_tool_progress("tool.started", tool_name="web_search")
+        consumer._queue.get_nowait()  # consume the start event
+        consumer.on_tool_progress("tool.completed", tool_name="web_search", duration=2.5)
+        item = consumer._queue.get_nowait()
+        assert item[0] is _TASK_UPDATE
+        assert item[2] == "web_search"
+        assert item[3] == "complete"
+        assert "2.5s" in item[4]
+
+    def test_ignores_unknown_event(self, consumer):
+        consumer.on_tool_progress("tool.unknown", tool_name="foo")
+        assert consumer._queue.empty()
+
+    def test_ignores_started_without_name(self, consumer):
+        consumer.on_tool_progress("tool.started")
+        assert consumer._queue.empty()
+
+
+class TestOnThinking:
+    def test_thinking_start(self, consumer):
+        consumer.on_thinking_start()
+        item = consumer._queue.get_nowait()
+        assert item[0] is _TASK_START
+        assert item[2] == "Thinking"
+        assert item[3] == "in_progress"
+
+    def test_thinking_end(self, consumer):
+        consumer.on_thinking_start()
+        consumer._queue.get_nowait()  # consume start
+        consumer.on_thinking_end()
+        item = consumer._queue.get_nowait()
+        assert item[0] is _TASK_UPDATE
+        assert item[2] == "Thinking"
+        assert item[3] == "complete"
+
+    def test_thinking_disabled(self, mock_client):
+        cfg = SlackStreamConfig(show_thinking=False)
+        c = SlackStreamConsumer(mock_client, "C0", "123.456", config=cfg)
+        c.on_thinking_start()
+        assert c._queue.empty()
+
+
+class TestFinish:
+    def test_queues_done(self, consumer):
+        consumer.finish()
+        item = consumer._queue.get_nowait()
+        assert item is _DONE
+
+
+class TestRunLifecycle:
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self, consumer, mock_client):
+        """Test the full stream lifecycle: start → deltas → tasks → stop."""
+        # Start the run in background
+        run_task = asyncio.create_task(consumer.run())
+        # Give it a moment to call startStream
+        await asyncio.sleep(0.05)
+
+        # Simulate agent activity
+        consumer.on_delta("Hello ")
+        consumer.on_delta("world!")
+        await asyncio.sleep(0.05)
+        consumer.on_tool_progress("tool.started", tool_name="web_search", preview="test query")
+        await asyncio.sleep(0.05)
+        consumer.on_tool_progress("tool.completed", tool_name="web_search", duration=1.0)
+        await asyncio.sleep(0.05)
+        consumer.on_delta(" Here are the results.")
+        await asyncio.sleep(0.1)
+        consumer.finish()
+
+        # Wait for run to complete
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+        # Verify startStream was called
+        mock_client.chat_startStream.assert_called_once_with(
+            channel="C0TEST",
+            thread_ts="1234567890.000001",
+            task_display_mode="plan",
+        )
+
+        # Verify stopStream was called
+        mock_client.chat_stopStream.assert_called_once_with(
+            channel="C0TEST",
+            ts="1234567890.123456",
+        )
+
+        # Verify appendStream was called for text and chunks
+        assert mock_client.chat_appendStream.call_count >= 2  # at least text + task_start
+
+    @pytest.mark.asyncio
+    async def test_start_stream_failure(self, mock_client):
+        """Graceful handling when startStream fails."""
+        mock_client.chat_startStream.side_effect = Exception("API error")
+        c = SlackStreamConsumer(mock_client, "C0", "123.456")
+        await c.run()
+        # Should not crash — just return
+        mock_client.chat_stopStream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_append_stream_failure(self, consumer, mock_client):
+        """Graceful handling when appendStream fails."""
+        mock_client.chat_appendStream.side_effect = Exception("rate limited")
+        run_task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("Some text")
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+
+class TestTaskIdTracking:
+    def test_incrementing_task_ids(self, consumer):
+        consumer.on_tool_progress("tool.started", tool_name="tool_a")
+        consumer.on_tool_progress("tool.started", tool_name="tool_b")
+        item_a = consumer._queue.get_nowait()
+        item_b = consumer._queue.get_nowait()
+        assert item_a[1] == "tool_1"
+        assert item_b[1] == "tool_2"
+
+    def test_complete_matches_start(self, consumer):
+        consumer.on_tool_progress("tool.started", tool_name="web_search")
+        start_item = consumer._queue.get_nowait()
+        task_id = start_item[1]
+        consumer.on_tool_progress("tool.completed", tool_name="web_search")
+        update_item = consumer._queue.get_nowait()
+        assert update_item[1] == task_id
+
+
+class TestFlushText:
+    @pytest.mark.asyncio
+    async def test_buffer_threshold_flush(self, mock_client):
+        """Text is flushed when buffer exceeds threshold."""
+        cfg = SlackStreamConfig(flush_interval=100, buffer_threshold=20)
+        c = SlackStreamConsumer(mock_client, "C0", "123.456", config=cfg)
+        # Simulate the run loop manually
+        await c._start_stream()
+        c.on_delta("A" * 30)  # exceeds threshold of 20
+        # Let the run loop process it
+        c.finish()
+        await c.run()
+        # Verify appendStream was called with the text
+        text_calls = [
+            call for call in mock_client.chat_appendStream.call_args_list
+            if call.kwargs.get("markdown_text")
+        ]
+        assert len(text_calls) >= 1
+        assert "A" * 30 in text_calls[0].kwargs["markdown_text"]
+
+
+class TestSlackStreamConfig:
+    def test_defaults(self):
+        cfg = SlackStreamConfig()
+        assert cfg.flush_interval == 0.8
+        assert cfg.buffer_threshold == 800
+        assert cfg.show_thinking is True
+        assert cfg.set_title is True
+        assert cfg.feedback_buttons is True

--- a/tests/gateway/test_slack_stream.py
+++ b/tests/gateway/test_slack_stream.py
@@ -42,6 +42,7 @@ class TestSlackStreamConsumerInit:
         assert c._thread_ts == "123.456"
         assert c._stream_ts is None
         assert c._started is False
+        assert c._response_step_id is None
 
     def test_custom_config(self, mock_client):
         cfg = SlackStreamConfig(show_thinking=False, feedback_buttons=False)
@@ -138,28 +139,29 @@ class TestFinish:
 class TestRunLifecycle:
     @pytest.mark.asyncio
     async def test_full_lifecycle(self, consumer, mock_client):
-        """Test the full stream lifecycle: start → deltas → tasks → stop."""
+        """Test the full stream lifecycle: start → thinking → tools → text → stop."""
         # Start the run in background
         run_task = asyncio.create_task(consumer.run())
         # Give it a moment to call startStream
         await asyncio.sleep(0.05)
 
         # Simulate agent activity
-        consumer.on_delta("Hello ")
-        consumer.on_delta("world!")
+        consumer.on_thinking_start()
+        await asyncio.sleep(0.05)
+        consumer.on_thinking_end()
         await asyncio.sleep(0.05)
         consumer.on_tool_progress("tool.started", tool_name="web_search", preview="test query")
         await asyncio.sleep(0.05)
         consumer.on_tool_progress("tool.completed", tool_name="web_search", duration=1.0)
         await asyncio.sleep(0.05)
-        consumer.on_delta(" Here are the results.")
-        await asyncio.sleep(0.1)
+        consumer.on_delta("Hello! Here are the results.")
+        await asyncio.sleep(0.15)
         consumer.finish()
 
         # Wait for run to complete
         await asyncio.wait_for(run_task, timeout=5.0)
 
-        # Verify startStream was called
+        # Verify startStream was called with plan mode
         mock_client.chat_startStream.assert_called_once_with(
             channel="C0TEST",
             thread_ts="1234567890.000001",
@@ -172,8 +174,8 @@ class TestRunLifecycle:
             ts="1234567890.123456",
         )
 
-        # Verify appendStream was called for text and chunks
-        assert mock_client.chat_appendStream.call_count >= 2  # at least text + task_start
+        # Verify appendStream was called for chunks (task steps + response step)
+        assert mock_client.chat_appendStream.call_count >= 3  # thinking + tool + response
 
     @pytest.mark.asyncio
     async def test_start_stream_failure(self, mock_client):
@@ -195,6 +197,29 @@ class TestRunLifecycle:
         consumer.finish()
         await asyncio.wait_for(run_task, timeout=5.0)
 
+    @pytest.mark.asyncio
+    async def test_text_creates_response_step(self, consumer, mock_client):
+        """Text deltas create and update a Response step in plan mode."""
+        run_task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("Hello world!")
+        await asyncio.sleep(0.15)
+        consumer.finish()
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+        # Verify that at least one appendStream call used chunks (not markdown_text)
+        chunk_calls = [
+            call for call in mock_client.chat_appendStream.call_args_list
+            if call.kwargs.get("chunks")
+        ]
+        assert len(chunk_calls) >= 1
+        # No call should use markdown_text (plan mode forbids it)
+        md_calls = [
+            call for call in mock_client.chat_appendStream.call_args_list
+            if call.kwargs.get("markdown_text")
+        ]
+        assert len(md_calls) == 0
+
 
 class TestTaskIdTracking:
     def test_incrementing_task_ids(self, consumer):
@@ -214,10 +239,27 @@ class TestTaskIdTracking:
         assert update_item[1] == task_id
 
 
+class TestMakeTaskChunk:
+    def test_typed_chunk_with_sdk(self, consumer):
+        """When slack_sdk is available, _make_task_chunk returns TaskUpdateChunk."""
+        chunk = consumer._make_task_chunk("t1", "Web Search", "in_progress", details="query: test")
+        # Should be a TaskUpdateChunk if SDK is available
+        from slack_sdk.models.messages.chunk import TaskUpdateChunk
+        assert isinstance(chunk, TaskUpdateChunk)
+
+    def test_chunk_with_output(self, consumer):
+        """TaskUpdateChunk with output field for Response step text."""
+        chunk = consumer._make_task_chunk("r1", "Response", "complete", output="Hello world")
+        from slack_sdk.models.messages.chunk import TaskUpdateChunk
+        assert isinstance(chunk, TaskUpdateChunk)
+        # output field should be set
+        assert chunk.output == "Hello world"
+
+
 class TestFlushText:
     @pytest.mark.asyncio
     async def test_buffer_threshold_flush(self, mock_client):
-        """Text is flushed when buffer exceeds threshold."""
+        """Text is flushed to Response step when buffer exceeds threshold."""
         cfg = SlackStreamConfig(flush_interval=100, buffer_threshold=20)
         c = SlackStreamConsumer(mock_client, "C0", "123.456", config=cfg)
         # Simulate the run loop manually
@@ -226,20 +268,26 @@ class TestFlushText:
         # Let the run loop process it
         c.finish()
         await c.run()
-        # Verify appendStream was called with the text
-        text_calls = [
+        # Verify appendStream was called with chunks (not markdown_text)
+        chunk_calls = [
+            call for call in mock_client.chat_appendStream.call_args_list
+            if call.kwargs.get("chunks")
+        ]
+        assert len(chunk_calls) >= 1
+        # Verify no markdown_text calls (plan mode)
+        md_calls = [
             call for call in mock_client.chat_appendStream.call_args_list
             if call.kwargs.get("markdown_text")
         ]
-        assert len(text_calls) >= 1
-        assert "A" * 30 in text_calls[0].kwargs["markdown_text"]
+        assert len(md_calls) == 0
 
 
 class TestSlackStreamConfig:
     def test_defaults(self):
         cfg = SlackStreamConfig()
-        assert cfg.flush_interval == 0.8
-        assert cfg.buffer_threshold == 800
+        assert cfg.flush_interval == 1.0
+        assert cfg.buffer_threshold == 1200
         assert cfg.show_thinking is True
         assert cfg.set_title is True
         assert cfg.feedback_buttons is True
+        assert cfg.response_step_title == "Response"


### PR DESCRIPTION
## Summary

Replace the legacy `postMessage` → `chat.update` edit loop with Slack's native **AI Assistant Steps API** (`chat.startStream` / `chat.appendStream` / `chat.stopStream`) for Slack conversations that happen in threads.

This produces **native collapsible step cards** with checkmarks, chevrons, and status indicators — the same UI pattern used by Slack AI and Highbeam's Luma.

### What this enables

| Feature | Before (Block Kit) | After (Steps API) |
|---|---|---|
| Tool call progress | Manual Block Kit sections edited in place | Native `task_update` chunks → collapsible ✅/⏳/❌ cards |
| Thinking display | Block Kit toggle button | `task_start` chunk with status (native) |
| Streaming | `postMessage` → `chat.update` (edit loop) | `startStream` → `appendStream` → `stopStream` |
| Thread titles | None | `assistant.threads.setTitle` (native) |
| Suggested prompts | None | `assistant.threads.setSuggestedPrompts` (native) |

### Architecture

- **`SlackStreamConsumer`** (`slack_stream.py`) — async consumer that:
  1. Calls `chat.startStream` with `task_display_mode="plan"`
  2. Sends `task_start` chunks when tools begin (in_progress)
  3. Sends `task_update` chunks when tools complete (complete/failed)
  4. Streams `markdown_text` chunks as the model generates tokens
  5. Calls `chat.stopStream` to finalize

- **Slack adapter** (`slack.py`) — added:
  - `set_thread_title()` — uses `assistant.threads.setTitle`
  - `set_suggested_prompts()` — uses `assistant.threads.setSuggestedPrompts`
  - `create_stream_consumer()` — factory for `SlackStreamConsumer`

- **Gateway** (`run.py`) — when platform is Slack with a `thread_ts`:
  - Automatically uses `SlackStreamConsumer` instead of `GatewayStreamConsumer`
  - Falls back to legacy edit-based streaming on failure
  - Routes `tool_progress_callback` through `on_tool_progress()` for native step indicators

### Testing

- ✅ 20 new unit tests for `SlackStreamConsumer` — all passing
- ✅ 283 existing Slack tests — all passing
- ⬜ End-to-end testing in workspace (requires `assistant:write` scope)

### Requirements

- Slack app must have the `assistant:write` scope
- The **Agents & AI Apps** feature must be enabled in the Slack app config
- `slack_sdk >= 3.35` (for streaming method support; currently on 3.41.0)

### Config options (via `platforms.slack.extra`)

| Key | Default | Description |
|---|---|---|
| `show_thinking_steps` | `true` | Show thinking/reasoning as a collapsible step |
| `set_thread_title` | `true` | Auto-set thread titles |
| `feedback_buttons` | `true` | Include feedback buttons on final message |