### PR TITLE
feat: get version from skill.md

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -8,17 +8,11 @@ from unittest.mock import patch
 import pytest
 
 import tools.skills_tool as skills_tool_module
-from tools.skills_tool import (
-    _get_required_environment_variables,
-    _parse_frontmatter,
-    _parse_tags,
-    _get_category_from_path,
-    _find_all_skills,
-    skill_matches_platform,
-    skills_list,
-    skill_view,
-    MAX_DESCRIPTION_LENGTH,
-)
+from tools.skills_tool import (MAX_DESCRIPTION_LENGTH, _find_all_skills,
+                               _get_category_from_path,
+                               _get_required_environment_variables,
+                               _parse_frontmatter, _parse_tags,
+                               skill_matches_platform, skill_view, skills_list)
 
 
 def _make_skill(
@@ -357,6 +351,24 @@ class TestSkillsList:
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
 
+    def test_includes_version_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha",
+                        frontmatter_extra="version: 1.2.3\n")
+            _make_skill(tmp_path, "beta")
+            raw = skills_list()
+        result = json.loads(raw)
+        by_name = {s["name"]: s for s in result["skills"]}
+        assert by_name["alpha"]["version"] == "1.2.3"
+        assert "version" not in by_name["beta"]
+
+    def test_version_coerced_to_string(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "intver", frontmatter_extra="version: 2\n")
+            raw = skills_list()
+        result = json.loads(raw)
+        assert result["skills"][0]["version"] == "2"
+
 
 # ---------------------------------------------------------------------------
 # skill_view
@@ -372,6 +384,21 @@ class TestSkillView:
         assert result["success"] is True
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
+
+    def test_view_returns_version_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "versioned",
+                        frontmatter_extra="version: 1.2.3\n")
+            raw = skill_view("versioned")
+        result = json.loads(raw)
+        assert result["version"] == "1.2.3"
+
+    def test_view_returns_none_version_when_absent(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "noversion")
+            raw = skill_view("noversion")
+        result = json.loads(raw)
+        assert result["version"] is None
 
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,18 +68,17 @@ Usage:
 
 import json
 import logging
-
-from hermes_constants import get_hermes_home, display_hermes_home
 import os
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
-from tools.registry import registry, tool_error
-from hermes_cli.config import cfg_get
-from utils import env_var_enabled
 from agent.skill_utils import EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS
+from hermes_cli.config import cfg_get
+from hermes_constants import display_hermes_home, get_hermes_home
+from tools.registry import registry, tool_error
+from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -506,7 +505,6 @@ def _parse_tags(tags_value) -> List[str]:
     return [t.strip().strip("\"'") for t in tags_value.split(",") if t.strip()]
 
 
-
 def _get_disabled_skill_names() -> Set[str]:
     """Load disabled skill names from config.
 
@@ -610,13 +608,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
                 category = _get_category_from_path(skill_md)
+                version = frontmatter.get("version")
 
                 seen_names.add(name)
-                skills.append({
+                entry = {
                     "name": name,
                     "description": description,
                     "category": category,
-                })
+                }
+                if version:
+                    entry["version"] = str(version)
+                skills.append(entry)
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
@@ -803,6 +805,7 @@ def _serve_plugin_skill(
             "name": f"{namespace}:{bare}",
             "content": f"{banner}{rendered_content}" if banner else rendered_content,
             "description": description,
+            "version": str(parsed_frontmatter["version"]) if parsed_frontmatter.get("version") else None,
             "linked_files": None,
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
         },
@@ -1346,6 +1349,7 @@ def skill_view(
             "success": True,
             "name": skill_name,
             "description": frontmatter.get("description", ""),
+            "version": str(frontmatter["version"]) if frontmatter.get("version") else None,
             "tags": tags,
             "related_skills": related_skills,
             "content": rendered_content,
@@ -1400,8 +1404,6 @@ def skill_view(
 
     except Exception as e:
         return tool_error(str(e), success=False)
-
-
 
 
 if __name__ == "__main__":
@@ -1495,6 +1497,8 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
+
+
 def _skill_view_with_bump(args, **kw):
     """Invoke skill_view, then bump view_count on success. Best-effort: a
     telemetry failure never breaks the tool call."""


### PR DESCRIPTION
## What does this PR do?

The SKILL.md frontmatter documentation already lists `version: 1.0.0` as a valid optional field, but the `skills_list` / `skill_view` tools never actually read it back to the agent, so the agent has no version information when picking a skill. This PR extracts the `version` field from frontmatter and exposes it through all three return paths: the local skill list, the local skill detail view, and the plugin-served skill detail view.

The implementation follows the existing `frontmatter.get("description", "")` pattern to stay consistent with the surrounding code. `version` is uniformly coerced via `str(...)` so that YAML parsing differences (`1.0.0` → string, `2` → int) don't leak a mixed type to downstream consumers.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/skills_tool.py`
  - `_find_all_skills()`: when frontmatter contains `version`, the list entry carries a `"version"` field (omitted when absent, to avoid noise).
  - `skill_view()`: the returned dict gains `"version": str | None`.
  - `_serve_plugin_skill()`: the plugin-served skill dict also gains `"version": str | None`, matching the local skill path.
- `tests/tools/test_skills_tool.py`
  - `TestSkillsList.test_includes_version_when_present`
  - `TestSkillsList.test_version_coerced_to_string`
  - `TestSkillView.test_view_returns_version_when_present`
  - `TestSkillView.test_view_returns_none_version_when_absent`

## How to Test

1. `scripts/run_tests.sh tests/tools/test_skills_tool.py` — 90 tests passed.
2. Add `version: 1.2.3` to the frontmatter of `~/.hermes/skills/<cat>/demo/SKILL.md`, start the agent, and invoke `skills_list`. The `demo` entry should carry `"version": "1.2.3"`; skills without a version should not carry a `version` key.
3. Invoke `skill_view("demo")`. The returned dict should have `version == "1.2.3"`. For a skill with no `version`, `version is None`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the test suite for the touched file and all tests pass (90/90)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] N/A — module docstring already lists `version` as a valid optional frontmatter field
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — pure data extraction, no platform-specific code
- [x] N/A — tool schemas/descriptions unchanged (only payload gains an extra key)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_skills_tool.py
[100.0% | 90/90 | ✓90 | ✗ 0] ✓ tests/tools/test_skills_tool.py (90✓, 2.2s)
=== Summary: 1 files, 90 tests passed, 0 failed (100% complete) in 2.2s ===
```