### PR TITLE
fix(desktop): render approval/sudo/secret prompts so tools stop silently timing out

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -13,6 +13,7 @@ import { useLocation } from 'react-router-dom'
 import { Thread } from '@/components/assistant-ui/thread'
 import { Backdrop } from '@/components/Backdrop'
 import { NotificationStack } from '@/components/notifications'
+import { PromptOverlays } from '@/components/prompt-overlays'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { getGlobalModelOptions, type HermesGateway } from '@/hermes'
@@ -315,6 +316,7 @@ export function ChatView({
       />
 
       <NotificationStack />
+      <PromptOverlays />
 
       <div
         className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -19,6 +19,7 @@ import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
+import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   setCurrentBranch,
   setCurrentCwd,
@@ -751,6 +752,13 @@ export function useMessageStream({
           return
         }
 
+        // Turn ended — drop any blocking prompt that's still open (e.g. the
+        // agent was interrupted, or the approval already resolved). Prevents a
+        // stale overlay from outliving the turn that raised it.
+        if (isActiveEvent) {
+          clearAllPrompts()
+        }
+
         flushQueuedDeltas(sessionId)
 
         if (isActiveEvent) {
@@ -816,9 +824,59 @@ export function useMessageStream({
             sessionId: sessionId ?? null
           })
         }
+      } else if (event.type === 'approval.request') {
+        if (!isActiveEvent) {
+          return
+        }
+
+        // Dangerous-command / execute_code approval. The Python side is
+        // blocked in _await_gateway_decision() until approval.respond lands;
+        // without this the agent stalls until its 5-min timeout and the tool
+        // is BLOCKED. Approval is session-keyed (no request_id) — the overlay
+        // sends back {choice, session_id}.
+        setApprovalRequest({
+          command: typeof payload?.command === 'string' ? payload.command : '',
+          description: typeof payload?.description === 'string' ? payload.description : 'dangerous command',
+          sessionId: sessionId ?? null
+        })
+      } else if (event.type === 'sudo.request') {
+        if (!isActiveEvent) {
+          return
+        }
+
+        // Sudo password capture (tools/terminal_tool.py). Blocked on
+        // sudo.respond {request_id, password}.
+        const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+
+        if (requestId) {
+          setSudoRequest({ requestId })
+        }
+      } else if (event.type === 'secret.request') {
+        if (!isActiveEvent) {
+          return
+        }
+
+        // Skill credential capture (tools/skills_tool.py). Blocked on
+        // secret.respond {request_id, value}.
+        const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+
+        if (requestId) {
+          setSecretRequest({
+            requestId,
+            envVar: typeof payload?.env_var === 'string' ? payload.env_var : '',
+            prompt: typeof payload?.prompt === 'string' ? payload.prompt : ''
+          })
+        }
       } else if (event.type === 'error') {
         const errorMessage = payload?.message || 'Hermes reported an error'
         const looksLikeProviderSetup = isProviderSetupErrorMessage(errorMessage)
+
+        // A turn that errors out has also ended — drop any open blocking
+        // prompt so an approval/sudo/secret overlay can't linger past the
+        // failed turn (same intent as the message.complete clear).
+        if (isActiveEvent) {
+          clearAllPrompts()
+        }
 
         if (looksLikeProviderSetup) {
           requestDesktopOnboarding(errorMessage)

--- a/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import { $gateway } from '@/store/gateway'
+import { $approvalRequest } from '@/store/prompts'
+
+import { PendingToolApproval } from './tool-approval'
+import type { ToolPart } from './tool-fallback-model'
+
+function part(toolName: string): ToolPart {
+  return { toolName, type: `tool-${toolName}` } as unknown as ToolPart
+}
+
+function setRequest(command = 'rm -rf /tmp/x') {
+  $approvalRequest.set({ command, description: 'dangerous command', sessionId: 'sess-1' })
+}
+
+function mockGateway() {
+  const request = vi.fn().mockResolvedValue({ resolved: true })
+  $gateway.set({ request } as unknown as HermesGateway)
+
+  return request
+}
+
+afterEach(() => {
+  cleanup()
+  $approvalRequest.set(null)
+  $gateway.set(null)
+})
+
+describe('PendingToolApproval', () => {
+  it('renders nothing when there is no pending approval', () => {
+    const { container } = render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for tools that never raise approval', () => {
+    setRequest()
+    const { container } = render(<PendingToolApproval part={part('read_file')} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the inline bar with the command on the pending terminal row', () => {
+    setRequest('chmod -R 777 /tmp/x')
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(screen.queryByText('Approval required')).not.toBeNull()
+    expect(screen.queryByText(/chmod -R 777/)).not.toBeNull()
+    expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+  })
+
+  it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {
+    const request = mockGateway()
+    setRequest()
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+    })
+    expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('sends choice "deny" on Reject', async () => {
+    const request = mockGateway()
+    setRequest()
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Reject/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'sess-1' })
+    })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
@@ -47,9 +47,9 @@ describe('PendingToolApproval', () => {
     setRequest('chmod -R 777 /tmp/x')
     render(<PendingToolApproval part={part('terminal')} />)
 
-    expect(screen.queryByText('Approval required')).not.toBeNull()
     expect(screen.queryByText(/chmod -R 777/)).not.toBeNull()
     expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
   it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {

--- a/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
@@ -43,11 +43,10 @@ describe('PendingToolApproval', () => {
     expect(container.innerHTML).toBe('')
   })
 
-  it('renders the inline bar with the command on the pending terminal row', () => {
+  it('renders the inline run/reject controls on the pending terminal row', () => {
     setRequest('chmod -R 777 /tmp/x')
     render(<PendingToolApproval part={part('terminal')} />)
 
-    expect(screen.queryByText(/chmod -R 777/)).not.toBeNull()
     expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
   })

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -1,35 +1,38 @@
 'use client'
 
 import { useStore } from '@nanostores/react'
-import { type FC, useCallback, useState } from 'react'
+import { type FC, useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { triggerHaptic } from '@/lib/haptics'
-import { AlertTriangle, Loader2, Play, X } from '@/lib/icons'
-import { cn } from '@/lib/utils'
+import { ChevronDown, Loader2, Terminal } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/store/prompts'
 
 import type { ToolPart } from './tool-fallback-model'
 
-// Inline, Cursor-style approval bar. Rendered under the pending tool row that
-// raised the approval instead of as a modal overlay.
+// Inline, Cursor-style command-approval card. Rendered under the pending tool
+// row that raised the approval instead of as a modal overlay.
 //
 // Binding is POSITIONAL, not command-matched: the desktop `tool.start` payload
 // carries no structured args (only tool_id/name/context — see
 // tui_gateway/server.py::_on_tool_start), so we cannot join the approval to the
 // row by command string. But `approval.request` only ever fires from the
-// `terminal` / `execute_code` guards, and the agent thread blocks on exactly
-// one approval at a time, so the single pending row of those tools IS the row
-// that raised it. The command/description text comes from `$approvalRequest`
-// (the event payload), which is the only place that data reliably exists.
+// `terminal` / `execute_code` guards and the agent thread blocks on exactly one
+// approval at a time, so the single pending row of those tools IS the row that
+// raised it. The command/description text comes from `$approvalRequest` (the
+// event payload), which is the only place that data reliably exists.
 const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
 
 // Canonical gateway choices (ui-tui/src/components/prompts.tsx).
 type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
-
-const APPROVAL_CMD_PREVIEW_LINES = 8
 
 export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   const request = useStore($approvalRequest)
@@ -41,6 +44,8 @@ export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   return <ApprovalBar request={request} />
 }
 
+const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform)
+
 const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   const gateway = useStore($gateway)
   const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
@@ -48,6 +53,12 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
+      // Another bar (or the keyboard path) may have already resolved this
+      // approval; the atom is the single source of truth, so bail if it's gone.
+      if (busy || !$approvalRequest.get()) {
+        return
+      }
+
       if (!gateway) {
         notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
 
@@ -68,74 +79,77 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
         setSubmitting(null)
       }
     },
-    [gateway, request.sessionId]
+    [busy, gateway, request.sessionId]
   )
 
-  const rawLines = request.command.split('\n')
-  const shown = rawLines.slice(0, APPROVAL_CMD_PREVIEW_LINES)
-  const overflow = rawLines.length - shown.length
+  // ⌘/Ctrl+Enter → Run, Esc → Reject — matching Cursor's accept/skip bindings.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        void respond('once')
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        void respond('deny')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [respond])
+
+  const command = request.command.trim()
 
   return (
     <div
-      className={cn(
-        'mt-1.5 grid gap-2.5 rounded-[0.625rem] border border-amber-500/30 bg-amber-500/[0.06] px-3 py-2.5 text-sm',
-        'shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_3%,transparent)]'
-      )}
+      className="mt-1.5 overflow-hidden rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) text-sm"
       data-slot="tool-approval-inline"
     >
-      <div className="flex items-start gap-2.5">
-        <span
-          aria-hidden
-          className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md bg-amber-500/15 text-amber-600 ring-1 ring-inset ring-amber-500/25 dark:text-amber-400"
-        >
-          <AlertTriangle className="size-3.5" />
-        </span>
-        <div className="grid flex-1 gap-0.5">
-          <span className="text-[0.6875rem] font-medium uppercase tracking-wide text-amber-700/90 dark:text-amber-300/90">
-            Approval required
-          </span>
-          <span className="leading-snug text-foreground/90">
-            {request.description || 'This command needs your approval before it runs.'}
-          </span>
-        </div>
+      <div className="flex items-start gap-2 px-3 py-2.5">
+        <Terminal className="mt-px size-3.5 shrink-0 text-(--ui-text-tertiary)" />
+        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[0.8125rem] leading-snug text-foreground">
+          {command || request.description}
+        </pre>
       </div>
 
-      {request.command.trim() && (
-        <pre
-          className={cn(
-            'max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary)',
-            'bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-[0.75rem] leading-snug text-foreground'
-          )}
-        >
-          {shown.join('\n')}
-          {overflow > 0 ? `\n… +${overflow} more line${overflow === 1 ? '' : 's'}` : ''}
-        </pre>
-      )}
+      <div className="flex items-center justify-between gap-2 border-t border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,var(--foreground)_3%,transparent)] px-2.5 py-1.5">
+        <span className="min-w-0 truncate text-xs text-(--ui-text-tertiary)">{request.description}</span>
 
-      <div className="flex flex-wrap items-center gap-1.5">
-        <Button disabled={busy} onClick={() => void respond('once')} size="sm" type="button">
-          {submitting === 'once' ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
-          Run
-        </Button>
-        <Button disabled={busy} onClick={() => void respond('session')} size="sm" type="button" variant="outline">
-          {submitting === 'session' && <Loader2 className="size-3.5 animate-spin" />}
-          Allow this session
-        </Button>
-        <Button disabled={busy} onClick={() => void respond('always')} size="sm" type="button" variant="ghost">
-          {submitting === 'always' && <Loader2 className="size-3.5 animate-spin" />}
-          Always allow
-        </Button>
-        <Button
-          className="ml-auto text-destructive hover:text-destructive"
-          disabled={busy}
-          onClick={() => void respond('deny')}
-          size="sm"
-          type="button"
-          variant="ghost"
-        >
-          {submitting === 'deny' ? <Loader2 className="size-3.5 animate-spin" /> : <X className="size-3.5" />}
-          Reject
-        </Button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button className="gap-1.5" disabled={busy} onClick={() => void respond('deny')} size="sm" variant="ghost">
+            {submitting === 'deny' ? <Loader2 className="size-3.5 animate-spin" /> : 'Reject'}
+            {submitting !== 'deny' && <span className="text-[0.6875rem] opacity-55">Esc</span>}
+          </Button>
+
+          <div className="flex items-stretch">
+            <Button className="gap-1.5 rounded-r-none" disabled={busy} onClick={() => void respond('once')} size="sm">
+              {submitting === 'once' ? <Loader2 className="size-3.5 animate-spin" /> : 'Run'}
+              {submitting !== 'once' && (
+                <span className="text-[0.6875rem] opacity-70">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>
+              )}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label="More approval options"
+                  className="rounded-l-none border-l border-primary-foreground/25 px-1.5"
+                  disabled={busy}
+                  size="sm"
+                >
+                  <ChevronDown className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-44">
+                <DropdownMenuItem onSelect={() => void respond('session')}>Allow this session</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => void respond('always')}>Always allow</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
+                  Reject
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -103,23 +103,26 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
 
   return (
     <div className="mt-1 flex items-center gap-1 ps-5" data-slot="tool-approval-inline">
-      <div className="flex items-stretch">
+      <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-(--ui-stroke-secondary) bg-background">
         <Button
-          className="h-6 gap-1 rounded-md rounded-r-none px-2 text-xs font-medium"
+          className="h-full gap-1 rounded-none px-2 text-xs font-normal"
           disabled={busy}
           onClick={() => void respond('once')}
-          size="sm"
+          variant="ghost"
         >
           {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : 'Run'}
-          {submitting !== 'once' && <span className="text-[0.625rem] opacity-70">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>}
+          {submitting !== 'once' && (
+            <span className="text-[0.625rem] text-(--ui-text-tertiary)">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>
+          )}
         </Button>
+        <span aria-hidden className="w-px self-stretch bg-(--ui-stroke-secondary)" />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               aria-label="More approval options"
-              className="h-6 rounded-md rounded-l-none border-l border-primary-foreground/25 px-1"
+              className="h-full rounded-none px-1"
               disabled={busy}
-              size="sm"
+              variant="ghost"
             >
               <ChevronDown className="size-3" />
             </Button>
@@ -135,10 +138,9 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
       </div>
 
       <Button
-        className="h-6 gap-1 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground"
+        className="h-6 gap-1 rounded-md px-2 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
         disabled={busy}
         onClick={() => void respond('deny')}
-        size="sm"
         variant="ghost"
       >
         {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : 'Reject'}

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useStore } from '@nanostores/react'
+import { type FC, useCallback, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { triggerHaptic } from '@/lib/haptics'
+import { AlertTriangle, Loader2, Play, X } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/store/prompts'
+
+import type { ToolPart } from './tool-fallback-model'
+
+// Inline, Cursor-style approval bar. Rendered under the pending tool row that
+// raised the approval instead of as a modal overlay.
+//
+// Binding is POSITIONAL, not command-matched: the desktop `tool.start` payload
+// carries no structured args (only tool_id/name/context — see
+// tui_gateway/server.py::_on_tool_start), so we cannot join the approval to the
+// row by command string. But `approval.request` only ever fires from the
+// `terminal` / `execute_code` guards, and the agent thread blocks on exactly
+// one approval at a time, so the single pending row of those tools IS the row
+// that raised it. The command/description text comes from `$approvalRequest`
+// (the event payload), which is the only place that data reliably exists.
+const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
+
+// Canonical gateway choices (ui-tui/src/components/prompts.tsx).
+type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
+
+const APPROVAL_CMD_PREVIEW_LINES = 8
+
+export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
+  const request = useStore($approvalRequest)
+
+  if (!request || !APPROVAL_TOOLS.has(part.toolName)) {
+    return null
+  }
+
+  return <ApprovalBar request={request} />
+}
+
+const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
+  const gateway = useStore($gateway)
+  const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
+  const busy = submitting !== null
+
+  const respond = useCallback(
+    async (choice: ApprovalChoice) => {
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
+
+        return
+      }
+
+      setSubmitting(choice)
+
+      try {
+        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+          choice,
+          session_id: request.sessionId ?? undefined
+        })
+        triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
+        clearApprovalRequest()
+      } catch (error) {
+        notifyError(error, 'Could not send approval response')
+        setSubmitting(null)
+      }
+    },
+    [gateway, request.sessionId]
+  )
+
+  const rawLines = request.command.split('\n')
+  const shown = rawLines.slice(0, APPROVAL_CMD_PREVIEW_LINES)
+  const overflow = rawLines.length - shown.length
+
+  return (
+    <div
+      className={cn(
+        'mt-1.5 grid gap-2.5 rounded-[0.625rem] border border-amber-500/30 bg-amber-500/[0.06] px-3 py-2.5 text-sm',
+        'shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_3%,transparent)]'
+      )}
+      data-slot="tool-approval-inline"
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          aria-hidden
+          className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md bg-amber-500/15 text-amber-600 ring-1 ring-inset ring-amber-500/25 dark:text-amber-400"
+        >
+          <AlertTriangle className="size-3.5" />
+        </span>
+        <div className="grid flex-1 gap-0.5">
+          <span className="text-[0.6875rem] font-medium uppercase tracking-wide text-amber-700/90 dark:text-amber-300/90">
+            Approval required
+          </span>
+          <span className="leading-snug text-foreground/90">
+            {request.description || 'This command needs your approval before it runs.'}
+          </span>
+        </div>
+      </div>
+
+      {request.command.trim() && (
+        <pre
+          className={cn(
+            'max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary)',
+            'bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-[0.75rem] leading-snug text-foreground'
+          )}
+        >
+          {shown.join('\n')}
+          {overflow > 0 ? `\n… +${overflow} more line${overflow === 1 ? '' : 's'}` : ''}
+        </pre>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Button disabled={busy} onClick={() => void respond('once')} size="sm" type="button">
+          {submitting === 'once' ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+          Run
+        </Button>
+        <Button disabled={busy} onClick={() => void respond('session')} size="sm" type="button" variant="outline">
+          {submitting === 'session' && <Loader2 className="size-3.5 animate-spin" />}
+          Allow this session
+        </Button>
+        <Button disabled={busy} onClick={() => void respond('always')} size="sm" type="button" variant="ghost">
+          {submitting === 'always' && <Loader2 className="size-3.5 animate-spin" />}
+          Always allow
+        </Button>
+        <Button
+          className="ml-auto text-destructive hover:text-destructive"
+          disabled={busy}
+          onClick={() => void respond('deny')}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {submitting === 'deny' ? <Loader2 className="size-3.5 animate-spin" /> : <X className="size-3.5" />}
+          Reject
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -5,6 +5,14 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -51,6 +59,9 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navi
 const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   const gateway = useStore($gateway)
   const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
+  // "Always allow" persists the pattern to ~/.hermes/config.yaml permanently, so
+  // it goes through a confirm step rather than firing straight from the menu.
+  const [confirmAlways, setConfirmAlways] = useState(false)
   const busy = submitting !== null
 
   const respond = useCallback(
@@ -85,7 +96,13 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject — matching Cursor's accept/skip bindings.
+  // While the confirm dialog is open it owns the keyboard (Esc closes it), so
+  // the strip-level shortcuts stand down to avoid denying the whole approval.
   useEffect(() => {
+    if (confirmAlways) {
+      return
+    }
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault()
@@ -99,7 +116,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
     window.addEventListener('keydown', onKeyDown, true)
 
     return () => window.removeEventListener('keydown', onKeyDown, true)
-  }, [respond])
+  }, [confirmAlways, respond])
 
   return (
     <div className="mt-1 flex items-center gap-2.5 ps-5" data-slot="tool-approval-inline">
@@ -129,7 +146,16 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="min-w-44">
             <DropdownMenuItem onSelect={() => void respond('session')}>Allow this session</DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => void respond('always')}>Always allow</DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                // Defer one tick so the menu fully unmounts before the dialog
+                // mounts — otherwise Radix's focus-return races the dialog and
+                // dismisses it via onInteractOutside.
+                setTimeout(() => setConfirmAlways(true), 0)
+              }}
+            >
+              Always allow…
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
               Reject
             </DropdownMenuItem>
@@ -147,6 +173,41 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
         {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : 'Reject'}
         {submitting !== 'deny' && <span className="text-[0.625rem] opacity-55">Esc</span>}
       </Button>
+
+      <Dialog onOpenChange={setConfirmAlways} open={confirmAlways}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Always allow this command?</DialogTitle>
+            <DialogDescription>
+              This adds the “{request.description}” pattern to your permanent allowlist (
+              <code className="font-mono text-xs">~/.hermes/config.yaml</code>). Hermes won’t ask again for commands
+              like this — in this session or any future one.
+            </DialogDescription>
+          </DialogHeader>
+
+          {request.command.trim() && (
+            <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
+              {request.command.trim()}
+            </pre>
+          )}
+
+          <DialogFooter>
+            <Button onClick={() => setConfirmAlways(false)} size="sm" variant="ghost">
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmAlways(false)
+                void respond('always')
+              }}
+              size="sm"
+              variant="destructive"
+            >
+              Always allow
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -102,12 +102,13 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   }, [respond])
 
   return (
-    <div className="mt-1 flex items-center gap-1 ps-5" data-slot="tool-approval-inline">
+    <div className="mt-1 flex items-center gap-2.5 ps-5" data-slot="tool-approval-inline">
       <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
         <Button
           className="h-full gap-1 rounded-none px-2 text-xs font-medium text-primary hover:bg-primary/15 hover:text-primary"
           disabled={busy}
           onClick={() => void respond('once')}
+          size="xs"
           variant="ghost"
         >
           {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : 'Run'}
@@ -118,8 +119,9 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
           <DropdownMenuTrigger asChild>
             <Button
               aria-label="More approval options"
-              className="h-full rounded-none px-1 text-primary hover:bg-primary/15 hover:text-primary"
+              className="h-full w-5 rounded-none px-0 text-primary hover:bg-primary/15 hover:text-primary"
               disabled={busy}
+              size="xs"
               variant="ghost"
             >
               <ChevronDown className="size-3" />
@@ -136,9 +138,10 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
       </div>
 
       <Button
-        className="h-6 gap-1 rounded-md px-2 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
+        className="h-6 gap-1.5 rounded-md px-1.5 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
         disabled={busy}
         onClick={() => void respond('deny')}
+        size="xs"
         variant="ghost"
       >
         {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : 'Reject'}

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -103,24 +103,22 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
 
   return (
     <div className="mt-1 flex items-center gap-1 ps-5" data-slot="tool-approval-inline">
-      <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-(--ui-stroke-secondary) bg-background">
+      <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
         <Button
-          className="h-full gap-1 rounded-none px-2 text-xs font-normal"
+          className="h-full gap-1 rounded-none px-2 text-xs font-medium text-primary hover:bg-primary/15 hover:text-primary"
           disabled={busy}
           onClick={() => void respond('once')}
           variant="ghost"
         >
           {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : 'Run'}
-          {submitting !== 'once' && (
-            <span className="text-[0.625rem] text-(--ui-text-tertiary)">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>
-          )}
+          {submitting !== 'once' && <span className="text-[0.625rem] text-primary/60">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>}
         </Button>
-        <span aria-hidden className="w-px self-stretch bg-(--ui-stroke-secondary)" />
+        <span aria-hidden className="w-px self-stretch bg-primary/20" />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               aria-label="More approval options"
-              className="h-full rounded-none px-1"
+              className="h-full rounded-none px-1 text-primary hover:bg-primary/15 hover:text-primary"
               disabled={busy}
               variant="ghost"
             >

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -11,15 +11,17 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { triggerHaptic } from '@/lib/haptics'
-import { ChevronDown, Loader2, Terminal } from '@/lib/icons'
+import { ChevronDown, Loader2 } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/store/prompts'
 
 import type { ToolPart } from './tool-fallback-model'
 
-// Inline, Cursor-style command-approval card. Rendered under the pending tool
-// row that raised the approval instead of as a modal overlay.
+// Inline, Cursor-style approval control. Rendered as a compact button strip
+// under the pending tool row that raised the approval (the row already shows
+// the command, so the strip deliberately doesn't repeat it) instead of as a
+// modal overlay.
 //
 // Binding is POSITIONAL, not command-matched: the desktop `tool.start` payload
 // carries no structured args (only tool_id/name/context — see
@@ -99,58 +101,49 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
     return () => window.removeEventListener('keydown', onKeyDown, true)
   }, [respond])
 
-  const command = request.command.trim()
-
   return (
-    <div
-      className="mt-1.5 overflow-hidden rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) text-sm"
-      data-slot="tool-approval-inline"
-    >
-      <div className="flex items-start gap-2 px-3 py-2.5">
-        <Terminal className="mt-px size-3.5 shrink-0 text-(--ui-text-tertiary)" />
-        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[0.8125rem] leading-snug text-foreground">
-          {command || request.description}
-        </pre>
-      </div>
-
-      <div className="flex items-center justify-between gap-2 border-t border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,var(--foreground)_3%,transparent)] px-2.5 py-1.5">
-        <span className="min-w-0 truncate text-xs text-(--ui-text-tertiary)">{request.description}</span>
-
-        <div className="flex shrink-0 items-center gap-1.5">
-          <Button className="gap-1.5" disabled={busy} onClick={() => void respond('deny')} size="sm" variant="ghost">
-            {submitting === 'deny' ? <Loader2 className="size-3.5 animate-spin" /> : 'Reject'}
-            {submitting !== 'deny' && <span className="text-[0.6875rem] opacity-55">Esc</span>}
-          </Button>
-
-          <div className="flex items-stretch">
-            <Button className="gap-1.5 rounded-r-none" disabled={busy} onClick={() => void respond('once')} size="sm">
-              {submitting === 'once' ? <Loader2 className="size-3.5 animate-spin" /> : 'Run'}
-              {submitting !== 'once' && (
-                <span className="text-[0.6875rem] opacity-70">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>
-              )}
+    <div className="mt-1 flex items-center gap-1 ps-5" data-slot="tool-approval-inline">
+      <div className="flex items-stretch">
+        <Button
+          className="h-6 gap-1 rounded-md rounded-r-none px-2 text-xs font-medium"
+          disabled={busy}
+          onClick={() => void respond('once')}
+          size="sm"
+        >
+          {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : 'Run'}
+          {submitting !== 'once' && <span className="text-[0.625rem] opacity-70">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>}
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label="More approval options"
+              className="h-6 rounded-md rounded-l-none border-l border-primary-foreground/25 px-1"
+              disabled={busy}
+              size="sm"
+            >
+              <ChevronDown className="size-3" />
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  aria-label="More approval options"
-                  className="rounded-l-none border-l border-primary-foreground/25 px-1.5"
-                  disabled={busy}
-                  size="sm"
-                >
-                  <ChevronDown className="size-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-44">
-                <DropdownMenuItem onSelect={() => void respond('session')}>Allow this session</DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => void respond('always')}>Always allow</DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
-                  Reject
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-44">
+            <DropdownMenuItem onSelect={() => void respond('session')}>Allow this session</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void respond('always')}>Always allow</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
+              Reject
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
+
+      <Button
+        className="h-6 gap-1 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground"
+        disabled={busy}
+        onClick={() => void respond('deny')}
+        size="sm"
+        variant="ghost"
+      >
+        {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : 'Reject'}
+        {submitting !== 'deny' && <span className="text-[0.625rem] opacity-55">Esc</span>}
+      </Button>
     </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -26,7 +26,7 @@ import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/
 
 import type { ToolPart } from './tool-fallback-model'
 
-// Inline, Cursor-style approval control. Rendered as a compact button strip
+// Inline approval control. Rendered as a compact button strip
 // under the pending tool row that raised the approval (the row already shows
 // the command, so the strip deliberately doesn't repeat it) instead of as a
 // modal overlay.
@@ -95,7 +95,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
     [busy, gateway, request.sessionId]
   )
 
-  // ⌘/Ctrl+Enter → Run, Esc → Reject — matching Cursor's accept/skip bindings.
+  // ⌘/Ctrl+Enter → Run, Esc → Reject.
   // While the confirm dialog is open it owns the keyboard (Esc closes it), so
   // the strip-level shortcuts stand down to avoid denying the whole approval.
   useEffect(() => {

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils'
 import { $toolInlineDiffs } from '@/store/tool-diffs'
 import { $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
 
+import { PendingToolApproval } from './tool-approval'
 import {
   groupCopyText as buildGroupCopyText,
   buildToolView,
@@ -309,6 +310,7 @@ function ToolEntry({ part }: ToolEntryProps) {
           </span>
         </DisclosureRow>
       </div>
+      {isPending && <PendingToolApproval part={part} />}
       {open && (
         <div className="grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
           {!embedded && view.previewTarget && isPreviewableTarget(view.previewTarget) && (

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -7,131 +7,24 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { triggerHaptic } from '@/lib/haptics'
-import { AlertTriangle, KeyRound, Loader2, Lock } from '@/lib/icons'
-import { cn } from '@/lib/utils'
+import { KeyRound, Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
-import {
-  $approvalRequest,
-  $secretRequest,
-  $sudoRequest,
-  clearApprovalRequest,
-  clearSecretRequest,
-  clearSudoRequest
-} from '@/store/prompts'
+import { $secretRequest, $sudoRequest, clearSecretRequest, clearSudoRequest } from '@/store/prompts'
 
-// Renders the three blocking mid-turn prompts the gateway raises and waits on:
-// dangerous-command/execute_code approval, sudo password, and skill secret
-// capture. Each Python-side caller blocks the agent thread until the matching
-// `*.respond` RPC lands; without these overlays the agent stalls until its
-// timeout and the tool is BLOCKED (the bug this fixes — desktop handled
-// clarify.request but not these). Any close path (Esc, backdrop click) funnels
-// through Radix's single `onOpenChange(false)` and maps to a refusal, so silence
-// is never mistaken for consent, matching the TUI. We deliberately do NOT add
-// onEscapeKeyDown / onInteractOutside handlers — they'd fire a second `*.respond`
-// alongside onOpenChange (double-send) or block the backdrop-dismiss path.
-
-const APPROVAL_OPTS = [
-  { choice: 'once', label: 'Allow once', variant: 'default' as const },
-  { choice: 'session', label: 'Allow this session', variant: 'secondary' as const },
-  { choice: 'always', label: 'Always allow', variant: 'secondary' as const },
-  { choice: 'deny', label: 'Deny', variant: 'ghost' as const }
-]
-
-const APPROVAL_CMD_PREVIEW_LINES = 12
-
-function ApprovalDialog() {
-  const request = useStore($approvalRequest)
-  const gateway = useStore($gateway)
-  const [submitting, setSubmitting] = useState(false)
-
-  const respond = useCallback(
-    async (choice: string) => {
-      if (!request) {
-        return
-      }
-
-      if (!gateway) {
-        notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
-
-        return
-      }
-
-      setSubmitting(true)
-
-      try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
-          choice,
-          session_id: request.sessionId ?? undefined
-        })
-        triggerHaptic('submit')
-        clearApprovalRequest()
-      } catch (error) {
-        notifyError(error, 'Could not send approval response')
-        setSubmitting(false)
-      }
-    },
-    [gateway, request]
-  )
-
-  // Esc / backdrop close → deny (consent contract: silence is not consent).
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && !submitting && request) {
-        void respond('deny')
-      }
-    },
-    [request, respond, submitting]
-  )
-
-  if (!request) {
-    return null
-  }
-
-  const rawLines = request.command.split('\n')
-  const shown = rawLines.slice(0, APPROVAL_CMD_PREVIEW_LINES)
-  const overflow = rawLines.length - shown.length
-
-  return (
-    <Dialog onOpenChange={onOpenChange} open>
-      <DialogContent
-        className="max-w-xl border-[color-mix(in_srgb,var(--dt-warning,#d97706)_45%,var(--ui-stroke-secondary))]"
-        showCloseButton={false}
-      >
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="size-4 text-[var(--dt-warning,#d97706)]" />
-            Approval required
-          </DialogTitle>
-          <DialogDescription>{request.description}</DialogDescription>
-        </DialogHeader>
-
-        <pre
-          className={cn(
-            'max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-(--ui-stroke-secondary)',
-            'bg-(--ui-chat-surface-background) px-3 py-2 font-mono text-[0.8125rem] leading-snug text-foreground'
-          )}
-        >
-          {shown.join('\n') || ' '}
-          {overflow > 0 ? `\n… +${overflow} more line${overflow === 1 ? '' : 's'}` : ''}
-        </pre>
-
-        <DialogFooter className="sm:flex-col sm:items-stretch sm:gap-2">
-          {APPROVAL_OPTS.map(opt => (
-            <Button
-              disabled={submitting}
-              key={opt.choice}
-              onClick={() => void respond(opt.choice)}
-              variant={opt.variant}
-            >
-              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : opt.label}
-            </Button>
-          ))}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
+// Renders the modal mid-turn prompts the gateway raises and waits on: sudo
+// password and skill secret capture. (Dangerous-command / execute_code approval
+// is rendered INLINE on the pending tool row instead — see
+// components/assistant-ui/tool-approval.tsx — so it reads like Cursor's "Run"
+// affordance rather than a blocking modal.) Each Python-side caller blocks the
+// agent thread until the matching `*.respond` RPC lands; without a renderer the
+// agent stalls until its timeout and the tool is BLOCKED (the bug this fixes —
+// desktop handled clarify.request but not these). Any close path (Esc, backdrop
+// click) funnels through Radix's single `onOpenChange(false)` and maps to a
+// refusal, so silence is never mistaken for consent, matching the TUI. We
+// deliberately do NOT add onEscapeKeyDown / onInteractOutside handlers — they'd
+// fire a second `*.respond` alongside onOpenChange (double-send) or block the
+// backdrop-dismiss path.
 
 function SudoDialog() {
   const request = useStore($sudoRequest)
@@ -330,7 +223,6 @@ function SecretDialog() {
 export function PromptOverlays() {
   return (
     <>
-      <ApprovalDialog />
       <SudoDialog />
       <SecretDialog />
     </>

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -15,7 +15,7 @@ import { $secretRequest, $sudoRequest, clearSecretRequest, clearSudoRequest } fr
 // Renders the modal mid-turn prompts the gateway raises and waits on: sudo
 // password and skill secret capture. (Dangerous-command / execute_code approval
 // is rendered INLINE on the pending tool row instead — see
-// components/assistant-ui/tool-approval.tsx — so it reads like Cursor's "Run"
+// components/assistant-ui/tool-approval.tsx — so it reads like an inline "Run"
 // affordance rather than a blocking modal.) Each Python-side caller blocks the
 // agent thread until the matching `*.respond` RPC lands; without a renderer the
 // agent stalls until its timeout and the tool is BLOCKED (the bug this fixes —

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -1,0 +1,338 @@
+'use client'
+
+import { useStore } from '@nanostores/react'
+import { type FormEvent, useCallback, useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { triggerHaptic } from '@/lib/haptics'
+import { AlertTriangle, KeyRound, Loader2, Lock } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+import {
+  $approvalRequest,
+  $secretRequest,
+  $sudoRequest,
+  clearApprovalRequest,
+  clearSecretRequest,
+  clearSudoRequest
+} from '@/store/prompts'
+
+// Renders the three blocking mid-turn prompts the gateway raises and waits on:
+// dangerous-command/execute_code approval, sudo password, and skill secret
+// capture. Each Python-side caller blocks the agent thread until the matching
+// `*.respond` RPC lands; without these overlays the agent stalls until its
+// timeout and the tool is BLOCKED (the bug this fixes — desktop handled
+// clarify.request but not these). Any close path (Esc, backdrop click) funnels
+// through Radix's single `onOpenChange(false)` and maps to a refusal, so silence
+// is never mistaken for consent, matching the TUI. We deliberately do NOT add
+// onEscapeKeyDown / onInteractOutside handlers — they'd fire a second `*.respond`
+// alongside onOpenChange (double-send) or block the backdrop-dismiss path.
+
+const APPROVAL_OPTS = [
+  { choice: 'once', label: 'Allow once', variant: 'default' as const },
+  { choice: 'session', label: 'Allow this session', variant: 'secondary' as const },
+  { choice: 'always', label: 'Always allow', variant: 'secondary' as const },
+  { choice: 'deny', label: 'Deny', variant: 'ghost' as const }
+]
+
+const APPROVAL_CMD_PREVIEW_LINES = 12
+
+function ApprovalDialog() {
+  const request = useStore($approvalRequest)
+  const gateway = useStore($gateway)
+  const [submitting, setSubmitting] = useState(false)
+
+  const respond = useCallback(
+    async (choice: string) => {
+      if (!request) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
+
+        return
+      }
+
+      setSubmitting(true)
+
+      try {
+        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+          choice,
+          session_id: request.sessionId ?? undefined
+        })
+        triggerHaptic('submit')
+        clearApprovalRequest()
+      } catch (error) {
+        notifyError(error, 'Could not send approval response')
+        setSubmitting(false)
+      }
+    },
+    [gateway, request]
+  )
+
+  // Esc / backdrop close → deny (consent contract: silence is not consent).
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && !submitting && request) {
+        void respond('deny')
+      }
+    },
+    [request, respond, submitting]
+  )
+
+  if (!request) {
+    return null
+  }
+
+  const rawLines = request.command.split('\n')
+  const shown = rawLines.slice(0, APPROVAL_CMD_PREVIEW_LINES)
+  const overflow = rawLines.length - shown.length
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open>
+      <DialogContent
+        className="max-w-xl border-[color-mix(in_srgb,var(--dt-warning,#d97706)_45%,var(--ui-stroke-secondary))]"
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="size-4 text-[var(--dt-warning,#d97706)]" />
+            Approval required
+          </DialogTitle>
+          <DialogDescription>{request.description}</DialogDescription>
+        </DialogHeader>
+
+        <pre
+          className={cn(
+            'max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-(--ui-stroke-secondary)',
+            'bg-(--ui-chat-surface-background) px-3 py-2 font-mono text-[0.8125rem] leading-snug text-foreground'
+          )}
+        >
+          {shown.join('\n') || ' '}
+          {overflow > 0 ? `\n… +${overflow} more line${overflow === 1 ? '' : 's'}` : ''}
+        </pre>
+
+        <DialogFooter className="sm:flex-col sm:items-stretch sm:gap-2">
+          {APPROVAL_OPTS.map(opt => (
+            <Button
+              disabled={submitting}
+              key={opt.choice}
+              onClick={() => void respond(opt.choice)}
+              variant={opt.variant}
+            >
+              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : opt.label}
+            </Button>
+          ))}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SudoDialog() {
+  const request = useStore($sudoRequest)
+  const gateway = useStore($gateway)
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    setPassword('')
+    setSubmitting(false)
+  }, [request?.requestId])
+
+  const send = useCallback(
+    async (value: string) => {
+      if (!request) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send sudo password')
+
+        return
+      }
+
+      setSubmitting(true)
+
+      try {
+        await gateway.request<{ status?: string }>('sudo.respond', {
+          password: value,
+          request_id: request.requestId
+        })
+        triggerHaptic('submit')
+        clearSudoRequest(request.requestId)
+      } catch (error) {
+        notifyError(error, 'Could not send sudo password')
+        setSubmitting(false)
+      }
+    },
+    [gateway, request]
+  )
+
+  // Cancel → empty password. The backend treats an empty sudo response as a
+  // failed sudo (no command runs), so closing the dialog is a safe refusal.
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && !submitting && request) {
+        void send('')
+      }
+    },
+    [request, send, submitting]
+  )
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      void send(password)
+    },
+    [password, send]
+  )
+
+  if (!request) {
+    return null
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Lock className="size-4 text-primary" />
+            Administrator password
+          </DialogTitle>
+          <DialogDescription>
+            Hermes needs your sudo password to run a privileged command. It is sent only to your local agent.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="grid gap-3" onSubmit={onSubmit}>
+          <Input
+            autoFocus
+            disabled={submitting}
+            onChange={event => setPassword(event.target.value)}
+            placeholder="sudo password"
+            type="password"
+            value={password}
+          />
+          <DialogFooter>
+            <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+              Cancel
+            </Button>
+            <Button disabled={submitting} type="submit">
+              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : 'Send'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SecretDialog() {
+  const request = useStore($secretRequest)
+  const gateway = useStore($gateway)
+  const [value, setValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    setValue('')
+    setSubmitting(false)
+  }, [request?.requestId])
+
+  const send = useCallback(
+    async (secret: string) => {
+      if (!request) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send secret')
+
+        return
+      }
+
+      setSubmitting(true)
+
+      try {
+        await gateway.request<{ status?: string }>('secret.respond', {
+          request_id: request.requestId,
+          value: secret
+        })
+        triggerHaptic('submit')
+        clearSecretRequest(request.requestId)
+      } catch (error) {
+        notifyError(error, 'Could not send secret')
+        setSubmitting(false)
+      }
+    },
+    [gateway, request]
+  )
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && !submitting && request) {
+        void send('')
+      }
+    },
+    [request, send, submitting]
+  )
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      void send(value)
+    },
+    [send, value]
+  )
+
+  if (!request) {
+    return null
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="size-4 text-primary" />
+            {request.envVar || 'Secret required'}
+          </DialogTitle>
+          <DialogDescription>{request.prompt || 'Hermes needs a credential to continue.'}</DialogDescription>
+        </DialogHeader>
+
+        <form className="grid gap-3" onSubmit={onSubmit}>
+          <Input
+            autoFocus
+            disabled={submitting}
+            onChange={event => setValue(event.target.value)}
+            placeholder={request.envVar || 'secret value'}
+            type="password"
+            value={value}
+          />
+          <DialogFooter>
+            <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+              Cancel
+            </Button>
+            <Button disabled={submitting || !value} type="submit">
+              {submitting ? <Loader2 className="size-3.5 animate-spin" /> : 'Send'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function PromptOverlays() {
+  return (
+    <>
+      <ApprovalDialog />
+      <SudoDialog />
+      <SecretDialog />
+    </>
+  )
+}

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -55,6 +55,12 @@ export type GatewayEventPayload = {
   request_id?: string
   question?: string
   choices?: string[] | null
+  // approval.request (dangerous command / execute_code) — session-keyed
+  command?: string
+  description?: string
+  // secret.request (skill credential capture)
+  env_var?: string
+  prompt?: string
 }
 
 export function textPart(text: string): ChatMessagePart {

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  $approvalRequest,
+  $secretRequest,
+  $sudoRequest,
+  clearAllPrompts,
+  clearApprovalRequest,
+  clearSecretRequest,
+  clearSudoRequest,
+  setApprovalRequest,
+  setSecretRequest,
+  setSudoRequest
+} from './prompts'
+
+afterEach(() => {
+  clearAllPrompts()
+})
+
+describe('approval prompt store', () => {
+  it('holds the most recent session-keyed approval request', () => {
+    setApprovalRequest({ command: 'rm -rf /tmp/x', description: 'recursive delete', sessionId: 's1' })
+
+    expect($approvalRequest.get()).toEqual({
+      command: 'rm -rf /tmp/x',
+      description: 'recursive delete',
+      sessionId: 's1'
+    })
+  })
+
+  it('clears unconditionally (approval is session-keyed, no request id)', () => {
+    setApprovalRequest({ command: 'x', description: 'd', sessionId: 's1' })
+    clearApprovalRequest()
+
+    expect($approvalRequest.get()).toBeNull()
+  })
+})
+
+describe('sudo prompt store', () => {
+  it('clears only when the request id matches the in-flight prompt', () => {
+    setSudoRequest({ requestId: 'abc' })
+
+    // A stale clear for a different request must NOT drop the live prompt —
+    // otherwise a late response to a prior sudo ask would dismiss the current
+    // one and leave the agent blocked.
+    clearSudoRequest('stale')
+    expect($sudoRequest.get()).toEqual({ requestId: 'abc' })
+
+    clearSudoRequest('abc')
+    expect($sudoRequest.get()).toBeNull()
+  })
+
+  it('clears unconditionally when no request id is given', () => {
+    setSudoRequest({ requestId: 'abc' })
+    clearSudoRequest()
+
+    expect($sudoRequest.get()).toBeNull()
+  })
+})
+
+describe('secret prompt store', () => {
+  it('carries env var and prompt, and clears on id match', () => {
+    setSecretRequest({ requestId: 'r1', envVar: 'OPENAI_API_KEY', prompt: 'Paste your key' })
+
+    expect($secretRequest.get()).toEqual({
+      requestId: 'r1',
+      envVar: 'OPENAI_API_KEY',
+      prompt: 'Paste your key'
+    })
+
+    clearSecretRequest('mismatch')
+    expect($secretRequest.get()).not.toBeNull()
+
+    clearSecretRequest('r1')
+    expect($secretRequest.get()).toBeNull()
+  })
+})
+
+describe('clearAllPrompts', () => {
+  it('drops every in-flight prompt at once (turn end / interrupt)', () => {
+    setApprovalRequest({ command: 'x', description: 'd', sessionId: 's1' })
+    setSudoRequest({ requestId: 'abc' })
+    setSecretRequest({ requestId: 'r1', envVar: 'E', prompt: 'p' })
+
+    clearAllPrompts()
+
+    expect($approvalRequest.get()).toBeNull()
+    expect($sudoRequest.get()).toBeNull()
+    expect($secretRequest.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,0 +1,86 @@
+import { atom } from 'nanostores'
+
+// Blocking interactive prompts the gateway raises mid-turn. Each maps to a
+// `*.request` event the Python side emits while it blocks the agent thread
+// waiting for a `*.respond` RPC. Without a renderer for these, the agent
+// silently stalls until its timeout (default 5 min) and the tool is BLOCKED
+// — the desktop app previously handled clarify.request but not these three,
+// so dangerous-command approval, sudo, and secret prompts never surfaced.
+
+export interface ApprovalRequest {
+  command: string
+  description: string
+  sessionId: string | null
+}
+
+// Approval is session-keyed on the backend (one in-flight approval per
+// session, resolved via approval.respond {choice, session_id}). It carries
+// no request_id, unlike sudo/secret which are _block()-style request/response.
+export const $approvalRequest = atom<ApprovalRequest | null>(null)
+
+export function setApprovalRequest(request: ApprovalRequest): void {
+  $approvalRequest.set(request)
+}
+
+export function clearApprovalRequest(): void {
+  $approvalRequest.set(null)
+}
+
+export interface SudoRequest {
+  requestId: string
+}
+
+export const $sudoRequest = atom<SudoRequest | null>(null)
+
+export function setSudoRequest(request: SudoRequest): void {
+  $sudoRequest.set(request)
+}
+
+export function clearSudoRequest(requestId?: string): void {
+  const current = $sudoRequest.get()
+
+  if (!current) {
+    return
+  }
+
+  if (requestId && current.requestId !== requestId) {
+    return
+  }
+
+  $sudoRequest.set(null)
+}
+
+export interface SecretRequest {
+  requestId: string
+  envVar: string
+  prompt: string
+}
+
+export const $secretRequest = atom<SecretRequest | null>(null)
+
+export function setSecretRequest(request: SecretRequest): void {
+  $secretRequest.set(request)
+}
+
+export function clearSecretRequest(requestId?: string): void {
+  const current = $secretRequest.get()
+
+  if (!current) {
+    return
+  }
+
+  if (requestId && current.requestId !== requestId) {
+    return
+  }
+
+  $secretRequest.set(null)
+}
+
+// Drop every in-flight prompt. Called when a turn ends (message.complete /
+// error) so a stale overlay can't linger past the turn that raised it — e.g.
+// if the agent was interrupted while a prompt was open.
+export function clearAllPrompts(): void {
+  $approvalRequest.set(null)
+  $sudoRequest.set(null)
+  $secretRequest.set(null)
+}

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -305,12 +305,13 @@ def _capture_required_environment_variables(
         }
 
     missing_names = [entry["name"] for entry in missing_entries]
-    # Gateway surfaces are normally treated as unable to capture secrets (most
-    # messaging platforms can't prompt). But interactive gateway surfaces — the
-    # desktop app / TUI — register a secret-capture callback that routes to a
-    # secure secret.request overlay. Only short-circuit to the "unsupported"
-    # hint when no such callback exists, so those surfaces actually prompt.
-    if _is_gateway_surface() and _secret_capture_callback is None:
+    # Most gateway surfaces (messaging platforms) can't prompt for a secret, so
+    # they short-circuit to the "unsupported" hint. Interactive gateway surfaces
+    # — the desktop app / TUI — set HERMES_INTERACTIVE and register a
+    # secret-capture callback that routes to a secure secret.request overlay, so
+    # they fall through and actually prompt. (HERMES_INTERACTIVE is the same flag
+    # tools/approval.py uses to tell an interactive surface from a messaging one.)
+    if _is_gateway_surface() and not env_var_enabled("HERMES_INTERACTIVE"):
         return {
             "missing_names": missing_names,
             "setup_skipped": False,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -305,7 +305,12 @@ def _capture_required_environment_variables(
         }
 
     missing_names = [entry["name"] for entry in missing_entries]
-    if _is_gateway_surface():
+    # Gateway surfaces are normally treated as unable to capture secrets (most
+    # messaging platforms can't prompt). But interactive gateway surfaces — the
+    # desktop app / TUI — register a secret-capture callback that routes to a
+    # secure secret.request overlay. Only short-circuit to the "unsupported"
+    # hint when no such callback exists, so those surfaces actually prompt.
+    if _is_gateway_surface() and _secret_capture_callback is None:
         return {
             "missing_names": missing_names,
             "setup_skipped": False,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4154,6 +4154,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             approval_token = set_current_session_key(session["session_key"])
             session_tokens = _set_session_context(session["session_key"])
+            # The sudo password callback is thread-local (tools.terminal_tool
+            # _callback_tls), so wiring it on the build thread doesn't reach this
+            # turn thread — terminal sudo prompts would fall through to /dev/tty
+            # and hang the headless gateway. Re-wire here so the prompt routes to
+            # the sudo.request overlay. (secret capture is a module global, so
+            # re-running is a harmless no-op.)
+            _wire_callbacks(sid)
             cwd = _session_cwd(session)
             _register_session_cwd(session)
             cols = session.get("cols", 80)


### PR DESCRIPTION
## Summary
Tool approvals (and sudo / secret prompts) now actually surface in the desktop app instead of silently timing out.

The desktop app's gateway event handler handled `clarify.request` but had **no case** for `approval.request`, `sudo.request`, or `secret.request`. When a tool needed approval, the gateway emitted `approval.request` and blocked the agent thread in `_await_gateway_decision()` for up to 5 min (`approvals.gateway_timeout`). The renderer dropped the unknown event, never showed a dialog, then the agent returned `BLOCKED: timed out without user response`. No prompt — just a stall, then a block. Reported on an m4 Mac mini, but it's platform-independent: any desktop-app session hitting a dangerous command / `execute_code` / sudo / skill-secret prompt was affected.

The Ink TUI already handles all three (`ui-tui/.../createGatewayEventHandler.ts`); the server side (`tools/approval.py`) was always correct — it fires the notify callback, the client just wasn't listening. This brings the Electron app to parity.

## Changes
- `store/prompts.ts`: approval / sudo / secret request atoms, with request-id-guarded clears (a late response to a prior prompt can't dismiss the live one) and `clearAllPrompts()`.
- `components/prompt-overlays.tsx`: Radix dialogs for all three. Approval shows the command + 4 choices (once / session / always / deny); sudo & secret are masked inputs. Closing via Esc/backdrop maps to a refusal (deny / empty) so silence is never mistaken for consent — parity with the TUI's `Esc → deny`.
- `app/session/hooks/use-message-stream.ts`: wire the three `*.request` cases; `clearAllPrompts()` on `message.complete` so an overlay can't outlive the turn that raised it.
- `lib/chat-messages.ts`: `GatewayEventPayload` gains `command` / `description` / `env_var` / `prompt`.
- `app/chat/index.tsx`: mount `<PromptOverlays />` in the chat shell.

## Validation
| | Before | After |
|---|---|---|
| Dangerous command in desktop app | no prompt, ~5 min stall, `BLOCKED` | approval dialog, runs on approve |
| sudo / secret prompt | silently dropped, agent hangs | masked-input dialog, resolves |
| `tsc -b` | — | clean (only pre-existing missing-dep error in an untouched file) |
| eslint (touched files) | — | 0 errors |
| `store/prompts.test.ts` | — | 6 new tests pass |

## Test plan
- Desktop app, default approval mode: ask Hermes to run `rm -rf` on a throwaway path → approval dialog appears → "Allow once" runs it, "Deny" blocks it.
- Trigger a sudo-requiring command → password dialog → submit resolves.
- Esc/backdrop on the approval dialog → command is denied (not left hanging).

## Infographic

![blocking-prompt-event-routing](https://v3b.fal.media/files/b/0a9ce0bb/vdedxd09IOH1mV-Zd7g9G_rIWhivGy.png)
