### PR TITLE
feat(plugins): expose API server route extensions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -46,10 +46,12 @@ import errno
 import hashlib
 import hmac
 import itertools
+import inspect
 import json
 from contextlib import contextmanager, nullcontext, suppress
 from contextvars import ContextVar
-from functools import wraps
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial, wraps
 import logging
 import os
 import re
@@ -59,7 +61,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -116,6 +118,12 @@ class _ArtifactScopeFacade:
 _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 _BROWSER_CONTROL_WS_PROTOCOL = "hermes-browser-control-v1"
 _BROWSER_CONTROL_TICKET_PROTOCOL_PREFIX = "hermes-browser-control-ticket."
+
+# Enabled plugin code is trusted, but it must not monopolize the shared API
+# event loop or leave an HTTP request open forever.
+PLUGIN_API_HANDLER_TIMEOUT_SECONDS = 30.0
+PLUGIN_CAPABILITY_TIMEOUT_SECONDS = 5.0
+PLUGIN_SYNC_MAX_WORKERS = 4
 
 
 def _approval_event_choices(
@@ -1609,6 +1617,13 @@ class APIServerAdapter(BasePlatformAdapter):
         # _inject_browser_control_artifacts().
         self._browser_control_artifacts: Dict[str, ArtifactStore] = {}
         self._browser_control_artifact_limiter: Optional[ArtifactRateLimiter] = None
+        # Synchronous plugin handlers are isolated from asyncio's process-wide
+        # default executor.  A matching admission gate prevents timed-out
+        # callbacks (which Python cannot forcibly stop) from spawning or
+        # queueing an unbounded number of worker threads.
+        self._plugin_sync_executor: Optional[ThreadPoolExecutor] = None
+        self._plugin_sync_slots: Optional[asyncio.BoundedSemaphore] = None
+        self._plugin_manager = self._load_plugin_manager()
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -1738,6 +1753,234 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             pass
         return active_api_runs, process_depth, active_delegations
+
+    def _load_plugin_manager(self):
+        """Best-effort plugin manager discovery for API-server plugin hooks."""
+        try:
+            from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+            discover_plugins()
+            return get_plugin_manager()
+        except Exception as exc:
+            logger.debug(
+                "[%s] Plugin manager unavailable for API server hooks (%s)",
+                self.name,
+                type(exc).__name__,
+            )
+            return None
+
+    def _get_plugin_sync_runtime(
+        self,
+    ) -> tuple[ThreadPoolExecutor, asyncio.BoundedSemaphore]:
+        """Return the adapter-owned bounded runtime for synchronous plugins."""
+        if self._plugin_sync_executor is None or self._plugin_sync_slots is None:
+            workers = max(1, int(PLUGIN_SYNC_MAX_WORKERS))
+            self._plugin_sync_executor = ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix="hermes-plugin-api",
+            )
+            self._plugin_sync_slots = asyncio.BoundedSemaphore(workers)
+        return self._plugin_sync_executor, self._plugin_sync_slots
+
+    async def _run_plugin_sync(
+        self,
+        callback: Callable,
+        *args: Any,
+        timeout: float,
+        **kwargs: Any,
+    ) -> Any:
+        """Run one synchronous plugin callback with bounded admission.
+
+        The slot is released only when the worker really exits, not when the
+        HTTP request times out.  That distinction keeps hung callbacks from
+        accumulating executor threads or queued work across later requests.
+        """
+        loop = asyncio.get_running_loop()
+        executor, slots = self._get_plugin_sync_runtime()
+        started = loop.time()
+        await asyncio.wait_for(slots.acquire(), timeout=timeout)
+        remaining = timeout - (loop.time() - started)
+        if remaining <= 0:
+            slots.release()
+            raise asyncio.TimeoutError
+
+        try:
+            future = loop.run_in_executor(
+                executor,
+                partial(callback, *args, **kwargs),
+            )
+        except BaseException:
+            slots.release()
+            raise
+
+        future.add_done_callback(lambda _future, _slots=slots: _slots.release())
+        return await asyncio.wait_for(asyncio.shield(future), timeout=remaining)
+
+    def _mount_plugin_api_routes(self, router: Any) -> None:
+        """Mount default-profile plugin routes without breaking core startup.
+
+        The plugin manager is process-global and belongs to the profile that
+        launched the shared listener.  Do not mirror these routes into
+        ``/p/<profile>/``: doing so would expose a default-profile plugin in a
+        profile where it may not be installed or enabled.
+        """
+        manager = getattr(self, "_plugin_manager", None)
+        if manager is None or not hasattr(manager, "get_api_server_routes"):
+            return
+        from hermes_cli.plugins import is_safe_api_server_plugin_id
+
+        existing_routes: set[tuple[str, str]] = set()
+        for resource in router.resources():
+            path = getattr(resource, "canonical", None)
+            if not path:
+                continue
+            for route_info in resource:
+                method = getattr(route_info, "method", None)
+                if method:
+                    existing_routes.add((str(method).upper(), path))
+
+        try:
+            plugin_routes = list(manager.get_api_server_routes() or [])
+        except Exception as exc:
+            logger.warning(
+                "[%s] Plugin route collection failed (%s); skipping extensions",
+                self.name,
+                type(exc).__name__,
+            )
+            return
+
+        for route in plugin_routes:
+            method = "<invalid>"
+            path = "<invalid>"
+            plugin = "unknown"
+            try:
+                if not isinstance(route, dict):
+                    raise TypeError("route definition must be a dictionary")
+                method = str(route.get("method", "")).upper()
+                path = route.get("path")
+                handler = route.get("handler")
+                plugin = str(route.get("plugin", "")).strip("/")
+                if not method or not path or not callable(handler):
+                    raise ValueError("missing method/path/handler")
+                if not is_safe_api_server_plugin_id(plugin):
+                    raise ValueError(
+                        "plugin namespace must contain safe URL path segments"
+                    )
+                if not isinstance(path, str) or not path.startswith("/"):
+                    raise ValueError("path must start with /")
+                if not path.startswith("/v1/plugins/"):
+                    raise ValueError("path must be under /v1/plugins/")
+                if not plugin or not path.startswith(f"/v1/plugins/{plugin}/"):
+                    raise ValueError("path must stay under the plugin's own namespace")
+                if (method, path) in existing_routes:
+                    raise ValueError(f"route already registered: {method} {path}")
+                add_fn = getattr(router, f"add_{method.lower()}", None)
+                if add_fn is None:
+                    raise ValueError(f"unsupported method: {method}")
+
+                async def _authed_plugin_handler(
+                    request: "web.Request",
+                    _handler: Callable = handler,
+                    _method: str = method,
+                    _path: str = path,
+                    _plugin: str = str(route.get("plugin", "unknown")),
+                ) -> "web.Response":
+                    # Defense in depth if a future route-table refactor ever
+                    # mirrors this resource under /p/<profile>/.
+                    if _api_request_profile.get() is not None:
+                        return web.json_response(
+                            {"error": "Plugin route not found"},
+                            status=404,
+                        )
+                    auth_err = self._check_auth(request)
+                    if auth_err:
+                        return auth_err
+                    try:
+                        async def _invoke_handler():
+                            if inspect.iscoroutinefunction(_handler):
+                                result = _handler(request)
+                            else:
+                                result = await self._run_plugin_sync(
+                                    _handler,
+                                    request,
+                                    timeout=PLUGIN_API_HANDLER_TIMEOUT_SECONDS,
+                                )
+                            if inspect.isawaitable(result):
+                                result = await result
+                            return result
+
+                        result = await asyncio.wait_for(
+                            _invoke_handler(),
+                            timeout=PLUGIN_API_HANDLER_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[%s] Plugin route handler timed out for %s %s (plugin=%s)",
+                            self.name,
+                            _method,
+                            _path,
+                            _plugin,
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route failed",
+                                err_type="server_error",
+                                code="plugin_route_failed",
+                            ),
+                            status=500,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[%s] Plugin route handler failed for %s %s (plugin=%s): %s",
+                            self.name,
+                            _method,
+                            _path,
+                            _plugin,
+                            redact_sensitive_text(str(exc), force=True),
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route failed",
+                                err_type="server_error",
+                                code="plugin_route_failed",
+                            ),
+                            status=500,
+                        )
+                    if not isinstance(result, web.StreamResponse):
+                        logger.warning(
+                            "[%s] Plugin route returned %s instead of aiohttp.web.StreamResponse "
+                            "for %s %s (plugin=%s)",
+                            self.name,
+                            type(result).__name__,
+                            _method,
+                            _path,
+                            _plugin,
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route returned an invalid response",
+                                err_type="server_error",
+                                code="plugin_route_invalid_response",
+                            ),
+                            status=500,
+                        )
+                    return result
+
+                route_name = route.get("name")
+                if route_name:
+                    add_fn(path, _authed_plugin_handler, name=route_name)
+                else:
+                    add_fn(path, _authed_plugin_handler)
+                existing_routes.add((method, path))
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Failed to register plugin route %s %s (plugin=%s): %s",
+                    self.name,
+                    method,
+                    path,
+                    plugin,
+                    redact_sensitive_text(str(exc), force=True),
+                )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -3435,7 +3678,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        return web.json_response({
+        payload = {
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
             "model": self._model_name,
@@ -3545,7 +3788,52 @@ class APIServerAdapter(BasePlatformAdapter):
                     "path": "/v1/artifacts/download/{artifact_id}",
                 },
             },
-        })
+        }
+
+        manager = self._plugin_manager
+        # The process-global manager belongs to the listener's launch profile.
+        # Never advertise its extensions on a multiplexed profile response.
+        if (
+            _api_request_profile.get() is None
+            and manager is not None
+            and hasattr(manager, "get_api_server_capabilities")
+        ):
+            try:
+                from hermes_cli.plugins import ApiServerCapabilityContext
+
+                plugin_caps = await self._run_plugin_sync(
+                    manager.get_api_server_capabilities,
+                    context=ApiServerCapabilityContext(
+                        server_name="api_server",
+                        request_method="GET",
+                        request_path="/v1/capabilities",
+                        auth_required=bool(self._api_key),
+                        profile=_api_request_profile.get(),
+                    ),
+                    timeout=PLUGIN_CAPABILITY_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] Plugin capability providers timed out; omitting extensions",
+                    self.name,
+                )
+                plugin_caps = []
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Plugin capability resolution failed (%s); omitting extensions",
+                    self.name,
+                    type(exc).__name__,
+                )
+                plugin_caps = []
+            if plugin_caps:
+                payload.setdefault("extensions", {})
+                payload["extensions"]["plugins"] = {
+                    str(entry.get("plugin")): entry.get("capabilities", {})
+                    for entry in plugin_caps
+                    if isinstance(entry, dict) and entry.get("plugin")
+                }
+
+        return web.json_response(payload)
 
     # ------------------------------------------------------------------
     # Browser-extension control (authenticated local/VPS API)
@@ -7933,6 +8221,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if self.gateway_runner is not None:
                 self._app["gateway_runner"] = self.gateway_runner
 
+            self._mount_plugin_api_routes(self._app.router)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:
@@ -8066,6 +8355,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 await self._runner.cleanup()
                 self._runner = None
         finally:
+            plugin_executor = self._plugin_sync_executor
+            self._plugin_sync_executor = None
+            self._plugin_sync_slots = None
+            if plugin_executor is not None:
+                plugin_executor.shutdown(wait=False, cancel_futures=True)
             self._close_cached_session_dbs()
             self._app = None
         logger.info("[%s] API server stopped", self.name)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1452,6 +1452,7 @@ class APIServerAdapter(BasePlatformAdapter):
         manager = getattr(self, "_plugin_manager", None)
         if manager is None or not hasattr(manager, "get_api_server_routes"):
             return
+        from hermes_cli.plugins import is_safe_api_server_plugin_id
 
         existing_routes: set[tuple[str, str]] = set()
         for resource in router.resources():
@@ -1486,6 +1487,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 plugin = str(route.get("plugin", "")).strip("/")
                 if not method or not path or not callable(handler):
                     raise ValueError("missing method/path/handler")
+                if not is_safe_api_server_plugin_id(plugin):
+                    raise ValueError(
+                        "plugin namespace must contain safe URL path segments"
+                    )
                 if not isinstance(path, str) or not path.startswith("/"):
                     raise ValueError("path must start with /")
                 if not path.startswith("/v1/plugins/"):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -47,7 +47,8 @@ import inspect
 import json
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
-from functools import wraps
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial, wraps
 import logging
 import os
 import re
@@ -73,6 +74,7 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
 # event loop or leave an HTTP request open forever.
 PLUGIN_API_HANDLER_TIMEOUT_SECONDS = 30.0
 PLUGIN_CAPABILITY_TIMEOUT_SECONDS = 5.0
+PLUGIN_SYNC_MAX_WORKERS = 4
 
 
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
@@ -1286,6 +1288,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Shutdown counts this reservation so the request cannot slip through
         # the drain between its first await and _run_agent()/task registration.
         self._pending_agent_requests: int = 0
+        # Synchronous plugin handlers are isolated from asyncio's process-wide
+        # default executor.  A matching admission gate prevents timed-out
+        # callbacks (which Python cannot forcibly stop) from spawning or
+        # queueing an unbounded number of worker threads.
+        self._plugin_sync_executor: Optional[ThreadPoolExecutor] = None
+        self._plugin_sync_slots: Optional[asyncio.BoundedSemaphore] = None
         self._plugin_manager = self._load_plugin_manager()
 
     def active_agent_work_count(self) -> int:
@@ -1386,6 +1394,53 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             return None
 
+    def _get_plugin_sync_runtime(
+        self,
+    ) -> tuple[ThreadPoolExecutor, asyncio.BoundedSemaphore]:
+        """Return the adapter-owned bounded runtime for synchronous plugins."""
+        if self._plugin_sync_executor is None or self._plugin_sync_slots is None:
+            workers = max(1, int(PLUGIN_SYNC_MAX_WORKERS))
+            self._plugin_sync_executor = ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix="hermes-plugin-api",
+            )
+            self._plugin_sync_slots = asyncio.BoundedSemaphore(workers)
+        return self._plugin_sync_executor, self._plugin_sync_slots
+
+    async def _run_plugin_sync(
+        self,
+        callback: Callable,
+        *args: Any,
+        timeout: float,
+        **kwargs: Any,
+    ) -> Any:
+        """Run one synchronous plugin callback with bounded admission.
+
+        The slot is released only when the worker really exits, not when the
+        HTTP request times out.  That distinction keeps hung callbacks from
+        accumulating executor threads or queued work across later requests.
+        """
+        loop = asyncio.get_running_loop()
+        executor, slots = self._get_plugin_sync_runtime()
+        started = loop.time()
+        await asyncio.wait_for(slots.acquire(), timeout=timeout)
+        remaining = timeout - (loop.time() - started)
+        if remaining <= 0:
+            slots.release()
+            raise asyncio.TimeoutError
+
+        try:
+            future = loop.run_in_executor(
+                executor,
+                partial(callback, *args, **kwargs),
+            )
+        except BaseException:
+            slots.release()
+            raise
+
+        future.add_done_callback(lambda _future, _slots=slots: _slots.release())
+        return await asyncio.wait_for(asyncio.shield(future), timeout=remaining)
+
     def _mount_plugin_api_routes(self, router: Any) -> None:
         """Mount default-profile plugin routes without breaking core startup.
 
@@ -1465,7 +1520,11 @@ class APIServerAdapter(BasePlatformAdapter):
                             if inspect.iscoroutinefunction(_handler):
                                 result = _handler(request)
                             else:
-                                result = await asyncio.to_thread(_handler, request)
+                                result = await self._run_plugin_sync(
+                                    _handler,
+                                    request,
+                                    timeout=PLUGIN_API_HANDLER_TIMEOUT_SECONDS,
+                                )
                             if inspect.isawaitable(result):
                                 result = await result
                             return result
@@ -3105,11 +3164,16 @@ class APIServerAdapter(BasePlatformAdapter):
             and hasattr(manager, "get_api_server_capabilities")
         ):
             try:
-                plugin_caps = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        manager.get_api_server_capabilities,
-                        adapter=self,
-                        request=request,
+                from hermes_cli.plugins import ApiServerCapabilityContext
+
+                plugin_caps = await self._run_plugin_sync(
+                    manager.get_api_server_capabilities,
+                    context=ApiServerCapabilityContext(
+                        server_name="api_server",
+                        request_method="GET",
+                        request_path="/v1/capabilities",
+                        auth_required=bool(self._api_key),
+                        profile=_api_request_profile.get(),
                     ),
                     timeout=PLUGIN_CAPABILITY_TIMEOUT_SECONDS,
                 )
@@ -7151,6 +7215,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
+        plugin_executor = self._plugin_sync_executor
+        self._plugin_sync_executor = None
+        self._plugin_sync_slots = None
+        if plugin_executor is not None:
+            plugin_executor.shutdown(wait=False, cancel_futures=True)
         self._app = None
         logger.info("[%s] API server stopped", self.name)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -69,6 +69,12 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
+# Enabled plugin code is trusted, but it must not monopolize the shared API
+# event loop or leave an HTTP request open forever.
+PLUGIN_API_HANDLER_TIMEOUT_SECONDS = 30.0
+PLUGIN_CAPABILITY_TIMEOUT_SECONDS = 5.0
+
+
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
     if smart_denied:
         return ["once", "deny"]
@@ -1364,6 +1370,7 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             pass
         return active_api_runs, process_depth, active_delegations
+
     def _load_plugin_manager(self):
         """Best-effort plugin manager discovery for API-server plugin hooks."""
         try:
@@ -1372,11 +1379,21 @@ class APIServerAdapter(BasePlatformAdapter):
             discover_plugins()
             return get_plugin_manager()
         except Exception as exc:
-            logger.debug("[%s] Plugin manager unavailable for API server hooks: %s", self.name, exc)
+            logger.debug(
+                "[%s] Plugin manager unavailable for API server hooks (%s)",
+                self.name,
+                type(exc).__name__,
+            )
             return None
 
     def _mount_plugin_api_routes(self, router: Any) -> None:
-        """Mount plugin-contributed API routes without breaking core startup."""
+        """Mount default-profile plugin routes without breaking core startup.
+
+        The plugin manager is process-global and belongs to the profile that
+        launched the shared listener.  Do not mirror these routes into
+        ``/p/<profile>/``: doing so would expose a default-profile plugin in a
+        profile where it may not be installed or enabled.
+        """
         manager = getattr(self, "_plugin_manager", None)
         if manager is None or not hasattr(manager, "get_api_server_routes"):
             return
@@ -1391,22 +1408,41 @@ class APIServerAdapter(BasePlatformAdapter):
                 if method:
                     existing_routes.add((str(method).upper(), path))
 
-        for route in manager.get_api_server_routes() or []:
+        try:
+            plugin_routes = list(manager.get_api_server_routes() or [])
+        except Exception as exc:
+            logger.warning(
+                "[%s] Plugin route collection failed (%s); skipping extensions",
+                self.name,
+                type(exc).__name__,
+            )
+            return
+
+        for route in plugin_routes:
+            method = "<invalid>"
+            path = "<invalid>"
+            plugin = "unknown"
             try:
+                if not isinstance(route, dict):
+                    raise TypeError("route definition must be a dictionary")
                 method = str(route.get("method", "")).upper()
                 path = route.get("path")
                 handler = route.get("handler")
+                plugin = str(route.get("plugin", "")).strip("/")
                 if not method or not path or not callable(handler):
                     raise ValueError("missing method/path/handler")
                 if not isinstance(path, str) or not path.startswith("/"):
                     raise ValueError("path must start with /")
                 if not path.startswith("/v1/plugins/"):
                     raise ValueError("path must be under /v1/plugins/")
+                if not plugin or not path.startswith(f"/v1/plugins/{plugin}/"):
+                    raise ValueError("path must stay under the plugin's own namespace")
                 if (method, path) in existing_routes:
                     raise ValueError(f"route already registered: {method} {path}")
                 add_fn = getattr(router, f"add_{method.lower()}", None)
                 if add_fn is None:
                     raise ValueError(f"unsupported method: {method}")
+
                 async def _authed_plugin_handler(
                     request: "web.Request",
                     _handler: Callable = handler,
@@ -1414,13 +1450,46 @@ class APIServerAdapter(BasePlatformAdapter):
                     _path: str = path,
                     _plugin: str = str(route.get("plugin", "unknown")),
                 ) -> "web.Response":
+                    # Defense in depth if a future route-table refactor ever
+                    # mirrors this resource under /p/<profile>/.
+                    if _api_request_profile.get() is not None:
+                        return web.json_response(
+                            {"error": "Plugin route not found"},
+                            status=404,
+                        )
                     auth_err = self._check_auth(request)
                     if auth_err:
                         return auth_err
                     try:
-                        result = _handler(request)
-                        if inspect.isawaitable(result):
-                            result = await result
+                        async def _invoke_handler():
+                            if inspect.iscoroutinefunction(_handler):
+                                result = _handler(request)
+                            else:
+                                result = await asyncio.to_thread(_handler, request)
+                            if inspect.isawaitable(result):
+                                result = await result
+                            return result
+
+                        result = await asyncio.wait_for(
+                            _invoke_handler(),
+                            timeout=PLUGIN_API_HANDLER_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[%s] Plugin route handler timed out for %s %s (plugin=%s)",
+                            self.name,
+                            _method,
+                            _path,
+                            _plugin,
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route failed",
+                                err_type="server_error",
+                                code="plugin_route_failed",
+                            ),
+                            status=500,
+                        )
                     except Exception as exc:
                         logger.warning(
                             "[%s] Plugin route handler failed for %s %s (plugin=%s): %s",
@@ -1428,7 +1497,7 @@ class APIServerAdapter(BasePlatformAdapter):
                             _method,
                             _path,
                             _plugin,
-                            redact_sensitive_text(str(exc)),
+                            redact_sensitive_text(str(exc), force=True),
                         )
                         return web.json_response(
                             _openai_error(
@@ -1468,11 +1537,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.warning(
                     "[%s] Failed to register plugin route %s %s (plugin=%s): %s",
                     self.name,
-                    route.get("method"),
-                    route.get("path"),
-                    route.get("plugin"),
-                    exc,
+                    method,
+                    path,
+                    plugin,
+                    redact_sensitive_text(str(exc), force=True),
                 )
+
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
         """Normalize configured CORS origins into a stable tuple."""
@@ -3027,8 +3097,35 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
         manager = self._plugin_manager
-        if manager is not None and hasattr(manager, "get_api_server_capabilities"):
-            plugin_caps = manager.get_api_server_capabilities(adapter=self, request=request) or []
+        # The process-global manager belongs to the listener's launch profile.
+        # Never advertise its extensions on a multiplexed profile response.
+        if (
+            _api_request_profile.get() is None
+            and manager is not None
+            and hasattr(manager, "get_api_server_capabilities")
+        ):
+            try:
+                plugin_caps = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        manager.get_api_server_capabilities,
+                        adapter=self,
+                        request=request,
+                    ),
+                    timeout=PLUGIN_CAPABILITY_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] Plugin capability providers timed out; omitting extensions",
+                    self.name,
+                )
+                plugin_caps = []
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Plugin capability resolution failed (%s); omitting extensions",
+                    self.name,
+                    type(exc).__name__,
+                )
+                plugin_caps = []
             if plugin_caps:
                 payload.setdefault("extensions", {})
                 payload["extensions"]["plugins"] = {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -43,6 +43,7 @@ import asyncio
 import errno
 import hashlib
 import hmac
+import inspect
 import json
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
@@ -55,7 +56,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -1279,6 +1280,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Shutdown counts this reservation so the request cannot slip through
         # the drain between its first await and _run_agent()/task registration.
         self._pending_agent_requests: int = 0
+        self._plugin_manager = self._load_plugin_manager()
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -1362,7 +1364,76 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             pass
         return active_api_runs, process_depth, active_delegations
+    def _load_plugin_manager(self):
+        """Best-effort plugin manager discovery for API-server plugin hooks."""
+        try:
+            from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
+            discover_plugins()
+            return get_plugin_manager()
+        except Exception as exc:
+            logger.debug("[%s] Plugin manager unavailable for API server hooks: %s", self.name, exc)
+            return None
+
+    def _mount_plugin_api_routes(self, router: Any) -> None:
+        """Mount plugin-contributed API routes without breaking core startup."""
+        manager = getattr(self, "_plugin_manager", None)
+        if manager is None or not hasattr(manager, "get_api_server_routes"):
+            return
+
+        existing_routes: set[tuple[str, str]] = set()
+        for resource in router.resources():
+            path = getattr(resource, "canonical", None)
+            if not path:
+                continue
+            for route_info in resource:
+                method = getattr(route_info, "method", None)
+                if method:
+                    existing_routes.add((str(method).upper(), path))
+
+        for route in manager.get_api_server_routes() or []:
+            try:
+                method = str(route.get("method", "")).upper()
+                path = route.get("path")
+                handler = route.get("handler")
+                if not method or not path or not callable(handler):
+                    raise ValueError("missing method/path/handler")
+                if not isinstance(path, str) or not path.startswith("/"):
+                    raise ValueError("path must start with /")
+                if not path.startswith("/v1/plugins/"):
+                    raise ValueError("path must be under /v1/plugins/")
+                if (method, path) in existing_routes:
+                    raise ValueError(f"route already registered: {method} {path}")
+                add_fn = getattr(router, f"add_{method.lower()}", None)
+                if add_fn is None:
+                    raise ValueError(f"unsupported method: {method}")
+                async def _authed_plugin_handler(
+                    request: "web.Request",
+                    _handler: Callable = handler,
+                ) -> "web.Response":
+                    auth_err = self._check_auth(request)
+                    if auth_err:
+                        return auth_err
+                    result = _handler(request)
+                    if inspect.isawaitable(result):
+                        return await result
+                    return result
+
+                route_name = route.get("name")
+                if route_name:
+                    add_fn(path, _authed_plugin_handler, name=route_name)
+                else:
+                    add_fn(path, _authed_plugin_handler)
+                existing_routes.add((method, path))
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Failed to register plugin route %s %s (plugin=%s): %s",
+                    self.name,
+                    route.get("method"),
+                    route.get("path"),
+                    route.get("plugin"),
+                    exc,
+                )
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
         """Normalize configured CORS origins into a stable tuple."""
@@ -2843,7 +2914,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        return web.json_response({
+        payload = {
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
             "model": self._model_name,
@@ -2914,7 +2985,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
                 "session_model_lock": {"method": "POST", "path": "/api/sessions/{session_id}/model"},
             },
-        })
+        }
+
+        manager = self._plugin_manager
+        if manager is not None and hasattr(manager, "get_api_server_capabilities"):
+            plugin_caps = manager.get_api_server_capabilities(adapter=self, request=request) or []
+            if plugin_caps:
+                payload.setdefault("extensions", {})
+                payload["extensions"]["plugins"] = {
+                    str(entry.get("plugin")): entry.get("capabilities", {})
+                    for entry in plugin_caps
+                    if isinstance(entry, dict) and entry.get("plugin")
+                }
+
+        return web.json_response(payload)
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
         """GET /v1/skills — list installed skills visible to the API-server agent.
@@ -6804,6 +6888,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if self.gateway_runner is not None:
                 self._app["gateway_runner"] = self.gateway_runner
 
+            self._mount_plugin_api_routes(self._app.router)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1410,13 +1410,52 @@ class APIServerAdapter(BasePlatformAdapter):
                 async def _authed_plugin_handler(
                     request: "web.Request",
                     _handler: Callable = handler,
+                    _method: str = method,
+                    _path: str = path,
+                    _plugin: str = str(route.get("plugin", "unknown")),
                 ) -> "web.Response":
                     auth_err = self._check_auth(request)
                     if auth_err:
                         return auth_err
-                    result = _handler(request)
-                    if inspect.isawaitable(result):
-                        return await result
+                    try:
+                        result = _handler(request)
+                        if inspect.isawaitable(result):
+                            result = await result
+                    except Exception as exc:
+                        logger.warning(
+                            "[%s] Plugin route handler failed for %s %s (plugin=%s): %s",
+                            self.name,
+                            _method,
+                            _path,
+                            _plugin,
+                            redact_sensitive_text(str(exc)),
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route failed",
+                                err_type="server_error",
+                                code="plugin_route_failed",
+                            ),
+                            status=500,
+                        )
+                    if not isinstance(result, web.StreamResponse):
+                        logger.warning(
+                            "[%s] Plugin route returned %s instead of aiohttp.web.StreamResponse "
+                            "for %s %s (plugin=%s)",
+                            self.name,
+                            type(result).__name__,
+                            _method,
+                            _path,
+                            _plugin,
+                        )
+                        return web.json_response(
+                            _openai_error(
+                                "Plugin route returned an invalid response",
+                                err_type="server_error",
+                                code="plugin_route_invalid_response",
+                            ),
+                            status=500,
+                        )
                     return result
 
                 route_name = route.get("name")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -41,6 +41,7 @@ import importlib.metadata
 import importlib.util
 import inspect
 import json
+import keyword
 import logging
 import os
 import queue
@@ -681,6 +682,15 @@ def _get_enabled_plugins() -> Optional[set]:
 # ---------------------------------------------------------------------------
 
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_API_PLUGIN_ID_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def is_safe_api_server_plugin_id(plugin_id: str) -> bool:
+    """Return whether a plugin id is safe to embed as literal URL segments."""
+    return bool(plugin_id) and all(
+        _API_PLUGIN_ID_SEGMENT_RE.fullmatch(segment)
+        for segment in plugin_id.split("/")
+    )
 
 
 def _portable_skill_namespace(key: str) -> str:
@@ -1268,6 +1278,23 @@ class PluginRegistration:
         finally:
             if self._on_dispose is not None:
                 self._on_dispose(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ApiServerCapabilityContext:
+    """Stable, non-secret context exposed to API capability providers.
+
+    Capability discovery runs outside the aiohttp event loop.  Passing the
+    live adapter or request into that worker would expose mutable server state,
+    credentials, and a request object owned by another thread.  This value
+    object is the complete provider contract instead.
+    """
+
+    server_name: str
+    request_method: str
+    request_path: str
+    auth_required: bool
+    profile: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -3591,6 +3618,94 @@ class PluginContext:
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
         return handle
 
+    # -- API server registration --------------------------------------------
+
+    def register_api_server_route(
+        self,
+        method: str,
+        path: str,
+        handler: Callable,
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Register an aiohttp route contribution for the API server adapter."""
+        if not callable(handler):
+            raise TypeError("API server route handler must be callable")
+        normalized_method = str(method or "").upper()
+        if normalized_method not in {"DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"}:
+            raise ValueError(f"unsupported method: {normalized_method or '<empty>'}")
+        if not isinstance(path, str):
+            raise TypeError("API server route path must be a string")
+        if not path.startswith("/v1/plugins/"):
+            raise ValueError("API server route path must be under /v1/plugins/")
+        if path == "/v1/plugins/":
+            raise ValueError("API server route path must include a route name")
+        plugin_id = str(self.manifest.key or self.manifest.name).strip("/")
+        if not is_safe_api_server_plugin_id(plugin_id):
+            raise ValueError(
+                "API server plugin namespace must contain safe URL path segments"
+            )
+        plugin_namespace = f"/v1/plugins/{plugin_id}/"
+        if not plugin_id or not path.startswith(plugin_namespace):
+            raise ValueError(
+                "API server route path must stay under the plugin's own namespace: "
+                f"{plugin_namespace}"
+            )
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise TypeError("API server route name must be a non-empty string or None")
+        if name is not None and any(
+            not part.isidentifier() or keyword.iskeyword(part)
+            for part in re.split(r"[.:-]", name)
+        ):
+            raise ValueError(
+                "API server route name must contain Python identifiers separated "
+                "by dash, dot, or colon"
+            )
+        for route in self._manager._api_server_routes:
+            if (route.get("method"), route.get("path")) == (normalized_method, path):
+                raise ValueError(f"API server route already registered: {normalized_method} {path}")
+            if name is not None and route.get("name") == name:
+                raise ValueError(f"API server route name already registered: {name}")
+        self._manager._api_server_routes.append(
+            {
+                "method": normalized_method,
+                "path": path,
+                "handler": handler,
+                "name": name,
+                "plugin": plugin_id,
+            }
+        )
+        logger.debug(
+            "Plugin %s registered API server route: %s %s",
+            self.manifest.name,
+            normalized_method,
+            path,
+        )
+
+    def register_api_server_capability(self, provider: Callable) -> None:
+        """Register a provider callback for /v1/capabilities extensions."""
+        if not callable(provider):
+            raise TypeError("API server capability provider must be callable")
+        if inspect.iscoroutinefunction(provider) or inspect.iscoroutinefunction(
+            getattr(provider, "__call__", None)
+        ):
+            raise TypeError("API server capability provider must be synchronous")
+        plugin_id = str(self.manifest.key or self.manifest.name).strip("/")
+        if any(
+            entry.get("plugin") == plugin_id
+            for entry in self._manager._api_server_capability_providers
+        ):
+            raise ValueError(
+                f"API server capability provider already registered for plugin: {plugin_id}"
+            )
+        self._manager._api_server_capability_providers.append(
+            {
+                "plugin": plugin_id,
+                "provider": provider,
+            }
+        )
+        logger.debug("Plugin %s registered API server capability provider", self.manifest.name)
+
     # -- skill registration -------------------------------------------------
 
     @_serialized_replacement
@@ -3835,6 +3950,8 @@ class PluginManager:
         # ``register_telegram_handler`` is a thin alias writing into the
         # "telegram" bucket.
         self._platform_handler_factories: Dict[str, List[tuple]] = {}
+        self._api_server_routes: List[Dict[str, Any]] = []
+        self._api_server_capability_providers: List[Dict[str, Any]] = []
 
     # -----------------------------------------------------------------------
     # Registration ledger internals
@@ -4182,6 +4299,8 @@ class PluginManager:
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
             self._platform_handler_factories.clear()
+            self._api_server_routes.clear()
+            self._api_server_capability_providers.clear()
             self._context_engine = None
             with self._hook_timeout_lock:
                 self._hook_running_callbacks.clear()
@@ -6096,6 +6215,52 @@ class PluginManager:
                 }
             )
         return result
+
+    def get_api_server_routes(self) -> List[Dict[str, Any]]:
+        """Return plugin-contributed API server routes in registration order."""
+        return list(self._api_server_routes)
+
+    def get_api_server_capabilities(
+        self,
+        *,
+        context: ApiServerCapabilityContext,
+    ) -> List[Dict[str, Any]]:
+        """Resolve plugin capability contributions for /v1/capabilities."""
+        if not isinstance(context, ApiServerCapabilityContext):
+            raise TypeError("context must be an ApiServerCapabilityContext")
+        results: List[Dict[str, Any]] = []
+        for entry in self._api_server_capability_providers:
+            plugin_name = entry.get("plugin", "unknown")
+            provider = entry.get("provider")
+            if not callable(provider):
+                continue
+            try:
+                payload = provider(context=context)
+            except Exception as exc:
+                logger.warning(
+                    "Plugin '%s' API server capability provider failed (%s); skipping",
+                    plugin_name,
+                    type(exc).__name__,
+                )
+                continue
+            if payload is None:
+                continue
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Plugin '%s' API server capability provider returned non-dict payload; skipping",
+                    plugin_name,
+                )
+                continue
+            try:
+                json.dumps(payload)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Plugin '%s' API server capability provider returned a non-JSON-serializable payload; skipping",
+                    plugin_name,
+                )
+                continue
+            results.append({"plugin": plugin_name, "capabilities": payload})
+        return results
 
     # -----------------------------------------------------------------------
     # Plugin skill lookups

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1212,6 +1212,47 @@ class PluginContext:
         self._manager._middleware.setdefault(kind, []).append(callback)
         logger.debug("Plugin %s registered middleware: %s", self.manifest.name, kind)
 
+    # -- API server registration --------------------------------------------
+
+    def register_api_server_route(
+        self,
+        method: str,
+        path: str,
+        handler: Callable,
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Register an aiohttp route contribution for the API server adapter."""
+        if not callable(handler):
+            raise TypeError("API server route handler must be callable")
+        self._manager._api_server_routes.append(
+            {
+                "method": str(method or "").upper(),
+                "path": path,
+                "handler": handler,
+                "name": name,
+                "plugin": self.manifest.name,
+            }
+        )
+        logger.debug(
+            "Plugin %s registered API server route: %s %s",
+            self.manifest.name,
+            str(method or "").upper(),
+            path,
+        )
+
+    def register_api_server_capability(self, provider: Callable) -> None:
+        """Register a provider callback for /v1/capabilities extensions."""
+        if not callable(provider):
+            raise TypeError("API server capability provider must be callable")
+        self._manager._api_server_capability_providers.append(
+            {
+                "plugin": self.manifest.name,
+                "provider": provider,
+            }
+        )
+        logger.debug("Plugin %s registered API server capability provider", self.manifest.name)
+
     # -- skill registration -------------------------------------------------
 
     def register_skill(
@@ -1290,6 +1331,8 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        self._api_server_routes: List[Dict[str, Any]] = []
+        self._api_server_capability_providers: List[Dict[str, Any]] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1319,6 +1362,8 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._api_server_routes.clear()
+            self._api_server_capability_providers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -2017,6 +2062,38 @@ class PluginManager:
                 }
             )
         return result
+
+    def get_api_server_routes(self) -> List[Dict[str, Any]]:
+        """Return plugin-contributed API server routes in registration order."""
+        return list(self._api_server_routes)
+
+    def get_api_server_capabilities(self, *, adapter: Any = None, request: Any = None) -> List[Dict[str, Any]]:
+        """Resolve plugin capability contributions for /v1/capabilities."""
+        results: List[Dict[str, Any]] = []
+        for entry in self._api_server_capability_providers:
+            plugin_name = entry.get("plugin", "unknown")
+            provider = entry.get("provider")
+            if not callable(provider):
+                continue
+            try:
+                payload = provider(adapter=adapter, request=request)
+            except Exception as exc:
+                logger.warning(
+                    "Plugin '%s' API server capability provider failed: %s",
+                    plugin_name,
+                    exc,
+                )
+                continue
+            if payload is None:
+                continue
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Plugin '%s' API server capability provider returned non-dict payload; skipping",
+                    plugin_name,
+                )
+                continue
+            results.append({"plugin": plugin_name, "capabilities": payload})
+        return results
 
     # -----------------------------------------------------------------------
     # Plugin skill lookups

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -37,6 +37,7 @@ import asyncio
 import importlib.metadata
 import importlib.util
 import inspect
+import json
 import logging
 import os
 import sys
@@ -1225,9 +1226,25 @@ class PluginContext:
         """Register an aiohttp route contribution for the API server adapter."""
         if not callable(handler):
             raise TypeError("API server route handler must be callable")
+        normalized_method = str(method or "").upper()
+        if normalized_method not in {"DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"}:
+            raise ValueError(f"unsupported method: {normalized_method or '<empty>'}")
+        if not isinstance(path, str):
+            raise TypeError("API server route path must be a string")
+        if not path.startswith("/v1/plugins/"):
+            raise ValueError("API server route path must be under /v1/plugins/")
+        if path == "/v1/plugins/":
+            raise ValueError("API server route path must include a route name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise TypeError("API server route name must be a non-empty string or None")
+        for route in self._manager._api_server_routes:
+            if (route.get("method"), route.get("path")) == (normalized_method, path):
+                raise ValueError(f"API server route already registered: {normalized_method} {path}")
+            if name is not None and route.get("name") == name:
+                raise ValueError(f"API server route name already registered: {name}")
         self._manager._api_server_routes.append(
             {
-                "method": str(method or "").upper(),
+                "method": normalized_method,
                 "path": path,
                 "handler": handler,
                 "name": name,
@@ -1237,7 +1254,7 @@ class PluginContext:
         logger.debug(
             "Plugin %s registered API server route: %s %s",
             self.manifest.name,
-            str(method or "").upper(),
+            normalized_method,
             path,
         )
 
@@ -1245,6 +1262,17 @@ class PluginContext:
         """Register a provider callback for /v1/capabilities extensions."""
         if not callable(provider):
             raise TypeError("API server capability provider must be callable")
+        if inspect.iscoroutinefunction(provider) or inspect.iscoroutinefunction(
+            getattr(provider, "__call__", None)
+        ):
+            raise TypeError("API server capability provider must be synchronous")
+        if any(
+            entry.get("plugin") == self.manifest.name
+            for entry in self._manager._api_server_capability_providers
+        ):
+            raise ValueError(
+                f"API server capability provider already registered for plugin: {self.manifest.name}"
+            )
         self._manager._api_server_capability_providers.append(
             {
                 "plugin": self.manifest.name,
@@ -2089,6 +2117,14 @@ class PluginManager:
             if not isinstance(payload, dict):
                 logger.warning(
                     "Plugin '%s' API server capability provider returned non-dict payload; skipping",
+                    plugin_name,
+                )
+                continue
+            try:
+                json.dumps(payload)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Plugin '%s' API server capability provider returned a non-JSON-serializable payload; skipping",
                     plugin_name,
                 )
                 continue

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -335,6 +335,23 @@ class LoadedPlugin:
     deferred: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class ApiServerCapabilityContext:
+    """Stable, non-secret context exposed to API capability providers.
+
+    Capability discovery runs outside the aiohttp event loop.  Passing the
+    live adapter or request into that worker would expose mutable server state,
+    credentials, and a request object owned by another thread.  This value
+    object is the complete provider contract instead.
+    """
+
+    server_name: str
+    request_method: str
+    request_path: str
+    auth_required: bool
+    profile: Optional[str] = None
+
+
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
@@ -2113,8 +2130,14 @@ class PluginManager:
         """Return plugin-contributed API server routes in registration order."""
         return list(self._api_server_routes)
 
-    def get_api_server_capabilities(self, *, adapter: Any = None, request: Any = None) -> List[Dict[str, Any]]:
+    def get_api_server_capabilities(
+        self,
+        *,
+        context: ApiServerCapabilityContext,
+    ) -> List[Dict[str, Any]]:
         """Resolve plugin capability contributions for /v1/capabilities."""
+        if not isinstance(context, ApiServerCapabilityContext):
+            raise TypeError("context must be an ApiServerCapabilityContext")
         results: List[Dict[str, Any]] = []
         for entry in self._api_server_capability_providers:
             plugin_name = entry.get("plugin", "unknown")
@@ -2122,7 +2145,7 @@ class PluginManager:
             if not callable(provider):
                 continue
             try:
-                payload = provider(adapter=adapter, request=request)
+                payload = provider(context=context)
             except Exception as exc:
                 logger.warning(
                     "Plugin '%s' API server capability provider failed (%s); skipping",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -278,6 +278,15 @@ def _get_enabled_plugins() -> Optional[set]:
 # ---------------------------------------------------------------------------
 
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_API_PLUGIN_ID_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def is_safe_api_server_plugin_id(plugin_id: str) -> bool:
+    """Return whether a plugin id is safe to embed as literal URL segments."""
+    return bool(plugin_id) and all(
+        _API_PLUGIN_ID_SEGMENT_RE.fullmatch(segment)
+        for segment in plugin_id.split("/")
+    )
 
 
 @dataclass
@@ -1255,6 +1264,10 @@ class PluginContext:
         if path == "/v1/plugins/":
             raise ValueError("API server route path must include a route name")
         plugin_id = str(self.manifest.key or self.manifest.name).strip("/")
+        if not is_safe_api_server_plugin_id(plugin_id):
+            raise ValueError(
+                "API server plugin namespace must contain safe URL path segments"
+            )
         plugin_namespace = f"/v1/plugins/{plugin_id}/"
         if not plugin_id or not path.startswith(plugin_namespace):
             raise ValueError(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -38,8 +38,10 @@ import importlib.metadata
 import importlib.util
 import inspect
 import json
+import keyword
 import logging
 import os
+import re
 import sys
 import threading
 import types
@@ -1235,8 +1237,23 @@ class PluginContext:
             raise ValueError("API server route path must be under /v1/plugins/")
         if path == "/v1/plugins/":
             raise ValueError("API server route path must include a route name")
+        plugin_id = str(self.manifest.key or self.manifest.name).strip("/")
+        plugin_namespace = f"/v1/plugins/{plugin_id}/"
+        if not plugin_id or not path.startswith(plugin_namespace):
+            raise ValueError(
+                "API server route path must stay under the plugin's own namespace: "
+                f"{plugin_namespace}"
+            )
         if name is not None and (not isinstance(name, str) or not name.strip()):
             raise TypeError("API server route name must be a non-empty string or None")
+        if name is not None and any(
+            not part.isidentifier() or keyword.iskeyword(part)
+            for part in re.split(r"[.:-]", name)
+        ):
+            raise ValueError(
+                "API server route name must contain Python identifiers separated "
+                "by dash, dot, or colon"
+            )
         for route in self._manager._api_server_routes:
             if (route.get("method"), route.get("path")) == (normalized_method, path):
                 raise ValueError(f"API server route already registered: {normalized_method} {path}")
@@ -1248,7 +1265,7 @@ class PluginContext:
                 "path": path,
                 "handler": handler,
                 "name": name,
-                "plugin": self.manifest.name,
+                "plugin": plugin_id,
             }
         )
         logger.debug(
@@ -1266,16 +1283,17 @@ class PluginContext:
             getattr(provider, "__call__", None)
         ):
             raise TypeError("API server capability provider must be synchronous")
+        plugin_id = str(self.manifest.key or self.manifest.name).strip("/")
         if any(
-            entry.get("plugin") == self.manifest.name
+            entry.get("plugin") == plugin_id
             for entry in self._manager._api_server_capability_providers
         ):
             raise ValueError(
-                f"API server capability provider already registered for plugin: {self.manifest.name}"
+                f"API server capability provider already registered for plugin: {plugin_id}"
             )
         self._manager._api_server_capability_providers.append(
             {
-                "plugin": self.manifest.name,
+                "plugin": plugin_id,
                 "provider": provider,
             }
         )
@@ -2107,9 +2125,9 @@ class PluginManager:
                 payload = provider(adapter=adapter, request=request)
             except Exception as exc:
                 logger.warning(
-                    "Plugin '%s' API server capability provider failed: %s",
+                    "Plugin '%s' API server capability provider failed (%s); skipping",
                     plugin_name,
-                    exc,
+                    type(exc).__name__,
                 )
                 continue
             if payload is None:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -17,6 +17,7 @@ import json
 import os
 import stat
 import sys
+import threading
 import time
 import types
 import uuid
@@ -31,6 +32,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _api_request_profile,
     _derive_chat_session_id,
     _hermes_version,
     _redact_api_error_text,
@@ -39,6 +41,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_cli.plugins import ApiServerCapabilityContext
 
 
 # ---------------------------------------------------------------------------
@@ -895,6 +898,576 @@ class TestCapabilitiesEndpoint:
             response = await cli.get("/v1/capabilities")
             data = await response.json()
         assert data["features"]["runs_idempotency"]["durable"] is False
+
+    @pytest.mark.asyncio
+    async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 401
+
+            authed = await cli.get(
+                "/v1/capabilities",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert authed.status == 200
+            data = await authed.json()
+            assert data["auth"]["required"] is True
+
+    @pytest.mark.asyncio
+    async def test_capabilities_include_plugin_extension_payload(self, adapter):
+        seen = []
+
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, context):
+                seen.append(context)
+                return [
+                    {"plugin": "alpha", "capabilities": {"alpha_flag": True}},
+                    {"plugin": "beta", "capabilities": {"beta_count": 2}},
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["extensions"]["plugins"] == {
+                "alpha": {"alpha_flag": True},
+                "beta": {"beta_count": 2},
+            }
+        assert seen == [
+            ApiServerCapabilityContext(
+                server_name="api_server",
+                request_method="GET",
+                request_path="/v1/capabilities",
+                auth_required=False,
+                profile=None,
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_plugin_capability_providers_run_off_event_loop(self, adapter):
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, context):
+                return [{"plugin": "alpha", "capabilities": {"enabled": True}}]
+
+        adapter._plugin_manager = _PluginManager()
+        calls = []
+
+        async def _run_plugin_sync(func, *args, timeout, **kwargs):
+            calls.append(func)
+            return func(*args, **kwargs)
+
+        request = MagicMock()
+        request.headers = {}
+        with patch.object(
+            adapter,
+            "_run_plugin_sync",
+            new=_run_plugin_sync,
+        ):
+            response = await adapter._handle_capabilities(request)
+
+        assert response.status == 200
+        assert calls == [adapter._plugin_manager.get_api_server_capabilities]
+
+    @pytest.mark.asyncio
+    async def test_profile_capabilities_do_not_leak_default_plugin_metadata(self, adapter):
+        provider_called = False
+
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, context):
+                nonlocal provider_called
+                provider_called = True
+                return [{"plugin": "default-only", "capabilities": {"enabled": True}}]
+
+        adapter._plugin_manager = _PluginManager()
+        request = MagicMock()
+        request.headers = {}
+        token = _api_request_profile.set("coder")
+        try:
+            response = await adapter._handle_capabilities(request)
+        finally:
+            _api_request_profile.reset(token)
+
+        payload = json.loads(response.text)
+        assert "extensions" not in payload
+        assert provider_called is False
+
+    @pytest.mark.asyncio
+    async def test_plugin_capability_timeout_preserves_core_response(self, adapter):
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, context):
+                raise AssertionError("provider should be represented by patched runner")
+
+        adapter._plugin_manager = _PluginManager()
+        request = MagicMock()
+        request.headers = {}
+
+        async def _times_out(func, *args, **kwargs):
+            raise asyncio.TimeoutError
+
+        with (
+            patch.object(
+                adapter,
+                "_run_plugin_sync",
+                new=_times_out,
+            ),
+            patch(
+                "gateway.platforms.api_server.PLUGIN_CAPABILITY_TIMEOUT_SECONDS",
+                0.01,
+            ),
+        ):
+            response = await adapter._handle_capabilities(request)
+
+        payload = json.loads(response.text)
+        assert response.status == 200
+        assert "extensions" not in payload
+
+
+class TestPluginApiServerRoutes:
+    def test_mount_plugin_routes_after_core_routes(self, adapter):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/test-ping",
+                        "handler": _plugin_handler,
+                        "name": "test_ping",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "/v1/plugins/plugin-test/test-ping" in paths
+        assert paths.index("/v1/plugins/plugin-test/test-ping") > paths.index("/v1/models")
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_uses_api_server_auth(self, auth_adapter):
+        called = 0
+
+        async def _plugin_handler(request):
+            nonlocal called
+            called += 1
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/secure-ping",
+                        "handler": _plugin_handler,
+                        "name": "secure_ping",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        auth_adapter._plugin_manager = _PluginManager()
+        app = _create_app(auth_adapter)
+        auth_adapter._mount_plugin_api_routes(app.router)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/plugins/plugin-test/secure-ping")
+            assert resp.status == 401
+            assert called == 0
+
+            authed = await cli.get(
+                "/v1/plugins/plugin-test/secure-ping",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert authed.status == 200
+            assert await authed.json() == {"ok": True}
+            assert called == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_plugin_route_handler_runs_off_event_loop(self, adapter):
+        def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/sync",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        calls = []
+
+        async def _run_plugin_sync(func, *args, timeout, **kwargs):
+            calls.append(func)
+            return func(*args, **kwargs)
+
+        with patch.object(
+            adapter,
+            "_run_plugin_sync",
+            new=_run_plugin_sync,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/sync")
+
+        assert response.status == 200
+        assert calls == [_plugin_handler]
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_rejects_multiplex_profile_context(self, adapter):
+        called = False
+
+        async def _plugin_handler(request):
+            nonlocal called
+            called = True
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/default-only",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        token = _api_request_profile.set("coder")
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/default-only")
+        finally:
+            _api_request_profile.reset(token)
+
+        assert response.status == 404
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_handler_exception_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            raise RuntimeError("private plugin detail")
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/failing",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with caplog.at_level("WARNING"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/plugins/plugin-test/failing")
+                body = await resp.json()
+
+        assert resp.status == 500
+        assert body["error"]["code"] == "plugin_route_failed"
+        assert "private plugin detail" not in str(body)
+        assert "plugin-test" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_handler_timeout_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            await asyncio.Event().wait()
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/timeout",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with (
+            patch(
+                "gateway.platforms.api_server.PLUGIN_API_HANDLER_TIMEOUT_SECONDS",
+                0.01,
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/timeout")
+                body = await response.json()
+
+        assert response.status == 500
+        assert body["error"]["code"] == "plugin_route_failed"
+        assert "timed out" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_timed_out_sync_handlers_do_not_accumulate_worker_threads(self, adapter):
+        release = threading.Event()
+        lock = threading.Lock()
+        calls = 0
+
+        def _plugin_handler(request):
+            nonlocal calls
+            with lock:
+                calls += 1
+            release.wait(timeout=2)
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/bounded-sync",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        try:
+            with (
+                patch(
+                    "gateway.platforms.api_server.PLUGIN_API_HANDLER_TIMEOUT_SECONDS",
+                    0.05,
+                ),
+                patch(
+                    "gateway.platforms.api_server.PLUGIN_SYNC_MAX_WORKERS",
+                    2,
+                    create=True,
+                ),
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    first = await asyncio.gather(
+                        cli.get("/v1/plugins/plugin-test/bounded-sync"),
+                        cli.get("/v1/plugins/plugin-test/bounded-sync"),
+                    )
+                    assert [response.status for response in first] == [500, 500]
+
+                    third = await cli.get("/v1/plugins/plugin-test/bounded-sync")
+                    assert third.status == 500
+
+            with lock:
+                assert calls == 2
+        finally:
+            release.set()
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_invalid_response_is_isolated(self, adapter, caplog):
+        def _plugin_handler(request):
+            return {"not": "an aiohttp response"}
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/invalid-response",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with caplog.at_level("WARNING"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/plugins/plugin-test/invalid-response")
+                body = await resp.json()
+
+        assert resp.status == 500
+        assert body["error"]["code"] == "plugin_route_invalid_response"
+        assert "plugin-test" in caplog.text
+
+    def test_plugin_route_registration_failure_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "NOPE",
+                        "path": "/v1/plugins/plugin-test/bad",
+                        "handler": _plugin_handler,
+                        "name": "bad",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "/v1/plugins/plugin-test/bad" not in paths
+        assert "plugin route" in caplog.text.lower()
+
+    def test_plugin_route_collection_failure_is_isolated(self, adapter, caplog):
+        class _PluginManager:
+            def get_api_server_routes(self):
+                raise RuntimeError("private discovery detail")
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "private discovery detail" not in caplog.text
+        assert "plugin route collection failed" in caplog.text.lower()
+
+    def test_malformed_plugin_route_entry_is_isolated(self, adapter, caplog):
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [object()]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "failed to register plugin route" in caplog.text.lower()
+
+    def test_plugin_route_must_use_plugin_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/models",
+                        "handler": _plugin_handler,
+                        "name": "models",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        matching = [res for res in app.router.resources() if res.canonical == "/v1/models"]
+        assert len(matching) == 1
+        assert "under /v1/plugins" in caplog.text.lower()
+
+    def test_plugin_route_must_stay_in_own_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/other-plugin/status",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/plugins/other-plugin/status" not in paths
+        assert "own namespace" in caplog.text.lower()
+
+    def test_plugin_route_rejects_unsafe_plugin_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/{tail:.*}/status",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test/{tail:.*}",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/plugins/plugin-test/{tail}/status" not in paths
+        assert "safe url path segments" in caplog.text.lower()
+
+    def test_duplicate_plugin_route_is_rejected(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-a/dup",
+                        "handler": _plugin_handler,
+                        "name": "dup_one",
+                        "plugin": "plugin-a",
+                    },
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-a/dup",
+                        "handler": _plugin_handler,
+                        "name": "dup_two",
+                        "plugin": "plugin-a",
+                    },
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        matching = [
+            res
+            for res in app.router.resources()
+            if res.canonical == "/v1/plugins/plugin-a/dup"
+        ]
+        assert len(matching) == 1
+        assert "route already registered" in caplog.text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -747,6 +747,65 @@ class TestPluginApiServerRoutes:
             assert await authed.json() == {"ok": True}
             assert called == 1
 
+    @pytest.mark.asyncio
+    async def test_plugin_route_handler_exception_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            raise RuntimeError("private plugin detail")
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/failing",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with caplog.at_level("WARNING"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/plugins/failing")
+                body = await resp.json()
+
+        assert resp.status == 500
+        assert body["error"]["code"] == "plugin_route_failed"
+        assert "private plugin detail" not in str(body)
+        assert "plugin-test" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_invalid_response_is_isolated(self, adapter, caplog):
+        def _plugin_handler(request):
+            return {"not": "an aiohttp response"}
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/invalid-response",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with caplog.at_level("WARNING"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/plugins/invalid-response")
+                body = await resp.json()
+
+        assert resp.status == 500
+        assert body["error"]["code"] == "plugin_route_invalid_response"
+        assert "plugin-test" in caplog.text
+
     def test_plugin_route_registration_failure_is_isolated(self, adapter, caplog):
         async def _plugin_handler(request):
             return web.json_response({"ok": True})

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1161,6 +1161,30 @@ class TestPluginApiServerRoutes:
         assert "/v1/plugins/other-plugin/status" not in paths
         assert "own namespace" in caplog.text.lower()
 
+    def test_plugin_route_rejects_unsafe_plugin_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/{tail:.*}/status",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test/{tail:.*}",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/plugins/plugin-test/{tail}/status" not in paths
+        assert "safe url path segments" in caplog.text.lower()
+
     def test_duplicate_plugin_route_is_rejected(self, adapter, caplog):
         async def _plugin_handler(request):
             return web.json_response({"ok": True})

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -648,6 +648,187 @@ class TestCapabilitiesEndpoint:
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 
+    @pytest.mark.asyncio
+    async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 401
+
+            authed = await cli.get(
+                "/v1/capabilities",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert authed.status == 200
+            data = await authed.json()
+            assert data["auth"]["required"] is True
+
+    @pytest.mark.asyncio
+    async def test_capabilities_include_plugin_extension_payload(self, adapter):
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, adapter=None, request=None):
+                return [
+                    {"plugin": "alpha", "capabilities": {"alpha_flag": True}},
+                    {"plugin": "beta", "capabilities": {"beta_count": 2}},
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["extensions"]["plugins"] == {
+                "alpha": {"alpha_flag": True},
+                "beta": {"beta_count": 2},
+            }
+
+
+class TestPluginApiServerRoutes:
+    def test_mount_plugin_routes_after_core_routes(self, adapter):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/test-ping",
+                        "handler": _plugin_handler,
+                        "name": "test_ping",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "/v1/plugins/test-ping" in paths
+        assert paths.index("/v1/plugins/test-ping") > paths.index("/v1/models")
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_uses_api_server_auth(self, auth_adapter):
+        called = 0
+
+        async def _plugin_handler(request):
+            nonlocal called
+            called += 1
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/secure-ping",
+                        "handler": _plugin_handler,
+                        "name": "secure_ping",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        auth_adapter._plugin_manager = _PluginManager()
+        app = _create_app(auth_adapter)
+        auth_adapter._mount_plugin_api_routes(app.router)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/plugins/secure-ping")
+            assert resp.status == 401
+            assert called == 0
+
+            authed = await cli.get(
+                "/v1/plugins/secure-ping",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert authed.status == 200
+            assert await authed.json() == {"ok": True}
+            assert called == 1
+
+    def test_plugin_route_registration_failure_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "NOPE",
+                        "path": "/v1/plugins/bad",
+                        "handler": _plugin_handler,
+                        "name": "bad",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "/v1/plugins/bad" not in paths
+        assert "plugin route" in caplog.text.lower()
+
+    def test_plugin_route_must_use_plugin_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/models",
+                        "handler": _plugin_handler,
+                        "name": "models",
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        matching = [res for res in app.router.resources() if res.canonical == "/v1/models"]
+        assert len(matching) == 1
+        assert "under /v1/plugins" in caplog.text.lower()
+
+    def test_duplicate_plugin_route_is_rejected(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/dup",
+                        "handler": _plugin_handler,
+                        "name": "dup_one",
+                        "plugin": "plugin-a",
+                    },
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/dup",
+                        "handler": _plugin_handler,
+                        "name": "dup_two",
+                        "plugin": "plugin-b",
+                    },
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        matching = [res for res in app.router.resources() if res.canonical == "/v1/plugins/dup"]
+        assert len(matching) == 1
+        assert "route already registered" in caplog.text.lower()
+
 
 # ---------------------------------------------------------------------------
 # /v1/skills and /v1/toolsets endpoints
@@ -2616,5 +2797,4 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -31,6 +31,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _api_request_profile,
     _derive_chat_session_id,
     _hermes_version,
     _redact_api_error_text,
@@ -683,6 +684,82 @@ class TestCapabilitiesEndpoint:
                 "beta": {"beta_count": 2},
             }
 
+    @pytest.mark.asyncio
+    async def test_plugin_capability_providers_run_off_event_loop(self, adapter):
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, adapter=None, request=None):
+                return [{"plugin": "alpha", "capabilities": {"enabled": True}}]
+
+        adapter._plugin_manager = _PluginManager()
+        calls = []
+
+        async def _to_thread(func, *args, **kwargs):
+            calls.append(func)
+            return func(*args, **kwargs)
+
+        request = MagicMock()
+        request.headers = {}
+        with patch(
+            "gateway.platforms.api_server.asyncio.to_thread",
+            new=_to_thread,
+        ):
+            response = await adapter._handle_capabilities(request)
+
+        assert response.status == 200
+        assert calls == [adapter._plugin_manager.get_api_server_capabilities]
+
+    @pytest.mark.asyncio
+    async def test_profile_capabilities_do_not_leak_default_plugin_metadata(self, adapter):
+        provider_called = False
+
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, adapter=None, request=None):
+                nonlocal provider_called
+                provider_called = True
+                return [{"plugin": "default-only", "capabilities": {"enabled": True}}]
+
+        adapter._plugin_manager = _PluginManager()
+        request = MagicMock()
+        request.headers = {}
+        token = _api_request_profile.set("coder")
+        try:
+            response = await adapter._handle_capabilities(request)
+        finally:
+            _api_request_profile.reset(token)
+
+        payload = json.loads(response.text)
+        assert "extensions" not in payload
+        assert provider_called is False
+
+    @pytest.mark.asyncio
+    async def test_plugin_capability_timeout_preserves_core_response(self, adapter):
+        class _PluginManager:
+            def get_api_server_capabilities(self, *, adapter=None, request=None):
+                raise AssertionError("provider should be represented by patched to_thread")
+
+        adapter._plugin_manager = _PluginManager()
+        request = MagicMock()
+        request.headers = {}
+
+        async def _never_returns(func, *args, **kwargs):
+            await asyncio.Event().wait()
+
+        with (
+            patch(
+                "gateway.platforms.api_server.asyncio.to_thread",
+                new=_never_returns,
+            ),
+            patch(
+                "gateway.platforms.api_server.PLUGIN_CAPABILITY_TIMEOUT_SECONDS",
+                0.01,
+            ),
+        ):
+            response = await adapter._handle_capabilities(request)
+
+        payload = json.loads(response.text)
+        assert response.status == 200
+        assert "extensions" not in payload
+
 
 class TestPluginApiServerRoutes:
     def test_mount_plugin_routes_after_core_routes(self, adapter):
@@ -694,7 +771,7 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/test-ping",
+                        "path": "/v1/plugins/plugin-test/test-ping",
                         "handler": _plugin_handler,
                         "name": "test_ping",
                         "plugin": "plugin-test",
@@ -706,8 +783,8 @@ class TestPluginApiServerRoutes:
         adapter._mount_plugin_api_routes(app.router)
         paths = [res.canonical for res in app.router.resources()]
         assert "/v1/models" in paths
-        assert "/v1/plugins/test-ping" in paths
-        assert paths.index("/v1/plugins/test-ping") > paths.index("/v1/models")
+        assert "/v1/plugins/plugin-test/test-ping" in paths
+        assert paths.index("/v1/plugins/plugin-test/test-ping") > paths.index("/v1/models")
 
     @pytest.mark.asyncio
     async def test_plugin_route_uses_api_server_auth(self, auth_adapter):
@@ -723,7 +800,7 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/secure-ping",
+                        "path": "/v1/plugins/plugin-test/secure-ping",
                         "handler": _plugin_handler,
                         "name": "secure_ping",
                         "plugin": "plugin-test",
@@ -735,17 +812,85 @@ class TestPluginApiServerRoutes:
         auth_adapter._mount_plugin_api_routes(app.router)
 
         async with TestClient(TestServer(app)) as cli:
-            resp = await cli.get("/v1/plugins/secure-ping")
+            resp = await cli.get("/v1/plugins/plugin-test/secure-ping")
             assert resp.status == 401
             assert called == 0
 
             authed = await cli.get(
-                "/v1/plugins/secure-ping",
+                "/v1/plugins/plugin-test/secure-ping",
                 headers={"Authorization": "Bearer sk-secret"},
             )
             assert authed.status == 200
             assert await authed.json() == {"ok": True}
             assert called == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_plugin_route_handler_runs_off_event_loop(self, adapter):
+        def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/sync",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        calls = []
+
+        async def _to_thread(func, *args, **kwargs):
+            calls.append(func)
+            return func(*args, **kwargs)
+
+        with patch(
+            "gateway.platforms.api_server.asyncio.to_thread",
+            new=_to_thread,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/sync")
+
+        assert response.status == 200
+        assert calls == [_plugin_handler]
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_rejects_multiplex_profile_context(self, adapter):
+        called = False
+
+        async def _plugin_handler(request):
+            nonlocal called
+            called = True
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/default-only",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+        token = _api_request_profile.set("coder")
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/default-only")
+        finally:
+            _api_request_profile.reset(token)
+
+        assert response.status == 404
+        assert called is False
 
     @pytest.mark.asyncio
     async def test_plugin_route_handler_exception_is_isolated(self, adapter, caplog):
@@ -757,7 +902,7 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/failing",
+                        "path": "/v1/plugins/plugin-test/failing",
                         "handler": _plugin_handler,
                         "plugin": "plugin-test",
                     }
@@ -769,13 +914,48 @@ class TestPluginApiServerRoutes:
 
         with caplog.at_level("WARNING"):
             async with TestClient(TestServer(app)) as cli:
-                resp = await cli.get("/v1/plugins/failing")
+                resp = await cli.get("/v1/plugins/plugin-test/failing")
                 body = await resp.json()
 
         assert resp.status == 500
         assert body["error"]["code"] == "plugin_route_failed"
         assert "private plugin detail" not in str(body)
         assert "plugin-test" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_plugin_route_handler_timeout_is_isolated(self, adapter, caplog):
+        async def _plugin_handler(request):
+            await asyncio.Event().wait()
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/timeout",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        with (
+            patch(
+                "gateway.platforms.api_server.PLUGIN_API_HANDLER_TIMEOUT_SECONDS",
+                0.01,
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get("/v1/plugins/plugin-test/timeout")
+                body = await response.json()
+
+        assert response.status == 500
+        assert body["error"]["code"] == "plugin_route_failed"
+        assert "timed out" in caplog.text
 
     @pytest.mark.asyncio
     async def test_plugin_route_invalid_response_is_isolated(self, adapter, caplog):
@@ -787,7 +967,7 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/invalid-response",
+                        "path": "/v1/plugins/plugin-test/invalid-response",
                         "handler": _plugin_handler,
                         "plugin": "plugin-test",
                     }
@@ -799,7 +979,7 @@ class TestPluginApiServerRoutes:
 
         with caplog.at_level("WARNING"):
             async with TestClient(TestServer(app)) as cli:
-                resp = await cli.get("/v1/plugins/invalid-response")
+                resp = await cli.get("/v1/plugins/plugin-test/invalid-response")
                 body = await resp.json()
 
         assert resp.status == 500
@@ -815,7 +995,7 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "NOPE",
-                        "path": "/v1/plugins/bad",
+                        "path": "/v1/plugins/plugin-test/bad",
                         "handler": _plugin_handler,
                         "name": "bad",
                         "plugin": "plugin-test",
@@ -828,8 +1008,37 @@ class TestPluginApiServerRoutes:
             adapter._mount_plugin_api_routes(app.router)
         paths = [res.canonical for res in app.router.resources()]
         assert "/v1/models" in paths
-        assert "/v1/plugins/bad" not in paths
+        assert "/v1/plugins/plugin-test/bad" not in paths
         assert "plugin route" in caplog.text.lower()
+
+    def test_plugin_route_collection_failure_is_isolated(self, adapter, caplog):
+        class _PluginManager:
+            def get_api_server_routes(self):
+                raise RuntimeError("private discovery detail")
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "private discovery detail" not in caplog.text
+        assert "plugin route collection failed" in caplog.text.lower()
+
+    def test_malformed_plugin_route_entry_is_isolated(self, adapter, caplog):
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [object()]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/models" in paths
+        assert "failed to register plugin route" in caplog.text.lower()
 
     def test_plugin_route_must_use_plugin_namespace(self, adapter, caplog):
         async def _plugin_handler(request):
@@ -856,6 +1065,30 @@ class TestPluginApiServerRoutes:
         assert len(matching) == 1
         assert "under /v1/plugins" in caplog.text.lower()
 
+    def test_plugin_route_must_stay_in_own_namespace(self, adapter, caplog):
+        async def _plugin_handler(request):
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/other-plugin/status",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING"):
+            adapter._mount_plugin_api_routes(app.router)
+
+        paths = [res.canonical for res in app.router.resources()]
+        assert "/v1/plugins/other-plugin/status" not in paths
+        assert "own namespace" in caplog.text.lower()
+
     def test_duplicate_plugin_route_is_rejected(self, adapter, caplog):
         async def _plugin_handler(request):
             return web.json_response({"ok": True})
@@ -865,17 +1098,17 @@ class TestPluginApiServerRoutes:
                 return [
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/dup",
+                        "path": "/v1/plugins/plugin-a/dup",
                         "handler": _plugin_handler,
                         "name": "dup_one",
                         "plugin": "plugin-a",
                     },
                     {
                         "method": "GET",
-                        "path": "/v1/plugins/dup",
+                        "path": "/v1/plugins/plugin-a/dup",
                         "handler": _plugin_handler,
                         "name": "dup_two",
-                        "plugin": "plugin-b",
+                        "plugin": "plugin-a",
                     },
                 ]
 
@@ -884,7 +1117,11 @@ class TestPluginApiServerRoutes:
         with caplog.at_level("WARNING"):
             adapter._mount_plugin_api_routes(app.router)
 
-        matching = [res for res in app.router.resources() if res.canonical == "/v1/plugins/dup"]
+        matching = [
+            res
+            for res in app.router.resources()
+            if res.canonical == "/v1/plugins/plugin-a/dup"
+        ]
         assert len(matching) == 1
         assert "route already registered" in caplog.text.lower()
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -17,6 +17,7 @@ import json
 import os
 import stat
 import sys
+import threading
 import time
 import types
 import uuid
@@ -40,6 +41,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_cli.plugins import ApiServerCapabilityContext
 
 
 # ---------------------------------------------------------------------------
@@ -666,8 +668,11 @@ class TestCapabilitiesEndpoint:
 
     @pytest.mark.asyncio
     async def test_capabilities_include_plugin_extension_payload(self, adapter):
+        seen = []
+
         class _PluginManager:
-            def get_api_server_capabilities(self, *, adapter=None, request=None):
+            def get_api_server_capabilities(self, *, context):
+                seen.append(context)
                 return [
                     {"plugin": "alpha", "capabilities": {"alpha_flag": True}},
                     {"plugin": "beta", "capabilities": {"beta_count": 2}},
@@ -683,25 +688,35 @@ class TestCapabilitiesEndpoint:
                 "alpha": {"alpha_flag": True},
                 "beta": {"beta_count": 2},
             }
+        assert seen == [
+            ApiServerCapabilityContext(
+                server_name="api_server",
+                request_method="GET",
+                request_path="/v1/capabilities",
+                auth_required=False,
+                profile=None,
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_plugin_capability_providers_run_off_event_loop(self, adapter):
         class _PluginManager:
-            def get_api_server_capabilities(self, *, adapter=None, request=None):
+            def get_api_server_capabilities(self, *, context):
                 return [{"plugin": "alpha", "capabilities": {"enabled": True}}]
 
         adapter._plugin_manager = _PluginManager()
         calls = []
 
-        async def _to_thread(func, *args, **kwargs):
+        async def _run_plugin_sync(func, *args, timeout, **kwargs):
             calls.append(func)
             return func(*args, **kwargs)
 
         request = MagicMock()
         request.headers = {}
-        with patch(
-            "gateway.platforms.api_server.asyncio.to_thread",
-            new=_to_thread,
+        with patch.object(
+            adapter,
+            "_run_plugin_sync",
+            new=_run_plugin_sync,
         ):
             response = await adapter._handle_capabilities(request)
 
@@ -713,7 +728,7 @@ class TestCapabilitiesEndpoint:
         provider_called = False
 
         class _PluginManager:
-            def get_api_server_capabilities(self, *, adapter=None, request=None):
+            def get_api_server_capabilities(self, *, context):
                 nonlocal provider_called
                 provider_called = True
                 return [{"plugin": "default-only", "capabilities": {"enabled": True}}]
@@ -734,20 +749,21 @@ class TestCapabilitiesEndpoint:
     @pytest.mark.asyncio
     async def test_plugin_capability_timeout_preserves_core_response(self, adapter):
         class _PluginManager:
-            def get_api_server_capabilities(self, *, adapter=None, request=None):
-                raise AssertionError("provider should be represented by patched to_thread")
+            def get_api_server_capabilities(self, *, context):
+                raise AssertionError("provider should be represented by patched runner")
 
         adapter._plugin_manager = _PluginManager()
         request = MagicMock()
         request.headers = {}
 
-        async def _never_returns(func, *args, **kwargs):
-            await asyncio.Event().wait()
+        async def _times_out(func, *args, **kwargs):
+            raise asyncio.TimeoutError
 
         with (
-            patch(
-                "gateway.platforms.api_server.asyncio.to_thread",
-                new=_never_returns,
+            patch.object(
+                adapter,
+                "_run_plugin_sync",
+                new=_times_out,
             ),
             patch(
                 "gateway.platforms.api_server.PLUGIN_CAPABILITY_TIMEOUT_SECONDS",
@@ -845,13 +861,14 @@ class TestPluginApiServerRoutes:
         adapter._mount_plugin_api_routes(app.router)
         calls = []
 
-        async def _to_thread(func, *args, **kwargs):
+        async def _run_plugin_sync(func, *args, timeout, **kwargs):
             calls.append(func)
             return func(*args, **kwargs)
 
-        with patch(
-            "gateway.platforms.api_server.asyncio.to_thread",
-            new=_to_thread,
+        with patch.object(
+            adapter,
+            "_run_plugin_sync",
+            new=_run_plugin_sync,
         ):
             async with TestClient(TestServer(app)) as cli:
                 response = await cli.get("/v1/plugins/plugin-test/sync")
@@ -956,6 +973,61 @@ class TestPluginApiServerRoutes:
         assert response.status == 500
         assert body["error"]["code"] == "plugin_route_failed"
         assert "timed out" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_timed_out_sync_handlers_do_not_accumulate_worker_threads(self, adapter):
+        release = threading.Event()
+        lock = threading.Lock()
+        calls = 0
+
+        def _plugin_handler(request):
+            nonlocal calls
+            with lock:
+                calls += 1
+            release.wait(timeout=2)
+            return web.json_response({"ok": True})
+
+        class _PluginManager:
+            def get_api_server_routes(self):
+                return [
+                    {
+                        "method": "GET",
+                        "path": "/v1/plugins/plugin-test/bounded-sync",
+                        "handler": _plugin_handler,
+                        "plugin": "plugin-test",
+                    }
+                ]
+
+        adapter._plugin_manager = _PluginManager()
+        app = _create_app(adapter)
+        adapter._mount_plugin_api_routes(app.router)
+
+        try:
+            with (
+                patch(
+                    "gateway.platforms.api_server.PLUGIN_API_HANDLER_TIMEOUT_SECONDS",
+                    0.05,
+                ),
+                patch(
+                    "gateway.platforms.api_server.PLUGIN_SYNC_MAX_WORKERS",
+                    2,
+                    create=True,
+                ),
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    first = await asyncio.gather(
+                        cli.get("/v1/plugins/plugin-test/bounded-sync"),
+                        cli.get("/v1/plugins/plugin-test/bounded-sync"),
+                    )
+                    assert [response.status for response in first] == [500, 500]
+
+                    third = await cli.get("/v1/plugins/plugin-test/bounded-sync")
+                    assert third.status == 500
+
+            with lock:
+                assert calls == 2
+        finally:
+            release.set()
 
     @pytest.mark.asyncio
     async def test_plugin_route_invalid_response_is_isolated(self, adapter, caplog):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -5,6 +5,7 @@ import json
 import sys
 import threading
 import types
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ import pytest
 import yaml
 
 from hermes_cli.plugins import (
+    ApiServerCapabilityContext,
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
     PluginContext,
@@ -2294,6 +2296,259 @@ class TestPluginDispatchTool:
 
         call_kwargs = mock_registry.dispatch.call_args
         assert call_kwargs[1]["parent_agent"] is explicit_agent
+
+
+class TestPluginApiServerHooks:
+    def test_register_api_server_route_rejects_non_callable_handler(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises(TypeError, match="handler must be callable"):
+            ctx.register_api_server_route(
+                "GET", "/v1/plugins/api-plugin/bad", "not-callable"
+            )
+
+        assert mgr.get_api_server_routes() == []
+
+    def test_register_api_server_capability_rejects_non_callable_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises(TypeError, match="provider must be callable"):
+            ctx.register_api_server_capability(object())
+
+        assert mgr._api_server_capability_providers == []
+
+    def test_register_api_server_capability_rejects_async_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        async def _provider(**kwargs):
+            return {"feature": True}
+
+        with pytest.raises(TypeError, match="must be synchronous"):
+            ctx.register_api_server_capability(_provider)
+
+        assert mgr._api_server_capability_providers == []
+
+    def test_register_api_server_route_tracks_route_definition(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="api-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        async def _handler(request):
+            return None
+
+        ctx.register_api_server_route(
+            "GET",
+            "/v1/plugins/api-plugin/ping",
+            _handler,
+            name="plugin_ping",
+        )
+
+        routes = mgr.get_api_server_routes()
+        assert len(routes) == 1
+        assert routes[0]["method"] == "GET"
+        assert routes[0]["path"] == "/v1/plugins/api-plugin/ping"
+        assert routes[0]["handler"] is _handler
+        assert routes[0]["name"] == "plugin_ping"
+        assert routes[0]["plugin"] == "api-plugin"
+
+    @pytest.mark.parametrize(
+        ("method", "path", "name", "message"),
+        [
+            ("NOPE", "/v1/plugins/api-plugin/ping", None, "unsupported method"),
+            ("GET", "/v1/models", None, "under /v1/plugins/"),
+            ("GET", "/v1/plugins/", None, "include a route name"),
+            ("GET", "/v1/plugins/api-plugin/ping", "", "name must be"),
+            (
+                "GET",
+                "/v1/plugins/api-plugin/ping",
+                "invalid/name",
+                "Python identifiers",
+            ),
+        ],
+    )
+    def test_register_api_server_route_rejects_invalid_definition(
+        self, method, path, name, message
+    ):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises((TypeError, ValueError), match=message):
+            ctx.register_api_server_route(method, path, lambda request: None, name=name)
+
+        assert mgr.get_api_server_routes() == []
+
+    def test_register_api_server_route_rejects_duplicate_method_and_path(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        handler = lambda request: None
+
+        ctx.register_api_server_route("GET", "/v1/plugins/api-plugin/ping", handler)
+
+        with pytest.raises(ValueError, match="already registered"):
+            ctx.register_api_server_route("get", "/v1/plugins/api-plugin/ping", handler)
+
+        assert len(mgr.get_api_server_routes()) == 1
+
+    def test_register_api_server_route_rejects_duplicate_name(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        handler = lambda request: None
+
+        ctx.register_api_server_route(
+            "GET", "/v1/plugins/api-plugin/one", handler, name="api_plugin_route"
+        )
+
+        with pytest.raises(ValueError, match="name already registered"):
+            ctx.register_api_server_route(
+                "POST",
+                "/v1/plugins/api-plugin/two",
+                handler,
+                name="api_plugin_route",
+            )
+
+        assert len(mgr.get_api_server_routes()) == 1
+
+    def test_register_api_server_route_rejects_another_plugin_namespace(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="display-name",
+            key="category/api-plugin",
+            source="user",
+        )
+        ctx = PluginContext(manifest, mgr)
+
+        with pytest.raises(ValueError, match="own namespace"):
+            ctx.register_api_server_route(
+                "GET",
+                "/v1/plugins/other-plugin/status",
+                lambda request: None,
+            )
+
+        ctx.register_api_server_route(
+            "GET",
+            "/v1/plugins/category/api-plugin/status",
+            lambda request: None,
+        )
+        assert mgr.get_api_server_routes()[0]["plugin"] == "category/api-plugin"
+
+    @pytest.mark.parametrize(
+        "plugin_key",
+        [
+            "api plugin",
+            "../api-plugin",
+            "api-plugin/{tail:.*}",
+        ],
+    )
+    def test_register_api_server_route_rejects_unsafe_plugin_namespace(
+        self, plugin_key
+    ):
+        mgr = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="display-name", key=plugin_key, source="user"),
+            mgr,
+        )
+
+        with pytest.raises(ValueError, match="safe URL path segments"):
+            ctx.register_api_server_route(
+                "GET",
+                f"/v1/plugins/{plugin_key}/status",
+                lambda request: None,
+            )
+
+        assert mgr.get_api_server_routes() == []
+
+    def test_register_api_server_capability_provider_is_invoked_with_safe_context(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="display-name",
+            key="category/api-plugin",
+            source="user",
+        )
+        ctx = PluginContext(manifest, mgr)
+
+        seen = {}
+
+        def _provider(*, context):
+            seen["context"] = context
+            return {"feature_flag": True}
+
+        ctx.register_api_server_capability(_provider)
+
+        context = ApiServerCapabilityContext(
+            server_name="api_server",
+            request_method="GET",
+            request_path="/v1/capabilities",
+            auth_required=True,
+            profile=None,
+        )
+        capabilities = mgr.get_api_server_capabilities(context=context)
+        assert capabilities == [
+            {
+                "plugin": "category/api-plugin",
+                "capabilities": {"feature_flag": True},
+            }
+        ]
+        assert seen == {"context": context}
+        assert not hasattr(context, "adapter")
+        assert not hasattr(context, "request")
+        with pytest.raises(FrozenInstanceError):
+            context.request_path = "/mutated"
+
+    def test_plugin_capability_provider_failure_isolated(self, caplog):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="api-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        def _bad_provider(*, context):
+            raise RuntimeError("boom")
+
+        ctx.register_api_server_capability(_bad_provider)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            capabilities = mgr.get_api_server_capabilities(
+                context=ApiServerCapabilityContext(
+                    server_name="api_server",
+                    request_method="GET",
+                    request_path="/v1/capabilities",
+                    auth_required=False,
+                    profile=None,
+                )
+            )
+        assert capabilities == []
+        assert "api server capability provider" in caplog.text.lower()
+
+    def test_register_api_server_capability_rejects_duplicate_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        ctx.register_api_server_capability(lambda **kwargs: {"first": True})
+
+        with pytest.raises(ValueError, match="already registered"):
+            ctx.register_api_server_capability(lambda **kwargs: {"second": True})
+
+        assert len(mgr._api_server_capability_providers) == 1
+
+    def test_plugin_capability_provider_non_json_payload_is_isolated(self, caplog):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        ctx.register_api_server_capability(lambda **kwargs: {"bad": object()})
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            capabilities = mgr.get_api_server_capabilities(
+                context=ApiServerCapabilityContext(
+                    server_name="api_server",
+                    request_method="GET",
+                    request_path="/v1/capabilities",
+                    auth_required=False,
+                    profile=None,
+                )
+            )
+
+        assert capabilities == []
+        assert "json-serializable" in caplog.text.lower()
 
 
 class TestPluginDebugLogging:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1036,7 +1036,9 @@ class TestPluginApiServerHooks:
         ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
 
         with pytest.raises(TypeError, match="handler must be callable"):
-            ctx.register_api_server_route("GET", "/v1/plugins/bad", "not-callable")
+            ctx.register_api_server_route(
+                "GET", "/v1/plugins/api-plugin/bad", "not-callable"
+            )
 
         assert mgr.get_api_server_routes() == []
 
@@ -1069,12 +1071,17 @@ class TestPluginApiServerHooks:
         async def _handler(request):
             return None
 
-        ctx.register_api_server_route("GET", "/v1/plugins/ping", _handler, name="plugin_ping")
+        ctx.register_api_server_route(
+            "GET",
+            "/v1/plugins/api-plugin/ping",
+            _handler,
+            name="plugin_ping",
+        )
 
         routes = mgr.get_api_server_routes()
         assert len(routes) == 1
         assert routes[0]["method"] == "GET"
-        assert routes[0]["path"] == "/v1/plugins/ping"
+        assert routes[0]["path"] == "/v1/plugins/api-plugin/ping"
         assert routes[0]["handler"] is _handler
         assert routes[0]["name"] == "plugin_ping"
         assert routes[0]["plugin"] == "api-plugin"
@@ -1082,10 +1089,16 @@ class TestPluginApiServerHooks:
     @pytest.mark.parametrize(
         ("method", "path", "name", "message"),
         [
-            ("NOPE", "/v1/plugins/ping", None, "unsupported method"),
+            ("NOPE", "/v1/plugins/api-plugin/ping", None, "unsupported method"),
             ("GET", "/v1/models", None, "under /v1/plugins/"),
             ("GET", "/v1/plugins/", None, "include a route name"),
-            ("GET", "/v1/plugins/ping", "", "name must be"),
+            ("GET", "/v1/plugins/api-plugin/ping", "", "name must be"),
+            (
+                "GET",
+                "/v1/plugins/api-plugin/ping",
+                "invalid/name",
+                "Python identifiers",
+            ),
         ],
     )
     def test_register_api_server_route_rejects_invalid_definition(
@@ -1104,10 +1117,10 @@ class TestPluginApiServerHooks:
         ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
         handler = lambda request: None
 
-        ctx.register_api_server_route("GET", "/v1/plugins/ping", handler)
+        ctx.register_api_server_route("GET", "/v1/plugins/api-plugin/ping", handler)
 
         with pytest.raises(ValueError, match="already registered"):
-            ctx.register_api_server_route("get", "/v1/plugins/ping", handler)
+            ctx.register_api_server_route("get", "/v1/plugins/api-plugin/ping", handler)
 
         assert len(mgr.get_api_server_routes()) == 1
 
@@ -1117,19 +1130,49 @@ class TestPluginApiServerHooks:
         handler = lambda request: None
 
         ctx.register_api_server_route(
-            "GET", "/v1/plugins/one", handler, name="api_plugin_route"
+            "GET", "/v1/plugins/api-plugin/one", handler, name="api_plugin_route"
         )
 
         with pytest.raises(ValueError, match="name already registered"):
             ctx.register_api_server_route(
-                "POST", "/v1/plugins/two", handler, name="api_plugin_route"
+                "POST",
+                "/v1/plugins/api-plugin/two",
+                handler,
+                name="api_plugin_route",
             )
 
         assert len(mgr.get_api_server_routes()) == 1
 
+    def test_register_api_server_route_rejects_another_plugin_namespace(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(
+            name="display-name",
+            key="category/api-plugin",
+            source="user",
+        )
+        ctx = PluginContext(manifest, mgr)
+
+        with pytest.raises(ValueError, match="own namespace"):
+            ctx.register_api_server_route(
+                "GET",
+                "/v1/plugins/other-plugin/status",
+                lambda request: None,
+            )
+
+        ctx.register_api_server_route(
+            "GET",
+            "/v1/plugins/category/api-plugin/status",
+            lambda request: None,
+        )
+        assert mgr.get_api_server_routes()[0]["plugin"] == "category/api-plugin"
+
     def test_register_api_server_capability_provider_is_invoked_with_context(self):
         mgr = PluginManager()
-        manifest = PluginManifest(name="api-plugin", source="user")
+        manifest = PluginManifest(
+            name="display-name",
+            key="category/api-plugin",
+            source="user",
+        )
         ctx = PluginContext(manifest, mgr)
 
         seen = {}
@@ -1142,7 +1185,12 @@ class TestPluginApiServerHooks:
         ctx.register_api_server_capability(_provider)
 
         capabilities = mgr.get_api_server_capabilities(adapter="adapter-x", request="request-y")
-        assert capabilities == [{"plugin": "api-plugin", "capabilities": {"feature_flag": True}}]
+        assert capabilities == [
+            {
+                "plugin": "category/api-plugin",
+                "capabilities": {"feature_flag": True},
+            }
+        ]
         assert seen == {"adapter": "adapter-x", "request": "request-y"}
 
     def test_plugin_capability_provider_failure_isolated(self, caplog):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1168,6 +1168,32 @@ class TestPluginApiServerHooks:
         )
         assert mgr.get_api_server_routes()[0]["plugin"] == "category/api-plugin"
 
+    @pytest.mark.parametrize(
+        "plugin_key",
+        [
+            "api plugin",
+            "../api-plugin",
+            "api-plugin/{tail:.*}",
+        ],
+    )
+    def test_register_api_server_route_rejects_unsafe_plugin_namespace(
+        self, plugin_key
+    ):
+        mgr = PluginManager()
+        ctx = PluginContext(
+            PluginManifest(name="display-name", key=plugin_key, source="user"),
+            mgr,
+        )
+
+        with pytest.raises(ValueError, match="safe URL path segments"):
+            ctx.register_api_server_route(
+                "GET",
+                f"/v1/plugins/{plugin_key}/status",
+                lambda request: None,
+            )
+
+        assert mgr.get_api_server_routes() == []
+
     def test_register_api_server_capability_provider_is_invoked_with_safe_context(self):
         mgr = PluginManager()
         manifest = PluginManifest(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1030,6 +1030,77 @@ class TestPluginDispatchTool:
         assert call_kwargs[1]["parent_agent"] is explicit_agent
 
 
+class TestPluginApiServerHooks:
+    def test_register_api_server_route_rejects_non_callable_handler(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises(TypeError, match="handler must be callable"):
+            ctx.register_api_server_route("GET", "/v1/plugins/bad", "not-callable")
+
+        assert mgr.get_api_server_routes() == []
+
+    def test_register_api_server_capability_rejects_non_callable_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises(TypeError, match="provider must be callable"):
+            ctx.register_api_server_capability(object())
+
+        assert mgr._api_server_capability_providers == []
+
+    def test_register_api_server_route_tracks_route_definition(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="api-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        async def _handler(request):
+            return None
+
+        ctx.register_api_server_route("GET", "/v1/plugins/ping", _handler, name="plugin_ping")
+
+        routes = mgr.get_api_server_routes()
+        assert len(routes) == 1
+        assert routes[0]["method"] == "GET"
+        assert routes[0]["path"] == "/v1/plugins/ping"
+        assert routes[0]["handler"] is _handler
+        assert routes[0]["name"] == "plugin_ping"
+        assert routes[0]["plugin"] == "api-plugin"
+
+    def test_register_api_server_capability_provider_is_invoked_with_context(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="api-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        seen = {}
+
+        def _provider(*, adapter=None, request=None):
+            seen["adapter"] = adapter
+            seen["request"] = request
+            return {"feature_flag": True}
+
+        ctx.register_api_server_capability(_provider)
+
+        capabilities = mgr.get_api_server_capabilities(adapter="adapter-x", request="request-y")
+        assert capabilities == [{"plugin": "api-plugin", "capabilities": {"feature_flag": True}}]
+        assert seen == {"adapter": "adapter-x", "request": "request-y"}
+
+    def test_plugin_capability_provider_failure_isolated(self, caplog):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="api-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        def _bad_provider(*, adapter=None, request=None):
+            raise RuntimeError("boom")
+
+        ctx.register_api_server_capability(_bad_provider)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            capabilities = mgr.get_api_server_capabilities(adapter=None, request=None)
+        assert capabilities == []
+        assert "api server capability provider" in caplog.text.lower()
+
+
 class TestPluginDebugLogging:
     """HERMES_PLUGINS_DEBUG opt-in stderr handler for plugin developers."""
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import types
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ import pytest
 import yaml
 
 from hermes_cli.plugins import (
+    ApiServerCapabilityContext,
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
     PluginContext,
@@ -1166,7 +1168,7 @@ class TestPluginApiServerHooks:
         )
         assert mgr.get_api_server_routes()[0]["plugin"] == "category/api-plugin"
 
-    def test_register_api_server_capability_provider_is_invoked_with_context(self):
+    def test_register_api_server_capability_provider_is_invoked_with_safe_context(self):
         mgr = PluginManager()
         manifest = PluginManifest(
             name="display-name",
@@ -1177,34 +1179,52 @@ class TestPluginApiServerHooks:
 
         seen = {}
 
-        def _provider(*, adapter=None, request=None):
-            seen["adapter"] = adapter
-            seen["request"] = request
+        def _provider(*, context):
+            seen["context"] = context
             return {"feature_flag": True}
 
         ctx.register_api_server_capability(_provider)
 
-        capabilities = mgr.get_api_server_capabilities(adapter="adapter-x", request="request-y")
+        context = ApiServerCapabilityContext(
+            server_name="api_server",
+            request_method="GET",
+            request_path="/v1/capabilities",
+            auth_required=True,
+            profile=None,
+        )
+        capabilities = mgr.get_api_server_capabilities(context=context)
         assert capabilities == [
             {
                 "plugin": "category/api-plugin",
                 "capabilities": {"feature_flag": True},
             }
         ]
-        assert seen == {"adapter": "adapter-x", "request": "request-y"}
+        assert seen == {"context": context}
+        assert not hasattr(context, "adapter")
+        assert not hasattr(context, "request")
+        with pytest.raises(FrozenInstanceError):
+            context.request_path = "/mutated"
 
     def test_plugin_capability_provider_failure_isolated(self, caplog):
         mgr = PluginManager()
         manifest = PluginManifest(name="api-plugin", source="user")
         ctx = PluginContext(manifest, mgr)
 
-        def _bad_provider(*, adapter=None, request=None):
+        def _bad_provider(*, context):
             raise RuntimeError("boom")
 
         ctx.register_api_server_capability(_bad_provider)
 
         with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
-            capabilities = mgr.get_api_server_capabilities(adapter=None, request=None)
+            capabilities = mgr.get_api_server_capabilities(
+                context=ApiServerCapabilityContext(
+                    server_name="api_server",
+                    request_method="GET",
+                    request_path="/v1/capabilities",
+                    auth_required=False,
+                    profile=None,
+                )
+            )
         assert capabilities == []
         assert "api server capability provider" in caplog.text.lower()
 
@@ -1225,7 +1245,15 @@ class TestPluginApiServerHooks:
         ctx.register_api_server_capability(lambda **kwargs: {"bad": object()})
 
         with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
-            capabilities = mgr.get_api_server_capabilities(adapter=None, request=None)
+            capabilities = mgr.get_api_server_capabilities(
+                context=ApiServerCapabilityContext(
+                    server_name="api_server",
+                    request_method="GET",
+                    request_path="/v1/capabilities",
+                    auth_required=False,
+                    profile=None,
+                )
+            )
 
         assert capabilities == []
         assert "json-serializable" in caplog.text.lower()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1049,6 +1049,18 @@ class TestPluginApiServerHooks:
 
         assert mgr._api_server_capability_providers == []
 
+    def test_register_api_server_capability_rejects_async_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        async def _provider(**kwargs):
+            return {"feature": True}
+
+        with pytest.raises(TypeError, match="must be synchronous"):
+            ctx.register_api_server_capability(_provider)
+
+        assert mgr._api_server_capability_providers == []
+
     def test_register_api_server_route_tracks_route_definition(self):
         mgr = PluginManager()
         manifest = PluginManifest(name="api-plugin", source="user")
@@ -1066,6 +1078,54 @@ class TestPluginApiServerHooks:
         assert routes[0]["handler"] is _handler
         assert routes[0]["name"] == "plugin_ping"
         assert routes[0]["plugin"] == "api-plugin"
+
+    @pytest.mark.parametrize(
+        ("method", "path", "name", "message"),
+        [
+            ("NOPE", "/v1/plugins/ping", None, "unsupported method"),
+            ("GET", "/v1/models", None, "under /v1/plugins/"),
+            ("GET", "/v1/plugins/", None, "include a route name"),
+            ("GET", "/v1/plugins/ping", "", "name must be"),
+        ],
+    )
+    def test_register_api_server_route_rejects_invalid_definition(
+        self, method, path, name, message
+    ):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        with pytest.raises((TypeError, ValueError), match=message):
+            ctx.register_api_server_route(method, path, lambda request: None, name=name)
+
+        assert mgr.get_api_server_routes() == []
+
+    def test_register_api_server_route_rejects_duplicate_method_and_path(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        handler = lambda request: None
+
+        ctx.register_api_server_route("GET", "/v1/plugins/ping", handler)
+
+        with pytest.raises(ValueError, match="already registered"):
+            ctx.register_api_server_route("get", "/v1/plugins/ping", handler)
+
+        assert len(mgr.get_api_server_routes()) == 1
+
+    def test_register_api_server_route_rejects_duplicate_name(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        handler = lambda request: None
+
+        ctx.register_api_server_route(
+            "GET", "/v1/plugins/one", handler, name="api_plugin_route"
+        )
+
+        with pytest.raises(ValueError, match="name already registered"):
+            ctx.register_api_server_route(
+                "POST", "/v1/plugins/two", handler, name="api_plugin_route"
+            )
+
+        assert len(mgr.get_api_server_routes()) == 1
 
     def test_register_api_server_capability_provider_is_invoked_with_context(self):
         mgr = PluginManager()
@@ -1099,6 +1159,28 @@ class TestPluginApiServerHooks:
             capabilities = mgr.get_api_server_capabilities(adapter=None, request=None)
         assert capabilities == []
         assert "api server capability provider" in caplog.text.lower()
+
+    def test_register_api_server_capability_rejects_duplicate_provider(self):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+
+        ctx.register_api_server_capability(lambda **kwargs: {"first": True})
+
+        with pytest.raises(ValueError, match="already registered"):
+            ctx.register_api_server_capability(lambda **kwargs: {"second": True})
+
+        assert len(mgr._api_server_capability_providers) == 1
+
+    def test_plugin_capability_provider_non_json_payload_is_isolated(self, caplog):
+        mgr = PluginManager()
+        ctx = PluginContext(PluginManifest(name="api-plugin", source="user"), mgr)
+        ctx.register_api_server_capability(lambda **kwargs: {"bad": object()})
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            capabilities = mgr.get_api_server_capabilities(adapter=None, request=None)
+
+        assert capabilities == []
+        assert "json-serializable" in caplog.text.lower()
 
 
 class TestPluginDebugLogging:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -306,18 +306,27 @@ def register(ctx):
 
 Route handlers receive an `aiohttp.web.Request` and may be synchronous or
 asynchronous, but must return an `aiohttp.web.StreamResponse` such as
-`web.Response` or `web.json_response(...)`. Routes inherit the API server's
-bearer authentication and security middleware. Methods are limited to
-`GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`; paths must be
-non-empty and live below `/v1/plugins/`; and method/path pairs and optional
-route names must be unique.
+`web.Response` or `web.json_response(...)`. Synchronous handlers are moved off
+the event loop, and every handler has a bounded execution time. Routes inherit
+the API server's bearer authentication and security middleware. Methods are
+limited to `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`.
+Each path must be non-empty and remain below the registering plugin's canonical
+namespace, `/v1/plugins/<plugin-key>/`; method/path pairs and optional route
+names must be unique.
 
 Capability providers are synchronous callbacks invoked with keyword-only
 `adapter` and `request` context. Register at most one provider per plugin and
 return either a JSON-serializable dictionary or `None`. Valid dictionaries are
-published at `extensions.plugins.<plugin-name>` in `GET /v1/capabilities`.
+published at `extensions.plugins.<plugin-key>` in `GET /v1/capabilities`.
 Provider failures and invalid payloads are logged and skipped so one plugin
 cannot break capability discovery for the server.
+
+When `gateway.multiplex_profiles` is enabled, these extensions belong only to
+the default profile that owns the shared listener. They are not mirrored into
+`/p/<profile>/`, and named-profile capability responses do not advertise them.
+This prevents a plugin enabled in the default profile from becoming reachable
+through an independent profile. Run a separate profile gateway when that
+profile needs its own plugin API extensions.
 
 **`dispatch_tool` example — a slash command that runs a tool:**
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -276,6 +276,8 @@ def register(ctx):
 - `ctx.register_hook()` subscribes to lifecycle events
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
+- `ctx.register_api_server_route()` registers an authenticated API-server route under `/v1/plugins/`
+- `ctx.register_api_server_capability()` contributes plugin-owned metadata to `/v1/capabilities`
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -281,6 +281,44 @@ def register(ctx):
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 
+### Extend the API server
+
+API-server extensions are registered during plugin startup:
+
+```python
+from aiohttp import web
+
+async def health(request):
+    return web.json_response({"status": "ready"})
+
+def capabilities(*, adapter, request):
+    return {"health": {"method": "GET", "path": "/v1/plugins/acme/health"}}
+
+def register(ctx):
+    ctx.register_api_server_route(
+        "GET",
+        "/v1/plugins/acme/health",
+        health,
+        name="acme_health",
+    )
+    ctx.register_api_server_capability(capabilities)
+```
+
+Route handlers receive an `aiohttp.web.Request` and may be synchronous or
+asynchronous, but must return an `aiohttp.web.StreamResponse` such as
+`web.Response` or `web.json_response(...)`. Routes inherit the API server's
+bearer authentication and security middleware. Methods are limited to
+`GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`; paths must be
+non-empty and live below `/v1/plugins/`; and method/path pairs and optional
+route names must be unique.
+
+Capability providers are synchronous callbacks invoked with keyword-only
+`adapter` and `request` context. Register at most one provider per plugin and
+return either a JSON-serializable dictionary or `None`. Valid dictionaries are
+published at `extensions.plugins.<plugin-name>` in `GET /v1/capabilities`.
+Provider failures and invalid payloads are logged and skipped so one plugin
+cannot break capability discovery for the server.
+
 **`dispatch_tool` example — a slash command that runs a tool:**
 
 ```python

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -511,9 +511,72 @@ def register(ctx):
 - `ctx.register_hook()` subscribes to lifecycle events
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
+- `ctx.register_api_server_route()` registers an authenticated API-server route under `/v1/plugins/`
+- `ctx.register_api_server_capability()` contributes plugin-owned metadata to `/v1/capabilities`
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - `ctx.get_config()` / `ctx.set_config()` access only this plugin's settings namespace; `ctx.state` stores plugin-owned runtime data under the active profile.
 - If this function crashes, the plugin is disabled but Hermes continues fine
+
+### Extend the API server
+
+API-server extensions are registered during plugin startup:
+
+```python
+from aiohttp import web
+
+async def health(request):
+    return web.json_response({"status": "ready"})
+
+def capabilities(*, context):
+    return {
+        "health": {"method": "GET", "path": "/v1/plugins/acme/health"},
+        "auth_required": context.auth_required,
+    }
+
+def register(ctx):
+    ctx.register_api_server_route(
+        "GET",
+        "/v1/plugins/acme/health",
+        health,
+        name="acme_health",
+    )
+    ctx.register_api_server_capability(capabilities)
+```
+
+Route handlers receive an `aiohttp.web.Request` and may be synchronous or
+asynchronous, but must return an `aiohttp.web.StreamResponse` such as
+`web.Response` or `web.json_response(...)`. Synchronous handlers are moved off
+the event loop, and every handler has a bounded execution time. Routes inherit
+the API server's bearer authentication and security middleware. Methods are
+limited to `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`.
+Each path must be non-empty and remain below the registering plugin's canonical
+namespace, `/v1/plugins/<plugin-key>/`; method/path pairs and optional route
+names must be unique. Every plugin-key segment must start with an ASCII letter
+or digit and contain only ASCII letters, digits, dots, underscores, or hyphens;
+aiohttp route-template syntax is not allowed in the namespace itself.
+
+Capability providers are synchronous callbacks invoked with one keyword-only
+`context` argument. The context is an immutable
+`ApiServerCapabilityContext` containing only `server_name`, `request_method`,
+`request_path`, `auth_required`, and `profile`; it deliberately does not expose
+the live adapter, request, headers, or API key across the worker-thread
+boundary. Register at most one provider per plugin and return either a
+JSON-serializable dictionary or `None`. Valid dictionaries are published at
+`extensions.plugins.<plugin-key>` in `GET /v1/capabilities`. Provider failures
+and invalid payloads are logged and skipped so one plugin cannot break
+capability discovery for the server.
+
+Synchronous route handlers and capability discovery use an adapter-owned,
+bounded executor. A timed-out callback keeps its worker slot until it actually
+returns, so repeated hung plugin calls cannot grow the process-wide executor or
+queue additional plugin work without bound.
+
+When `gateway.multiplex_profiles` is enabled, these extensions belong only to
+the default profile that owns the shared listener. They are not mirrored into
+`/p/<profile>/`, and named-profile capability responses do not advertise them.
+This prevents a plugin enabled in the default profile from becoming reachable
+through an independent profile. Run a separate profile gateway when that
+profile needs its own plugin API extensions.
 
 **`dispatch_tool` example — a slash command that runs a tool:**
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -315,7 +315,9 @@ the API server's bearer authentication and security middleware. Methods are
 limited to `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT`, `PATCH`, and `DELETE`.
 Each path must be non-empty and remain below the registering plugin's canonical
 namespace, `/v1/plugins/<plugin-key>/`; method/path pairs and optional route
-names must be unique.
+names must be unique. Every plugin-key segment must start with an ASCII letter
+or digit and contain only ASCII letters, digits, dots, underscores, or hyphens;
+aiohttp route-template syntax is not allowed in the namespace itself.
 
 Capability providers are synchronous callbacks invoked with one keyword-only
 `context` argument. The context is an immutable

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -291,8 +291,11 @@ from aiohttp import web
 async def health(request):
     return web.json_response({"status": "ready"})
 
-def capabilities(*, adapter, request):
-    return {"health": {"method": "GET", "path": "/v1/plugins/acme/health"}}
+def capabilities(*, context):
+    return {
+        "health": {"method": "GET", "path": "/v1/plugins/acme/health"},
+        "auth_required": context.auth_required,
+    }
 
 def register(ctx):
     ctx.register_api_server_route(
@@ -314,12 +317,21 @@ Each path must be non-empty and remain below the registering plugin's canonical
 namespace, `/v1/plugins/<plugin-key>/`; method/path pairs and optional route
 names must be unique.
 
-Capability providers are synchronous callbacks invoked with keyword-only
-`adapter` and `request` context. Register at most one provider per plugin and
-return either a JSON-serializable dictionary or `None`. Valid dictionaries are
-published at `extensions.plugins.<plugin-key>` in `GET /v1/capabilities`.
-Provider failures and invalid payloads are logged and skipped so one plugin
-cannot break capability discovery for the server.
+Capability providers are synchronous callbacks invoked with one keyword-only
+`context` argument. The context is an immutable
+`ApiServerCapabilityContext` containing only `server_name`, `request_method`,
+`request_path`, `auth_required`, and `profile`; it deliberately does not expose
+the live adapter, request, headers, or API key across the worker-thread
+boundary. Register at most one provider per plugin and return either a
+JSON-serializable dictionary or `None`. Valid dictionaries are published at
+`extensions.plugins.<plugin-key>` in `GET /v1/capabilities`. Provider failures
+and invalid payloads are logged and skipped so one plugin cannot break
+capability discovery for the server.
+
+Synchronous route handlers and capability discovery use an adapter-owned,
+bounded executor. A timed-out callback keeps its worker slot until it actually
+returns, so repeated hung plugin calls cannot grow the process-wide executor or
+queue additional plugin work without bound.
 
 When `gateway.multiplex_profiles` is enabled, these extensions belong only to
 the default profile that owns the shared listener. They are not mirrored into

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -259,6 +259,37 @@ Returns a machine-readable description of the API server's stable surface for ex
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
+Enabled plugins may add metadata under `extensions.plugins.<plugin-key>`.
+Each value is supplied by that plugin's capability provider; clients should
+treat unknown plugin keys as optional extension data.
+
+Plugins may also register HTTP handlers under their canonical
+`/v1/plugins/<plugin-key>/...` namespace. These
+routes use the same `API_SERVER_KEY` bearer authentication as core API-server
+routes. Plugin handlers receive the native `aiohttp.web.Request` and must
+return an `aiohttp.web.StreamResponse` (synchronously or asynchronously).
+Hermes rejects non-callable handlers, invalid methods and paths, duplicate
+method/path pairs, duplicate route names, and plugin namespaces containing
+unsafe URL path segments or route-template syntax during registration. A
+handler exception or invalid response produces a stable JSON `500` response
+without exposing the exception to the API client.
+
+Capability providers are synchronous, one per plugin, and must return a
+JSON-serializable object or `None`. Invalid or failing providers are skipped so
+they cannot break the core capability response. Plugin routes cannot leave the
+registering plugin's namespace or replace a core route. Synchronous handlers
+and capability providers run off the API event loop, and both surfaces have
+bounded execution time and bounded worker admission. Timed-out synchronous
+callbacks retain their worker slot until they really exit, preventing repeated
+hung plugin calls from accumulating threads. Providers receive only an
+immutable, non-secret capability context—not the live adapter, request,
+headers, or bearer key.
+
+In multiplex mode, plugin API routes and capability extensions are available
+only on the unprefixed default-profile listener. Hermes does not expose the
+default profile's enabled plugins through `/p/<profile>/` or advertise them in
+a named profile's `/v1/capabilities` response.
+
 ## Browser-extension control
 
 Hermes can route browser tools through an authenticated extension that controls
@@ -410,7 +441,6 @@ Example:
   ]
 }
 ```
-
 ### GET /health
 
 Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** for OpenAI-compatible clients that expect the `/v1/` prefix.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -276,7 +276,11 @@ JSON-serializable object or `None`. Invalid or failing providers are skipped so
 they cannot break the core capability response. Plugin routes cannot leave the
 registering plugin's namespace or replace a core route. Synchronous handlers
 and capability providers run off the API event loop, and both surfaces have
-bounded execution time.
+bounded execution time and bounded worker admission. Timed-out synchronous
+callbacks retain their worker slot until they really exit, preventing repeated
+hung plugin calls from accumulating threads. Providers receive only an
+immutable, non-secret capability context—not the live adapter, request,
+headers, or bearer key.
 
 In multiplex mode, plugin API routes and capability extensions are available
 only on the unprefixed default-profile listener. Hermes does not expose the

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -267,7 +267,8 @@ routes use the same `API_SERVER_KEY` bearer authentication as core API-server
 routes. Plugin handlers receive the native `aiohttp.web.Request` and must
 return an `aiohttp.web.StreamResponse` (synchronously or asynchronously).
 Hermes rejects non-callable handlers, invalid methods and paths, duplicate
-method/path pairs, and duplicate route names during plugin registration. A
+method/path pairs, duplicate route names, and plugin namespaces containing
+unsafe URL path segments or route-template syntax during registration. A
 handler exception or invalid response produces a stable JSON `500` response
 without exposing the exception to the API client.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -257,11 +257,12 @@ Returns a machine-readable description of the API server's stable surface for ex
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
-Enabled plugins may add metadata under `extensions.plugins.<plugin-name>`.
+Enabled plugins may add metadata under `extensions.plugins.<plugin-key>`.
 Each value is supplied by that plugin's capability provider; clients should
 treat unknown plugin keys as optional extension data.
 
-Plugins may also register HTTP handlers under `/v1/plugins/<name>`. These
+Plugins may also register HTTP handlers under their canonical
+`/v1/plugins/<plugin-key>/...` namespace. These
 routes use the same `API_SERVER_KEY` bearer authentication as core API-server
 routes. Plugin handlers receive the native `aiohttp.web.Request` and must
 return an `aiohttp.web.StreamResponse` (synchronously or asynchronously).
@@ -273,7 +274,14 @@ without exposing the exception to the API client.
 Capability providers are synchronous, one per plugin, and must return a
 JSON-serializable object or `None`. Invalid or failing providers are skipped so
 they cannot break the core capability response. Plugin routes cannot leave the
-`/v1/plugins/` namespace or replace a core route.
+registering plugin's namespace or replace a core route. Synchronous handlers
+and capability providers run off the API event loop, and both surfaces have
+bounded execution time.
+
+In multiplex mode, plugin API routes and capability extensions are available
+only on the unprefixed default-profile listener. Hermes does not expose the
+default profile's enabled plugins through `/p/<profile>/` or advertise them in
+a named profile's `/v1/capabilities` response.
 
 ## Per-request model selection
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -257,6 +257,18 @@ Returns a machine-readable description of the API server's stable surface for ex
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
+Enabled plugins may add metadata under `extensions.plugins.<plugin-name>`.
+Each value is supplied by that plugin's capability provider; clients should
+treat unknown plugin keys as optional extension data.
+
+Plugins may also register HTTP handlers under `/v1/plugins/<name>`. These
+routes use the same `API_SERVER_KEY` bearer authentication as core API-server
+routes. Plugin handlers receive the native `aiohttp.web.Request` and must
+return an `aiohttp.web.Response` (synchronously or asynchronously). Hermes
+rejects non-callable handlers/providers during plugin registration, refuses
+paths outside `/v1/plugins/`, and does not allow plugin routes to replace a
+core route.
+
 ## Per-request model selection
 
 Authenticated clients can override Hermes' default model selection per request
@@ -319,7 +331,6 @@ Example:
   ]
 }
 ```
-
 ### GET /health
 
 Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** for OpenAI-compatible clients that expect the `/v1/` prefix.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -264,10 +264,16 @@ treat unknown plugin keys as optional extension data.
 Plugins may also register HTTP handlers under `/v1/plugins/<name>`. These
 routes use the same `API_SERVER_KEY` bearer authentication as core API-server
 routes. Plugin handlers receive the native `aiohttp.web.Request` and must
-return an `aiohttp.web.Response` (synchronously or asynchronously). Hermes
-rejects non-callable handlers/providers during plugin registration, refuses
-paths outside `/v1/plugins/`, and does not allow plugin routes to replace a
-core route.
+return an `aiohttp.web.StreamResponse` (synchronously or asynchronously).
+Hermes rejects non-callable handlers, invalid methods and paths, duplicate
+method/path pairs, and duplicate route names during plugin registration. A
+handler exception or invalid response produces a stable JSON `500` response
+without exposing the exception to the API client.
+
+Capability providers are synchronous, one per plugin, and must return a
+JSON-serializable object or `None`. Invalid or failing providers are skipped so
+they cannot break the core capability response. Plugin routes cannot leave the
+`/v1/plugins/` namespace or replace a core route.
 
 ## Per-request model selection
 


### PR DESCRIPTION
## What does this PR do?

Adds a narrow plugin extension point to Hermes' existing authenticated API server. Enabled plugins can expose plugin-owned HTTP routes and capability metadata without adding a core model tool or running a second server.

Related to #8500; this PR provides the API extension surface only, not browser UI.

## Changes

- Add `PluginContext.register_api_server_route(...)` and `register_api_server_capability(...)`.
- Require routes to stay under `/v1/plugins/<canonical-plugin-key>/...` and reject unsafe namespaces, templates, duplicates, malformed definitions, and non-callable handlers.
- Reuse API-server authentication and security middleware.
- Keep extensions default-profile-only under multiplexing.
- Give capability providers an immutable, non-secret context rather than the live adapter or request.
- Isolate synchronous work in a bounded adapter-owned executor with timeouts, completion-based slot release, and disconnect cleanup.
- Return stable redacted errors without allowing plugin failures to prevent core API startup or responses.
- Document the registration, authentication, profile, failure, and execution contracts.

## Verification

Rebased directly onto `upstream/main` at `8defb9fd60bebe2802eaab7c57fa2ee6a4ff6281`; current head `75a56bc87fdf481b5220b699bad1f44445f41ba9`.

```bash
scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/gateway/test_api_server.py
```

Result: `166 passed` (`54` plugin tests and `112` API-server tests).

```bash
.venv/bin/python -m ruff check gateway/platforms/api_server.py hermes_cli/plugins.py \
  tests/gateway/test_api_server.py tests/hermes_cli/test_plugins.py
git diff --check upstream/main...HEAD
```

Result: passed. No added line contains a `TODO`, `FIXME`, or `HACK` marker.

GitHub Actions for this fork head require maintainer approval before jobs can start; no pending check is represented as green.

## Risks / mitigations

- **Authentication bypass:** routes reuse API-server bearer authentication and middleware.
- **Cross-profile leakage:** named profiles neither mount default-profile plugin routes nor advertise their metadata.
- **Namespace injection:** registration and mounting both validate literal URL-safe plugin-key segments and reject core-route replacement.
- **Event-loop starvation:** synchronous callbacks use a dedicated bounded executor; timed-out work retains its slot until it exits.
- **Secret leakage:** capability providers receive a frozen safe context and clients receive redacted errors.

## Checklist

- [x] Based on current upstream main
- [x] Scope limited to plugin API-server extensions
- [x] Request/response and bounded-saturation tests pass after rebase
- [x] Developer and user documentation updated
