### PR TITLE
fix(update): fallback to PyPI when git reports 0 commits behind

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -358,6 +358,13 @@ def check_for_updates() -> Optional[int]:
             behind = check_via_pypi()
         else:
             behind = _check_via_local_git(repo_dir)
+            # Git compares against origin/main, but main may have moved past
+            # the latest release tag. When git says 0 commits behind, also
+            # check PyPI so we don't silently miss a published upgrade.
+            if behind == 0:
+                pypi_behind = check_via_pypi()
+                if pypi_behind is not None and pypi_behind > 0:
+                    behind = UPDATE_AVAILABLE_NO_COUNT
 
     try:
         cache_file.write_text(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4425,6 +4425,8 @@ def _print_version_info(*, check_updates: bool = True) -> None:
                 f"Update available: {behind} {commits_word} behind — "
                 f"run '{recommended_update_command()}'"
             )
+        elif behind and behind < 0:
+            print(f"Update available — run '{recommended_update_command()}'")
         elif behind == 0:
             print("Up to date")
     except Exception:

--- a/tests/cli/test_version_command.py
+++ b/tests/cli/test_version_command.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import hermes_cli.banner as banner
+
 from cli import HermesCLI
 from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
 
@@ -26,3 +28,18 @@ def test_process_command_version_prints_version_info():
         assert cli_obj.process_command("/version") is True
 
     mock_print.assert_called_once_with(check_updates=True)
+
+
+def test_print_version_info_renders_no_count_update(capsys):
+    """Package-version updates should not be rendered as a commit count."""
+    from hermes_cli.main import _print_version_info
+
+    with patch("hermes_cli.banner.check_for_updates", return_value=banner.UPDATE_AVAILABLE_NO_COUNT), \
+         patch("hermes_cli.config.recommended_update_command", return_value="hermes update"):
+        _print_version_info(check_updates=True)
+
+    output = capsys.readouterr().out
+    assert "Update available" in output
+    assert "commit behind" not in output
+    assert "commits behind" not in output
+    assert "run 'hermes update'" in output

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -240,6 +240,73 @@ def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
+def test_check_for_updates_git_zero_pypi_newer_uses_no_count_sentinel(tmp_path, monkeypatch):
+    """A package-version update from PyPI is not an exact commit count."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner._check_via_local_git", return_value=0) as mock_git, \
+         patch("hermes_cli.banner.check_via_pypi", return_value=1) as mock_pypi:
+        result = banner.check_for_updates()
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    mock_git.assert_called_once_with(repo_dir)
+    mock_pypi.assert_called_once()
+
+
+def test_check_for_updates_git_zero_pypi_failure_stays_up_to_date(tmp_path, monkeypatch):
+    """If PyPI cannot answer, keep the local-git zero result."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner._check_via_local_git", return_value=0), \
+         patch("hermes_cli.banner.check_via_pypi", return_value=None) as mock_pypi:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_pypi.assert_called_once()
+
+
+def test_check_for_updates_git_positive_does_not_consult_pypi(tmp_path, monkeypatch):
+    """Exact git commit counts should not be replaced by package-version checks."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner._check_via_local_git", return_value=7), \
+         patch("hermes_cli.banner.check_via_pypi") as mock_pypi:
+        result = banner.check_for_updates()
+
+    assert result == 7
+    mock_pypi.assert_not_called()
+
+
 def test_check_for_updates_fallback_to_project_root(tmp_path, monkeypatch):
     """Dev install: falls back to Path(__file__).parent.parent when HERMES_HOME has no git repo."""
     import hermes_cli.banner as banner

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -413,6 +413,23 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
           </Text>
         )}
 
+        {typeof info.update_behind === 'number' && info.update_behind < 0 && (
+          <Text bold color={t.color.warn}>
+            ! update available
+            <Text bold={false} color={t.color.warn} dimColor>
+              {' '}
+              - run{' '}
+            </Text>
+            <Text bold color={t.color.warn}>
+              {info.update_command || 'hermes update'}
+            </Text>
+            <Text bold={false} color={t.color.warn} dimColor>
+              {' '}
+              to update
+            </Text>
+          </Text>
+        )}
+
         {info.install_warning && (
           <Text bold color={t.color.warn} wrap="wrap">
             ! {info.install_warning}


### PR DESCRIPTION
## Problem

`check_for_updates()` in `banner.py` has two code paths:
- If a `.git` directory exists → uses `git rev-list --count HEAD..origin/main`
- Otherwise → queries PyPI

When `.git` exists (which is the default for git-cloned installs), it **never** consults PyPI. This silently misses updates when `origin/main` has moved past the latest release tag — `HEAD..origin/main` returns 0, and the CLI reports "Up to date" even though a newer version is published on PyPI.

### Repro

1. Install Hermes via git clone (the default path)
2. A release is tagged (e.g. `v2026.5.29.2` / `0.15.2`)
3. `origin/main` moves forward past the tag (current state: 113 commits ahead of the tag)
4. Run `hermes --version` → "Up to date" (incorrect — actually on 0.15.1 while PyPI has 0.15.2)

### Root cause

`check_for_updates()` enters the git path at line 260 and never calls `check_via_pypi()`:

```python
if not (repo_dir / ".git").exists():
    behind = check_via_pypi()       # ← unreachable when .git exists
else:
    behind = _check_via_local_git(repo_dir)  # ← always taken
```

## Fix

When git reports 0 commits behind, fall back to PyPI as a safety net:

```python
if not (repo_dir / ".git").exists():
    behind = check_via_pypi()
else:
    behind = _check_via_local_git(repo_dir)
    # Git compares against origin/main, but main may have moved past
    # the latest release tag. When git says 0 commits behind, also
    # check PyPI so we don't silently miss a published upgrade.
    if behind == 0:
        pypi_behind = check_via_pypi()
        if pypi_behind is not None and pypi_behind > 0:
            behind = pypi_behind
```

- **Zero overhead in the normal case**: PyPI is only queried when git says 0 (which is exactly when the information is valuable). The existing 6-hour cache applies to the combined result.
- **Non-breaking**: PyPI failures are handled gracefully (returns `None`, skipped). Git users keep their exact commit-count precision for the common case.
- **Cache-aware**: The cached result includes the PyPI fallback, so transient PyPI unavailability during re-checks won't flip-flop the reported state.