### PR TITLE
feat(weixin): populate optional iLink media fields (video play_length, image aeskey/hd_size, file md5)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -22,6 +22,7 @@ import os
 import re
 import secrets
 import struct
+import subprocess
 import tempfile
 import textwrap
 import time
@@ -156,6 +157,39 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 def check_weixin_requirements() -> bool:
     """Return True when runtime dependencies for Weixin are available."""
     return AIOHTTP_AVAILABLE and CRYPTO_AVAILABLE
+
+
+def _ffprobe_duration_ms(path: str) -> Optional[int]:
+    """Return media duration in milliseconds via ``ffprobe``.
+
+    Returns None when ffprobe is missing, the call fails, or the duration is
+    unavailable. The iLink spec marks ``video_item.play_length`` (and
+    ``voice_item.playtime``) as optional and expressed in milliseconds, so a
+    missing value is non-fatal — callers simply omit the field and let the
+    client default it. This keeps ffprobe an optional, best-effort dependency
+    rather than a hard requirement for sending media.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = (result.stdout or "").strip()
+    if not raw or raw == "N/A":
+        return None
+    try:
+        return int(float(raw) * 1000)
+    except ValueError:
+        return None
 
 
 def _safe_id(value: Optional[str], keep: int = 8) -> str:
@@ -2022,6 +2056,9 @@ class WeixinAdapter(BasePlatformAdapter):
         item_kwargs = {
             "encrypt_query_param": encrypted_query_param,
             "aes_key_for_api": aes_key_for_api,
+            # aes_key as hex (spec field ``aeskey``); some clients read this
+            # instead of the base64 ``aes_key``. Cheap to send both.
+            "aes_key_hex": aes_key.hex(),
             "ciphertext_size": len(ciphertext),
             "plaintext_size": rawsize,
             "filename": Path(path).name,
@@ -2031,6 +2068,12 @@ class WeixinAdapter(BasePlatformAdapter):
             item_kwargs["encode_type"] = 6
             item_kwargs["sample_rate"] = 24000
             item_kwargs["bits_per_sample"] = 16
+        elif media_type == MEDIA_VIDEO:
+            # Real duration (ms) so the client shows the video length badge
+            # instead of "0s". Omitted when ffprobe is unavailable.
+            duration_ms = _ffprobe_duration_ms(path)
+            if duration_ms is not None:
+                item_kwargs["play_length"] = duration_ms
         media_item = item_builder(**item_kwargs)
 
         last_message_id = None
@@ -2078,7 +2121,9 @@ class WeixinAdapter(BasePlatformAdapter):
                         "aes_key": kw["aes_key_for_api"],
                         "encrypt_type": 1,
                     },
+                    "aeskey": kw["aes_key_hex"],
                     "mid_size": kw["ciphertext_size"],
+                    "hd_size": kw["ciphertext_size"],
                 },
             }
         if mime.startswith("video/"):
@@ -2120,6 +2165,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         "encrypt_type": 1,
                     },
                     "file_name": kw["filename"],
+                    "md5": kw["rawfilemd5"],
                     "len": str(kw["plaintext_size"]),
                 },
             }
@@ -2132,6 +2178,7 @@ class WeixinAdapter(BasePlatformAdapter):
                     "encrypt_type": 1,
                 },
                 "file_name": kw["filename"],
+                "md5": kw["rawfilemd5"],
                 "len": str(kw["plaintext_size"]),
             },
         }

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -636,12 +637,91 @@ class TestWeixinMediaBuilder:
         item = builder(
             encrypt_query_param="eq",
             aes_key_for_api=expected_aes,
+            aes_key_hex=fake_hex_key,
             ciphertext_size=1024,
             plaintext_size=1000,
             filename="photo.jpg",
             rawfilemd5="abc123",
         )
         assert item["image_item"]["media"]["aes_key"] == expected_aes
+
+    def test_image_builder_includes_aeskey_hex_and_hd_size(self):
+        adapter = _make_adapter()
+        _, builder = adapter._outbound_media_builder("photo.jpg")
+        fake_hex_key = "0123456789abcdef0123456789abcdef"
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="ignored",
+            aes_key_hex=fake_hex_key,
+            ciphertext_size=1024,
+            plaintext_size=1000,
+            filename="photo.jpg",
+            rawfilemd5="abc123",
+        )
+        # aeskey is the hex form of the key (spec field, hex not base64).
+        assert item["image_item"]["aeskey"] == fake_hex_key
+        # hd_size lets the client resolve the HD image variant.
+        assert item["image_item"]["hd_size"] == 1024
+
+    def test_file_builder_includes_md5(self):
+        adapter = _make_adapter()
+        # .bin falls through to the generic file branch.
+        _, builder = adapter._outbound_media_builder("report.bin")
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="fakekey",
+            aes_key_hex="00",
+            ciphertext_size=512,
+            plaintext_size=500,
+            filename="report.bin",
+            rawfilemd5="9d2a7b9c",
+        )
+        assert item["type"] == weixin.ITEM_FILE
+        assert item["file_item"]["md5"] == "9d2a7b9c"
+
+    def test_audio_file_builder_includes_md5(self):
+        adapter = _make_adapter()
+        _, builder = adapter._outbound_media_builder("note.mp3")
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="fakekey",
+            aes_key_hex="00",
+            ciphertext_size=512,
+            plaintext_size=500,
+            filename="note.mp3",
+            rawfilemd5="abc",
+        )
+        assert item["file_item"]["md5"] == "abc"
+
+    def test_video_builder_uses_real_play_length_when_probed(self):
+        adapter = _make_adapter()
+        _, builder = adapter._outbound_media_builder("clip.mp4")
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="fakekey",
+            aes_key_hex="00",
+            ciphertext_size=2048,
+            plaintext_size=2000,
+            filename="clip.mp4",
+            rawfilemd5="deadbeef",
+            play_length=18320,
+        )
+        assert item["video_item"]["play_length"] == 18320
+
+    def test_video_builder_defaults_play_length_to_zero(self):
+        adapter = _make_adapter()
+        _, builder = adapter._outbound_media_builder("clip.mp4")
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="fakekey",
+            aes_key_hex="00",
+            ciphertext_size=2048,
+            plaintext_size=2000,
+            filename="clip.mp4",
+            rawfilemd5="deadbeef",
+        )
+        # ffprobe unavailable -> field omitted upstream -> builder falls back to 0.
+        assert item["video_item"]["play_length"] == 0
 
     def test_video_builder_includes_md5(self):
         adapter = _make_adapter()
@@ -678,6 +758,36 @@ class TestWeixinMediaBuilder:
         adapter = _make_adapter()
         media_type, builder = adapter._outbound_media_builder("recording.silk")
         assert media_type == weixin.MEDIA_VOICE
+
+
+class TestWeixinFfprobeDuration:
+    """``_ffprobe_duration_ms`` is best-effort: failures degrade to None."""
+
+    def test_missing_ffprobe_returns_none(self):
+        with patch.object(weixin.subprocess, "run", side_effect=FileNotFoundError):
+            assert weixin._ffprobe_duration_ms("clip.mp4") is None
+
+    def test_nonzero_exit_returns_none(self):
+        fake = SimpleNamespace(returncode=1, stdout="", stderr="boom")
+        with patch.object(weixin.subprocess, "run", return_value=fake):
+            assert weixin._ffprobe_duration_ms("clip.mp4") is None
+
+    def test_na_duration_returns_none(self):
+        fake = SimpleNamespace(returncode=0, stdout="N/A\n", stderr="")
+        with patch.object(weixin.subprocess, "run", return_value=fake):
+            assert weixin._ffprobe_duration_ms("clip.mp4") is None
+
+    def test_seconds_converted_to_milliseconds(self):
+        fake = SimpleNamespace(returncode=0, stdout="18.32\n", stderr="")
+        with patch.object(weixin.subprocess, "run", return_value=fake):
+            assert weixin._ffprobe_duration_ms("clip.mp4") == 18320
+
+    def test_timeout_returns_none(self):
+        with patch.object(
+            weixin.subprocess, "run",
+            side_effect=weixin.subprocess.TimeoutExpired(cmd="ffprobe", timeout=10),
+        ):
+            assert weixin._ffprobe_duration_ms("clip.mp4") is None
 
 
 class TestWeixinSendImageFileParameterName:


### PR DESCRIPTION
## What

Populate the optional `iLink` Bot media-item fields that the Weixin outbound
builder currently leaves empty. All of these are documented as optional in the
iLink spec; emitting them gives the receiving WeChat client metadata it can
already use.

- **Video `play_length`** — was hard-coded to `0`, so the client never showed a
  duration badge. We now probe the real duration with `ffprobe` and send it in
  milliseconds (the spec expresses `play_length` in ms).
- **Image `aeskey` + `hd_size`** — emit the hex form of the AES key alongside the
  existing base64 `aes_key` (some clients read the hex `aeskey` field), and send
  `hd_size` so the HD image variant resolves.
- **File `md5`** — emit the raw-file md5 for integrity, matching the spec example.

## Why

These fields are all spec-defined and optional, but omitting them degrades the
receiver UX (most visibly: every outbound video shows `0s`).

## ffprobe is best-effort, not a hard dependency

`_ffprobe_duration_ms` returns `None` when `ffprobe` is missing, errors, or times
out. In that case the caller omits `play_length` and the builder falls back to
`0` — i.e. behavior is **identical to today** when ffprobe is unavailable. No new
required dependency is introduced.

## Tests

`tests/gateway/test_weixin.py`:
- builder now emits `aeskey`/`hd_size` (image), `md5` (file + audio-fallback),
  and real `play_length` (video, with 0 fallback)
- `_ffprobe_duration_ms` degradation paths: missing binary, non-zero exit,
  `N/A` duration, timeout, and the seconds→ms conversion

```
75 passed
```
