### PR TITLE
feat(agent): expose max reasoning effort for Anthropic 4.7+ models

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -53,7 +53,7 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if normalized_model.startswith("gemini-2.5-"):
         return thinking_config
 
-    if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
+    if effort not in {"minimal", "low", "medium", "high", "xhigh", "max"}:
         effort = "medium"
 
     # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
@@ -63,13 +63,13 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         if "flash" in normalized_model:
             if effort in {"minimal", "low"}:
                 thinking_config["thinkingLevel"] = "low"
-            elif effort in {"high", "xhigh"}:
+            elif effort in {"high", "xhigh", "max"}:
                 thinking_config["thinkingLevel"] = "high"
             else:
                 thinking_config["thinkingLevel"] = "medium"
         elif "pro" in normalized_model:
             thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh"} else "low"
+                "high" if effort in {"high", "xhigh", "max"} else "low"
             )
 
     return thinking_config

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1261,7 +1261,7 @@ def main(
         print("🧠 Reasoning: DISABLED (effort=none)")
     elif reasoning_effort:
         # Use specified effort level
-        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
         if reasoning_effort not in valid_efforts:
             print(f"❌ Error: --reasoning_effort must be one of: {', '.join(valid_efforts)}")
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12752,7 +12752,7 @@ class GatewayRunner:
             return t("gateway.reasoning.reset_done")
         if effort == "none":
             parsed = {"enabled": False}
-        elif effort in {"minimal", "low", "medium", "high", "xhigh"}:
+        elif effort in {"minimal", "low", "medium", "high", "xhigh", "max"}:
             parsed = {"enabled": True, "effort": effort}
         else:
             return t(

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -145,7 +145,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "show", "hide", "on", "off")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4924,7 +4924,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             str(effort).strip().lower() for effort in efforts if str(effort).strip()
         )
     )
-    canonical_order = ("minimal", "low", "medium", "high", "xhigh")
+    canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max")
     ordered = [effort for effort in canonical_order if effort in deduped]
     ordered.extend(effort for effort in deduped if effort not in canonical_order)
     if not ordered:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -308,13 +308,16 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
+    "max" is the strongest level on Anthropic adaptive-thinking models
+    (Opus/Sonnet 4.7+); providers without a distinct max tier clamp it to
+    their strongest available level (never weaker than xhigh).
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4548,7 +4548,7 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "high" in supported_efforts:
+        if requested_effort in {"xhigh", "max"} and "high" in supported_efforts:
             requested_effort = "high"
         elif requested_effort not in supported_efforts:
             if requested_effort == "minimal" and "low" in supported_efforts:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -179,6 +179,7 @@ class TestParseReasoningEffort:
             ("High", "high"),
             ("  low  ", "low"),
             ("\tXHIGH\n", "xhigh"),
+            ("MAX", "max"),
             ("None", False),
         ],
     )
@@ -192,7 +193,7 @@ class TestParseReasoningEffort:
 
     @pytest.mark.parametrize(
         "value",
-        ["bogus", "very-high", "max", "0", "off", "true", "default"],
+        ["bogus", "very-high", "0", "off", "true", "default"],
     )
     def test_unknown_levels_return_none(self, value):
         """Unrecognized strings fall back to the caller default (None)."""
@@ -205,7 +206,7 @@ class TestParseReasoningEffort:
         If someone removes one from VALID_REASONING_EFFORTS without updating
         the docstring, this test will fail and force the call out.
         """
-        documented = {"minimal", "low", "medium", "high", "xhigh"}
+        documented = {"minimal", "low", "medium", "high", "xhigh", "max"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
 
 


### PR DESCRIPTION
## What does this PR do?

Anthropic's adaptive-thinking models (Opus/Sonnet 4.7+, including 4.8) expose five reasoning effort levels: `low / medium / high / xhigh / max`. Hermes' config layer (`VALID_REASONING_EFFORTS`) only accepted up to `xhigh`, so users who set `reasoning_effort: max` in `config.yaml` or ran `/reasoning max` had it silently rejected and fell back to `medium` — even though the Anthropic adapter's `ADAPTIVE_EFFORT_MAP` already maps `max -> max` correctly. This PR opens the config gate so the strongest level is actually reachable.

## Related Issue

<!-- No existing issue. -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`: add `max` to `VALID_REASONING_EFFORTS`; update `parse_reasoning_effort` docstring.
- `gateway/run.py`: accept `max` in the `/reasoning` command.
- `batch_runner.py`: accept `max` for the `--reasoning_effort` CLI flag.
- `hermes_cli/commands.py`: add `max` to `/reasoning` slash-command completion.
- `hermes_cli/main.py`: add
- `max` to the reasoning picker order.
- `agent/transports/chat_completions.py`: Gemini Flash/Pro thinking-level mapping treats `max` the same as `high` (never weaker than `xhigh`).
- `run_agent.py`: GitHub Models effort resolution downgrades `xhigh`/`max` to the strongest supported level.
- `tests/test_hermes_constants.py`: move `max` from the invalid-levels list to a valid level; add case-normalization coverage.

Providers without a distinct `max` tier clamp it to their strongest available level, so `max` is never weaker than `xhigh` anywhere and never triggers a 400 on pre-4.7 Anthropic models. The Anthropic adapter already mapped `max -> max`; this PR only opens the config gate that was rejecting it.

## How to Test

1. Run the affected suites (CI-parity):
    scripts/run_tests.sh tests/test_hermes_constants.py tests/agent/test_anthropic_adapter.py tests/agent/transports/test_chat_completions.py
   
   275 passed locally.
2. Manual: `hermes config set agent.reasoning_effort max`, then start a new session on `claude-opus-4-7`/`claude-opus-4-8`. The request sends `output_config={"effort": "max"}` with `thinking={"type": "adaptive", "display": "summarized"}`.

## Platforms Tested

WSL2 (Ubuntu 24.04), Python 3.11. Pure config/string changes — no OS-specific paths touched.