### PR TITLE
feat(gateway): support .hwpx document delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1109,6 +1109,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".hwpx": "application/haansofthwpx",
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
@@ -1169,7 +1170,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub", ".hwpx",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,7 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx", ".hwpx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES
@@ -206,6 +206,28 @@ class TestCacheMediaBytes:
         assert result is not None
         assert result.kind == "document"
         assert result.media_type == "text/csv"
+
+    def test_hwpx_routes_to_document(self):
+        from gateway.platforms.base import cache_media_bytes
+        # HWPX (Hancom Office Hangul) is a zip container — PK magic bytes.
+        result = cache_media_bytes(
+            b"PK\x03\x04hwpx-body", filename="report.hwpx", mime_type="application/haansofthwpx"
+        )
+        assert result is not None
+        assert result.kind == "document"
+        assert result.media_type == "application/haansofthwpx"
+        assert "report.hwpx" in result.display_name
+        assert os.path.exists(result.path)
+
+    def test_hwpx_mime_only_resolves_extension(self):
+        from gateway.platforms.base import cache_media_bytes
+        # Exercises the reverse MIME->ext lookup; proves the MIME is unique.
+        result = cache_media_bytes(
+            b"PK\x03\x04", filename="", mime_type="application/haansofthwpx"
+        )
+        assert result is not None
+        assert result.kind == "document"
+        assert result.media_type == "application/haansofthwpx"
 
     def test_unsupported_document_returns_none(self):
         from gateway.platforms.base import cache_media_bytes

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -574,6 +574,21 @@ class TestMediaExtensionAllowlistParity:
         for ext in (".md", ".json", ".yaml", ".yml", ".xml", ".html", ".htm"):
             assert ext in MEDIA_DELIVERY_EXTS
 
+    def test_hwpx_in_shared_extension_set(self):
+        from gateway.platforms.base import MEDIA_DELIVERY_EXTS
+        assert ".hwpx" in MEDIA_DELIVERY_EXTS
+
+    def test_hwpx_extracts_via_media_tag(self):
+        path = "/tmp/report.hwpx"
+        media, _ = BasePlatformAdapter.extract_media(f"Done: MEDIA:{path}")
+        assert media == [(path, False)], ".hwpx should extract via MEDIA: tag"
+
+    def test_hwpx_bare_path_extracts_as_local_file(self, tmp_path):
+        f = tmp_path / "deliverable.hwpx"
+        f.write_bytes(b"PK\x03\x04")
+        files, _ = BasePlatformAdapter.extract_local_files(f"Saved to {f}")
+        assert str(f) in files, ".hwpx bare path should be delivered outbound"
+
     def test_unknown_extension_not_black_holed_by_cleanup(self):
         """A MEDIA: tag with an unknown extension is NOT stripped from the
         body — it survives so extract_local_files can still see the bare path,


### PR DESCRIPTION
## Summary
- Add `.hwpx` to gateway supported document types for inbound document caching
- Add `.hwpx` to outbound media delivery extension allowlist
- Cover HWPX inbound MIME handling, MEDIA tag extraction, and bare-path delivery with tests

## Test Plan
- `python -m pytest tests/gateway/test_document_cache.py tests/gateway/test_platform_base.py -q`