### PR TITLE
fix(google-meet): store node registry tokens owner-only

### DIFF
--- a/plugins/google_meet/node/registry.py
+++ b/plugins/google_meet/node/registry.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 
 def _default_path() -> Path:
@@ -52,10 +53,12 @@ class NodeRegistry:
         return data
 
     def _save(self, data: Dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        tmp.replace(self.path)
+        # Registry entries contain bearer tokens with full remote-node RPC
+        # access.  The shared writer creates a unique same-directory temp file,
+        # flushes and fsyncs it, and atomically replaces the old registry.  An
+        # explicit mode prevents both new and updated registries from inheriting
+        # process-default or previously permissive permissions.
+        atomic_json_write(self.path, data, indent=2, mode=0o600)
 
     # ----- public API ---------------------------------------------------
 

--- a/tests/plugins/test_google_meet_node.py
+++ b/tests/plugins/test_google_meet_node.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -144,6 +145,90 @@ def test_registry_add_get_roundtrip_persists(tmp_path):
     assert entry["url"] == "ws://mac.local:18789"
     assert entry["token"] == "deadbeef"
     assert "added_at" in entry
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits only")
+def test_registry_add_stores_token_file_owner_only(tmp_path):
+    from plugins.google_meet.node.registry import NodeRegistry
+
+    p = tmp_path / "nodes.json"
+    r = NodeRegistry(path=p)
+
+    old_umask = os.umask(0o022)
+    try:
+        r.add("mac", "ws://mac.local:18789", "deadbeef")
+    finally:
+        os.umask(old_umask)
+
+    assert p.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits only")
+def test_registry_update_preserves_owner_only_token_file(tmp_path):
+    from plugins.google_meet.node.registry import NodeRegistry
+
+    p = tmp_path / "nodes.json"
+    p.write_text(
+        json.dumps(
+            {
+                "nodes": {
+                    "mac": {
+                        "url": "ws://mac.local:18789",
+                        "token": "deadbeef",
+                        "added_at": 1.0,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    p.chmod(0o644)
+    r = NodeRegistry(path=p)
+
+    old_umask = os.umask(0o022)
+    try:
+        r.add("mac", "ws://mac.local:18789", "cafebabe")
+    finally:
+        os.umask(old_umask)
+
+    assert p.stat().st_mode & 0o777 == 0o600
+    assert json.loads(p.read_text(encoding="utf-8"))["nodes"]["mac"]["token"] == "cafebabe"
+
+
+def test_registry_failed_atomic_replace_preserves_previous_tokens(tmp_path, monkeypatch):
+    from plugins.google_meet.node.registry import NodeRegistry
+    import utils
+
+    p = tmp_path / "nodes.json"
+    r = NodeRegistry(path=p)
+    r.add("mac", "ws://mac.local:18789", "deadbeef")
+    original = p.read_bytes()
+
+    def fail_replace(_tmp, _target):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(utils, "atomic_replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        r.add("mac", "ws://mac.local:18789", "cafebabe")
+
+    assert p.read_bytes() == original
+    assert json.loads(p.read_text(encoding="utf-8"))["nodes"]["mac"]["token"] == "deadbeef"
+    assert not list(tmp_path.glob(".nodes_*.tmp"))
+
+
+def test_registry_save_works_without_fchmod(tmp_path, monkeypatch):
+    from plugins.google_meet.node.registry import NodeRegistry
+    import utils
+
+    no_fchmod = {name: getattr(os, name) for name in dir(os) if name != "fchmod"}
+    monkeypatch.setattr(utils, "os", type("FakeOs", (), no_fchmod))
+
+    p = tmp_path / "nodes.json"
+    r = NodeRegistry(path=p)
+    r.add("mac", "ws://mac.local:18789", "deadbeef")
+
+    assert json.loads(p.read_text(encoding="utf-8"))["nodes"]["mac"]["token"] == "deadbeef"
 
 
 def test_registry_get_returns_none_when_missing(tmp_path):


### PR DESCRIPTION
## Summary

The Google Meet node registry stores bearer tokens that grant remote-node RPC access. On upstream `main`, `NodeRegistry._save()` still writes `workspace/meetings/nodes.json` through `Path.write_text()`, so a normal `022` umask can create a token-bearing registry with mode `0644`.

This PR routes every registry mutation through the repository's current secure atomic JSON writer:

- Create a unique temporary file in the registry directory instead of reusing a predictable `.json.tmp` path.
- Write with explicit `mode=0o600` so new registries never inherit process-default permissions.
- Replace an existing permissive registry with an owner-only file rather than preserving its old broad mode.
- Flush and `fsync` before atomic replacement, preserve the previous registry on failure, and clean up failed temporary files.
- Use the shared no-`fchmod` path so platforms without `os.fchmod` still save valid registries without crashing.

## Linked issue

Closes #38622

## Current behavior proof

Verified before rebasing against upstream `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`:

1. `plugins/google_meet/node/registry.py:54-58` still used `Path.write_text()` followed by `Path.replace()` with no restrictive creation mode.
2. `NodeRegistry.add()` and `NodeRegistry.remove()` both route persistence through `_save()`.
3. The registry token is passed to `NodeClient` as the remote node authentication credential.
4. Under a normal POSIX `022` umask, a newly created registry can therefore be readable by other local accounts.

After this change, `_save()` calls `atomic_json_write(self.path, data, indent=2, mode=0o600)`. The shared writer creates its temporary file restrictively, flushes and fsyncs it, atomically replaces the destination, reapplies the explicit final mode, preserves the existing owner where supported, and cleans up on failure.

## Files changed

- `plugins/google_meet/node/registry.py`
- `tests/plugins/test_google_meet_node.py`

## Behavior covered

- Initial registry creation under a `022` umask results in `0600` on POSIX.
- Updating a pre-existing `0644` token registry replaces it with `0600` and persists the new token.
- A failed atomic replacement leaves the previous token registry byte-for-byte intact and removes the staged temporary file.
- The save path remains functional when `os.fchmod` is unavailable, matching the shared Windows-compatible path.

## Validation

- `scripts/run_tests.sh tests/plugins/test_google_meet_node.py -q` — 46 passed, 0 failed
- All Google Meet plugin tests — 117 passed, 0 failed
- Shared atomic JSON and atomic-replace/symlink suites — 32 passed, 0 failed
- Ruff on both changed files — passed
- Windows-footgun diff scan — passed
- `git diff --check` — passed

## Rebase receipt

- Current upstream base: `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`
- Rebased PR head: `15772d703c5b8d543c204f2721fabb7f94da8014`
- Existing contributor branch and PR preserved; no replacement PR was created.

## Risk

The change is limited to the Google Meet node registry's persistence primitive and behavior tests. Registry schema, lookup behavior, node authentication, and CLI surfaces are unchanged.
