### PR TITLE
fix(webhook): make autonomous webhook runs work (approval + clarify escape hatches, Linear signature)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -682,6 +682,15 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
+        # Linear: Linear-Signature = <hex HMAC-SHA256 of raw body>
+        # Same algorithm as the generic path, different header name.
+        linear_sig = _header("Linear-Signature")
+        if linear_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_sig, expected)
+
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -492,13 +492,25 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        # Build a unique delivery ID for idempotency/dedup. Check the known
+        # per-provider delivery headers. Linear sends ``Linear-Delivery``; if we
+        # fall through to a fresh timestamp, every retry (and every agent-caused
+        # re-fire) gets a unique id and the dedup cache can never hit — which
+        # also removes one brake on a webhook feedback loop. Prefer a stable,
+        # provider-supplied id whenever one exists.
+        def _hdr(name: str) -> str:
+            return (
+                request.headers.get(name, "")
+                or request.headers.get(name.lower(), "")
+                or request.headers.get(name.upper(), "")
+            )
+
+        delivery_id = (
+            _hdr("X-GitHub-Delivery")
+            or _hdr("svix-id")
+            or _hdr("Linear-Delivery")
+            or _hdr("X-Request-ID")
+            or str(int(time.time() * 1000))
         )
 
         # ── Idempotency ─────────────────────────────────────────

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17796,6 +17796,26 @@ class GatewayRunner:
                 if not _status_adapter:
                     return ""
 
+                # Webhook (autonomous) sessions have no human to answer a
+                # clarify prompt. Blocking on wait_for_response would freeze
+                # the run for the full clarify timeout (minutes) per call.
+                # Short-circuit with a sentinel so the agent makes its own
+                # reasonable default instead — mirrors the webhook approval
+                # escape hatch.
+                try:
+                    _plat = getattr(_status_adapter, "platform", None)
+                    _plat_val = getattr(_plat, "value", _plat)
+                    if str(_plat_val).lower() == "webhook":
+                        return (
+                            "[autonomous webhook run: no user is available to "
+                            "answer. Do NOT call clarify again. Make the most "
+                            "reasonable default decision yourself and proceed, "
+                            "or stop and report what is blocking via your "
+                            "configured delivery channel.]"
+                        )
+                except Exception:
+                    pass
+
                 clarify_id = _uuid.uuid4().hex[:10]
                 _clarify_mod.register(
                     clarify_id=clarify_id,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1789,10 +1789,16 @@ DEFAULT_CONFIG = {
     # cron_mode — what to do when a cron job hits a dangerous command:
     #   deny    — block the command and let the agent find another way (default, safe)
     #   approve — auto-approve all dangerous commands in cron jobs
+    # webhook_mode — same semantics for webhook-triggered (autonomous) runs.
+    #   Webhook runs have no interactive channel to answer /approve, so a
+    #   dangerous command must resolve here rather than hang on a prompt.
+    #   deny (default, safe) — block and let the agent find another way.
+    #   approve — auto-approve dangerous commands in webhook runs.
     "approvals": {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        "webhook_mode": "deny",
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -151,6 +151,22 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Gitlab-Token": "wrong"})
         assert adapter._validate_signature(req, b"{}", "correct") is False
 
+    def test_validate_linear_signature_valid(self):
+        """Valid Linear-Signature (hex HMAC-SHA256 of body) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"action": "create", "type": "Issue"}'
+        secret = "linear-webhook-secret"
+        sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        req = _mock_request(headers={"Linear-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_invalid(self):
+        """Wrong Linear-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action": "create", "type": "Issue"}'
+        req = _mock_request(headers={"Linear-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, "linear-webhook-secret") is False
+
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()

--- a/tests/tools/test_webhook_approval_mode.py
+++ b/tests/tools/test_webhook_approval_mode.py
@@ -1,0 +1,102 @@
+"""Tests for webhook approval mode (autonomous webhook runs).
+
+Webhook-triggered agent runs have no interactive channel to answer /approve,
+so dangerous commands must resolve via approvals.webhook_mode (deny|approve)
+instead of hanging on submit_pending(). Mirrors cron_mode behavior.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch as mock_patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import tools.approval as approval
+
+
+def _webhook_session():
+    """Context: simulate a webhook session (platform == 'webhook', not cron)."""
+    return mock_patch.multiple(
+        approval,
+        _get_session_platform=lambda: "webhook",
+    )
+
+
+def test_is_webhook_session_true_for_webhook_platform():
+    with mock_patch.object(approval, "_get_session_platform", lambda: "webhook"):
+        with mock_patch.object(approval, "env_var_enabled", lambda v: False):
+            assert approval._is_webhook_session() is True
+
+
+def test_is_webhook_session_false_when_cron():
+    # Cron takes precedence even if a platform is bound.
+    with mock_patch.object(approval, "_get_session_platform", lambda: "webhook"):
+        with mock_patch.object(approval, "env_var_enabled",
+                               lambda v: v == "HERMES_CRON_SESSION"):
+            assert approval._is_webhook_session() is False
+
+
+def test_is_webhook_session_false_for_telegram():
+    with mock_patch.object(approval, "_get_session_platform", lambda: "telegram"):
+        with mock_patch.object(approval, "env_var_enabled", lambda v: False):
+            assert approval._is_webhook_session() is False
+
+
+def test_webhook_mode_default_deny():
+    with mock_patch("hermes_cli.config.load_config", return_value={}):
+        assert approval._get_webhook_approval_mode() == "deny"
+
+
+def test_webhook_mode_approve_when_configured():
+    with mock_patch("hermes_cli.config.load_config",
+                    return_value={"approvals": {"webhook_mode": "approve"}}):
+        assert approval._get_webhook_approval_mode() == "approve"
+
+
+def test_webhook_deny_blocks_dangerous_command_without_hanging():
+    """A dangerous command in a webhook run (mode=deny) returns BLOCKED, not pending."""
+    with mock_patch.object(approval, "_get_session_platform", lambda: "webhook"), \
+         mock_patch.object(approval, "_get_webhook_approval_mode", lambda: "deny"), \
+         mock_patch.object(approval, "_get_approval_mode", lambda: "manual"), \
+         mock_patch.object(approval, "env_var_enabled",
+                           lambda v: v in {"HERMES_GATEWAY_SESSION"}):
+        # rm -rf of a non-root path: dangerous but not hardline
+        result = approval.check_all_command_guards("rm -rf /tmp/somedir/data", "local")
+    assert result["approved"] is False
+    assert "webhook" in result["message"].lower()
+    assert result.get("status") != "approval_required"
+    assert "approval_pending" not in result
+
+
+def test_webhook_approve_allows_dangerous_command():
+    with mock_patch.object(approval, "_get_session_platform", lambda: "webhook"), \
+         mock_patch.object(approval, "_get_webhook_approval_mode", lambda: "approve"), \
+         mock_patch.object(approval, "_get_approval_mode", lambda: "manual"), \
+         mock_patch.object(approval, "env_var_enabled",
+                           lambda v: v in {"HERMES_GATEWAY_SESSION"}):
+        result = approval.check_all_command_guards("rm -rf /tmp/somedir/data", "local")
+    assert result["approved"] is True
+    assert result.get("webhook_approved") is True
+
+
+def test_webhook_deny_still_blocks_hardline():
+    """webhook_mode=approve must NOT bypass the hardline floor (rm -rf /)."""
+    with mock_patch.object(approval, "_get_session_platform", lambda: "webhook"), \
+         mock_patch.object(approval, "_get_webhook_approval_mode", lambda: "approve"), \
+         mock_patch.object(approval, "_get_approval_mode", lambda: "manual"):
+        result = approval.check_all_command_guards("rm -rf /", "local")
+    assert result["approved"] is False
+    assert "hardline" in result["message"].lower()
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"[PASS] {name}")
+            except Exception as e:
+                fails += 1
+                print(f"[FAIL] {name}: {e!r}")
+    print("ALL PASS" if not fails else f"{fails} FAILURE(S)")
+    sys.exit(1 if fails else 0)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -927,6 +927,41 @@ def _get_cron_approval_mode() -> str:
         return "deny"
 
 
+def _is_webhook_session() -> bool:
+    """True when this agent run was triggered by an inbound webhook POST.
+
+    Webhook runs are autonomous like cron — there is no interactive channel
+    to answer a /approve prompt (the webhook adapter never registers a
+    gateway notify callback). Without this, a dangerous command in a webhook
+    run falls through to the gateway branch, calls submit_pending() with no
+    listener, and blocks the run indefinitely. Governed by
+    ``approvals.webhook_mode`` config, mirroring cron's ``cron_mode``.
+    """
+    # Cron takes precedence: a cron job that happens to bind a platform is
+    # still a cron session, handled by its own mode.
+    if env_var_enabled("HERMES_CRON_SESSION"):
+        return False
+    return _get_session_platform() == "webhook"
+
+
+def _get_webhook_approval_mode() -> str:
+    """Read the webhook approval mode from config. Returns 'deny' or 'approve'.
+
+    Defaults to 'deny' (safe): a dangerous command in a webhook run is
+    blocked with a helpful message so the agent finds another way, rather
+    than hanging on an approval no human can answer.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        mode = str(cfg_get(config, "approvals", "webhook_mode", default="deny")).lower().strip()
+        if mode in {"approve", "off", "allow", "yes"}:
+            return "approve"
+        return "deny"
+    except Exception:
+        return "deny"
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -1349,6 +1384,32 @@ def check_all_command_guards(command: str, env_type: str,
     all_keys = [key for key, _, _ in warnings]
     has_tirith = any(is_t for _, _, is_t in warnings)
 
+    # Webhook sessions: autonomous like cron, no interactive channel to answer
+    # /approve. Resolve via approvals.webhook_mode instead of falling through to
+    # the gateway branch, where submit_pending() would block with no listener.
+    if _is_webhook_session():
+        if _get_webhook_approval_mode() == "approve":
+            for key, _, _ in warnings:
+                approve_session(session_key, key)
+            logger.warning(
+                "WEBHOOK AUTO-APPROVED dangerous command (webhook_mode=approve): "
+                "%s — %s", combined_desc, command[:200],
+            )
+            return {"approved": True, "message": None, "webhook_approved": True,
+                    "description": combined_desc}
+        return {
+            "approved": False,
+            "message": (
+                f"BLOCKED: Command flagged as dangerous ({combined_desc}) "
+                "but webhook-triggered runs have no user present to approve it. "
+                "Find an alternative approach that avoids this command. "
+                "To allow dangerous commands in webhook runs, set "
+                "approvals.webhook_mode: approve in config.yaml."
+            ),
+            "pattern_key": primary_key,
+            "description": combined_desc,
+        }
+
     # Gateway/async approval — block the agent thread until the user
     # responds with /approve or /deny, mirroring the CLI's synchronous
     # input() flow.  The agent never sees "approval_required"; it either
@@ -1598,6 +1659,30 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
                 "user_consent": False,
             }
         # verdict == "escalate" → fall through to manual approval
+
+    # Webhook sessions: autonomous, no interactive channel. Resolve via
+    # approvals.webhook_mode instead of hanging on submit_pending() below.
+    if _is_webhook_session():
+        if _get_webhook_approval_mode() == "approve":
+            logger.warning(
+                "WEBHOOK AUTO-APPROVED execute_code (webhook_mode=approve): %s",
+                description,
+            )
+            return {"approved": True, "message": None, "webhook_approved": True,
+                    "description": description}
+        return {
+            "approved": False,
+            "message": (
+                f"BLOCKED: execute_code flagged as dangerous ({description}) "
+                "but webhook-triggered runs have no user present to approve it. "
+                "Find an alternative approach. To allow dangerous code in "
+                "webhook runs, set approvals.webhook_mode: approve in config.yaml."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": "blocked",
+            "user_consent": False,
+        }
 
     notify_cb = None
     with _lock:


### PR DESCRIPTION
## What does this PR do?

Makes **webhook-triggered agent runs** (the `webhook` platform adapter) actually
work autonomously. Today, an agent woken by an inbound webhook POST will **hang
indefinitely** the moment it does anything that needs a human, because the
webhook session is treated like an interactive gateway session even though no
human is present to respond.

Three independent dead-ends, all hit in a real Linear→Hermes integration:

1. **Command approval hang.** A dangerous-pattern command (e.g. loading a
   secret, `curl`) routes through the gateway approval branch, calls
   `submit_pending()` with no listener, and blocks forever. Cron already solved
   this with `approvals.cron_mode`; webhooks had no equivalent.

2. **`clarify()` hang.** If the agent calls the `clarify` tool, the gateway
   callback blocks on `wait_for_response` for the full clarify timeout (minutes)
   per call, with nobody to answer.

3. **Linear signature rejected.** `_validate_signature` knew GitHub / GitLab /
   Svix / generic headers but not Linear's `Linear-Signature` (hex HMAC-SHA256
   of the raw body), so genuine Linear webhooks 401'd.

The approach mirrors the **existing cron escape hatch** rather than inventing a
new pattern: autonomous sessions resolve these locally instead of waiting on a
human who will never arrive.

## Related Issue

No existing issue — happy to file one if preferred. Reproducible by pointing any
webhook subscription's agent at a prompt that loads a secret or calls `clarify`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (`approvals.webhook_mode`, Linear signature support)

## Changes Made

- `tools/approval.py`
  - `_is_webhook_session()` — detects `platform == "webhook"` (cron takes
    precedence).
  - `_get_webhook_approval_mode()` — reads `approvals.webhook_mode`
    (`deny` default / `approve`), analogous to `cron_mode`.
  - Both guard paths (`check_all_command_guards` for terminal,
    `check_execute_code_guard` for execute_code) resolve webhook sessions via
    that mode instead of `submit_pending()`. The hardline floor (disk wipes,
    power-off, fork bombs) is still absolute — `webhook_mode: approve` cannot
    bypass it.
- `hermes_cli/config.py` — adds `approvals.webhook_mode: "deny"` to the default
  config with documentation.
- `gateway/run.py` — `_clarify_callback_sync` short-circuits on
  `platform == "webhook"`, returning a sentinel that tells the agent to make a
  reasonable default instead of blocking.
- `gateway/platforms/webhook.py` — `_validate_signature` recognizes Linear's
  `Linear-Signature` header (hex HMAC-SHA256 of the body).
- Tests: `tests/tools/test_webhook_approval_mode.py` (new, 8 cases incl. a
  hardline-bypass guard), `tests/gateway/test_webhook_adapter.py` (+2 Linear
  signature cases).

## How to Test

1. Enable the webhook platform (`platforms.webhook.enabled: true`) and create a
   subscription whose prompt loads a secret or runs `curl`:
   `hermes webhook subscribe demo --prompt "..." --skills ...`.
2. POST a signed event to the route. **Before:** the run reaches API call #1
   then stalls (no tool execution, no completion); `clarify`/approval block for
   minutes. **After:** the run completes — dangerous commands are denied with a
   "find another way" message (or auto-approved if `webhook_mode: approve`), and
   `clarify` returns an immediate "decide yourself" sentinel.
3. Linear specifically: create a webhook in Linear pointed at the route. The
   `Linear-Signature` header now validates instead of 401.
4. `./venv/bin/python -m pytest tests/tools/test_approval.py tests/tools/test_webhook_approval_mode.py tests/tools/test_hardline_blocklist.py tests/gateway/test_webhook_adapter.py -o 'addopts=' -q` → 372 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(webhook):`, `feat(webhook):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant test suites and all pass (372 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 (verified end-to-end with a live Linear webhook)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (config docstring for `webhook_mode`)
- [x] I've updated the default config (`hermes_cli/config.py`) with the new `approvals.webhook_mode` key — N/A for `cli-config.yaml.example` (not present in tree)
- [ ] N/A — no architecture/workflow doc changes
- [x] I've considered cross-platform impact — logic is platform-agnostic (string compare + config reads)
- [x] I've updated tool behavior docs — N/A, no tool schema changes
