### PR TITLE
fix(cron): make _run_job_script work on Windows pythonw.exe + non-UTF-8 locales

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -924,7 +924,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             )
         argv = [_bash, str(path)]
     else:
-        argv = [sys.executable, str(path)]
+        # Bug fix (issue #38633): On Windows, when Hermes runs under pythonw.exe
+        # (no console subsystem), spawning a child pythonw.exe gives the child no
+        # console and stdout is lost when captured via subprocess.PIPE.  Prefer
+        # python.exe (console subsystem) from the same directory when available.
+        _py = sys.executable
+        if sys.platform == "win32" and os.path.basename(_py).lower() == "pythonw.exe":
+            _console_py = os.path.join(os.path.dirname(_py), "python.exe")
+            if os.path.isfile(_console_py):
+                _py = _console_py
+        argv = [_py, str(path)]
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())
@@ -943,6 +952,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=run_env,

--- a/tests/cron/test_run_job_script_windows.py
+++ b/tests/cron/test_run_job_script_windows.py
@@ -1,0 +1,100 @@
+"""Tests for cron _run_job_script Windows-specific fixes (issue #38633).
+
+Bug 1: pythonw.exe loses stdout when spawning child pythonw.exe — the scheduler
+should substitute python.exe (console subsystem) from the same dir on Windows.
+
+Bug 2: subprocess.run(text=True) without explicit encoding uses locale encoding
+(GBK on Chinese Windows), crashing the reader thread on non-ASCII output. The
+scheduler must pass encoding="utf-8", errors="replace".
+"""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron import scheduler as cron_scheduler
+
+
+@pytest.fixture
+def script_path(tmp_path, monkeypatch):
+    """Create a script inside an isolated HERMES_HOME/scripts/ directory."""
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    p = home / "scripts" / "job.py"
+    p.write_text("print('hi')\n", encoding="utf-8")
+    return p
+
+
+def test_run_job_script_passes_utf8_encoding_and_replace(script_path):
+    """Bug 2: subprocess.run must be called with encoding='utf-8', errors='replace'."""
+    completed = mock.MagicMock(returncode=0, stdout="ok", stderr="")
+    with mock.patch.object(cron_scheduler.subprocess, "run", return_value=completed) as run_mock:
+        cron_scheduler._run_job_script(str(script_path))
+
+    assert run_mock.call_count == 1, "subprocess.run should be invoked once"
+    kwargs = run_mock.call_args.kwargs
+    assert kwargs.get("encoding") == "utf-8", f"expected utf-8 encoding, got {kwargs.get('encoding')!r}"
+    assert kwargs.get("errors") == "replace", f"expected errors='replace', got {kwargs.get('errors')!r}"
+    assert kwargs.get("text") is True
+    assert kwargs.get("capture_output") is True
+
+
+def test_run_job_script_substitutes_python_exe_for_pythonw_on_windows(script_path, tmp_path):
+    """Bug 1: on Windows, pythonw.exe must be swapped for sibling python.exe."""
+    fake_dir = tmp_path / "py"
+    fake_dir.mkdir()
+    pythonw = fake_dir / "pythonw.exe"
+    pythonw.write_text("")
+    python = fake_dir / "python.exe"
+    python.write_text("")
+
+    completed = mock.MagicMock(returncode=0, stdout="", stderr="")
+    with mock.patch.object(cron_scheduler.sys, "platform", "win32"), \
+         mock.patch.object(cron_scheduler.sys, "executable", str(pythonw)), \
+         mock.patch.object(cron_scheduler.subprocess, "run", return_value=completed) as run_mock:
+        cron_scheduler._run_job_script(str(script_path))
+
+    argv = run_mock.call_args.args[0]
+    assert argv[0] == str(python), f"expected python.exe, got argv={argv!r}"
+
+
+def test_run_job_script_keeps_pythonw_when_no_sibling_python(script_path, tmp_path):
+    """Bug 1 fallback: if no python.exe exists next to pythonw.exe, keep pythonw."""
+    fake_dir = tmp_path / "py"
+    fake_dir.mkdir()
+    pythonw = fake_dir / "pythonw.exe"
+    pythonw.write_text("")
+    # no python.exe sibling
+
+    completed = mock.MagicMock(returncode=0, stdout="", stderr="")
+    with mock.patch.object(cron_scheduler.sys, "platform", "win32"), \
+         mock.patch.object(cron_scheduler.sys, "executable", str(pythonw)), \
+         mock.patch.object(cron_scheduler.subprocess, "run", return_value=completed) as run_mock:
+        cron_scheduler._run_job_script(str(script_path))
+
+    argv = run_mock.call_args.args[0]
+    assert argv[0] == str(pythonw)
+
+
+def test_run_job_script_does_not_substitute_on_non_windows(script_path, tmp_path):
+    """Bug 1: pythonw substitution must be Windows-only."""
+    fake_dir = tmp_path / "py"
+    fake_dir.mkdir()
+    pythonw = fake_dir / "pythonw.exe"
+    pythonw.write_text("")
+    python = fake_dir / "python.exe"
+    python.write_text("")
+
+    completed = mock.MagicMock(returncode=0, stdout="", stderr="")
+    with mock.patch.object(cron_scheduler.sys, "platform", "linux"), \
+         mock.patch.object(cron_scheduler.sys, "executable", str(pythonw)), \
+         mock.patch.object(cron_scheduler.subprocess, "run", return_value=completed) as run_mock:
+        cron_scheduler._run_job_script(str(script_path))
+
+    argv = run_mock.call_args.args[0]
+    assert argv[0] == str(pythonw), "must not rewrite on non-Windows"


### PR DESCRIPTION
Closes #38633.

## Problem

`cron/scheduler.py::_run_job_script` has two latent Windows bugs that combine to make every `no_agent=True` Python cron job silently produce empty output on Chinese (or any non-UTF-8 locale) Windows installs:

### Bug 1 — `pythonw.exe` has no console

When Hermes is launched via the gateway / Scheduled Task path, `sys.executable` is `pythonw.exe` (GUI subsystem). The scheduler reuses `sys.executable` to run job scripts:

```python
argv = [sys.executable, str(path)]
```

A child `pythonw.exe` has no console — anything written to `stdout` is lost the moment `subprocess.run(capture_output=True)` tries to read the pipe. The scheduler treats the empty stdout as "nothing to report" and never delivers the result.

### Bug 2 — `text=True` decodes with locale (GBK on Chinese Windows)

```python
result = subprocess.run(argv, capture_output=True, text=True, ...)
```

Without an explicit `encoding`, the pipe-reader thread uses `locale.getpreferredencoding()` = `cp936` (GBK) on Chinese Windows. The first non-ASCII byte raises `UnicodeDecodeError`, the reader thread dies, `result.stdout` comes back empty. Because `pythonw.exe` has no visible window, the user sees no error at all — just silent cron failures.

Stack trace from the reporter (visible only in the hidden gateway console):
```
Exception in thread Thread-3 (_readerthread):
  File "...\Lib\subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 14: illegal multibyte sequence
```

## Fix

1. When building `argv` for the Python branch, on Windows detect `pythonw.exe` (case-insensitive basename) and substitute the sibling `python.exe` (console subsystem) when it exists. Falls back to the original interpreter when no sibling is found, so portable / embedded layouts still work.
2. Pass `encoding="utf-8", errors="replace"` to `subprocess.run` so non-ASCII script output is preserved (and never crashes the reader thread) on every platform.

Both changes are no-ops on Linux/macOS layouts and on installs where `python.exe` already is the interpreter — the Windows-only branch is guarded by `sys.platform == "win32"`.

## Tests

`tests/cron/test_run_job_script_windows.py` — 4 new tests:

- `test_run_job_script_passes_utf8_encoding_and_replace` — verifies the explicit `encoding`/`errors` kwargs reach `subprocess.run`.
- `test_run_job_script_substitutes_python_exe_for_pythonw_on_windows` — verifies the `pythonw.exe` → `python.exe` swap when both exist.
- `test_run_job_script_keeps_pythonw_when_no_sibling_python` — falls back to `pythonw.exe` when no sibling `python.exe` is on disk.
- `test_run_job_script_does_not_substitute_on_non_windows` — guard: the substitution must be Windows-only.

```
$ pytest tests/cron/test_run_job_script_windows.py
============================== 4 passed in 0.12s ===============================
```

## Risk

Touches one helper in `cron/scheduler.py`. Linux/macOS code paths are unchanged. Existing `tests/cron/test_cron_script.py` continues to pass for the same tests it passed before this branch (one pre-existing `test_script_timeout` flake on macOS reproduces on `main` unchanged — unrelated).
