### PR TITLE
fix(cron): extract markdown images in cron delivery path

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -665,6 +665,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
+    # Also extract markdown images (![alt](url)) so they get sent as native
+    # attachments instead of raw markdown text.  Without this, Discord bot
+    # messages containing `![alt](url)` render as plain text and never embed.
+    images, cleaned_delivery_content = BasePlatformAdapter.extract_images(cleaned_delivery_content)
+
     try:
         config = load_gateway_config()
     except Exception as e:
@@ -767,6 +772,38 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job,
                         platform=platform,
                     )
+
+                # Send extracted markdown images as native attachments
+                if adapter_ok and images:
+                    from agent.async_utils import safe_schedule_threadsafe
+                    for image_url, alt_text in images:
+                        try:
+                            future = safe_schedule_threadsafe(
+                                runtime_adapter.send_image(
+                                    chat_id, image_url,
+                                    caption=alt_text if alt_text else None,
+                                    metadata=send_metadata,
+                                ),
+                                loop,
+                            )
+                            if future is None:
+                                continue
+                            try:
+                                img_result = future.result(timeout=30)
+                            except TimeoutError:
+                                future.cancel()
+                                raise
+                            if img_result and not getattr(img_result, "success", True):
+                                logger.warning(
+                                    "Job '%s': image send failed for %s: %s",
+                                    job.get("id", "?"), image_url[:80],
+                                    getattr(img_result, "error", "unknown"),
+                                )
+                        except Exception as img_err:
+                            logger.warning(
+                                "Job '%s': failed to send image %s: %s",
+                                job.get("id", "?"), image_url[:80], img_err,
+                            )
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)


### PR DESCRIPTION
What does this PR do?

Fixes a parity gap in the cron job delivery path. The interactive response path (gateway/platforms/base.py) calls both extract_media() and extract_images() to handle markdown images in responses. The cron delivery path (cron/scheduler.py) only called extract_media(), so `![alt](url)` images in cron job responses were sent as raw markdown text. On Discord, bot messages don't auto-embed raw markdown image syntax, so images never rendered.

This PR adds the missing extract_images() call and an image sending loop to _deliver_result(), bringing cron delivery into parity with the interactive path.

Related Issue: N/A (unreported — discovered via end-to-end testing with Discord)

Type of Change: 🐛 Bug fix

Changes Made:
cron/scheduler.py: Added extract_images() call after extract_media() in _deliver_result() to extract markdown images `(![alt](url))` from delivery content
cron/scheduler.py: Added image sending loop via adapter.send_image() for each extracted image URL, mirroring the existing _send_media_via_adapter() pattern for local MEDIA: files

How to Test:
Create a cron job that generates an image and includes `![alt](url)` in its response
Set deliver to a Discord channel
Trigger the job
Before fix: image renders as raw `![alt](url)` text
After fix: image is extracted and sent as a native Discord attachment

Checklist — Code:
[x] Contributing Guide
[x] Conventional Commits
[x] No duplicate PRs
[x] Only related changes
[ ] pytest tests/ -q (not run — test suite requires full env setup)
[ ] Tests added (manual testing only — fix is self-contained to existing infrastructure)
[x] Tested on Ubuntu 24.04

Documentation & Housekeeping:
[x] N/A (no docs/config/tool changes)
[x] N/A
[x] N/A
[x] N/A
[x] N/A
