### PR TITLE
feat(plugin-providers): add neosantara provider to `plugins/`

### DIFF
--- a/plugins/model-providers/neosantara/__init__.py
+++ b/plugins/model-providers/neosantara/__init__.py
@@ -1,0 +1,26 @@
+"""Neosantara provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+neosantara = ProviderProfile(
+    name="neosantara",
+    aliases=("ns",),
+    display_name="Neosantara",
+    description="Neosantara - AI Gateway Indonesia",
+    signup_url="https://app.neosantara.xyz/api-keys",
+    env_vars=("NEOSANTARA_API_KEY", "NEOSANTARA_BASE_URL"),
+    base_url="https://api.neosantara.xyz/v1",
+    models_url="https://api.neosantara.xyz/v1/models",
+    auth_type="api_key",
+    default_aux_model="garda-core",
+    fallback_models=(
+        "garda-core",
+        "neosantara-gen-2045",
+        "grok-4.1-fast-non-reasoning",
+        "claude-3-haiku",
+        "gemini-3.1-flash-lite-preview",
+    ),
+)
+
+register_provider(neosantara)

--- a/plugins/model-providers/neosantara/plugin.yaml
+++ b/plugins/model-providers/neosantara/plugin.yaml
@@ -1,0 +1,5 @@
+name: neosantara-provider
+kind: model-provider
+version: 1.0.0
+description: Neosantara - AI Gateway Indonesia
+author: Neosantara

--- a/tests/plugins/model_providers/test_neosantara_profile.py
+++ b/tests/plugins/model_providers/test_neosantara_profile.py
@@ -1,0 +1,71 @@
+"""Focused tests for the Neosantara model provider profile."""
+
+from __future__ import annotations
+
+
+def test_neosantara_profile_fields():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("neosantara")
+
+    assert profile is not None
+    assert profile.name == "neosantara"
+    assert profile.aliases == ("ns",)
+    assert profile.display_name == "Neosantara"
+    assert profile.signup_url == "https://app.neosantara.xyz/api-keys"
+    assert profile.env_vars == (
+        "NEOSANTARA_API_KEY",
+        "NEOSANTARA_BASE_URL",
+    )
+    assert profile.base_url == "https://api.neosantara.xyz/v1"
+    assert profile.models_url == "https://api.neosantara.xyz/v1/models"
+    assert profile.default_aux_model == "garda-core"
+    assert profile.fallback_models
+
+
+def test_neosantara_provider_alias_resolves():
+    from providers import get_provider_profile
+
+    assert get_provider_profile("ns").name == "neosantara"
+
+
+def test_neosantara_auto_registers_auth_config():
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    config = PROVIDER_REGISTRY["neosantara"]
+
+    assert config.name == "Neosantara"
+    assert config.auth_type == "api_key"
+    assert config.inference_base_url == "https://api.neosantara.xyz/v1"
+    assert config.api_key_env_vars == ("NEOSANTARA_API_KEY",)
+    assert config.base_url_env_var == "NEOSANTARA_BASE_URL"
+
+
+def test_neosantara_env_vars_are_exposed_to_setup():
+    from hermes_cli.config import OPTIONAL_ENV_VARS
+
+    assert OPTIONAL_ENV_VARS["NEOSANTARA_API_KEY"]["url"] == (
+        "https://app.neosantara.xyz/api-keys"
+    )
+    assert OPTIONAL_ENV_VARS["NEOSANTARA_API_KEY"]["category"] == "provider"
+    assert OPTIONAL_ENV_VARS["NEOSANTARA_API_KEY"]["password"] is True
+    assert OPTIONAL_ENV_VARS["NEOSANTARA_BASE_URL"]["password"] is False
+
+
+def test_neosantara_provider_model_ids_falls_back_to_profile_models(monkeypatch):
+    from providers import get_provider_profile
+    from hermes_cli.models import provider_model_ids
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda provider_id: {
+            "provider": provider_id,
+            "api_key": "",
+            "base_url": "https://api.neosantara.xyz/v1",
+            "source": "test",
+        },
+    )
+
+    models = provider_model_ids("neosantara")
+
+    assert models == list(get_provider_profile("neosantara").fallback_models)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Neosantara is an Indonesia-based AI gateway with OpenAI-compatible chat
  completions and a local billing experience, including Rupiah-denominated
  balance/usage flows. Before this change, users could only configure it
  manually as a custom endpoint, which hid the provider identity, setup URL,
  model fallback list, and regional billing context.

This is the right approach because Neosantara already exposes an OpenAI-
  compatible /v1/chat/completions API, so Hermes does not need a custom
  adapter or changes in `run_agent.py`

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

https://github.com/NousResearch/hermes-agent/issues/38595

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added `plugins/model-providers/neosantara/__init__.py` with a `ProviderProfile` for the Neosantara OpenAI-compatible gateway.
- Added `plugins/model-providers/neosantara/plugin.yaml` so Hermes can categorize the provider plugin.
- Added `tests/plugins/model_providers/test_neosantara_profile.py` covering provider discovery, alias resolution, auth auto-registration, setup env vars, and fallback model behavior.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `UV_CACHE_DIR=.uv-cache uv run --extra dev pytest -q tests/plugins/model_providers/test_neosantara_profile.py`
2. Run `UV_CACHE_DIR=.uv-cache uv run --extra dev pytest -q tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py tests/plugins/model_providers/test_neosantara_profile.py`
3. Run `UV_CACHE_DIR=.uv-cache uv run --extra dev ruff check plugins/model-providers/neosantara tests/plugins/model_providers/test_neosantara_profile.py`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (only specific for this feature)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

