### PR TITLE
Tag direct OpenAI API traffic as Hermes Agent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -715,6 +715,9 @@ def init_agent(
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers
                 client_kwargs["default_headers"] = build_or_headers()
+            elif base_url_host_matches(effective_base, "api.openai.com"):
+                from agent.auxiliary_client import _openai_api_attribution_headers
+                client_kwargs["default_headers"] = _openai_api_attribution_headers()
             elif base_url_host_matches(effective_base, "integrate.api.nvidia.com"):
                 from agent.auxiliary_client import build_nvidia_nim_headers
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -376,6 +376,29 @@ _NVIDIA_NIM_CLOUD_HEADERS = {
 }
 
 
+def _openai_api_attribution_headers() -> Dict[str, str]:
+    """Headers that let OpenAI attribute direct API traffic to Hermes Agent."""
+    from hermes_cli import __version__ as _HERMES_VERSION
+
+    return {
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+        "originator": "hermes-agent",
+    }
+
+
+def _apply_openai_api_attribution_headers(
+    client_kwargs: Dict[str, Any],
+    base_url: str | None,
+) -> None:
+    """Attach Hermes attribution headers for the public OpenAI API only."""
+    if not base_url_host_matches(str(base_url or ""), "api.openai.com"):
+        return
+    existing = client_kwargs.get("default_headers")
+    headers = dict(existing) if isinstance(existing, dict) else {}
+    headers.update(_openai_api_attribution_headers())
+    client_kwargs["default_headers"] = headers
+
+
 def build_nvidia_nim_headers(base_url: str | None) -> dict:
     """Return NVIDIA NIM cloud attribution headers for build.nvidia.com traffic."""
     if base_url_host_matches(str(base_url or ""), "integrate.api.nvidia.com"):
@@ -1447,6 +1470,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 extra["default_headers"] = copilot_default_headers()
             elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
                 extra["default_headers"] = build_nvidia_nim_headers(base_url)
+            elif base_url_host_matches(base_url, "api.openai.com"):
+                extra["default_headers"] = _openai_api_attribution_headers()
             else:
                 try:
                     from providers import get_provider_profile as _gpf_aux
@@ -1484,6 +1509,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             extra["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             extra["default_headers"] = build_nvidia_nim_headers(base_url)
+        elif base_url_host_matches(base_url, "api.openai.com"):
+            extra["default_headers"] = _openai_api_attribution_headers()
         else:
             try:
                 from providers import get_provider_profile as _gpf_aux2
@@ -1882,6 +1909,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     _clean_base, _dq = _extract_url_query_params(custom_base)
     _extra = {"default_query": _dq} if _dq else {}
+    _apply_openai_api_attribution_headers(_extra, _clean_base)
     if custom_mode == "codex_responses":
         real_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
@@ -3237,6 +3265,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
+    elif base_url_host_matches(sync_base_url, "api.openai.com"):
+        async_kwargs["default_headers"] = _openai_api_attribution_headers()
     else:
         # Fall back to profile.default_headers for providers that declare
         # client-level headers on their ProviderProfile (e.g. attribution
@@ -3528,6 +3558,8 @@ def resolve_provider_client(
                 )
             elif base_url_host_matches(custom_base, "integrate.api.nvidia.com"):
                 extra["default_headers"] = build_nvidia_nim_headers(custom_base)
+            elif base_url_host_matches(custom_base, "api.openai.com"):
+                extra["default_headers"] = _openai_api_attribution_headers()
             else:
                 # Fall back to profile.default_headers for providers that
                 # declare client-level attribution headers on their profile.
@@ -3614,6 +3646,7 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                _apply_openai_api_attribution_headers(_extra2, _clean_base2)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -3636,6 +3669,7 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        _apply_openai_api_attribution_headers(_fb_extra, _fb_clean)
                         client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))
@@ -3773,6 +3807,8 @@ def resolve_provider_client(
             ))
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             headers.update(build_nvidia_nim_headers(base_url))
+        elif base_url_host_matches(base_url, "api.openai.com"):
+            headers.update(_openai_api_attribution_headers())
         else:
             # Fall back to profile.default_headers for providers that declare
             # client-level attribution headers on their profile (e.g. GMI

--- a/run_agent.py
+++ b/run_agent.py
@@ -3628,10 +3628,13 @@ class AIAgent:
         from agent.auxiliary_client import (
             build_nvidia_nim_headers,
             build_or_headers,
+            _openai_api_attribution_headers,
         )
 
         if base_url_host_matches(base_url, "openrouter.ai"):
             self._client_kwargs["default_headers"] = build_or_headers()
+        elif base_url_host_matches(base_url, "api.openai.com"):
+            self._client_kwargs["default_headers"] = _openai_api_attribution_headers()
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -917,6 +917,9 @@ class TestGetTextAuxiliaryClient:
         assert model == "gpt-5.3-codex"
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.openai.com/v1"
         assert mock_openai.call_args.kwargs["api_key"] == "sk-test"
+        headers = mock_openai.call_args.kwargs["default_headers"]
+        assert headers["originator"] == "hermes-agent"
+        assert headers["User-Agent"].startswith("HermesAgent/")
 
 
 class TestVisionClientFallback:
@@ -3253,6 +3256,29 @@ class TestNvidiaBillingHeaders:
         call_kwargs = mock_openai.call_args[1]
         headers = call_kwargs.get("default_headers", {})
         assert "X-BILLING-INVOKE-ORIGIN" not in headers
+
+
+class TestOpenAIAPIAttributionHeaders:
+    def test_resolve_provider_client_openai_api_adds_hermes_originator(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        mock_openai = MagicMock()
+        mock_openai.return_value = MagicMock(name="openai-api-client")
+
+        with patch("agent.auxiliary_client.OpenAI", mock_openai):
+            client, model = resolve_provider_client(
+                provider="openai-api",
+                model="gpt-5",
+            )
+
+        assert client is not None
+        assert model == "gpt-5"
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["base_url"] == "https://api.openai.com/v1"
+        headers = call_kwargs["default_headers"]
+        assert headers["originator"] == "hermes-agent"
+        assert headers["User-Agent"].startswith("HermesAgent/")
 
 
 class TestOpenRouterExplicitApiKey:

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -6,6 +6,71 @@ from run_agent import AIAgent
 
 
 @patch("run_agent.OpenAI")
+def test_openai_api_base_url_applies_hermes_originator_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        provider="openai-api",
+        model="gpt-5",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["originator"] == "hermes-agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+    init_headers = mock_openai.call_args.kwargs["default_headers"]
+    assert init_headers["originator"] == "hermes-agent"
+    assert init_headers["User-Agent"].startswith("HermesAgent/")
+
+    agent._apply_client_headers_for_base_url("https://api.openai.com/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["originator"] == "hermes-agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
+def test_openai_api_provider_default_applies_hermes_originator_headers(
+    mock_openai,
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mock_openai.return_value = MagicMock()
+
+    def _fake_routed_client(**kwargs):
+        return SimpleNamespace(
+            api_key=kwargs["api_key"],
+            base_url=kwargs["base_url"],
+            _custom_headers=kwargs.get("default_headers"),
+        )
+
+    with patch("agent.auxiliary_client.OpenAI", side_effect=_fake_routed_client) as routed_openai:
+        agent = AIAgent(
+            provider="openai-api",
+            model="gpt-5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    routed_headers = routed_openai.call_args.kwargs["default_headers"]
+    assert routed_headers["originator"] == "hermes-agent"
+    assert routed_headers["User-Agent"].startswith("HermesAgent/")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["originator"] == "hermes-agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+    init_headers = mock_openai.call_args.kwargs["default_headers"]
+    assert init_headers["originator"] == "hermes-agent"
+    assert init_headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
 def test_openrouter_base_url_applies_or_headers(mock_openai):
     mock_openai.return_value = MagicMock()
     agent = AIAgent(

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -403,9 +403,15 @@ class TrajectoryCompressor:
                     f"Missing API key. Set {self.config.api_key_env} "
                     f"environment variable.")
             from openai import OpenAI
-            from agent.auxiliary_client import _to_openai_base_url
+            from agent.auxiliary_client import (
+                _apply_openai_api_attribution_headers,
+                _to_openai_base_url,
+            )
+            base_url = _to_openai_base_url(self.config.base_url)
+            client_kwargs = {"api_key": api_key, "base_url": base_url}
+            _apply_openai_api_attribution_headers(client_kwargs, base_url)
             self.client = OpenAI(
-                api_key=api_key, base_url=_to_openai_base_url(self.config.base_url))
+                **client_kwargs)
             # AsyncOpenAI is created lazily in _get_async_client() so it
             # binds to the current event loop — avoids "Event loop is closed"
             # when process_directory() is called multiple times (each call
@@ -424,11 +430,19 @@ class TrajectoryCompressor:
         avoiding "Event loop is closed" errors on repeated calls.
         """
         from openai import AsyncOpenAI
-        from agent.auxiliary_client import _to_openai_base_url
+        from agent.auxiliary_client import (
+            _apply_openai_api_attribution_headers,
+            _to_openai_base_url,
+        )
+        base_url = _to_openai_base_url(self.config.base_url)
+        client_kwargs = {
+            "api_key": self._async_client_api_key,
+            "base_url": base_url,
+        }
+        _apply_openai_api_attribution_headers(client_kwargs, base_url)
         # Always create a fresh client so it binds to the running loop.
         self.async_client = AsyncOpenAI(
-            api_key=self._async_client_api_key,
-            base_url=_to_openai_base_url(self.config.base_url),
+            **client_kwargs,
         )
         return self.async_client
 


### PR DESCRIPTION
Hermes' direct OpenAI API path was creating OpenAI SDK clients without a stable attribution header, which means usage reporting could not separate Hermes traffic from generic OpenAI API calls.

This adds Hermes attribution only when the effective host is api.openai.com: originator: hermes-agent plus a HermesAgent/<version> User-Agent. The wiring covers the main AIAgent initialization and client rebuild path, auxiliary provider resolution/custom endpoint flows, async client conversion, and trajectory compression. The Codex runtime and ChatGPT Cloudflare path keeps its existing codex_cli_rs headers unchanged.

I also added regression coverage for the default openai-api provider flow, explicit api.openai.com base URLs, auxiliary resolution, and the codex_responses wrapper path.