### PR TITLE
fix(plugins): guard disk-cleanup against deleting cron/jobs.json (#37721)

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -246,6 +246,28 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
 # Quick cleanup
 # ---------------------------------------------------------------------------
 
+def _is_valid_cron_output_path(p: Path) -> bool:
+    """Return True only if *p* resolves to within ``$HERMES_HOME/cron/output/``
+    or ``$HERMES_HOME/cronjobs/output/``.
+
+    Guards against stale ``tracked.json`` entries that were incorrectly
+    classified as ``cron-output`` before issue #32164 was fixed — e.g. an
+    entry pointing at ``cron/jobs.json`` (the live scheduler registry) that
+    would be silently deleted once it aged past the 14-day threshold.
+    See bug #37721.
+    """
+    hermes_home = get_hermes_home()
+    resolved = p.resolve()
+    for cron_top in ("cron", "cronjobs"):
+        output_dir = (hermes_home / cron_top / "output").resolve()
+        try:
+            resolved.relative_to(output_dir)
+            return True
+        except ValueError:
+            pass
+    return False
+
+
 def quick() -> Dict[str, Any]:
     """Safe deterministic cleanup — no prompts.
 
@@ -268,6 +290,17 @@ def quick() -> Dict[str, Any]:
             continue
 
         age = (now - datetime.fromisoformat(item["timestamp"])).days
+
+        # Guard against stale cron-output entries that point at control-plane
+        # files (e.g. cron/jobs.json mis-classified before bug #32164 was
+        # fixed).  If the resolved path is NOT under cron/output/, evict the
+        # entry from tracking and skip deletion entirely.
+        if cat == "cron-output" and not _is_valid_cron_output_path(p):
+            _log(
+                f"EVICT: {p} (cron-output entry outside cron/output/ — "
+                "stale mis-classification, evicted without deletion)"
+            )
+            continue  # drop from new_tracked → evicted
 
         should_delete = (
             cat == "test"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -223,6 +223,123 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    # ------------------------------------------------------------------
+    # Bug #37721 — stale cron-output entries must never delete control-
+    # plane files like cron/jobs.json
+    # ------------------------------------------------------------------
+
+    def test_quick_evicts_stale_cron_output_pointing_at_jobs_json(
+        self, _isolate_env
+    ):
+        """Regression for #37721.
+
+        A tracked.json entry with category='cron-output' but a path that
+        resolves to cron/jobs.json (outside cron/output/) must be evicted
+        from tracking WITHOUT deleting the file.
+        """
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        jobs_json = cron_dir / "jobs.json"
+        jobs_json.write_text('{"jobs": []}')
+
+        # Manually inject a stale mis-classified entry (bypasses track()
+        # which would correctly refuse to track this path as cron-output).
+        import json as _json
+        from datetime import datetime, timezone, timedelta
+        stale_ts = (
+            datetime.now(timezone.utc) - timedelta(days=20)
+        ).isoformat()
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(
+            _json.dumps([
+                {
+                    "path": str(jobs_json.resolve()),
+                    "timestamp": stale_ts,
+                    "category": "cron-output",
+                    "size": jobs_json.stat().st_size,
+                }
+            ])
+        )
+
+        summary = dg.quick()
+
+        # The scheduler registry must survive.
+        assert jobs_json.exists(), "jobs.json must NOT be deleted"
+        # The entry must be evicted (not re-saved to tracked.json).
+        remaining = _json.loads(tracked_file.read_text())
+        assert remaining == [], "stale entry should be evicted from tracked.json"
+        # And the deletion counter must be zero.
+        assert summary["deleted"] == 0
+
+    def test_quick_evicts_stale_cron_output_pointing_at_cron_root_file(
+        self, _isolate_env
+    ):
+        """Any file directly under cron/ (not cron/output/) is control-plane."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        tick_lock = cron_dir / ".tick.lock"
+        tick_lock.write_text("")
+
+        import json as _json
+        from datetime import datetime, timezone, timedelta
+        stale_ts = (
+            datetime.now(timezone.utc) - timedelta(days=20)
+        ).isoformat()
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(
+            _json.dumps([
+                {
+                    "path": str(tick_lock.resolve()),
+                    "timestamp": stale_ts,
+                    "category": "cron-output",
+                    "size": 0,
+                }
+            ])
+        )
+
+        dg.quick()
+
+        assert tick_lock.exists(), ".tick.lock must NOT be deleted"
+        remaining = _json.loads(tracked_file.read_text())
+        assert remaining == []
+
+    def test_quick_still_deletes_legitimate_aged_cron_output(
+        self, _isolate_env
+    ):
+        """A real cron/output/ artifact aged > 14 days must still be deleted."""
+        dg = _load_lib()
+        output_dir = _isolate_env / "cron" / "output" / "job_42"
+        output_dir.mkdir(parents=True)
+        run_md = output_dir / "run.md"
+        run_md.write_text("output")
+
+        import json as _json
+        from datetime import datetime, timezone, timedelta
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(days=15)
+        ).isoformat()
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(
+            _json.dumps([
+                {
+                    "path": str(run_md.resolve()),
+                    "timestamp": old_ts,
+                    "category": "cron-output",
+                    "size": run_md.stat().st_size,
+                }
+            ])
+        )
+
+        summary = dg.quick()
+
+        assert not run_md.exists(), "expired cron output should be deleted"
+        assert summary["deleted"] == 1
+
 
 class TestStatus:
     def test_empty_status(self, _isolate_env):


### PR DESCRIPTION
Closes #37721. Before deleting any cron-output entry, validate resolved path is under $HERMES_HOME/cron/output/. Stale entries pointing at control-plane files (cron/jobs.json, .tick.lock) are evicted from tracked.json without touching the file. Adds 3 regression tests.