### PR TITLE
fix(hindsight): sanitize runtime IDs before memory calls

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import queue
+import re
 import threading
 
 from datetime import datetime, timezone
@@ -379,6 +380,76 @@ def _normalize_retain_tags(value: Any) -> List[str]:
 def _utc_timestamp() -> str:
     """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+_HINDSIGHT_STRIP_BLOCK_PATTERNS = [
+    re.compile(r"(?is)<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>.*?<<<END_OPENCLAW_INTERNAL_CONTEXT>>>"),
+    re.compile(r"(?is)<hindsight_memories\b[^>]*>.*?</hindsight_memories>"),
+    re.compile(r"(?is)<summary\b[^>]*>.*?</summary>"),
+    re.compile(r"(?is)^\s*Conversation info \(untrusted metadata\):\s*```json\s*\{.*?\}\s*```\s*", re.MULTILINE),
+    re.compile(r"(?is)^\s*Sender \(untrusted metadata\):\s*```json\s*\{.*?\}\s*```\s*", re.MULTILINE),
+    re.compile(r"(?is)\[context\].*?\[/context\]"),
+]
+_HINDSIGHT_OPERATIONAL_KEYS = (
+    "message_id",
+    "open_id",
+    "union_id",
+    "user_id",
+    "sender",
+    "sender_id",
+    "chat_id",
+    "thread_id",
+    "conversation_id",
+    "tenant_key",
+)
+_HINDSIGHT_BRACKET_METADATA_LINE_RE = re.compile(
+    rf"(?im)^\s*\[(?:{'|'.join(_HINDSIGHT_OPERATIONAL_KEYS)}):\s*[^\]]+\]\s*\n?"
+)
+_HINDSIGHT_METADATA_LINE_RE = re.compile(
+    rf"(?im)^\s*(?:{'|'.join(_HINDSIGHT_OPERATIONAL_KEYS)})\s*[:=]\s*.+\n?"
+)
+_HINDSIGHT_RUNTIME_JSON_PAIR_RE = re.compile(
+    r'(?i)"(?:message_id|open_id|union_id|user_id|sender_id|chat_id|thread_id|conversation_id|tenant_key|id)"\s*:\s*"'
+    r'(?:user:)?(?:ou|oc|om|on|open)_[A-Za-z0-9_:-]{8,}"\s*,?'
+)
+_HINDSIGHT_RUNTIME_ID_RE = re.compile(r"\b(?:ou|oc|om|on|open)_[A-Za-z0-9_:-]{8,}\b")
+_HINDSIGHT_LEADING_SENDER_RE = re.compile(
+    r"(?s)^\s*(?:user:)?(?:ou|oc|om|on|open)_[A-Za-z0-9_:-]{8,}\s*:\s*"
+)
+
+
+def _coerce_hindsight_text(value: Any) -> str:
+    """Coerce memory input values to text before redaction."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list, tuple)):
+        try:
+            return json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            return str(value)
+    return str(value)
+
+
+def _sanitize_hindsight_input(value: Any) -> str:
+    """Remove transport/runtime metadata before retain or recall hits Hindsight."""
+    text = _coerce_hindsight_text(value)
+    if not text:
+        return ""
+
+    for pattern in _HINDSIGHT_STRIP_BLOCK_PATTERNS:
+        text = pattern.sub("\n", text)
+
+    text = _HINDSIGHT_RUNTIME_JSON_PAIR_RE.sub("", text)
+    text = _HINDSIGHT_BRACKET_METADATA_LINE_RE.sub("", text)
+    text = _HINDSIGHT_METADATA_LINE_RE.sub("", text)
+    text = _HINDSIGHT_LEADING_SENDER_RE.sub("", text)
+    text = _HINDSIGHT_RUNTIME_ID_RE.sub("", text)
+
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.splitlines()]
+    text = "\n".join(line for line in lines if line)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -1316,6 +1387,12 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         return f"{header}\n\n{result}"
 
+    def _sanitize_recall_query(self, query: Any) -> str:
+        text = _sanitize_hindsight_input(query)
+        if self._recall_max_input_chars and len(text) > self._recall_max_input_chars:
+            return text[:self._recall_max_input_chars].rstrip()
+        return text
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._memory_mode == "tools":
             logger.debug("Prefetch: skipped (tools-only mode)")
@@ -1326,9 +1403,10 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._shutting_down.is_set():
             logger.debug("Prefetch: skipped (shutting down)")
             return
-        # Truncate query to max chars
-        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+        query = self._sanitize_recall_query(query)
+        if not query:
+            logger.debug("Prefetch: skipped (empty query after sanitization)")
+            return
 
         def _run():
             try:
@@ -1363,15 +1441,17 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
+        user_text = _sanitize_hindsight_input(user_content)
+        assistant_text = _sanitize_hindsight_input(assistant_content)
         return [
             {
                 "role": "user",
-                "content": f"{self._retain_user_prefix}: {user_content}",
+                "content": f"{self._retain_user_prefix}: {user_text}",
                 "timestamp": now,
             },
             {
                 "role": "assistant",
-                "content": f"{self._retain_assistant_prefix}: {assistant_content}",
+                "content": f"{self._retain_assistant_prefix}: {assistant_text}",
                 "timestamp": now,
             },
         ]
@@ -1517,7 +1597,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
-            content = args.get("content", "")
+            content = _sanitize_hindsight_input(args.get("content", ""))
             if not content:
                 return tool_error("Missing required parameter: content")
             context = args.get("context")
@@ -1537,7 +1617,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error(f"Failed to store memory: {e}")
 
         elif tool_name == "hindsight_recall":
-            query = args.get("query", "")
+            query = self._sanitize_recall_query(args.get("query", ""))
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
@@ -1564,7 +1644,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error(f"Failed to search memory: {e}")
 
         elif tool_name == "hindsight_reflect":
-            query = args.get("query", "")
+            query = self._sanitize_recall_query(args.get("query", ""))
             if not query:
                 return tool_error("Missing required parameter: query")
             try:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -25,6 +25,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _sanitize_hindsight_input,
 )
 
 
@@ -151,6 +152,27 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
     assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
+
+
+def test_sanitize_hindsight_input_strips_runtime_identifiers():
+    dirty = """Conversation info (untrusted metadata):
+```json
+{"message_id": "om_x100000000000", "open_id": "ou_cb100000000000"}
+```
+[message_id: om_x200000000000]
+sender: ou_cb200000000000
+ou_cb300000000000: check retain semantics
+<hindsight_memories>old temporary recall</hindsight_memories>
+<summary>old session summary</summary>
+[context]sender_id: ou_cb400000000000[/context]
+"""
+
+    clean = _sanitize_hindsight_input(dirty)
+
+    assert clean == "check retain semantics"
+    assert "message_id" not in clean
+    assert "om_x" not in clean
+    assert "ou_cb" not in clean
 
 
 # ---------------------------------------------------------------------------
@@ -473,6 +495,21 @@ class TestToolHandlers:
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["content"] == "user likes dark mode"
 
+    def test_retain_tool_strips_runtime_identifiers(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain",
+            {
+                "content": (
+                    "[message_id: om_x100000000000]\n"
+                    "sender: ou_cb100000000000\n"
+                    "user likes compact UI"
+                )
+            },
+        ))
+        assert result["result"] == "Memory stored successfully."
+        call_kwargs = provider._client.aretain.call_args.kwargs
+        assert call_kwargs["content"] == "user likes compact UI"
+
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
@@ -505,6 +542,23 @@ class TestToolHandlers:
         ))
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
+
+    def test_recall_tool_strips_runtime_identifiers(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": (
+                    "Conversation info (untrusted metadata):\n"
+                    "```json\n"
+                    '{"message_id": "om_x100000000000", "open_id": "ou_cb100000000000"}\n'
+                    "```\n"
+                    "ou_cb200000000000: check retain semantics"
+                )
+            },
+        ))
+        assert "Memory 1" in result["result"]
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["query"] == "check retain semantics"
 
     def test_recall_passes_max_tokens(self, provider_with_config):
         p = provider_with_config(recall_max_tokens=2048)
@@ -543,6 +597,15 @@ class TestToolHandlers:
             "hindsight_reflect", {"query": "summarize"}
         ))
         assert result["result"] == "Synthesized answer"
+
+    def test_reflect_tool_strips_runtime_identifiers(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect",
+            {"query": "[open_id: ou_cb100000000000]\nsummarize project status"},
+        ))
+        assert result["result"] == "Synthesized answer"
+        call_kwargs = provider._client.areflect.call_args.kwargs
+        assert call_kwargs["query"] == "summarize project status"
 
     def test_reflect_missing_query(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -647,6 +710,23 @@ class TestPrefetch:
         # The query passed to arecall should be truncated
         if original_query is not None:
             assert len(original_query) <= 10
+
+    def test_queue_prefetch_strips_runtime_identifiers_from_query(self, provider):
+        provider.queue_prefetch(
+            "[message_id: om_x100000000000]\n"
+            "ou_cb100000000000: check retain semantics"
+        )
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["query"] == "check retain semantics"
+
+    def test_queue_prefetch_skips_empty_query_after_sanitization(self, provider):
+        provider.queue_prefetch("[message_id: om_x100000000000]")
+
+        assert provider._prefetch_thread is None
+        provider._client.arecall.assert_not_called()
 
     def test_queue_prefetch_passes_recall_params(self, provider_with_config):
         p = provider_with_config(
@@ -779,6 +859,32 @@ class TestSyncTurn:
         assert content[-1][1]["content"] == "Assistant: turn3-asst"
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
+
+    def test_sync_turn_strips_runtime_identifiers_from_retain_content(self, provider):
+        dirty_user = """Conversation info (untrusted metadata):
+```json
+{"message_id": "om_x100000000000", "open_id": "ou_cb100000000000"}
+```
+[message_id: om_x200000000000]
+ou_cb300000000000: check retain semantics
+[context]sender_id: ou_cb400000000000[/context]
+<hindsight_memories>old temporary recall</hindsight_memories>
+<summary>old session summary</summary>
+"""
+
+        provider.sync_turn(dirty_user, "normal reply")
+        provider._retain_queue.join()
+
+        content = provider._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "check retain semantics" in content
+        assert "normal reply" in content
+        assert "message_id" not in content
+        assert "om_x" not in content
+        assert "ou_cb" not in content
+        assert "[context]" not in content
+        assert "sender_id" not in content
+        assert "hindsight_memories" not in content
+        assert "old session summary" not in content
 
     def test_sync_turn_accumulates_full_session(self, provider_with_config):
         """Each retain sends the ENTIRE session, not just the latest batch."""


### PR DESCRIPTION
## Summary
- strip transport/runtime identifiers from Hindsight retain and recall inputs
- apply the same cleanup to auto prefetch and memory tools
- add regression coverage for message/open IDs in retain, recall, reflect, and prefetch paths

## Validation
- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `uv run --extra dev pytest tests/plugins/memory/test_hindsight_provider.py -q`
- `git diff --check`
