### PR TITLE
fix(plugins): add 30s overall timeout to DDGS web search (#36776)

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -1,31 +1,67 @@
 """DuckDuckGo search — plugin form (via the ``ddgs`` package).
 
-Subclasses the plugin-facing :class:`agent.web_search_provider.WebSearchProvider`.
-The legacy in-tree module ``tools.web_providers.ddgs`` was removed in the
-same commit that moved this code under ``plugins/``; this file is now the
-canonical implementation.
+Subclasses the plugin-facing
+:class:`agent.web_search_provider.WebSearchProvider`.
+The legacy in-tree module ``tools.web_providers.ddgs`` was removed in
+the same commit that moved this code under ``plugins/``; this file is
+now the canonical implementation.
 
-The ``ddgs`` package is an optional dependency. ``is_available()`` reflects
-whether the package is importable; the plugin still registers either way so
-``hermes tools`` can prompt the user to install it.
+The ``ddgs`` package is an optional dependency. ``is_available()``
+reflects whether the package is importable; the plugin still registers
+either way so ``hermes tools`` can prompt the user to install it.
 """
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
+# Hard wall-clock cap on any single DDGS search call.  DDGS can hang for
+# 20+ minutes when DuckDuckGo rate-limits it because individual HTTP
+# request timeouts do not bound the *total* retry loop time.
+_SEARCH_TIMEOUT_SECONDS = 30
+
+
+def _run_ddgs_search(query: str, safe_limit: int) -> List[Dict[str, Any]]:
+    """Blocking helper executed inside a worker thread.
+
+    Isolated so that :func:`concurrent.futures.Future.result` can kill
+    the wait after ``_SEARCH_TIMEOUT_SECONDS`` even though the thread
+    itself cannot be forcibly interrupted.
+    """
+    from ddgs import DDGS  # type: ignore
+
+    web_results: List[Dict[str, Any]] = []
+    with DDGS() as client:
+        for i, hit in enumerate(
+            client.text(query, max_results=safe_limit)
+        ):
+            if i >= safe_limit:
+                break
+            url = str(hit.get("href") or hit.get("url") or "")
+            web_results.append(
+                {
+                    "title": str(hit.get("title", "")),
+                    "url": url,
+                    "description": str(hit.get("body", "")),
+                    "position": i + 1,
+                }
+            )
+    return web_results
+
 
 class DDGSWebSearchProvider(WebSearchProvider):
     """DuckDuckGo HTML-scrape search provider.
 
-    No API key needed. Rate limits are enforced server-side by DuckDuckGo;
-    the provider surfaces ``DuckDuckGoSearchException`` and other ddgs errors
-    as ``{"success": False, "error": ...}`` rather than raising.
+    No API key needed. Rate limits are enforced server-side by
+    DuckDuckGo; the provider surfaces ``DuckDuckGoSearchException`` and
+    other ddgs errors as ``{"success": False, "error": ...}`` rather
+    than raising.
     """
 
     @property
@@ -39,9 +75,9 @@ class DDGSWebSearchProvider(WebSearchProvider):
     def is_available(self) -> bool:
         """Return True when the ``ddgs`` package is importable.
 
-        Probes the import once; cheap because Python caches the import. Must
-        NOT perform network I/O — runs at tool-registration time and on every
-        ``hermes tools`` paint.
+        Probes the import once; cheap because Python caches the import.
+        Must NOT perform network I/O — runs at tool-registration time
+        and on every ``hermes tools`` paint.
         """
         try:
             import ddgs  # noqa: F401
@@ -57,48 +93,79 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return False
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        """Execute a DuckDuckGo search and return normalized results."""
+        """Execute a DuckDuckGo search and return normalized results.
+
+        The call is run in a thread and bounded by
+        ``_SEARCH_TIMEOUT_SECONDS`` (default 30 s).  When DuckDuckGo
+        rate-limits the ddgs client it can retry internally for 20+
+        minutes; this cap prevents the agent from hanging indefinitely.
+        """
         try:
-            from ddgs import DDGS  # type: ignore
+            from ddgs import DDGS  # noqa: F401 — confirm package present
         except ImportError:
             return {
                 "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
+                "error": (
+                    "ddgs package is not installed"
+                    " — run `pip install ddgs`"
+                ),
             }
 
-        # DDGS().text yields at most `max_results` items; we cap defensively
+        # DDGS().text yields at most `max_results` items; cap defensively
         # in case the package ignores the hint.
         safe_limit = max(1, int(limit))
 
         try:
-            web_results = []
-            with DDGS() as client:
-                for i, hit in enumerate(client.text(query, max_results=safe_limit)):
-                    if i >= safe_limit:
-                        break
-                    url = str(hit.get("href") or hit.get("url") or "")
-                    web_results.append(
-                        {
-                            "title": str(hit.get("title", "")),
-                            "url": url,
-                            "description": str(hit.get("body", "")),
-                            "position": i + 1,
-                        }
-                    )
-        except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=1
+            ) as executor:
+                future = executor.submit(
+                    _run_ddgs_search, query, safe_limit
+                )
+                web_results = future.result(
+                    timeout=_SEARCH_TIMEOUT_SECONDS
+                )
+        except concurrent.futures.TimeoutError:
+            logger.warning(
+                "DDGS search timed out after %ds for query %r",
+                _SEARCH_TIMEOUT_SECONDS,
+                query,
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"DuckDuckGo search timed out after"
+                    f" {_SEARCH_TIMEOUT_SECONDS} seconds"
+                    " (likely rate-limited). Try again later or"
+                    " switch to a different search provider."
+                ),
+            }
+        except Exception as exc:  # noqa: BLE001
             logger.warning("DDGS search error: %s", exc)
-            return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}
+            return {
+                "success": False,
+                "error": f"DuckDuckGo search failed: {exc}",
+            }
 
-        logger.info("DDGS search '%s': %d results (limit %d)", query, len(web_results), limit)
+        logger.info(
+            "DDGS search %r: %d results (limit %d)",
+            query,
+            len(web_results),
+            limit,
+        )
         return {"success": True, "data": {"web": web_results}}
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "DuckDuckGo (ddgs)",
             "badge": "free · no key · search only",
-            "tag": "Search via the ddgs Python package — no API key (pair with any extract provider)",
+            "tag": (
+                "Search via the ddgs Python package"
+                " — no API key (pair with any extract provider)"
+            ),
             "env_vars": [],
-            # Trigger `_run_post_setup("ddgs")` after the user picks this row
-            # so the ddgs Python package gets pip-installed on first selection.
+            # Trigger `_run_post_setup("ddgs")` after the user picks
+            # this row so the ddgs Python package gets pip-installed on
+            # first selection.
             "post_setup": "ddgs",
         }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -496,3 +496,94 @@ class TestErrorResponseShapes:
         assert isinstance(result, dict)
         assert result.get("success") is False
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# DDGS overall timeout (bug #36776)
+# ---------------------------------------------------------------------------
+
+
+class TestDDGSSearchTimeout:
+    """The DDGS provider returns a clear error when the search hangs."""
+
+    def test_search_returns_error_on_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hanging ddgs call is bounded by _SEARCH_TIMEOUT_SECONDS.
+
+        We patch ``_run_ddgs_search`` (the blocking helper) to sleep
+        longer than the configured timeout, and separately lower the
+        timeout constant so the test completes quickly.
+        """
+        import time
+
+        import plugins.web.ddgs.provider as ddgs_provider
+
+        # Lower the cap so the test doesn't wait 30 s.
+        monkeypatch.setattr(
+            ddgs_provider, "_SEARCH_TIMEOUT_SECONDS", 1
+        )
+
+        def _slow_search(query: str, safe_limit: int):
+            time.sleep(10)  # far exceeds the patched 1-second cap
+            return []
+
+        monkeypatch.setattr(
+            ddgs_provider, "_run_ddgs_search", _slow_search
+        )
+
+        # Patch the import-guard so the provider doesn't bail out early
+        # with "ddgs not installed".
+        import types
+
+        fake_ddgs = types.ModuleType("ddgs")
+        fake_ddgs.DDGS = object  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            __import__("sys").modules, "ddgs", fake_ddgs
+        )
+
+        provider = ddgs_provider.DDGSWebSearchProvider()
+        result = provider.search("test query", limit=3)
+
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+        error_msg = result["error"]
+        assert "timed out" in error_msg.lower()
+        assert "1 second" in error_msg
+
+    def test_successful_search_not_affected_by_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fast searches still return results normally."""
+        import plugins.web.ddgs.provider as ddgs_provider
+
+        def _fast_search(query: str, safe_limit: int):
+            return [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "description": "An example result",
+                    "position": 1,
+                }
+            ]
+
+        monkeypatch.setattr(
+            ddgs_provider, "_run_ddgs_search", _fast_search
+        )
+
+        import types
+
+        fake_ddgs = types.ModuleType("ddgs")
+        fake_ddgs.DDGS = object  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            __import__("sys").modules, "ddgs", fake_ddgs
+        )
+
+        provider = ddgs_provider.DDGSWebSearchProvider()
+        result = provider.search("test query", limit=3)
+
+        assert result.get("success") is True
+        assert "data" in result
+        assert len(result["data"]["web"]) == 1
+        assert result["data"]["web"][0]["url"] == "https://example.com"


### PR DESCRIPTION
Closes #36776. DDGS retry loop had no aggregate deadline; rate-limited DuckDuckGo could block agent for 20+ minutes. Wrap blocking iteration in ThreadPoolExecutor with future.result(timeout=30). Returns clear user-facing error on timeout. Adds 2 tests.