### PR TITLE
fix(agent): skip temperature/topP for Opus 4.7/4.8 on Bedrock (#36151)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -900,10 +900,18 @@ def build_converse_kwargs(
     if system_prompt:
         kwargs["system"] = system_prompt
 
-    if temperature is not None:
+    # Guard: some models (Opus 4.7+, 4.8+) reject non-default sampling
+    # parameters with ValidationException ("temperature is deprecated").
+    # Re-use the same guard that the Anthropic-native adapter applies.
+    try:
+        from agent.anthropic_adapter import _forbids_sampling_params as _no_sampling
+    except ImportError:
+        _no_sampling = lambda _m: False  # noqa: E731 — fallback if SDK not installed
+
+    if temperature is not None and not _no_sampling(model):
         kwargs["inferenceConfig"]["temperature"] = temperature
 
-    if top_p is not None:
+    if top_p is not None and not _no_sampling(model):
         kwargs["inferenceConfig"]["topP"] = top_p
 
     if stop_sequences:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -605,6 +605,68 @@ class TestBuildConverseKwargs:
         assert kwargs["inferenceConfig"]["temperature"] == 0.7
         assert kwargs["inferenceConfig"]["topP"] == 0.9
 
+    def test_omits_temperature_and_top_p_for_opus_4_7(self):
+        """Opus 4.7+ rejects temperature/top_p — guard must strip them on Bedrock path."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        for model_id in [
+            "anthropic.claude-opus-4-7-20260101-v1:0",
+            "us.anthropic.claude-opus-4-7",
+        ]:
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.7,
+                top_p=0.9,
+            )
+            assert "temperature" not in kwargs["inferenceConfig"], (
+                f"temperature should be stripped for {model_id}"
+            )
+            assert "topP" not in kwargs["inferenceConfig"], (
+                f"topP should be stripped for {model_id}"
+            )
+
+    def test_omits_temperature_and_top_p_for_opus_4_8(self):
+        """Opus 4.8 also rejects temperature/top_p — guard must cover 4-8/4.8 variants."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        for model_id in [
+            "anthropic.claude-opus-4-8-20270101-v1:0",
+            "us.anthropic.claude-opus-4-8",
+            "anthropic.claude-opus-4.8",
+        ]:
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.5,
+                top_p=0.95,
+            )
+            assert "temperature" not in kwargs["inferenceConfig"], (
+                f"temperature should be stripped for {model_id}"
+            )
+            assert "topP" not in kwargs["inferenceConfig"], (
+                f"topP should be stripped for {model_id}"
+            )
+
+    def test_includes_temperature_and_top_p_for_non_restricted_models(self):
+        """Non-restricted models (Sonnet 4.6, Haiku 4.5, etc.) should keep sampling params."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        for model_id in [
+            "anthropic.claude-sonnet-4-6-20250514-v1:0",
+            "anthropic.claude-haiku-4-5",
+            "test-model",
+        ]:
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.7,
+                top_p=0.9,
+            )
+            assert kwargs["inferenceConfig"].get("temperature") == 0.7, (
+                f"temperature should be included for {model_id}"
+            )
+            assert kwargs["inferenceConfig"].get("topP") == 0.9, (
+                f"topP should be included for {model_id}"
+            )
+
     def test_includes_guardrail_config(self):
         from agent.bedrock_adapter import build_converse_kwargs
         guardrail = {


### PR DESCRIPTION
Closes #36151. Bedrock Converse rejects sampling params for Opus 4.7/4.8 with ValidationException. Apply existing _forbids_sampling_params() guard from anthropic_adapter in bedrock_adapter's build_converse_kwargs() before writing temperature/topP. Adds 3 tests.