### PR TITLE
fix(dump): count configured MCP servers

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -17,6 +17,7 @@ from hermes_cli.config import get_hermes_home, get_env_path, get_project_root, l
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 from agent.skill_utils import is_excluded_skill_path
+from utils import is_truthy_value
 
 
 def _get_git_commit(project_root: Path) -> str:
@@ -100,9 +101,18 @@ def _count_skills(hermes_home: Path) -> int:
 
 def _count_mcp_servers(config: dict) -> int:
     """Count configured MCP servers."""
-    mcp = config.get("mcp", {})
-    servers = mcp.get("servers", {})
-    return len(servers)
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        mcp = config.get("mcp", {})
+        servers = mcp.get("servers", {}) if isinstance(mcp, dict) else {}
+    if not isinstance(servers, dict):
+        return 0
+    return sum(
+        1
+        for server_cfg in servers.values()
+        if not isinstance(server_cfg, dict)
+        or is_truthy_value(server_cfg.get("enabled"), default=True)
+    )
 
 
 def _cron_summary(hermes_home: Path) -> str:

--- a/tests/hermes_cli/test_dump_git_commit.py
+++ b/tests/hermes_cli/test_dump_git_commit.py
@@ -11,6 +11,50 @@ These tests cover both paths plus the failure modes (no git, no baked file).
 from unittest.mock import MagicMock, patch
 
 
+def test_count_mcp_servers_uses_top_level_mcp_servers_config():
+    """Current config stores MCP servers at top-level ``mcp_servers``."""
+    from hermes_cli import dump
+
+    config = {
+        "mcp_servers": {
+            "filesystem": {"command": "npx", "args": ["-y", "server"]},
+            "github": {"url": "https://example.com/mcp"},
+        }
+    }
+
+    assert dump._count_mcp_servers(config) == 2
+
+
+def test_count_mcp_servers_ignores_disabled_servers():
+    """Disabled MCP entries are configured but not active/connected."""
+    from hermes_cli import dump
+
+    config = {
+        "mcp_servers": {
+            "enabled": {"command": "npx"},
+            "disabled_bool": {"command": "npx", "enabled": False},
+            "disabled_string": {"command": "npx", "enabled": "false"},
+        }
+    }
+
+    assert dump._count_mcp_servers(config) == 1
+
+
+def test_count_mcp_servers_keeps_legacy_nested_config_compatibility():
+    """Older config snapshots used ``mcp.servers``."""
+    from hermes_cli import dump
+
+    config = {
+        "mcp": {
+            "servers": {
+                "legacy": {"command": "npx"},
+            }
+        }
+    }
+
+    assert dump._count_mcp_servers(config) == 1
+
+
 def test_get_git_commit_uses_live_git_when_available(tmp_path):
     """Source install: ``git rev-parse --short=8 HEAD`` wins; no fallback."""
     from hermes_cli import dump


### PR DESCRIPTION
## Summary

Fixes the `hermes dump` MCP server count for the current config shape.

`hermes dump` was still reading the legacy nested `mcp.servers` config, while Hermes now stores MCP server definitions at top-level `mcp_servers`. That made dumps report `mcp_servers: 0` even when MCP servers were configured.

This change:
- counts top-level `mcp_servers`
- ignores entries with `enabled: false` / `enabled: "false"`
- preserves compatibility with older `mcp.servers` snapshots

Partially addresses #38650 by fixing the deterministic `hermes dump` count path. The separate welcome-screen stale status path may still need a dedicated startup/status refresh fix.

## Validation

- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_dump_git_commit.py -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check hermes_cli/dump.py tests/hermes_cli/test_dump_git_commit.py`
- `git diff --check`
