### PR TITLE
fix(env): preserve desktop session token despite pinned .env value

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -234,6 +234,17 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _sanitize_env_file_if_needed(project_env_path)
 
+    # Preserve the desktop-spawned process-level session token before
+    # ``override=True`` clobbers it with the pinned value from .env.
+    # The Desktop app sets HERMES_DASHBOARD_TUI=1 and injects its own
+    # auto-generated token via the process environment (main.cjs).
+    # A pinned HERMES_DASHBOARD_SESSION_TOKEN in .env is meant for
+    # *remote* mode only; letting it override the desktop's token
+    # causes a token mismatch → infinite SIGTERM boot loop (#38575).
+    _desktop_token: str | None = None
+    if os.environ.get("HERMES_DASHBOARD_TUI") == "1":
+        _desktop_token = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN")
+
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
@@ -241,6 +252,12 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+
+    # Restore the desktop token if .env overwrote it.
+    if _desktop_token is not None:
+        current = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN")
+        if current != _desktop_token:
+            os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = _desktop_token
 
     _apply_external_secret_sources(home_path)
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,47 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_desktop_token_preserved_despite_pinned_dotenv(tmp_path, monkeypatch):
+    """Desktop-spawned process-level HERMES_DASHBOARD_SESSION_TOKEN must not
+    be clobbered by a pinned value in .env (fixes #38575 boot loop)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=pinned-from-dotenv\n",
+        encoding="utf-8",
+    )
+
+    # Simulate the Desktop app spawning the backend: it sets
+    # HERMES_DASHBOARD_TUI=1 and injects its own auto-generated token.
+    monkeypatch.setenv("HERMES_DASHBOARD_TUI", "1")
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "desktop-auto-generated-token")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    # The desktop's auto-generated token must survive, not be replaced
+    # by the pinned value from .env.
+    assert os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") == "desktop-auto-generated-token"
+
+
+def test_pinned_token_applied_when_not_desktop_mode(tmp_path, monkeypatch):
+    """Without HERMES_DASHBOARD_TUI, the pinned token from .env should
+    apply normally (remote-backend use case)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=pinned-for-remote\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("HERMES_DASHBOARD_TUI", raising=False)
+    monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") == "pinned-for-remote"


### PR DESCRIPTION
## What does this PR do?

Preserves the Desktop-spawned process-level `HERMES_DASHBOARD_SESSION_TOKEN` when `~/.hermes/.env` also pins a value for the same variable. Without this fix, a pinned token in `.env` causes the local-mode Desktop app to enter an infinite SIGTERM boot loop because the backend enforces the pinned token while the renderer presents the auto-generated one.

## Related Issue

Fixes #38575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py`: In `load_hermes_dotenv()`, detect the Desktop app's presence via `HERMES_DASHBOARD_TUI=1` (set by `main.cjs` line 3363) and save the process-level `HERMES_DASHBOARD_SESSION_TOKEN` before `override=True` runs, then restore it afterward if dotenv overwrote it with the pinned `.env` value.
- `tests/hermes_cli/test_env_loader.py`: Added two tests — `test_desktop_token_preserved_despite_pinned_dotenv` (desktop token survives `.env` override) and `test_pinned_token_applied_when_not_desktop_mode` (pinned token still applies in remote-backend use case).

## How to Test

1. Set `HERMES_DASHBOARD_SESSION_TOKEN=pinned-value` in `~/.hermes/.env`
2. Launch Hermes Desktop in local mode (Settings → Gateway → Remote gateway OFF)
3. Before this fix: observe infinite boot loop in `~/.hermes/logs/desktop.log` (SIGTERM + restart cycle)
4. After this fix: Desktop starts normally — the backend uses the Desktop's auto-generated token, ignoring the pinned value
5. Verify remote mode still works: `hermes dashboard` (without Desktop) should still honor the pinned token from `.env`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_env_loader.py -v` and all tests pass (8/8)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Desktop app is macOS-only; env_loader.py is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/env_loader.py:load_hermes_dotenv()` — called from `hermes_cli/main.py`, `gateway/run.py`, `cron/scheduler.py`, `hermes_cli/doctor.py`, `hermes_cli/dump.py` (6 call sites)
- Blast radius: LOW — adds a guard that only activates when `HERMES_DASHBOARD_TUI=1` (Desktop mode); all non-Desktop code paths are unaffected
- Related patterns: `main.cjs` line 3362 sets `HERMES_DASHBOARD_SESSION_TOKEN` in the spawn env; line 3363 sets `HERMES_DASHBOARD_TUI=1`; `web_server.py` line 135 reads the token at import time
