### PR TITLE
fix(gateway): use get_hermes_dir for WhatsApp LID session path (#36664)

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_dir
 
 
 def normalize_whatsapp_identifier(value: str) -> str:
@@ -82,7 +82,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
     if not normalized:
         return set()
 
-    session_dir = get_hermes_home() / "whatsapp" / "session"
+    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
     resolved: Set[str] = set()
     queue = [normalized]
 


### PR DESCRIPTION
Closes #36664. expand_whatsapp_aliases() read from hardcoded legacy path; adapter writes to modern consolidated path via get_hermes_dir(). On fresh installs the paths differ so LID messages silently dropped. Fix: use get_hermes_dir() in resolver.