### PR TITLE
test(docker): make tty-passthrough probe robust to container boot-log noise

### DIFF
--- a/tests/docker/test_tui_passthrough.py
+++ b/tests/docker/test_tui_passthrough.py
@@ -11,6 +11,7 @@ pass after the Phase 2 s6 migration. Any drift is a regression.
 """
 from __future__ import annotations
 
+import re
 import shlex
 import shutil
 import subprocess
@@ -25,7 +26,18 @@ pytestmark = pytest.mark.skipif(
 
 def test_tty_passthrough_to_container(built_image: str) -> None:
     """``docker run -t`` must deliver a real TTY to the container process."""
-    probe = "if [ -t 1 ]; then tput cols; else echo NO_TTY; fi"
+    # Emit the probe result behind a unique marker. The container's s6 boot
+    # output (cont-init diagnostics, skills-sync summaries like
+    # "Done: 90 new, 0 updated, ...", the preinit "uid=0 ... egid=0" line)
+    # is written to the SAME PTY stream before this runs, so we must NOT
+    # scan the whole stream for "the first number" — that picks up a stray
+    # 0 from the boot log and flips the assertion (assert 0 > 0) whenever
+    # boot output shifts (e.g. a new bundled dep changes the skills-sync
+    # counts). Parse only the value tagged with our marker.
+    marker = "HERMES_TTY_COLS"
+    probe = (
+        f'if [ -t 1 ]; then echo "{marker}=$(tput cols)"; else echo "{marker}=NO_TTY"; fi'
+    )
     cmd = (
         f"docker run --rm -t -e COLUMNS=123 {built_image} "
         f"sh -c {shlex.quote(probe)}"
@@ -34,11 +46,13 @@ def test_tty_passthrough_to_container(built_image: str) -> None:
         ["script", "-qc", cmd, "/dev/null"],
         capture_output=True, text=True, timeout=120,
     )
-    output = r.stdout.strip()
-    assert "NO_TTY" not in output, f"TTY passthrough failed: {output!r}"
-    numeric_lines = [s for s in output.split() if s.strip().isdigit()]
-    assert numeric_lines, f"No numeric width in output: {output!r}"
-    assert int(numeric_lines[0]) > 0
+    output = r.stdout
+    matches = re.findall(rf"{marker}=(\S+)", output)
+    assert matches, f"No {marker} marker in output: {output!r}"
+    value = matches[-1].strip()
+    assert value != "NO_TTY", f"TTY passthrough failed: {output!r}"
+    assert value.isdigit(), f"Non-numeric column width {value!r} in: {output!r}"
+    assert int(value) > 0
 
 
 def test_tui_flag_recognized(built_image: str) -> None:


### PR DESCRIPTION
## Problem

`tests/docker/test_tui_passthrough.py::test_tty_passthrough_to_container` allocates a PTY, runs `tput cols` inside the container, and asserted:

```python
numeric_lines = [s for s in output.split() if s.strip().isdigit()]
assert int(numeric_lines[0]) > 0
```

But the container's **s6 boot output is written to the same PTY stream before the probe runs** — the preinit `container permissions: uid=0 ... egid=0` line, cont-init diagnostics, and the skills-sync summary `Done: 90 new, 0 updated, 0 unchanged. 90 total bundled.`. So `numeric_lines[0]` is really "the first numeric token *anywhere in the boot log*", not the `tput cols` result. The test passed only **by luck** on whatever that first digit happened to be.

Any PR that shifts boot output flips that first digit to a stray `0` → `assert 0 > 0` → red, **even though TTY passthrough works perfectly** (`tput cols` returns the correct value). It's a latent landmine for every Docker PR that changes boot output.

This surfaced on #38649 (promoting `markdown` to a core dependency), which changes the skills-sync counts in the boot log. That PR is correct and its `tput cols` returns `123` — but this brittle test went red on it.

## Fix

Emit the probe result behind a unique marker and parse only the marked value:

```python
marker = "HERMES_TTY_COLS"
probe = f'if [ -t 1 ]; then echo "{marker}=$(tput cols)"; else echo "{marker}=NO_TTY"; fi'
...
value = re.findall(rf"{marker}=(\S+)", output)[-1]
assert value != "NO_TTY"
assert value.isdigit() and int(value) > 0
```

Boot-log noise is ignored; the test's real intent (verify `docker run -t` delivers a real TTY with a positive column count) is preserved — `NO_TTY` and non-numeric values still fail.

## Verification (real build, adversarial)

- Built an image with the extra boot output that surfaced this (the #38649 markdown change). The **old** logic grabs a stray `0` → reproduced `assert 0 > 0` locally.
- The **hardened** test PASSES against that same boot-shifted image **and** against a clean image. `tput cols` correctly returns `123` in both.
- Both tests in the file pass: `2 passed`.

## Follow-up

Once this lands, #38649 (markdown core dep) will be rebased on top and go green — its `build-amd64` failure was solely this brittle test.
