### PR TITLE
fix(gateway): resolve uv pythonw for task launcher

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -335,13 +335,28 @@ def _build_gateway_cmd_script(
     lines.append(f'set "HERMES_HOME={hermes_home}"')
     lines.append('set "PYTHONIOENCODING=utf-8"')
     lines.append('set "HERMES_GATEWAY_DETACHED=1"')
-    # VIRTUAL_ENV lets the gateway's own python detection find the venv
-    # if someone imports hermes_constants-based logic during startup.
-    venv_dir = str(Path(python_path).resolve().parent.parent)
-    lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
 
-    pythonw_path = _derive_venv_pythonw(python_path)
-    prog_args = [pythonw_path, "-m", "hermes_cli.main"]
+    # Resolve the real pythonw.exe — for uv-created venvs the venv Scripts/
+    # pythonw is a redirector that spawns console python.exe, leaving a
+    # visible blank window.  Read pyvenv.cfg and use the base interpreter's
+    # pythonw.exe directly, with PYTHONPATH injected so imports resolve
+    # without the venv launcher shim.  (Same logic as _resolve_detached_python
+    # used by _spawn_detached / _build_gateway_argv.)
+    resolved_python, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
+    lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
+    if extra_pythonpath:
+        # Include working_dir first (so project code resolves), then the
+        # extra paths from the base interpreter (so venv site-packages etc.
+        # are found without the venv launcher shim).  Mirrors what
+        # _build_gateway_argv does via _prepend_pythonpath.
+        pp_entries = [working_dir, *extra_pythonpath]
+        lines.append(
+            'set "PYTHONPATH='
+            + os.pathsep.join(pp_entries)
+            + ';%PYTHONPATH%"'
+        )
+
+    prog_args = [resolved_python, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -150,7 +150,11 @@ def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
 
 def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypatch):
     """Scheduled Task wrapper should launch pythonw once and avoid replace loops."""
-    monkeypatch.setattr(gateway_windows, "_derive_venv_pythonw", lambda exe: exe.replace("python.exe", "pythonw.exe"))
+    monkeypatch.setattr(
+        gateway_windows,
+        "_resolve_detached_python",
+        lambda exe: (exe.replace("python.exe", "pythonw.exe"), Path(exe).parent.parent, []),
+    )
 
     content = gateway_windows._build_gateway_cmd_script(
         r"C:\\Hermes\\hermes-agent\\venv\\Scripts\\python.exe",
@@ -162,7 +166,57 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
     assert "pythonw.exe" in content
     assert "gateway run" in content
     assert "--replace" not in content
-    assert "start \"\"" not in content
+    assert 'start ""' not in content
+    assert "exit /b 0" in content
+    # When extra_pythonpath is empty, no PYTHONPATH set statement emitted
+    assert "PYTHONPATH" not in content
+
+
+def test_gateway_cmd_script_uses_base_pythonw_for_uv_venv(monkeypatch, tmp_path):
+    """Avoid uv's venv pythonw redirector in the .cmd script — same as the argv path."""
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    site_packages = project / "venv" / "Lib" / "site-packages"
+    base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
+    scripts.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    base.mkdir(parents=True)
+
+    venv_python = scripts / "python.exe"
+    venv_pythonw = scripts / "pythonw.exe"
+    base_pythonw = base / "pythonw.exe"
+    for exe in (venv_python, venv_pythonw, base_pythonw):
+        exe.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(
+        f"home = {base}\nimplementation = CPython\nuv = 0.11.14\nversion_info = 3.11.15\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+
+    content = gateway_windows._build_gateway_cmd_script(
+        str(venv_python),
+        str(project),
+        str(tmp_path / "hermes-home"),
+        "",
+    )
+
+    # The .cmd script should reference the base pythonw.exe, not scripts/pythonw.exe
+    assert str(base_pythonw) in content
+    assert str(venv_pythonw) not in content
+    assert "gateway run" in content
+
+    # VIRTUAL_ENV should point at the venv dir
+    assert f"VIRTUAL_ENV={project / 'venv'}" in content
+
+    # PYTHONPATH should include working_dir first and site-packages
+    assert f"PYTHONPATH={project}" in content
+    assert str(site_packages) in content
+    assert f";%PYTHONPATH%\"" in content
+
+    # No replace, no start churn
+    assert "--replace" not in content
+    assert 'start ""' not in content
     assert "exit /b 0" in content
 
 


### PR DESCRIPTION
Fixes #38387

## What changed

- Updated the Windows gateway Scheduled Task `.cmd` launcher to resolve the detached interpreter through `_resolve_detached_python()`.
- For uv-created venvs, the generated script now launches the base `pythonw.exe` directly instead of the venv `Scripts/pythonw.exe` redirector.
- Preserves `VIRTUAL_ENV` and injects `PYTHONPATH` with the project root plus venv site-packages so imports still resolve when bypassing the redirector.
- Added regression coverage for the generated `.cmd` script path.

## Behavior proof

Generated-script proof using a temporary uv-style venv layout:

```text
$ cd /Users/allahyar/Documents/fastino-tasks/hermes-tui-38387b
$ .venv/bin/python - <<'PY'
from pathlib import Path
from tempfile import TemporaryDirectory
import hermes_cli.gateway_windows as gateway_windows

with TemporaryDirectory() as tmp:
    root = Path(tmp)
    project = root / "project"
    scripts = project / "venv" / "Scripts"
    site_packages = project / "venv" / "Lib" / "site-packages"
    base = root / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
    scripts.mkdir(parents=True)
    site_packages.mkdir(parents=True)
    base.mkdir(parents=True)
    venv_python = scripts / "python.exe"
    venv_pythonw = scripts / "pythonw.exe"
    base_pythonw = base / "pythonw.exe"
    for exe in (venv_python, venv_pythonw, base_pythonw):
        exe.write_text("", encoding="utf-8")
    (project / "venv" / "pyvenv.cfg").write_text(
        f"home = {base}\nimplementation = CPython\nuv = 0.11.14\nversion_info = 3.11.15\n",
        encoding="utf-8",
    )

    original_platform = gateway_windows.sys.platform
    gateway_windows.sys.platform = "win32"
    try:
        content = gateway_windows._build_gateway_cmd_script(
            str(venv_python),
            str(project),
            str(root / "hermes-home"),
            "",
        )
    finally:
        gateway_windows.sys.platform = original_platform

    print("base_pythonw_in_script=", str(base_pythonw) in content)
    print("venv_pythonw_in_script=", str(venv_pythonw) in content)
    for line in content.splitlines():
        if "VIRTUAL_ENV" in line or "PYTHONPATH" in line or "hermes_cli.main" in line:
            print(line)
PY
base_pythonw_in_script= True
venv_pythonw_in_script= False
set "VIRTUAL_ENV=/var/folders/zt/6txd70rn1wn9x37_3hkv_ft80000gn/T/tmpqbkdujth/project/venv"
set "PYTHONPATH=/var/folders/zt/6txd70rn1wn9x37_3hkv_ft80000gn/T/tmpqbkdujth/project:/var/folders/zt/6txd70rn1wn9x37_3hkv_ft80000gn/T/tmpqbkdujth/project/venv/Lib/site-packages;%PYTHONPATH%"
/var/folders/zt/6txd70rn1wn9x37_3hkv_ft80000gn/T/tmpqbkdujth/uv/python/cpython-3.11-windows-x86_64-none/pythonw.exe -m hermes_cli.main gateway run
```

## Tests

```text
$ cd /Users/allahyar/Documents/fastino-tasks/hermes-tui-38387b
$ scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -- -v --tb=short
running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
Discovered 1 test files (0 tests) under ['tests/hermes_cli/test_gateway_windows.py']; running with -j 36
[  0.0% |     0/0 | ✓32 | ✗ 0] ✓ tests/hermes_cli/test_gateway_windows.py (32✓, 4.0s)

=== Summary: 1 files, 32 tests passed, 0 failed (0% complete) in 4.0s (36 workers) ===
```

## Platform

- Tested locally on macOS with the repository test wrapper.
- The changed code path is Windows-specific and is covered by the generated `.cmd` script proof above.
