### PR TITLE
feat(providers): add Claude Code ACP provider (claude-code-acp)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -355,7 +355,8 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider != "claude-code-acp"
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -708,7 +709,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in ("copilot-acp", "claude-code-acp"):
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1280,6 +1280,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "claude-code-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://claude-code"):
+        from agent.claude_code_acp_client import ClaudeCodeACPClient
+
+        client = ClaudeCodeACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude Code ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,6 +155,9 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-acp": "claude-code-acp",
+    "claude-code-acp-agent": "claude-code-acp",
+    "zed-claude-acp": "claude-code-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -1158,8 +1161,9 @@ def _maybe_wrap_anthropic(
     except ImportError:
         pass
     try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if _safe_isinstance(client_obj, CopilotACPClient):
+        # Base class covers both Copilot and Claude Code ACP subprocess clients.
+        from agent.copilot_acp_client import ACPSubprocessClient
+        if _safe_isinstance(client_obj, ACPSubprocessClient):
             return client_obj
     except ImportError:
         pass
@@ -3214,8 +3218,9 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     except ImportError:
         pass
     try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if isinstance(sync_client, CopilotACPClient):
+        # Base class covers both Copilot and Claude Code ACP subprocess clients.
+        from agent.copilot_acp_client import ACPSubprocessClient
+        if isinstance(sync_client, ACPSubprocessClient):
             return sync_client, model
     except ImportError:
         pass
@@ -3823,26 +3828,29 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in ("copilot-acp", "claude-code-acp"):
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured", provider
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete", provider
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "claude-code-acp":
+                from agent.claude_code_acp_client import ClaudeCodeACPClient as _ACPClient
+            else:
+                from agent.copilot_acp_client import CopilotACPClient as _ACPClient
 
-            client = CopilotACPClient(
+            client = _ACPClient(
                 api_key=api_key,
                 base_url=base_url,
                 command=command,

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -1,0 +1,44 @@
+"""ACP subprocess client for Claude Code.
+
+Lets Hermes treat Claude Code as a chat-style backend by spawning the
+`claude-code-acp` bridge (https://github.com/zed-industries/claude-code-acp,
+published as `@zed-industries/claude-code-acp` — the same bridge the Zed editor
+uses to drive Claude Code over the Agent Client Protocol). Each request starts
+a short-lived ACP session over stdio, sends the formatted conversation as a
+single prompt, collects the streamed text chunks, and converts the result back
+into the minimal shape Hermes expects from an OpenAI client.
+
+Authentication is delegated entirely to the Claude Code binary the bridge
+spawns (i.e. whatever `claude` login the user already has). Hermes does not
+manage an Anthropic API key for this provider.
+"""
+
+from __future__ import annotations
+
+from agent.copilot_acp_client import ACPSubprocessClient
+
+ACP_MARKER_BASE_URL = "acp://claude-code"
+
+
+class ClaudeCodeACPClient(ACPSubprocessClient):
+    """ACP subprocess client for the Claude Code ACP bridge."""
+
+    PROVIDER_LABEL = "Claude Code ACP"
+    MARKER_BASE_URL = ACP_MARKER_BASE_URL
+    DEFAULT_API_KEY = "claude-code-acp"
+    DEFAULT_MODEL = "claude-code-acp"
+    # The bridge ships a `claude-code-acp` binary and speaks ACP over stdio
+    # with no extra flags. Override the command/args via env if it lives
+    # elsewhere or needs wrapping (e.g. `npx @zed-industries/claude-code-acp`).
+    COMMAND_ENV_VARS = ("HERMES_CLAUDE_CODE_ACP_COMMAND",)
+    DEFAULT_COMMAND = "claude-code-acp"
+    ARGS_ENV_VAR = "HERMES_CLAUDE_CODE_ACP_ARGS"
+    DEFAULT_ARGS = ()
+
+    def _startup_error_message(self, command: str) -> str:
+        return (
+            f"Could not start Claude Code ACP command '{command}'. "
+            "Install the bridge with `npm install -g @zed-industries/claude-code-acp` "
+            "(and Claude Code itself), or point Hermes at it explicitly via "
+            "HERMES_CLAUDE_CODE_ACP_COMMAND."
+        )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1315,8 +1315,8 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider == "copilot-acp"
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in ("copilot-acp", "claude-code-acp")
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -319,7 +319,7 @@ def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
 
 
 class _ACPChatCompletions:
-    def __init__(self, client: "CopilotACPClient"):
+    def __init__(self, client: "ACPSubprocessClient"):
         self._client = client
 
     def create(self, **kwargs: Any) -> Any:
@@ -327,12 +327,58 @@ class _ACPChatCompletions:
 
 
 class _ACPChatNamespace:
-    def __init__(self, client: "CopilotACPClient"):
+    def __init__(self, client: "ACPSubprocessClient"):
         self.completions = _ACPChatCompletions(client)
 
 
-class CopilotACPClient:
-    """Minimal OpenAI-client-compatible facade for Copilot ACP."""
+class ACPSubprocessClient:
+    """OpenAI-client-compatible facade for an external ACP subprocess agent.
+
+    Speaks the Agent Client Protocol (JSON-RPC over stdio: ``initialize`` →
+    ``session/new`` → ``session/prompt``) to any local agent binary, and
+    converts the result into the minimal shape Hermes expects from an OpenAI
+    client. Provider-specific behaviour (which binary to spawn, display label,
+    startup/early-exit error hints) is supplied by subclasses via the class
+    attributes and ``_resolve_command`` / ``_resolve_args`` / ``*_error``
+    hooks below.
+    """
+
+    # --- Provider-specific surface (override in subclasses) ----------------
+    PROVIDER_LABEL = "ACP"
+    MARKER_BASE_URL = "acp://agent"
+    DEFAULT_API_KEY = "acp"
+    DEFAULT_MODEL = "acp"
+    # Env vars consulted (in order) for the command, then the fallback binary.
+    COMMAND_ENV_VARS: tuple[str, ...] = ()
+    DEFAULT_COMMAND = ""
+    # Env var holding shlex-split args, then the fallback args.
+    ARGS_ENV_VAR = ""
+    DEFAULT_ARGS: tuple[str, ...] = ()
+
+    def _resolve_command(self) -> str:
+        for env_var in self.COMMAND_ENV_VARS:
+            value = os.getenv(env_var, "").strip()
+            if value:
+                return value
+        return self.DEFAULT_COMMAND
+
+    def _resolve_args(self) -> list[str]:
+        raw = os.getenv(self.ARGS_ENV_VAR, "").strip() if self.ARGS_ENV_VAR else ""
+        if raw:
+            return shlex.split(raw)
+        return list(self.DEFAULT_ARGS)
+
+    def _startup_error_message(self, command: str) -> str:
+        """Error raised when the ACP binary cannot be spawned."""
+        return (
+            f"Could not start {self.PROVIDER_LABEL} command '{command}'. "
+            "Install the agent CLI or set its command via the provider's "
+            "HERMES_*_ACP_COMMAND environment variable."
+        )
+
+    def _early_exit_message(self, stderr_text: str) -> str:
+        """Error raised when the ACP process exits before responding."""
+        return f"{self.PROVIDER_LABEL} process exited early: {stderr_text}"
 
     def __init__(
         self,
@@ -347,11 +393,11 @@ class CopilotACPClient:
         args: list[str] | None = None,
         **_: Any,
     ):
-        self.api_key = api_key or "copilot-acp"
-        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self.api_key = api_key or self.DEFAULT_API_KEY
+        self.base_url = base_url or self.MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
-        self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_command = acp_command or command or self._resolve_command()
+        self._acp_args = list(acp_args or args or self._resolve_args())
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
@@ -432,7 +478,7 @@ class CopilotACPClient:
         return SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=model or self.DEFAULT_MODEL,
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
@@ -448,14 +494,13 @@ class CopilotACPClient:
                 env=_build_subprocess_env(),
             )
         except FileNotFoundError as exc:
-            raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
-            ) from exc
+            raise RuntimeError(self._startup_error_message(self._acp_command)) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError(
+                f"{self.PROVIDER_LABEL} process did not expose stdin/stdout pipes."
+            )
 
         self.is_closed = False
         with self._active_process_lock:
@@ -522,29 +567,16 @@ class CopilotACPClient:
                 if "error" in msg:
                     err = msg.get("error") or {}
                     raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                        f"{self.PROVIDER_LABEL} {method} failed: {err.get('message') or err}"
                     )
                 return msg.get("result")
 
             stderr_text = "\n".join(stderr_tail).strip()
             if proc.poll() is not None and stderr_text:
-                if _is_gh_copilot_deprecation_message(stderr_text):
-                    raise RuntimeError(
-                        "Hermes ACP mode requires the NEW GitHub Copilot CLI "
-                        "(github.com/github/copilot-cli), but the binary it just "
-                        "spawned is the deprecated `gh copilot` extension.\n\n"
-                        "Install the new CLI:\n"
-                        "  npm install -g @github/copilot\n"
-                        "  # then verify with: copilot --help\n\n"
-                        "If `copilot` already resolves to the new CLI but you still see this,\n"
-                        "point Hermes at it explicitly:\n"
-                        "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
-                        "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
-                        "directly with a Copilot subscription token) via `hermes setup`.\n\n"
-                        f"Original error:\n{stderr_text}"
-                    )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+                raise RuntimeError(self._early_exit_message(stderr_text))
+            raise TimeoutError(
+                f"Timed out waiting for {self.PROVIDER_LABEL} response to {method}."
+            )
 
         try:
             _request(
@@ -684,3 +716,40 @@ class CopilotACPClient:
         process.stdin.write(json.dumps(response) + "\n")
         process.stdin.flush()
         return True
+
+
+class CopilotACPClient(ACPSubprocessClient):
+    """ACP subprocess client for the GitHub Copilot CLI (`copilot --acp`)."""
+
+    PROVIDER_LABEL = "Copilot ACP"
+    MARKER_BASE_URL = ACP_MARKER_BASE_URL
+    DEFAULT_API_KEY = "copilot-acp"
+    DEFAULT_MODEL = "copilot-acp"
+    COMMAND_ENV_VARS = ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH")
+    DEFAULT_COMMAND = "copilot"
+    ARGS_ENV_VAR = "HERMES_COPILOT_ACP_ARGS"
+    DEFAULT_ARGS = ("--acp", "--stdio")
+
+    def _startup_error_message(self, command: str) -> str:
+        return (
+            f"Could not start Copilot ACP command '{command}'. "
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
+
+    def _early_exit_message(self, stderr_text: str) -> str:
+        if _is_gh_copilot_deprecation_message(stderr_text):
+            return (
+                "Hermes ACP mode requires the NEW GitHub Copilot CLI "
+                "(github.com/github/copilot-cli), but the binary it just "
+                "spawned is the deprecated `gh copilot` extension.\n\n"
+                "Install the new CLI:\n"
+                "  npm install -g @github/copilot\n"
+                "  # then verify with: copilot --help\n\n"
+                "If `copilot` already resolves to the new CLI but you still see this,\n"
+                "point Hermes at it explicitly:\n"
+                "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
+                "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
+                "directly with a Copilot subscription token) via `hermes setup`.\n\n"
+                f"Original error:\n{stderr_text}"
+            )
+        return f"Copilot ACP process exited early: {stderr_text}"

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-code-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -90,6 +90,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CODE_ACP_BASE_URL = "acp://claude-code"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -162,6 +163,13 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # For external-process (ACP subprocess) providers: how to find/launch the
+    # local agent binary, and the synthetic api_key marker the client uses.
+    process_command_env_vars: tuple = ()
+    process_default_command: str = ""
+    process_args_env_var: str = ""
+    process_default_args: tuple = ()
+    process_api_key: str = ""
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -228,6 +236,23 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+        process_command_env_vars=("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+        process_default_command="copilot",
+        process_args_env_var="HERMES_COPILOT_ACP_ARGS",
+        process_default_args=("--acp", "--stdio"),
+        process_api_key="copilot-acp",
+    ),
+    "claude-code-acp": ProviderConfig(
+        id="claude-code-acp",
+        name="Claude Code ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CODE_ACP_BASE_URL,
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
+        process_command_env_vars=("HERMES_CLAUDE_CODE_ACP_COMMAND",),
+        process_default_command="claude-code-acp",
+        process_args_env_var="HERMES_CLAUDE_CODE_ACP_ARGS",
+        process_default_args=(),
+        process_api_key="claude-code-acp",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1499,6 +1524,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "claude-acp": "claude-code-acp", "claude-code-acp-agent": "claude-code-acp",
+        "zed-claude-acp": "claude-code-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -5672,19 +5699,39 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _resolve_external_process_command(pconfig: "ProviderConfig") -> tuple:
+    """Resolve ``(command, args)`` for an external-process provider.
+
+    Reads the provider's configured command/args env vars (in priority order),
+    falling back to its defaults. Backwards-compatible with the original
+    Copilot-only behaviour because ``copilot-acp`` declares the same env vars
+    and defaults it used before.
+    """
+    command = ""
+    for env_var in pconfig.process_command_env_vars:
+        value = os.getenv(env_var, "").strip()
+        if value:
+            command = value
+            break
+    if not command:
+        command = pconfig.process_default_command
+
+    raw_args = (
+        os.getenv(pconfig.process_args_env_var, "").strip()
+        if pconfig.process_args_env_var
+        else ""
+    )
+    args = shlex.split(raw_args) if raw_args else list(pconfig.process_default_args)
+    return command, args
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _resolve_external_process_command(pconfig)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -5721,7 +5768,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in ("copilot-acp", "claude-code-acp"):
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -5875,25 +5922,20 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _resolve_external_process_command(pconfig)
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        env_hint = " / ".join(pconfig.process_command_env_vars) or "the provider command env var"
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {pconfig.name} command '{command}'. "
+            f"Install the agent CLI or set {env_hint}.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_acp_command",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": pconfig.process_api_key or provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2747,6 +2747,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-code-acp":
+        _model_flow_claude_code_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -5289,6 +5291,79 @@ def _model_flow_copilot_acp(config, current_model=""):
         )
         or selected
     )
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_code_acp(config, current_model=""):
+    """Claude Code ACP flow using the local claude-code-acp bridge."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-code-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "claude-code-acp"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code ACP delegates Hermes turns to the claude-code-acp bridge")
+    print("  (npm: @zed-industries/claude-code-acp) over stdio.")
+    print("  Authentication is handled by your existing Claude Code login.")
+    print("  Hermes uses your selected model as a hint for the ACP session.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Install with `npm install -g @zed-industries/claude-code-acp` or set "
+            "HERMES_CLAUDE_CODE_ACP_COMMAND if it lives elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
     _save_model_choice(selected)
 
     cfg = load_config()

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -86,6 +86,8 @@ _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
 _AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset({
     "gemini",
     "huggingface",
+    # Claude Code ACP forwards the model hint to the bridge as-is.
+    "claude-code-acp",
 })
 
 # Direct providers that accept bare native names but should repair a matching

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -214,6 +214,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code-acp": [
+        "claude-code-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -916,6 +919,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("claude-code-acp", "Claude Code ACP",         "Claude Code ACP (Spawns the claude-code-acp bridge over stdio)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
@@ -1077,6 +1081,9 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-acp": "claude-code-acp",
+    "claude-code-acp-agent": "claude-code-acp",
+    "zed-claude-acp": "claude-code-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/plugins/model-providers/claude-code-acp/__init__.py
+++ b/plugins/model-providers/claude-code-acp/__init__.py
@@ -1,0 +1,36 @@
+"""Claude Code ACP provider profile.
+
+claude-code-acp uses an external ACP subprocess (the `claude-code-acp` bridge,
+npm `@zed-industries/claude-code-acp`) — NOT the standard transport. Routing is
+handled separately in agent_runtime_helpers.py via the ``acp://claude-code``
+base-url marker. The profile captures auth + endpoint metadata for registry
+migration. Authentication is delegated to the user's existing Claude Code login.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCodeACPProfile(ProviderProfile):
+    """Claude Code ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+claude_code_acp = ClaudeCodeACPProfile(
+    name="claude-code-acp",
+    aliases=("claude-acp", "claude-code-acp-agent", "zed-claude-acp"),
+    api_mode="chat_completions",  # ACP subprocess uses chat_completions routing
+    env_vars=(),  # Managed by ACP subprocess / Claude Code login
+    base_url="acp://claude-code",  # ACP internal scheme
+    auth_type="external_process",
+)
+
+register_provider(claude_code_acp)

--- a/plugins/model-providers/claude-code-acp/plugin.yaml
+++ b/plugins/model-providers/claude-code-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-code-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Claude Code via ACP subprocess
+author: Nous Research

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -1,0 +1,145 @@
+"""Regressions for the Claude Code ACP subprocess client.
+
+ClaudeCodeACPClient subclasses ACPSubprocessClient (defined in
+agent.copilot_acp_client), so the safety layer is shared with Copilot ACP.
+These tests confirm the shared behaviour still holds for the Claude Code
+client and that the provider-specific surface (command, marker URL, error
+text, api_key) is wired correctly.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_code_acp_client import ClaudeCodeACPClient
+from agent.copilot_acp_client import ACPSubprocessClient
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+
+
+class ClaudeCodeACPClientConfigTests(unittest.TestCase):
+    def test_is_acp_subprocess_client(self) -> None:
+        self.assertTrue(issubclass(ClaudeCodeACPClient, ACPSubprocessClient))
+
+    def test_provider_defaults(self) -> None:
+        client = ClaudeCodeACPClient(acp_cwd="/tmp")
+        self.assertEqual(client.api_key, "claude-code-acp")
+        self.assertEqual(client.base_url, "acp://claude-code")
+        # Default command is the bridge binary; no extra args by default.
+        self.assertEqual(client._acp_command, "claude-code-acp")
+        self.assertEqual(client._acp_args, [])
+
+    def test_command_env_override(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_CLAUDE_CODE_ACP_COMMAND": "/opt/bin/cc-acp",
+                "HERMES_CLAUDE_CODE_ACP_ARGS": "--foo --bar",
+            },
+            clear=False,
+        ):
+            client = ClaudeCodeACPClient(acp_cwd="/tmp")
+        self.assertEqual(client._acp_command, "/opt/bin/cc-acp")
+        self.assertEqual(client._acp_args, ["--foo", "--bar"])
+
+    def test_explicit_command_wins_over_env(self) -> None:
+        client = ClaudeCodeACPClient(
+            acp_cwd="/tmp", command="explicit-bin", args=["--x"]
+        )
+        self.assertEqual(client._acp_command, "explicit-bin")
+        self.assertEqual(client._acp_args, ["--x"])
+
+
+class ClaudeCodeACPClientSafetyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ClaudeCodeACPClient(acp_cwd="/tmp")
+
+    def _dispatch(self, message: dict, *, cwd: str) -> dict:
+        process = _FakeProcess()
+        handled = self.client._handle_server_message(
+            message,
+            process=process,
+            cwd=cwd,
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        payload = process.stdin.getvalue().strip()
+        self.assertTrue(payload)
+        return json.loads(payload)
+
+    def test_request_permission_is_not_auto_allowed(self) -> None:
+        response = self._dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/request_permission",
+                "params": {},
+            },
+            cwd="/tmp",
+        )
+        outcome = (((response.get("result") or {}).get("outcome") or {}).get("outcome"))
+        self.assertEqual(outcome, "cancelled")
+
+    def test_write_text_file_reuses_write_denylist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            target = home / ".ssh" / "id_rsa"
+            target.parent.mkdir(parents=True, exist_ok=True)
+
+            # The fs handler lives in the shared base (copilot_acp_client module).
+            with patch("agent.copilot_acp_client.is_write_denied", return_value=True, create=True):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 4,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(target),
+                            "content": "fake-private-key",
+                        },
+                    },
+                    cwd=str(home),
+                )
+
+        self.assertIn("error", response)
+        self.assertFalse(target.exists())
+
+
+def _fake_popen_capture(captured):
+    def _fake(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        raise FileNotFoundError("claude-code-acp not found")
+    return _fake
+
+
+def test_startup_error_mentions_claude_code(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    captured = {}
+    client = ClaudeCodeACPClient(acp_cwd=str(tmp_path))
+
+    # _run_prompt is inherited from the base class in copilot_acp_client.
+    with patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Claude Code ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["cmd"][0] == "claude-code-acp"
+    assert captured["kwargs"]["env"]["HOME"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Claude Code ACP** | `hermes model` (spawns local `claude-code-acp` bridge over stdio) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
@@ -208,6 +209,20 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+**`claude-code-acp` — Claude Code ACP agent backend**. Spawns the local `claude-code-acp` bridge (npm [`@zed-industries/claude-code-acp`](https://github.com/zed-industries/claude-code-acp), the same bridge the Zed editor uses) as a subprocess. Authentication is delegated to your existing Claude Code login — Hermes does not manage an Anthropic API key for this provider.
+
+```bash
+hermes chat --provider claude-code-acp --model claude-code-acp
+# Requires the claude-code-acp bridge in PATH (npm i -g @zed-industries/claude-code-acp)
+# and a working `claude` login.
+```
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `HERMES_CLAUDE_CODE_ACP_COMMAND` | Override the bridge binary path (default: `claude-code-acp`) |
+| `HERMES_CLAUDE_CODE_ACP_ARGS` | Override ACP args (default: none) |
+| `CLAUDE_CODE_ACP_BASE_URL` | Override the ACP base-url marker (default: `acp://claude-code`) |
 
 ### First-Class API-Key Providers
 
@@ -1522,7 +1537,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `claude-code-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).


### PR DESCRIPTION
## What

Adds **Claude Code** as a first-class ACP-subprocess model provider
(`claude-code-acp`), modeled on the existing `copilot-acp` provider.

Hermes spawns the [`claude-code-acp`](https://github.com/zed-industries/claude-code-acp)
bridge (npm `@zed-industries/claude-code-acp` — the same bridge the Zed editor
uses to drive Claude Code over the Agent Client Protocol) and talks to it over
stdio: `initialize` → `session/new` → `session/prompt`. Authentication is
delegated to the user's existing Claude Code login; Hermes manages no Anthropic
API key for this provider.

```bash
hermes chat --provider claude-code-acp --model claude-code-acp
# Requires: npm i -g @zed-industries/claude-code-acp  + a working `claude` login
```

## Design — shared ACP base class

Rather than duplicate the ~600-line ACP client, the generic protocol machinery
in `copilot_acp_client.py` is extracted into a provider-agnostic
**`ACPSubprocessClient`** base class. It stays in the same module so existing
patch targets and tests are unaffected. `CopilotACPClient` and the new
`ClaudeCodeACPClient` are now thin subclasses that only declare:

- command / args (env vars + defaults)
- display label, base-url marker, api-key marker
- provider-specific startup / early-exit error hints (e.g. Copilot keeps its
  gh-copilot deprecation hint)

**Copilot behavior is unchanged** — its tests pass without modification.

## Wiring (parallels `copilot-acp` throughout)

| Area | Change |
|------|--------|
| `agent_runtime_helpers` | route `provider==claude-code-acp` / `acp://claude-code` |
| `agent_init` | pass `acp_command`/`args`; exclude all `acp://` from the Responses-API upgrade |
| `auxiliary_client` | aliases; external-process client factory; isinstance checks now target the shared base so both ACP clients are recognized |
| `conversation_loop` | disable streaming for `acp://` runtimes (generalized) |
| `model_metadata` | provider prefix |
| `hermes_cli/auth` | `ProviderConfig` gains external-process command/args metadata so the two external-process resolvers are no longer Copilot-hardcoded; add the `claude-code-acp` config + status dispatch + aliases |
| `hermes_cli/models`, `main`, `model_normalize` | registry entries + `hermes setup` flow |
| `plugins/model-providers/claude-code-acp` | provider profile |
| `website/docs/integrations/providers.md` | docs entry |

## Configuration

| Env var | Description |
|---------|-------------|
| `HERMES_CLAUDE_CODE_ACP_COMMAND` | Override the bridge binary (default: `claude-code-acp`) |
| `HERMES_CLAUDE_CODE_ACP_ARGS` | Override ACP args (default: none) |
| `CLAUDE_CODE_ACP_BASE_URL` | Override the ACP base-url marker (default: `acp://claude-code`) |

## Tests

`tests/agent/test_claude_code_acp_client.py` covers:
- the shared safety layer (permission requests denied, write denylist honored)
- the provider-specific surface (command resolution, env overrides, marker URL,
  startup error text)

Existing copilot ACP tests pass unchanged. Full provider/ACP/CLI suite green
(2188 passed locally; the one unrelated failure is a missing `ruamel` dev dep
in my environment, not touched by this PR).

## Note

The mechanism is exercised by unit tests; I run this exact setup interactively
(Claude Code via ACP in Zed), but the end-to-end Hermes path has not been run in
CI here since it requires the bridge binary + a live Claude login. Happy to
adjust naming/structure to maintainer preference.
