### PR TITLE
fix(security): reject skill_view name traversal that escapes trusted skills dir

### DIFF
--- a/tests/tools/test_skill_view_traversal.py
+++ b/tests/tools/test_skill_view_traversal.py
@@ -80,3 +80,81 @@ class TestPathTraversalBlocked:
         assert result["success"] is False
         assert "sk-do-not-leak" not in result.get("content", "")
         assert "sk-do-not-leak" not in json.dumps(result)
+
+
+@pytest.fixture()
+def fake_skills_with_sibling(tmp_path):
+    """Skills dir containing one legit skill, plus a sibling skill *outside*
+    the trusted skills root that holds a SKILL.md and a sensitive .env file.
+
+    Simulates issue #38643: the untrusted ``name`` parameter (not
+    ``file_path``) is used to escape the trusted skills directory via ``..``.
+    """
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Test Skill\nlegit body.")
+
+    # A real category sub-directory inside the skills root. Strategy 1b
+    # (categorized form) only escapes when the intermediate segment exists on
+    # disk, so "mlops:../../outside-skill" -> skills/mlops/../../outside-skill
+    # is needed to exercise the categorized escape rather than failing on a
+    # non-existent intermediate component.
+    (skills_dir / "mlops").mkdir()
+
+    # Sibling skill *outside* skills_dir (one level up): SKILLS_DIR/../outside-skill
+    outside = tmp_path / "outside-skill"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("# Outside Skill\nLEAKED-SKILL-BODY")
+    (outside / ".env").write_text("SECRET_API_KEY=sk-do-not-leak")
+
+    # Deeper escape target two levels up: SKILLS_DIR/../../far-skill
+    far = tmp_path.parent / "far-skill"
+    far.mkdir(exist_ok=True)
+    (far / "SKILL.md").write_text("# Far Skill\nFAR-LEAKED-BODY")
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+        yield {"skills_dir": skills_dir, "outside": outside, "far": far}
+
+
+class TestNameParameterTraversal:
+    """Issue #38643: the ``name`` parameter must not escape the trusted skills
+    directory. ``name='../outside-skill'`` previously selected and served a
+    SKILL.md (and, via file_path, sibling files like .env) from outside the
+    trusted root with only a logged warning.
+    """
+
+    def test_name_dotdot_selects_sibling_skill_md_rejected(self, fake_skills_with_sibling):
+        """``name='../outside-skill'`` must be rejected, not serve the sibling."""
+        result = json.loads(skill_view("../outside-skill"))
+        assert result["success"] is False
+        assert "LEAKED-SKILL-BODY" not in json.dumps(result)
+
+    def test_name_dotdot_plus_env_file_path_rejected(self, fake_skills_with_sibling):
+        """``name='../outside-skill'`` + ``file_path='.env'`` must not leak .env."""
+        result = json.loads(skill_view("../outside-skill", file_path=".env"))
+        assert result["success"] is False
+        assert "sk-do-not-leak" not in json.dumps(result)
+
+    def test_name_nested_dotdot_rejected(self, fake_skills_with_sibling):
+        """A deeper ``../../`` escape must also be rejected."""
+        result = json.loads(skill_view("../../far-skill"))
+        assert result["success"] is False
+        assert "FAR-LEAKED-BODY" not in json.dumps(result)
+
+    def test_legit_name_still_resolves(self, fake_skills_with_sibling):
+        """Containment must not break normal in-root lookups."""
+        result = json.loads(skill_view("test-skill"))
+        assert result["success"] is True
+
+    def test_categorized_name_traversal_rejected(self, fake_skills_with_sibling):
+        """The categorized (namespaced) form must not escape either.
+
+        With a real intermediate category dir present, ``mlops:../../outside-skill``
+        becomes the on-disk path ``skills/mlops/../../outside-skill`` (Strategy
+        1b), which normalizes above the skills root. On unpatched main this
+        served the sibling SKILL.md; it must now be rejected.
+        """
+        result = json.loads(skill_view("mlops:../../outside-skill"))
+        assert result["success"] is False
+        assert "LEAKED-SKILL-BODY" not in json.dumps(result)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -956,24 +956,34 @@ def skill_view(
             seen_md.add(key)
             candidates.append((sd, smd))
 
+        from tools.path_security import validate_within_dir
+
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
+            #
+            # Security: `name` is untrusted. A value like "../outside-skill"
+            # would resolve `direct_path` outside `search_dir` and let an
+            # attacker select a SKILL.md (and, via file_path, sibling files
+            # such as .env) from outside the trusted skills root. Reject any
+            # candidate that escapes `search_dir` before recording it.
             direct_path = search_dir / name
-            if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists():
-                _record(None, direct_path.with_suffix(".md"))
+            if validate_within_dir(direct_path, search_dir) is None:
+                if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
+                    _record(direct_path, direct_path / "SKILL.md")
+                elif direct_path.with_suffix(".md").exists():
+                    _record(None, direct_path.with_suffix(".md"))
 
             # Strategy 1b: categorized form for plugin namespace fall-through
             # (e.g., a "myplugin:explore" name with no plugin registered also
             # tries the on-disk path "myplugin/explore").
             if local_category_name:
                 categorized_path = search_dir / local_category_name
-                if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(".md").exists():
-                    _record(None, categorized_path.with_suffix(".md"))
+                if validate_within_dir(categorized_path, search_dir) is None:
+                    if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
+                        _record(categorized_path, categorized_path / "SKILL.md")
+                    elif categorized_path.with_suffix(".md").exists():
+                        _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name).
@@ -1066,6 +1076,45 @@ def skill_view(
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
             logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
 
+        # Security (defense in depth): fail closed when the selected skill's
+        # *logical* path escapes every trusted root via ``..`` traversal.
+        #
+        # This is deliberately a LEXICAL check (normpath collapses ``..``
+        # without touching the filesystem) rather than reusing the symlink-
+        # resolving `_outside_skills_dir` flag above. A skill legitimately
+        # placed under SKILLS_DIR through a symlinked category dir (e.g.
+        # ``skills/linked -> /external/repo``) has its logical path INSIDE the
+        # root even though ``resolve()`` jumps outside — that case must keep
+        # working. Only a path that lexically climbs above every trusted root
+        # (the issue #38643 ``name='../...'`` traversal) is rejected here.
+        def _lexically_within(child: Path, root: Path) -> bool:
+            try:
+                c = os.path.normpath(str(child))
+                r = os.path.normpath(str(root))
+            except Exception:
+                return False
+            return c == r or c.startswith(r + os.sep)
+
+        # Trusted roots = the local skills dir plus every configured external
+        # dir. `all_dirs` already contains SKILLS_DIR when it exists; include
+        # it explicitly so the check is correct even before first install.
+        _logical_roots = [SKILLS_DIR, *all_dirs]
+        if not any(_lexically_within(skill_md, _root) for _root in _logical_roots):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        "Skill resolves outside the trusted skills directory — "
+                        "refusing to read."
+                    ),
+                    "hint": (
+                        "Load skills by name or by a relative path within your "
+                        "skills directory; '..' traversal is not allowed."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
         parsed_frontmatter: Dict[str, Any] = {}
         try:
             parsed_frontmatter, _ = _parse_frontmatter(content)
@@ -1098,7 +1147,7 @@ def skill_view(
 
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:
-            from tools.path_security import validate_within_dir, has_traversal_component
+            from tools.path_security import has_traversal_component
 
             # Security: Prevent path traversal attacks
             if has_traversal_component(file_path):


### PR DESCRIPTION
## What does this PR do?

Closes a path-traversal information-disclosure in `skill_view` (`tools/skills_tool.py`) reachable through the **`name`** parameter — distinct from the previously-fixed `file_path` vector.

`name` is untrusted but was joined directly onto each search directory during candidate selection (Strategy 1 / 1b) with no containment check. `skill_view("../outside-skill")` resolves to `SKILLS_DIR/../outside-skill`, escaping the trusted skills root. If a sibling directory there holds a `SKILL.md`, it is selected and its body is served unconditionally; a follow-up `skill_view("../outside-skill", file_path=".env")` then passes the existing per-file guard (because `.env` *is* inside the already-escaped skill dir), leaking arbitrary sibling files such as `.env`. The later outside-trusted-dir detector only **logged a warning** and proceeded, so nothing actually blocked the read.

The fix mirrors the existing `file_path` containment precedence (`validate_within_dir(target, skill_dir)`), applying the same resolve-and-contain check at the earlier **selection** site, plus a fail-closed defense-in-depth layer. The defense-in-depth layer uses a *lexical* `..`-normalizing containment check (not the symlink-resolving flag) so skills legitimately placed under the root via a symlinked category dir keep working.

## Related Issue

Fixes #38643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/skills_tool.py` — selection-site containment: gate the Strategy 1 (direct) and Strategy 1b (categorized) `_record` calls with `validate_within_dir`, so a candidate whose resolved path escapes `search_dir` is never selected. Strategies 2/3 are inherently contained (`rglob` treats `..` literally; `parent.name` never equals `../x`).
- `tools/skills_tool.py` — defense in depth: convert the warn-only outside-trusted-dir branch into a hard rejection, using a lexical containment check against every trusted root so legitimate in-root symlinked category dirs are unaffected.
- `tests/tools/test_skill_view_traversal.py` — adds `TestNameParameterTraversal` covering the direct, nested, categorized, and `file_path`-chained escapes, plus a regression guard that legitimate in-root lookups still resolve.

## How to Test

1. On `main`, `skill_view("../outside-skill")` (with a sibling skill dir outside the skills root) returns `success: true` and leaks the sibling `SKILL.md`; `skill_view("../outside-skill", file_path=".env")` leaks the sibling `.env`.
2. With this PR, both return `success: false` ("Skill resolves outside the trusted skills directory — refusing to read") and no sibling content appears in the result.
3. Regression coverage (red before / green after verified locally): `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_skill_view_traversal.py -v` — 11 passed. The four traversal cases fail with the production hunks stashed and pass with them restored; the legitimate-lookup case passes both ways. Adjacent `tests/tools/test_skills_tool.py` (incl. the symlinked-category-dir case) and `test_skill_view_path_check.py` remain green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A