### PR TITLE
Add inline buttons for cron Telegram delivery

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -509,6 +509,40 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def normalize_buttons(buttons: Optional[Any]) -> Optional[List[Dict[str, str]]]:
+    """Normalize optional cron inline-button definitions.
+
+    Storage shape is a flat list of ``{text, value}`` mappings. A plain string
+    becomes both the visible label and the callback value. Invalid or blank
+    entries are ignored; labels/values are trimmed before storage.
+    """
+    if not buttons:
+        return None
+    if isinstance(buttons, str):
+        buttons = [buttons]
+    elif not isinstance(buttons, list):
+        return None
+
+    normalized: List[Dict[str, str]] = []
+    for item in buttons:
+        if isinstance(item, str):
+            text = item.strip()
+            value = text
+        elif isinstance(item, dict):
+            text = str(item.get("text") or item.get("label") or "").strip()
+            value = str(item.get("value") or item.get("data") or text).strip()
+        else:
+            continue
+        if not text:
+            continue
+        if not value:
+            value = text
+        normalized.append({"text": text[:80], "value": value[:120]})
+        if len(normalized) >= 20:
+            break
+    return normalized or None
+
+
 # Fields whose presence in an update can turn a runnable job into an empty one.
 _PAYLOAD_FIELDS = frozenset({"prompt", "script", "skill", "skills", "no_agent"})
 
@@ -590,6 +624,8 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     # half-paused record (enabled=true + state/paused_at) cannot render as
     # "paused" while the fleet is still live. See effective_job_state().
     normalized["state"] = effective_job_state(normalized)
+
+    normalized["buttons"] = normalize_buttons(normalized.get("buttons"))
 
     return normalized
 
@@ -1933,6 +1969,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    buttons: Optional[List[Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2000,6 +2037,8 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        buttons: Optional inline buttons to attach when the delivery platform
+                supports them. Stored as ``[{"text": ..., "value": ...}]``.
 
     Returns:
         The created job dict
@@ -2037,13 +2076,12 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    normalized_buttons = normalize_buttons(buttons)
 
-    # Monitor-mode validation: exactly one source, and monitor mode only
-    # makes sense when there IS an agent to suppress/wake.
-    # no_agent jobs are meaningless without a script — the script IS the job.
-    # Surface these as clear ValueErrors at create time so bad configs never
-    # reach the scheduler (shared with update_job, see
-    # _validate_job_mode_invariants).
+    # Surface execution-mode invariants as clear ValueErrors at create time so
+    # bad configs never reach the scheduler (shared with update_job, see
+    # _validate_job_mode_invariants). Monitor mode needs exactly one source and
+    # a real agent to suppress/wake; no_agent jobs need a script to execute.
     _validate_job_mode_invariants(
         normalized_monitor_script,
         normalized_monitor_url,
@@ -2139,6 +2177,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "buttons": normalized_buttons,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -2263,6 +2302,8 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["reasoning_effort"] = _normalize_reasoning_effort(
                     updates["reasoning_effort"]
                 )
+            if "buttons" in updates:
+                updates["buttons"] = normalize_buttons(updates.get("buttons"))
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -427,6 +427,45 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def normalize_buttons(buttons: Optional[Any]) -> Optional[List[Dict[str, str]]]:
+    """Normalize optional cron inline-button definitions.
+
+    Storage shape is a flat list of ``{text, value}`` mappings.  A plain
+    string becomes both the visible label and the callback value.  Invalid or
+    blank entries are ignored; over-long labels/values are trimmed so Telegram
+    callback payloads stay safely below Bot API limits once the job id/index
+    prefix is added.
+    """
+    if not buttons:
+        return None
+    if isinstance(buttons, str):
+        buttons = [buttons]
+    elif not isinstance(buttons, list):
+        return None
+
+    normalized: List[Dict[str, str]] = []
+    for idx, item in enumerate(buttons):
+        if isinstance(item, str):
+            text = item.strip()
+            value = text
+        elif isinstance(item, dict):
+            text = str(item.get("text") or item.get("label") or "").strip()
+            value = str(item.get("value") or item.get("data") or text).strip()
+        else:
+            continue
+        if not text:
+            continue
+        if not value:
+            value = text
+        normalized.append({
+            "text": text[:80],
+            "value": value[:120],
+        })
+        if len(normalized) >= 20:
+            break
+    return normalized or None
+
+
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
@@ -476,6 +515,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     # "paused" while the fleet is still live. See effective_job_state().
     normalized["state"] = effective_job_state(normalized)
 
+    normalized["buttons"] = normalize_buttons(normalized.get("buttons"))
     return normalized
 
 
@@ -1586,6 +1626,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    buttons: Optional[List[Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1643,6 +1684,8 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        buttons: Optional inline buttons to attach when the delivery platform
+                supports them. Stored as ``[{"text": ..., "value": ...}]``.
 
     Returns:
         The created job dict
@@ -1680,12 +1723,12 @@ def create_job(
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
 
-    # Monitor-mode validation: exactly one source, and monitor mode only
-    # makes sense when there IS an agent to suppress/wake.
-    # no_agent jobs are meaningless without a script — the script IS the job.
-    # Surface these as clear ValueErrors at create time so bad configs never
-    # reach the scheduler (shared with update_job, see
-    # _validate_job_mode_invariants).
+    normalized_buttons = normalize_buttons(buttons)
+
+    # Surface execution-mode invariants as clear ValueErrors at create time so
+    # bad configs never reach the scheduler (shared with update_job, see
+    # _validate_job_mode_invariants). Monitor mode needs exactly one source and
+    # a real agent to suppress/wake; no_agent jobs need a script to execute.
     _validate_job_mode_invariants(
         normalized_monitor_script,
         normalized_monitor_url,
@@ -1777,6 +1820,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "buttons": normalized_buttons,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1890,6 +1934,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates[_mon_field] = _mv or None
 
             previous_inference_axes = _normalized_inference_axes(job)
+
+            if "buttons" in updates:
+                updates["buttons"] = normalize_buttons(updates.get("buttons"))
+
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1681,6 +1681,17 @@ def _resolve_cron_surface_mode(pconfig, logical_platform_name: str) -> str:
     return "thread"
 
 
+def _cron_button_metadata(job: dict) -> dict | None:
+    buttons = job.get("buttons")
+    if not buttons:
+        return None
+    return {
+        "job_id": str(job.get("id", "")),
+        "job_name": str(job.get("name") or job.get("id") or "cron job"),
+        "buttons": buttons,
+    }
+
+
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
 
@@ -3332,6 +3343,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
                 runtime_adapter, chat_id, loop, job["id"],
             )
+            cron_buttons = _cron_button_metadata(job)
             if route_via_dm_topic:
                 # Genuine Bot API channel Direct-Messages topic (#22773 mode 2):
                 # routed via direct_messages_topic_id, no bare thread_id.
@@ -3373,6 +3385,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata.setdefault("scope_id", str(origin["scope_id"]))
                 media_metadata = dict(media_metadata or {})
                 media_metadata.setdefault("scope_id", str(origin["scope_id"]))
+            if cron_buttons:
+                route_metadata["cron_buttons"] = cron_buttons
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1469,6 +1469,17 @@ _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
 _IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
 
 
+def _cron_button_metadata(job: dict) -> dict | None:
+    buttons = job.get("buttons")
+    if not buttons:
+        return None
+    return {
+        "job_id": str(job.get("id", "")),
+        "job_name": str(job.get("name") or job.get("id") or "cron job"),
+        "buttons": buttons,
+    }
+
+
 def _send_media_via_adapter(
     adapter,
     chat_id: str,
@@ -1892,6 +1903,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 looks_like_telegram_private_chat_id,
             )
 
+            cron_buttons = _cron_button_metadata(job)
             is_ambiguous_telegram_topic = (
                 platform == Platform.TELEGRAM
                 and thread_id is not None
@@ -1926,7 +1938,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
-
+            if cron_buttons:
+                route_metadata["cron_buttons"] = cron_buttons
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
                 # Route through the gateway's DeliveryRouter so the live send

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -15,6 +15,7 @@ import logging
 import os
 import html as _html
 import re
+import secrets
 import threading
 import time
 from contextvars import ContextVar
@@ -2256,6 +2257,9 @@ class TelegramAdapter(BasePlatformAdapter):
         payload.update(self._notification_kwargs(metadata))
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
+        cron_reply_markup = self._cron_buttons_reply_markup(metadata)
+        if cron_reply_markup is not None:
+            payload["reply_markup"] = cron_reply_markup
         if reply_to_id is not None:
             # Spec: sendRichMessage takes reply_parameters (ReplyParameters
             # object), NOT the legacy reply_to_message_id scalar. Unknown
@@ -5325,6 +5329,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
+            cron_reply_markup = self._cron_buttons_reply_markup(metadata)
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -5389,29 +5394,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
-                            msg = await self._bot.send_message(
-                                chat_id=normalize_telegram_chat_id(chat_id),
-                                text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
-                                reply_to_message_id=reply_to_id,
+                            send_kwargs = {
+                                "chat_id": normalize_telegram_chat_id(chat_id),
+                                "text": chunk,
+                                "parse_mode": ParseMode.MARKDOWN_V2,
+                                "reply_to_message_id": reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
-                            )
+                            }
+                            if cron_reply_markup is not None and i == len(chunks) - 1:
+                                send_kwargs["reply_markup"] = cron_reply_markup
+                            msg = await self._bot.send_message(**send_kwargs)
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
-                                msg = await self._bot.send_message(
-                                    chat_id=normalize_telegram_chat_id(chat_id),
-                                    text=plain_chunk,
-                                    parse_mode=None,
-                                    reply_to_message_id=reply_to_id,
+                                plain_send_kwargs = {
+                                    "chat_id": normalize_telegram_chat_id(chat_id),
+                                    "text": plain_chunk,
+                                    "parse_mode": None,
+                                    "reply_to_message_id": reply_to_id,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
-                                )
+                                }
+                                if cron_reply_markup is not None and i == len(chunks) - 1:
+                                    plain_send_kwargs["reply_markup"] = cron_reply_markup
+                                msg = await self._bot.send_message(**plain_send_kwargs)
                             else:
                                 raise
                         break  # success
@@ -6250,6 +6261,186 @@ class TelegramAdapter(BasePlatformAdapter):
                 retry_kwargs.pop("message_thread_id", None)
                 return await self._bot.send_message(**retry_kwargs)
             raise
+
+    def _cron_button_token_path(self):
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "cron" / "button_tokens.json"
+
+    def _load_cron_button_tokens(self) -> Dict[str, Dict[str, Any]]:
+        path = self._cron_button_token_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return {
+                        str(token): value
+                        for token, value in data.items()
+                        if isinstance(value, dict)
+                    }
+        except Exception:
+            logger.debug("[%s] failed to load cron button tokens", self.name, exc_info=True)
+        return {}
+
+    def _save_cron_button_tokens(self, tokens: Dict[str, Dict[str, Any]]) -> None:
+        path = self._cron_button_token_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(tokens, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+    def _register_cron_button_token(
+        self,
+        *,
+        job_id: str,
+        job_name: Optional[str],
+        button_index: int,
+        label: str,
+        value: str,
+    ) -> str:
+        """Persist an immutable delivery-time button mapping and return its token."""
+        tokens = self._load_cron_button_tokens()
+        for _ in range(8):
+            token = secrets.token_urlsafe(9)
+            if token not in tokens:
+                break
+        else:
+            token = secrets.token_urlsafe(12)
+        tokens[token] = {
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "platform": "telegram",
+            "job_id": job_id,
+            "job_name": job_name,
+            "button_index": button_index,
+            "button_text": label,
+            "button_value": value,
+        }
+        if len(tokens) > 1000:
+            tokens = dict(list(tokens.items())[-1000:])
+        self._save_cron_button_tokens(tokens)
+        return token
+
+    def _cron_buttons_reply_markup(self, metadata: Optional[Dict[str, Any]]) -> Optional[Any]:
+        """Build Telegram inline keyboard for cron delivery buttons."""
+        cron_meta = (metadata or {}).get("cron_buttons") if isinstance(metadata, dict) else None
+        if not isinstance(cron_meta, dict):
+            return None
+        job_id = str(cron_meta.get("job_id") or "").strip()
+        job_name = str(cron_meta.get("job_name") or "").strip() or None
+        buttons = cron_meta.get("buttons")
+        if not job_id or not isinstance(buttons, list):
+            return None
+
+        rows = []
+        row = []
+        for idx, button in enumerate(buttons[:20]):
+            if isinstance(button, str):
+                label = button.strip()
+                value = label
+            elif isinstance(button, dict):
+                label = str(button.get("text") or button.get("label") or "").strip()
+                value = str(button.get("value") or button.get("data") or label).strip()
+            else:
+                continue
+            if not label:
+                continue
+            if not value:
+                value = label
+            token = self._register_cron_button_token(
+                job_id=job_id,
+                job_name=job_name,
+                button_index=idx,
+                label=label,
+                value=value,
+            )
+            row.append(InlineKeyboardButton(label[:64], callback_data=f"cj:{token}"))
+            if len(row) == 2:
+                rows.append(row)
+                row = []
+        if row:
+            rows.append(row)
+        return InlineKeyboardMarkup(rows) if rows else None
+
+    async def _handle_cron_button_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Record a cron inline-button response in the local cron journal."""
+        parts = data.split(":", 1)
+        if len(parts) != 2 or not parts[1]:
+            await query.answer(text="Invalid cron button data.")
+            return
+        token = parts[1]
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to answer this cron prompt.")
+            return
+
+        token_record = self._load_cron_button_tokens().get(token)
+        if not isinstance(token_record, dict):
+            await query.answer(text="This cron button is no longer available.")
+            return
+
+        job_id = str(token_record.get("job_id") or "")
+        job_name = token_record.get("job_name")
+        try:
+            idx = int(token_record.get("button_index", 0))
+        except (TypeError, ValueError):
+            idx = 0
+        label = str(token_record.get("button_text") or token_record.get("button_value") or idx + 1)
+        value = str(token_record.get("button_value") or label)
+
+        user_display = getattr(query.from_user, "first_name", "User")
+        try:
+            from hermes_constants import get_hermes_home
+
+            response_dir = get_hermes_home() / "cron"
+            response_dir.mkdir(parents=True, exist_ok=True)
+            response_path = response_dir / "button_responses.jsonl"
+            record = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "platform": "telegram",
+                "job_id": job_id,
+                "job_name": job_name,
+                "button_index": idx,
+                "button_text": label,
+                "button_value": value,
+                "chat_id": str(query_chat_id) if query_chat_id is not None else None,
+                "thread_id": str(query_thread_id) if query_thread_id is not None else None,
+                "message_id": str(getattr(getattr(query, "message", None), "message_id", "")) or None,
+                "user_id": caller_id or None,
+                "user_name": user_display,
+            }
+            with response_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception as exc:
+            logger.error("[%s] failed to record cron button response: %s", self.name, exc, exc_info=True)
+            await query.answer(text="Could not record this response.")
+            return
+
+        await query.answer(text=f"✓ {label[:60]}")
+        try:
+            original = getattr(getattr(query, "message", None), "text", "") or ""
+            await query.edit_message_text(
+                text=f"{_html.escape(original)}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(label)}",
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
 
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
@@ -7396,6 +7587,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Cron delivery feedback callbacks (cj:opaque-token) ---
+        if data.startswith("cj:"):
+            await self._handle_cron_button_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,6 +16,7 @@ import logging
 import os
 import html as _html
 import re
+import secrets
 import threading
 import time
 from contextvars import ContextVar
@@ -1888,6 +1889,9 @@ class TelegramAdapter(BasePlatformAdapter):
         payload.update(self._notification_kwargs(metadata))
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
+        cron_reply_markup = self._cron_buttons_reply_markup(metadata)
+        if cron_reply_markup is not None:
+            payload["reply_markup"] = cron_reply_markup
         if reply_to_id is not None:
             # Spec: sendRichMessage takes reply_parameters (ReplyParameters
             # object), NOT the legacy reply_to_message_id scalar. Unknown
@@ -4587,6 +4591,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
+            cron_reply_markup = self._cron_buttons_reply_markup(metadata)
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -4651,29 +4656,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
-                            msg = await self._bot.send_message(
-                                chat_id=normalize_telegram_chat_id(chat_id),
-                                text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
-                                reply_to_message_id=reply_to_id,
+                            send_kwargs = {
+                                "chat_id": normalize_telegram_chat_id(chat_id),
+                                "text": chunk,
+                                "parse_mode": ParseMode.MARKDOWN_V2,
+                                "reply_to_message_id": reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
-                            )
+                            }
+                            if cron_reply_markup is not None and i == len(chunks) - 1:
+                                send_kwargs["reply_markup"] = cron_reply_markup
+                            msg = await self._bot.send_message(**send_kwargs)
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
-                                msg = await self._bot.send_message(
-                                    chat_id=normalize_telegram_chat_id(chat_id),
-                                    text=plain_chunk,
-                                    parse_mode=None,
-                                    reply_to_message_id=reply_to_id,
+                                plain_send_kwargs = {
+                                    "chat_id": normalize_telegram_chat_id(chat_id),
+                                    "text": plain_chunk,
+                                    "parse_mode": None,
+                                    "reply_to_message_id": reply_to_id,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
-                                )
+                                }
+                                if cron_reply_markup is not None and i == len(chunks) - 1:
+                                    plain_send_kwargs["reply_markup"] = cron_reply_markup
+                                msg = await self._bot.send_message(**plain_send_kwargs)
                             else:
                                 raise
                         break  # success
@@ -5495,6 +5506,187 @@ class TelegramAdapter(BasePlatformAdapter):
                 retry_kwargs.pop("message_thread_id", None)
                 return await self._bot.send_message(**retry_kwargs)
             raise
+
+    def _cron_button_token_path(self):
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "cron" / "button_tokens.json"
+
+    def _load_cron_button_tokens(self) -> Dict[str, Dict[str, Any]]:
+        path = self._cron_button_token_path()
+        try:
+            if path.exists():
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return {
+                        str(token): value
+                        for token, value in data.items()
+                        if isinstance(value, dict)
+                    }
+        except Exception:
+            logger.debug("[%s] failed to load cron button tokens", self.name, exc_info=True)
+        return {}
+
+    def _save_cron_button_tokens(self, tokens: Dict[str, Dict[str, Any]]) -> None:
+        path = self._cron_button_token_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(tokens, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+    def _register_cron_button_token(
+        self,
+        *,
+        job_id: str,
+        job_name: Optional[str],
+        button_index: int,
+        label: str,
+        value: str,
+    ) -> str:
+        """Persist an immutable delivery-time button mapping and return its token."""
+        tokens = self._load_cron_button_tokens()
+        for _ in range(8):
+            token = secrets.token_urlsafe(9)
+            if token not in tokens:
+                break
+        else:
+            token = secrets.token_urlsafe(12)
+        tokens[token] = {
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "platform": "telegram",
+            "job_id": job_id,
+            "job_name": job_name,
+            "button_index": button_index,
+            "button_text": label,
+            "button_value": value,
+        }
+        # Keep the token store bounded; old buttons remain useful for a long
+        # time, but the file should not grow forever on high-volume gateways.
+        if len(tokens) > 1000:
+            tokens = dict(list(tokens.items())[-1000:])
+        self._save_cron_button_tokens(tokens)
+        return token
+
+    def _cron_buttons_reply_markup(self, metadata: Optional[Dict[str, Any]]) -> Optional[Any]:
+        """Build Telegram inline keyboard for cron delivery buttons."""
+        cron_meta = (metadata or {}).get("cron_buttons") if isinstance(metadata, dict) else None
+        if not isinstance(cron_meta, dict):
+            return None
+        job_id = str(cron_meta.get("job_id") or "").strip()
+        job_name = str(cron_meta.get("job_name") or "").strip() or None
+        buttons = cron_meta.get("buttons")
+        if not job_id or not isinstance(buttons, list):
+            return None
+
+        rows = []
+        row = []
+        for idx, button in enumerate(buttons[:20]):
+            if isinstance(button, str):
+                label = button.strip()
+                value = label
+            elif isinstance(button, dict):
+                label = str(button.get("text") or button.get("label") or "").strip()
+                value = str(button.get("value") or button.get("data") or label).strip()
+            else:
+                continue
+            if not label:
+                continue
+            if not value:
+                value = label
+            token = self._register_cron_button_token(
+                job_id=job_id,
+                job_name=job_name,
+                button_index=idx,
+                label=label,
+                value=value,
+            )
+            row.append(InlineKeyboardButton(label[:64], callback_data=f"cj:{token}"))
+            if len(row) == 2:
+                rows.append(row)
+                row = []
+        if row:
+            rows.append(row)
+        return InlineKeyboardMarkup(rows) if rows else None
+
+    async def _handle_cron_button_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Record a cron inline-button response in the local cron journal."""
+        parts = data.split(":", 1)
+        if len(parts) != 2 or not parts[1]:
+            await query.answer(text="Invalid cron button data.")
+            return
+        token = parts[1]
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to answer this cron prompt.")
+            return
+
+        token_record = self._load_cron_button_tokens().get(token)
+        if not isinstance(token_record, dict):
+            await query.answer(text="This cron button is no longer available.")
+            return
+
+        job_id = str(token_record.get("job_id") or "")
+        job_name = token_record.get("job_name")
+        try:
+            idx = int(token_record.get("button_index", 0))
+        except (TypeError, ValueError):
+            idx = 0
+        label = str(token_record.get("button_text") or token_record.get("button_value") or idx + 1)
+        value = str(token_record.get("button_value") or label)
+
+        user_display = getattr(query.from_user, "first_name", "User")
+        try:
+            from hermes_constants import get_hermes_home
+            response_dir = get_hermes_home() / "cron"
+            response_dir.mkdir(parents=True, exist_ok=True)
+            response_path = response_dir / "button_responses.jsonl"
+            record = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "platform": "telegram",
+                "job_id": job_id,
+                "job_name": job_name,
+                "button_index": idx,
+                "button_text": label,
+                "button_value": value,
+                "chat_id": str(query_chat_id) if query_chat_id is not None else None,
+                "thread_id": str(query_thread_id) if query_thread_id is not None else None,
+                "message_id": str(getattr(getattr(query, "message", None), "message_id", "")) or None,
+                "user_id": caller_id or None,
+                "user_name": user_display,
+            }
+            with response_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception as exc:
+            logger.error("[%s] failed to record cron button response: %s", self.name, exc, exc_info=True)
+            await query.answer(text="Could not record this response.")
+            return
+
+        await query.answer(text=f"✓ {label[:60]}")
+        try:
+            original = getattr(getattr(query, "message", None), "text", "") or ""
+            await query.edit_message_text(
+                text=f"{_html.escape(original)}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(label)}",
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
 
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
@@ -6757,6 +6949,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,
                     )
+            return
+
+        # --- Cron delivery feedback callbacks (cj:opaque-token) ---
+        if data.startswith("cj:"):
+            await self._handle_cron_button_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
 
         # --- Update prompt callbacks ---

--- a/tests/gateway/test_telegram_cron_buttons.py
+++ b/tests/gateway/test_telegram_cron_buttons.py
@@ -1,0 +1,196 @@
+"""Tests for Telegram inline buttons on cron deliveries."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+TelegramAdapter = load_plugin_adapter("telegram").TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra=extra or {}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_send_attaches_cron_buttons_to_telegram_message(tmp_path, monkeypatch):
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+
+    adapter = _make_adapter()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 123
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        "12345",
+        "Cron text",
+        metadata={
+            "cron_buttons": {
+                "job_id": "abc123",
+                "job_name": "test cron",
+                "buttons": [
+                    {"text": "1 — done", "value": "done"},
+                    {"text": "2 — skipped", "value": "skipped"},
+                ],
+            }
+        },
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    assert bot.send_message.call_args is not None
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 12345
+    assert kwargs["text"] == "Cron text"
+    assert kwargs["reply_markup"] is not None
+    tokens_path = tmp_path / "cron" / "button_tokens.json"
+    tokens = json.loads(tokens_path.read_text(encoding="utf-8"))
+    assert len(tokens) == 2
+    stored = list(tokens.values())
+    assert stored[0]["job_id"] == "abc123"
+    assert stored[0]["job_name"] == "test cron"
+    assert stored[0]["button_text"] == "1 — done"
+    assert stored[0]["button_value"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_cron_button_callback_records_response(tmp_path, monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **k: True)
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    token = adapter._register_cron_button_token(
+        job_id="abc123",
+        job_name="test cron",
+        button_index=1,
+        label="2 — skipped",
+        value="skipped",
+    )
+
+    query = AsyncMock()
+    query.data = f"cj:{token}"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 987
+    query.message.message_thread_id = 42
+    query.message.text = "Cron text"
+    query.message.chat = MagicMock()
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    await adapter._handle_callback_query(update, MagicMock())
+
+    query.answer.assert_awaited_once()
+    query.edit_message_text.assert_awaited_once()
+    response_path = tmp_path / "cron" / "button_responses.jsonl"
+    assert response_path.exists()
+    line = response_path.read_text(encoding="utf-8").strip()
+    assert '"job_id": "abc123"' in line
+    assert '"button_value": "skipped"' in line
+    assert '"thread_id": "42"' in line
+
+
+@pytest.mark.asyncio
+async def test_cron_button_callback_uses_delivery_time_mapping_after_job_edit(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **k: True)
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    token = adapter._register_cron_button_token(
+        job_id="abc123",
+        job_name="test cron",
+        button_index=0,
+        label="Original choice",
+        value="original-value",
+    )
+
+    query = AsyncMock()
+    query.data = f"cj:{token}"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 987
+    query.message.message_thread_id = None
+    query.message.text = "Cron text"
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    # Simulate the job being edited after this delivery.  The callback must not
+    # reload current job.buttons by job_id/index, because that would record the
+    # new choice rather than the immutable choice shown on the old message.
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(
+        jobs_mod,
+        "get_job",
+        lambda job_id: {
+            "id": job_id,
+            "name": "test cron",
+            "buttons": [{"text": "Edited choice", "value": "edited-value"}],
+        },
+    )
+
+    update = MagicMock()
+    update.callback_query = query
+
+    await adapter._handle_callback_query(update, MagicMock())
+
+    response_path = tmp_path / "cron" / "button_responses.jsonl"
+    line = response_path.read_text(encoding="utf-8").strip()
+    assert '"button_text": "Original choice"' in line
+    assert '"button_value": "original-value"' in line
+    assert "edited-value" not in line

--- a/tests/gateway/test_telegram_cron_buttons.py
+++ b/tests/gateway/test_telegram_cron_buttons.py
@@ -1,0 +1,200 @@
+"""Tests for Telegram inline buttons on cron deliveries."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+TelegramAdapter = load_plugin_adapter("telegram").TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra=extra or {}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_send_attaches_cron_buttons_to_telegram_message(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+
+    adapter = _make_adapter()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 123
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        "12345",
+        "Cron text",
+        metadata={
+            "cron_buttons": {
+                "job_id": "abc123",
+                "job_name": "test cron",
+                "buttons": [
+                    {"text": "1 — done", "value": "done"},
+                    {"text": "2 — skipped", "value": "skipped"},
+                ],
+            }
+        },
+    )
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    assert bot.send_message.call_args is not None
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 12345
+    assert kwargs["text"] == "Cron text"
+    assert kwargs["reply_markup"] is not None
+    tokens_path = tmp_path / "cron" / "button_tokens.json"
+    tokens = json.loads(tokens_path.read_text(encoding="utf-8"))
+    assert len(tokens) == 2
+    stored = list(tokens.values())
+    assert stored[0]["job_id"] == "abc123"
+    assert stored[0]["job_name"] == "test cron"
+    assert stored[0]["button_text"] == "1 — done"
+    assert stored[0]["button_value"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_cron_button_callback_records_response(tmp_path, monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **k: True)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    token = adapter._register_cron_button_token(
+        job_id="abc123",
+        job_name="test cron",
+        button_index=1,
+        label="2 — skipped",
+        value="skipped",
+    )
+
+    query = AsyncMock()
+    query.data = f"cj:{token}"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 987
+    query.message.message_thread_id = 42
+    query.message.text = "Cron text"
+    query.message.chat = MagicMock()
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    await adapter._handle_callback_query(update, MagicMock())
+
+    query.answer.assert_awaited_once()
+    query.edit_message_text.assert_awaited_once()
+    response_path = tmp_path / "cron" / "button_responses.jsonl"
+    assert response_path.exists()
+    line = response_path.read_text(encoding="utf-8").strip()
+    assert '"job_id": "abc123"' in line
+    assert '"button_value": "skipped"' in line
+    assert '"thread_id": "42"' in line
+
+
+@pytest.mark.asyncio
+async def test_cron_button_callback_uses_delivery_time_mapping_after_job_edit(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **k: True)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    token = adapter._register_cron_button_token(
+        job_id="abc123",
+        job_name="test cron",
+        button_index=0,
+        label="Original choice",
+        value="original-value",
+    )
+
+    query = AsyncMock()
+    query.data = f"cj:{token}"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 987
+    query.message.message_thread_id = None
+    query.message.text = "Cron text"
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    # Simulate the job being edited after this delivery. The callback must not
+    # reload current job.buttons by job_id/index, because that would record the
+    # new choice rather than the immutable choice shown on the old message.
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(
+        jobs_mod,
+        "get_job",
+        lambda job_id: {
+            "id": job_id,
+            "name": "test cron",
+            "buttons": [{"text": "Edited choice", "value": "edited-value"}],
+        },
+    )
+
+    update = MagicMock()
+    update.callback_query = query
+
+    await adapter._handle_callback_query(update, MagicMock())
+
+    response_path = tmp_path / "cron" / "button_responses.jsonl"
+    line = response_path.read_text(encoding="utf-8").strip()
+    assert '"button_text": "Original choice"' in line
+    assert '"button_value": "original-value"' in line
+    assert "edited-value" not in line

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -793,6 +793,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("buttons"):
+        result["buttons"] = job["buttons"]
     stored_refs = job.get("context_from") or []
     if isinstance(stored_refs, str):
         stored_refs = [stored_refs]
@@ -1369,6 +1371,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    buttons: Optional[List[Any]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1485,6 +1488,7 @@ def cronjob(
                     # dispatch below: models do not make model-config
                     # decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    buttons=buttons,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1783,6 +1787,9 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if buttons is not None:
+                from cron.jobs import normalize_buttons
+                updates["buttons"] = normalize_buttons(buttons)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1905,6 +1912,23 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "boolean",
                 "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the origin DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts."
             },
+            "buttons": {
+                "type": "array",
+                "description": "Optional inline buttons to attach to cron delivery on supported platforms (currently Telegram live gateway). Each item may be a string or an object with text and optional value. Button presses are recorded locally for later review.",
+                "items": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "text": {"type": "string"},
+                                "value": {"type": "string"}
+                            },
+                            "required": ["text"]
+                        }
+                    ]
+                }
+            },
         },
         "required": ["action"]
     }
@@ -1972,6 +1996,7 @@ def _cronjob_handler(args, **kw):
         no_agent=args.get("no_agent"),
         monitor_script=_mon_script,
         monitor_url=_mon_url,
+        buttons=args.get("buttons"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     )

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -594,6 +594,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("buttons"):
+        result["buttons"] = job["buttons"]
     return result
 
 
@@ -1052,6 +1054,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    buttons: Optional[List[Any]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1140,6 +1143,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    buttons=buttons,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1399,6 +1403,9 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if buttons is not None:
+                from cron.jobs import normalize_buttons
+                updates["buttons"] = normalize_buttons(buttons)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1552,6 +1559,23 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "buttons": {
+                "type": "array",
+                "description": "Optional inline buttons to attach to cron delivery on supported platforms (currently Telegram live gateway). Each item may be a string or an object with text and optional value. Button presses are recorded locally for later review.",
+                "items": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "text": {"type": "string"},
+                                "value": {"type": "string"}
+                            },
+                            "required": ["text"]
+                        }
+                    ]
+                }
+            },
         },
         "required": ["action"]
     }
@@ -1611,6 +1635,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        buttons=args.get("buttons"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),


### PR DESCRIPTION
## Summary
- Add optional `buttons` storage/schema support for cron jobs.
- Attach Telegram inline keyboards to live cron deliveries when a job has buttons.
- Handle cron button callback presses and append responses to `~/.hermes/cron/button_responses.jsonl`.
- Add Telegram gateway tests for sending cron buttons and recording callback responses.

## Tests
- `python -m py_compile cron/jobs.py cron/scheduler.py tools/cronjob_tools.py gateway/platforms/telegram.py tests/gateway/test_telegram_cron_buttons.py`
- `scripts/run_tests.sh tests/gateway/test_telegram_cron_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_approval_buttons.py tests/tools/test_cronjob_tools.py tests/cron`
