### PR TITLE
feat(tools): expose tool progress metadata hook

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -359,7 +359,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(name, args)
-                agent.tool_progress_callback("tool.started", name, preview, args)
+                agent.tool_progress_callback(
+                    "tool.started", name, preview, args, tool_call_id=tc.id
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -610,6 +612,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=is_error,
                         result=function_result,
+                        tool_call_id=tc.id,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
@@ -803,7 +806,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if not _execution_blocked and agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(function_name, function_args)
-                agent.tool_progress_callback("tool.started", function_name, preview, function_args)
+                agent.tool_progress_callback(
+                    "tool.started",
+                    function_name,
+                    preview,
+                    function_args,
+                    tool_call_id=tool_call.id,
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -1160,6 +1169,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     "tool.completed", function_name, None, None,
                     duration=tool_duration, is_error=_is_error_result,
                     result=function_result,
+                    tool_call_id=tool_call.id,
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")

--- a/cli.py
+++ b/cli.py
@@ -11118,6 +11118,20 @@ class HermesCLI:
         stacked line to scrollback on tool.completed so users can see the
         full history of tool calls (not just the current one in the spinner).
         """
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            get_plugin_manager().invoke_hook(
+                "on_tool_progress",
+                event_type=event_type,
+                function_name=function_name,
+                preview=preview,
+                function_args=function_args,
+                **kwargs,
+            )
+        except Exception:
+            pass
+
         if event_type == "tool.completed":
             self._tool_start_time = 0.0
             # Print stacked scrollback line for "all" / "new" modes

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -153,6 +153,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Agent/tool progress observer. Plugins can mirror tool progress to
+    # external control planes without core importing plugin-specific code.
+    # Kwargs: event_type, function_name, preview, function_args, plus callback
+    # metadata such as tool_call_id, duration, and is_error.
+    "on_tool_progress",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/cli/test_tool_progress_scrollback.py
+++ b/tests/cli/test_tool_progress_scrollback.py
@@ -63,6 +63,41 @@ def _make_cli(tool_progress="all", verbose=_UNSET):
 class TestToolProgressScrollback:
     """Stacked scrollback lines for 'all' and 'new' modes."""
 
+    def test_progress_callback_invokes_plugin_hook_with_metadata(self, monkeypatch):
+        cli = _make_cli(tool_progress="none")
+        calls = []
+
+        class FakePluginManager:
+            def invoke_hook(self, name, **kwargs):
+                calls.append((name, kwargs))
+                return []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_manager",
+            lambda: FakePluginManager(),
+        )
+
+        cli._on_tool_progress(
+            "tool.started",
+            "terminal",
+            "git status",
+            {"command": "git status"},
+            tool_call_id="call_1",
+        )
+
+        assert calls == [
+            (
+                "on_tool_progress",
+                {
+                    "event_type": "tool.started",
+                    "function_name": "terminal",
+                    "preview": "git status",
+                    "function_args": {"command": "git status"},
+                    "tool_call_id": "call_1",
+                },
+            )
+        ]
+
     def test_all_mode_prints_scrollback_on_completed(self):
         """In 'all' mode, tool.completed prints a stacked line."""
         cli = _make_cli(tool_progress="all")

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -332,6 +332,9 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_valid_hooks_include_tool_progress_observer(self):
+        assert "on_tool_progress" in VALID_HOOKS
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -103,7 +103,10 @@ def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_e
 
     mock_hfc.assert_called_once()
     assert len(starts) == 1
-    assert any(event[0][0] == "tool.completed" for event in progress)
+    completed = [event for event in progress if event[0][0] == "tool.completed"]
+    assert len(completed) == 1
+    assert completed[0][1]["tool_call_id"] == "c-soft"
+    assert "repeated_exact_failure_warning" in completed[0][1]["result"]
     assert len(messages) == 1
     assert messages[0]["role"] == "tool"
     assert messages[0]["tool_call_id"] == "c-soft"
@@ -215,9 +218,11 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert starts == [("c-allow", "web_search", allowed_args)]
     started_events = [event for event in progress_events if event[0] == "tool.started"]
     completed_events = [event for event in progress_events if event[0] == "tool.completed"]
-    assert started_events == [("tool.started", "web_search", allowed_args, {})]
+    assert started_events == [("tool.started", "web_search", allowed_args, {"tool_call_id": "c-allow"})]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
+    assert completed_events[0][3]["tool_call_id"] == "c-allow"
+    assert completed_events[0][3]["result"] == json.dumps({"ok": "allowed"})
 
 
 def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():


### PR DESCRIPTION
## What does this PR do?

Adds structured tool-progress metadata for tool callbacks and exposes a defensive `on_tool_progress` plugin hook.

This lets plugin authors and external control planes observe tool lifecycle events without scraping CLI display text. The important value is correlation: concurrent tool calls can now be matched by `tool_call_id` from `tool.started` through `tool.completed`, while existing callback behavior such as `result=` on completion remains intact.

## Related Issue

No issue.

Related but not duplicative:
- #31120 adds broader ACP durable tool-call timing metadata.
- #30053 requests a structured event stream for non-interactive runs.
- #38994 requests correlated tool lifecycle events from the session chat streaming endpoint; it cites this PR as lower-level callback/plugin metadata work, not a duplicate API event contract.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_executor.py`: passes `tool_call_id` through `tool.started` and `tool.completed` progress callbacks in both concurrent and sequential execution paths.
- `cli.py`: invokes the `on_tool_progress` plugin hook from the existing CLI progress callback while preserving core scrollback behavior.
- `hermes_cli/plugins.py`: registers `on_tool_progress` as a valid plugin hook.
- `tests/cli/test_tool_progress_scrollback.py`: covers plugin hook invocation and metadata forwarding.
- `tests/hermes_cli/test_plugins.py`: covers hook registration.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: verifies callback metadata while preserving completion `result=` behavior.

## How to Test

```bash
PYTHONPATH="$PWD" python -m pytest tests/cli/test_tool_progress_scrollback.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/hermes_cli/test_plugins.py -q -k "tool_progress or tool_call_id" --tb=short -p no:xdist -o addopts=
```

Result: `17 passed, 82 deselected`.

```bash
PYTHONPATH="$PWD" python -m pytest tests/cli/test_tool_progress_scrollback.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/hermes_cli/test_plugins.py -q --tb=short -p no:xdist -o addopts=
```

Result: `99 passed`.

```bash
python -m ruff check .
git diff --check upstream/main
git merge-tree upstream/main HEAD
```

Results: ruff passed, diff-check passed, and merge-tree returned a clean tree id with no conflicts.

## CI / Baseline Note

The full-suite checkbox below is intentionally left unchecked. This PR was validated with the focused tool-progress tests, the complete touched test files, lint, whitespace, and merge conflict preview.

After the latest synchronize, GitHub currently reports an empty status check rollup for this fork PR, so there is no upstream CI result to claim here. That is outside this code change; the exact local gates above passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
