### PR TITLE
fix(send_message): attach media for email targets

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1200,6 +1200,9 @@ async def _standalone_send(
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
     import smtplib
     import ssl as _ssl
+    from email import encoders
+    from email.mime.base import MIMEBase
+    from email.mime.multipart import MIMEMultipart
     from email.mime.text import MIMEText
     from email.utils import formatdate
 
@@ -1216,7 +1219,19 @@ async def _standalone_send(
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
     try:
-        msg = MIMEText(message, "plain", "utf-8")
+        if media_files:
+            msg = MIMEMultipart()
+            msg.attach(MIMEText(message or "See attached file(s).", "plain", "utf-8"))
+            for media_path, _is_voice in media_files:
+                path = Path(media_path)
+                with path.open("rb") as handle:
+                    part = MIMEBase("application", "octet-stream")
+                    part.set_payload(handle.read())
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", "attachment", filename=path.name)
+                msg.attach(part)
+        else:
+            msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -332,6 +332,87 @@ class TestDispatchMessage(unittest.TestCase):
             self.assertEqual(len(captured), 1)
 
 
+class TestStandaloneSend(unittest.TestCase):
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "bot@example.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.example.com",
+        "EMAIL_SMTP_PORT": "587",
+    }, clear=False)
+    def test_media_files_are_mime_attachments(self):
+        import asyncio
+        import tempfile
+
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import _standalone_send
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as attachment:
+            attachment.write(b"%PDF-1.4 fake")
+            attachment_path = attachment.name
+
+        try:
+            with patch("smtplib.SMTP") as smtp_cls:
+                server = MagicMock()
+                smtp_cls.return_value = server
+
+                result = asyncio.run(
+                    _standalone_send(
+                        PlatformConfig(enabled=True),
+                        "user@example.com",
+                        "See attached.",
+                        media_files=[(attachment_path, False)],
+                    )
+                )
+
+            self.assertTrue(result["success"])
+            sent_msg = server.send_message.call_args.args[0]
+            attachments = [
+                part for part in sent_msg.walk()
+                if part.get_content_disposition() == "attachment"
+            ]
+            self.assertEqual(len(attachments), 1)
+            self.assertEqual(attachments[0].get_filename(), os.path.basename(attachment_path))
+        finally:
+            os.unlink(attachment_path)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "bot@example.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.example.com",
+    }, clear=False)
+    def test_media_only_send_uses_default_body(self):
+        import asyncio
+        import tempfile
+
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import _standalone_send
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as attachment:
+            attachment.write(b"%PDF-1.4 fake")
+            attachment_path = attachment.name
+
+        try:
+            with patch("smtplib.SMTP") as smtp_cls:
+                server = MagicMock()
+                smtp_cls.return_value = server
+
+                result = asyncio.run(
+                    _standalone_send(
+                        PlatformConfig(enabled=True),
+                        "user@example.com",
+                        "",
+                        media_files=[(attachment_path, False)],
+                    )
+                )
+
+            self.assertTrue(result["success"])
+            sent_msg = server.send_message.call_args.args[0]
+            body = next(part for part in sent_msg.walk() if part.get_content_type() == "text/plain")
+            self.assertEqual(body.get_payload(decode=True).decode(body.get_content_charset()), "See attached file(s).")
+        finally:
+            os.unlink(attachment_path)
+
+
 class TestThreadContext(unittest.TestCase):
     """Test email reply threading logic."""
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -711,6 +711,85 @@ class TestSendToPlatformWhatsapp:
         assert _call.args[2] == "hello from hermes"
 
 
+class TestSendToPlatformEmailMedia:
+    def test_email_media_routes_through_plugin_sender(self, tmp_path):
+        from gateway.platform_registry import platform_registry
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        attachment = tmp_path / "report.pdf"
+        attachment.write_bytes(b"%PDF-1.4 fake")
+        email_entry = platform_registry.get("email")
+        pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+        original_sender = email_entry.standalone_sender_fn
+        sender = AsyncMock(
+            return_value={"success": True, "platform": "email", "chat_id": "user@example.com"}
+        )
+        email_entry.standalone_sender_fn = sender
+
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.EMAIL,
+                    pconfig,
+                    "user@example.com",
+                    "See attached.",
+                    media_files=[(str(attachment), False)],
+                )
+            )
+        finally:
+            email_entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        sender.assert_awaited_once_with(
+            pconfig,
+            "user@example.com",
+            "See attached.",
+            thread_id=None,
+            media_files=[(str(attachment), False)],
+            force_document=False,
+        )
+
+    def test_long_email_media_body_stays_in_one_message(self, tmp_path):
+        from gateway.platform_registry import platform_registry
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        attachment = tmp_path / "report.pdf"
+        attachment.write_bytes(b"%PDF-1.4 fake")
+        body = "x" * 50_001
+        email_entry = platform_registry.get("email")
+        pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+        original_sender = email_entry.standalone_sender_fn
+        sender = AsyncMock(
+            return_value={"success": True, "platform": "email", "chat_id": "user@example.com"}
+        )
+        email_entry.standalone_sender_fn = sender
+
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.EMAIL,
+                    pconfig,
+                    "user@example.com",
+                    body,
+                    media_files=[(str(attachment), False)],
+                )
+            )
+        finally:
+            email_entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        sender.assert_awaited_once_with(
+            pconfig,
+            "user@example.com",
+            body,
+            thread_id=None,
+            media_files=[(str(attachment), False)],
+            force_document=False,
+        )
+
+
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML
     and that plain / markdown messages use MarkdownV2."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -985,6 +985,18 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Email: native MIME attachment support via the plugin sender ---
+    if platform == Platform.EMAIL and media_files:
+        return await _registry_standalone_send(
+            "email",
+            pconfig,
+            chat_id,
+            message,
+            thread_id,
+            media_files=media_files,
+            force_document=force_document,
+        )
+
     # --- Slack: native media via files_upload_v2 in the plugin's
     # standalone_sender_fn (plugins/platforms/slack/adapter.py::_standalone_send).
     # Gateway in-channel MEDIA: delivery already worked; send_message previously
@@ -1107,7 +1119,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp, slack and email; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -1115,7 +1127,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp, slack and email"
         )
 
     last_result = None
@@ -1497,7 +1509,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(
+    platform_name,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    *,
+    media_files=None,
+    force_document=False,
+):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1510,7 +1531,14 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    return await entry.standalone_sender_fn(
+        pconfig,
+        chat_id,
+        message,
+        thread_id=thread_id,
+        media_files=media_files,
+        force_document=force_document,
+    )
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,


### PR DESCRIPTION
## What changed

Fixes #38708 by routing `send_message` email targets with `MEDIA:` files through a MIME attachment path instead of falling back to text-only `_send_email`.

Email now behaves like the other native media-capable targets:
- text + `MEDIA:/path/file` sends one email with the text body and attachment
- media-only messages are deliverable with a small default body
- unsupported non-email platforms still get the existing omission/error behavior

This is a clean alternative to #38719; that PR currently fails its own focused tests locally because its tests patch `tools.send_message_tool.smtplib.SMTP` while `smtplib` is imported inside the helper.

## Validation

- `python -m pytest tests/tools/test_send_message_email_media.py -q` -> 3 passed
- `python -m pytest tests/gateway/test_email.py::TestSendEmailStandalone tests/gateway/test_send_multiple_images.py::TestEmailMultiImage tests/tools/test_send_message_email_media.py -q` -> 9 passed
- `python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_email_media.py` -> passed
- `git diff --check` -> passed