### PR TITLE
fix(auth): parse Retry-After HTTP dates

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -28,6 +28,7 @@ import stat
 import sys
 import base64
 import hashlib
+import math
 import subprocess
 import threading
 import time
@@ -36,6 +37,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
@@ -753,8 +755,9 @@ def is_rate_limited_auth_error(error: Exception) -> bool:
 def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     """Best-effort parse of a ``Retry-After`` header into whole seconds.
 
-    Supports the delta-seconds form (e.g. ``"120"``). HTTP-date forms and
-    missing/unparseable values return ``None`` rather than guessing.
+    Supports the delta-seconds form (e.g. ``"120"``) and the HTTP-date form
+    allowed by RFC 9110. Missing/unparseable values return ``None`` rather
+    than guessing.
     """
     if headers is None:
         return None
@@ -767,7 +770,16 @@ def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     try:
         seconds = int(str(raw).strip())
     except (TypeError, ValueError):
-        return None
+        try:
+            retry_at = parsedate_to_datetime(str(raw).strip())
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        delta = (
+            retry_at.astimezone(timezone.utc) - datetime.now(timezone.utc)
+        ).total_seconds()
+        return max(0, math.ceil(delta))
     return seconds if seconds >= 0 else None
 
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -3,6 +3,8 @@
 import json
 import time
 import base64
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -602,6 +604,28 @@ def test_refresh_429_without_retry_after_header(monkeypatch):
     assert err.code == CODEX_RATE_LIMITED_CODE
     assert err.relogin_required is False
     assert "quota exhausted" in str(err).lower()
+
+
+def test_parse_retry_after_http_date():
+    """Retry-After may be an HTTP-date, not only delta-seconds."""
+    from hermes_cli.auth import _parse_retry_after_seconds
+
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=90)
+    header = format_datetime(retry_at, usegmt=True)
+
+    parsed = _parse_retry_after_seconds({"retry-after": header})
+
+    assert parsed is not None
+    assert 0 < parsed <= 90
+
+
+def test_parse_retry_after_past_http_date_returns_zero():
+    from hermes_cli.auth import _parse_retry_after_seconds
+
+    retry_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+    header = format_datetime(retry_at, usegmt=True)
+
+    assert _parse_retry_after_seconds({"retry-after": header}) == 0
 
 
 def test_is_rate_limited_auth_error_distinguishes_credential_errors():


### PR DESCRIPTION
## What changed
- Extend `_parse_retry_after_seconds` to support the HTTP-date form of `Retry-After` in addition to delta-seconds.
- Add focused tests for future and past HTTP-date retry headers.

## Why
`Retry-After` can legally be sent as either seconds or an HTTP-date. Hermes already uses the parsed value in auth rate-limit messages, but date-form headers were treated as unparseable, so users could lose useful retry timing guidance.

## Before / after
Before, `Retry-After: <HTTP-date>` returned `None` and produced a generic quota/rate-limit message.

After, date-form headers are converted to whole seconds, while expired/past dates resolve to `0` and malformed values still return `None`.

## Verification
- `python -m pytest -o addopts= tests\hermes_cli\test_auth_codex_provider.py -q`