### PR TITLE
fix(tui): re-wire sudo/secret callbacks on background and preview-restart threads

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5533,3 +5533,168 @@ def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, t
     assert payload["session_start"] == "2026-01-01T12:00:00"
     assert payload["system_prompt"] == "You are Hermes."
     assert payload["messages"] == history
+
+
+# ── _wire_callbacks called on background / preview-restart threads ────────────
+
+
+def _make_fake_agent_ns():
+    """Minimal namespace that satisfies _background_agent_kwargs getattr calls."""
+    return types.SimpleNamespace(
+        base_url=None,
+        api_key=None,
+        provider=None,
+        api_mode=None,
+        acp_command=None,
+        acp_args=None,
+        model="test-model",
+        enabled_toolsets=None,
+        ephemeral_system_prompt=None,
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        openrouter_min_coding_score=None,
+        reasoning_config=None,
+        service_tier=None,
+        request_overrides={},
+        _fallback_model=None,
+    )
+
+
+def test_prompt_background_wires_callbacks_on_worker_thread(monkeypatch):
+    """prompt.background must call _wire_callbacks on the worker thread before
+    AIAgent.run_conversation so the thread-local sudo/secret callbacks are active.
+
+    The session-build thread wires callbacks once, but threading.local means
+    that wiring never reaches the background worker thread — any terminal
+    command requiring sudo or a skill needing a secret would fall through to
+    /dev/tty and hang the headless gateway.  The fix re-wires inside run().
+    """
+    sid = "bg-wire-sid"
+    wired = []
+    done = threading.Event()
+
+    class _FakeAIAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, **kwargs):
+            done.set()
+            return {"final_response": "ok"}
+
+    server._sessions[sid] = {
+        "agent": _make_fake_agent_ns(),
+        "session_key": "bg-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cwd": "/tmp",
+    }
+
+    monkeypatch.setattr(server, "_wire_callbacks", lambda s: wired.append(s))
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal"])
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: None)
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _s: "/tmp")
+
+    # run_agent triggers a long import chain unavailable in the test venv.
+    # Inject a fake module so the `from run_agent import AIAgent` inside run()
+    # resolves without touching real dependencies.
+    fake_ra = types.ModuleType("run_agent")
+    fake_ra.AIAgent = _FakeAIAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_ra)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.background",
+                "params": {"session_id": sid, "text": "run something"},
+            }
+        )
+        assert resp.get("result"), f"unexpected error: {resp.get('error')}"
+        assert done.wait(timeout=3.0), "background thread never completed run_conversation"
+        assert wired == [sid], (
+            f"_wire_callbacks was not called with the parent sid on the "
+            f"background worker thread; recorded calls: {wired}"
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_preview_restart_wires_callbacks_on_worker_thread(monkeypatch):
+    """preview.restart must call _wire_callbacks on the worker thread before
+    AIAgent.run_conversation.
+
+    This agent explicitly enables the terminal toolset, so sudo prompts are
+    realistic.  Without re-wiring, the thread-local sudo callback is unset and
+    the prompt falls through to /dev/tty, hanging the headless gateway.
+    """
+    sid = "pr-wire-sid"
+    wired = []
+    done = threading.Event()
+
+    class _FakeAIAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, **kwargs):
+            done.set()
+            return {"final_response": "server restarted"}
+
+    server._sessions[sid] = {
+        "agent": _make_fake_agent_ns(),
+        "session_key": "pr-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cwd": "/tmp",
+    }
+
+    monkeypatch.setattr(server, "_wire_callbacks", lambda s: wired.append(s))
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal"])
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: None)
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _s: "/tmp")
+
+    fake_ra = types.ModuleType("run_agent")
+    fake_ra.AIAgent = _FakeAIAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_ra)
+
+    # terminal_tool.register_task_env_overrides is called inside run().
+    # Stub it out so the test doesn't need the real tool chain.
+    fake_tt = types.ModuleType("tools.terminal_tool")
+    fake_tt.register_task_env_overrides = lambda *a, **kw: None
+    fake_tt.clear_task_env_overrides = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "tools.terminal_tool", fake_tt)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "preview.restart",
+                "params": {
+                    "session_id": sid,
+                    "url": "http://localhost:3000",
+                    "cwd": "",
+                    "context": "",
+                },
+            }
+        )
+        assert resp.get("result"), f"unexpected error: {resp.get('error')}"
+        assert done.wait(timeout=3.0), "preview.restart thread never completed run_conversation"
+        assert wired == [sid], (
+            f"_wire_callbacks was not called with the parent sid on the "
+            f"preview.restart worker thread; recorded calls: {wired}"
+        )
+    finally:
+        server._sessions.pop(sid, None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4712,6 +4712,12 @@ def _(rid, params: dict) -> dict:
         try:
             from run_agent import AIAgent
 
+            # The sudo password callback is thread-local (tools.terminal_tool
+            # _callback_tls), so wiring it on the session-build thread doesn't
+            # reach this background thread.  Re-wire here so sudo/secret prompts
+            # route to the parent session's overlay instead of falling through
+            # to /dev/tty and hanging.  (Mirrors _run_prompt_submit.)
+            _wire_callbacks(parent)
             result = AIAgent(
                 **_background_agent_kwargs(session["agent"], task_id)
             ).run_conversation(
@@ -4813,6 +4819,13 @@ def _(rid, params: dict) -> dict:
             if preview_cwd:
                 register_task_env_overrides(task_id, {"cwd": preview_cwd})
 
+            # The sudo password callback is thread-local (tools.terminal_tool
+            # _callback_tls), so wiring it on the session-build thread doesn't
+            # reach this preview thread.  Re-wire here; this agent explicitly
+            # enables the terminal toolset, so sudo prompts are realistic and
+            # must route to the parent session's overlay instead of /dev/tty.
+            # (Mirrors _run_prompt_submit.)
+            _wire_callbacks(parent)
             history_note = (
                 f" (with {len(parent_history)} parent-session messages of context)"
                 if parent_history


### PR DESCRIPTION
## Problem

`prompt.background` and `preview.restart` both spawn a daemon thread and call
`AIAgent.run_conversation()` **without** first calling `_wire_callbacks()`.

The sudo password callback lives in `tools.terminal_tool._callback_tls` — a
`threading.local`.  Wiring it on the session-build thread leaves it invisible
on the new worker thread.  When a terminal command requires sudo the callback
is absent, so the tool falls through to `/dev/tty` and **hangs the headless
gateway**.  The secret-capture callback is a module global but its closure
captures the parent session's sid from whichever session last called
`_wire_callbacks()` — routing the `secret.request` overlay to the wrong client
under concurrent sessions.

`preview.restart` explicitly sets `enabled_toolsets: ["terminal", "file"]`, so
sudo prompts are a realistic scenario (port reclamation, server restarts that
need elevation).  `prompt.background` inherits the parent agent's
`enabled_toolsets`, which commonly includes `terminal`.

## Root cause

`f66a929a6` fixed `_run_prompt_submit` by adding `_wire_callbacks(sid)` at the
top of its `run()` inner function, but the two sibling handlers that also spawn
threads were not updated:

- `@method("prompt.background")` — line 4710
- `@method("preview.restart")` — line 4805

## Fix

Add `_wire_callbacks(parent)` inside each handler's `run()` function before
`AIAgent` is instantiated, mirroring the pattern from `_run_prompt_submit`.

In both handlers `parent = params.get("session_id", "")` is the WebSocket
session id used to key `_sessions` and to route `_emit()` calls, so it is the
correct target for the sudo/secret overlays.

## Tests

Two new unit tests verify that `_wire_callbacks` is called with the parent
session sid on the worker thread before `run_conversation()`:

- `test_prompt_background_wires_callbacks_on_worker_thread`
- `test_preview_restart_wires_callbacks_on_worker_thread`

## Checklist

- [x] `_wire_callbacks(parent)` added to `prompt.background` worker thread
- [x] `_wire_callbacks(parent)` added to `preview.restart` worker thread
- [x] Both additions placed before `AIAgent.run_conversation()`, matching `_run_prompt_submit` order
- [x] Tests confirm callback is wired on the correct thread with the correct sid
- [x] No new test failures introduced (baseline: 48 pre-existing failures unchanged)