### PR TITLE
fix(cli): restore session cwd on mid-chat /resume and /sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7032,6 +7032,14 @@ class HermesCLI:
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 
+        # Retarget the process + tool cwd to where the session was started, so a
+        # mid-chat /resume (and /sessions <id>, which delegates here) lands in the
+        # same directory as a startup `hermes -c`/`--resume`. The startup resume
+        # paths already call this; without it, the terminal/code-exec tools and
+        # relative-path resolution keep operating in the wrong repo. Idempotent
+        # and a no-op when the session recorded no cwd. See #38562.
+        self._restore_session_cwd(session_meta)
+
     def _consume_pending_resume_selection(self, text: str) -> bool:
         """Resolve a bare numeric reply that follows a bare ``/resume`` prompt.
 

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
@@ -117,6 +118,78 @@ class TestCliResumeCommand:
 
         printed = " ".join(str(call) for call in mock_cprint.call_args_list)
         assert "<half" in printed
+
+
+class TestCliResumeRestoresCwd:
+    """Mid-chat /resume must retarget the working directory to where the
+    session was started — the same contract as a startup ``hermes -c`` /
+    ``--resume``.
+
+    Regression coverage for #38562: ``_restore_session_cwd()`` was wired into
+    the startup resume paths but not into ``_handle_resume_command()``, so an
+    interactive ``/resume`` (and ``/sessions <id>``, which delegates here) left
+    the process + ``TERMINAL_CWD`` pointing at whatever directory the user had
+    cd'd into — so the terminal/code-exec tools and relative paths ran in the
+    wrong repo.
+    """
+
+    def _resumable_cli(self, session_meta):
+        cli_obj = _make_cli()
+        cli_obj._session_db.get_session.return_value = session_meta
+        cli_obj._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hello"},
+        ]
+        cli_obj._session_db.resolve_resume_session_id.return_value = session_meta["id"]
+        return cli_obj
+
+    def test_handle_resume_restores_recorded_cwd(self, tmp_path):
+        recorded = str(tmp_path)
+        cli_obj = self._resumable_cli({"id": "sess_dir", "title": "Dir", "cwd": recorded})
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="sess_dir"),
+            patch("cli._cprint"),
+            patch.object(cli_obj, "_console_print"),
+            patch("os.chdir") as mock_chdir,
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            cli_obj._handle_resume_command("/resume Dir")
+            # Assert inside the patch.dict scope — it restores os.environ on exit.
+            assert os.environ.get("TERMINAL_CWD") == recorded
+
+        mock_chdir.assert_called_once_with(recorded)
+
+    def test_handle_resume_without_recorded_cwd_does_not_chdir(self):
+        # Gateway/remote/older sessions record no cwd — restore must no-op.
+        cli_obj = self._resumable_cli({"id": "sess_dir", "title": "Dir"})
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="sess_dir"),
+            patch("cli._cprint"),
+            patch.object(cli_obj, "_console_print"),
+            patch("os.chdir") as mock_chdir,
+        ):
+            cli_obj._handle_resume_command("/resume Dir")
+
+        mock_chdir.assert_not_called()
+
+    def test_sessions_command_restores_recorded_cwd(self, tmp_path):
+        # /sessions <id> delegates to the resume flow, so it restores cwd too.
+        recorded = str(tmp_path)
+        cli_obj = self._resumable_cli({"id": "sess_dir", "title": "Dir", "cwd": recorded})
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="sess_dir"),
+            patch("cli._cprint"),
+            patch.object(cli_obj, "_console_print"),
+            patch("os.chdir") as mock_chdir,
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            cli_obj._handle_sessions_command("/sessions Dir")
+            # Assert inside the patch.dict scope — it restores os.environ on exit.
+            assert os.environ.get("TERMINAL_CWD") == recorded
+
+        mock_chdir.assert_called_once_with(recorded)
 
 
 class TestPendingResumeNumberedSelection:


### PR DESCRIPTION


## What & Why

A startup `hermes -c` / `--resume` correctly relaunches a session in the
directory it was started from (#38562). The same guarantee was missing for
the interactive `/resume` and `/sessions <id>` commands.

`_restore_session_cwd()` was only wired into the startup resume paths, so a
mid-conversation `/resume` loaded the transcript but left the process and
`TERMINAL_CWD` pointing at wherever the user happened to be. As a result the
`terminal` and `execute_code` tools — and all relative-path resolution — ran
against the wrong project, with a real risk of writes landing in the wrong
repository.

## Change

`_handle_resume_command()` now calls `_restore_session_cwd(session_meta)`
after the session is loaded, matching the startup behavior. Because
`/sessions <id>` delegates to the same handler, a single call fixes both
commands.

The helper is idempotent and safe: it no-ops when the session recorded no
`cwd` (gateway/remote/older sessions) or when already in that directory, and
degrades to a single dim warning when the directory no longer exists.

## How to Test

1. Start `hermes` in project A and exchange a message (session A is created).
2. Change into project B.
3. In the same CLI, run `/resume <session A>` (or `/sessions <session A>`).
4. The working directory is restored to project A — `terminal`, `read_file`,
   `patch`, and relative paths now resolve there.

## Tests

Added regression coverage in `tests/cli/test_cli_resume_command.py`
(`TestCliResumeRestoresCwd`):

- `/resume` restores the recorded `cwd` (`os.chdir` + `TERMINAL_CWD`)
- `/resume` is a no-op when no `cwd` was recorded
- `/sessions <id>` restores the `cwd` via delegation

### Results

| Suite | Result |
|------|--------|
| `tests/cli/test_cli_resume_command.py` (incl. 3 new) | 15 passed |
| `tests/cli/test_cli_init.py` | 41 passed |
| `tests/cli/test_resume_display.py` | 40 passed |
| `tests/cli/test_cwd_env_respect.py` | 9 passed |
| `tests/cli/test_resume_quiet_stderr.py` | 4 passed |
| `tests/gateway/test_resume_command.py` | passed |

No regressions in the resume/session/cwd paths.

Closes #38562 (interactive resume parity).