### PR TITLE
docs: fix post-install shell reload hint to prefer zsh on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you already have Git installed, the installer detects it and uses that instea
 After installation:
 
 ```bash
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
+source ~/.zshrc     # reload shell — zsh (macOS default); use ~/.bashrc for bash
 hermes              # start chatting!
 ```
 


### PR DESCRIPTION
## Summary

- macOS has defaulted to zsh since Catalina (2019), but the README's post-install snippet told users to run `source ~/.bashrc` with zsh as a parenthetical alternative
- The install script itself already detects the user's shell and prints the correct command (`~/.zshrc` for zsh users, `~/.bashrc` for bash users)
- This PR aligns the README example with what the installer actually tells users

## Change

```diff
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
+source ~/.zshrc     # reload shell — zsh (macOS default); use ~/.bashrc for bash
```

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the snippet matches what `install.sh` prints for zsh users (lines 2058–2060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)