### PR TITLE
fix(desktop): persist new-session drafts

### DIFF
--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -4,6 +4,7 @@ import {
   activeSessionCountLabel,
   canTypeOrchestratorPrompt,
   clampOrchestratorSelection,
+  clearPendingNewSessionDraft,
   closeFallbackAfterClose,
   currentSessionSelectionIndex,
   draftModelArgFromPickerValue,
@@ -20,11 +21,13 @@ import {
   orchestratorHintSegmentColor,
   orchestratorRowClickAction,
   orchestratorVisibleRowIndexes,
+  readPendingNewSessionDraft,
   relativeSessionAge,
   resumableHistory,
   selectedSessionRowStyle,
   sessionRowKindAt,
-  sessionsCountLabel
+  sessionsCountLabel,
+  writePendingNewSessionDraft
 } from '../components/activeSessionSwitcher.js'
 import type { SessionActiveItem } from '../gatewayTypes.js'
 import type { SessionListItem } from '../gatewayTypes.js'
@@ -91,6 +94,23 @@ describe('session orchestrator helpers', () => {
     expect(draftModelArgFromPickerValue('openai/gpt-5.5 --provider openai-codex --global')).toBe(
       'openai/gpt-5.5 --provider openai-codex'
     )
+  })
+
+  it('persists pending new-session drafts across overlay remounts until submit clears them', () => {
+    clearPendingNewSessionDraft()
+    expect(readPendingNewSessionDraft()).toEqual({ modelArg: '', prompt: '' })
+
+    writePendingNewSessionDraft({
+      modelArg: 'kimi-k2.6 --provider ollama-cloud',
+      prompt: 'Build the websocket orchestrator panel'
+    })
+    expect(readPendingNewSessionDraft()).toEqual({
+      modelArg: 'kimi-k2.6 --provider ollama-cloud',
+      prompt: 'Build the websocket orchestrator panel'
+    })
+
+    clearPendingNewSessionDraft()
+    expect(readPendingNewSessionDraft()).toEqual({ modelArg: '', prompt: '' })
   })
 
   it('highlights the current live session when the picker opens', () => {

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -22,6 +22,7 @@ const VISIBLE = 12
 const MIN_WIDTH = 64
 const MAX_WIDTH = 128
 const TITLE_MAX = 64
+const EMPTY_PENDING_NEW_SESSION_DRAFT = Object.freeze({ modelArg: '', prompt: '' })
 
 const STATUS_GLYPH: Record<string, string> = {
   idle: '✓',
@@ -41,6 +42,23 @@ const CTRL_OFFSET = 96
 
 const shortModel = (model = '') => model.replace(/^.*\//, '') || 'model?'
 const ctrlChar = (letter: string) => String.fromCharCode(letter.charCodeAt(0) - CTRL_OFFSET)
+
+export interface PendingNewSessionDraft {
+  modelArg: string
+  prompt: string
+}
+
+let pendingNewSessionDraft: PendingNewSessionDraft = { ...EMPTY_PENDING_NEW_SESSION_DRAFT }
+
+export const readPendingNewSessionDraft = (): PendingNewSessionDraft => ({ ...pendingNewSessionDraft })
+
+export const writePendingNewSessionDraft = (next: PendingNewSessionDraft) => {
+  pendingNewSessionDraft = { modelArg: next.modelArg, prompt: next.prompt }
+}
+
+export const clearPendingNewSessionDraft = () => {
+  pendingNewSessionDraft = { ...EMPTY_PENDING_NEW_SESSION_DRAFT }
+}
 
 export const fixedSessionColumnStyle = () => ({ flexShrink: 0 })
 
@@ -229,6 +247,7 @@ export const draftModelNameFromArg = (value: string) => {
 
     if (part === '--provider') {
       i++
+
       continue
     }
 
@@ -302,13 +321,14 @@ export function ActiveSessionSwitcher({
   onSelect,
   t
 }: ActiveSessionSwitcherProps) {
+  const initialDraft = readPendingNewSessionDraft()
   const [items, setItems] = useState<SessionActiveItem[]>([])
   const [history, setHistory] = useState<SessionListItem[]>([])
   const [err, setErr] = useState('')
   const [sel, setSel] = useState(0)
   const [loading, setLoading] = useState(true)
-  const [draft, setDraft] = useState('')
-  const [draftModel, setDraftModel] = useState('')
+  const [draft, setDraft] = useState(initialDraft.prompt)
+  const [draftModel, setDraftModel] = useState(initialDraft.modelArg)
   const [pickingModel, setPickingModel] = useState(false)
   const [closingId, setClosingId] = useState('')
   // When non-null, the user pressed `d` on this (history) session and we await
@@ -331,6 +351,10 @@ export function ActiveSessionSwitcher({
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
   const promptColumns = Math.max(20, width - 11)
+
+  useEffect(() => {
+    writePendingNewSessionDraft({ modelArg: draftModel, prompt: draft })
+  }, [draft, draftModel])
 
   // Rows are [new][live…][history…]: the "+ new" row is pinned first (index 0,
   // always rendered) and the live+history list is windowed below it. `total`
@@ -360,6 +384,7 @@ export function ActiveSessionSwitcher({
           }),
           includeHistory ? gw.request<SessionListResponse>('session.list', { limit: 200 }) : Promise.resolve(null)
         ])
+
         const r = liveRes.status === 'fulfilled' ? asRpcResult<SessionActiveListResponse>(liveRes.value) : null
 
         if (!r) {
@@ -460,7 +485,9 @@ export function ActiveSessionSwitcher({
         return
       }
 
+      clearPendingNewSessionDraft()
       setDraft('')
+      setDraftModel('')
       onNewPrompt(prompt, draftModel || undefined)
     },
     [draftModel, onNewPrompt]
@@ -752,6 +779,7 @@ export function ActiveSessionSwitcher({
         if (kind === 'history') {
           const h = history[i - 1 - items.length]!
           const pendingDelete = confirmDelete === h.id
+
           const title = pendingDelete
             ? 'press d again to delete'
             : deleting && selected


### PR DESCRIPTION
## Summary
- persist the session orchestrator's `+ new` prompt/model draft across overlay remounts
- clear the saved draft once the prompt is submitted into a new live session
- add regression coverage for the pending draft store helpers

Closes #38498.

## Testing
- `npm test -- src/__tests__/activeSessionSwitcher.test.ts`
- `npx eslint src/components/activeSessionSwitcher.tsx src/__tests__/activeSessionSwitcher.test.ts`
- `git diff --check`
