### PR TITLE
fix(tui): persist timed-out/cancelled clarify prompts in transcript

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1113,4 +1113,68 @@ describe('createGatewayEventHandler', () => {
       vi.useRealTimers()
     }
   })
+
+  it('persists an abandoned (timed-out) clarify into the transcript when the clarify tool completes', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    // Backend clarify timed out: the overlay is still live (Python returned an
+    // empty answer), and the clarify tool's own tool.complete then fires.
+    patchOverlayState({
+      clarify: { choices: ['Scope A', 'Scope B'], question: 'How do you want to scope?', requestId: 'req-1' }
+    })
+
+    onEvent({ payload: { duration_s: 300, name: 'clarify', tool_id: 'clar-1' }, type: 'tool.complete' } as any)
+
+    const record = appended.find(msg => msg.role === 'system' && msg.text.startsWith('ask How do you want to scope?'))
+    expect(record).toBeDefined()
+    expect(record?.text).toContain('1. Scope A')
+    expect(record?.text).toContain('2. Scope B')
+    expect(record?.text).toContain('timed out — no selection')
+    // The live overlay is cleared so it doesn't double-render with the record.
+    expect(getOverlayState().clarify).toBeNull()
+  })
+
+  it('only persists an abandoned clarify once even if tool.complete fires twice', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchOverlayState({
+      clarify: { choices: ['A'], question: 'Pick?', requestId: 'req-3' }
+    })
+
+    onEvent({ payload: { name: 'clarify', tool_id: 'clar-1' }, type: 'tool.complete' } as any)
+    // A duplicate clarify tool.complete must not re-persist the same prompt.
+    onEvent({ payload: { name: 'clarify', tool_id: 'clar-1' }, type: 'tool.complete' } as any)
+
+    const records = appended.filter(msg => msg.role === 'system' && msg.text.startsWith('ask Pick?'))
+    expect(records).toHaveLength(1)
+  })
+
+  it('does not flush the clarify overlay when a non-clarify tool completes', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    // A clarify is live, but it's a *different* tool that just completed — the
+    // clarify itself is still pending, so we must not persist or clear it.
+    patchOverlayState({
+      clarify: { choices: ['A', 'B'], question: 'Pick?', requestId: 'req-4' }
+    })
+
+    onEvent({ payload: { name: 'search', tool_id: 'tool-1' }, type: 'tool.complete' } as any)
+
+    expect(appended.some(msg => msg.role === 'system' && msg.text.startsWith('ask '))).toBe(false)
+    expect(getOverlayState().clarify).not.toBeNull()
+  })
+
+  it('does not persist when an answered clarify already cleared the overlay before tool.complete', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    // Answered path (answerClarify) clears the overlay before the agent's
+    // tool.complete arrives, so there's nothing live to persist.
+    onEvent({ payload: { duration_s: 4.2, name: 'clarify', tool_id: 'clar-1' }, type: 'tool.complete' } as any)
+
+    expect(appended.some(msg => msg.role === 'system' && msg.text.startsWith('ask '))).toBe(false)
+  })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -11,7 +11,7 @@ import type {
 } from '../gatewayTypes.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
-import { formatToolCall, stripAnsi } from '../lib/text.js'
+import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
@@ -86,6 +86,35 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   let pendingThinkingStatus = ''
   let thinkingStatusTimer: null | ReturnType<typeof setTimeout> = null
   let startupPromptSubmitted = false
+
+  // Request IDs of clarify prompts we've already flushed to the transcript as
+  // an abandoned-prompt record, so the tool.complete and message.complete
+  // paths can't both persist the same prompt twice.
+  const persistedAbandonedClarify = new Set<string>()
+
+  // When a clarify prompt is dismissed without an answer (the backend _block
+  // timed out and returned an empty string), the live ClarifyPrompt overlay is
+  // left set until the next turn's idle() silently nulls it — so the question
+  // and options vanish from the screen while the agent's follow-up still refers
+  // to them.  The reliable signal is the clarify tool's own tool.complete (and,
+  // as a backstop, message.complete): at those points the overlay is provably
+  // still set on a timeout, but already cleared by answerClarify() on a real
+  // answer (so this no-ops there).  Flush the question + options into the
+  // transcript as a persistent system line, then clear the overlay.
+  const flushAbandonedClarify = () => {
+    const { clarify } = getOverlayState()
+
+    if (!clarify || persistedAbandonedClarify.has(clarify.requestId)) {
+      return
+    }
+
+    persistedAbandonedClarify.add(clarify.requestId)
+    appendMessage({
+      role: 'system',
+      text: formatAbandonedClarify(clarify.question, clarify.choices, 'timed out')
+    })
+    patchOverlayState({ clarify: null })
+  }
 
   // Inject the disk-save callback into turnController so recordMessageComplete
   // can fire-and-forget a persist without having to plumb a gateway ref around.
@@ -624,6 +653,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'tool.complete': {
+        // The clarify tool finishing with its overlay still live means it was
+        // abandoned (backend _block timed out, empty answer). A real answer
+        // clears the overlay in answerClarify() before this fires, so this
+        // no-ops there. Persist the question + options so they don't vanish.
+        if (ev.payload.name === 'clarify') {
+          flushAbandonedClarify()
+        }
+
         const inlineDiffText =
           ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -25,7 +25,7 @@ import { appendTranscriptMessage } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
-import { buildToolTrailLine, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
+import { buildToolTrailLine, formatAbandonedClarify, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
 import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
@@ -608,13 +608,19 @@ export function useMainApp(gw: GatewayClient) {
           appendMessage({ role: 'user', text: answer })
           patchUiState({ status: 'running…' })
         } else {
-          sys('prompt cancelled')
+          // Esc / Ctrl+C cancel: persist the question + options as a system
+          // line (not a transient "prompt cancelled" flash) so the prompt
+          // survives on screen as standard output, matching the timeout path.
+          appendMessage({
+            role: 'system',
+            text: formatAbandonedClarify(clarify.question, clarify.choices, 'cancelled')
+          })
         }
 
         patchOverlayState({ clarify: null })
       })
     },
-    [appendMessage, overlay.clarify, rpc, sys]
+    [appendMessage, overlay.clarify, rpc]
   )
 
   const paste = useCallback(

--- a/ui-tui/src/lib/text.test.ts
+++ b/ui-tui/src/lib/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { stripTrailingPasteNewlines } from './text.js'
+import { formatAbandonedClarify, stripTrailingPasteNewlines } from './text.js'
 
 describe('stripTrailingPasteNewlines', () => {
   it('removes trailing newline runs from pasted text', () => {
@@ -14,5 +14,36 @@ describe('stripTrailingPasteNewlines', () => {
 
   it('preserves newline-only pastes', () => {
     expect(stripTrailingPasteNewlines('\n\n')).toBe('\n\n')
+  })
+})
+
+describe('formatAbandonedClarify', () => {
+  it('renders the question, numbered options, and reason', () => {
+    const out = formatAbandonedClarify('How do you want to scope?', ['Option A', 'Option B', 'Option C'], 'timed out')
+
+    expect(out).toBe(
+      ['ask How do you want to scope?', '  1. Option A', '  2. Option B', '  3. Option C', '  (timed out — no selection)'].join(
+        '\n'
+      )
+    )
+  })
+
+  it('handles a prompt with no choices (free-text clarify)', () => {
+    const out = formatAbandonedClarify('What is the target branch?', null, 'cancelled')
+
+    expect(out).toBe(['ask What is the target branch?', '  (cancelled — no selection)'].join('\n'))
+  })
+
+  it('trims surrounding whitespace on the question', () => {
+    const out = formatAbandonedClarify('  trailing space  ', [], 'timed out')
+
+    expect(out.split('\n')[0]).toBe('ask trailing space')
+  })
+
+  it('numbers options 1-based to match the live ClarifyPrompt', () => {
+    const out = formatAbandonedClarify('q', ['first'], 'timed out')
+
+    expect(out).toContain('  1. first')
+    expect(out).not.toContain('  0.')
   })
 })

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -338,6 +338,22 @@ export const estimateRows = (text: string, w: number, compact = false) => {
   return Math.max(1, rows)
 }
 
+/**
+ * Render an unanswered clarify prompt (timed out, or cancelled with Esc/Ctrl+C)
+ * as a persistent transcript block.  The live `ClarifyPrompt` overlay is torn
+ * down the moment the turn settles, so without this the question + options
+ * vanish from the screen while the agent's follow-up still refers to "the
+ * options above".  Mirrors the option formatting in ClarifyPrompt (the same
+ * 1-based numbered list) so the persisted record reads identically to what was
+ * on screen.  `reason` states why the prompt ended ("timed out", "cancelled").
+ */
+export const formatAbandonedClarify = (question: string, choices: string[] | null, reason: string) => {
+  const head = `ask ${question.trim()}`
+  const opts = (choices ?? []).map((c, i) => `  ${i + 1}. ${c}`)
+
+  return [head, ...opts, `  (${reason} — no selection)`].join('\n')
+}
+
 export const flat = (r: Record<string, string[]>) => Object.values(r).flat()
 
 const COMPACT_NUMBER = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1, notation: 'compact' })


### PR DESCRIPTION
## Problem

In the `--tui` interface, when a `Clarify` options prompt **times out** or is dismissed with **Esc/Ctrl+C**, the options list is wiped off the screen — but the agent's follow-up message still refers to "the options above." The user is left being asked about a list they can no longer see.

**Impact case:** This fires on the common path — any clarify the user doesn't answer within the timeout window (stepped away, thinking), or cancels with Esc. The agent resumes with an empty answer and typically says *"the clarify came back without a selection — the options are above"*, but the overlay has already evaporated. It's the default behaviour of every unanswered clarify in the TUI.

## Root cause

The clarify lifecycle has two exit paths, and only one preserved the prompt:

- **Answered** (`answerClarify` in `useMainApp.ts`): persists the question + the chosen answer to the transcript. Survives on screen. ✅
- **Timeout / cancel**: no persistent write. On timeout, Python `_block()` returns `""` and the turn continues; `turnController.idle() → resetFlowOverlays()` sets `clarify: null`, tearing down the live `ClarifyPrompt` overlay with no trace. The explicit Esc/Ctrl+C path only emitted a transient `sys('prompt cancelled')`. ❌

This asymmetry is the bug.

## Fix (TUI layer only — no Python / protocol change)

- **`formatAbandonedClarify()`** in `lib/text.ts` renders the question + the same 1-based numbered option list that `ClarifyPrompt` shows, plus a reason (`timed out` / `cancelled`).
- **Timeout**: `createGatewayEventHandler` flushes a still-live clarify into the transcript as a plain **system line** when the clarify tool's own `tool.complete` fires, then clears the overlay. A per-`requestId` guard set prevents double-persisting.
- **Explicit cancel**: `answerClarify('')` now persists the prompt as a system line instead of the transient flash.

System lines always render (unlike trail lines, which `/details` mode can hide), so the record reliably survives on screen as standard output — exactly the "they should become standard output after the timeout" behaviour requested.

### Why `tool.complete` (and not `message.start`/`tool.start`)

This was pinned down with a **live capture of the gateway event stream** during a real timeout. The observed sequence is:

```
clarify.request    overlay=null   ← overlay set right after this
   (timeout elapses)
tool.complete      overlay=SET     ← clarify tool returns; overlay STILL live  ← flush here
message.complete   overlay=SET     ← turn ends; overlay STILL live
```

There is **no** intervening `message.start` / `tool.start` after a clarify times out — the agent does not "resume" with a fresh message or tool event. The only point where the overlay is provably still set is the clarify tool's own `tool.complete`. (On a real answer, `answerClarify()` clears the overlay *before* `tool.complete` arrives, so the same hook correctly no-ops — no double-write.)

## Tests

- `formatAbandonedClarify` unit cases (numbered options, no-choices free-text clarify, whitespace trim, 1-based numbering).
- gateway-handler behavioral cases: persist on clarify `tool.complete`; **no** flush when a non-clarify tool completes while a clarify is pending; no double-persist on a repeated `tool.complete`; no-op when the overlay was already cleared by an answer.

`type-check`, `eslint`, and `vitest run` clean for the touched files (the pre-existing `execFileNoThrow.ts` type errors and the `no-control-regex` lint error are baseline on `main`, untouched). 61/61 tests pass in the two affected suites.

## Verified live

Built the worktree bundle and ran it in a real TUI. Confirmed: an Esc-cancelled 5-option clarify now leaves the question + options + `(cancelled — no selection)` in the transcript after the turn ends, instead of vanishing.

## Follow-ups (out of scope here)

1. **Other flow overlays ("Option B")** — the same evaporate-on-unanswered asymmetry technically applies to `approval`, `confirm`, `sudo`, `secret`. This PR fixes only `clarify` (the reported bug), the cleanest/lowest-risk slice. A general fix needs per-overlay resolved-action wording (approval → "denied", confirm → "treated as No"), a deliberately value-blind `secret` formatter, and threading an "answered vs abandoned" signal through the shared `idle()` call sites. ~3.5–5h, noted for later.
2. **Clarify 5→4 choice truncation** — while testing this, a *separate* backend bug surfaced: passing 5 choices to `clarify` results in only 4 reaching the tool/overlay (the 5th is silently dropped). This PR's persistence faithfully echoes the 4 the overlay actually received; the truncation itself is a distinct issue and will be fixed in its own PR.
