### PR TITLE
fix(line): bind postback cache entries to chat ids

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1017,6 +1017,13 @@ class LineAdapter(BasePlatformAdapter):
         entry = self._cache.get(request_id)
         if not self._client or not reply_token or not entry:
             return
+        if entry.chat_id != chat_id:
+            logger.warning(
+                "LINE: rejecting postback for request %s from mismatched chat %s",
+                request_id,
+                chat_id,
+            )
+            return
 
         if entry.state is State.READY:
             payload = entry.payload or ""

--- a/tests/plugins/test_line_postback_cache.py
+++ b/tests/plugins/test_line_postback_cache.py
@@ -1,0 +1,113 @@
+"""Regression tests for LINE slow-response postback cache delivery."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.platforms.line.adapter import LineAdapter, State
+
+
+class _ReplyRecorder:
+    def __init__(self) -> None:
+        self.replies: list[tuple[str, list[dict[str, object]]]] = []
+        self.pushes: list[tuple[str, list[dict[str, object]]]] = []
+
+    async def reply(self, reply_token: str, messages: list[dict[str, object]]) -> None:
+        self.replies.append((reply_token, messages))
+
+    async def push(self, chat_id: str, messages: list[dict[str, object]]) -> None:
+        self.pushes.append((chat_id, messages))
+
+
+def _adapter() -> LineAdapter:
+    return LineAdapter(SimpleNamespace(extra={}))
+
+
+def _postback_event(chat_id: str, reply_token: str, request_id: str) -> dict[str, object]:
+    return {
+        "replyToken": reply_token,
+        "source": {"type": "user", "userId": chat_id},
+        "postback": {
+            "data": json.dumps(
+                {"action": "show_response", "request_id": request_id}
+            )
+        },
+    }
+
+
+def _cache_entry_in_state(adapter: LineAdapter, state: State) -> str:
+    request_id = adapter._cache.register_pending("U-chat-a")
+    if state is State.READY:
+        adapter._cache.set_ready(request_id, "cached private answer")
+    elif state is State.ERROR:
+        adapter._cache.set_error(request_id, "cached private error")
+    elif state is State.DELIVERED:
+        adapter._cache.set_ready(request_id, "cached private answer")
+        adapter._cache.mark_delivered(request_id)
+    return request_id
+
+
+@pytest.mark.parametrize("state", list(State))
+@pytest.mark.asyncio
+async def test_postback_cache_rejects_every_state_from_different_chat(
+    state: State,
+) -> None:
+    adapter = _adapter()
+    client = _ReplyRecorder()
+    adapter._client = client
+
+    request_id = _cache_entry_in_state(adapter, state)
+    entry = adapter._cache.get(request_id)
+    original = (entry.state, entry.payload, entry.updated_at)
+    adapter._pending_buttons["U-chat-a"] = request_id
+
+    await adapter._handle_postback_event(
+        _postback_event("U-chat-b", "reply-token-b", request_id)
+    )
+
+    assert client.replies == []
+    assert client.pushes == []
+    entry = adapter._cache.get(request_id)
+    assert (entry.state, entry.payload, entry.updated_at) == original
+    assert adapter._pending_buttons == {"U-chat-a": request_id}
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_text", "expected_final_state"),
+    [
+        (State.READY, "cached private answer", State.DELIVERED),
+        (State.ERROR, "cached private error", State.DELIVERED),
+        (State.DELIVERED, None, State.DELIVERED),
+        (State.PENDING, None, State.PENDING),
+    ],
+)
+@pytest.mark.asyncio
+async def test_postback_cache_preserves_origin_chat_behavior(
+    state: State,
+    expected_text: str | None,
+    expected_final_state: State,
+) -> None:
+    adapter = _adapter()
+    client = _ReplyRecorder()
+    adapter._client = client
+
+    request_id = _cache_entry_in_state(adapter, state)
+    if expected_text is None:
+        expected_text = (
+            adapter.delivered_text
+            if state is State.DELIVERED
+            else adapter.pending_text
+        )
+
+    await adapter._handle_postback_event(
+        _postback_event("U-chat-a", "reply-token-a", request_id)
+    )
+
+    assert client.replies == [
+        ("reply-token-a", [{"type": "text", "text": expected_text}])
+    ]
+    assert client.pushes == []
+    assert adapter._cache.get(request_id).state is expected_final_state


### PR DESCRIPTION
## Summary

A slow-response LINE postback now succeeds only when the incoming event resolves to the same chat ID stored with the cached request.

The ownership check runs before every cache-state branch, so a request ID from another chat cannot expose:

- a READY cached response
- an ERROR payload
- DELIVERED status
- PENDING status

Same-chat behavior is preserved for all four states, including READY/ERROR delivery transitions and the existing DELIVERED/PENDING responses.

## Root cause

`RequestCache.register_pending(chat_id)` already recorded the originating chat, but `_handle_postback_event()` looked up entries by `request_id` alone and then replied or pushed using the incoming event's chat. The request ID therefore acted as a cross-chat authorization handle.

## Validation

- `scripts/run_tests.sh tests/plugins/test_line_postback_cache.py tests/gateway/test_line_plugin.py -q` — 84 passed
  - 8 dedicated postback-binding cases cover rejected cross-chat and preserved same-chat behavior across READY, ERROR, DELIVERED, and PENDING
  - 76 existing LINE adapter tests preserve current behavior
- `.venv/bin/ruff check plugins/platforms/line/adapter.py tests/plugins/test_line_postback_cache.py` — passed
- `git diff --check origin/main...HEAD` — passed

Rebased onto `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`.
Head: `83cb67f10c7bbc2a8ab2a49d86a27acdba37984f`.

Closes #38628