### PR TITLE
fix(docker): don't require >0 TTY width in passthrough test

### DIFF
--- a/tests/docker/test_tui_passthrough.py
+++ b/tests/docker/test_tui_passthrough.py
@@ -38,7 +38,13 @@ def test_tty_passthrough_to_container(built_image: str) -> None:
     assert "NO_TTY" not in output, f"TTY passthrough failed: {output!r}"
     numeric_lines = [s for s in output.split() if s.strip().isdigit()]
     assert numeric_lines, f"No numeric width in output: {output!r}"
-    assert int(numeric_lines[0]) > 0
+    # The container saw a real TTY (``[ -t 1 ]`` was true, so we got a number
+    # rather than ``NO_TTY``) and terminfo resolved ``tput cols``. That is the
+    # passthrough contract this test guards. The reported width itself depends
+    # on the host PTY's window-size ioctl: a ``script(1)``-allocated PTY on a
+    # headless CI runner has a 0x0 window, so ``tput cols`` legitimately prints
+    # ``0`` while still being a TTY. Assert non-negative, not strictly positive.
+    assert int(numeric_lines[0]) >= 0
 
 
 def test_tui_flag_recognized(built_image: str) -> None:


### PR DESCRIPTION
## Summary

Unblocks `build-amd64` CI. `test_tty_passthrough_to_container` asserted `tput cols > 0`, but a `script(1)`-allocated PTY on a headless CI runner has a 0×0 window — so `tput cols` legitimately prints `0` while the container still receives a real TTY. The over-strict positive-width check turned the Docker integration job consistently red across recent PRs and main runs.

## Changes
- `tests/docker/test_tui_passthrough.py`: loosen the final assertion from `> 0` to `>= 0`. The passthrough contract is still fully enforced — the `NO_TTY` guard proves the container saw `[ -t 1 ]` true, and the numeric-output assertion proves terminfo resolved. Only the window-dimension assumption is relaxed.

## Validation
| | Before | After |
|---|---|---|
| `test_tty_passthrough_to_container` on headless runner | `AssertionError: assert 0 > 0` | passes |
| TTY-passthrough contract | enforced via NO_TTY + numeric assert | unchanged |
| `py_compile` | — | clean |

Root cause: the test conflated "TTY present" with "TTY has non-zero window size". A PTY can be a genuine TTY with a 0×0 window; the window-size ioctl on a CI runner's `script` PTY reports zero.

## Infographic

![tty-passthrough-width-fix](https://v3b.fal.media/files/b/0a9ce3bd/RMD8preKiP6TNi8C7bfYH_MwsW7zHj.png)
