### PR TITLE
fix(update): refresh stale launchd plists and restart all profile gateways on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -3351,6 +3352,134 @@ def launchd_restart():
         )
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
+
+
+def _launchd_agents_dir() -> Path:
+    """Directory holding the per-user launchd gateway plists."""
+    return _launchd_user_home() / "Library" / "LaunchAgents"
+
+
+def _iter_hermes_launchd_plists() -> list[Path]:
+    """Every installed Hermes gateway launchd plist (default + named profiles).
+
+    The launchd analogue of ``systemctl list-units hermes-gateway*``: every
+    profile's agent lives in the same per-user ``LaunchAgents`` directory,
+    named ``ai.hermes.gateway.plist`` (default) or
+    ``ai.hermes.gateway-<suffix>.plist`` (named profile / custom HERMES_HOME).
+    """
+    agents_dir = _launchd_agents_dir()
+    try:
+        return sorted(agents_dir.glob("ai.hermes.gateway*.plist"))
+    except OSError:
+        return []
+
+
+def _hermes_home_from_launchd_plist(plist_path: Path) -> str | None:
+    """Return the HERMES_HOME a launchd plist was generated for, or ``None``.
+
+    The plist authoritatively records its own profile home in
+    ``EnvironmentVariables.HERMES_HOME`` (see :func:`generate_launchd_plist`),
+    so the caller can re-enter that profile's context without reversing the
+    label suffix.  Unreadable / malformed plists yield ``None`` (skip them).
+    """
+    from xml.parsers.expat import ExpatError
+
+    try:
+        with plist_path.open("rb") as fh:
+            data = plistlib.load(fh)
+    except (OSError, ValueError, ExpatError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    env = data.get("EnvironmentVariables")
+    if not isinstance(env, dict):
+        return None
+    home = env.get("HERMES_HOME")
+    return str(home) if home else None
+
+
+def _launchd_service_is_loaded(label: str) -> bool:
+    """Whether ``launchctl list <label>`` reports the job as loaded."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def restart_launchd_gateways_for_update(drain_timeout: float | None = None) -> list[str]:
+    """Refresh stale launchd definitions and restart every *loaded* gateway.
+
+    Used by the macOS ``hermes update`` postflight.  Two reasons the plain
+    :func:`launchd_restart` is not enough here:
+
+    * **Stale definitions.** launchd never hot-reloads a plist — a changed
+      definition is only applied by ``bootout``/``bootstrap``
+      (:func:`refresh_launchd_plist_if_needed`).  ``launchd_restart`` is the
+      fast, graceful path for a *current* definition and deliberately skips the
+      refresh, so the update path must reload stale definitions itself.
+    * **Named profiles.** Every profile has its own LaunchAgent; the old
+      postflight only ever touched the current profile's, leaving named-profile
+      gateways pinned to the previous code.
+
+    Each discovered plist is handled in its own HERMES_HOME context (via the
+    ``_HERMES_HOME_OVERRIDE`` ContextVar) so its regenerated definition matches
+    that profile.  Only *loaded* services are touched; in-flight agent runs are
+    drained gracefully (SIGUSR1) before a stale definition is reloaded.
+
+    Returns the launchd labels that were restarted/refreshed.
+    """
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from gateway.status import get_running_pid
+
+    restarted: list[str] = []
+    for plist_path in _iter_hermes_launchd_plists():
+        home = _hermes_home_from_launchd_plist(plist_path)
+        if not home:
+            continue
+        token = set_hermes_home_override(home)
+        try:
+            label = get_launchd_label()
+            # Guard against corrupt / foreign plists: only act when this profile
+            # context resolves back to the very file we discovered.
+            if get_launchd_plist_path().resolve() != plist_path.resolve():
+                continue
+            if not _launchd_service_is_loaded(label):
+                continue  # never touch a gateway that isn't loaded
+            if launchd_plist_is_current():
+                # Definition already matches; a graceful restart re-execs the
+                # new code without a bootout/bootstrap cycle.
+                launchd_restart()
+            else:
+                # Stale definition: launchd must reload it.  Drain in-flight
+                # agent runs gracefully (SIGUSR1) first so we don't SIGKILL
+                # them, then rewrite the plist and bootout/bootstrap.
+                pid = get_running_pid()
+                if pid is not None:
+                    if drain_timeout is None:
+                        drain_timeout = _get_restart_drain_timeout()
+                    _graceful_restart_via_sigusr1(pid, drain_timeout=drain_timeout)
+                refresh_launchd_plist_if_needed()
+            restarted.append(label)
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ) as e:
+            stderr = (getattr(e, "stderr", "") or "").strip()
+            detail = f": {stderr}" if stderr else ""
+            print(f"  ⚠ Gateway restart failed for {get_launchd_label()}{detail}")
+        finally:
+            reset_hermes_home_override(token)
+    return restarted
 
 
 def launchd_status(deep: bool = False):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9793,6 +9793,24 @@ def _cmd_update_pip(args):
     print("✓ Update complete! Restart hermes to use the new version.")
 
 
+def _restart_macos_launchd_gateways(restarted_services: list) -> None:
+    """macOS ``hermes update`` postflight: refresh stale launchd plists and
+    gracefully restart every *loaded* gateway across all profiles (default and
+    named), appending each restarted label to ``restarted_services``.
+
+    Delegates to :func:`hermes_cli.gateway.restart_launchd_gateways_for_update`,
+    which reloads stale service definitions (launchd can't hot-reload a plist)
+    and handles named-profile LaunchAgents — neither of which the previous
+    single-profile, refresh-less branch did.
+    """
+    try:
+        from hermes_cli.gateway import restart_launchd_gateways_for_update
+
+        restarted_services.extend(restart_launchd_gateways_for_update())
+    except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
+        pass
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -10938,31 +10956,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         pass
 
             # --- Launchd services (macOS) ---
+            # Refresh stale launchd definitions and gracefully restart every
+            # loaded gateway across all profiles (default + named).  launchd
+            # can't hot-reload a plist, so a stale definition needs a
+            # bootout/bootstrap reload — see restart_launchd_gateways_for_update.
             if is_macos():
-                try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
-
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
-                    pass
+                _restart_macos_launchd_gateways(restarted_services)
 
             # --- Manual (non-service) gateways ---
             # Kill any remaining gateway processes not managed by a service.

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -830,3 +830,32 @@ termux = ["rich>=14"]
 
     assert hm._load_installable_optional_extras(group="all") == ["mcp"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
+
+
+class TestRestartMacosLaunchdGatewaysPostflight:
+    """The macOS update postflight delegates to the gateway orchestrator and
+    records every restarted launchd label, without running live commands."""
+
+    def test_extends_restarted_services_with_orchestrator_result(self, monkeypatch):
+        import hermes_cli.main as main
+
+        monkeypatch.setattr(
+            "hermes_cli.gateway.restart_launchd_gateways_for_update",
+            lambda: ["ai.hermes.gateway", "ai.hermes.gateway-coder"],
+        )
+        restarted = []
+        main._restart_macos_launchd_gateways(restarted)
+        assert restarted == ["ai.hermes.gateway", "ai.hermes.gateway-coder"]
+
+    def test_swallows_orchestrator_errors(self, monkeypatch):
+        import hermes_cli.main as main
+
+        def boom():
+            raise subprocess.TimeoutExpired(cmd="launchctl", timeout=5)
+
+        monkeypatch.setattr(
+            "hermes_cli.gateway.restart_launchd_gateways_for_update", boom
+        )
+        restarted = ["existing-service"]
+        main._restart_macos_launchd_gateways(restarted)  # must not raise
+        assert restarted == ["existing-service"]

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2579,3 +2579,271 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+
+class TestLaunchdUpdatePostflight:
+    """`hermes update` on macOS must refresh stale launchd service definitions
+    and restart every *loaded* gateway across all profiles — default and named —
+    without the user having to run `hermes gateway start` per profile.
+
+    Regression guard for two bugs:
+      1. `launchd_restart()` never refreshes a stale plist (launchd can't
+         hot-reload a definition — only bootout/bootstrap applies it), so a
+         kickstart respawns the stale code.
+      2. The update postflight only ever looked at the *current* profile's
+         LaunchAgent, leaving named-profile gateways on the old definition.
+
+    Every launchctl / signal side effect is mocked: no live `hermes gateway`
+    commands run, and no real launchctl is invoked.
+    """
+
+    @staticmethod
+    def _agents_dir(tmp_path, monkeypatch):
+        """Point the launchd user home (and therefore the LaunchAgents dir and
+        every per-profile plist path) at a throwaway tmp tree."""
+        machine_home = tmp_path / "machine-home"
+        agents = machine_home / "Library" / "LaunchAgents"
+        agents.mkdir(parents=True)
+        monkeypatch.setattr(
+            pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(machine_home))
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        return agents
+
+    @staticmethod
+    def _write_stale_plist(path, hermes_home, label):
+        """Write a minimal, *stale* (does not match generate_launchd_plist())
+        plist that still records its HERMES_HOME, like a real install would."""
+        import plistlib
+
+        data = {
+            "Label": label,
+            "ProgramArguments": ["/usr/bin/python", "-m", "hermes_cli.main", "gateway", "run"],
+            "EnvironmentVariables": {"HERMES_HOME": str(hermes_home)},
+        }
+        with open(path, "wb") as fh:
+            plistlib.dump(data, fh)
+
+    # ----- discovery helpers -----
+
+    def test_reads_hermes_home_from_plist(self, tmp_path):
+        home = tmp_path / ".hermes" / "profiles" / "coder"
+        plist = tmp_path / "ai.hermes.gateway-coder.plist"
+        self._write_stale_plist(plist, home, "ai.hermes.gateway-coder")
+        assert gateway_cli._hermes_home_from_launchd_plist(plist) == str(home)
+
+    def test_reads_none_from_unparseable_plist(self, tmp_path):
+        garbage = tmp_path / "ai.hermes.gateway.plist"
+        garbage.write_text("not a plist at all", encoding="utf-8")
+        badxml = tmp_path / "ai.hermes.gateway-x.plist"
+        badxml.write_text("<plist><dict><key>oops", encoding="utf-8")
+        assert gateway_cli._hermes_home_from_launchd_plist(garbage) is None
+        assert gateway_cli._hermes_home_from_launchd_plist(badxml) is None
+
+    def test_iter_plists_empty_when_dir_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(tmp_path / "nope"))
+        )
+        assert gateway_cli._iter_hermes_launchd_plists() == []
+
+    def test_iter_plists_discovers_default_and_named_only(self, tmp_path, monkeypatch):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / "ai.hermes.gateway.plist").write_text("<plist/>", encoding="utf-8")
+        (agents / "ai.hermes.gateway-coder.plist").write_text("<plist/>", encoding="utf-8")
+        (agents / "com.apple.other.plist").write_text("<plist/>", encoding="utf-8")
+        names = [p.name for p in gateway_cli._iter_hermes_launchd_plists()]
+        assert names == ["ai.hermes.gateway-coder.plist", "ai.hermes.gateway.plist"]
+
+    def test_service_loaded_check(self, monkeypatch):
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        assert gateway_cli._launchd_service_is_loaded("ai.hermes.gateway") is True
+        assert seen["cmd"] == ["launchctl", "list", "ai.hermes.gateway"]
+
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=113, stdout="", stderr=""),
+        )
+        assert gateway_cli._launchd_service_is_loaded("ai.hermes.gateway") is False
+
+        def boom(*a, **k):
+            raise FileNotFoundError("launchctl missing")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", boom)
+        assert gateway_cli._launchd_service_is_loaded("ai.hermes.gateway") is False
+
+    # ----- orchestrator: stale refresh across all loaded profiles (criteria 1-4) -----
+
+    def test_update_refreshes_stale_plists_for_all_loaded_profiles(self, tmp_path, monkeypatch):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        hermes_root = tmp_path / ".hermes"
+        coder_home = hermes_root / "profiles" / "coder"
+        coder_home.mkdir(parents=True)
+
+        default_plist = agents / "ai.hermes.gateway.plist"
+        coder_plist = agents / "ai.hermes.gateway-coder.plist"
+        self._write_stale_plist(default_plist, hermes_root, "ai.hermes.gateway")
+        self._write_stale_plist(coder_plist, coder_home, "ai.hermes.gateway-coder")
+
+        loaded = {"ai.hermes.gateway", "ai.hermes.gateway-coder"}
+        calls = []
+        drained = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                rc = 0 if cmd[2] in loaded else 113
+                return SimpleNamespace(returncode=rc, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, drain_timeout: drained.append((pid, drain_timeout)) or True,
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+
+        restarted = gateway_cli.restart_launchd_gateways_for_update()
+
+        # Both loaded profiles handled; sorted glob order (named sorts first).
+        assert restarted == ["ai.hermes.gateway-coder", "ai.hermes.gateway"]
+
+        # Each stale plist was rewritten to the *current* definition, generated
+        # in its own profile context (named profile keeps its --profile arg).
+        default_text = default_plist.read_text(encoding="utf-8")
+        coder_text = coder_plist.read_text(encoding="utf-8")
+        assert "RunAtLoad" in default_text and "RunAtLoad" in coder_text
+        assert str(hermes_root.resolve()) in default_text
+        assert str(coder_home.resolve()) in coder_text
+        assert "<string>--profile</string>" in coder_text
+        assert "<string>coder</string>" in coder_text
+        assert "--profile" not in default_text
+
+        # launchd reloaded each definition (only bootout/bootstrap applies a
+        # changed plist), draining in-flight runs first.
+        domain = gateway_cli._launchd_domain()
+        assert ["launchctl", "bootout", f"{domain}/ai.hermes.gateway"] in calls
+        assert ["launchctl", "bootout", f"{domain}/ai.hermes.gateway-coder"] in calls
+        assert any(
+            c[:2] == ["launchctl", "bootstrap"] and c[-1] == str(default_plist) for c in calls
+        )
+        assert any(
+            c[:2] == ["launchctl", "bootstrap"] and c[-1] == str(coder_plist) for c in calls
+        )
+        assert drained == [(4242, 12.0), (4242, 12.0)]
+
+        # No live gateway commands: every subprocess invocation was launchctl.
+        assert calls and all(c and c[0] == "launchctl" for c in calls)
+
+    def test_update_restarts_without_refresh_when_definition_current(self, tmp_path, monkeypatch):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        default_plist = agents / "ai.hermes.gateway.plist"
+        self._write_stale_plist(default_plist, hermes_root, "ai.hermes.gateway")
+
+        # Definition already matches the install -> a graceful restart re-execs
+        # the new code; no bootout/bootstrap reload is needed.
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        restart_calls = []
+        refresh_calls = []
+        monkeypatch.setattr(gateway_cli, "launchd_restart", lambda: restart_calls.append("restart"))
+        monkeypatch.setattr(
+            gateway_cli, "refresh_launchd_plist_if_needed", lambda: refresh_calls.append("refresh")
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        restarted = gateway_cli.restart_launchd_gateways_for_update()
+
+        assert restarted == ["ai.hermes.gateway"]
+        assert restart_calls == ["restart"]
+        assert refresh_calls == []
+        # The current plist was left untouched on disk.
+        assert "RunAtLoad" not in default_plist.read_text(encoding="utf-8")
+
+    def test_update_skips_unloaded_gateways(self, tmp_path, monkeypatch):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        self._write_stale_plist(agents / "ai.hermes.gateway.plist", hermes_root, "ai.hermes.gateway")
+
+        restart_calls = []
+        refresh_calls = []
+        monkeypatch.setattr(gateway_cli, "launchd_restart", lambda: restart_calls.append("r"))
+        monkeypatch.setattr(
+            gateway_cli, "refresh_launchd_plist_if_needed", lambda: refresh_calls.append("f")
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=113, stdout="", stderr="not loaded"),
+        )
+
+        restarted = gateway_cli.restart_launchd_gateways_for_update()
+
+        assert restarted == []
+        assert restart_calls == [] and refresh_calls == []
+
+    def test_update_skips_plist_without_hermes_home(self, tmp_path, monkeypatch):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / "ai.hermes.gateway.plist").write_text("garbage", encoding="utf-8")
+
+        def explode(*a, **k):
+            raise AssertionError("no subprocess should run for an unreadable plist")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", explode)
+        assert gateway_cli.restart_launchd_gateways_for_update() == []
+
+    def test_update_continues_after_one_profile_fails(self, tmp_path, monkeypatch, capsys):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        hermes_root = tmp_path / ".hermes"
+        coder_home = hermes_root / "profiles" / "coder"
+        coder_home.mkdir(parents=True)
+        self._write_stale_plist(agents / "ai.hermes.gateway.plist", hermes_root, "ai.hermes.gateway")
+        self._write_stale_plist(
+            agents / "ai.hermes.gateway-coder.plist", coder_home, "ai.hermes.gateway-coder"
+        )
+
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        def flaky_restart():
+            # First profile (named, sorts first) blows up; second must still run.
+            if gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder":
+                raise gateway_cli.subprocess.CalledProcessError(
+                    1, ["launchctl", "kickstart"], stderr="kaboom"
+                )
+
+        monkeypatch.setattr(gateway_cli, "launchd_restart", flaky_restart)
+
+        restarted = gateway_cli.restart_launchd_gateways_for_update()
+
+        assert restarted == ["ai.hermes.gateway"]
+        out = capsys.readouterr().out
+        assert "ai.hermes.gateway-coder" in out and "failed" in out.lower()
+
+    def test_update_no_op_when_no_plists_installed(self, tmp_path, monkeypatch):
+        self._agents_dir(tmp_path, monkeypatch)  # empty LaunchAgents dir
+
+        def explode(*a, **k):
+            raise AssertionError("no subprocess when there are no gateways")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", explode)
+        assert gateway_cli.restart_launchd_gateways_for_update() == []


### PR DESCRIPTION
## What does this PR do?

On macOS, `hermes update` left running gateways on **stale launchd service definitions** and only restarted the **current** profile's LaunchAgent, leaving named-profile gateways pinned to the old code.

Two root causes:

1. **Stale definitions are never reloaded.** launchd does not hot-reload a plist — a changed definition is only applied by `bootout`/`bootstrap`. The update postflight called `launchd_restart()`, which `kickstart`s the *cached* definition, so a service whose plist changed across the update came back running the old one. `launchd_start()` self-heals via `refresh_launchd_plist_if_needed()`; the update path did not, forcing users to manually run `hermes gateway start`.
2. **Only the current profile was restarted.** The macOS branch inspected a single `get_launchd_label()` / `get_launchd_plist_path()`. The Linux/systemd branch right above it already enumerates all `hermes-gateway*` units; launchd was the outlier.

### Fix

New `restart_launchd_gateways_for_update()` in `hermes_cli/gateway.py`:

- Discovers every `~/Library/LaunchAgents/ai.hermes.gateway*.plist` (the launchd analogue of `systemctl list-units hermes-gateway*` — all profiles share one LaunchAgents dir).
- Reads each plist's own recorded `HERMES_HOME` and re-enters that profile's context via the existing `_HERMES_HOME_OVERRIDE` ContextVar, so each plist is regenerated for the correct profile.
- For each **loaded** service: graceful-restarts a current definition, or (for a stale one) drains in-flight agent runs with `SIGUSR1` first, then `refresh_launchd_plist_if_needed()` does the bootout/bootstrap reload.

The macOS update postflight now delegates to it. `launchd_restart()` is unchanged, so its existing graceful-restart contract (and tests) are preserved.

## Related Issue

Fixes #38053

This is distinct from the other open macOS launchd-restart PRs: it specifically addresses multi-profile enumeration **and** stale-plist refresh in the `hermes update` postflight, rather than KeepAlive/missing-plist/throttle behaviour in `launchd_restart()` itself (which is left untouched).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/gateway.py`: add `_launchd_agents_dir`, `_iter_hermes_launchd_plists`, `_hermes_home_from_launchd_plist`, `_launchd_service_is_loaded`, and `restart_launchd_gateways_for_update()`. No existing function is modified (only `import plistlib` is added).
- `hermes_cli/main.py`: replace the single-profile macOS restart branch in `_cmd_update_impl` with a delegation to a small helper `_restart_macos_launchd_gateways()`.
- `tests/hermes_cli/test_gateway_service.py`: `TestLaunchdUpdatePostflight` (11 tests).
- `tests/hermes_cli/test_cmd_update.py`: `TestRestartMacosLaunchdGatewaysPostflight` (2 tests).

## How to Test

All side effects (launchctl, signals, subprocess) are mocked — no live gateway commands run.

```
pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdUpdatePostflight \
       tests/hermes_cli/test_cmd_update.py::TestRestartMacosLaunchdGatewaysPostflight -q
```

Coverage includes: stale plist rewritten + bootout/bootstrap reload; a named profile regenerated in its own context (keeps its `--profile` arg); unloaded agents skipped; unreadable plists skipped; one profile failing does not abort the rest; and an assertion that every subprocess invocation is `launchctl` (proving no live `hermes` commands are needed).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(update): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (this targets the unclaimed #38053; see Related Issue)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the gateway + update test suites and they pass — note: a full `pytest tests/ -q` on macOS has pre-existing `systemd`/`seed_supervise` env failures unrelated to this change (CI runs the full suite on Linux)
- [x] I've added tests for my changes (13)
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] Docstrings added; README/`docs/` — N/A
- [x] No config keys added/changed — `cli-config.yaml.example` N/A
- [x] No architecture/workflow change — `CONTRIBUTING.md`/`AGENTS.md` N/A
- [x] Cross-platform impact considered — the launchd path is macOS-only; systemd/Windows untouched
- [x] No tool behaviour/schema change — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
