### PR TITLE
fix(agent): rebuild correct client on stream retry and add reasoning-only stream watchdog

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -25,7 +25,11 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
+from hermes_cli.timeouts import (
+    get_provider_content_stale_timeout,
+    get_provider_request_timeout,
+    get_provider_stale_timeout,
+)
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
@@ -120,6 +124,59 @@ def _env_float(name: str, default: float) -> float:
         return float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         return default
+
+
+def _is_deepseek_stream_target(agent) -> bool:
+    """Return True when a stream belongs to DeepSeek or a DeepSeek-compatible URL.
+
+    The visible-output watchdog below is intentionally narrow by default: it
+    protects the known DeepSeek failure mode without changing behavior for
+    providers whose long reasoning/prefill pauses are expected.
+    """
+    values = (
+        getattr(agent, "provider", None),
+        getattr(agent, "model", None),
+        getattr(agent, "base_url", None),
+        getattr(agent, "_anthropic_base_url", None),
+        getattr(agent, "_base_url_lower", None),
+        getattr(agent, "_base_url_hostname", None),
+    )
+    return any("deepseek" in str(value).lower() for value in values if value)
+
+
+def _compute_stream_content_stale_timeout(agent) -> float:
+    """Seconds of reasoning-only stream activity allowed before reconnect.
+
+    ``inf`` means disabled. Provider/model config wins, then explicit env vars.
+    With no explicit setting, enable only for DeepSeek at 300s. A value <= 0
+    disables the watchdog.
+    """
+    configured = get_provider_content_stale_timeout(
+        getattr(agent, "provider", ""), getattr(agent, "model", None)
+    )
+    if configured is not None:
+        if configured <= 0:
+            return float("inf")
+        return configured
+
+    for env_name in (
+        "HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS",
+        "HERMES_STREAM_CONTENT_STALE_TIMEOUT",
+    ):
+        raw = os.getenv(env_name)
+        if raw is None:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value <= 0:
+            return float("inf")
+        return value
+
+    if _is_deepseek_stream_target(agent):
+        return 300.0
+    return float("inf")
 
 
 def interruptible_api_call(agent, api_kwargs: dict):
@@ -1662,6 +1719,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Separate visible-output timer for DeepSeek reasoning-only streams. A
+    # provider can keep the wire active forever by sending reasoning chunks;
+    # those should not postpone a reconnect when no user-visible text or
+    # tool-call deltas arrive.
+    last_visible_output_time = {"t": last_chunk_time["t"]}
+    reasoning_since_visible_output = {"yes": False}
+
+    def _mark_visible_stream_output() -> None:
+        last_visible_output_time["t"] = time.time()
+        reasoning_since_visible_output["yes"] = False
+
+    def _mark_reasoning_stream_output() -> None:
+        reasoning_since_visible_output["yes"] = True
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1721,6 +1791,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
+        last_visible_output_time["t"] = last_chunk_time["t"]
+        reasoning_since_visible_output["yes"] = False
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1796,11 +1868,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
+                _mark_reasoning_stream_output()
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
+                _mark_visible_stream_output()
                 content_parts.append(delta.content)
                 if not tool_calls_acc:
                     _fire_first_delta()
@@ -1826,6 +1900,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                _mark_visible_stream_output()
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -1970,6 +2045,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         # Reset stale-stream timer for this attempt
         last_chunk_time["t"] = time.time()
+        last_visible_output_time["t"] = last_chunk_time["t"]
+        reasoning_since_visible_output["yes"] = False
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -2015,6 +2092,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 if event_type == "content_block_start":
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
+                        _mark_visible_stream_output()
                         has_tool_use = True
                         tool_name = getattr(block, "name", None)
                         if tool_name:
@@ -2027,6 +2105,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         delta_type = getattr(delta, "type", None)
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
+                            if text:
+                                _mark_visible_stream_output()
                             if text and not has_tool_use:
                                 _fire_first_delta()
                                 agent._fire_stream_delta(text)
@@ -2034,11 +2114,32 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                _mark_reasoning_stream_output()
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
 
             # Return the native Anthropic Message for downstream processing
             return stream.get_final_message()
+
+    def _rebuild_stream_pool_client(reason: str) -> None:
+        if agent.api_mode == "anthropic_messages":
+            try:
+                client = getattr(agent, "_anthropic_client", None)
+                if client is not None:
+                    client.close()
+            except Exception:
+                pass
+            try:
+                agent._rebuild_anthropic_client()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to rebuild Anthropic client (%s) %s error=%s",
+                    reason,
+                    agent._client_log_context(),
+                    exc,
+                )
+        else:
+            agent._replace_primary_openai_client(reason=reason)
 
     def _call():
         import httpx as _httpx
@@ -2168,9 +2269,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         )
                         _close_request_client_once("stream_mid_tool_retry_cleanup")
                         try:
-                            agent._replace_primary_openai_client(
-                                reason="stream_mid_tool_retry_pool_cleanup"
-                            )
+                            _rebuild_stream_pool_client("stream_mid_tool_retry_pool_cleanup")
                         except Exception:
                             pass
                         continue
@@ -2221,9 +2320,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Also rebuild the primary client to purge
                             # any dead connections from the pool.
                             try:
-                                agent._replace_primary_openai_client(
-                                    reason="stream_retry_pool_cleanup"
-                                )
+                                _rebuild_stream_pool_client("stream_retry_pool_cleanup")
                             except Exception:
                                 pass
                             continue
@@ -2313,6 +2410,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
 
+    _stream_content_stale_timeout = _compute_stream_content_stale_timeout(agent)
+
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -2361,7 +2460,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                _rebuild_stream_pool_client("stale_stream_pool_cleanup")
             except Exception:
                 pass
             # Reset the timer so we don't kill repeatedly while
@@ -2370,6 +2469,45 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )
+
+        # DeepSeek V4 Flash can emit reasoning/thinking tokens indefinitely
+        # without visible text or tool-call deltas. Those chunks keep the
+        # normal wire-activity stale detector fresh, so use a separate
+        # visible-output watchdog gated by observed reasoning activity.
+        if reasoning_since_visible_output["yes"] and _stream_content_stale_timeout < float("inf"):
+            _content_stale_elapsed = time.time() - last_visible_output_time["t"]
+            if _content_stale_elapsed > _stream_content_stale_timeout:
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                logger.warning(
+                    "Stream content-stale for %.0fs (threshold %.0fs) — reasoning "
+                    "chunks received but no visible output. model=%s context=~%s "
+                    "tokens. Killing connection.",
+                    _content_stale_elapsed,
+                    _stream_content_stale_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ Provider sent reasoning for {int(_content_stale_elapsed)}s "
+                    "without visible text or a tool call. Reconnecting..."
+                )
+                try:
+                    _close_request_client_once("content_stale_stream_kill")
+                except Exception:
+                    pass
+                try:
+                    _rebuild_stream_pool_client("content_stale_stream_pool_cleanup")
+                except Exception:
+                    pass
+                # Avoid repeated kills while the worker thread notices the
+                # aborted connection and enters the retry/error path.
+                _now = time.time()
+                last_chunk_time["t"] = _now
+                last_visible_output_time["t"] = _now
+                reasoning_since_visible_output["yes"] = False
+                agent._touch_activity(
+                    f"content-stale stream detected after {int(_content_stale_elapsed)}s, reconnecting"
+                )
 
         if agent._interrupt_requested:
             try:

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
 
-def _coerce_timeout(raw: object) -> float | None:
+def _coerce_timeout(value: object) -> float | None:
     try:
-        timeout = float(raw)
+        timeout = float(value)
     except (TypeError, ValueError):
         return None
     if timeout <= 0:
         return None
     return timeout
 
+
+def _coerce_optional_timeout(value: object) -> float | None:
+    """Coerce timeout values where 0 is a valid explicit override.
+
+    Used by opt-in watchdogs so ``0`` can mean "disabled" at the caller.
+    Negative values are still treated as invalid/missing.
+    """
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return None
+    if timeout < 0:
+        return None
+    return timeout
 
 def get_provider_request_timeout(
     provider_id: str, model: str | None = None
@@ -67,6 +81,47 @@ def get_provider_stale_timeout(
             return timeout
 
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
+
+
+def get_provider_content_stale_timeout(
+    provider_id: str, model: str | None = None
+) -> float | None:
+    """Return a configured stream visible-output stale timeout, if any.
+
+    This is separate from ``stale_timeout_seconds``: the normal stale timeout
+    tracks wire activity, while this timeout tracks real assistant output
+    (visible text or tool-call deltas) so reasoning-only streams can be cut
+    off without penalizing healthy streams that are emitting content.
+    """
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return None
+
+    keys = ("content_stale_timeout_seconds", "stream_content_stale_timeout_seconds")
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        for key in keys:
+            timeout = _coerce_optional_timeout(model_config.get(key))
+            if timeout is not None:
+                return timeout
+
+    for key in keys:
+        timeout = _coerce_optional_timeout(provider_config.get(key))
+        if timeout is not None:
+            return timeout
+    return None
 
 
 def _get_model_config(

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import textwrap
 
 from hermes_cli.timeouts import (
+    get_provider_content_stale_timeout,
     get_provider_request_timeout,
     get_provider_stale_timeout,
 )
@@ -128,6 +129,48 @@ def test_invalid_stale_timeout_values_return_none(monkeypatch, tmp_path):
 
     assert get_provider_stale_timeout("openai-codex", "gpt-5.4") is None
     assert get_provider_stale_timeout("openai-codex", "gpt-5.5") is None
+
+
+def test_content_stale_timeout_model_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          deepseek:
+            content_stale_timeout_seconds: 300
+            models:
+              deepseek-v4-flash:
+                content_stale_timeout_seconds: 120
+        """,
+    )
+
+    assert get_provider_content_stale_timeout("deepseek", "deepseek-v4-flash") == 120.0
+    assert get_provider_content_stale_timeout("deepseek", "deepseek-chat") == 300.0
+
+
+def test_content_stale_timeout_legacy_key_and_invalid_values(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          deepseek:
+            stream_content_stale_timeout_seconds: 240
+            models:
+              deepseek-v4-flash:
+                content_stale_timeout_seconds: -1
+          anthropic:
+            content_stale_timeout_seconds: "slow"
+          gemini:
+            content_stale_timeout_seconds: 0
+        """,
+    )
+
+    assert get_provider_content_stale_timeout("deepseek", "deepseek-chat") == 240.0
+    assert get_provider_content_stale_timeout("deepseek", "deepseek-v4-flash") == 240.0
+    assert get_provider_content_stale_timeout("anthropic", "claude-opus-4.6") is None
+    assert get_provider_content_stale_timeout("gemini", "gemini-pro") == 0.0
 
 
 def test_anthropic_adapter_honors_timeout_kwarg():

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -711,8 +711,101 @@ class TestReasoningStreaming:
         assert response.choices[0].message.reasoning_content == "Let me think about this"
         assert response.choices[0].message.content == "The answer is 42"
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_deepseek_reasoning_only_chat_stream_trips_content_stale_watchdog(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """DeepSeek reasoning chunks must not postpone visible-output stale detection forever."""
+        from run_agent import AIAgent
+        import httpx
+        import time
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "30")
+        monkeypatch.setenv("HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS", "0.05")
+
+        class _ReasoningOnlyStream:
+            def __init__(self, client):
+                self.client = client
+                self.guard_exhausted = False
+                self.chunks = 0
+
+            def __iter__(self):
+                while not self.client.closed and self.chunks < 200:
+                    self.chunks += 1
+                    time.sleep(0.005)
+                    yield _make_stream_chunk(reasoning_content="thinking")
+                if self.client.closed:
+                    raise httpx.ReadTimeout("closed by content stale watchdog")
+                self.guard_exhausted = True
+                raise AssertionError(
+                    "content stale watchdog did not close reasoning-only stream"
+                )
+
+        client = SimpleNamespace(closed=False)
+        stream = _ReasoningOnlyStream(client)
+        client.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: stream)
+        )
+        mock_create.return_value = client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.deepseek.com/v1",
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._abort_request_openai_client = lambda c, reason=None: setattr(c, "closed", True)
+
+        with pytest.raises(httpx.ReadTimeout, match="content stale watchdog"):
+            agent._interruptible_streaming_api_call({})
+
+        assert client.closed is True
+        assert stream.guard_exhausted is False
+
 
 # ── Test: _has_stream_consumers ──────────────────────────────────────────
+
+
+def test_content_stale_watchdog_default_is_deepseek_only(monkeypatch):
+    from agent.chat_completion_helpers import _compute_stream_content_stale_timeout
+
+    monkeypatch.delenv("HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_STREAM_CONTENT_STALE_TIMEOUT", raising=False)
+
+    deepseek_agent = SimpleNamespace(
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com/anthropic",
+    )
+    anthropic_agent = SimpleNamespace(
+        provider="anthropic",
+        model="claude-opus-4.6",
+        base_url="https://api.anthropic.com",
+    )
+
+    assert _compute_stream_content_stale_timeout(deepseek_agent) == 300.0
+    assert _compute_stream_content_stale_timeout(anthropic_agent) == float("inf")
+
+
+def test_content_stale_watchdog_env_zero_disables(monkeypatch):
+    from agent.chat_completion_helpers import _compute_stream_content_stale_timeout
+
+    monkeypatch.setenv("HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS", "0")
+    agent = SimpleNamespace(
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com/anthropic",
+    )
+
+    assert _compute_stream_content_stale_timeout(agent) == float("inf")
+
 
 
 class TestHasStreamConsumers:
@@ -986,11 +1079,82 @@ class TestAnthropicStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
 
-    @patch("run_agent.AIAgent._replace_primary_openai_client")
-    def test_anthropic_stream_parser_valueerror_retries_before_delivery(
-        self, mock_replace, monkeypatch,
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
+    def test_deepseek_reasoning_only_anthropic_stream_hits_content_stale_watchdog(
+        self, mock_rebuild, monkeypatch,
     ):
-        """Malformed Anthropic event-stream frames retry instead of surfacing HTTP None."""
+        """DeepSeek /anthropic thinking deltas must not bypass stale detection."""
+        from run_agent import AIAgent
+        import httpx
+        import time
+
+        class _ReasoningOnlyAnthropicStream:
+            response = None
+
+            def __init__(self, client):
+                self.client = client
+                self.guard_events = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                while not self.client.closed:
+                    self.guard_events += 1
+                    if self.guard_events > 200:
+                        raise AssertionError("content-stale watchdog did not close Anthropic stream")
+                    time.sleep(0.005)
+                    yield SimpleNamespace(
+                        type="content_block_delta",
+                        delta=SimpleNamespace(type="thinking_delta", thinking="thinking"),
+                    )
+                raise httpx.ReadTimeout("closed by content-stale watchdog")
+
+            def get_final_message(self):
+                return SimpleNamespace(content=[], stop_reason="end_turn")
+
+        class _AnthropicClient:
+            def __init__(self):
+                self.closed = False
+                self.messages = SimpleNamespace(
+                    stream=lambda **_kw: _ReasoningOnlyAnthropicStream(self)
+                )
+
+            def close(self):
+                self.closed = True
+
+        client = _AnthropicClient()
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.deepseek.com/anthropic",
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        agent._anthropic_client = client
+        agent._try_refresh_anthropic_client_credentials = lambda: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "10")
+        monkeypatch.setenv("HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS", "0.05")
+
+        with pytest.raises(httpx.ReadTimeout, match="content-stale watchdog"):
+            agent._interruptible_streaming_api_call({})
+
+        assert client.closed is True
+        assert mock_rebuild.call_count >= 1
+
+    @patch("run_agent.AIAgent._rebuild_anthropic_client")
+    def test_anthropic_stream_parser_valueerror_retries_before_delivery(
+        self, mock_rebuild, monkeypatch,
+    ):
+        """Malformed Anthropic event-stream frames retry with an Anthropic client rebuild."""
         from run_agent import AIAgent
 
         agent = AIAgent(
@@ -1035,7 +1199,7 @@ class TestAnthropicStreamCallbacks:
 
         assert response is final_message
         assert agent._anthropic_client.messages.stream.call_count == 2
-        assert mock_replace.call_count == 1
+        assert mock_rebuild.call_count == 1
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_generic_anthropic_valueerror_still_propagates_without_stream_retry(


### PR DESCRIPTION
## Summary

Fix two DeepSeek streaming bugs: credential loss during stream retry, and reasoning-only infinite hangs.

### 1. Stream retry credential loss

Anthropic-wire providers (including DeepSeek `/anthropic`) lost credentials during stream retry and pool cleanup because the code unconditionally rebuilt the OpenAI client. Add `_rebuild_stream_pool_client()` that dispatches to `_rebuild_anthropic_client()` for `anthropic_messages` streams.

Refs #23678

### 2. Reasoning-only infinite hang

DeepSeek V4 Flash can emit reasoning/thinking tokens indefinitely without visible output. Those chunks keep the wire-activity stale detector fresh, preventing reconnects until the ~600s server-side HTTP timeout.

Add a visible-output watchdog (default 300s, DeepSeek only) that tracks real assistant output (text deltas, tool-call deltas, tool_use blocks) separately from reasoning activity. Reasoning deltas do NOT refresh this timer.

Configurable via `content_stale_timeout_seconds` (provider/model config) or `HERMES_STREAM_CONTENT_STALE_TIMEOUT_SECONDS` env var. Set to `0` to disable. Other providers are completely unaffected.

Refs #23286, #29796

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `agent/chat_completion_helpers.py` | +154 | `_rebuild_stream_pool_client()` dispatches by api_mode; `last_visible_output_time` / `reasoning_since_visible_output` trackers; visible-output watchdog in outer poll loop |
| `hermes_cli/timeouts.py` | +59 | `get_provider_content_stale_timeout()` reads provider/model config; `_coerce_optional_timeout()` allows `0` as explicit disable |
| `tests/run_agent/test_streaming.py` | +172 | 5 new tests: credential rebuild dispatch + watchdog trigger (chat_completions & anthropic_messages) + DeepSeek-only default + env-zero disable |
| `tests/hermes_cli/test_timeouts.py` | +43 | 2 new tests: model override priority + legacy-key + illegal-value handling |

## How to test

```bash
pytest tests/run_agent/test_streaming.py tests/hermes_cli/test_timeouts.py \
       tests/agent/test_local_stream_timeout.py \
       tests/agent/test_non_stream_stale_timeout.py \
       tests/agent/transports/test_chat_completions.py -q
```

## Platforms tested

macOS 15.3.2

## Validation

- **198 passed** (streaming + timeout + chat_completions)
- `tests/agent/` full suite: **3727 passed** (7 pre-existing unrelated failures)
- `ruff check`: All checks passed
- `git diff --check`: no whitespace/format issues
