### PR TITLE
[Human Verified] feat: Improve the user prefix for hindsight memory, by using the actual user name and ID for retain task

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1361,12 +1361,41 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
+    def _build_user_prefix(self) -> str:
+        """Build the prefix prepended to retained user-turn content.
+
+        Format:
+        - With user metadata: ``{user_name}({platform}:{user_id})``
+        - With non-DM chat metadata: append `` in group {chat_name}({chat_id})``
+        - Fallback when ``user_id`` is absent: use ``user_name`` if present,
+          otherwise ``retain_user_prefix``, otherwise literal ``User``.
+
+        Examples:
+        - DM: ``Alice(telegram:12345)``
+        - Group: ``Alice(telegram:12345) in awesome-hermes-community(100100)``
+        - CLI/TUI fallback with ``retain_user_prefix='User'``: ``User``
+        """
+        user = self._user_name or self._retain_user_prefix or "User"
+        if self._user_id:
+            platform = self._platform or "unknown"
+            label = f"{user}({platform}:{self._user_id})"
+        else:
+            label = user
+
+        if self._chat_type and self._chat_type != "dm" and (self._chat_name or self._chat_id):
+            group = self._chat_name or self._chat_id
+            if self._chat_id:
+                group = f"{group}({self._chat_id})"
+            label = f"{label} in {group}"
+
+        return label
+
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
             {
                 "role": "user",
-                "content": f"{self._retain_user_prefix}: {user_content}",
+                "content": f"{self._build_user_prefix()}: {user_content}",
                 "timestamp": now,
             },
             {

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -707,7 +707,10 @@ class TestSyncTurn:
         content = json.loads(item["content"])
         assert len(content) == 1
         assert content[0][0]["role"] == "user"
-        assert content[0][0]["content"] == "User (fakeusername): hello"
+        assert content[0][0]["content"] == (
+            "fakeusername(discord:fakeusername-123) "
+            "in fakeassistantname-forums(1485316232612941897): hello"
+        )
         assert content[0][1]["role"] == "assistant"
         assert content[0][1]["content"] == "Assistant (fakeassistantname): hi there"
         assert item["metadata"]["source"] == "hermes"


### PR DESCRIPTION
## What does this PR fix

When Hermes send conversation chunk to hindsight memory plugin, it always prefix the user message as a static configured value (such as "user", "speaker", "human", "Fang", etc.).

**This usually isn't an issue for DMs. But for group chats, especially when multiple person collaborate in the same group, this static configured prefix caused ambiguous and less-optimal performance for hindsight to understand who is speaking**.

This PR fixed the issue.

Examples:
        - DM: `Alice(telegram:12345)`
        - Group: `Alice(telegram:12345) in awesome-hermes-community(100100)`
        - CLI/TUI fallback with `retain_user_prefix='User'`: `User`

## Summary
- Build better retain_user_prefix for hindsight memory plugin, based on actual platform user name and user ID.
- Include platform/user id and non-DM group context as retain user prefixes
- Keep existing retain_user_prefix fallback for CLI/TUI or missing user information

## Before Change

Currenly, Hermes send following chunks to Hindsight

```
{"role": "user", "content": "<retain_user_prefix>: Hi"},
{"role": "assistant", "content": "<retain_assistant_prefix>: hi there"},
```

## After Change

After the RP, Hermes send following chunks to Hindsight

```
// Telegram user `Alice` in group `awesome-hermes-community` says "Hi"

{"role": "user", "content": "Alice(telegram:12345) in awesome-hermes-community(100100): Hi"},
{"role": "assistant", "content": "<retain_assistant_prefix>: hi there"}
```

```
// Telegram user `Alice` says "Hi" directly

{"role": "user", "content": "Alice(telegram:12345): Hi"},
{"role": "assistant", "content": "<retain_assistant_prefix>: hi there"},

```

```
// Say "Hi" via Hermes TUI/CLI, while retain_user_prefix = 'Alice'
// Fallback to configured user prefix

{"role": "user", "content": "Alice: Hi"},
{"role": "assistant", "content": "<retain_assistant_prefix>: hi there"},

```