### PR TITLE
feat(gateway): add Matrix reaction-menu (present_menu) tap-to-choose capability

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -395,6 +395,9 @@ def init_agent(
     agent.thinking_callback = thinking_callback
     agent.reasoning_callback = reasoning_callback
     agent.clarify_callback = clarify_callback
+    # Non-blocking reaction-menu sender; gateway sets this on the agent instance
+    # for reaction-capable platforms (None in CLI / non-gateway contexts).
+    agent.present_menu_callback = None
     agent.step_callback = step_callback
     agent.stream_delta_callback = stream_delta_callback
     agent.interim_assistant_callback = interim_assistant_callback

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1747,6 +1747,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 callback=agent.clarify_callback,
             )
         )
+    elif function_name == "present_menu":
+        from tools.reaction_menu_tool import present_menu_tool as _present_menu_tool
+        return _present_menu_tool(
+            prompt=function_args.get("prompt", ""),
+            options=function_args.get("options"),
+            context_id=function_args.get("context_id"),
+            callback=getattr(agent, "present_menu_callback", None),
+        )
     elif function_name == "delegate_task":
         return _finish_agent_tool(agent._dispatch_delegate_task(function_args))
     else:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -938,6 +938,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "present_menu":
+            from tools.reaction_menu_tool import present_menu_tool as _present_menu_tool
+            function_result = _present_menu_tool(
+                prompt=function_args.get("prompt", ""),
+                options=function_args.get("options"),
+                context_id=function_args.get("context_id"),
+                callback=getattr(agent, "present_menu_callback", None),
+            )
+            tool_duration = time.time() - tool_start_time
         elif function_name == "delegate_task":
             tasks_arg = function_args.get("tasks")
             if tasks_arg and isinstance(tasks_arg, list):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2455,6 +2455,78 @@ class BasePlatformAdapter(ABC):
             metadata=metadata,
         )
 
+    async def send_reaction_menu(
+        self,
+        chat_id: str,
+        menu_id: str,
+        prompt: str,
+        options: list,
+        session_key: str,
+        source: Any = None,
+        context_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Present an interactive menu (default: numbered text fallback).
+
+        Reaction-capable platforms (Matrix today; Telegram/Discord buttons as a
+        fast-follow) override this to seed one tappable reaction per option. The
+        default renders a numbered list and registers the menu so the gateway's
+        text intercept (``GatewayRunner._maybe_intercept_menu_choice``) can
+        resolve a bare-number reply.
+
+        Text fallback supports ONE live menu per session (newest wins): a bare
+        number resolves it and ``more`` reprints it. Reaction/button consumers
+        keep the consumer-agnostic per-message core, which supports many live
+        menus at once.
+        """
+        lines = [prompt, ""]
+        for i, opt in enumerate(options, start=1):
+            lines.append(f"  {i}. {opt['emoji']} {opt['label']}")
+        lines.append("")
+        lines.append("Reply with the option number, or 'more' to see it again.")
+        text = "\n".join(lines)
+
+        result = await self.send(chat_id=chat_id, content=text, metadata=metadata)
+        if not result.success:
+            return result
+
+        try:
+            from tools import reaction_menu_gateway as _rmg
+            src = source.to_dict() if source is not None and hasattr(source, "to_dict") else None
+            _rmg.register(
+                menu_id=menu_id,
+                session_key=session_key,
+                platform=self.name or "text",
+                chat_id=chat_id,
+                message_id=result.message_id or menu_id,
+                prompt=prompt,
+                options=options,
+                context_id=context_id,
+                source=src,
+            )
+        except Exception as exc:
+            logger.debug("[%s] reaction-menu registry register failed: %s", self.name, exc)
+
+        return result
+
+    async def reprint_reaction_menu(
+        self,
+        chat_id: str,
+        prompt: str,
+        options: list,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Re-send a menu's numbered text (text-fallback ``more``)."""
+        lines = [prompt, ""]
+        for i, opt in enumerate(options, start=1):
+            lines.append(f"  {i}. {opt['emoji']} {opt['label']}")
+        lines.append("")
+        lines.append("Reply with the option number, or 'more' to see it again.")
+        try:
+            await self.send(chat_id=chat_id, content="\n".join(lines), metadata=metadata)
+        except Exception as exc:
+            logger.debug("[%s] reaction-menu reprint failed: %s", self.name, exc)
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -188,6 +188,50 @@ class _MatrixApprovalPrompt:
         self.resolved = resolved
         self.bot_reaction_events: dict[str, str] = {}  # emoji -> event_id
 
+
+@dataclass
+class _MatrixMenuPrompt:
+    """Tracks a live reaction-menu (parallel to ``_MatrixApprovalPrompt``).
+
+    Distinct from the approval path on purpose: keyed per message (no per-session
+    single-slot) so MANY menus can be live in one session at once.
+    """
+
+    def __init__(self, menu_id, session_key, chat_id, message_id, prompt,
+                 options, source=None, context_id=None, resolved=False):
+        self.menu_id = menu_id
+        self.session_key = session_key
+        self.chat_id = chat_id
+        self.message_id = message_id
+        self.prompt = prompt
+        self.options = options          # normalised list of option dicts
+        self.source = source            # SessionSource (for forging the choice turn)
+        self.context_id = context_id
+        self.resolved = resolved
+        self.bot_reaction_events: dict[str, str] = {}  # emoji -> seed reaction event_id
+
+    def option_for_emoji(self, emoji):
+        for opt in self.options:
+            if opt.get("emoji") == emoji:
+                return opt
+        return None
+
+
+@dataclass
+class _MatrixMenuReload:
+    """A one-shot ♻️ reload handle seeded on a collapsed menu message."""
+
+    def __init__(self, session_key, chat_id, prompt, options, source=None,
+                 context_id=None, reload_reaction_event_id=None):
+        self.session_key = session_key
+        self.chat_id = chat_id
+        self.prompt = prompt
+        self.options = options
+        self.source = source
+        self.context_id = context_id
+        self.reload_reaction_event_id = reload_reaction_event_id
+
+
 # Matrix message size limit (4000 chars practical, spec has no hard limit
 # but clients render poorly above this).
 MAX_MESSAGE_LENGTH = 4000
@@ -554,6 +598,11 @@ class MatrixAdapter(BasePlatformAdapter):
         }
         self._approval_prompts_by_event: Dict[str, _MatrixApprovalPrompt] = {}
         self._approval_prompt_by_session: Dict[str, str] = {}
+        # Reaction-menu tracking — keyed per message (NOT per session) so many
+        # menus can be live simultaneously. Parallel to, and independent of, the
+        # approval path above.
+        self._menu_prompts_by_event: Dict[str, _MatrixMenuPrompt] = {}
+        self._menu_reload_by_event: Dict[str, _MatrixMenuReload] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
@@ -1027,10 +1076,54 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
+        # Restore any reaction-menus left live by a previous gateway process so
+        # taps on them still resolve after a restart (spec §6).
+        self._restore_persisted_menus()
+
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
         self._mark_connected()
         return True
+
+    def _restore_persisted_menus(self) -> None:
+        """Rebuild ``_menu_prompts_by_event`` from persisted unresolved menus.
+
+        Seed reaction event-ids aren't persisted, so post-restart collapse can't
+        redact the bot's original seeds (best-effort) — but the menu still
+        resolves and injects the chosen turn, which is the durability contract.
+        """
+        try:
+            from tools import reaction_menu_gateway as _rmg
+            from gateway.session import SessionSource
+        except Exception as exc:
+            logger.debug("Matrix: menu restore imports failed: %s", exc)
+            return
+        try:
+            restored = _rmg.load_persisted(platform="matrix")
+        except Exception as exc:
+            logger.debug("Matrix: menu restore load failed: %s", exc)
+            return
+        count = 0
+        for entry in restored:
+            source = None
+            if entry.source:
+                try:
+                    source = SessionSource.from_dict(entry.source)
+                except Exception:
+                    source = None
+            self._menu_prompts_by_event[entry.message_id] = _MatrixMenuPrompt(
+                menu_id=entry.menu_id,
+                session_key=entry.session_key,
+                chat_id=entry.chat_id,
+                message_id=entry.message_id,
+                prompt=entry.prompt,
+                options=entry.options,
+                source=source,
+                context_id=entry.context_id,
+            )
+            count += 1
+        if count:
+            logger.info("Matrix: restored %d live reaction-menu(s) from persistence", count)
 
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
@@ -1380,6 +1473,141 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.debug("Matrix: failed to add approval reaction %s: %s", emoji, exc)
 
         return result
+
+    # ------------------------------------------------------------------
+    # Reaction menus (parallel to the exec-approval reaction path)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _render_menu_text(prompt: str, options: list) -> str:
+        """Render the menu message body: prompt + an emoji/label line each."""
+        lines = [prompt, ""]
+        for opt in options:
+            lines.append(f"{opt['emoji']} {opt['label']}")
+        lines.append("")
+        lines.append("Tap a reaction below to choose.")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_menu_resolved(prompt: str, options: list, chosen: dict) -> str:
+        """Render the collapsed menu: keep every option visible, mark the choice.
+
+        Preserves the full option list (with a ✓ on the chosen line) so the user
+        can still see what the alternatives were after resolving.
+        """
+        lines = [prompt, ""]
+        for opt in options:
+            mark = " ✓" if opt["emoji"] == chosen["emoji"] else ""
+            lines.append(f"{opt['emoji']} {opt['label']}{mark}")
+        lines.append("")
+        lines.append(f"You chose: {chosen['emoji']} {chosen['label']}")
+        return "\n".join(lines)
+
+    async def send_reaction_menu(
+        self,
+        chat_id: str,
+        menu_id: str,
+        prompt: str,
+        options: list,
+        session_key: str,
+        source: Any = None,
+        context_id: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        """Send a reaction-menu message and seed one reaction per option.
+
+        Non-blocking: presents the menu and registers it. The user's later tap
+        is handled by the menu branch of :meth:`_on_reaction`.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        text = self._render_menu_text(prompt, options)
+        result = await self.send(chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        menu = _MatrixMenuPrompt(
+            menu_id=menu_id,
+            session_key=session_key,
+            chat_id=chat_id,
+            message_id=result.message_id,
+            prompt=prompt,
+            options=options,
+            source=source,
+            context_id=context_id,
+        )
+        self._menu_prompts_by_event[result.message_id] = menu
+
+        # Register in the consumer-agnostic gateway store (+ persistence) so the
+        # menu survives a gateway restart.
+        try:
+            from tools import reaction_menu_gateway as _rmg
+            _src_dict = source.to_dict() if source is not None and hasattr(source, "to_dict") else None
+            _rmg.register(
+                menu_id=menu_id,
+                session_key=session_key,
+                platform="matrix",
+                chat_id=chat_id,
+                message_id=result.message_id,
+                prompt=prompt,
+                options=options,
+                context_id=context_id,
+                source=_src_dict,
+            )
+        except Exception as exc:
+            logger.debug("Matrix: reaction-menu registry register failed: %s", exc)
+
+        for opt in options:
+            try:
+                rid = await self._send_reaction(chat_id, result.message_id, opt["emoji"])
+                if rid:
+                    menu.bot_reaction_events[opt["emoji"]] = str(rid)
+            except Exception as exc:
+                logger.debug("Matrix: failed to seed menu reaction %s: %s", opt.get("emoji"), exc)
+
+        return result
+
+    async def _redact_bot_menu_reactions(
+        self,
+        room_id: str,
+        menu: "_MatrixMenuPrompt",
+    ) -> None:
+        """Redact the bot's seeded option reactions, leaving the user's tap."""
+        for emoji, evt_id in menu.bot_reaction_events.items():
+            self._schedule_reaction_redaction(room_id, evt_id, "menu resolved")
+
+    async def _inject_menu_choice(
+        self,
+        menu: "_MatrixMenuPrompt",
+        option: dict,
+    ) -> None:
+        """Forge a synthetic ``[menu-choice]`` user turn for the chosen option.
+
+        Dispatches through ``handle_message`` — the SAME inbound path a real user
+        message takes — so the turn is queued behind any busy agent (FIFO/promote)
+        AND, crucially, its response is delivered back to the channel. Calling the
+        bare ``_message_handler`` directly runs the turn but never sends the reply,
+        because response delivery lives in ``handle_message`` (see base.py).
+        """
+        from tools.reaction_menu_gateway import build_menu_choice_body
+
+        if self._message_handler is None:
+            logger.warning("Matrix: no message handler; dropping menu choice")
+            return
+
+        source = menu.source
+        if source is None:
+            logger.warning("Matrix: menu %s has no source; cannot route choice", menu.menu_id)
+            return
+
+        body = build_menu_choice_body(option["payload"])
+        event = MessageEvent(
+            text=body,
+            source=source,
+            internal=True,
+        )
+        await self.handle_message(event)
 
     def format_message(self, content: str) -> str:
         """Pass-through — Matrix supports standard Markdown natively."""
@@ -2339,6 +2567,115 @@ class MatrixAdapter(BasePlatformAdapter):
                         await self._redact_bot_approval_reactions(room_id, prompt)
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Matrix reaction: %s", exc)
+                return
+
+            # Not an approval reaction — try the reaction-menu path. Parallel to
+            # the approval branch above; the approval flow is untouched.
+            await self._handle_menu_reaction(room_id, reacts_to, key, sender)
+
+    def _is_reaction_user_authorized(self, sender: str) -> bool:
+        """Fail-closed auth for reaction-driven actions (mirrors approval auth)."""
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+            return True
+        return bool(self._allowed_user_ids and sender in self._allowed_user_ids)
+
+    async def _handle_menu_reaction(
+        self,
+        room_id: str,
+        reacts_to: str,
+        key: str,
+        sender: str,
+    ) -> None:
+        """Resolve a tap on a live reaction-menu, or a ♻️ reload tap.
+
+        Choreography (spec §5):
+          * Authorized tap on an option → collapse (redact bot seeds, keep the
+            user's reaction, best-effort edit to show the choice, seed ♻️ unless
+            the option is terminal) → inject a ``[menu-choice]`` synthetic turn.
+          * Authorized ♻️ tap on a collapsed menu → repost a FRESH menu, no model
+            turn. One-shot.
+        Unauthorized taps are ignored, leaving the menu live and unresolved.
+        """
+        from tools import reaction_menu_gateway as _rmg
+
+        menu = self._menu_prompts_by_event.get(reacts_to)
+        if menu is not None and not menu.resolved:
+            if room_id != menu.chat_id:
+                return
+            option = menu.option_for_emoji(key)
+            if option is None:
+                return  # unrelated reaction on the menu message
+            if not self._is_reaction_user_authorized(sender):
+                logger.info(
+                    "Matrix: ignoring menu reaction from unauthorized user %s on %s",
+                    sender, reacts_to,
+                )
+                return
+            # Dedup double-taps: only the first resolution injects a turn.
+            if not _rmg.mark_resolved(menu.menu_id):
+                return
+            menu.resolved = True
+            self._menu_prompts_by_event.pop(reacts_to, None)
+
+            await self._redact_bot_menu_reactions(room_id, menu)
+            # Best-effort edit so the message reflects the chosen option.
+            try:
+                await self.edit_message(
+                    room_id, reacts_to,
+                    self._render_menu_resolved(menu.prompt, menu.options, option),
+                )
+            except Exception as exc:
+                logger.debug("Matrix: menu collapse edit failed: %s", exc)
+
+            if not option.get("terminal"):
+                reload_rid = None
+                try:
+                    reload_rid = await self._send_reaction(room_id, reacts_to, _rmg.RELOAD_EMOJI)
+                except Exception as exc:
+                    logger.debug("Matrix: failed to seed reload reaction: %s", exc)
+                self._menu_reload_by_event[reacts_to] = _MatrixMenuReload(
+                    session_key=menu.session_key,
+                    chat_id=room_id,
+                    prompt=menu.prompt,
+                    options=menu.options,
+                    source=menu.source,
+                    context_id=menu.context_id,
+                    reload_reaction_event_id=str(reload_rid) if reload_rid else None,
+                )
+
+            logger.info(
+                "Matrix: menu %s resolved (option=%s, user=%s)",
+                menu.menu_id, option["emoji"], sender,
+            )
+            await self._inject_menu_choice(menu, option)
+            return
+
+        # Reload (♻️) tap on a previously collapsed menu — repost a fresh menu.
+        reload = self._menu_reload_by_event.get(reacts_to)
+        if reload is not None and key == _rmg.RELOAD_EMOJI:
+            if not self._is_reaction_user_authorized(sender):
+                return
+            self._menu_reload_by_event.pop(reacts_to, None)
+            if reload.reload_reaction_event_id:
+                self._schedule_reaction_redaction(
+                    room_id, reload.reload_reaction_event_id, "menu reloaded",
+                )
+            import uuid as _uuid
+            new_menu_id = _uuid.uuid4().hex[:12]
+            logger.info("Matrix: reloading menu in %s (new id %s)", room_id, new_menu_id)
+            try:
+                await self.send_reaction_menu(
+                    chat_id=reload.chat_id,
+                    menu_id=new_menu_id,
+                    prompt=reload.prompt,
+                    options=reload.options,
+                    session_key=reload.session_key,
+                    source=reload.source,
+                    context_id=reload.context_id,
+                )
+            except Exception as exc:
+                logger.error("Matrix: menu reload failed: %s", exc)
+            return
 
     async def _redact_bot_approval_reactions(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7500,6 +7500,49 @@ class GatewayRunner:
                     # itself will produce the next user-facing message.
                     return ""
 
+        # Intercept bare-number / 'more' replies to a live reaction-menu — the
+        # text fallback for platforms without reaction UIs. One live menu per
+        # session (newest wins): a number resolves it (rewriting THIS turn into
+        # a [menu-choice] turn the agent then runs); 'more' reprints it.
+        try:
+            from tools import reaction_menu_gateway as _rmg_mod
+            _live_menu = _rmg_mod.get_newest_for_session(_quick_key)
+        except Exception:
+            _rmg_mod = None
+            _live_menu = None
+        if _live_menu is not None:
+            _menu_reply = (event.text or "").strip()
+            if _menu_reply.lower() == "more":
+                _menu_adapter = self.adapters.get(event.source.platform)
+                if _menu_adapter is not None and getattr(
+                    type(_menu_adapter), "reprint_reaction_menu", None
+                ) is not None:
+                    try:
+                        await _menu_adapter.reprint_reaction_menu(
+                            chat_id=event.source.chat_id,
+                            prompt=_live_menu.prompt,
+                            options=_live_menu.options,
+                            metadata=self._thread_metadata_for_source(
+                                event.source, event.message_id
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.debug("reaction-menu reprint failed: %s", exc)
+                return ""
+            _menu_choice = None
+            if _menu_reply.isdigit():
+                _menu_idx = int(_menu_reply) - 1
+                if 0 <= _menu_idx < len(_live_menu.options):
+                    _menu_choice = _live_menu.options[_menu_idx]
+            if _menu_choice is not None and _rmg_mod.mark_resolved(_live_menu.menu_id):
+                logger.info(
+                    "Gateway intercepted reaction-menu text choice (session=%s, menu=%s)",
+                    _quick_key, _live_menu.menu_id,
+                )
+                # Rewrite this turn into a synthetic [menu-choice] turn and fall
+                # through so the agent runs the chosen payload as the next turn.
+                event.text = _rmg_mod.build_menu_choice_body(_menu_choice["payload"])
+
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are
         # /approve, /always, /cancel (plus short aliases).  Anything else
@@ -16969,6 +17012,14 @@ class GatewayRunner:
             if event_type not in {"tool.started",}:
                 return
 
+            # present_menu's output IS a user-facing message (the menu itself),
+            # so a tool-progress bubble for it is redundant noise that also
+            # leaks the raw prompt (incl. any model-escaped unicode) and whose
+            # 🎛️ tool emoji trips client-side message effects (Element's
+            # space-invaders). Suppress it — the menu is the visible artifact.
+            if tool_name == "present_menu":
+                return
+
             # Suppress tool-progress bubbles once the user has sent `stop`.
             # When the LLM response carries N parallel tool calls, the agent
             # fires N "tool.started" events back-to-back before checking for
@@ -17852,6 +17903,78 @@ class GatewayRunner:
                 return response
 
             agent.clarify_callback = _clarify_callback_sync
+
+            # ------------------------------------------------------------------
+            # present_menu callback: present a reaction-menu and return at once.
+            #
+            # Unlike clarify, this does NOT block: it schedules the adapter's
+            # send_reaction_menu on the event loop, waits only long enough to
+            # confirm delivery, and returns. The user's later tap arrives as a
+            # fresh inbound turn (Matrix: the menu branch of _on_reaction forges
+            # it; text platforms: the gateway text intercept rewrites the reply).
+            # ------------------------------------------------------------------
+            def _present_menu_callback_sync(prompt, options, context_id):
+                import uuid as _uuid
+
+                if not _status_adapter:
+                    return ""
+                if getattr(type(_status_adapter), "send_reaction_menu", None) is None:
+                    return ""
+
+                menu_id = _uuid.uuid4().hex[:12]
+
+                def _do_menu_send():
+                    return safe_schedule_threadsafe(
+                        _status_adapter.send_reaction_menu(
+                            chat_id=_status_chat_id,
+                            menu_id=menu_id,
+                            prompt=prompt,
+                            options=options,
+                            session_key=session_key or "",
+                            source=source,
+                            context_id=context_id,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                        logger=logger,
+                        log_message="present_menu send failed to schedule",
+                    )
+
+                # Ordering fix: a menu sent mid-turn lands ABOVE the turn's
+                # narrative reply, because the reply is only delivered once the
+                # agent loop ends (post-`_run_agent`).  The user then finishes
+                # reading the reply and has to scroll UP to find the live menu.
+                # Defer the send to a post-delivery callback (fires in base.py's
+                # handle_message finally, after the reply is on the wire) so the
+                # menu always lands directly BELOW the reply — at the bottom of
+                # the chat, where the eye ends up.  This chains cleanly with the
+                # background-review release callback registered just above.
+                # present_menu is the last tool of the turn and ends it, so
+                # reporting an optimistic "delivered" here (before the deferred
+                # send) is safe — the model only uses the result to stop.
+                if session_key and getattr(
+                    type(_status_adapter), "register_post_delivery_callback", None
+                ) is not None:
+                    _status_adapter.register_post_delivery_callback(
+                        session_key,
+                        _do_menu_send,
+                        generation=run_generation,
+                    )
+                    return "delivered"
+
+                # Fallback for sessions/adapters without the post-delivery hook:
+                # send immediately and confirm delivery, as before.
+                fut = _do_menu_send()
+                if fut is None:
+                    return ""
+                try:
+                    result = fut.result(timeout=15)
+                    return "delivered" if bool(getattr(result, "success", False)) else ""
+                except Exception as exc:
+                    logger.warning("present_menu send failed: %s", exc)
+                    return ""
+
+            agent.present_menu_callback = _present_menu_callback_sync
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -71,6 +71,7 @@ CONFIGURABLE_TOOLSETS = [
     ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
+    ("reaction_menu",   "🎛️  Reaction Menus",          "present_menu (tap-to-choose; off by default)"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
@@ -96,7 +97,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "reaction_menu"}
 
 
 def _xai_credentials_present() -> bool:

--- a/tests/gateway/test_matrix_reaction_menu.py
+++ b/tests/gateway/test_matrix_reaction_menu.py
@@ -1,0 +1,322 @@
+"""Tests for the Matrix reaction-menu choreography (present_menu capability).
+
+Mirrors the structure of test_matrix_exec_approval.py /
+test_matrix_approval_reaction_fail_closed.py. The reaction-menu path is built
+PARALLEL to the exec-approval path; these tests also assert the approval path is
+untouched (the do-not-refactor guard) by exercising both on the same adapter.
+"""
+
+import asyncio
+import sys
+import types
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub mautrix so gateway.platforms.matrix imports without the SDK.
+# ---------------------------------------------------------------------------
+
+def _stub_mautrix():
+    stub = types.ModuleType("mautrix")
+    for sub in ("mautrix.types", "mautrix.client", "mautrix.client.api",
+                "mautrix.errors", "mautrix.crypto", "mautrix.util",
+                "mautrix.util.config"):
+        sys.modules.setdefault(sub, types.ModuleType(sub))
+    sys.modules.setdefault("mautrix", stub)
+    m = sys.modules["mautrix.types"]
+    for attr in (
+        "ContentURI", "EventID", "EventType", "PaginationDirection",
+        "PresenceState", "RoomCreatePreset", "RoomID", "SyncToken",
+        "TrustState", "UserID",
+    ):
+        if not hasattr(m, attr):
+            setattr(m, attr, str)
+
+
+_stub_mautrix()
+
+from gateway.config import Platform  # noqa: E402
+from gateway.platforms.matrix import (  # noqa: E402
+    MatrixAdapter,
+    _MatrixApprovalPrompt,
+    _MatrixMenuPrompt,
+)
+from gateway.session import SessionSource  # noqa: E402
+from tools import reaction_menu_gateway as rmg  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path):
+    rmg.reset_state()
+    rmg.set_db_path(tmp_path / "menus.db")
+    yield
+    rmg.reset_state()
+    rmg.set_db_path(None)
+
+
+def _make_adapter(allowed=("@dan:x",)):
+    """Bare MatrixAdapter with only the state the menu path touches."""
+    adapter = object.__new__(MatrixAdapter)
+    adapter._client = SimpleNamespace()
+    adapter._user_id = "@bot:x"
+    adapter._allowed_user_ids = set(allowed)
+    adapter._approval_reaction_map = {"✅": "once", "❎": "deny"}
+    adapter._approval_prompts_by_event = {}
+    adapter._approval_prompt_by_session = {}
+    adapter._menu_prompts_by_event = {}
+    adapter._menu_reload_by_event = {}
+    adapter._processed_events = deque(maxlen=512)
+    adapter._processed_events_set = set()
+    adapter._reaction_redaction_delay_seconds = 0.0
+    adapter._reaction_redaction_tasks = set()
+    # Async surface
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="$menu1"))
+    adapter._send_reaction = AsyncMock(return_value="$seed")
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="$edit"))
+    # _message_handler is the non-None sentinel _inject_menu_choice guards on;
+    # the synthetic turn is dispatched through handle_message (the full inbound
+    # path that also delivers the response), so that's what the tests assert on.
+    adapter._message_handler = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    # Record reaction redactions instead of scheduling real tasks.
+    adapter._redactions = []
+    adapter._schedule_reaction_redaction = lambda room, evt, reason="": adapter._redactions.append((evt, reason))
+    return adapter
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.MATRIX, chat_id="!room:x", chat_type="dm",
+        user_id="@dan:x", user_name="dan",
+    )
+
+
+def _options():
+    return [
+        {"emoji": "📖", "label": "Read next", "payload": "read next passage", "terminal": False},
+        {"emoji": "🛑", "label": "Stop", "payload": "stop reading", "terminal": True},
+    ]
+
+
+def _reaction_event(sender, reacts_to, key):
+    return SimpleNamespace(
+        sender=sender,
+        event_id=f"$r-{sender}-{reacts_to}-{key}",
+        room_id="!room:x",
+        content={"m.relates_to": {"event_id": reacts_to, "key": key}},
+    )
+
+
+def _present(adapter, menu_id="m1"):
+    """Drive send_reaction_menu and return the menu's message_id."""
+    result = asyncio.run(adapter.send_reaction_menu(
+        chat_id="!room:x", menu_id=menu_id, prompt="Continue?",
+        options=_options(), session_key="s1", source=_source(), context_id="story",
+    ))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 1. present seeds emoji
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_present_seeds_emoji():
+    adapter = _make_adapter()
+    result = _present(adapter)
+    assert result.success
+    menu = adapter._menu_prompts_by_event["$menu1"]
+    assert menu.menu_id == "m1"
+    # One seed per option, in order.
+    seeded = [c.args[2] for c in adapter._send_reaction.await_args_list]
+    assert seeded == ["📖", "🛑"]
+    assert set(menu.bot_reaction_events) == {"📖", "🛑"}
+    # Registered in the consumer-agnostic store + persisted.
+    assert rmg.get_by_message("$menu1").context_id == "story"
+
+
+# ---------------------------------------------------------------------------
+# 2. tap injects synthetic [menu-choice] turn, nothing blocked
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_tap_injects_synthetic_turn():
+    adapter = _make_adapter()
+    _present(adapter)
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$menu1", "📖")))
+
+    adapter.handle_message.assert_awaited_once()
+    # Must go through handle_message (which delivers the response), NOT the bare
+    # _message_handler (which runs the turn but never sends the reply). Guards
+    # the "tap rewrote the message but nothing else happened" regression.
+    adapter._message_handler.assert_not_awaited()
+    injected = adapter.handle_message.await_args.args[0]
+    assert injected.text.startswith(rmg.MENU_CHOICE_MARKER)
+    assert "read next passage" in injected.text
+    assert injected.internal is True
+    assert injected.source.user_id == "@dan:x"
+
+
+# ---------------------------------------------------------------------------
+# 3. collapse redacts bot seeds, keeps user reaction, seeds ♻️ (non-terminal)
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_collapse_redacts_bot_seeds_keeps_user_react():
+    adapter = _make_adapter()
+    _present(adapter)
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$menu1", "📖")))
+
+    # Both bot seeds scheduled for redaction (the user's own reaction is never
+    # touched — we only redact ids we seeded).
+    redacted = {evt for evt, _ in adapter._redactions}
+    assert "$seed" in redacted
+    # Non-terminal choice → reload reaction seeded on the collapsed message.
+    assert "$menu1" in adapter._menu_reload_by_event
+    # Collapse edit happened.
+    adapter.edit_message.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 4. terminal option → no reload reaction
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_terminal_option_no_reload():
+    adapter = _make_adapter()
+    _present(adapter)
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$menu1", "🛑")))
+
+    assert "$menu1" not in adapter._menu_reload_by_event
+    adapter.handle_message.assert_awaited_once()
+    assert "stop reading" in adapter.handle_message.await_args.args[0].text
+
+
+# ---------------------------------------------------------------------------
+# 5. reload ♻️ spawns a fresh menu, no model turn
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_reload_spawns_fresh_menu():
+    adapter = _make_adapter()
+    _present(adapter)
+    # First, a non-terminal choice to seed the ♻️ reload handle.
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$menu1", "📖")))
+    adapter.handle_message.reset_mock()
+    adapter.send.reset_mock()
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="$menu2")
+
+    # Tap ♻️ on the collapsed message.
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$menu1", rmg.RELOAD_EMOJI)))
+
+    # A fresh menu message was sent; NO synthetic turn injected.
+    adapter.send.assert_awaited()
+    adapter.handle_message.assert_not_awaited()
+    assert "$menu2" in adapter._menu_prompts_by_event
+    # The one-shot reload handle is consumed.
+    assert "$menu1" not in adapter._menu_reload_by_event
+
+
+# ---------------------------------------------------------------------------
+# 6. fail-closed: unauthorized tap leaves the menu live + unresolved
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_fail_closed_unauthorized(monkeypatch):
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = _make_adapter(allowed=("@dan:x",))
+    _present(adapter)
+    asyncio.run(adapter._on_reaction(_reaction_event("@mallory:x", "$menu1", "📖")))
+
+    adapter.handle_message.assert_not_awaited()
+    assert not adapter._menu_prompts_by_event["$menu1"].resolved
+    assert rmg.get_by_message("$menu1") is not None
+
+
+# ---------------------------------------------------------------------------
+# 7. dedup: a double-tap injects exactly one turn
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_dedup_double_tap():
+    adapter = _make_adapter()
+    _present(adapter)
+    ev1 = _reaction_event("@dan:x", "$menu1", "📖")
+    ev2 = SimpleNamespace(sender="@dan:x", event_id="$r-second", room_id="!room:x",
+                          content={"m.relates_to": {"event_id": "$menu1", "key": "📖"}})
+    asyncio.run(adapter._on_reaction(ev1))
+    asyncio.run(adapter._on_reaction(ev2))
+    assert adapter.handle_message.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. persistence: a menu survives a simulated gateway restart
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_persists_across_restart():
+    adapter = _make_adapter()
+    _present(adapter)
+
+    # Simulate restart: new adapter process, in-memory state gone.
+    rmg.reset_state()
+    adapter2 = _make_adapter()
+    adapter2._restore_persisted_menus()
+
+    assert "$menu1" in adapter2._menu_prompts_by_event
+    restored = adapter2._menu_prompts_by_event["$menu1"]
+    assert restored.source.user_id == "@dan:x"
+    # And a tap still resolves + injects after restore.
+    asyncio.run(adapter2._on_reaction(_reaction_event("@dan:x", "$menu1", "📖")))
+    adapter2.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 9. many live menus resolve independently
+# ---------------------------------------------------------------------------
+
+def test_reaction_menu_many_live_menus_independent():
+    adapter = _make_adapter()
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="$mA")
+    asyncio.run(adapter.send_reaction_menu(
+        chat_id="!room:x", menu_id="mA", prompt="A?", options=_options(),
+        session_key="s1", source=_source()))
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="$mB")
+    asyncio.run(adapter.send_reaction_menu(
+        chat_id="!room:x", menu_id="mB", prompt="B?", options=_options(),
+        session_key="s1", source=_source()))
+
+    # Resolve menu A; menu B stays live and resolvable.
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$mA", "📖")))
+    assert "$mA" not in adapter._menu_prompts_by_event
+    assert "$mB" in adapter._menu_prompts_by_event
+    asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$mB", "📖")))
+    assert adapter.handle_message.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Do-not-refactor guard: the approval path still resolves on the same adapter
+# ---------------------------------------------------------------------------
+
+def test_approval_path_untouched_by_menu_branch():
+    import tools.approval as _approval
+
+    adapter = _make_adapter()
+    adapter._redact_bot_approval_reactions = AsyncMock()
+    adapter._approval_prompts_by_event["$appr"] = _MatrixApprovalPrompt(
+        session_key="s1", chat_id="!room:x", message_id="$appr",
+    )
+    adapter._approval_prompt_by_session["s1"] = "$appr"
+
+    calls = {}
+    _orig = _approval.resolve_gateway_approval
+    _approval.resolve_gateway_approval = lambda sk, choice: calls.setdefault("c", (sk, choice)) or 1
+    try:
+        asyncio.run(adapter._on_reaction(_reaction_event("@dan:x", "$appr", "✅")))
+    finally:
+        _approval.resolve_gateway_approval = _orig
+
+    assert calls["c"] == ("s1", "once")
+    assert "$appr" not in adapter._approval_prompts_by_event
+    # The menu handler must NOT have fired for an approval reaction.
+    adapter.handle_message.assert_not_awaited()

--- a/tests/gateway/test_reaction_menu_gateway.py
+++ b/tests/gateway/test_reaction_menu_gateway.py
@@ -1,0 +1,289 @@
+"""Unit tests for the consumer-agnostic reaction-menu gateway primitive
+and the present_menu tool dispatcher.  No platform adapter required."""
+
+import json
+
+import pytest
+
+from tools import reaction_menu_gateway as rmg
+from tools.reaction_menu_gateway import MenuValidationError, validate_options
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path):
+    """Each test gets a clean registry + a throwaway persistence DB."""
+    rmg.reset_state()
+    rmg.set_db_path(tmp_path / "menus.db")
+    yield
+    rmg.reset_state()
+    rmg.set_db_path(None)
+
+
+def _opts(*emojis):
+    return [
+        {"emoji": e, "label": f"label-{e}", "payload": f"payload-{e}"}
+        for e in emojis
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_normalizes_and_defaults_terminal_false(self):
+        out = validate_options([{"emoji": "📖", "label": "Read", "payload": "go"}])
+        assert out == [{"emoji": "📖", "label": "Read", "payload": "go", "terminal": False}]
+
+    def test_terminal_flag_preserved(self):
+        out = validate_options([{"emoji": "🛑", "label": "Stop", "payload": "stop", "terminal": True}])
+        assert out[0]["terminal"] is True
+
+    def test_silent_is_rejected(self):
+        with pytest.raises(MenuValidationError, match="silent"):
+            validate_options([{"emoji": "📖", "label": "x", "payload": "y", "silent": True}])
+
+    def test_too_many_options_rejected(self):
+        with pytest.raises(MenuValidationError, match="1.5 options"):
+            validate_options(_opts("1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣"))
+
+    def test_empty_options_rejected(self):
+        with pytest.raises(MenuValidationError):
+            validate_options([])
+
+    def test_duplicate_emoji_rejected(self):
+        with pytest.raises(MenuValidationError, match="duplicate"):
+            validate_options(_opts("📖", "📖"))
+
+    def test_reserved_reload_emoji_rejected(self):
+        with pytest.raises(MenuValidationError, match="reload"):
+            validate_options([{"emoji": rmg.RELOAD_EMOJI, "label": "x", "payload": "y"}])
+
+    def test_missing_fields_rejected(self):
+        with pytest.raises(MenuValidationError, match="emoji"):
+            validate_options([{"label": "x", "payload": "y"}])
+        with pytest.raises(MenuValidationError, match="payload"):
+            validate_options([{"emoji": "📖", "label": "x"}])
+
+
+# ---------------------------------------------------------------------------
+# Marker helpers
+# ---------------------------------------------------------------------------
+
+class TestMarker:
+    def test_build_and_parse_roundtrip(self):
+        body = rmg.build_menu_choice_body("read passage 4")
+        assert body.startswith(rmg.MENU_CHOICE_MARKER)
+        assert rmg.is_menu_choice_text(body)
+        assert rmg.parse_menu_choice_payload(body) == "read passage 4"
+
+    def test_plain_text_not_a_choice(self):
+        assert not rmg.is_menu_choice_text("hello there")
+
+    def test_recognizes_event_like_object(self):
+        evt = type("E", (), {"text": rmg.build_menu_choice_body("p")})()
+        assert rmg.is_menu_choice_text(evt)
+
+
+# ---------------------------------------------------------------------------
+# Registry + dedup
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    def _register(self, menu_id="m1", session="s1", message="$evt1", emojis=("📖", "🔁")):
+        return rmg.register(
+            menu_id=menu_id, session_key=session, platform="matrix",
+            chat_id="!room:x", message_id=message, prompt="pick",
+            options=validate_options(_opts(*emojis)), context_id="ctx",
+        )
+
+    def test_register_and_lookup_by_message(self):
+        self._register()
+        entry = rmg.get_by_message("$evt1")
+        assert entry is not None and entry.menu_id == "m1"
+        assert entry.option_for_emoji("📖")["payload"] == "payload-📖"
+
+    def test_mark_resolved_is_idempotent_dedup(self):
+        self._register()
+        assert rmg.mark_resolved("m1") is True   # first tap wins
+        assert rmg.mark_resolved("m1") is False  # double-tap deduped
+        assert rmg.get_by_message("$evt1") is None
+
+    def test_many_live_menus_independent(self):
+        self._register(menu_id="m1", message="$e1", emojis=("📖", "🔁"))
+        self._register(menu_id="m2", message="$e2", emojis=("🍎", "🍌"))
+        assert rmg.mark_resolved("m1") is True
+        # m2 untouched by m1's resolution — proves no single-live-surface core.
+        assert rmg.get_by_message("$e2").menu_id == "m2"
+        assert rmg.mark_resolved("m2") is True
+
+    def test_newest_pointer_tracks_latest_and_promotes(self):
+        self._register(menu_id="m1", message="$e1")
+        self._register(menu_id="m2", message="$e2")
+        assert rmg.get_newest_for_session("s1").menu_id == "m2"
+        rmg.mark_resolved("m2")
+        # Resolving newest promotes the prior live menu.
+        assert rmg.get_newest_for_session("s1").menu_id == "m1"
+
+    def test_clear_session(self):
+        self._register(menu_id="m1", message="$e1")
+        self._register(menu_id="m2", message="$e2")
+        assert rmg.clear_session("s1") == 2
+        assert rmg.list_for_session("s1") == []
+        assert rmg.get_newest_for_session("s1") is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_unresolved_menu_survives_reload(self):
+        rmg.register(
+            menu_id="m1", session_key="s1", platform="matrix", chat_id="!room:x",
+            message_id="$evt1", prompt="pick",
+            options=validate_options(_opts("📖", "🔁")),
+            context_id="ctx",
+            source={"platform": "matrix", "chat_id": "!room:x", "user_id": "@u:x"},
+        )
+        # Simulate a restart: wipe memory, reload from DB.
+        rmg.reset_state()
+        assert rmg.get("m1") is None
+        restored = rmg.load_persisted(platform="matrix")
+        assert len(restored) == 1
+        entry = rmg.get_by_message("$evt1")
+        assert entry is not None and entry.context_id == "ctx"
+        assert entry.source["user_id"] == "@u:x"
+
+    def test_resolved_menu_not_reloaded(self):
+        rmg.register(
+            menu_id="m1", session_key="s1", platform="matrix", chat_id="!room:x",
+            message_id="$evt1", prompt="pick",
+            options=validate_options(_opts("📖", "🔁")),
+        )
+        rmg.mark_resolved("m1")
+        rmg.reset_state()
+        assert rmg.load_persisted() == []
+
+    def test_platform_filter_on_load(self):
+        rmg.register(
+            menu_id="m1", session_key="s1", platform="matrix", chat_id="c",
+            message_id="$e1", prompt="p", options=validate_options(_opts("📖")),
+        )
+        rmg.reset_state()
+        assert rmg.load_persisted(platform="telegram") == []
+        # Still loadable for its own platform.
+        rmg.reset_state()
+        assert len(rmg.load_persisted(platform="matrix")) == 1
+
+
+# ---------------------------------------------------------------------------
+# present_menu tool dispatcher
+# ---------------------------------------------------------------------------
+
+class TestPresentMenuTool:
+    def test_silent_rejected_at_tool_layer(self):
+        from tools.reaction_menu_tool import present_menu_tool
+        out = json.loads(present_menu_tool(
+            prompt="pick", options=[{"emoji": "📖", "label": "x", "payload": "y", "silent": True}],
+            callback=lambda *a: "ok",
+        ))
+        assert "error" in out and "silent" in out["error"]
+
+    def test_missing_callback_errors(self):
+        from tools.reaction_menu_tool import present_menu_tool
+        out = json.loads(present_menu_tool(prompt="pick", options=_opts("📖"), callback=None))
+        assert "error" in out and "not available" in out["error"]
+
+    def test_blank_prompt_errors(self):
+        from tools.reaction_menu_tool import present_menu_tool
+        out = json.loads(present_menu_tool(prompt="  ", options=_opts("📖"), callback=lambda *a: "ok"))
+        assert "error" in out
+
+    def test_successful_present_delegates_to_callback(self):
+        from tools.reaction_menu_tool import present_menu_tool
+        seen = {}
+
+        def cb(prompt, options, context_id):
+            seen["prompt"] = prompt
+            seen["options"] = options
+            seen["context_id"] = context_id
+            return "delivered"
+
+        out = json.loads(present_menu_tool(
+            prompt="Read next?",
+            options=[
+                {"emoji": "📖", "label": "Read", "payload": "read next"},
+                {"emoji": "🛑", "label": "Stop", "payload": "stop", "terminal": True},
+            ],
+            context_id="story-1",
+            callback=cb,
+        ))
+        assert out["status"] == "menu_presented"
+        assert out["context_id"] == "story-1"
+        assert seen["options"][1]["terminal"] is True
+        assert {o["emoji"] for o in out["options_offered"]} == {"📖", "🛑"}
+
+    def test_undelivered_menu_errors(self):
+        from tools.reaction_menu_tool import present_menu_tool
+        out = json.loads(present_menu_tool(
+            prompt="pick", options=_opts("📖"), callback=lambda *a: "",
+        ))
+        assert "error" in out and "deliver" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Base-adapter text fallback (numbered list; number resolves; one live menu)
+# ---------------------------------------------------------------------------
+
+class TestTextFallback:
+    def _fake_self(self, sent):
+        import types as _t
+
+        async def _send(chat_id, content, metadata=None):
+            sent.append(content)
+            return _t.SimpleNamespace(success=True, message_id="$txt1")
+
+        return _t.SimpleNamespace(name="signal", send=_send)
+
+    def test_send_reaction_menu_renders_numbered_list_and_registers(self):
+        import asyncio
+        from gateway.platforms.base import BasePlatformAdapter
+
+        sent = []
+        opts = validate_options([
+            {"emoji": "📖", "label": "Read", "payload": "read next"},
+            {"emoji": "🛑", "label": "Stop", "payload": "stop"},
+        ])
+        result = asyncio.run(BasePlatformAdapter.send_reaction_menu(
+            self._fake_self(sent), chat_id="c", menu_id="m1", prompt="Continue?",
+            options=opts, session_key="s1",
+        ))
+        assert result.success
+        body = sent[0]
+        assert "1. 📖 Read" in body and "2. 🛑 Stop" in body
+        # Registered as the live menu for the session.
+        assert rmg.get_newest_for_session("s1").menu_id == "m1"
+
+    def test_numbered_reply_resolves_to_payload(self):
+        """The intercept logic: newest menu + number → payload, deduped."""
+        import asyncio
+        from gateway.platforms.base import BasePlatformAdapter
+
+        sent = []
+        opts = validate_options([
+            {"emoji": "📖", "label": "Read", "payload": "read next"},
+            {"emoji": "🛑", "label": "Stop", "payload": "stop"},
+        ])
+        asyncio.run(BasePlatformAdapter.send_reaction_menu(
+            self._fake_self(sent), chat_id="c", menu_id="m1", prompt="Continue?",
+            options=opts, session_key="s1",
+        ))
+
+        menu = rmg.get_newest_for_session("s1")
+        choice = menu.options[1]              # user typed "2"
+        assert rmg.mark_resolved(menu.menu_id) is True
+        assert rmg.build_menu_choice_body(choice["payload"]) == \
+            rmg.MENU_CHOICE_MARKER + "\nstop"
+        # Deduped: a second "2" finds no live menu.
+        assert rmg.get_newest_for_session("s1") is None

--- a/tools/reaction_menu_gateway.py
+++ b/tools/reaction_menu_gateway.py
@@ -1,0 +1,495 @@
+"""Gateway-side reaction-menu primitive (non-blocking, consumer-agnostic).
+
+Unlike the ``clarify`` and ``approval`` primitives, ``present_menu`` does **not**
+block the agent thread.  The tool presents a menu — a message with one seeded
+reaction per option — and ends the turn.  When the user later taps an option,
+the platform adapter forges a synthetic ``[menu-choice]`` user turn and dispatches
+it through its own message handler; the FIFO / promote machinery in the runner
+queues that turn behind any busy agent for free (see ``GatewayRunner._enqueue_fifo``).
+
+So this module is pure bookkeeping — there is no ``threading.Event`` here:
+
+  * a per-message registry of live menus, keyed by ``menu_id``;
+  * option validation (1–5 options, unique emoji, ``silent`` rejected in v1);
+  * a resolve/dedup primitive so a double-tap injects exactly one turn;
+  * a per-session "newest menu" pointer used **only** by the text fallback, where
+    a bare numeric reply can't disambiguate between several live menus;
+  * optional SQLite persistence so unresolved menus survive a gateway restart.
+
+Two layers (spec §2, deliberately consumer-agnostic):
+
+  * The core registry is keyed by ``menu_id`` (one per message) and supports
+    MANY live menus in a single session simultaneously.  Reaction and (future)
+    button consumers drive it directly.
+  * The ``newest``-per-session pointer is a thin convenience for the text
+    fallback only.  It does not constrain the core.
+
+State is module-level (same shape as ``tools.approval`` / ``tools.clarify_gateway``)
+so platform adapters can resolve a menu without holding a back-reference to the
+``GatewayRunner``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# Synthetic-turn marker (mirrors the /goal continuation marker in run.py)
+# =========================================================================
+# A tapped menu injects a normal user-role turn whose body is prefixed with
+# this marker.  The runner recognises the prefix to treat it like a goal
+# continuation for pause/clear purposes; the model reads the marker as a
+# provenance signal for the chosen path.
+
+MENU_CHOICE_MARKER = "[menu-choice]"
+
+
+def build_menu_choice_body(payload: str) -> str:
+    """Build the synthetic-turn body for a chosen option payload."""
+    return f"{MENU_CHOICE_MARKER}\n{payload}"
+
+
+def is_menu_choice_text(text_or_event: Any) -> bool:
+    """Return True for a synthetic ``[menu-choice]`` turn (text or event)."""
+    text = getattr(text_or_event, "text", text_or_event) or ""
+    return str(text).startswith(MENU_CHOICE_MARKER)
+
+
+def parse_menu_choice_payload(text: str) -> str:
+    """Extract the payload from a ``[menu-choice]\\n{payload}`` body."""
+    raw = str(text or "")
+    if not raw.startswith(MENU_CHOICE_MARKER):
+        return raw
+    return raw[len(MENU_CHOICE_MARKER):].lstrip("\n")
+
+
+# =========================================================================
+# Option validation
+# =========================================================================
+
+MIN_OPTIONS = 1
+MAX_OPTIONS = 5
+
+# Reaction reserved by the menu choreography itself (reload / regenerate).
+# An option may NOT claim it.
+RELOAD_EMOJI = "♻️"  # ♻️
+
+
+class MenuValidationError(ValueError):
+    """Raised when an option list fails validation."""
+
+
+def validate_options(options: Any) -> List[Dict[str, Any]]:
+    """Validate and normalise a menu's option list.
+
+    Each option is a dict with:
+      * ``emoji``    (str, required) — the reaction key / number anchor.
+      * ``label``    (str, required) — human-readable choice text.
+      * ``payload``  (str, required) — injected as the synthetic turn body.
+      * ``terminal`` (bool, optional, default False) — when True the chosen
+        path ends the menu lifecycle: no ``♻️`` reload reaction is seeded.
+
+    Rules: 1–5 options; ``emoji``/``label``/``payload`` non-empty; emoji unique
+    within the menu and never the reserved ``♻️``; ``silent: true`` is reserved
+    and rejected in v1 (spec §8).
+
+    Returns the normalised list.  Raises :class:`MenuValidationError` otherwise.
+    """
+    if not isinstance(options, list):
+        raise MenuValidationError("options must be a list")
+    if not (MIN_OPTIONS <= len(options) <= MAX_OPTIONS):
+        raise MenuValidationError(
+            f"a menu needs {MIN_OPTIONS}–{MAX_OPTIONS} options, got {len(options)}"
+        )
+
+    normalized: List[Dict[str, Any]] = []
+    seen_emoji: set[str] = set()
+    for idx, opt in enumerate(options):
+        if not isinstance(opt, dict):
+            raise MenuValidationError(f"option {idx} must be an object")
+        if opt.get("silent"):
+            raise MenuValidationError(
+                "silent menus are reserved and not supported in this version"
+            )
+        emoji = str(opt.get("emoji", "")).strip()
+        label = str(opt.get("label", "")).strip()
+        payload = str(opt.get("payload", "")).strip()
+        if not emoji:
+            raise MenuValidationError(f"option {idx} is missing 'emoji'")
+        if not label:
+            raise MenuValidationError(f"option {idx} is missing 'label'")
+        if not payload:
+            raise MenuValidationError(f"option {idx} is missing 'payload'")
+        if emoji == RELOAD_EMOJI:
+            raise MenuValidationError(
+                f"option {idx} uses the reserved reload reaction {RELOAD_EMOJI}"
+            )
+        if emoji in seen_emoji:
+            raise MenuValidationError(f"duplicate emoji {emoji!r} in menu")
+        seen_emoji.add(emoji)
+        normalized.append({
+            "emoji": emoji,
+            "label": label,
+            "payload": payload,
+            "terminal": bool(opt.get("terminal", False)),
+        })
+    return normalized
+
+
+# =========================================================================
+# Registry entry
+# =========================================================================
+
+@dataclass
+class _MenuEntry:
+    """One live menu, keyed by ``menu_id`` (per message, consumer-agnostic)."""
+
+    menu_id: str
+    session_key: str
+    platform: str
+    chat_id: str
+    message_id: str
+    prompt: str
+    options: List[Dict[str, Any]]
+    context_id: Optional[str] = None
+    # Serialised SessionSource (see gateway.session.SessionSource.to_dict) so
+    # the adapter can forge a routed synthetic turn — even after a restart.
+    source: Optional[Dict[str, Any]] = None
+    resolved: bool = False
+    created_ts: float = field(default_factory=time.time)
+
+    def option_for_emoji(self, emoji: str) -> Optional[Dict[str, Any]]:
+        for opt in self.options:
+            if opt["emoji"] == emoji:
+                return opt
+        return None
+
+    def to_row(self) -> Tuple:
+        return (
+            self.menu_id,
+            self.session_key,
+            self.platform,
+            self.chat_id,
+            self.message_id,
+            self.prompt,
+            json.dumps(self.options, ensure_ascii=False),
+            self.context_id,
+            json.dumps(self.source, ensure_ascii=False) if self.source else None,
+            1 if self.resolved else 0,
+            self.created_ts,
+        )
+
+    @classmethod
+    def from_row(cls, row: Tuple) -> "_MenuEntry":
+        return cls(
+            menu_id=row[0],
+            session_key=row[1],
+            platform=row[2],
+            chat_id=row[3],
+            message_id=row[4],
+            prompt=row[5],
+            options=json.loads(row[6]) if row[6] else [],
+            context_id=row[7],
+            source=json.loads(row[8]) if row[8] else None,
+            resolved=bool(row[9]),
+            created_ts=row[10],
+        )
+
+
+# =========================================================================
+# Module-level state
+# =========================================================================
+
+_lock = threading.RLock()
+_menus: Dict[str, _MenuEntry] = {}                  # menu_id → entry
+_session_index: Dict[str, List[str]] = {}           # session_key → [menu_id, …]
+_session_newest: Dict[str, str] = {}                # session_key → newest menu_id (text fallback)
+_notify_cbs: Dict[str, Callable[[_MenuEntry], None]] = {}  # session_key → send callback
+
+# GC thresholds (spec §6).
+_UNRESOLVED_TTL_SECONDS = 30 * 24 * 3600   # 30 days
+_RESOLVED_TTL_SECONDS = 7 * 24 * 3600      # 7 days (only relevant if kept)
+
+
+# =========================================================================
+# Persistence (SQLite)
+# =========================================================================
+
+_db_path_override: Optional[Path] = None
+
+
+def set_db_path(path: Optional[str | Path]) -> None:
+    """Override the persistence DB path (used by tests).  None resets to default."""
+    global _db_path_override
+    _db_path_override = Path(path) if path is not None else None
+
+
+def _db_path() -> Path:
+    if _db_path_override is not None:
+        return _db_path_override
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "reaction_menus.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS reaction_menus (
+            menu_id     TEXT PRIMARY KEY,
+            session_key TEXT,
+            platform    TEXT,
+            chat_id     TEXT,
+            message_id  TEXT,
+            prompt      TEXT,
+            options     TEXT,
+            context_id  TEXT,
+            source      TEXT,
+            resolved    INTEGER DEFAULT 0,
+            created_ts  REAL
+        )
+        """
+    )
+    return conn
+
+
+def _persist(entry: _MenuEntry) -> None:
+    try:
+        with _connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO reaction_menus "
+                "(menu_id, session_key, platform, chat_id, message_id, prompt, "
+                " options, context_id, source, resolved, created_ts) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                entry.to_row(),
+            )
+    except Exception as exc:  # persistence is best-effort
+        logger.debug("reaction_menu: persist failed for %s: %s", entry.menu_id, exc)
+
+
+def _delete_persisted(menu_id: str) -> None:
+    try:
+        with _connect() as conn:
+            conn.execute("DELETE FROM reaction_menus WHERE menu_id = ?", (menu_id,))
+    except Exception as exc:
+        logger.debug("reaction_menu: delete failed for %s: %s", menu_id, exc)
+
+
+def load_persisted(platform: Optional[str] = None) -> List[_MenuEntry]:
+    """Load unresolved persisted menus into the in-memory registry.
+
+    Called by an adapter on startup so it can rebuild its platform-specific
+    tracking (e.g. ``_menu_prompts_by_event``).  Returns the restored entries,
+    optionally filtered to one ``platform``.  Expired rows are GC'd here.
+    """
+    restored: List[_MenuEntry] = []
+    now = time.time()
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                "SELECT menu_id, session_key, platform, chat_id, message_id, "
+                "prompt, options, context_id, source, resolved, created_ts "
+                "FROM reaction_menus WHERE resolved = 0"
+            ).fetchall()
+    except Exception as exc:
+        logger.debug("reaction_menu: load failed: %s", exc)
+        return restored
+
+    for row in rows:
+        try:
+            entry = _MenuEntry.from_row(row)
+        except Exception:
+            continue
+        if now - entry.created_ts > _UNRESOLVED_TTL_SECONDS:
+            _delete_persisted(entry.menu_id)
+            continue
+        if platform is not None and entry.platform != platform:
+            continue
+        with _lock:
+            _menus[entry.menu_id] = entry
+            self_ids = _session_index.setdefault(entry.session_key, [])
+            if entry.menu_id not in self_ids:
+                self_ids.append(entry.menu_id)
+            _session_newest[entry.session_key] = entry.menu_id
+        restored.append(entry)
+    return restored
+
+
+# =========================================================================
+# Registry API
+# =========================================================================
+
+def register(
+    menu_id: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    message_id: str,
+    prompt: str,
+    options: List[Dict[str, Any]],
+    context_id: Optional[str] = None,
+    source: Optional[Dict[str, Any]] = None,
+    persist: bool = True,
+) -> _MenuEntry:
+    """Register a live menu and return the entry.
+
+    ``options`` must already be normalised (call :func:`validate_options`).
+    Adds the menu to the per-session index and marks it the newest live menu
+    for that session (text-fallback disambiguation).
+    """
+    entry = _MenuEntry(
+        menu_id=menu_id,
+        session_key=session_key,
+        platform=platform,
+        chat_id=chat_id,
+        message_id=message_id,
+        prompt=prompt,
+        options=list(options),
+        context_id=context_id,
+        source=source,
+    )
+    with _lock:
+        _menus[menu_id] = entry
+        _session_index.setdefault(session_key, []).append(menu_id)
+        _session_newest[session_key] = menu_id
+    if persist:
+        _persist(entry)
+    return entry
+
+
+def get(menu_id: str) -> Optional[_MenuEntry]:
+    with _lock:
+        return _menus.get(menu_id)
+
+
+def get_by_message(message_id: str) -> Optional[_MenuEntry]:
+    """Return the live menu attached to a platform message, or None."""
+    if not message_id:
+        return None
+    with _lock:
+        for entry in _menus.values():
+            if entry.message_id == message_id and not entry.resolved:
+                return entry
+    return None
+
+
+def mark_resolved(menu_id: str) -> bool:
+    """Flip a menu to resolved.  Returns True only on the first transition.
+
+    The dedup primitive: a double-tap calls this twice but only the first
+    call returns True, so exactly one synthetic turn is injected.  The
+    resolved entry is dropped from the registry and from persistence.
+    """
+    with _lock:
+        entry = _menus.get(menu_id)
+        if entry is None or entry.resolved:
+            return False
+        entry.resolved = True
+        _drop_locked(menu_id)
+    _delete_persisted(menu_id)
+    return True
+
+
+def remove(menu_id: str) -> None:
+    """Remove a menu from the registry and persistence (no resolve semantics)."""
+    with _lock:
+        _drop_locked(menu_id)
+    _delete_persisted(menu_id)
+
+
+def _drop_locked(menu_id: str) -> None:
+    """Remove a menu from the in-memory indices.  Caller holds ``_lock``."""
+    entry = _menus.pop(menu_id, None)
+    if entry is None:
+        return
+    ids = _session_index.get(entry.session_key)
+    if ids and menu_id in ids:
+        ids.remove(menu_id)
+        if not ids:
+            _session_index.pop(entry.session_key, None)
+    if _session_newest.get(entry.session_key) == menu_id:
+        # Promote the next-most-recent surviving menu, if any.
+        remaining = _session_index.get(entry.session_key) or []
+        if remaining:
+            _session_newest[entry.session_key] = remaining[-1]
+        else:
+            _session_newest.pop(entry.session_key, None)
+
+
+def get_newest_for_session(session_key: str) -> Optional[_MenuEntry]:
+    """Return the newest live menu for a session (text-fallback resolution)."""
+    with _lock:
+        menu_id = _session_newest.get(session_key)
+        if not menu_id:
+            return None
+        entry = _menus.get(menu_id)
+        return entry if entry and not entry.resolved else None
+
+
+def list_for_session(session_key: str) -> List[_MenuEntry]:
+    with _lock:
+        return [
+            _menus[mid]
+            for mid in _session_index.get(session_key, [])
+            if mid in _menus
+        ]
+
+
+def clear_session(session_key: str) -> int:
+    """Drop every live menu for a session (e.g. ``/new``, eviction).  Returns count."""
+    with _lock:
+        ids = list(_session_index.get(session_key, []) or [])
+        for mid in ids:
+            _drop_locked(mid)
+    for mid in ids:
+        _delete_persisted(mid)
+    return len(ids)
+
+
+# =========================================================================
+# Per-session notify hook (gateway → adapter send bridge)
+# =========================================================================
+# Mirrors tools.approval / tools.clarify_gateway: the gateway runner registers
+# a per-session callback that sends the menu to the user.  ``present_menu``
+# invokes it synchronously on the agent thread; the callback schedules the
+# adapter's ``send_reaction_menu`` on the event loop and returns once delivery
+# is confirmed (non-blocking — it does NOT wait for the user to tap).
+
+def register_notify(session_key: str, cb: Callable[[_MenuEntry], None]) -> None:
+    with _lock:
+        _notify_cbs[session_key] = cb
+
+
+def unregister_notify(session_key: str) -> None:
+    with _lock:
+        _notify_cbs.pop(session_key, None)
+
+
+def get_notify(session_key: str) -> Optional[Callable[[_MenuEntry], None]]:
+    with _lock:
+        return _notify_cbs.get(session_key)
+
+
+# =========================================================================
+# Test / lifecycle helpers
+# =========================================================================
+
+def reset_state() -> None:
+    """Drop all in-memory state.  For tests and full gateway resets."""
+    with _lock:
+        _menus.clear()
+        _session_index.clear()
+        _session_newest.clear()
+        _notify_cbs.clear()

--- a/tools/reaction_menu_tool.py
+++ b/tools/reaction_menu_tool.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Reaction-Menu Tool — present_menu
+
+Lets the agent present an interactive menu the user resolves by TAPPING a
+reaction, rather than typing.  On Matrix the menu is a message with one seeded
+emoji per option; tapping an emoji collapses the menu and injects the chosen
+option's ``payload`` as the next user turn.  On platforms without reaction UIs
+the base adapter renders a numbered text list and a bare-number reply resolves it.
+
+Unlike ``clarify``, ``present_menu`` is **non-blocking and terminal for the turn**:
+it presents the menu and returns immediately, ending the agent's turn.  The user
+may tap now or much later — their tap starts a fresh turn through the normal
+inbound path (queued behind any busy agent automatically).  Call it LAST.
+
+The actual send + choreography lives in the platform layer (the gateway wires a
+``present_menu`` callback in ``gateway/run.py`` that bridges to the adapter's
+``send_reaction_menu``).  This module defines the schema, validation, and a thin
+dispatcher that delegates to that callback.
+"""
+
+import json
+from typing import Any, Callable, List, Optional
+
+from tools.reaction_menu_gateway import (
+    MAX_OPTIONS,
+    MIN_OPTIONS,
+    MenuValidationError,
+    validate_options,
+)
+
+
+def present_menu_tool(
+    prompt: str,
+    options: Optional[List[dict]] = None,
+    context_id: Optional[str] = None,
+    callback: Optional[Callable] = None,
+) -> str:
+    """Present an interactive reaction menu to the user.
+
+    Args:
+        prompt:     Short text shown above the options (what is being chosen).
+        options:    1–5 option objects, each ``{emoji, label, payload,
+                    terminal?}``.  ``payload`` is injected as the next user turn
+                    when that option is tapped; ``terminal`` (default False)
+                    suppresses the ♻️ reload reaction for ending choices.
+        context_id: Optional caller-defined id echoed back, so the agent can tell
+                    which menu a later choice belongs to.
+        callback:   Platform-provided sender, injected by the gateway runner.
+                    Signature: ``callback(prompt, options, context_id) -> str``.
+
+    Returns:
+        JSON string describing the outcome.
+    """
+    if not prompt or not str(prompt).strip():
+        return tool_error("prompt text is required.")
+    prompt = str(prompt).strip()
+
+    try:
+        normalized = validate_options(options)
+    except MenuValidationError as exc:
+        return tool_error(str(exc))
+
+    if callback is None:
+        return tool_error(
+            "present_menu is not available in this execution context "
+            "(no reaction-capable platform attached)."
+        )
+
+    try:
+        outcome = callback(prompt, normalized, context_id)
+    except Exception as exc:
+        return tool_error(f"failed to present menu: {exc}")
+
+    if not outcome:
+        return tool_error("menu could not be delivered.")
+
+    return json.dumps(
+        {
+            "status": "menu_presented",
+            "context_id": context_id,
+            "options_offered": [
+                {"emoji": o["emoji"], "label": o["label"]} for o in normalized
+            ],
+            "note": (
+                "Menu presented. This turn is complete — the user's tap will "
+                "arrive as a new turn. Do not wait or poll for it."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
+def check_present_menu_requirements() -> bool:
+    """No external requirements — availability is gated by the platform callback."""
+    return True
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+PRESENT_MENU_SCHEMA = {
+    "name": "present_menu",
+    "description": (
+        "Present an interactive menu the user resolves by TAPPING a reaction "
+        "(no typing). Use when you want to offer a small set of next steps and "
+        "let the user pick one with a single tap — e.g. 'read the next passage / "
+        "re-read / stop', or picking among a few drafted options.\n\n"
+        "This tool is NON-BLOCKING and ENDS YOUR TURN: it presents the menu and "
+        "returns immediately. The user may tap now or later; their tap arrives as "
+        "a brand-new turn carrying the chosen option's payload. Do NOT wait or "
+        "poll for the choice, and call this tool LAST in your turn.\n\n"
+        "The menu is posted as its own message DIRECTLY AFTER your reply text, at "
+        "the bottom of the chat. Do NOT tell the user where to find it (no 'the "
+        "menu is above/below') — just present the choices in your reply.\n\n"
+        "Each option has an `emoji` (the tappable reaction), a short `label`, and "
+        "a `payload` (the text delivered to you as the next turn when tapped). "
+        "Mark an option `terminal: true` when choosing it should end the menu "
+        "(no reload offered). Provide 1–5 options with distinct emoji.\n\n"
+        "FORMATTING — the `prompt` and option `label`/`emoji` are shown to the user "
+        "EXACTLY as written. Write all emoji, dashes, and accented characters as "
+        "literal characters (📖, 🌌, —, é), NEVER as escape sequences such as "
+        "\\uXXXX — escapes are rendered verbatim and look broken.\n\n"
+        "Prefer `clarify` instead when you need a typed/free-form answer or must "
+        "block until the user responds."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Text shown above the options, rendered verbatim. Use literal "
+                    "emoji/dashes/accents (📖, 🌌, —), never \\uXXXX escapes."
+                ),
+            },
+            "options": {
+                "type": "array",
+                "minItems": MIN_OPTIONS,
+                "maxItems": MAX_OPTIONS,
+                "description": "1–5 tappable options with distinct emoji.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "emoji": {
+                            "type": "string",
+                            "description": "The reaction the user taps to pick this option.",
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Short human-readable choice text.",
+                        },
+                        "payload": {
+                            "type": "string",
+                            "description": (
+                                "Text delivered to you as the next user turn when "
+                                "this option is tapped."
+                            ),
+                        },
+                        "terminal": {
+                            "type": "boolean",
+                            "description": (
+                                "When true, picking this option ends the menu (no "
+                                "reload reaction is offered). Default false."
+                            ),
+                        },
+                    },
+                    "required": ["emoji", "label", "payload"],
+                },
+            },
+            "context_id": {
+                "type": "string",
+                "description": (
+                    "Optional id echoed back so you can tell which menu a later "
+                    "choice belongs to."
+                ),
+            },
+        },
+        "required": ["prompt", "options"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry, tool_error
+
+registry.register(
+    name="present_menu",
+    toolset="reaction_menu",
+    schema=PRESENT_MENU_SCHEMA,
+    handler=lambda args, **kw: present_menu_tool(
+        prompt=args.get("prompt", ""),
+        options=args.get("options"),
+        context_id=args.get("context_id"),
+        callback=kw.get("present_menu_callback") or kw.get("callback"),
+    ),
+    check_fn=check_present_menu_requirements,
+    emoji="🎛️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -233,7 +233,17 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
-    
+
+    "reaction_menu": {
+        "description": (
+            "Present tap-to-choose menus the user resolves with a reaction "
+            "(Matrix today; numbered text fallback elsewhere). Off by default — "
+            "enable via `hermes tools` → Reaction Menu to add present_menu."
+        ),
+        "tools": ["present_menu"],
+        "includes": []
+    },
+
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
         "tools": ["execute_code"],


### PR DESCRIPTION
## What does this PR do?

Adds an **interactive reaction-menu capability** to the messaging gateway: a
`present_menu` tool the agent calls to offer a small set of choices that the
user resolves with a **single tap**, rather than typing a reply.

- **Matrix:** options render as message **reactions** — the user taps one and
  the gateway delivers that choice back into the conversation as a turn.
- **Reaction-less platforms:** falls back to a **numbered text menu** the user
  answers by number — no platform feature required.

It is **off by default**, exposed as a standalone `reaction_menu` toolset
(enable via `hermes tools`), so it has zero effect on existing deployments
unless explicitly turned on.

**Why a tool and not a skill?** Per the contributing guide's "Skill or Tool?"
test, this requires real-time platform events (reaction add/redact) and
platform-specific delivery (posting reactions, intercepting the tap) that can't
go through the terminal or be expressed as shell + existing tools. It lives in
the gateway alongside the other platform-delivery code.

## Related Issue

No existing issue — happy to open one if the maintainers prefer to track it.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/reaction_menu_tool.py` — `present_menu` tool (schema + handler),
  self-registered into the `reaction_menu` toolset via `registry.register(...)`.
- `tools/reaction_menu_gateway.py` — menu lifecycle: option↔reaction mapping,
  one-live-menu enforcement on text, synthetic choice-turn injection.
- `gateway/platforms/matrix.py` — post option reactions, watch reaction events,
  deliver the chosen option as a turn.
- `gateway/platforms/base.py` — numbered-text fallback for reaction-less
  platforms.
- `gateway/run.py` — wire the menu callback and intercept the choice turn; the
  menu send is **deferred to a post-delivery callback** so it lands directly
  below the turn's reply instead of above it.
- `agent/tool_executor.py`, `agent/agent_runtime_helpers.py`,
  `agent/agent_init.py` — surface `present_menu` through the tool executor.
- `toolsets.py` — register the off-by-default `reaction_menu` toolset.
- `tests/gateway/test_matrix_reaction_menu.py`,
  `tests/gateway/test_reaction_menu_gateway.py` — 36 tests covering the matrix
  choreography and the menu lifecycle/fallback.

## How to Test

1. Enable the toolset: `hermes tools` → enable **Reaction Menu** (or add
   `reaction_menu` to a platform's toolsets in `config.yaml`).
2. Start the gateway on a Matrix account and message the bot something that
   invites a choice (e.g. *"give me three lunch options to pick from"*).
3. The reply lands, and a menu appears **directly below it** with one reaction
   per option. **Tap a reaction** — the bot proceeds as if you'd typed that
   choice.
4. Reaction-less fallback: on a platform without reactions (or in the text
   path), the same menu renders as a **numbered list**; reply with the number.
5. Automated: `scripts/run_tests.sh` (or the per-file CI runner) on
   `tests/gateway/test_matrix_reaction_menu.py` and
   `tests/gateway/test_reaction_menu_gateway.py` → 36 passing.

**Platforms tested:** Linux, Matrix via Element. The feature has
been dogfooded live on a self-hosted Matrix homeserver (Continuwuity) over an
extended period — the post-delivery-callback ordering, collapse-keeps-options,
and progress-bubble suppression are all fixes that came out of that dogfooding.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the affected suites via the CI-parity per-file runner — 36 feature
      tests pass, and the upstream suites for the files I touch
      (`tests/gateway/test_matrix.py` 162, `tests/hermes_cli/test_tools_config.py`
      95) stay green
- [x] I've added tests for my changes (36 new tests)
- [x] I've tested on my platform: Linux + Matrix (Element)

### Documentation & Housekeeping

- [x] The toolset is self-documenting (its `toolsets.py` description tells users
      how to enable it); no README/docs change needed — or N/A
- [x] No new config keys — the capability is enabled via `hermes tools`, so
      `cli-config.yaml.example` is unchanged — N/A
- [ ] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform: the only platform-specific path is Matrix reaction
      delivery, which degrades to the numbered-text fallback everywhere else
