### PR TITLE
fix(tts): check HTTP status before parsing MiniMax t2a_v2 response

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1258,6 +1258,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
         }
 
     response = requests.post(base_url, json=payload, headers=headers, timeout=60)
+    response.raise_for_status()
 
     if is_t2a_v2:
         # t2a_v2 returns JSON with hex-encoded audio


### PR DESCRIPTION
## Summary

Add `response.raise_for_status()` after the `requests.post()` call in `_generate_minimax_tts()` to catch HTTP errors before attempting to parse the response as JSON.

### Bug

When MiniMax TTS API returns HTTP 4xx/5xx (e.g., rate limit, auth failure, server error), the t2a_v2 code path calls `response.json()` directly. If the error response is HTML (common for 502/503 from proxies) or non-JSON, this raises `JSONDecodeError` instead of a meaningful HTTP error.

The non-t2a_v2 code path already handles this correctly at line 1299 (`response.raise_for_status()` in the fallback). This fix makes both paths consistent.

### Fix

```python
response = requests.post(base_url, json=payload, headers=headers, timeout=60)
response.raise_for_status()  # <-- added

if is_t2a_v2:
    result = response.json()
```

### Impact

- **Before**: HTTP errors from MiniMax may cause confusing `JSONDecodeError`
- **After**: HTTP errors raise `requests.HTTPError` with status code and message