### PR TITLE
fix(desktop): detect linux arm64 binary

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7225,6 +7225,8 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
         candidates = [
             release_dir / "linux-unpacked" / "hermes",
             release_dir / "linux-unpacked" / "Hermes",
+            release_dir / "linux-arm64-unpacked" / "hermes",
+            release_dir / "linux-arm64-unpacked" / "Hermes",
         ]
 
     existing = [p for p in candidates if p.exists()]


### PR DESCRIPTION
## What does this PR do?

The desktop binary detection in `hermes_cli/main.py` only looks for `linux-unpacked/hermes` (and the `Hermes` variant), which is the x86_64 build. On ARM64 Linux systems, the unpacked directory is named `linux-arm64-unpacked` instead, so the desktop app fails to find its own binary.

This PR adds `linux-arm64-unpacked` candidate paths to the lookup list so the desktop launch works on ARM64 Linux.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: Added `linux-arm64-unpacked/hermes` and `linux-arm64-unpacked/Hermes` to the `candidates` list in the desktop binary detection logic

## How to Test

1. Build or download a Hermes desktop release for `linux-arm64`
2. Run `hermes` on an ARM64 Linux machine — previously it would fail to locate the binary; after this change it finds it in `linux-arm64-unpacked/`
3. Verify x86_64 desktop still works (existing `linux-unpacked` candidates remain first in the list)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Linux ARM64

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, `docs/`, docstrings)
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is Linux-specific, no impact on other platforms
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

N/A