### PR TITLE
fix: thread Slack send_message targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -31,6 +31,7 @@ from tools.send_message_tool import (
     _parse_target_ref,
     _send_matrix_via_adapter,
     _send_signal,
+    _send_slack,
     _send_telegram,
     _send_to_platform,
     send_message_tool,
@@ -300,6 +301,135 @@ class TestSendMessageTool:
             media_files=[],
             force_document=False,
         )
+
+    def test_send_to_platform_slack_passes_thread_id(self):
+        slack_cfg = SimpleNamespace(enabled=True, token="xoxb-test", extra={})
+
+        with patch(
+            "tools.send_message_tool._send_slack",
+            new=AsyncMock(return_value={"success": True}),
+        ) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    slack_cfg,
+                    "C123",
+                    "hello",
+                    thread_id="1234567890.123456",
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            "xoxb-test",
+            "C123",
+            "hello",
+            thread_id="1234567890.123456",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_slack_thread_payload_includes_thread_ts_without_broadcast_true(self, monkeypatch):
+        captured = []
+
+        class _FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def json(self):
+                return {"ok": True, "ts": "9876543210.987654"}
+
+        class _FakeSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, url, *, headers=None, json=None, **kwargs):
+                captured.append(json)
+                return _FakeResponse()
+
+        fake_aiohttp = SimpleNamespace(
+            ClientSession=_FakeSession,
+            ClientTimeout=lambda total: SimpleNamespace(total=total),
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr("gateway.platforms.base.resolve_proxy_url", lambda: None)
+        monkeypatch.setattr("gateway.platforms.base.proxy_kwargs_for_aiohttp", lambda _proxy: ({}, {}))
+
+        result = await _send_slack(
+            "xoxb-test",
+            "C123",
+            "hello",
+            thread_id="1234567890.123456",
+        )
+
+        assert result["success"] is True
+        assert captured == [
+            {
+                "channel": "C123",
+                "text": "hello",
+                "mrkdwn": True,
+                "reply_broadcast": False,
+                "thread_ts": "1234567890.123456",
+            }
+        ]
+        assert captured[0].get("reply_broadcast") is not True
+
+    @pytest.mark.asyncio
+    async def test_send_slack_channel_payload_omits_thread_ts(self, monkeypatch):
+        captured = []
+
+        class _FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def json(self):
+                return {"ok": True, "ts": "9876543210.987654"}
+
+        class _FakeSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, url, *, headers=None, json=None, **kwargs):
+                captured.append(json)
+                return _FakeResponse()
+
+        fake_aiohttp = SimpleNamespace(
+            ClientSession=_FakeSession,
+            ClientTimeout=lambda total: SimpleNamespace(total=total),
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr("gateway.platforms.base.resolve_proxy_url", lambda: None)
+        monkeypatch.setattr("gateway.platforms.base.proxy_kwargs_for_aiohttp", lambda _proxy: ({}, {}))
+
+        result = await _send_slack("xoxb-test", "C123", "hello")
+
+        assert result["success"] is True
+        assert captured == [
+            {
+                "channel": "C123",
+                "text": "hello",
+                "mrkdwn": True,
+                "reply_broadcast": False,
+            }
+        ]
+        assert "thread_ts" not in captured[0]
 
     def test_resolved_matrix_thread_name_preserves_thread_id(self):
         matrix_cfg = SimpleNamespace(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -767,7 +767,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(
+                pconfig.token,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+            )
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1049,7 +1054,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None, reply_broadcast=False):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1062,7 +1067,14 @@ async def _send_slack(token, chat_id, message):
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
-            payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            payload = {
+                "channel": chat_id,
+                "text": message,
+                "mrkdwn": True,
+                "reply_broadcast": bool(reply_broadcast),
+            }
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
- Thread standalone Slack send_message calls when the target includes a thread id.
- Add thread_ts to Slack chat.postMessage payloads when provided.
- Set reply_broadcast explicitly false by default so threaded sends do not broadcast unless opted in.

## Verification
- python -m pytest tests/tools/test_send_message_tool.py -q -k 'slack_thread or send_slack_channel or send_to_platform_slack' -o 'addopts='