### PR TITLE
fix(gateway): invalidate cached system prompt on session.cwd.set

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -851,6 +851,104 @@ def _session(agent=None, **extra):
     }
 
 
+def test_session_cwd_set_invalidates_cached_system_prompt(monkeypatch, tmp_path):
+    """A mid-session cwd change must invalidate agent._cached_system_prompt.
+
+    Otherwise the agent's "Current working directory" hint in the system
+    prompt remains stale for the rest of the session even though
+    session["cwd"], terminal_tool overrides, and the session.info event
+    all reflect the new directory.
+    """
+    project_a = tmp_path / "project-a"
+    project_a.mkdir()
+    project_b = tmp_path / "project-b"
+    project_b.mkdir()
+
+    # Build an agent stand-in with a pre-populated cached system prompt.
+    agent = types.SimpleNamespace(_cached_system_prompt="old prompt with cwd: A")
+
+    server._sessions["sid"] = _session(
+        agent=agent,
+        cwd=str(project_a),
+        session_key="session-key",
+    )
+
+    # Stub the DB so _set_session_cwd can persist the new cwd without
+    # touching the real hermes_state.sqlite.
+    class _StubDB:
+        def update_session_cwd(self, sid, cwd):
+            self.last = (sid, cwd)
+
+    stub_db = _StubDB()
+    monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+    # Stub terminal_tool.cleanup_vm (called by _set_session_cwd).
+    monkeypatch.setattr(
+        "tools.terminal_tool.cleanup_vm", lambda _sid: None, raising=False
+    )
+    # Stub register_task_env_overrides (also called by _set_session_cwd and
+    # _register_session_cwd) so the test doesn't reach into real tool state.
+    monkeypatch.setattr(
+        "tools.terminal_tool.register_task_env_overrides",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.cwd.set",
+            "params": {"session_id": "sid", "cwd": str(project_b)},
+        }
+    )
+
+    assert "error" not in resp, resp
+    assert resp["result"]["cwd"] == str(project_b)
+    # The cached prompt was cleared so the next turn rebuilds with the new cwd.
+    assert agent._cached_system_prompt is None
+    # The session's own cwd field was updated.
+    assert server._sessions["sid"]["cwd"] == str(project_b)
+    # The DB was told to persist the new cwd.
+    assert stub_db.last == ("session-key", str(project_b))
+
+
+def test_session_cwd_set_skips_invalidation_when_no_agent(monkeypatch, tmp_path):
+    """Lazy / draft sessions without an AIAgent must not crash on invalidation."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    server._sessions["sid"] = _session(
+        agent=None,
+        cwd=str(project),
+        session_key="session-key",
+    )
+
+    class _StubDB:
+        def update_session_cwd(self, sid, cwd):
+            self.last = (sid, cwd)
+
+    stub_db = _StubDB()
+    monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+    monkeypatch.setattr(
+        "tools.terminal_tool.cleanup_vm", lambda _sid: None, raising=False
+    )
+    monkeypatch.setattr(
+        "tools.terminal_tool.register_task_env_overrides",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.cwd.set",
+            "params": {"session_id": "sid", "cwd": str(project)},
+        }
+    )
+    assert "error" not in resp, resp
+    assert resp["result"]["cwd"] == str(project)
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3013,6 +3013,19 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
+    # The AIAgent caches its system prompt on ``_cached_system_prompt`` for
+    # the lifetime of the session (prefix-cache optimization). Without an
+    # invalidation here, the "Current working directory" line baked into that
+    # cache stays stale and subsequent turns see the previous cwd even though
+    # session["cwd"], terminal_tool overrides, and the session.info event
+    # all already reflect the new directory.
+    if agent is not None:
+        try:
+            from agent.system_prompt import invalidate_system_prompt
+
+            invalidate_system_prompt(agent)
+        except Exception:
+            pass
     info = _session_info(agent, session) if agent is not None else {
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),


### PR DESCRIPTION
The AIAgent caches its system prompt on `_cached_system_prompt` for the lifetime of a session (prefix-cache optimization). When `session.cwd.set` updates the session cwd mid-conversation, the cached prompt's "Current working directory" line stays stale, so subsequent turns keep answering from the old cwd even though session["cwd"], terminal_tool overrides, and the session.info event all already reflect the new directory.

After a successful cwd change, drop the cached prompt so the next turn rebuilds it from the live context. The lazy/draft path (no agent yet) is left untouched.

Tests:
- test_session_cwd_set_invalidates_cached_system_prompt verifies the agent's _cached_system_prompt is cleared, session["cwd"] is updated, and the new cwd is persisted to the DB.
- test_session_cwd_set_skips_invalidation_when_no_agent guards the agent=None (lazy) path.
## What does this PR do?

Fixes a stale-cwd bug where the LLM keeps answering from the previous
working directory after `session.cwd.set` updates it mid-conversation.

`build_system_prompt()` caches the assembled system prompt on
`agent._cached_system_prompt` for the lifetime of a session
(prefix-cache optimization). When a desktop client like hermes-solo
calls `session.cwd.set` to switch workspaces mid-conversation, the
handler updates `session["cwd"]`, the terminal/file tool overrides, and
emits a `session.info` event, but the cached prompt's "Current working
directory" line stays stale. Subsequent turns therefore see the old
cwd even though every other surface (UI status bar, terminal tool,
session.info event) already shows the new one.

After a successful cwd change, this PR drops the cached prompt so the
next turn rebuilds it from the live context. The lazy/draft path
(`agent is None`) is left untouched.

## Related Issue

None yet — happy to file an issue first if maintainers prefer the
"discuss-then-implement" flow. Otherwise this PR can land standalone.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — In the `session.cwd.set` handler, after a
  successful `_set_session_cwd`, call
  `agent.system_prompt.invalidate_system_prompt(agent)` when an agent
  is present. Lazy imports + try/except so a missing/broken import
  doesn't kill the cwd change.
- `tests/test_tui_gateway_server.py` — Add two tests:
  - `test_session_cwd_set_invalidates_cached_system_prompt` — verifies
    `_cached_system_prompt` is cleared, `session["cwd"]` is updated,
    and the new cwd is persisted to the DB.
  - `test_session_cwd_set_skips_invalidation_when_no_agent` — guards
    the `agent is None` (lazy/draft) path.

## How to Test

Reproduction (manual, against a running dashboard):

1. Open a new chat session in a desktop client.
2. `session.cwd.set({cwd: "/path/A"})` and ask the agent "what is the
   current working directory?" — confirms cwd A is visible.
3. `session.cwd.set({cwd: "/path/B"})`.
4. Ask again. **Before this fix** the agent still answers "/path/A".
   **After this fix** the agent answers "/path/B".

Automated:
$ ./venv/bin/python -m pytest tests/test_tui_gateway_server.py -k session_cwd_set -v
============================= test session starts ==============================
...
tests/test_tui_gateway_server.py::test_session_cwd_set_invalidates_cached_system_prompt PASSED
tests/test_tui_gateway_server.py::test_session_cwd_set_skips_invalidation_when_no_agent PASSED
================= 2 passed, 199 deselected, 1 warning in 1.62s =================
Full file run is 200/201 (the one failure is
`test_browser_manage_connect_default_local_reports_launch_hint`, which
needs a Chromium-family browser that isn't installed in this
environment and is unrelated to this change).


## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all related tests pass (200/201
  on `test_tui_gateway_server.py`; the one failure is an unrelated
  browser-environment test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (no public API change;
  the fix only affects a private cache invalidation)
- [x] I've updated `cli-config.yaml.example` if I added/changed config
  keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed
  architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (Python-only logic,
  no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior
  — N/A (`session.cwd.set` itself is unchanged; only its side effects
  on the agent's cache are corrected)


