### PR TITLE
fix: bump version from 0.15.1 to 0.15.2 to match release tag v2026.5.29.2

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's


### PR DESCRIPTION
## Summary

Bumps the version in `pyproject.toml` and `hermes_cli/__init__.py` from `0.15.1` to `0.15.2` to match release tag `v2026.5.29.2`.

## Problem

After release tag `v2026.5.29.2` was created with version `0.15.2`, the version on `main` was not updated — it remained at `0.15.1`. This caused confusing behavior where:

1. `hermes update` pulls `main` which still reports `0.15.1`
2. Users see "Update available: N commits behind — run hermes update"
3. Running `hermes update` does not resolve the version mismatch
4. The official GitHub release shows `v0.15.2` but the CLI reports `v0.15.1`

## Changes

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `version = \"0.15.1\"` | `version = \"0.15.2\"` |
| `hermes_cli/__init__.py` | `__version__ = \"0.15.1\"`, `__release_date__ = \"2026.5.29\"` | `__version__ = \"0.15.2\"`, `__release_date__ = \"2026.5.29.2\"` |

Closes #38618

## Verification

- Version bumped in `pyproject.toml` — used by pip/uv builds
- Version bumped in `hermes_cli/__init__.py` — displayed in CLI banner
- Release date matches the tag `v2026.5.29.2`
- Branch created, committed, pushed to fork
