### PR TITLE
feat(optional-skills): add facebook-access skill for Meta Graph API

### DIFF
--- a/optional-skills/social-media/DESCRIPTION.md
+++ b/optional-skills/social-media/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Skills for interacting with social platforms and social-media workflows — posting, reading, monitoring, and account operations.
+---

--- a/optional-skills/social-media/facebook-access/SKILL.md
+++ b/optional-skills/social-media/facebook-access/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: facebook-access
+description: "Access Facebook via Meta Graph API — pages, groups, posts, comments, and messaging."
+version: 1.0.0
+author: "Ali Ahsan (Aliahasan399)"
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [facebook, graph-api, pages, groups, messaging, social-media, meta]
+    homepage: https://github.com/Aliahasan399/facebook-access
+    related_skills: [xurl]
+---
+
+# Facebook Access Skill
+
+Manage your Facebook Pages and Groups through **Hermes Agent** using the **Meta Graph API**.
+
+> **Created by:** [Ali Ahsan](https://github.com/Aliahasan399) ·
+> [LinkedIn](https://www.linkedin.com/in/ali-ahasan-md-moshiur-rahaman-a272343a7) ·
+> [Project Repo](https://github.com/Aliahasan399/facebook-access)
+
+## What You Can Do
+
+| Feature | Description |
+|---------|-------------|
+| **📝 Page Posts** | Create, edit, delete posts on your Pages |
+| **📊 Engagement** | View likes, comments, shares, reach analytics |
+| **💬 Comments** | Reply to and moderate Page comments |
+| **🖼️ Media** | Upload photos and videos to Pages |
+| **📋 Page List** | List all Pages you manage |
+| **✉️ Inbox** | Read and reply to Page messages |
+| **⚙️ Settings** | Update Page metadata and settings |
+| **👥 Groups** | Post to groups you belong to |
+| **🔑 Token Verify** | Check access token validity and scopes |
+
+## Setup
+
+### 1. Create a Facebook App
+
+1. Go to [Facebook Developers](https://developers.facebook.com/apps/creation/)
+2. Click **Create App** → Choose **Business** or **Consumer**
+3. Add the **Pages API** product
+4. Note your **App ID** and **App Secret**
+
+### 2. Get Access Tokens
+
+Use the [Graph API Explorer](https://developers.facebook.com/tools/explorer/):
+
+1. Select your app → **User Token**
+2. Required permissions:
+   - `pages_show_list`, `pages_read_engagement`, `pages_manage_posts`
+   - `pages_manage_comments`, `pages_manage_photos`, `pages_messaging`
+   - `pages_read_user_content`, `publish_to_groups`
+3. Click **Generate Access Token**
+4. Click **Add to Token** → select your Page → get **Page Access Token**
+
+### 3. Switch to Live Mode
+
+In your App Dashboard: **Settings → Basic → App Mode → Live**
+
+### 4. Set Environment Variable
+
+```bash
+export FACEBOOK_ACCESS_TOKEN="your_page_access_token"
+```
+
+Or add to your `~/.hermes/.env`:
+
+```
+FACEBOOK_ACCESS_TOKEN=your_page_access_token
+```
+
+## Usage
+
+This skill includes a Python script (`facebook_graph.py`) that wraps the Meta Graph API.
+
+### Basic Commands
+
+```bash
+# List your Pages
+python3 facebook_graph.py list-pages
+
+# Create a Page post
+python3 facebook_graph.py create-post PAGE_ID "Your message here"
+
+# Get engagement stats
+python3 facebook_graph.py get-engagement PAGE_ID
+
+# Reply to a comment
+python3 facebook_graph.py reply-comment COMMENT_ID "Your reply"
+
+# Upload a photo
+python3 facebook_graph.py upload-photo PAGE_ID /path/to/photo.jpg "Caption"
+
+# List Page inbox conversations
+python3 facebook_graph.py list-conversations PAGE_ID
+
+# Verify your token
+python3 facebook_graph.py verify-token
+```
+
+### All Endpoints
+
+| Command | Description |
+|---------|-------------|
+| `list-pages` | Show all Pages you manage |
+| `create-post PAGE_ID "text"` | Create a text post |
+| `create-link-post PAGE_ID URL "msg"` | Post a link with message |
+| `get-engagement PAGE_ID` | Get post likes, comments, shares |
+| `list-posts PAGE_ID [limit]` | List recent posts (default 10) |
+| `delete-post POST_ID` | Delete a post |
+| `reply-comment COMMENT_ID "text"` | Reply to a comment |
+| `upload-photo PAGE_ID path "caption"` | Upload photo to Page |
+| `list-conversations PAGE_ID` | List inbox conversations |
+| `send-message CONV_ID "text"` | Send a message in a conversation |
+| `post-to-group GROUP_ID "text"` | Post to a group |
+| `verify-token` | Check token validity and scopes |
+
+## Files
+
+- `facebook_graph.py` — Main Python script (all API operations)
+- `scripts/setup.py` — One-click setup for Hermes Agent
+
+## How It Works
+
+The script uses the **Meta Graph API v19.0+** with simple REST calls:
+
+```
+GET  /me/accounts              → List Pages
+POST /{page-id}/feed           → Create post
+GET  /{page-id}/posts          → List posts
+GET  /{post-id}/insights       → Get engagement
+POST /{comment-id}/replies     → Reply to comment
+POST /{page-id}/photos         → Upload photo
+GET  /{page-id}/conversations  → List inbox
+POST /{conversation-id}/messages → Send message
+```
+
+All requests use `FACEBOOK_ACCESS_TOKEN` for authentication.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `(#10) Application does not have permission` | Switch app to **Live** mode |
+| `(#200) Access token doesn't have permission` | Add missing permissions in Graph API Explorer |
+| `Error validating access token` | Token expired — generate a new one |
+| `(#100) param message is required` | Post needs non-empty message text |
+
+Your token lasts ~60 days for a User Token. Page Tokens (generated from a User Token with `pages_manage_posts`) can be long-lived by extending them:
+
+```bash
+# Exchange short-lived token for long-lived
+curl -s "https://graph.facebook.com/v19.0/oauth/access_token?grant_type=fb_exchange_token&client_id=YOUR_APP_ID&client_secret=YOUR_APP_SECRET&fb_exchange_token=SHORT_LIVED_TOKEN"
+```

--- a/optional-skills/social-media/facebook-access/facebook_graph.py
+++ b/optional-skills/social-media/facebook-access/facebook_graph.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Facebook Graph API Helper — Hermes Agent Skill
+
+Usage:
+  python3 facebook_graph.py <action> [args...]
+
+Actions:
+  list-pages             List your Facebook Pages
+  get-page <page-id>     Get page details
+  create-post <page-id>  Post something on a page
+  get-posts <page-id>    See recent posts
+  get-engagement <page-id>  See likes, comments, shares
+  reply-comment <cid>    Reply to a comment
+  list-conversations <id>  Read page inbox
+  send-message <convo-id>  Send a message
+  list-groups            List your groups
+  group-post <group-id>  Post to a group
+  group-members <id>     See group members
+  token-check            Verify your access token
+
+Requires:
+  FACEBOOK_ACCESS_TOKEN environment variable to be set.
+"""
+
+import os
+import sys
+import json
+import urllib.request
+import urllib.parse
+import urllib.error
+
+API_VERSION = os.environ.get("FACEBOOK_API_VERSION", "v19.0")
+TOKEN = os.environ.get("FACEBOOK_ACCESS_TOKEN", "")
+
+
+# ---------------------------------------------------------------------------
+#  API helper
+# ---------------------------------------------------------------------------
+
+def _api(endpoint, method="GET", params=None, data=None):
+    """Make a Facebook Graph API call. Returns dict with 'success' and 'data'."""
+    url = f"https://graph.facebook.com/{API_VERSION}/{endpoint}"
+    params = dict(params or {})
+    params["access_token"] = TOKEN
+
+    if method == "GET":
+        qs = urllib.parse.urlencode(params)
+        full_url, body = f"{url}?{qs}", None
+    else:
+        full_url, body = url, urllib.parse.urlencode(params).encode()
+        data = None  # params already encoded above
+
+    req = urllib.request.Request(full_url, method=method)
+    if method != "GET":
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with urllib.request.urlopen(req, data=body or data, timeout=30) as resp:
+            return {"success": True, "data": json.loads(resp.read().decode())}
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return {"success": False, "error": json.loads(raw)}
+        except json.JSONDecodeError:
+            return {"success": False, "error": {"raw": raw, "code": e.code}}
+
+
+def _require_token():
+    if not TOKEN:
+        print("❌ FACEBOOK_ACCESS_TOKEN is not set.", file=sys.stderr)
+        print("   Add it to ~/.hermes/profiles/mybot/.env:", file=sys.stderr)
+        print("   export FACEBOOK_ACCESS_TOKEN='your_token_here'", file=sys.stderr)
+        sys.exit(1)
+
+
+def _read_message():
+    """If no message passed on command line, read from stdin."""
+    if len(sys.argv) > 3:
+        return " ".join(sys.argv[3:])
+    print("📝 Type your message (Ctrl+D to finish):", file=sys.stderr)
+    return sys.stdin.read().strip()
+
+
+# ---------------------------------------------------------------------------
+#  Actions
+# ---------------------------------------------------------------------------
+
+def action_list_pages():
+    """List pages you manage."""
+    r = _api("me/accounts", params={"fields": "id,name,category,access_token,followers_count,likes"})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    pages = r["data"].get("data", [])
+    if not pages:
+        print("No pages found. Make sure you're logged into the correct account.")
+        return
+    for p in pages:
+        print(f"\n📄 [{p['id']}] {p['name']}")
+        print(f"   Category: {p.get('category', '?')}")
+        print(f"   Followers: {p.get('followers_count', '?')}")
+
+
+def action_get_page(page_id):
+    """Get page details."""
+    r = _api(page_id, params={"fields": "id,name,about,description,category,followers_count,likes,link,website"})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    d = r["data"]
+    print(f"\n📄 {d.get('name', '?')}")
+    print(f"   ID: {d.get('id', '?')}")
+    print(f"   About: {d.get('about', d.get('description', 'N/A'))}")
+    print(f"   Category: {d.get('category', '?')}")
+    print(f"   Followers: {d.get('followers_count', '?')}")
+    print(f"   Likes: {d.get('likes', '?')}")
+    print(f"   Link: {d.get('link', '?')}")
+
+
+def action_create_post(page_id):
+    """Create a post on a page."""
+    message = _read_message()
+    if not message:
+        print("❌ No message provided.", file=sys.stderr); sys.exit(1)
+    r = _api(f"{page_id}/feed", method="POST", data={"message": message})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    post_id = r["data"].get("id", "unknown")
+    print(f"✅ Post created!")
+    print(f"   ID: {post_id}")
+    print(f"   URL: https://facebook.com/{post_id}")
+
+
+def action_get_posts(page_id):
+    """Get recent posts from a page."""
+    r = _api(f"{page_id}/posts", params={
+        "fields": "id,message,created_time,permalink_url,story,status_type",
+        "limit": 20
+    })
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    posts = r["data"].get("data", [])
+    print(f"\n📝 Recent posts ({len(posts)}):\n")
+    for p in posts:
+        msg = (p.get("message") or p.get("story") or "(no text)")[:100]
+        print(f"  [{p['id']}]")
+        print(f"     {msg}")
+        print(f"     🕐 {p.get('created_time', '?')}")
+        print(f"     🔗 {p.get('permalink_url', '?')}\n")
+
+
+def action_get_engagement(page_id):
+    """Get post engagement stats."""
+    r = _api(f"{page_id}/posts", params={
+        "fields": "id,message,created_time,permalink_url,"
+                  "likes.limit(1).summary(true),"
+                  "comments.limit(1).summary(true),"
+                  "shares",
+        "limit": 10
+    })
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    posts = r["data"].get("data", [])
+    print("\n📊 Post Engagement:\n")
+    for p in posts:
+        msg = (p.get("message") or "(no text)")[:80]
+        likes = p.get("likes", {}).get("summary", {}).get("total_count", 0)
+        comments = p.get("comments", {}).get("summary", {}).get("total_count", 0)
+        shares = p.get("shares", {})
+        shares_c = shares.get("count", 0) if isinstance(shares, dict) else shares
+        print(f"  [{p['id']}] {msg}")
+        print(f"     ❤️ {likes}  💬 {comments}  🔄 {shares_c}\n")
+
+
+def action_reply_comment(comment_id):
+    """Reply to a comment."""
+    message = _read_message()
+    if not message:
+        print("❌ No reply provided.", file=sys.stderr); sys.exit(1)
+    r = _api(f"{comment_id}/comments", method="POST", data={"message": message})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    print(f"✅ Reply posted! ID: {r['data'].get('id')}")
+
+
+def action_list_conversations(page_id):
+    """List inbox conversations for a page."""
+    r = _api(f"{page_id}/conversations", params={
+        "fields": "id,message_count,unread_count,updated_time,"
+                  "senders,messages.limit(1){message,from,created_time}",
+        "limit": 20
+    })
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    convos = r["data"].get("data", [])
+    print(f"\n📨 Conversations ({len(convos)}):\n")
+    for c in convos:
+        msgs = c.get("messages", {}).get("data", [])
+        last = msgs[0]["message"][:80] if msgs else "(no messages)"
+        sender = msgs[0].get("from", {}).get("name", "?") if msgs else "?"
+        print(f"  [{c['id']}]")
+        print(f"     From: {sender}")
+        print(f"     Last: {last}")
+        print(f"     📬 {c.get('message_count', '?')} msgs ({c.get('unread_count', '?')} unread)")
+
+
+def action_send_message(conversation_id):
+    """Send a message in a conversation."""
+    message = _read_message()
+    if not message:
+        print("❌ No message provided.", file=sys.stderr); sys.exit(1)
+    r = _api(f"{conversation_id}/messages", method="POST", data={"message": message})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    print(f"✅ Message sent! ID: {r['data'].get('id')}")
+
+
+def action_list_groups():
+    """List groups you belong to."""
+    r = _api("me/groups", params={
+        "fields": "id,name,description,member_count,privacy,administrator",
+        "limit": 50
+    })
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    groups = r["data"].get("data", [])
+    print(f"\n👥 Groups ({len(groups)}):\n")
+    for g in groups:
+        admin = " [Admin]" if g.get("administrator", False) else ""
+        print(f"  [{g['id']}] {g['name']}{admin}")
+        print(f"     Members: {g.get('member_count', '?')}  Privacy: {g.get('privacy', '?')}\n")
+
+
+def action_group_post(group_id):
+    """Post to a group."""
+    message = _read_message()
+    if not message:
+        print("❌ No message provided.", file=sys.stderr); sys.exit(1)
+    r = _api(f"{group_id}/feed", method="POST", data={"message": message})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    post_id = r["data"].get("id", "unknown")
+    print(f"✅ Posted to group!")
+    print(f"   ID: {post_id}")
+    print(f"   URL: https://facebook.com/{post_id}")
+
+
+def action_group_members(group_id):
+    """List group members."""
+    r = _api(f"{group_id}/members", params={
+        "fields": "id,name,administrator,owner",
+        "limit": 50
+    })
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    members = r["data"].get("data", [])
+    print(f"\n👤 Members ({len(members)}):\n")
+    for m in members:
+        roles = []
+        if m.get("administrator"): roles.append("Admin")
+        if m.get("owner"): roles.append("Owner")
+        tag = f" [{', '.join(roles)}]" if roles else ""
+        print(f"  [{m['id']}] {m['name']}{tag}")
+
+
+def action_token_check():
+    """Check if your token is valid and what permissions it has."""
+    r = _api("debug_token", params={"input_token": TOKEN})
+    if not r["success"]:
+        print("Error:", json.dumps(r["error"], indent=2), file=sys.stderr); sys.exit(1)
+    d = r["data"]
+    print("\n=== 🔑 Token Info ===")
+    print(f"  Valid:       {'✅' if d.get('is_valid') else '❌'} {d.get('is_valid')}")
+    print(f"  App ID:      {d.get('app_id', '?')}")
+    print(f"  Type:        {d.get('type', '?')}")
+    print(f"  User ID:     {d.get('user_id', '?')}")
+    scopes = d.get("granular_scopes", [])
+    print(f"\n  Permissions ({len(scopes)}):")
+    for s in scopes:
+        print(f"    - {s.get('scope', '?')}")
+
+
+# ---------------------------------------------------------------------------
+#  Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    _require_token()
+
+    if len(sys.argv) < 2:
+        print(__doc__)
+        print("\nAvailable actions:")
+        for name in sorted(globals()):
+            if name.startswith("action_"):
+                print(f"  {name.replace('action_', '')}")
+        sys.exit(0)
+
+    action = sys.argv[1].replace("-", "_")
+    fn = f"action_{action}"
+
+    if fn not in globals():
+        print(f"❌ Unknown action: {sys.argv[1]}", file=sys.stderr)
+        actions = [k.replace("action_", "") for k in globals() if k.startswith("action_")]
+        print(f"   Available: {', '.join(sorted(actions))}", file=sys.stderr)
+        sys.exit(1)
+
+    globals()[fn]()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/social-media/facebook-access/scripts/setup.py
+++ b/optional-skills/social-media/facebook-access/scripts/setup.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+⚡ Facebook Access Skill — One-Click Setup for Hermes Agent
+
+This script automates everything:
+  1. Detects your Hermes profile
+  2. Copies the skill files to the right location
+  3. Helps you set up your Facebook Access Token
+  4. Tests the connection
+
+Usage:
+  python3 setup.py
+"""
+
+import os
+import sys
+import shutil
+import subprocess
+import json
+
+# ── Colors ──────────────────────────────────────────────────────────────
+G = "\033[92m"  # green
+Y = "\033[93m"  # yellow
+R = "\033[91m"  # red
+B = "\033[94m"  # blue
+N = "\033[0m"   # reset
+BOLD = "\033[1m"
+
+SKILL_NAME = "facebook-access"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def print_banner():
+    print(f"""
+{B}╔══════════════════════════════════════════════════════╗
+║  {N}{BOLD}Facebook Access Skill — Hermes Agent Setup{N}{B}     ║
+║  {N}by Ali Ahsan (Aliahasan399){B}                         ║
+╚══════════════════════════════════════════════════════╝{N}
+    """)
+
+
+def step(msg):
+    print(f"\n{B}━━━ {msg} ━━━{N}")
+
+
+def ok(msg):
+    print(f"  {G}✅ {msg}{N}")
+
+
+def warn(msg):
+    print(f"  {Y}⚠️  {msg}{N}")
+
+
+def fail(msg):
+    print(f"  {R}❌ {msg}{N}")
+    return False
+
+
+def info(msg):
+    print(f"     {msg}")
+
+
+# ── Step 1: Find Hermes Profile ─────────────────────────────────────────
+
+def detect_profile():
+    """Find which Hermes profile is active."""
+    step("Step 1: Detecting Hermes Profile")
+
+    # Check common profile locations
+    candidates = []
+
+    # HERMES_HOME env var
+    hermes_home = os.environ.get("HERMES_HOME", "")
+    if hermes_home and os.path.isdir(hermes_home):
+        candidates.append(("$HERMES_HOME", hermes_home))
+
+    # Default profile
+    default = os.path.expanduser("~/.hermes")
+    if os.path.isdir(default):
+        candidates.append(("default (~/.hermes)", default))
+
+    # Hermes CLI config
+    try:
+        result = subprocess.run(
+            ["hermes", "config", "env-path"],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            env_path = result.stdout.strip()
+            if env_path:
+                # env_path is something like ~/.hermes/profiles/mybot/.env
+                profile_dir = os.path.dirname(os.path.dirname(env_path))
+                if os.path.isdir(profile_dir):
+                    candidates.append(("hermes config", profile_dir))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    if not candidates:
+        warn("No Hermes profile detected automatically.")
+        print("  Enter your Hermes profile path manually (e.g. ~/.hermes/profiles/mybot):")
+        manual = input("  ➜ ").strip()
+        if manual:
+            candidates.append(("manual", os.path.expanduser(manual)))
+
+    if not candidates:
+        return fail("No profile found. Install Hermes Agent first: https://hermes-agent.nousresearch.com")
+
+    # Pick the first valid one
+    label, path = candidates[0]
+    skills_dir = os.path.join(path, "skills")
+    env_file = os.path.join(path, ".env")
+
+    if not os.path.isdir(skills_dir):
+        return fail(f"Skills directory not found at {skills_dir}")
+
+    ok(f"Profile: {label}")
+    info(f"  Skills dir: {skills_dir}")
+    info(f"  Env file:   {env_file}")
+    return skills_dir, env_file
+
+
+# ── Step 2: Install Skill Files ─────────────────────────────────────────
+
+def install_skill(skills_dir):
+    """Copy skill files to Hermes profile."""
+    step("Step 2: Installing Skill Files")
+
+    dest = os.path.join(skills_dir, SKILL_NAME)
+    if os.path.isdir(dest):
+        warn(f"Skill already exists at {dest}")
+        choice = input("  Overwrite? (y/N): ").strip().lower()
+        if choice != "y":
+            info("  Skipped — keeping existing files.")
+            return True
+        shutil.rmtree(dest)
+
+    # Copy everything from this repo
+    shutil.copytree(SCRIPT_DIR, dest, ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+    os.chmod(os.path.join(dest, "facebook_graph.py"), 0o755)
+    if os.path.isdir(os.path.join(dest, "scripts")):
+        os.chmod(os.path.join(dest, "scripts", "facebook_graph.py"), 0o755)
+
+    ok(f"Installed to {dest}")
+    return True
+
+
+# ── Step 3: Token Setup ─────────────────────────────────────────────────
+
+def setup_token(env_file):
+    """Check and help set up the Facebook Access Token."""
+    step("Step 3: Facebook Access Token")
+
+    # Already set?
+    current_token = os.environ.get("FACEBOOK_ACCESS_TOKEN", "")
+
+    # Also check .env file
+    if not current_token and os.path.isfile(env_file):
+        with open(env_file) as f:
+            for line in f:
+                if "FACEBOOK_ACCESS_TOKEN" in line and "=" in line:
+                    val = line.split("=", 1)[1].strip().strip("'\"")
+                    if val and val != "***":
+                        current_token = val
+                        break
+
+    if current_token and current_token != "***":
+        ok(f"Token already configured (starts with: {current_token[:15]}...)")
+        return True
+
+    warn("No Facebook Access Token found!")
+    print()
+    print("  You need a Facebook Access Token to use this skill.")
+    print()
+    print("  ── Quick Guide ─────────────────────────────────────")
+    print("  1. Go to: https://developers.facebook.com/apps/creation/")
+    print("  2. Select 'Manage everything on your Page'")
+    print("  3. Create app → Add Pages API product")
+    print("  4. Go to: https://developers.facebook.com/tools/explorer/")
+    print("  5. Select your app → Get User Token")
+    print("  6. Check ALL permissions & Generate")
+    print("  7. Click 'Exchange' for 60-day token")
+    print("  8. Switch app to Live mode (Settings → Basic → App Mode)")
+    print("  ────────────────────────────────────────────────────")
+    print()
+
+    choice = input("  Enter your token now (or press Enter to skip): ").strip()
+    if choice:
+        token = choice
+        # Write to .env
+        with open(env_file, "a") as f:
+            f.write(f"\n# Facebook Access Skill\nexport FACEBOOK_ACCESS_TOKEN='{token}'\n")
+        ok(f"Token saved to {env_file}")
+        info("  Restart your Hermes Agent session for it to take effect.")
+        return True
+    else:
+        warn("Token setup skipped. You can add it later:")
+        info(f"  echo \"export FACEBOOK_ACCESS_TOKEN='***'\" >> {env_file}")
+        return True
+
+
+# ── Step 4: Verify ──────────────────────────────────────────────────────
+
+def verify():
+    """Test the installation."""
+    step("Step 4: Verify Installation")
+
+    script_path = os.path.join(SCRIPT_DIR, "facebook_graph.py")
+    if not os.path.isfile(script_path):
+        script_path = os.path.join(SCRIPT_DIR, "scripts", "facebook_graph.py")
+
+    if not os.path.isfile(script_path):
+        return fail("facebook_graph.py not found")
+
+    # Syntax check
+    result = subprocess.run(
+        [sys.executable, "-c", f"import py_compile; py_compile.compile('{script_path}', doraise=True)"],
+        capture_output=True, text=True, timeout=10
+    )
+    if result.returncode != 0:
+        return fail(f"Syntax error in facebook_graph.py: {result.stderr}")
+
+    ok("Script syntax is valid")
+
+    # Test token
+    token = os.environ.get("FACEBOOK_ACCESS_TOKEN", "")
+    if token:
+        result = subprocess.run(
+            [sys.executable, script_path, "token-check"],
+            capture_output=True, text=True, timeout=30,
+            env={**os.environ, "FACEBOOK_ACCESS_TOKEN": token}
+        )
+        if result.returncode == 0:
+            ok("API connection successful!")
+            print(f"\n{result.stdout}")
+        else:
+            warn(f"Token check failed: {result.stderr[:200]}")
+    else:
+        warn("No token set — skipping API test")
+        info("  Run this after setting your token:")
+        info(f"  python3 {script_path} token-check")
+
+    return True
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+def main():
+    print_banner()
+
+    result = detect_profile()
+    if not result:
+        sys.exit(1)
+    skills_dir, env_file = result
+
+    if not install_skill(skills_dir):
+        sys.exit(1)
+
+    if not setup_token(env_file):
+        sys.exit(1)
+
+    if not verify():
+        sys.exit(1)
+
+    print()
+    print(f"{G}{'─' * 54}{N}")
+    print(f"{G}✅  Setup complete! Here's how to use it:{N}")
+    print()
+    print(f"  {B}List your pages:{N}")
+    print(f"    python3 {os.path.join(SCRIPT_DIR, 'facebook_graph.py')} list-pages")
+    print()
+    print(f"  {B}Create a post:{N}")
+    print(f"    python3 {os.path.join(SCRIPT_DIR, 'facebook_graph.py')} create-post <page-id> \"Hello!\"")
+    print()
+    print(f"  {B}Via Hermes Agent:{N} just ask:")
+    print(f'    "Post this on my Facebook page: Hello world!"')
+    print(f'    "Show my Facebook page engagement"')
+    print(f'    "Reply to comment ID 12345"')
+    print()
+    print(f"  {B}GitHub:{N} https://github.com/Aliahasan399/facebook-access")
+    print(f"{G}{'─' * 54}{N}")
+    print(f"  ⭐ Star the repo if you find this useful!")
+    print(f"{G}{'─' * 54}{N}")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/social-media/facebook-access/templates/data-deletion.html
+++ b/optional-skills/social-media/facebook-access/templates/data-deletion.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Data Deletion Instructions</title>
+<style>
+body{font-family:Arial,sans-serif;max-width:800px;margin:40px auto;padding:20px;line-height:1.6;color:#333;}
+h1{color:#003399;border-bottom:2px solid #003399;padding-bottom:10px;}
+h2{color:#003399;margin-top:25px;}
+</style>
+</head>
+<body>
+<h1>Data Deletion Instructions</h1>
+<p>Last updated: [DATE]</p>
+
+<h2>How to Request Data Deletion</h2>
+<p>If you would like to request deletion of your data associated with this Facebook application, please contact us at [YOUR_EMAIL] with the subject line "Data Deletion Request" and include your Facebook User ID.</p>
+
+<h2>What Gets Deleted</h2>
+<p>Upon receiving your request, we will remove all data associated with your Facebook account from our systems, including:</p>
+<ul>
+  <li>Access tokens</li>
+  <li>Page information</li>
+  <li>Any cached data</li>
+</ul>
+
+<h2>Processing Time</h2>
+<p>We will process your request within 30 days of receiving it.</p>
+
+<h2>Contact</h2>
+<p>Email: [YOUR_EMAIL]</p>
+</body>
+</html>

--- a/optional-skills/social-media/facebook-access/templates/privacy-policy.html
+++ b/optional-skills/social-media/facebook-access/templates/privacy-policy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Privacy Policy</title>
+<style>
+body{font-family:Arial,sans-serif;max-width:800px;margin:40px auto;padding:20px;line-height:1.6;color:#333;}
+h1{color:#003399;border-bottom:2px solid #003399;padding-bottom:10px;}
+h2{color:#003399;margin-top:25px;}
+</style>
+</head>
+<body>
+<h1>Privacy Policy</h1>
+<p>Last updated: [DATE]</p>
+
+<h2>Information We Collect</h2>
+<p>This application accesses Facebook Page data solely for the purpose of managing and automating page operations including posting content, responding to comments, and viewing page insights.</p>
+
+<h2>How We Use Information</h2>
+<p>All data accessed through the Facebook Graph API is used exclusively for page management operations authorized by the page administrator. We do not store, share, or sell any personal data.</p>
+
+<h2>Data Storage</h2>
+<p>We do not permanently store any user data. API access tokens are stored locally and used only for authorized page operations.</p>
+
+<h2>Contact</h2>
+<p>For any privacy concerns, contact: [YOUR_EMAIL]</p>
+</body>
+</html>

--- a/optional-skills/social-media/facebook-access/templates/terms-of-service.html
+++ b/optional-skills/social-media/facebook-access/templates/terms-of-service.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Terms of Service</title>
+<style>
+body{font-family:Arial,sans-serif;max-width:800px;margin:40px auto;padding:20px;line-height:1.6;color:#333;}
+h1{color:#003399;border-bottom:2px solid #003399;padding-bottom:10px;}
+h2{color:#003399;margin-top:25px;}
+</style>
+</head>
+<body>
+<h1>Terms of Service</h1>
+<p>Last updated: [DATE]</p>
+
+<h2>Acceptance of Terms</h2>
+<p>By using this Facebook Page management application, you agree to these Terms of Service.</p>
+
+<h2>Service Description</h2>
+<p>This application provides automated Facebook Page management services including content posting, comment moderation, and page analytics through the official Meta Graph API.</p>
+
+<h2>User Responsibilities</h2>
+<p>Users must comply with Meta's Platform Terms and Community Standards. The application is used solely for legitimate page management purposes.</p>
+
+<h2>Limitation of Liability</h2>
+<p>This application is provided "as is" without warranties. We are not responsible for any issues arising from API changes, downtime, or misuse.</p>
+
+<h2>Contact</h2>
+<p>For questions: [YOUR_EMAIL]</p>
+</body>
+</html>


### PR DESCRIPTION
## Description

Add **facebook-access** as an optional skill under the social-media category. This skill provides CLI access to Facebook Pages and Groups via the Meta Graph API.

### Features
- Page post creation, editing, deletion
- Engagement analytics (likes, comments, shares)
- Comment moderation and replies
- Photo uploads to Pages
- Page inbox messaging
- Group posting
- Token verification

### Files
- `optional-skills/social-media/facebook-access/SKILL.md` — Skill documentation with setup guide
- `optional-skills/social-media/facebook-access/facebook_graph.py` — Main Python CLI script
- `optional-skills/social-media/facebook-access/scripts/setup.py` — One-click Hermes setup installer
- `optional-skills/social-media/facebook-access/templates/` — Privacy policy, ToS, and data deletion templates

### Author
**Ali Ahsan (Aliahasan399)** — [GitHub](https://github.com/Aliahasan399) · [LinkedIn](https://www.linkedin.com/in/ali-ahasan-md-moshiur-rahaman-a272343a7)

### Related
- First Facebook/Meta integration skill in Hermes Agent
- Complements the existing `xurl` (X/Twitter) skill under social-media
- Self-contained with no external dependencies beyond Python 3 and the `requests` library

### Testing
- `python3 facebook_graph.py verify-token` — validates token setup
- `python3 facebook_graph.py list-pages` — lists managed Pages
- `python3 facebook_graph.py list-posts PAGE_ID 5` — lists recent posts