### PR TITLE
fix(auth): parse manual OAuth callback fragments

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3136,7 +3136,9 @@ def _parse_pasted_callback(raw: str) -> dict:
             parsed = urlparse(stripped)
         except Exception:
             return result
-        query = parsed.query or ""
+        query = parsed.query or parsed.fragment or ""
+    elif stripped.startswith("#"):
+        query = stripped[1:]
     elif stripped.startswith("?"):
         query = stripped[1:]
     elif "=" in stripped:

--- a/tests/hermes_cli/test_auth_manual_paste.py
+++ b/tests/hermes_cli/test_auth_manual_paste.py
@@ -112,9 +112,23 @@ def test_parse_callback_url_https_and_extra_params():
     assert out["state"] == "xyz"
 
 
+def test_parse_callback_url_with_fragment_params():
+    out = auth_mod._parse_pasted_callback(
+        "http://127.0.0.1:56121/callback#code=frag-code&state=frag-state"
+    )
+    assert out["code"] == "frag-code"
+    assert out["state"] == "frag-state"
+
+
 def test_parse_bare_query_string_with_leading_question_mark():
     out = auth_mod._parse_pasted_callback("?code=p1&state=s1")
     assert out["code"] == "p1"
+    assert out["state"] == "s1"
+
+
+def test_parse_bare_fragment_with_leading_hash():
+    out = auth_mod._parse_pasted_callback("#code=f1&state=s1")
+    assert out["code"] == "f1"
     assert out["state"] == "s1"
 
 


### PR DESCRIPTION
## What changed
- Treat manual OAuth callback fragments such as `#code=...&state=...` the same way as query-string callbacks.
- Add parser coverage for both full callback URLs with fragments and bare fragment strings.

## Why
The manual-paste fallback already accepts full URLs, `?code=...`, and bare `code=...` strings. Some OAuth copy/paste flows expose the callback parameters in the URL fragment instead, which previously left `code` and `state` empty and caused the fallback to fail validation.

## Before / after
Before, pasting `http://127.0.0.1:56121/callback#code=abc&state=xyz` returned no code or state.

After, the same fragment payload is parsed into the expected callback fields.

## Verification
- `python -m pytest -o addopts= tests\hermes_cli\test_auth_manual_paste.py -q`