### PR TITLE
fix(webhook): execute configured script routes directly

### DIFF
--- a/apps/desktop/scripts/profile-typing-lag.md
+++ b/apps/desktop/scripts/profile-typing-lag.md
@@ -1,3 +1,13 @@
+---
+type: note
+title: Profiling renderer typing lag
+created: 2026-05-31
+tags:
+  - workflow
+  - desktop
+  - performance
+---
+
 # Profiling renderer typing lag
 
 Workflow for empirically measuring (and fixing) typing/submit lag in the

--- a/dream-cycle-summaries/2026-05-27.md
+++ b/dream-cycle-summaries/2026-05-27.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-05-27
+title: Dream cycle 2026-05-27
+dream_generated: true
+dream_cycle_date: '2026-05-27'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-05-27
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-05-28.md
+++ b/dream-cycle-summaries/2026-05-28.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-05-28
+title: Dream cycle 2026-05-28
+dream_generated: true
+dream_cycle_date: '2026-05-28'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-05-28
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-05-29.md
+++ b/dream-cycle-summaries/2026-05-29.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-05-29
+title: Dream cycle 2026-05-29
+dream_generated: true
+dream_cycle_date: '2026-05-29'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-05-29
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-05-30.md
+++ b/dream-cycle-summaries/2026-05-30.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-05-30
+title: Dream cycle 2026-05-30
+dream_generated: true
+dream_cycle_date: '2026-05-30'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-05-30
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-05-31.md
+++ b/dream-cycle-summaries/2026-05-31.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-05-31
+title: Dream cycle 2026-05-31
+dream_generated: true
+dream_cycle_date: '2026-05-31'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-05-31
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-06-01.md
+++ b/dream-cycle-summaries/2026-06-01.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-06-01
+title: Dream cycle 2026-06-01
+dream_generated: true
+dream_cycle_date: '2026-06-01'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-06-01
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-06-02.md
+++ b/dream-cycle-summaries/2026-06-02.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-06-02
+title: Dream cycle 2026-06-02
+dream_generated: true
+dream_cycle_date: '2026-06-02'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-06-02
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/dream-cycle-summaries/2026-06-03.md
+++ b/dream-cycle-summaries/2026-06-03.md
@@ -1,0 +1,15 @@
+---
+type: note
+created: 2026-06-03
+title: Dream cycle 2026-06-03
+dream_generated: true
+dream_cycle_date: '2026-06-03'
+tags:
+  - dream-cycle
+---
+
+# Dream cycle 2026-06-03
+
+**Children:** 0 completed, 3 failed/timeout.
+**Pages written:** 0.
+

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,9 +33,12 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
+import sys
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -351,6 +354,116 @@ class WebhookAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[webhook] Failed to reload dynamic routes: %s", e)
 
+    def _validate_script_route(self, route_config: dict) -> Optional[str]:
+        """Validate a deterministic script route configuration.
+
+        Script routes are intentionally narrow: they may only execute files under
+        the active profile's ~/.hermes/scripts or the root ~/.hermes/scripts
+        directory. This prevents a webhook subscription from becoming arbitrary
+        filesystem execution.
+        """
+        script = str(route_config.get("script") or "").strip()
+        if not script:
+            return None
+        if route_config.get("deliver_only"):
+            return "cannot combine 'script' with deliver_only=true"
+        try:
+            script_path = Path(script).expanduser().resolve()
+            profile_scripts = Path(os.environ.get("HERMES_HOME", "")).expanduser() / "scripts"
+            root_scripts = Path.home() / ".hermes" / "scripts"
+            allowed_dirs = [profile_scripts.resolve(), root_scripts.resolve()]
+            if not any(str(script_path).startswith(str(base) + os.sep) or script_path == base for base in allowed_dirs):
+                return "script path is outside allowed Hermes scripts directories"
+            if not script_path.exists() or not script_path.is_file():
+                return "script path does not exist or is not a file"
+        except Exception as exc:
+            return "invalid script path: %s" % exc
+        return None
+
+    async def _execute_script_route(
+        self,
+        route_name: str,
+        route_config: dict,
+        raw_body: bytes,
+        payload: Dict[str, Any],
+        event_type: str,
+        delivery_id: str,
+    ) -> Any:
+        """Run a preconfigured local script for a signed webhook route."""
+        err = self._validate_script_route(route_config)
+        if err:
+            logger.error("[webhook] script route invalid route=%s error=%s", route_name, err)
+            return web.json_response({"status": "error", "error": err, "delivery_id": delivery_id}, status=500)
+
+        script = str(Path(str(route_config.get("script"))).expanduser().resolve())
+        timeout = int(route_config.get("script_timeout_seconds", 120) or 120)
+        env = os.environ.copy()
+        env.update({
+            "HERMES_WEBHOOK_ROUTE": route_name,
+            "HERMES_WEBHOOK_EVENT_TYPE": event_type,
+            "HERMES_WEBHOOK_DELIVERY_ID": delivery_id,
+        })
+        logger.info(
+            "[webhook] script-start route=%s script=%s event=%s delivery=%s",
+            route_name,
+            script,
+            event_type,
+            delivery_id,
+        )
+        try:
+            proc = await asyncio.to_thread(
+                subprocess.run,
+                [sys.executable, script],
+                input=raw_body.decode("utf-8", errors="replace"),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("[webhook] script-timeout route=%s script=%s delivery=%s", route_name, script, delivery_id)
+            return web.json_response({"status": "error", "error": "Script timed out", "delivery_id": delivery_id}, status=504)
+        except Exception as exc:
+            logger.exception("[webhook] script-exception route=%s script=%s delivery=%s", route_name, script, delivery_id)
+            return web.json_response({"status": "error", "error": "Script execution failed", "detail": str(exc), "delivery_id": delivery_id}, status=502)
+
+        if proc.returncode != 0:
+            logger.error(
+                "[webhook] script-fail route=%s script=%s delivery=%s returncode=%s stdout=%s stderr=%s",
+                route_name,
+                script,
+                delivery_id,
+                proc.returncode,
+                proc.stdout[-500:],
+                proc.stderr[-500:],
+            )
+            return web.json_response({
+                "status": "error",
+                "error": "Script failed",
+                "returncode": proc.returncode,
+                "stdout_bytes": len(proc.stdout.encode("utf-8")),
+                "stderr_bytes": len(proc.stderr.encode("utf-8")),
+                "delivery_id": delivery_id,
+            }, status=502)
+
+        logger.info(
+            "[webhook] script-ok route=%s script=%s delivery=%s stdout=%s stderr=%s",
+            route_name,
+            script,
+            delivery_id,
+            proc.stdout[-500:],
+            proc.stderr[-500:],
+        )
+        return web.json_response({
+            "status": "script_executed",
+            "route": route_name,
+            "event": event_type,
+            "delivery_id": delivery_id,
+            "stdout_bytes": len(proc.stdout.encode("utf-8")),
+            "stderr_bytes": len(proc.stderr.encode("utf-8")),
+        }, status=200)
+
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
         # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
@@ -519,6 +632,20 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=200,
             )
         self._seen_deliveries[delivery_id] = now
+
+        # ── Deterministic script route ───────────────────────────
+        # Skip the agent entirely and execute one preconfigured local script.
+        # Script receives the raw request body on stdin plus HERMES_WEBHOOK_*
+        # environment variables. This is for fast, auditable pipeline triggers.
+        if route_config.get("script"):
+            return await self._execute_script_route(
+                route_name=route_name,
+                route_config=route_config,
+                raw_body=raw_body,
+                payload=payload,
+                event_type=event_type,
+                delivery_id=delivery_id,
+            )
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we

--- a/tests/gateway/test_webhook_script_routes.py
+++ b/tests/gateway/test_webhook_script_routes.py
@@ -1,0 +1,146 @@
+"""Tests for deterministic webhook script routes.
+
+Script routes let signed webhooks trigger one preconfigured local script without
+spawning an agent or granting the webhook platform terminal tools.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+
+
+def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
+    extra = {"host": "127.0.0.1", "port": 0, "routes": routes}
+    extra.update(extra_kw)
+    config = PlatformConfig(enabled=True, extra=extra)
+    return WebhookAdapter(config)
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _install_script(tmp_path: Path, name: str, body: str) -> Path:
+    scripts_dir = tmp_path / ".hermes" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / name
+    script.write_text(body, encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "admin"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_script_route_executes_without_agent(fake_home, tmp_path):
+    marker = tmp_path / "marker.json"
+    script = _install_script(
+        fake_home,
+        "webhook_script_ok.py",
+        """
+import json, os, pathlib, sys
+body = sys.stdin.read()
+pathlib.Path(r'__MARKER__').write_text(json.dumps({
+    'route': os.environ.get('HERMES_WEBHOOK_ROUTE'),
+    'event': os.environ.get('HERMES_WEBHOOK_EVENT_TYPE'),
+    'delivery': os.environ.get('HERMES_WEBHOOK_DELIVERY_ID'),
+    'payload': json.loads(body),
+}), encoding='utf-8')
+print('import ok')
+""".replace("__MARKER__", str(marker)),
+    )
+    routes = {
+        "import": {
+            "secret": _INSECURE_NO_AUTH,
+            "events": ["export.completed"],
+            "script": str(script),
+            "script_timeout_seconds": 10,
+        }
+    }
+    adapter = _make_adapter(routes)
+    handle_message_calls = []
+
+    async def _capture(event):
+        handle_message_calls.append(event)
+
+    adapter.handle_message = _capture
+    app = _create_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/webhooks/import",
+            json={"event_type": "export.completed", "note": {"title": "A"}},
+            headers={"X-GitHub-Delivery": "delivery-script-1"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 200
+    assert data["status"] == "script_executed"
+    assert data["route"] == "import"
+    assert data["event"] == "export.completed"
+    assert data["stdout_bytes"] > 0
+    assert handle_message_calls == []
+    marker_data = json.loads(marker.read_text(encoding="utf-8"))
+    assert marker_data["route"] == "import"
+    assert marker_data["event"] == "export.completed"
+    assert marker_data["delivery"] == "delivery-script-1"
+    assert marker_data["payload"]["note"]["title"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_script_route_failure_returns_502(fake_home):
+    script = _install_script(fake_home, "webhook_script_fail.py", "import sys; print('bad'); sys.exit(7)\n")
+    routes = {
+        "import": {
+            "secret": _INSECURE_NO_AUTH,
+            "script": str(script),
+        }
+    }
+    adapter = _make_adapter(routes)
+    app = _create_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/webhooks/import",
+            json={"event_type": "export.completed"},
+            headers={"X-GitHub-Delivery": "delivery-script-fail-1"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 502
+    assert data["status"] == "error"
+    assert data["error"] == "Script failed"
+    assert data["returncode"] == 7
+
+
+def test_script_route_rejects_paths_outside_hermes_scripts(fake_home):
+    outside = fake_home / "outside.py"
+    outside.write_text("print('no')\n", encoding="utf-8")
+    adapter = _make_adapter({})
+
+    assert (
+        adapter._validate_script_route({"script": str(outside)})
+        == "script path is outside allowed Hermes scripts directories"
+    )
+
+
+def test_script_route_rejects_deliver_only_combo(fake_home):
+    script = _install_script(fake_home, "webhook_script_ok.py", "print('ok')\n")
+    adapter = _make_adapter({})
+
+    assert adapter._validate_script_route({"script": str(script), "deliver_only": True}) == (
+        "cannot combine 'script' with deliver_only=true"
+    )


### PR DESCRIPTION
## Summary
- Execute webhook routes with a configured `script` directly, after auth/rate/idempotency checks, without dispatching into the agent prompt path.
- Restrict script execution to active profile/root Hermes scripts directories.
- Return explicit script execution status and byte counts while logging script-start/script-ok/script-fail.
- Add regression coverage for success, script failure, path rejection, and `deliver_only` conflict.

## Verification
- `python -m pytest tests/gateway/test_webhook_script_routes.py -q -o 'addopts='` → 4 passed
- `python -m pytest tests/gateway/test_webhook_script_routes.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_signature_rate_limit.py -vv -o 'addopts='` → 34 passed
- Production admin webhook smoke: signed `multi-agent-research-scan` route returned `status=script_executed`; gateway logs showed `script-start`/`script-ok` and no agent-dispatch lines for delivery `admin-prod-smoke-1780533599`.
