### PR TITLE
fix(mcp): ensure server.shutdown() on probe iteration failure

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -225,13 +225,15 @@ def _probe_single_server(
         server = await asyncio.wait_for(
             _connect_server(name, config), timeout=connect_timeout
         )
-        for t in server._tools:
-            desc = getattr(t, "description", "") or ""
-            # Truncate long descriptions for display
-            if len(desc) > 80:
-                desc = desc[:77] + "..."
-            tools_found.append((t.name, desc))
-        await server.shutdown()
+        try:
+            for t in server._tools:
+                desc = getattr(t, "description", "") or ""
+                # Truncate long descriptions for display
+                if len(desc) > 80:
+                    desc = desc[:77] + "..."
+                tools_found.append((t.name, desc))
+        finally:
+            await server.shutdown()
 
     try:
         _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)


### PR DESCRIPTION
## Summary

Wrap the `_tools` iteration in `_probe_single_server()` in `try/finally` so that `server.shutdown()` is always called, even if iterating tool metadata raises.

### Bug

In `hermes_cli/mcp_config.py`, the `_probe()` coroutine connects to an MCP server, iterates `server._tools`, then calls `server.shutdown()`. If the iteration raises (e.g., corrupted tool metadata, attribute error on tool objects), `server.shutdown()` is skipped and the connection leaks until `_stop_mcp_loop()` tears down the entire event loop.

### Fix

```python
async def _probe():
    server = await asyncio.wait_for(
        _connect_server(name, config), timeout=connect_timeout
    )
    try:
        for t in server._tools:
            ...
    finally:
        await server.shutdown()
```

### Impact

- **Before**: Partial tool metadata corruption causes connection leak
- **After**: Connection is always cleaned up properly