### PR TITLE
Generalize gateway follow-up grace

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2606,6 +2606,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     _startup_restore_in_progress: bool = False
+    _followup_grace_invalid_warnings: set[tuple[str, str]] = set()
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -2638,6 +2639,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._busy_text_mode = self._load_busy_text_mode()
+        self._followup_grace_cache: Dict[str, float] = {}
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
@@ -4613,6 +4615,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No explicit legacy knob → follow busy_input_mode.
         input_mode = GatewayRunner._load_busy_input_mode()
         return "queue" if input_mode == "queue" else "interrupt"
+
+    @staticmethod
+    def _load_followup_grace(platform: Any) -> float:
+        """Load per-platform follow-up queue/merge grace in seconds."""
+        platform_name = _gateway_platform_value(platform)
+        telegram_platform_name = _gateway_platform_value(Platform.TELEGRAM)
+
+        def _parse_seconds(raw: Any, label: str) -> Optional[float]:
+            if raw is None:
+                return None
+            if isinstance(raw, str) and not raw.strip():
+                return None
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                warning_key = (label, repr(raw))
+                if warning_key not in GatewayRunner._followup_grace_invalid_warnings:
+                    GatewayRunner._followup_grace_invalid_warnings.add(warning_key)
+                    logger.warning("Invalid followup grace seconds for %s: %r", label, raw)
+                return None
+
+        global_env = _parse_seconds(
+            os.getenv("HERMES_FOLLOWUP_GRACE_SECONDS"),
+            "HERMES_FOLLOWUP_GRACE_SECONDS",
+        )
+        if global_env is not None:
+            return global_env
+
+        if platform_name == telegram_platform_name:
+            telegram_env = _parse_seconds(
+                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS"),
+                "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS",
+            )
+            if telegram_env is not None:
+                return telegram_env
+
+        cfg = _load_gateway_runtime_config()
+        per_platform = cfg_get(
+            cfg,
+            "gateway",
+            "followup_grace_per_platform",
+            platform_name,
+            default=None,
+        )
+        parsed = _parse_seconds(
+            per_platform,
+            f"gateway.followup_grace_per_platform.{platform_name}",
+        )
+        if parsed is not None:
+            return parsed
+
+        global_config = _parse_seconds(
+            cfg_get(cfg, "gateway", "followup_grace_seconds", default=None),
+            "gateway.followup_grace_seconds",
+        )
+        if global_config is not None:
+            return global_config
+
+        if platform_name == telegram_platform_name:
+            return 3.0
+        return 0.0
+
+    def _get_followup_grace(self, platform: Any) -> float:
+        """Return cached per-platform follow-up grace seconds."""
+        platform_name = _gateway_platform_value(platform)
+        cache = getattr(self, "_followup_grace_cache", None)
+        if cache is None:
+            cache = {}
+            self._followup_grace_cache = cache
+        if platform_name not in cache:
+            cache[platform_name] = self._load_followup_grace(platform)
+        return cache[platform_name]
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -8998,20 +9072,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
+            _followup_grace = self._get_followup_grace(source.platform)
             _started_at = self._running_agents_ts.get(_quick_key, 0)
+            _followup_elapsed = time.time() - _started_at if _started_at else 0
             if (
-                source.platform == Platform.TELEGRAM
-                and event.message_type == MessageType.TEXT
-                and _telegram_followup_grace > 0
+                event.message_type == MessageType.TEXT
+                and _followup_grace > 0
                 and _started_at
-                and (time.time() - _started_at) <= _telegram_followup_grace
+                and _followup_elapsed <= _followup_grace
             ):
                 logger.debug(
-                    "Telegram follow-up arrived %.2fs after run start for %s — queueing without interrupt",
-                    time.time() - _started_at,
+                    "Follow-up arrived on %s %.2fs after run start for %s — queueing without interrupt",
+                    _gateway_platform_value(source.platform),
+                    _followup_elapsed,
                     _quick_key,
                 )
                 adapter = self.adapters.get(source.platform)

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -40,11 +40,19 @@ class _FakeAdapter:
 def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+        }
     )
-    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner.adapters = {
+        Platform.TELEGRAM: _FakeAdapter(),
+        Platform.DISCORD: _FakeAdapter(),
+    }
     runner._running_agents = {}
     runner._running_agents_ts = {}
+    runner._busy_input_mode = "interrupt"
+    runner._followup_grace_cache = {}
     runner._session_run_generation = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
@@ -67,9 +75,9 @@ def _make_runner():
     return runner
 
 
-def _make_event(text="hello", chat_id="12345"):
+def _make_event(text="hello", chat_id="12345", platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm",
+        platform=platform, chat_id=chat_id, chat_type="dm",
         user_id="u1",
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
@@ -263,8 +271,54 @@ def test_merge_pending_message_event_promotes_document_followups_over_text():
     assert merged.media_types == ["application/pdf"]
 
 
+def test_load_followup_grace_uses_global_env_override(monkeypatch):
+    monkeypatch.setenv("HERMES_FOLLOWUP_GRACE_SECONDS", "2.5")
+    monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "7.0")
+
+    runtime_config = {
+        "gateway": {
+            "followup_grace_per_platform": {
+                "discord": 0,
+            },
+            "followup_grace_seconds": 1.0,
+        },
+    }
+    with patch("gateway.run._load_gateway_runtime_config", return_value=runtime_config):
+        assert GatewayRunner._load_followup_grace(Platform.DISCORD) == 2.5
+        assert GatewayRunner._load_followup_grace(Platform.TELEGRAM) == 2.5
+
+
+def test_load_followup_grace_keeps_telegram_legacy_env(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "4.0")
+
+    with patch("gateway.run._load_gateway_runtime_config", return_value={}):
+        assert GatewayRunner._load_followup_grace(Platform.TELEGRAM) == 4.0
+        assert GatewayRunner._load_followup_grace(Platform.DISCORD) == 0.0
+
+
+def test_load_followup_grace_uses_platform_config_before_global(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runtime_config = {
+        "gateway": {
+            "followup_grace_per_platform": {
+                "telegram": 3.0,
+            },
+            "followup_grace_seconds": 1.0,
+        },
+    }
+    with patch("gateway.run._load_gateway_runtime_config", return_value=runtime_config):
+        assert GatewayRunner._load_followup_grace(Platform.TELEGRAM) == 3.0
+        assert GatewayRunner._load_followup_grace(Platform.DISCORD) == 1.0
+
+
 @pytest.mark.asyncio
-async def test_recent_telegram_text_followup_is_queued_without_interrupt():
+async def test_recent_telegram_text_followup_is_queued_without_interrupt(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
     runner = _make_runner()
     event = _make_event(text="follow-up")
     session_key = build_session_key(event.source)
@@ -275,7 +329,8 @@ async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     import time as _time
     runner._running_agents_ts[session_key] = _time.time()
 
-    result = await runner._handle_message(event)
+    with patch("gateway.run._load_gateway_runtime_config", return_value={}):
+        result = await runner._handle_message(event)
 
     assert result is None
     fake_agent.interrupt.assert_not_called()
@@ -284,7 +339,10 @@ async def test_recent_telegram_text_followup_is_queued_without_interrupt():
 
 
 @pytest.mark.asyncio
-async def test_recent_telegram_followups_append_in_pending_queue():
+async def test_recent_telegram_followups_append_in_pending_queue(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
     runner = _make_runner()
     first = _make_event(text="part one")
     second = _make_event(text="part two")
@@ -296,12 +354,69 @@ async def test_recent_telegram_followups_append_in_pending_queue():
     import time as _time
     runner._running_agents_ts[session_key] = _time.time()
 
-    await runner._handle_message(first)
-    await runner._handle_message(second)
+    with patch("gateway.run._load_gateway_runtime_config", return_value={}) as load_config:
+        await runner._handle_message(first)
+        await runner._handle_message(second)
 
     fake_agent.interrupt.assert_not_called()
+    assert load_config.call_count == 1
     adapter = runner.adapters[Platform.TELEGRAM]
     assert adapter._pending_messages[session_key].text == "part one\npart two"
+
+
+@pytest.mark.asyncio
+async def test_recent_discord_text_followup_defaults_to_interrupt(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner()
+    event = _make_event(text="follow-up", platform=Platform.DISCORD)
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time()
+
+    with patch("gateway.run._load_gateway_runtime_config", return_value={}):
+        result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.interrupt.assert_called_once_with("follow-up")
+    adapter = runner.adapters[Platform.DISCORD]
+    assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_recent_discord_text_followup_can_be_queued_by_config(monkeypatch):
+    monkeypatch.delenv("HERMES_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner()
+    event = _make_event(text="follow-up", platform=Platform.DISCORD)
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time()
+
+    runtime_config = {
+        "gateway": {
+            "followup_grace_per_platform": {
+                "discord": 3.0,
+            },
+        },
+    }
+    with patch("gateway.run._load_gateway_runtime_config", return_value=runtime_config):
+        result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.interrupt.assert_not_called()
+    adapter = runner.adapters[Platform.DISCORD]
+    assert adapter._pending_messages[session_key].text == "follow-up"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add platform-aware gateway follow-up grace loading from env and config
- Preserve Telegram's 3s default and legacy HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS behavior
- Queue and merge text follow-ups within the configured grace window for any enabled platform
- Add coverage for env precedence, platform/global config, Telegram compatibility, and Discord default/configured behavior

## Tests
- ./venv/bin/ruff check gateway/run.py tests/gateway/test_session_race_guard.py
- scripts/run_tests.sh tests/gateway/test_session_race_guard.py
