### PR TITLE
fix: restart launchd gateway via service manager

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10739,11 +10739,17 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # under systemd (KillMode=mixed kills the cgroup), launchd
+        # (KeepAlive.SuccessfulExit=false only relaunches non-zero exits), or
+        # Docker (tini exits when the gateway dies, taking the detached helper
+        # with it).
+        _under_systemd = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _xpc_service_name = os.environ.get("XPC_SERVICE_NAME", "")
+        _under_launchd = sys.platform == "darwin" and _xpc_service_name.startswith(
+            "ai.hermes.gateway"
+        )
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_systemd or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -99,10 +99,34 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under launchd (Hermes XPC service), /restart uses via_service=True."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_systemd_or_launchd(tmp_path, monkeypatch):
+    """Without systemd/launchd, /restart uses the detached subprocess approach."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary
- detect macOS launchd-managed Hermes gateway processes via XPC_SERVICE_NAME
- route gateway /restart through the service-manager restart path under launchd
- add regression coverage for launchd so /restart does not leave the job loaded but stopped

## Problem
On macOS launchd, the gateway plist uses KeepAlive.SuccessfulExit=false. If /restart takes the detached helper path and the gateway exits successfully, launchd keeps the job loaded but does not relaunch it, leaving Telegram polling stopped.

## Test Plan
- `python -m pytest tests/gateway/test_restart_notification.py -q`
- `git diff --check -- gateway/run.py tests/gateway/test_restart_notification.py`
