### PR TITLE
fix(cli): launchd KeepAlive unconditional restart + Windows venv rebuild (#37388 #37881)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -227,9 +227,8 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
 
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``
     which drains in-flight agent runs (up to ``agent.restart_drain_timeout``
-    seconds), then exits.  systemd relaunches clean exits via
-    ``Restart=always``; launchd still uses a non-zero planned-restart exit
-    because its plist has ``KeepAlive.SuccessfulExit = false``.
+    seconds), then exits.  Both systemd (``Restart=always``) and launchd
+    (unconditional ``<key>KeepAlive</key><true/>``) restart on any exit.
 
     This is the drain-aware alternative to ``systemctl restart`` / ``SIGTERM``,
     which SIGKILL in-flight agents after a short timeout.
@@ -3083,10 +3082,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -3249,7 +3245,7 @@ def launchd_stop():
         pass
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # immediately restarts it because KeepAlive is unconditionally true.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -105,13 +105,33 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
     old venv may point to a Python without FTS5, so we rebuild it with a
     fresh interpreter from the current managed uv.  Returns ``True`` on
     success.
+
+    On Windows, running hermes.exe / python.exe locks files inside the venv so
+    ``shutil.rmtree`` often fails silently (ignore_errors=True).  We therefore
+    always pass ``--clear`` to ``uv venv`` so uv itself handles the pre-existing
+    directory atomically, even when rmtree leaves behind locked files.
     """
     if venv_dir.exists():
         print(f"  → Rebuilding venv (old Python may lack FTS5)...")
-        shutil.rmtree(venv_dir, ignore_errors=True)
+        try:
+            shutil.rmtree(venv_dir)
+        except Exception as exc:
+            # On Windows, running hermes.exe / python.exe holds file locks
+            # inside the venv, so rmtree fails.  Log a warning and let
+            # ``uv venv --clear`` handle the leftover directory atomically.
+            logger.warning(
+                "Could not remove venv dir %s before rebuild (will rely on "
+                "`uv venv --clear` to clear it): %s",
+                venv_dir,
+                exc,
+            )
+            print(
+                f"  ⚠ Could not remove {venv_dir} ({exc}); "
+                "uv will clear it via --clear"
+            )
 
     result = subprocess.run(
-        [uv_bin, "venv", str(venv_dir), "--python", python_version],
+        [uv_bin, "venv", "--clear", str(venv_dir), "--python", python_version],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2579,3 +2579,24 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+    def test_launchd_plist_keepalive_unconditional(self, tmp_path, monkeypatch):
+        """KeepAlive must be unconditional <true/> so the gateway restarts on clean exits.
+
+        Bug #37388: the old ``KeepAlive.SuccessfulExit = false`` dict form meant
+        launchd would NOT restart after a zero-exit (e.g. ``gateway run --replace``
+        causes the old instance to exit cleanly).  Switching to the scalar
+        ``<key>KeepAlive</key><true/>`` makes launchd restart regardless of exit code.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        plist = gateway_cli.generate_launchd_plist()
+
+        # Scalar <true/> must be present immediately after the KeepAlive key
+        assert "<key>KeepAlive</key>" in plist
+        # The unconditional form
+        assert "<key>KeepAlive</key>\n    <true/>" in plist
+        # The old conditional dict form must NOT appear
+        assert "SuccessfulExit" not in plist
+        assert "<key>KeepAlive</key>\n    <dict>" not in plist

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -117,7 +117,7 @@ class TestRebuildVenv:
 
         def fake_run(cmd, **kwargs):
             m = MagicMock(returncode=0)
-            if cmd[1] == "venv":
+            if "venv" in cmd:
                 # Simulate uv creating the venv dir
                 venv_dir.mkdir(exist_ok=True)
                 bin_dir = venv_dir / "bin"
@@ -132,7 +132,62 @@ class TestRebuildVenv:
             from hermes_cli.managed_uv import rebuild_venv
             result = rebuild_venv(uv_bin, venv_dir)
             assert result is True
-            mock_rmtree.assert_called_once_with(venv_dir, ignore_errors=True)
+            # rmtree is called without ignore_errors; failures are caught explicitly
+            mock_rmtree.assert_called_once_with(venv_dir)
+
+    def test_uv_venv_called_with_clear_flag(self, tmp_path):
+        """uv venv must always receive --clear so locked Windows dirs are handled atomically."""
+        venv_dir = tmp_path / "venv"
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock(returncode=0)
+            if "venv" in cmd:
+                venv_dir.mkdir(exist_ok=True)
+                bin_dir = venv_dir / "bin"
+                bin_dir.mkdir(parents=True, exist_ok=True)
+                (bin_dir / "python").write_text("fake python")
+            elif "--version" in cmd:
+                m.stdout = "Python 3.11.0"
+            return m
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run) as mock_run, \
+             patch("hermes_cli.managed_uv.shutil.rmtree"):
+            from hermes_cli.managed_uv import rebuild_venv
+            rebuild_venv(uv_bin, venv_dir)
+
+        venv_call = next(c for c in mock_run.call_args_list if "venv" in c[0][0])
+        assert "--clear" in venv_call[0][0], "uv venv must be called with --clear"
+
+    def test_rmtree_failure_on_windows_is_warned_not_raised(self, tmp_path):
+        """On Windows, locked files cause rmtree to fail; this must be logged/warned, not raised."""
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock(returncode=0)
+            if "venv" in cmd:
+                venv_dir.mkdir(exist_ok=True)
+                bin_dir = venv_dir / "bin"
+                bin_dir.mkdir(parents=True, exist_ok=True)
+                (bin_dir / "python").write_text("fake python")
+            elif "--version" in cmd:
+                m.stdout = "Python 3.11.0"
+            return m
+
+        lock_error = PermissionError("file in use by another process")
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.managed_uv.shutil.rmtree", side_effect=lock_error), \
+             patch("hermes_cli.managed_uv.logger") as mock_logger:
+            from hermes_cli.managed_uv import rebuild_venv
+            # Must not raise even though rmtree failed
+            result = rebuild_venv(uv_bin, venv_dir)
+
+        assert result is True, "rebuild_venv should succeed when rmtree fails but uv --clear succeeds"
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "--clear" in warning_msg or "clear" in warning_msg.lower()
 
     def test_rebuild_failure_returns_false(self, tmp_path):
         venv_dir = tmp_path / "venv"


### PR DESCRIPTION
## Summary

Two independent service-lifecycle fixes:

- **launchd KeepAlive** (#37388): `generate_launchd_plist()` was emitting `KeepAlive.SuccessfulExit=false` which only restarts on non-zero exits. Changed to `<key>KeepAlive</key><true/>` so launchd restarts hermes-gateway on *any* exit, matching the drain-then-exit restart protocol used by `--graceful-restart`.
- **Windows venv rebuild** (#37881): `rebuild_venv()` in `managed_uv.py` silently swallowed `shutil.rmtree` failures. On Windows, running `hermes.exe` / `python.exe` holds file locks inside the venv, so `rmtree` raises `PermissionError`. Fix: catch the exception, log a warning, and pass `--clear` to `uv venv` so uv handles the leftover directory atomically.

## Test plan
- [ ] `tests/hermes_cli/test_gateway_service.py` — plist content asserts `<key>KeepAlive</key><true/>`
- [ ] `tests/hermes_cli/test_managed_uv.py` — verifies `--clear` flag is always passed and rmtree failure triggers warning + continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
