### PR TITLE
fix(desktop): sync file attachments to remote workspace

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -1,0 +1,158 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $composerAttachments, clearComposerAttachments, type ComposerAttachment } from '@/store/composer'
+
+import type { ClientSessionState } from '../../types'
+
+import { usePromptActions } from './use-prompt-actions'
+
+const INITIAL_SESSION_STATE: ClientSessionState = {
+  storedSessionId: null,
+  messages: [],
+  branch: '',
+  cwd: '',
+  busy: false,
+  awaitingResponse: false,
+  streamId: null,
+  sawAssistantPayload: false,
+  pendingBranchGroup: null,
+  interrupted: false
+}
+
+function fileAttachment(): ComposerAttachment {
+  return {
+    id: 'file:report.txt',
+    kind: 'file',
+    label: 'report.txt',
+    path: '/Users/alice/Downloads/report.txt',
+    refText: '@file:`/Users/alice/Downloads/report.txt`'
+  }
+}
+
+function PromptActionsHarness({
+  onReady,
+  requestGateway,
+  updateSessionState
+}: {
+  onReady: (submitText: (text: string) => Promise<boolean>) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}) {
+  const activeSessionIdRef = useRef<string | null>('sid')
+  const busyRef = useRef(false)
+  const selectedStoredSessionIdRef = useRef<string | null>(null)
+
+  const actions = usePromptActions({
+    activeSessionId: 'sid',
+    activeSessionIdRef,
+    busyRef,
+    branchCurrentSession: vi.fn(async () => false),
+    createBackendSessionForSend: vi.fn(async () => 'sid'),
+    handleSkinCommand: vi.fn(() => ''),
+    requestGateway,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft: vi.fn(),
+    sttEnabled: false,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    onReady(actions.submitText)
+  }, [actions.submitText, onReady])
+
+  return null
+}
+
+describe('usePromptActions file attachment sync', () => {
+  beforeEach(() => {
+    clearComposerAttachments()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        readFileDataUrl: vi.fn(async () => 'data:text/plain;base64,aGVsbG8gd29ybGQ=')
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearComposerAttachments()
+    vi.restoreAllMocks()
+  })
+
+  it('submits synced file refs instead of the local desktop path', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+    const states = new Map<string, ClientSessionState>()
+    let submitText: ((text: string) => Promise<boolean>) | null = null
+
+    $composerAttachments.set([fileAttachment()])
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'file.attach') {
+        return {
+          attached: true,
+          path: '/remote/work/.hermes/desktop-attachments/report.txt',
+          ref_text: '@file:.hermes/desktop-attachments/report.txt',
+          uploaded: true
+        }
+      }
+
+      if (method === 'prompt.submit') {
+        return { status: 'streaming' }
+      }
+
+      throw new Error(`Unexpected gateway method: ${method}`)
+    })
+
+    const updateSessionState = vi.fn(
+      (sessionId: string, updater: (state: ClientSessionState) => ClientSessionState) => {
+        const next = updater(states.get(sessionId) ?? INITIAL_SESSION_STATE)
+        states.set(sessionId, next)
+
+        return next
+      }
+    )
+
+    render(
+      <PromptActionsHarness
+        onReady={fn => {
+          submitText = fn
+        }}
+        requestGateway={requestGateway}
+        updateSessionState={updateSessionState}
+      />
+    )
+
+    await waitFor(() => {
+      expect(submitText).not.toBeNull()
+    })
+
+    await act(async () => {
+      const ok = await submitText?.('convert this to epub')
+      expect(ok).toBe(true)
+    })
+
+    expect(calls.map(call => call.method)).toEqual(['file.attach', 'prompt.submit'])
+    expect(calls[0]?.params).toMatchObject({
+      session_id: 'sid',
+      path: '/Users/alice/Downloads/report.txt',
+      name: 'report.txt'
+    })
+    expect(calls[1]?.params).toEqual({
+      session_id: 'sid',
+      text: '@file:.hermes/desktop-attachments/report.txt\n\nconvert this to epub'
+    })
+    expect(states.get('sid')?.messages.at(-1)?.attachmentRefs).toEqual([
+      '@file:.hermes/desktop-attachments/report.txt'
+    ])
+    expect($composerAttachments.get()).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -39,7 +39,7 @@ import {
   setYoloActive
 } from '@/store/session'
 
-import type { ClientSessionState, ImageAttachResponse, SlashExecResponse } from '../../types'
+import type { ClientSessionState, FileAttachResponse, ImageAttachResponse, SlashExecResponse } from '../../types'
 
 function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -55,6 +55,16 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     reader.addEventListener('error', () => reject(reader.error || new Error('Could not read recorded audio')))
     reader.readAsDataURL(blob)
   })
+}
+
+async function readAttachmentDataUrl(filePath: string): Promise<string> {
+  const reader = window.hermesDesktop?.readFileDataUrl
+
+  if (!reader) {
+    throw new Error('Desktop file bridge unavailable')
+  }
+
+  return await reader(filePath)
 }
 
 function isProviderSetupError(error: unknown) {
@@ -173,42 +183,81 @@ export function usePromptActions({
     [selectedStoredSessionIdRef, updateSessionState]
   )
 
-  const syncImageAttachmentsForSubmit = useCallback(
+  const syncAttachmentsForSubmit = useCallback(
     async (
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
     ) => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
-      const images = attachments.filter(attachment => attachment.kind === 'image' && attachment.path)
+      const synced: ComposerAttachment[] = []
 
-      for (const attachment of images) {
-        if (attachment.attachedSessionId === sessionId) {
+      for (const attachment of attachments) {
+        if (!attachment.path || attachment.attachedSessionId === sessionId) {
+          synced.push(attachment)
           continue
         }
 
-        const result = await requestGateway<ImageAttachResponse>('image.attach', {
-          session_id: sessionId,
-          path: attachment.path
-        })
+        if (attachment.kind === 'image') {
+          const result = await requestGateway<ImageAttachResponse>('image.attach', {
+            session_id: sessionId,
+            path: attachment.path
+          })
 
-        if (!result.attached) {
-          const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')
-          throw new Error(result.message || `Could not attach ${label}`)
-        }
+          if (!result.attached) {
+            const label = attachment.label || pathLabel(attachment.path)
+            throw new Error(result.message || `Could not attach ${label}`)
+          }
 
-        const attachedPath = result.path || attachment.path
-
-        if (updateComposerAttachments) {
-          addComposerAttachment({
+          const attachedPath = result.path || attachment.path
+          const nextAttachment = {
             ...attachment,
             id: attachment.id,
             label: attachedPath ? pathLabel(attachedPath) : attachment.label,
             path: attachedPath,
             attachedSessionId: sessionId
-          })
+          }
+
+          if (updateComposerAttachments) {
+            addComposerAttachment(nextAttachment)
+          }
+
+          synced.push(nextAttachment)
+          continue
         }
+
+        if (attachment.kind === 'file') {
+          const result = await requestGateway<FileAttachResponse>('file.attach', {
+            session_id: sessionId,
+            path: attachment.path,
+            data_url: await readAttachmentDataUrl(attachment.path),
+            name: attachment.label || pathLabel(attachment.path)
+          })
+
+          if (!result.attached || !result.ref_text) {
+            const label = attachment.label || pathLabel(attachment.path)
+            throw new Error(result.message || `Could not attach ${label}`)
+          }
+
+          const nextAttachment = {
+            ...attachment,
+            id: attachment.id,
+            refText: result.ref_text,
+            attachedSessionId: sessionId
+          }
+
+          if (updateComposerAttachments) {
+            addComposerAttachment(nextAttachment)
+          }
+
+          synced.push(nextAttachment)
+          continue
+        }
+
+        synced.push(attachment)
       }
+
+      return synced
     },
     [requestGateway]
   )
@@ -218,32 +267,21 @@ export function usePromptActions({
       const visibleText = rawText.trim()
       const usingComposerAttachments = !options?.attachments
       const attachments = options?.attachments ?? $composerAttachments.get()
-
-      const contextRefs = attachments
-        .map(a => a.refText)
-        .filter(Boolean)
-        .join('\n')
-
-      const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
-      const hasImage = attachments.some(a => a.kind === 'image')
       const attachmentRefs = attachments.map(attachmentDisplayText).filter((r): r is string => Boolean(r))
 
-      const text =
-        [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
-        (hasImage ? 'What do you see in this image?' : '')
-
-      if (!text || busyRef.current) {
+      if ((!visibleText && attachments.length === 0) || busyRef.current) {
         return false
       }
 
       const optimisticId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      let optimisticAttachmentRefs = attachmentRefs
 
-      const userMessage: ChatMessage = {
+      const buildUserMessage = (): ChatMessage => ({
         id: optimisticId,
         role: 'user',
-        parts: [textPart(visibleText || (attachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
-        attachmentRefs
-      }
+        parts: [textPart(visibleText || (optimisticAttachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
+        attachmentRefs: optimisticAttachmentRefs
+      })
 
       const releaseBusy = () => {
         busyRef.current = false
@@ -260,12 +298,22 @@ export function usePromptActions({
             ...state,
             messages: state.messages.some(m => m.id === optimisticId)
               ? state.messages
-              : [...state.messages, userMessage],
+              : [...state.messages, buildUserMessage()],
             busy: true,
             awaitingResponse: true,
             pendingBranchGroup: null,
             sawAssistantPayload: false,
             interrupted: state.interrupted
+          }),
+          selectedStoredSessionIdRef.current
+        )
+
+      const rewriteOptimistic = (sid: string) =>
+        updateSessionState(
+          sid,
+          state => ({
+            ...state,
+            messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
           selectedStoredSessionIdRef.current
         )
@@ -300,7 +348,7 @@ export function usePromptActions({
       if (sessionId) {
         seedOptimistic(sessionId)
       } else {
-        setMessages(current => [...current, userMessage])
+        setMessages(current => [...current, buildUserMessage()])
       }
 
       if (!sessionId) {
@@ -326,9 +374,23 @@ export function usePromptActions({
       }
 
       try {
-        await syncImageAttachmentsForSubmit(sessionId, attachments, {
+        const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+        optimisticAttachmentRefs = syncedAttachments
+          .map(attachmentDisplayText)
+          .filter((r): r is string => Boolean(r))
+        rewriteOptimistic(sessionId)
+        const contextRefs = syncedAttachments
+          .map(a => a.refText)
+          .filter(Boolean)
+          .join('\n')
+        const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
+        const hasImage = syncedAttachments.some(a => a.kind === 'image')
+        const text =
+          [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
+          (hasImage ? 'What do you see in this image?' : '')
+
         await requestGateway('prompt.submit', { session_id: sessionId, text })
 
         if (usingComposerAttachments) {
@@ -375,7 +437,7 @@ export function usePromptActions({
       createBackendSessionForSend,
       requestGateway,
       selectedStoredSessionIdRef,
-      syncImageAttachmentsForSubmit,
+      syncAttachmentsForSubmit,
       updateSessionState
     ]
   )

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -15,6 +15,15 @@ export interface ImageAttachResponse {
   message?: string
 }
 
+export interface FileAttachResponse {
+  attached?: boolean
+  message?: string
+  path?: string
+  ref_path?: string
+  ref_text?: string
+  uploaded?: boolean
+}
+
 export interface ImageDetachResponse {
   detached?: boolean
   count?: number

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -68,7 +68,7 @@ function isUpdateToastSnoozed(): boolean {
 // Must match tui_gateway's DESKTOP_BACKEND_CONTRACT that this build was written
 // against. The backend reports its own value in session runtime info; a lower
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.
-const REQUIRED_BACKEND_CONTRACT = 1
+const REQUIRED_BACKEND_CONTRACT = 2
 const SKEW_TOAST_ID = 'backend-contract-skew'
 
 /**

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2501,6 +2501,67 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+def test_file_attach_uploads_missing_remote_file_into_session_workspace(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "file.attach",
+            "params": {
+                "session_id": "sid",
+                "path": "/Users/alice/Downloads/report.txt",
+                "name": "report.txt",
+                "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+            },
+        }
+    )
+
+    stored = workspace / ".hermes" / "desktop-attachments" / "report.txt"
+    assert resp["result"]["attached"] is True
+    assert resp["result"]["uploaded"] is True
+    assert resp["result"]["path"] == str(stored)
+    assert resp["result"]["ref_text"] == "@file:.hermes/desktop-attachments/report.txt"
+    assert stored.read_text(encoding="utf-8") == "hello world"
+
+
+def test_file_attach_copies_gateway_visible_file_when_outside_workspace(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = tmp_path / "outside.txt"
+    source.write_text("outside workspace", encoding="utf-8")
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: source
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": str(source)},
+        }
+    )
+
+    stored = workspace / ".hermes" / "desktop-attachments" / "outside.txt"
+    assert resp["result"]["attached"] is True
+    assert resp["result"]["uploaded"] is True
+    assert resp["result"]["path"] == str(stored)
+    assert resp["result"]["ref_text"] == "@file:.hermes/desktop-attachments/outside.txt"
+    assert stored.read_text(encoding="utf-8") == "outside workspace"
+
+
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1,4 +1,6 @@
 import atexit
+import base64
+import binascii
 import concurrent.futures
 import contextvars
 import copy
@@ -7,6 +9,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -1562,7 +1565,109 @@ def _current_profile_name() -> str:
 # backend reporting less than its required value (or none at all — a pre-GUI
 # checkout), surfacing a one-click "update to align" prompt instead of failing
 # cryptically downstream. Bump whenever the desktop's backend contract changes.
-DESKTOP_BACKEND_CONTRACT = 1
+DESKTOP_BACKEND_CONTRACT = 2
+
+
+_ATTACHMENT_REF_NEEDS_QUOTING_RE = re.compile(r"""[\s()\[\]{}<>"'`]""")
+
+
+def _format_ref_value(value: str) -> str:
+    if not value or not _ATTACHMENT_REF_NEEDS_QUOTING_RE.search(value):
+        return value
+    if "`" not in value:
+        return f"`{value}`"
+    if '"' not in value:
+        return f'"{value}"'
+    if "'" not in value:
+        return f"'{value}'"
+    return value
+
+
+def _attachment_ref_path(session: dict, target: Path) -> str:
+    workspace = Path(_session_cwd(session)).resolve()
+    try:
+        rel = target.resolve().relative_to(workspace)
+        return str(rel).replace(os.sep, "/")
+    except ValueError:
+        return str(target.resolve())
+
+
+def _decode_data_url_payload(data_url: str) -> bytes:
+    match = re.match(r"^data:(?:[^;,]+)?(?:;[^;,=]+=[^;,]+)*;base64,(.+)$", data_url, re.I)
+    if not match:
+        raise ValueError("invalid data_url payload")
+    try:
+        return base64.b64decode(match.group(1), validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("invalid data_url payload") from exc
+
+
+def _desktop_attachment_dir(session: dict) -> Path:
+    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _sanitize_attachment_name(name: str) -> str:
+    candidate = Path(str(name or "").strip()).name
+    candidate = re.sub(r"[\x00-\x1f]+", "_", candidate)
+    candidate = candidate.strip().strip(".")
+    return candidate or "attachment"
+
+
+def _unique_attachment_path(root: Path, filename: str) -> Path:
+    candidate = root / filename
+    if not candidate.exists():
+        return candidate
+    stem = Path(filename).stem or "attachment"
+    suffix = Path(filename).suffix
+    counter = 2
+    while True:
+        next_candidate = root / f"{stem}-{counter}{suffix}"
+        if not next_candidate.exists():
+            return next_candidate
+        counter += 1
+
+
+def _resolve_gateway_attachment_path(raw: str) -> Path | None:
+    if not raw:
+        return None
+    from cli import _detect_file_drop, _resolve_attachment_path, _split_path_input
+
+    dropped = _detect_file_drop(raw)
+    if dropped:
+        return Path(dropped["path"]).resolve()
+    path_token, _remainder = _split_path_input(raw)
+    resolved = _resolve_attachment_path(path_token)
+    return Path(resolved).resolve() if resolved is not None else None
+
+
+def _stage_session_file_attachment(
+    session: dict,
+    *,
+    raw_path: str,
+    data_url: str,
+    name: str,
+) -> tuple[Path, bool]:
+    workspace = Path(_session_cwd(session)).resolve()
+    resolved = _resolve_gateway_attachment_path(raw_path)
+    if resolved is not None:
+        try:
+            resolved.relative_to(workspace)
+            return resolved, False
+        except ValueError:
+            payload = resolved.read_bytes()
+            filename = resolved.name
+    else:
+        if not data_url:
+            raise ValueError("file not found on gateway and no data_url provided")
+        payload = _decode_data_url_payload(data_url)
+        filename = _sanitize_attachment_name(name or Path(str(raw_path or "")).name)
+
+    upload_dir = _desktop_attachment_dir(session)
+    target = _unique_attachment_path(upload_dir, _sanitize_attachment_name(filename))
+    target.write_bytes(payload)
+    return target.resolve(), True
 
 
 def _session_info(agent, session: dict | None = None) -> dict:
@@ -4621,6 +4726,36 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5027, str(e))
+
+
+@method("file.attach")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    raw = str(params.get("path", "") or "").strip()
+    data_url = str(params.get("data_url", "") or "").strip()
+    name = str(params.get("name", "") or "").strip()
+    if not raw and not data_url:
+        return _err(rid, 4015, "path or data_url required")
+    try:
+        stored_path, uploaded = _stage_session_file_attachment(
+            session, raw_path=raw, data_url=data_url, name=name
+        )
+        ref_path = _attachment_ref_path(session, stored_path)
+        return _ok(
+            rid,
+            {
+                "attached": True,
+                "name": stored_path.name,
+                "path": str(stored_path),
+                "ref_path": ref_path,
+                "ref_text": f"@file:{_format_ref_value(ref_path)}",
+                "uploaded": uploaded,
+            },
+        )
+    except Exception as e:
+        return _err(rid, 5028, str(e))
 
 
 @method("image.detach")


### PR DESCRIPTION
## Summary
- add a desktop `file.attach` gateway RPC that stages remote-only file attachments into the session workspace
- sync file attachment refs before `prompt.submit` so remote gateway turns use workspace-relative `@file:` refs instead of local desktop paths
- cover the backend staging path and desktop submit flow with targeted tests

Fixes #38464

## Verification
- `uv run --frozen pytest tests/test_tui_gateway_server.py -k "file_attach or image_attach"`
- `uv run --frozen ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
- `npx eslint src/app/session/hooks/use-prompt-actions.ts src/app/session/hooks/use-prompt-actions.test.tsx src/app/types.ts src/store/updates.ts`
- `git diff --check`
