### PR TITLE
fix(send_message): deliver MEDIA attachments as email targets

### DIFF
--- a/tests/tools/test_send_message_email_media.py
+++ b/tests/tools/test_send_message_email_media.py
@@ -1,0 +1,217 @@
+"""Regression test: send_message routes MEDIA attachments to email targets.
+
+Verifies that ``_send_to_platform`` dispatches to ``_send_email_with_media``
+when the platform is EMAIL and ``media_files`` is non-empty, and that the
+resulting SMTP call sends a multipart message with the expected attachments.
+
+Fixes: https://github.com/NousResearch/hermes-agent/issues/38708
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def _email_env(monkeypatch):
+    """Provide minimal email credentials via env vars."""
+    monkeypatch.setenv("EMAIL_ADDRESS", "test@example.com")
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setenv("EMAIL_SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("EMAIL_SMTP_PORT", "587")
+
+
+@pytest.fixture()
+def _sample_attachment(tmp_path):
+    """Create a small temp file to use as a media attachment."""
+    p = tmp_path / "report.pdf"
+    p.write_bytes(b"%PDF-1.4 fake pdf content")
+    return str(p)
+
+
+class TestSendEmailWithMedia:
+    """Unit tests for ``_send_email_with_media``."""
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_single_attachment(self, _sample_attachment):
+        from tools.send_message_tool import _send_email_with_media
+
+        captured = {}
+
+        with patch("tools.send_message_tool.smtplib.SMTP") as mock_smtp_cls:
+            mock_server = MagicMock()
+            mock_smtp_cls.return_value = mock_server
+
+            async def _run():
+                return await _send_email_with_media(
+                    extra={},
+                    chat_id="user@example.com",
+                    message="See attached report.",
+                    media_files=[(_sample_attachment, False)],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        assert result["success"] is True
+        assert result["attachments"] == 1
+        assert result["platform"] == "email"
+
+        # Verify send_message was called with a multipart message
+        mock_server.send_message.assert_called_once()
+        msg = mock_server.send_message.call_args[0][0]
+        assert msg.is_multipart()
+        parts = list(msg.walk())
+        # multipart/alternative + text/plain + application/octet-stream
+        assert len(parts) >= 3
+        # The last part should be the attachment
+        attachment_part = parts[-1]
+        assert "attachment" in attachment_part.get("Content-Disposition", "")
+        assert "report.pdf" in attachment_part.get("Content-Disposition", "")
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_multiple_attachments(self, tmp_path):
+        from tools.send_message_tool import _send_email_with_media
+
+        f1 = tmp_path / "doc1.txt"
+        f1.write_text("hello")
+        f2 = tmp_path / "doc2.csv"
+        f2.write_text("a,b,c")
+
+        with patch("tools.send_message_tool.smtplib.SMTP") as mock_smtp_cls:
+            mock_server = MagicMock()
+            mock_smtp_cls.return_value = mock_server
+
+            async def _run():
+                return await _send_email_with_media(
+                    extra={},
+                    chat_id="user@example.com",
+                    message="Two files attached.",
+                    media_files=[(str(f1), False), (str(f2), False)],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        assert result["success"] is True
+        assert result["attachments"] == 2
+
+        msg = mock_server.send_message.call_args[0][0]
+        parts = list(msg.walk())
+        # text/plain + 2 attachments = at least 4 parts (outer multipart + text + 2 attachments)
+        attachment_parts = [
+            p for p in parts
+            if "attachment" in p.get("Content-Disposition", "")
+        ]
+        assert len(attachment_parts) == 2
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_missing_file_skipped_with_warning(self, monkeypatch, caplog):
+        from tools.send_message_tool import _send_email_with_media
+
+        with patch("tools.send_message_tool.smtplib.SMTP") as mock_smtp_cls:
+            mock_server = MagicMock()
+            mock_smtp_cls.return_value = mock_server
+
+            async def _run():
+                return await _send_email_with_media(
+                    extra={},
+                    chat_id="user@example.com",
+                    message="Trying to attach missing file.",
+                    media_files=[("/nonexistent/path/file.pdf", False)],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        assert result["success"] is True
+        assert result["attachments"] == 0  # no valid files
+        # Should still send the text body (no crash)
+        mock_server.send_message.assert_called_once()
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_empty_media_files_sends_text_only(self):
+        from tools.send_message_tool import _send_email_with_media
+
+        with patch("tools.send_message_tool.smtplib.SMTP") as mock_smtp_cls:
+            mock_server = MagicMock()
+            mock_smtp_cls.return_value = mock_server
+
+            async def _run():
+                return await _send_email_with_media(
+                    extra={},
+                    chat_id="user@example.com",
+                    message="Just text, no attachments.",
+                    media_files=[],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        assert result["success"] is True
+        assert result["attachments"] == 0
+
+
+class TestSendToPlatformEmailMediaRouting:
+    """Integration-level test: _send_to_platform dispatches email+media correctly."""
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_email_with_media_calls_send_email_with_media(self, _sample_attachment):
+        from tools.send_message_tool import _send_to_platform
+
+        with patch(
+            "tools.send_message_tool._send_email_with_media",
+            new_callable=AsyncMock,
+            return_value={"success": True, "platform": "email", "chat_id": "u@e.com", "attachments": 1},
+        ) as mock_send, patch(
+            "tools.send_message_tool._send_email",
+            new_callable=AsyncMock,
+        ) as mock_plain:
+            from gateway.config import Platform
+
+            pconfig = MagicMock()
+            pconfig.extra = {}
+
+            async def _run():
+                return await _send_to_platform(
+                    Platform.EMAIL, pconfig, "u@e.com",
+                    "See attached.", media_files=[(_sample_attachment, False)],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        # Must route to the media-aware function, not the plain one
+        mock_send.assert_called_once()
+        mock_plain.assert_not_called()
+        assert result["success"] is True
+
+    @pytest.mark.usefixtures("_email_env")
+    def test_email_without_media_calls_plain_send(self):
+        from tools.send_message_tool import _send_to_platform
+
+        with patch(
+            "tools.send_message_tool._send_email_with_media",
+            new_callable=AsyncMock,
+        ) as mock_media, patch(
+            "tools.send_message_tool._send_email",
+            new_callable=AsyncMock,
+            return_value={"success": True, "platform": "email", "chat_id": "u@e.com"},
+        ) as mock_plain:
+            from gateway.config import Platform
+
+            pconfig = MagicMock()
+            pconfig.extra = {}
+
+            async def _run():
+                return await _send_to_platform(
+                    Platform.EMAIL, pconfig, "u@e.com",
+                    "Just text.", media_files=[],
+                )
+
+            result = asyncio.get_event_loop().run_until_complete(_run())
+
+        # Without media, should use the plain send
+        mock_plain.assert_called_once()
+        mock_media.assert_not_called()
+        assert result["success"] is True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -749,11 +749,27 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Email: native attachment support via SMTP multipart ---
+    if platform == Platform.EMAIL and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_email_with_media(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and email; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -761,7 +777,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and email"
         )
 
     last_result = None
@@ -1312,6 +1328,68 @@ async def _send_email(extra, chat_id, message):
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         return _error(f"Email send failed: {e}")
+
+
+async def _send_email_with_media(extra, chat_id, message, media_files=None):
+    """Send via SMTP with file attachments (multipart MIME).
+
+    ``media_files`` is a list of ``(path, is_voice)`` tuples produced by
+    ``BasePlatformAdapter.extract_media`` / ``filter_media_delivery_paths``.
+    Non-existent paths are silently skipped with a warning.
+    """
+    import smtplib
+    from email.mime.base import MIMEBase
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+    from email import encoders
+
+    address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
+    password = os.getenv("EMAIL_PASSWORD", "")
+    smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    try:
+        smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+    except (ValueError, TypeError):
+        smtp_port = 587
+
+    if not all([address, password, smtp_host]):
+        return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
+
+    # Validate media files
+    valid_paths = []
+    for media_path, _is_voice in (media_files or []):
+        if os.path.exists(media_path):
+            valid_paths.append(media_path)
+        else:
+            logger.warning("Email media file not found, skipping: %s", media_path)
+
+    try:
+        msg = MIMEMultipart()
+        msg["From"] = address
+        msg["To"] = chat_id
+        msg["Subject"] = "Hermes Agent"
+        msg["Date"] = formatdate(localtime=True)
+
+        if message:
+            msg.attach(MIMEText(message, "plain", "utf-8"))
+
+        for file_path in valid_paths:
+            fname = os.path.basename(file_path)
+            with open(file_path, "rb") as f:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(f.read())
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={fname}")
+                msg.attach(part)
+
+        server = smtplib.SMTP(smtp_host, smtp_port)
+        server.starttls(context=ssl.create_default_context())
+        server.login(address, password)
+        server.send_message(msg)
+        server.quit()
+        return {"success": True, "platform": "email", "chat_id": chat_id,
+                "attachments": len(valid_paths)}
+    except Exception as e:
+        return _error(f"Email send with attachments failed: {e}")
 
 
 async def _send_sms(auth_token, chat_id, message):


### PR DESCRIPTION
## What does this PR do?

Routes `MEDIA:` file attachments through a new `_send_email_with_media` helper in `send_message_tool.py`, so that `send_message` with an email target delivers files as SMTP attachments instead of silently dropping them.

## Related Issue

Fixes #38708

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: Added `_send_email_with_media()` function that constructs a `MIMEMultipart` email with file attachments via SMTP. Added an email+media dispatch branch in `_send_to_platform()` (before the non-media fallback) that routes `Platform.EMAIL` with non-empty `media_files` to the new helper. Updated error/warning messages to include "email" in the supported-platforms list.
- `tests/tools/test_send_message_email_media.py`: 6 tests covering single attachment, multiple attachments, missing file skip, empty media, and routing dispatch (email+media → new helper, email without media → plain `_send_email`).

## How to Test

1. Configure email platform credentials (`EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `EMAIL_SMTP_HOST`).
2. Ask the agent to send a message with a local file attachment via `send_message(target="email:user@example.com", message="See attached. MEDIA:/path/to/file.pdf")`.
3. Verify the recipient receives the email with the PDF attached (not just the text body).
4. Run `pytest tests/tools/test_send_message_email_media.py -v` — all 6 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/send_message_tool.py:_send_to_platform` (callers: `_handle_send`, `send_message_tool`; flows: send_message → extract_media → _send_to_platform → platform dispatch)
- Blast radius: LOW — new code path for EMAIL+media only; existing email text-only path unchanged
- Related patterns: same dispatch pattern as Telegram (line 637), Signal (line 705), Feishu (line 736) — platform-specific media branch before non-media fallback
