### PR TITLE
fix(tools): use display_hermes_home() in cron script validation error messages

### DIFF
--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -500,6 +500,23 @@ class TestCronjobToolScriptValidation:
         ))
         assert result["success"] is False
 
+    def test_absolute_path_error_references_actual_hermes_home(self, cron_env, monkeypatch):
+        """Error message must reflect the configured HERMES_HOME, not hardcoded ~/.hermes."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="/tmp/evil.py",
+        ))
+        assert result["success"] is False
+        # cron_env sets HERMES_HOME to a tmp path — the error must reference it,
+        # not the default ~/.hermes.
+        assert "~/.hermes" not in result["error"]
+        assert str(cron_env) in result["error"]
+
 
 class TestRunJobEnvVarCleanup:
     """Test that run_job() env vars are cleaned up even on early failure."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -395,12 +395,13 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     raw = script.strip()
 
     # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
+    # Only relative paths within $HERMES_HOME/scripts/ are allowed.
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
+        scripts_home = f"{display_hermes_home()}/scripts"
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {scripts_home}/. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts in {scripts_home}/ and use just the filename."
         )
 
     # Validate containment after resolution


### PR DESCRIPTION
## What changed and why

`_validate_cron_script_path` in `tools/cronjob_tools.py` correctly resolves the scripts directory via `get_hermes_home() / "scripts"` at runtime, but the error messages it returns hardcoded `~/.hermes/scripts/`. When `HERMES_HOME` points to a non-default location (e.g. `/opt/data` in Docker), users received misleading guidance directing them to the wrong directory.

The fix replaces the hardcoded string with `display_hermes_home()`, which already existed for exactly this purpose — its docstring says *"Use this in user-facing print/log messages instead of hardcoding `~/.hermes`"* — and was already used in the schema description on line 795 of the same file.

## Changes

- `tools/cronjob_tools.py`: replaced hardcoded `~/.hermes/scripts/` with `f"{display_hermes_home()}/scripts"` in the two error message lines inside `_validate_cron_script_path`
- `tests/cron/test_cron_script.py`: added `test_absolute_path_error_references_actual_hermes_home` regression test that sets `HERMES_HOME` to a temp path and asserts the error message reflects the configured path, not the default `~/.hermes`

## How to test

1. Set `HERMES_HOME=/tmp/custom-home` and attempt to create a cron job with `script="/tmp/evil.py"` — the error should reference `/tmp/custom-home/scripts/`, not `~/.hermes/scripts/`.
2. Run `pytest tests/cron/test_cron_script.py::TestCronjobToolScriptValidation -v` — all 8 tests should pass.

## Platforms tested

- macOS (Apple Silicon)

Fixes #38693