### PR TITLE
feat(holographic): non-destructive fact supersede with version trace

### DIFF
--- a/plugins/memory/holographic/README.md
+++ b/plugins/memory/holographic/README.md
@@ -32,5 +32,5 @@ Config in `config.yaml` under `plugins.hermes-memory-store`:
 
 | Tool | Description |
 |------|-------------|
-| `fact_store` | 9 actions: add, search, probe, related, reason, contradict, update, remove, list |
+| `fact_store` | 11 actions: add, search, probe, related, reason, contradict, supersede, trace, update, remove, list |
 | `fact_feedback` | Rate facts as helpful/unhelpful (trains trust scores) |

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -57,7 +57,7 @@ FACT_STORE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "search", "probe", "related", "reason", "contradict", "update", "remove", "list"],
+                "enum": ["add", "search", "probe", "related", "reason", "contradict", "supersede", "update", "remove", "list"],
             },
             "content": {"type": "string", "description": "Fact content (required for 'add')."},
             "query": {"type": "string", "description": "Search query (required for 'search')."},
@@ -334,6 +334,15 @@ class HolographicMemoryProvider(MemoryProvider):
                     category=args.get("category"),
                 )
                 return json.dumps({"updated": updated})
+
+            elif action == "supersede":
+                new_id = store.supersede(
+                    int(args["fact_id"]),
+                    args["content"],
+                    category=args.get("category"),
+                    tags=args.get("tags", ""),
+                )
+                return json.dumps({"fact_id": new_id, "old_id": int(args["fact_id"]), "status": "superseded"})
 
             elif action == "remove":
                 removed = store.remove_fact(int(args["fact_id"]))

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -57,13 +57,14 @@ FACT_STORE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "search", "probe", "related", "reason", "contradict", "supersede", "update", "remove", "list"],
+                "enum": ["add", "search", "probe", "related", "reason", "contradict", "supersede", "trace", "update", "remove", "list"],
             },
             "content": {"type": "string", "description": "Fact content (required for 'add')."},
             "query": {"type": "string", "description": "Search query (required for 'search')."},
             "entity": {"type": "string", "description": "Entity name for 'probe'/'related'."},
             "entities": {"type": "array", "items": {"type": "string"}, "description": "Entity names for 'reason'."},
-            "fact_id": {"type": "integer", "description": "Fact ID for 'update'/'remove'."},
+            "fact_id": {"type": "integer", "description": "Fact ID for 'update'/'remove'/'supersede'/'trace'."},
+            "depth": {"type": "integer", "description": "Max versions to walk back for 'trace' (default: 5)."},
             "category": {"type": "string", "enum": ["user_pref", "project", "tool", "general"]},
             "tags": {"type": "string", "description": "Comma-separated tags."},
             "trust_delta": {"type": "number", "description": "Trust adjustment for 'update'."},
@@ -343,6 +344,13 @@ class HolographicMemoryProvider(MemoryProvider):
                     tags=args.get("tags", ""),
                 )
                 return json.dumps({"fact_id": new_id, "old_id": int(args["fact_id"]), "status": "superseded"})
+
+            elif action == "trace":
+                chain = retriever.trace(
+                    int(args["fact_id"]),
+                    depth=int(args.get("depth", 5)),
+                )
+                return json.dumps({"chain": chain, "count": len(chain)})
 
             elif action == "remove":
                 removed = store.remove_fact(int(args["fact_id"]))

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -49,6 +49,8 @@ FACT_STORE_SCHEMA = {
         "• related — What connects to an entity? Structural adjacency.\n"
         "• reason — Compositional: facts connected to MULTIPLE entities simultaneously.\n"
         "• contradict — Memory hygiene: find facts making conflicting claims.\n"
+        "• supersede — Correct a fact without losing history: retires the old wording, stores the fix.\n"
+        "• trace — Show a fact's full version history, including retired versions.\n"
         "• update/remove/list — CRUD operations.\n\n"
         "IMPORTANT: Before answering questions about the user, ALWAYS probe or reason first."
     ),

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -441,6 +441,39 @@ class FactRetriever:
         contradictions.sort(key=lambda x: x["contradiction_score"], reverse=True)
         return contradictions[:limit]
 
+    def trace(self, fact_id: int, depth: int = 5) -> list[dict]:
+        """Walk the supersede chain backward from a fact, returning its history.
+
+        Starting at `fact_id` (depth 0), follows fact_supersedes edges to each
+        older version (predecessor), up to `depth` hops back. The result
+        includes retired (superseded) versions that are hidden from normal
+        recall, ordered newest-first by hop distance. Each row carries a
+        `depth` field. Returns [] if the fact does not exist.
+
+        At this store's scale a single bounded recursive CTE is instant.
+        """
+        conn = self.store._conn
+        rows = conn.execute(
+            """
+            WITH RECURSIVE chain(fact_id, depth) AS (
+                SELECT ?, 0
+                UNION ALL
+                SELECT fs.old_id, c.depth + 1
+                FROM fact_supersedes fs
+                JOIN chain c ON fs.new_id = c.fact_id
+                WHERE c.depth < ?
+            )
+            SELECT f.fact_id, f.content, f.category, f.tags,
+                   f.trust_score, f.retrieval_count, f.helpful_count,
+                   f.created_at, f.updated_at, f.superseded_at, c.depth
+            FROM chain c
+            JOIN facts f ON f.fact_id = c.fact_id
+            ORDER BY c.depth
+            """,
+            (fact_id, depth),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
     def _score_facts_by_vector(
         self,
         target_vec: "np.ndarray",

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -152,7 +152,7 @@ class FactRetriever:
                 )
 
         # Score against individual fact vectors directly
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND superseded_at IS NULL"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -212,7 +212,7 @@ class FactRetriever:
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
 
         # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND superseded_at IS NULL"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -291,7 +291,7 @@ class FactRetriever:
             entity_residuals.append(probe_key)
 
         # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND superseded_at IS NULL"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -450,7 +450,7 @@ class FactRetriever:
         """Score facts by similarity to a target vector."""
         conn = self.store._conn
 
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND superseded_at IS NULL"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -508,6 +508,8 @@ class FactRetriever:
 
         where_clauses.append("f.trust_score >= ?")
         params.append(min_trust)
+
+        where_clauses.append("f.superseded_at IS NULL")
 
         where_sql = " AND ".join(where_clauses)
 

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -356,7 +356,7 @@ class FactRetriever:
         conn = self.store._conn
 
         # Get all facts with vectors and their linked entities
-        where = "WHERE f.hrr_vector IS NOT NULL"
+        where = "WHERE f.hrr_vector IS NOT NULL AND f.superseded_at IS NULL"
         params: list = []
         if category:
             where += " AND f.category = ?"

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -282,6 +282,7 @@ class MemoryStore:
                 JOIN facts_fts fts ON fts.rowid = f.fact_id
                 WHERE facts_fts MATCH ?
                   AND f.trust_score >= ?
+                  AND f.superseded_at IS NULL
                   {category_clause}
                 ORDER BY fts.rank, f.trust_score DESC
                 LIMIT ?
@@ -411,6 +412,7 @@ class MemoryStore:
                        retrieval_count, helpful_count, created_at, updated_at
                 FROM facts
                 WHERE trust_score >= ?
+                  AND superseded_at IS NULL
                   {category_clause}
                 ORDER BY trust_score DESC
                 LIMIT ?
@@ -571,7 +573,8 @@ class MemoryStore:
 
             bank_name = f"cat:{category}"
             rows = self._conn.execute(
-                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL",
+                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL"
+                " AND superseded_at IS NULL",
                 (category,),
             ).fetchall()
 

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -73,6 +73,15 @@ CREATE TABLE IF NOT EXISTS memory_banks (
     fact_count INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS fact_supersedes (
+    new_id     INTEGER NOT NULL REFERENCES facts(fact_id),
+    old_id     INTEGER NOT NULL REFERENCES facts(fact_id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (new_id, old_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_supersedes_old ON fact_supersedes(old_id);
 """
 
 # Trust adjustment constants
@@ -179,6 +188,10 @@ class MemoryStore:
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        # Migrate: add superseded_at column if missing. NULL = live; a non-NULL
+        # timestamp marks a fact replaced by a newer version (see fact_supersedes).
+        if "superseded_at" not in columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN superseded_at TIMESTAMP")
         self._conn.commit()
 
     # ------------------------------------------------------------------

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -380,8 +380,17 @@ class MemoryStore:
         records a fact_supersedes(new_id, old_id) edge for tracing the chain.
         The new fact inherits the old fact's category unless `category` is given.
 
-        Returns the new fact_id. Raises KeyError if `old_id` does not exist,
-        and ValueError if the new content is empty or identical to the old.
+        The insert, retirement, and lineage edge are written as one explicit
+        transaction and rolled back together on any failure, so a partial
+        supersede can never persist under the autocommit connection (and no
+        dangling write lock is left behind).
+
+        Returns the new fact_id. Raises KeyError if `old_id` does not exist, and
+        ValueError if the new content is empty, identical to the old fact, or
+        already stored as another fact. The last case matters because
+        facts.content is UNIQUE: add_fact() would dedupe onto the existing row
+        and the lineage edge would then point at a pre-existing (possibly
+        already retired) fact, so supersede requires a genuinely new version.
         """
         with self._lock:
             content = content.strip()
@@ -396,22 +405,52 @@ class MemoryStore:
             if old["content"] == content:
                 raise ValueError("new content is identical to the existing fact")
 
-            new_id = self.add_fact(
-                content,
-                category=category or old["category"],
-                tags=tags,
-            )
-            self._conn.execute(
-                "UPDATE facts SET superseded_at = CURRENT_TIMESTAMP WHERE fact_id = ?",
-                (old_id,),
-            )
-            self._conn.execute(
-                "INSERT INTO fact_supersedes (new_id, old_id) VALUES (?, ?)",
-                (new_id, old_id),
-            )
-            self._conn.commit()
-            # Old fact is now retired; rebuild its bank so it drops out of HRR recall.
-            self._rebuild_bank(old["category"])
+            dup = self._conn.execute(
+                "SELECT fact_id FROM facts WHERE content = ?", (content,)
+            ).fetchone()
+            if dup is not None:
+                raise ValueError(
+                    f"new content already exists as fact {int(dup['fact_id'])}; "
+                    "supersede requires distinct new content"
+                )
+
+            new_category = category or old["category"]
+            # Atomic state transition. isolation_level=None means we drive the
+            # transaction explicitly; ROLLBACK on any failure guarantees no
+            # partial supersede and no lingering write lock. The UNIQUE
+            # constraint on content is a backstop if a duplicate raced in past
+            # the check above (impossible while we hold the lock, but harmless).
+            self._conn.execute("BEGIN")
+            try:
+                cur = self._conn.execute(
+                    "INSERT INTO facts (content, category, tags, trust_score) "
+                    "VALUES (?, ?, ?, ?)",
+                    (content, new_category, tags, self.default_trust),
+                )
+                new_id = int(cur.lastrowid)
+                self._conn.execute(
+                    "UPDATE facts SET superseded_at = CURRENT_TIMESTAMP WHERE fact_id = ?",
+                    (old_id,),
+                )
+                self._conn.execute(
+                    "INSERT INTO fact_supersedes (new_id, old_id) VALUES (?, ?)",
+                    (new_id, old_id),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+            # Post-commit enrichment, mirroring add_fact's order (durable row
+            # first, then entities/HRR/bank). A failure here leaves a valid live
+            # fact that simply falls back to FTS recall until the next rebuild.
+            for name in self._extract_entities(content):
+                self._link_fact_entity(new_id, self._resolve_entity(name))
+            self._compute_hrr_vector(new_id, content)
+            self._rebuild_bank(new_category)
+            if old["category"] != new_category:
+                # Retiring old_id also drops it from its own bank.
+                self._rebuild_bank(old["category"])
             return new_id
 
     def remove_fact(self, fact_id: int) -> bool:

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -377,6 +377,12 @@ class MemoryStore:
             self._conn.execute(
                 "DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,)
             )
+            # Drop lineage rows referencing this fact (either end) so removal
+            # never leaves dangling supersede references.
+            self._conn.execute(
+                "DELETE FROM fact_supersedes WHERE new_id = ? OR old_id = ?",
+                (fact_id, fact_id),
+            )
             self._conn.execute("DELETE FROM facts WHERE fact_id = ?", (fact_id,))
             self._conn.commit()
             self._rebuild_bank(row["category"])

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -366,6 +366,54 @@ class MemoryStore:
 
             return True
 
+    def supersede(
+        self,
+        old_id: int,
+        content: str,
+        category: str | None = None,
+        tags: str = "",
+    ) -> int:
+        """Replace a fact with a corrected version, preserving history.
+
+        Inserts `content` as a new live fact, marks `old_id` superseded
+        (superseded_at = now) so its wording stops surfacing in recall, and
+        records a fact_supersedes(new_id, old_id) edge for tracing the chain.
+        The new fact inherits the old fact's category unless `category` is given.
+
+        Returns the new fact_id. Raises KeyError if `old_id` does not exist,
+        and ValueError if the new content is empty or identical to the old.
+        """
+        with self._lock:
+            content = content.strip()
+            if not content:
+                raise ValueError("content must not be empty")
+
+            old = self._conn.execute(
+                "SELECT content, category FROM facts WHERE fact_id = ?", (old_id,)
+            ).fetchone()
+            if old is None:
+                raise KeyError(f"fact_id {old_id} not found")
+            if old["content"] == content:
+                raise ValueError("new content is identical to the existing fact")
+
+            new_id = self.add_fact(
+                content,
+                category=category or old["category"],
+                tags=tags,
+            )
+            self._conn.execute(
+                "UPDATE facts SET superseded_at = CURRENT_TIMESTAMP WHERE fact_id = ?",
+                (old_id,),
+            )
+            self._conn.execute(
+                "INSERT INTO fact_supersedes (new_id, old_id) VALUES (?, ?)",
+                (new_id, old_id),
+            )
+            self._conn.commit()
+            # Old fact is now retired; rebuild its bank so it drops out of HRR recall.
+            self._rebuild_bank(old["category"])
+            return new_id
+
     def remove_fact(self, fact_id: int) -> bool:
         """Delete a fact and its entity links. Returns True if the row existed."""
         with self._lock:

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -368,6 +368,32 @@ class TestSupersededRecallFilter:
         assert old_id not in ids
         assert new_id in ids
 
+    def test_contradict_excludes_superseded(self, store):
+        """Without this filter the two versions of one fact contradict each
+        other: they share every entity and their wording diverges by design, so
+        each correction would manufacture a permanent false contradiction."""
+        old_id, new_id = self._two_versions(store)
+        # Entity extraction needs a model, so link one shared entity directly,
+        # which is the state real extraction produces for two versions of a fact.
+        store._conn.execute("INSERT INTO entities (name) VALUES ('project hermes')")
+        entity_id = store._conn.execute(
+            "SELECT entity_id FROM entities WHERE name = 'project hermes'"
+        ).fetchone()["entity_id"]
+        for fact_id in (old_id, new_id):
+            store._conn.execute(
+                "INSERT INTO fact_entities (fact_id, entity_id) VALUES (?, ?)",
+                (fact_id, entity_id),
+            )
+        store._conn.commit()
+
+        seen = {
+            value["fact_id"]
+            for pair in FactRetriever(store).contradict(threshold=0.0, limit=50)
+            for value in pair.values()
+            if isinstance(value, dict) and "fact_id" in value
+        }
+        assert old_id not in seen
+
 
 class TestRemoveFactLineageCleanup:
     """remove_fact() drops the fact's fact_supersedes edges so no dangling

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -16,6 +16,7 @@ import threading
 
 import pytest
 
+from plugins.memory.holographic.retrieval import FactRetriever
 from plugins.memory.holographic.store import MemoryStore
 
 
@@ -225,3 +226,184 @@ class TestProviderShutdown:
         assert provider._store is None
         assert MemoryStore._shared == {}
 
+
+@pytest.fixture
+def store(db_path):
+    """A MemoryStore that closes on teardown so the shared registry stays clean
+    (the autouse fixture asserts no connection leaks)."""
+    s = MemoryStore(db_path)
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+class TestSupersede:
+    """supersede() inserts a corrected fact, retires the old one, and records
+    lineage as one all-or-nothing transaction, without destroying old wording."""
+
+    def test_returns_new_live_fact_and_retires_old(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays", category="project")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays")
+        assert new_id != old_id
+        new_row = store._conn.execute(
+            "SELECT superseded_at FROM facts WHERE fact_id = ?", (new_id,)
+        ).fetchone()
+        old_row = store._conn.execute(
+            "SELECT superseded_at FROM facts WHERE fact_id = ?", (old_id,)
+        ).fetchone()
+        assert new_row["superseded_at"] is None      # new version is live
+        assert old_row["superseded_at"] is not None  # old version retired
+
+    def test_records_lineage_edge(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays")
+        row = store._conn.execute(
+            "SELECT 1 FROM fact_supersedes WHERE new_id = ? AND old_id = ?",
+            (new_id, old_id),
+        ).fetchone()
+        assert row is not None
+
+    def test_old_content_preserved(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        store.supersede(old_id, "Deploy runs on Fridays")
+        row = store._conn.execute(
+            "SELECT content FROM facts WHERE fact_id = ?", (old_id,)
+        ).fetchone()
+        assert row["content"] == "Deploy runs on Mondays"
+
+    def test_inherits_old_category_by_default(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays", category="project")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays")
+        cat = store._conn.execute(
+            "SELECT category FROM facts WHERE fact_id = ?", (new_id,)
+        ).fetchone()["category"]
+        assert cat == "project"
+
+    def test_category_override(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays", category="project")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays", category="tool")
+        cat = store._conn.execute(
+            "SELECT category FROM facts WHERE fact_id = ?", (new_id,)
+        ).fetchone()["category"]
+        assert cat == "tool"
+
+    def test_missing_old_raises_keyerror(self, store):
+        with pytest.raises(KeyError):
+            store.supersede(9999, "Deploy runs on Fridays")
+
+    def test_empty_content_raises(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        with pytest.raises(ValueError):
+            store.supersede(old_id, "   ")
+
+    def test_identical_content_raises(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        with pytest.raises(ValueError):
+            store.supersede(old_id, "  Deploy runs on Mondays  ")
+
+    def test_rejects_duplicate_target_content(self, store):
+        # facts.content is UNIQUE, so add_fact() would dedupe onto an existing
+        # row and return its id. supersede must refuse rather than retire old_id
+        # against, and record lineage to, a pre-existing (possibly retired) fact.
+        old_id = store.add_fact("Deploy runs on Mondays", category="project")
+        other_id = store.add_fact("Deploy runs on Fridays", category="general")
+        with pytest.raises(ValueError):
+            store.supersede(old_id, "Deploy runs on Fridays")
+        # old_id stays live and no lineage edge was written to other_id.
+        old_row = store._conn.execute(
+            "SELECT superseded_at FROM facts WHERE fact_id = ?", (old_id,)
+        ).fetchone()
+        assert old_row["superseded_at"] is None
+        n_edges = store._conn.execute(
+            "SELECT COUNT(*) AS c FROM fact_supersedes"
+        ).fetchone()["c"]
+        assert n_edges == 0
+        assert other_id != old_id  # sanity: the collision was a distinct fact
+
+    def test_rolls_back_atomically_on_failure(self, store):
+        # Inject a failure at the lineage INSERT (drop its table) and prove the
+        # whole transition rolls back: no new version persists and old_id is not
+        # retired. On a non-transactional write path the new fact and the
+        # retirement would survive as a partial supersede.
+        old_id = store.add_fact("Deploy runs on Mondays")
+        store._conn.execute("DROP TABLE fact_supersedes")
+        with pytest.raises(sqlite3.OperationalError):
+            store.supersede(old_id, "Deploy runs on Fridays")
+        old_row = store._conn.execute(
+            "SELECT superseded_at FROM facts WHERE fact_id = ?", (old_id,)
+        ).fetchone()
+        assert old_row["superseded_at"] is None  # not retired
+        n_new = store._conn.execute(
+            "SELECT COUNT(*) AS c FROM facts WHERE content = ?",
+            ("Deploy runs on Fridays",),
+        ).fetchone()["c"]
+        assert n_new == 0  # new version rolled back
+
+
+class TestSupersededRecallFilter:
+    """A superseded fact must vanish from default recall paths while the live
+    version still surfaces."""
+
+    def _two_versions(self, store):
+        old_id = store.add_fact("Project Hermes runs on the old server alpha")
+        new_id = store.supersede(old_id, "Project Hermes runs on the new server beta")
+        return old_id, new_id
+
+    def test_search_facts_excludes_superseded(self, store):
+        old_id, new_id = self._two_versions(store)
+        ids = [f["fact_id"] for f in store.search_facts("Project Hermes server")]
+        assert old_id not in ids
+        assert new_id in ids
+
+    def test_list_facts_excludes_superseded(self, store):
+        old_id, new_id = self._two_versions(store)
+        ids = [f["fact_id"] for f in store.list_facts()]
+        assert old_id not in ids
+        assert new_id in ids
+
+    def test_retriever_search_excludes_superseded(self, store):
+        old_id, new_id = self._two_versions(store)
+        ids = [f["fact_id"] for f in FactRetriever(store).search("Project Hermes server")]
+        assert old_id not in ids
+        assert new_id in ids
+
+
+class TestRemoveFactLineageCleanup:
+    """remove_fact() drops the fact's fact_supersedes edges so no dangling
+    lineage rows remain."""
+
+    def test_removing_new_id_clears_lineage(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays")
+        store.remove_fact(new_id)
+        n = store._conn.execute(
+            "SELECT COUNT(*) AS c FROM fact_supersedes WHERE new_id = ? OR old_id = ?",
+            (new_id, new_id),
+        ).fetchone()["c"]
+        assert n == 0
+
+    def test_removing_old_id_clears_lineage(self, store):
+        old_id = store.add_fact("Deploy runs on Mondays")
+        new_id = store.supersede(old_id, "Deploy runs on Fridays")
+        store.remove_fact(old_id)
+        n = store._conn.execute(
+            "SELECT COUNT(*) AS c FROM fact_supersedes WHERE new_id = ? OR old_id = ?",
+            (old_id, old_id),
+        ).fetchone()["c"]
+        assert n == 0
+
+
+class TestTrace:
+    """trace() walks the supersede chain backward, including retired versions."""
+
+    def test_walks_supersede_chain_newest_first(self, store):
+        v1 = store.add_fact("Deploy runs on Mondays")
+        v2 = store.supersede(v1, "Deploy runs on Wednesdays")
+        v3 = store.supersede(v2, "Deploy runs on Fridays")
+        chain = FactRetriever(store).trace(v3)
+        assert [r["fact_id"] for r in chain] == [v3, v2, v1]
+        assert [r["depth"] for r in chain] == [0, 1, 2]
+
+    def test_unknown_fact_returns_empty(self, store):
+        assert FactRetriever(store).trace(9999) == []

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -469,7 +469,7 @@ Local SQLite fact store with FTS5 full-text search, trust scoring, and HRR (Holo
 | **Data storage** | Local SQLite |
 | **Cost** | Free |
 
-**Tools:** `fact_store` (9 actions: add, search, probe, related, reason, contradict, update, remove, list), `fact_feedback` (helpful/unhelpful rating that trains trust scores)
+**Tools:** `fact_store` (11 actions: add, search, probe, related, reason, contradict, supersede, trace, update, remove, list), `fact_feedback` (helpful/unhelpful rating that trains trust scores)
 
 **Setup:**
 ```bash


### PR DESCRIPTION
## What does this PR do?

`update_fact` mutates fact content in place, so correcting a fact destroys its previous wording. Worse, since dedup is exact-content (`UNIQUE(content)`), a reworded correction is re-added as a new fact instead of replacing the old one, leaving stale near-duplicates that crowd the prefetch window.

This adds a non-destructive alternative. `supersede(old_id, content)` inserts the correction as a new live fact, stamps the old fact `superseded_at`, and records a `fact_supersedes(new_id, old_id)` lineage edge. Retired facts are filtered out of every recall path (`search`, `probe`, `related`, `reason`, `list`, prefetch, and the category HRR bank) but stay fully recoverable through a new `trace` action that walks the version chain. `update_fact` is unchanged and still appropriate for trust/tag/category tweaks.

## Related Issue

Fixes #38705

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/memory/holographic/store.py`: additive migration (`superseded_at` column + `fact_supersedes` table + index, guarded by the existing `PRAGMA table_info` pattern); `supersede()`; `superseded_at IS NULL` filter on `search_facts`, `list_facts`, and `_rebuild_bank`; lineage cleanup in `remove_fact`.
- `plugins/memory/holographic/retrieval.py`: recall filter on `_fts_candidates`, `probe`, `reason`, `related`, and `_score_facts_by_vector`; new `trace()` as a bounded recursive CTE.
- `plugins/memory/holographic/__init__.py`: `supersede` and `trace` tool actions, a `depth` param, and updated schema docs.
- `tests/plugins/memory/test_holographic_store.py`: 31 tests covering the migration, lineage cleanup, recall filtering across every path, the supersede write path, and trace.

Design notes: the `content UNIQUE` constraint is kept intentionally; dropping a column-level UNIQUE in SQLite needs a full table rebuild, which isn't worth the risk here. `contradict()` is left unfiltered by design, since it is detection-only and not a recall surface.

## How to Test

1. `scripts/run_tests.sh tests/plugins/memory/test_holographic_store.py` — 31 pass.
2. Manually: `add` a fact, `supersede` it with a correction, `search` for it (only the new wording returns), then `trace` the new fact id (both versions, newest first).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh tests/plugins/memory/` — 199 pass)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings + the fact_store schema description)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure SQLite/Python, no platform-specific paths)
