### PR TITLE
fix(agent): parse OpenRouter/Nous output-cap errors to prevent infinite reset loop

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -948,36 +948,68 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
            Fix: reduce max_tokens (the output cap) for this call.
            Do NOT touch context_length — the window hasn't shrunk.
 
-    Anthropic's API returns errors like:
+    Supported provider error formats:
+
+    **Anthropic**:
       "max_tokens: 32768 > context_window: 200000 - input_tokens: 190000 = available_tokens: 10000"
 
-    Returns the number of output tokens that would fit (e.g. 10000 above), or None if
-    the error does not look like a max_tokens-too-large error.
+    **OpenRouter / Nous Research inference**:
+      "This endpoint's maximum context length is 256000 tokens. However, you requested
+       about 281093 tokens (5683 of text input, 13410 of tool input, 262000 in the output)."
+      → available = context_length - text_input - tool_input = 236907
+
+    Returns the number of output tokens that would fit, or None if the error does not
+    look like a max_tokens-too-large error.
     """
     error_lower = error_msg.lower()
 
-    # Must look like an output-cap error, not a prompt-length error.
-    is_output_cap_error = (
+    # ── Phase 1: detect whether this is an output-cap error ──────────────
+
+    # Anthropic: "available_tokens" or "available tokens" with "max_tokens"
+    is_anthropic = (
         "max_tokens" in error_lower
         and ("available_tokens" in error_lower or "available tokens" in error_lower)
     )
-    if not is_output_cap_error:
+
+    # OpenRouter / Nous: "N in the output" + "maximum context length is X"
+    is_openrouter = bool(re.search(r'\d+\s+in\s+the\s+output', error_lower))
+
+    if not is_anthropic and not is_openrouter:
         return None
 
-    # Extract the available_tokens figure.
+    # ── Phase 2: extract available output tokens ─────────────────────────
+
     # Anthropic format: "… = available_tokens: 10000"
-    patterns = [
-        r'available_tokens[:\s]+(\d+)',
-        r'available\s+tokens[:\s]+(\d+)',
-        # fallback: last number after "=" in expressions like "200000 - 190000 = 10000"
-        r'=\s*(\d+)\s*$',
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, error_lower)
-        if match:
-            tokens = int(match.group(1))
-            if tokens >= 1:
-                return tokens
+    if is_anthropic:
+        patterns = [
+            r'available_tokens[:\s]+(\d+)',
+            r'available\s+tokens[:\s]+(\d+)',
+            # fallback: last number after "=" in expressions like "200000 - 190000 = 10000"
+            r'=\s*(\d+)\s*$',
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, error_lower)
+            if match:
+                tokens = int(match.group(1))
+                if tokens >= 1:
+                    return tokens
+
+    # OpenRouter / Nous format: extract components and calculate available.
+    #   "maximum context length is 256000 tokens"
+    #   "5683 of text input, 13410 of tool input, 262000 in the output"
+    # available = context_length - text_input - tool_input
+    ctx_match = re.search(r'max(?:imum)?\s+context\s+length\s+is\s+(\d+)', error_lower)
+    text_match = re.search(r'(\d+)\s+of\s+text\s+input', error_lower)
+    tool_match = re.search(r'(\d+)\s+of\s+tool\s+input', error_lower)
+
+    if ctx_match:
+        ctx_len = int(ctx_match.group(1))
+        text_in = int(text_match.group(1)) if text_match else 0
+        tool_in = int(tool_match.group(1)) if tool_match else 0
+        available = ctx_len - text_in - tool_in
+        if available >= 1:
+            return available
+
     return None
 
 

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -102,6 +102,47 @@ class TestParseAvailableOutputTokens:
         msg = "rate_limit_error: too many requests per minute"
         assert self._parse(msg) is None
 
+    # ── OpenRouter / Nous Research format ─────────────────────────────────
+
+    def test_openrouter_nous_format(self):
+        """OpenRouter/Nous error: parse context_length - text_input - tool_input."""
+        msg = (
+            "This request is not valid. Check the model name and other parameters. "
+            "Additional info: This endpoint's maximum context length is 256000 tokens. "
+            "However, you requested about 281093 tokens "
+            "(5683 of text input, 13410 of tool input, 262000 in the output). "
+            "Please reduce the length of either one, or use the context-compression plugin "
+            "to compress your prompt automatically."
+        )
+        # available = 256000 - 5683 - 13410 = 236907
+        assert self._parse(msg) == 236907
+
+    def test_openrouter_format_without_tool_input(self):
+        """OpenRouter error with no tool input component."""
+        msg = (
+            "This endpoint's maximum context length is 128000 tokens. "
+            "However, you requested about 135000 tokens "
+            "(135000 in the output)."
+        )
+        # available = 128000 - 0 - 0 = 128000
+        assert self._parse(msg) == 128000
+
+    def test_openrouter_format_with_only_text_input(self):
+        """OpenRouter error with text input but no tool input."""
+        msg = (
+            "This endpoint's maximum context length is 200000 tokens. "
+            "However, you requested about 210000 tokens "
+            "(10000 of text input, 200000 in the output)."
+        )
+        # available = 200000 - 10000 - 0 = 190000
+        assert self._parse(msg) == 190000
+
+    def test_openrouter_format_no_context_length(self):
+        """OpenRouter-like error without context length should still detect output amount."""
+        msg = "You requested 50000 in the output which exceeds the limit."
+        # No context_length match → cannot calculate available → None
+        assert self._parse(msg) is None
+
 
 # ---------------------------------------------------------------------------
 # Context-overflow recovery — only trust provider-reported limits


### PR DESCRIPTION
## What does this PR do?

Adds OpenRouter / Nous Research inference error format support to `parse_available_output_tokens_from_error()`. Previously, the function only recognized Anthropic's `"available_tokens"` keyword. When using OpenRouter-compatible providers, errors with `"N in the output"` format were misclassified as prompt-too-long errors, causing infinite session reset loops when `max_tokens` exceeded the available context.

## Related Issue

Fixes #38652

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: Extended `parse_available_output_tokens_from_error()` to detect OpenRouter/Nous error format (`"N of text input, M of tool input, K in the output"`) and calculate available output tokens as `context_length - text_input - tool_input`. Refactored detection into two phases: (1) identify error format, (2) extract available tokens.
- `tests/test_ctx_halving_fix.py`: Added 4 tests covering the OpenRouter/Nous format: canonical format with all components, format without tool input, format with only text input, and format without context length (returns None).

## How to Test

1. Run `pytest tests/test_ctx_halving_fix.py -v` — all 31 tests should pass (4 new + 27 existing)
2. Run `pytest tests/agent/test_model_metadata.py -v` — all 93 tests should pass (no regressions)
3. Manual verification: configure a provider with `max_tokens` exceeding the context window and confirm the error recovery loop no longer occurs

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `parse_available_output_tokens_from_error` in `agent/model_metadata.py` (callers: `conversation_loop.py:2989`, `anthropic_adapter.py:2119`)
- Blast radius: LOW — pure parsing function, no side effects; callers already handle `None` return gracefully
- Related patterns: `parse_context_limit_from_error()` (sibling function, same file), `_ephemeral_max_output_tokens` (consumer in conversation loop)
