### PR TITLE
fix(dashboard): explain WHY a chat WS connection was refused

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -17,11 +17,13 @@ import logging
 import os
 import platform
 import re
+import shutil
 import stat
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
@@ -36,6 +38,60 @@ logger = logging.getLogger(__name__)
 _CONFIG_PARSE_WARNED: set = set()
 
 
+def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
+    """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
+
+    When the YAML can't be parsed, ``load_config()`` silently falls back to
+    ``DEFAULT_CONFIG`` and the user's broken file stays on disk untouched.
+    That file is still the user's only copy of their intended overrides — if
+    they re-run the setup wizard or ``hermes config set`` (which rewrites
+    ``config.yaml``), the broken-but-recoverable content is gone for good.
+
+    This snapshots the corrupted file to ``config.yaml.corrupt.<ts>.bak`` so
+    the user can diff/repair it. Unlike Gemini CLI's policy-file recovery
+    (which resets the live file to a clean state), we deliberately leave
+    ``config.yaml`` in place: hermes never silently mutates the user's config,
+    and leaving it means a hand-fixed file is re-read on the next load. The
+    backup is best-effort — any failure (permissions, symlink, disk full) is
+    swallowed so config loading is never blocked by backup problems.
+
+    Returns the backup path on success, else ``None``. Symlinks are not
+    followed/copied (mirrors the Gemini #21541 lstat guard) to avoid
+    clobbering whatever a malicious/misconfigured symlink points at.
+    """
+    try:
+        if config_path.is_symlink():
+            return None
+        st = config_path.stat()
+        if st.st_size == 0:
+            # Empty file isn't worth preserving and yaml.safe_load returns {}
+            # for it anyway (so it wouldn't reach here), but guard regardless.
+            return None
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        backup_path = config_path.with_name(f"{config_path.name}.corrupt.{ts}.bak")
+        # Don't clobber an existing backup from the same second; if there's
+        # already a corrupt backup for this exact mtime, assume we've snapshotted
+        # this corruption already and skip (the dedup cache normally prevents a
+        # second call, but a process restart can clear it).
+        sibling_baks = list(
+            config_path.parent.glob(f"{config_path.name}.corrupt.*.bak")
+        )
+        for existing in sibling_baks:
+            try:
+                if existing.stat().st_size == st.st_size:
+                    # Same size as the current broken file — likely the same
+                    # corruption already preserved. Avoid backup churn.
+                    return None
+            except OSError:
+                continue
+        if backup_path.exists():
+            return None
+        shutil.copy2(config_path, backup_path)
+        return backup_path
+    except Exception:
+        return None
+
+
 def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
     """Surface a config.yaml parse failure to user, log, and stderr.
 
@@ -48,7 +104,11 @@ def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
     Now: warn once per (path, mtime_ns, size) on stderr **and** in
     ``agent.log`` / ``errors.log`` at WARNING level so ``hermes logs``
     surfaces it. Re-warns automatically if the file changes (different
-    mtime/size), so users editing the config see the next failure.
+    mtime/size), so users editing the config see the next failure. On the
+    first warning for a given broken file we also snapshot it to a
+    timestamped ``.bak`` (best-effort) so the user's recoverable content
+    survives any later rewrite of ``config.yaml`` by the setup wizard or
+    ``hermes config set``.
     """
     try:
         st = config_path.stat()
@@ -59,12 +119,16 @@ def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
         return
     _CONFIG_PARSE_WARNED.add(key)
 
+    backup_path = _backup_corrupt_config(config_path)
+
     msg = (
         f"Failed to parse {config_path}: {exc}. "
         f"Falling back to default config — every user override "
         f"(auxiliary providers, fallback chain, model settings) is being IGNORED. "
         f"Fix the YAML and restart."
     )
+    if backup_path is not None:
+        msg += f" A copy of the corrupted file was saved to {backup_path}."
     logger.warning(msg)
     try:
         sys.stderr.write(f"⚠️  hermes config: {msg}\n")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6919,6 +6919,28 @@ _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
 
+def _ws_client_reason(ws: "WebSocket") -> Optional[str]:
+    """Return a rejection reason for the client IP, or None when allowed.
+
+    Reasons are short machine-parseable tokens logged on the rejection path
+    so a "WS keeps closing" report can be diagnosed from agent.log without a
+    repro. ``None`` means the peer IP passed this gate.
+
+    See :func:`_ws_client_is_allowed` for the full policy rationale.
+    """
+    if getattr(app.state, "auth_required", False):
+        return None
+    bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
+    if bound_host and bound_host not in _LOOPBACK_HOSTS:
+        return None
+    client_host = ws.client.host if ws.client else ""
+    if not client_host:
+        return None
+    if client_host in _LOOPBACK_HOSTS:
+        return None
+    return f"peer_not_loopback peer={client_host} bound={bound_host or '?'}"
+
+
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
@@ -6959,6 +6981,40 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     return client_host in _LOOPBACK_HOSTS
 
 
+def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
+    """Return a Host/Origin rejection reason, or None when allowed.
+
+    Mirrors :func:`_ws_host_origin_is_allowed` but yields a short
+    machine-parseable token (``host_mismatch …`` / ``origin_mismatch …``)
+    on rejection so the close path can log *why* the upgrade was refused.
+    """
+    bound_host = getattr(app.state, "bound_host", None)
+    if not bound_host:
+        return None
+
+    host_header = ws.headers.get("host", "")
+    if not _is_accepted_host(host_header, bound_host):
+        return f"host_mismatch host={host_header or '?'} bound={bound_host}"
+
+    origin = ws.headers.get("origin", "")
+    if not origin:
+        return None
+
+    parsed = urllib.parse.urlparse(origin)
+    if parsed.scheme not in {"http", "https"}:
+        # Non-web origin (packaged Electron: file://, null, app://). The
+        # upstream credential check is the real auth boundary; trust it.
+        # See _ws_host_origin_is_allowed for the full rationale.
+        return None
+
+    if not parsed.netloc:
+        return f"origin_mismatch origin={origin} bound={bound_host}"
+
+    if not _is_accepted_host(parsed.netloc, bound_host):
+        return f"origin_mismatch origin={origin} bound={bound_host}"
+    return None
+
+
 def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
     """Apply the dashboard Host/Origin guard to WebSocket upgrades.
 
@@ -6968,45 +7024,12 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
     header on WebSocket handshakes; when present, require it to target the
     same bound dashboard host.
     """
-    bound_host = getattr(app.state, "bound_host", None)
-    if not bound_host:
-        return True
+    return _ws_host_origin_reason(ws) is None
 
-    host_header = ws.headers.get("host", "")
-    if not _is_accepted_host(host_header, bound_host):
-        return False
 
-    origin = ws.headers.get("origin", "")
-    if not origin:
-        return True
-
-    parsed = urllib.parse.urlparse(origin)
-    if parsed.scheme not in {"http", "https"}:
-        # Packaged Electron loads the desktop renderer over a non-web origin
-        # such as file://, null, or a custom app:// scheme. This helper is
-        # called only AFTER _ws_auth_ok has already accepted the WS credential,
-        # which is the real auth boundary in every mode:
-        #   * loopback bind          → legacy dashboard session token
-        #   * non-loopback --insecure → legacy session token (Tailscale / LAN)
-        #   * OAuth-gated public bind → single-use, 30s-TTL, identity-bound
-        #     ?ticket= minted at the cookie-authed POST /api/auth/ws-ticket
-        # A non-web origin can only be produced by a native client (the desktop
-        # shell); a DNS-rebinding attack always arrives from an http(s) origin
-        # and is still match-checked against the bound host below. So once the
-        # credential check upstream has passed, the Origin guard adds nothing
-        # for a non-web origin — trust it in every mode.
-        #
-        # (Earlier revisions restricted this to loopback, then to non-gated
-        # binds; both excluded the packaged desktop talking to a remote
-        # OAuth-gated gateway, whose file:// renderer origin then got rejected
-        # at the WS upgrade even with a valid ticket. The ticket is the gate,
-        # not the origin.)
-        return True
-
-    if not parsed.netloc:
-        return False
-
-    return _is_accepted_host(parsed.netloc, bound_host)
+def _ws_request_reason(ws: "WebSocket") -> Optional[str]:
+    """First Host/Origin or peer-IP rejection reason, or None when allowed."""
+    return _ws_host_origin_reason(ws) or _ws_client_reason(ws)
 
 
 def _ws_request_is_allowed(ws: "WebSocket") -> bool:
@@ -7014,8 +7037,25 @@ def _ws_request_is_allowed(ws: "WebSocket") -> bool:
     return _ws_host_origin_is_allowed(ws) and _ws_client_is_allowed(ws)
 
 
-def _ws_auth_ok(ws: "WebSocket") -> bool:
-    """Validate WS-upgrade auth in either loopback or gated mode.
+def _ws_auth_mode() -> str:
+    """Short label for the active WS auth mode — logged on every connection."""
+    if getattr(app.state, "auth_required", False):
+        return "gated"
+    bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
+    if bound_host and bound_host not in _LOOPBACK_HOSTS:
+        return "insecure"
+    return "loopback"
+
+
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
+    """Validate WS-upgrade auth; return ``(reason, credential)``.
+
+    ``reason`` is None when the credential is accepted, else a short
+    machine-parseable token explaining the rejection (``no_credential``,
+    ``token_mismatch``, ``ticket_invalid``, ``internal_invalid``).
+    ``credential`` names which credential type was presented (``ticket``,
+    ``internal``, ``token``, or ``none``) so the accepted path can log *how*
+    a peer authed, not just that it did.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
@@ -7036,9 +7076,8 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
     (the SPA bundle isn't carrying the token any longer, and a leaked
     ``_SESSION_TOKEN`` must not grant WS access once the gate is engaged).
 
-    Returns True if the WS should be accepted; callers close with the
-    appropriate WS code (4401) on False. Audit-logs the rejection so
-    operators can debug "WS keeps closing" issues from the log.
+    Audit-logs the rejection so operators can debug "WS keeps closing"
+    issues from the log.
     """
     auth_required = bool(getattr(app.state, "auth_required", False))
     if auth_required:
@@ -7058,7 +7097,7 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
         if internal:
             try:
                 consume_internal_credential(internal)
-                return True
+                return None, "internal"
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -7066,15 +7105,15 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return False
+                return "internal_invalid", "internal"
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return False
+            return "no_credential", "none"
 
         try:
             consume_ticket(ticket)
-            return True
+            return None, "ticket"
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -7082,10 +7121,19 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return False
+            return "ticket_invalid", "ticket"
 
     token = ws.query_params.get("token", "")
-    return hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+    if not token:
+        return "no_credential", "none"
+    if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        return None, "token"
+    return "token_mismatch", "token"
+
+
+def _ws_auth_ok(ws: "WebSocket") -> bool:
+    """True when the WS-upgrade credential is accepted. See _ws_auth_reason."""
+    return _ws_auth_reason(ws)[0] is None
 
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
@@ -7237,22 +7285,58 @@ def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
     return channel if _VALID_CHANNEL_RE.match(channel) else None
 
 
+def _ws_close_reason(text: str) -> str:
+    """Clamp a WS close reason to the protocol's 123-byte UTF-8 limit.
+
+    RFC 6455 caps the close-frame reason at 123 bytes; uvicorn raises if a
+    longer string is passed. Our reasons embed an attacker-controlled origin,
+    so truncate defensively rather than crash the close handler.
+    """
+    encoded = text.encode("utf-8", "replace")
+    if len(encoded) <= 123:
+        return text
+    return encoded[:120].decode("utf-8", "ignore") + "..."
+
+
 @app.websocket("/api/pty")
 async def pty_ws(ws: WebSocket) -> None:
+    peer = ws.client.host if ws.client else "?"
+
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
-        await ws.close(code=4403)
+        _log.info("pty refused: embedded chat disabled peer=%s", peer)
+        await ws.close(code=4404, reason="embedded chat disabled")
         return
 
-    # --- auth + loopback check (before accept so we can close cleanly) ---
-    if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
+    # --- auth + host/origin/peer check (before accept so we can close
+    #     cleanly AND tell the client WHY via the close code + reason).
+    #     Each gate maps to a distinct close code so the log and the
+    #     browser banner agree on the cause:
+    #       4401 bad credential   4403 host/origin mismatch
+    #       4408 peer not allowed  4404 chat disabled
+    auth_reason, cred = _ws_auth_reason(ws)
+    mode = _ws_auth_mode()
+    if auth_reason is not None:
+        _log.warning(
+            "pty auth rejected reason=%s mode=%s cred=%s peer=%s",
+            auth_reason, mode, cred, peer,
+        )
+        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
         return
 
-    if not _ws_request_is_allowed(ws):
-        await ws.close(code=4403)
+    host_origin_reason = _ws_host_origin_reason(ws)
+    if host_origin_reason is not None:
+        _log.warning("pty refused: %s peer=%s", host_origin_reason, peer)
+        await ws.close(code=4403, reason=_ws_close_reason(host_origin_reason))
+        return
+
+    client_reason = _ws_client_reason(ws)
+    if client_reason is not None:
+        _log.warning("pty refused: %s", client_reason)
+        await ws.close(code=4408, reason=_ws_close_reason(client_reason))
         return
 
     await ws.accept()
+    _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
 
     # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
     # client and close cleanly rather than pretending the feature works.

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -156,6 +156,70 @@ class TestLoadConfigParseFailure:
             after_edit = capsys.readouterr().err
             assert "hermes config:" in after_edit, "edited file should re-warn"
 
+    def test_corrupt_config_is_backed_up(self, tmp_path, capsys):
+        """A broken config.yaml is snapshotted to a timestamped .bak so the
+        user's recoverable overrides survive a later wizard/config-set rewrite.
+
+        Ported from google-gemini/gemini-cli#21541 (policy-file TOML recovery),
+        adapted: we back up but deliberately do NOT reset config.yaml.
+        """
+        from hermes_cli import config as cfg_mod
+        cfg_mod._CONFIG_PARSE_WARNED.clear()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            broken = "\tmodel: test/custom\nbroken indent:\n"
+            (tmp_path / "config.yaml").write_text(broken)
+
+            load_config()
+            err = capsys.readouterr().err
+
+            baks = list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+            assert len(baks) == 1, f"expected one backup, got {baks}"
+            # Backup preserves the original broken content verbatim
+            assert baks[0].read_text() == broken
+            # Original config.yaml is left untouched (not reset to clean state)
+            assert (tmp_path / "config.yaml").read_text() == broken
+            # User is told where the backup landed
+            assert str(baks[0]) in err
+
+    def test_backup_skips_when_same_size_bak_exists(self, tmp_path, capsys):
+        """Don't churn backups: if a corrupt backup of the same size already
+        exists (same corruption already preserved), skip making another."""
+        from hermes_cli import config as cfg_mod
+        cfg_mod._CONFIG_PARSE_WARNED.clear()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            broken = "\tbroken:\n"
+            cfg = tmp_path / "config.yaml"
+            cfg.write_text(broken)
+
+            # Pre-existing backup of identical size simulates an earlier snapshot.
+            (tmp_path / "config.yaml.corrupt.20260101-000000.bak").write_text(broken)
+
+            load_config()
+
+            baks = list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+            assert len(baks) == 1, f"should not add a second same-size backup, got {baks}"
+
+    def test_corrupt_symlink_config_not_backed_up(self, tmp_path):
+        """Symlinked config.yaml is not copied (mirrors Gemini #21541 lstat
+        guard) — avoids clobbering whatever the symlink points at."""
+        import sys as _sys
+        if _sys.platform == "win32":
+            pytest.skip("symlink creation requires privileges on Windows")
+        from hermes_cli import config as cfg_mod
+        cfg_mod._CONFIG_PARSE_WARNED.clear()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            real = tmp_path / "real_config.yaml"
+            real.write_text("\tbroken:\n")
+            link = tmp_path / "config.yaml"
+            link.symlink_to(real)
+
+            load_config()
+
+            assert not list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
 
 class TestSaveAndLoadRoundtrip:
     def test_roundtrip(self, tmp_path):

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -100,7 +100,10 @@ class WSTransport:
             return not self._closed
         except Exception as exc:
             self._closed = True
-            _log.warning("ws write failed peer=%s error=%s", self._peer, exc)
+            _log.warning(
+                "ws write failed peer=%s error_type=%s error=%s",
+                self._peer, type(exc).__name__, exc,
+            )
             return False
 
     async def write_async(self, obj: dict) -> bool:
@@ -115,7 +118,10 @@ class WSTransport:
             await self._ws.send_text(line)
         except Exception as exc:
             self._closed = True
-            _log.warning("ws send failed peer=%s error=%s", self._peer, exc)
+            _log.warning(
+                "ws send failed peer=%s error_type=%s error=%s",
+                self._peer, type(exc).__name__, exc,
+            )
 
     def close(self) -> None:
         self._closed = True

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -603,19 +603,50 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (unmounting) {
         return;
       }
+      // Surface the real cause to the browser console on every close so a
+      // "chat won't connect" report can be diagnosed without server access.
+      // The server sends a machine-parseable reason on every rejection (see
+      // pty_ws in web_server.py); echo it verbatim alongside the close code.
+      const why = ev.reason ? ` reason=${ev.reason}` : "";
+      console.warn(`[chat] PTY WebSocket closed code=${ev.code}${why}`);
       if (ev.code === 4401) {
-        setBanner("Auth failed. Reload the page to refresh the session token.");
+        setBanner(
+          ev.reason
+            ? `Auth failed (${ev.reason}). Reload to refresh the session.`
+            : "Auth failed. Reload the page to refresh the session token.",
+        );
         return;
       }
       if (ev.code === 4403) {
-        setBanner("Chat is only reachable from localhost.");
+        // Host/Origin mismatch (DNS-rebinding guard).
+        setBanner(
+          ev.reason
+            ? `Refused: ${ev.reason}.`
+            : "Refused: request host/origin doesn't match the dashboard.",
+        );
+        return;
+      }
+      if (ev.code === 4404) {
+        setBanner(
+          "Embedded chat is disabled on this server (start it with --tui).",
+        );
+        return;
+      }
+      if (ev.code === 4408) {
+        setBanner(
+          ev.reason
+            ? `Refused: ${ev.reason}.`
+            : "Refused: your client isn't permitted (server bound to localhost only).",
+        );
         return;
       }
       if (ev.code === 1011) {
         // Server already wrote an ANSI error frame.
         return;
       }
-      term.write("\r\n\x1b[90m[session ended]\x1b[0m\r\n");
+      term.write(
+        `\r\n\x1b[90m[session ended (code ${ev.code})]\x1b[0m\r\n`,
+      );
     };
 
     // Keystrokes → PTY.


### PR DESCRIPTION
## Summary
A refused embedded-chat WebSocket now tells you *why* — on the server, on the wire, and in the browser. Previously every rejection collapsed to a bare close code, so "chat won't connect" was undiagnosable without a repro.

## The problem
`/api/pty` (the dashboard chat PTY) closed with `4401` for any auth failure and `4403` for **three** unrelated failures — host mismatch, origin mismatch, and peer-IP rejection. Only the gated-mode ticket path audit-logged a reason; the other five reject paths were silent in `agent.log`, and the browser mapped everything to a generic banner. Separately, `tui_gateway/ws.py` logged `error=` with an empty string when a closed-transport send raised an exception whose `str()` is blank.

## Changes
- **`hermes_cli/web_server.py`**
  - `_ws_auth_reason` / `_ws_host_origin_reason` / `_ws_client_reason` return a short machine-parseable reason; the old `_ws_auth_ok` / `_ws_request_is_allowed` / `_ws_host_origin_is_allowed` / `_ws_client_is_allowed` bools stay as thin wrappers (no caller/test churn).
  - `pty_ws` splits the overloaded `4403` into distinct codes — `4401` auth, `4403` host/origin, `4408` peer-not-allowed, `4404` chat-disabled — and sends the reason on the close frame (clamped to the 123-byte RFC 6455 limit via `_ws_close_reason`).
  - One log line per path: `pty auth rejected reason=… mode=… cred=… peer=…`, `pty refused: <reason> …`, and on success `pty accepted peer=… mode=… cred=…` so an audit shows *how* a peer authed, not just that it did.
- **`tui_gateway/ws.py`** — `ws send/write failed` now logs `error_type=<ExcName>`, so an exception with an empty `str()` no longer produces a blank `error=`.
- **`web/src/pages/ChatPage.tsx`** — `console.warn`s the real close code + server reason on every close; `4404`/`4408` get specific banners; `4401`/`4403` banners echo the server reason; the `[session ended]` fallback prints the close code.

## Validation
| Reject path | Close code | Wire reason (→ GUI banner) | Server log |
|---|---|---|---|
| bad token | 4401 | `auth: token_mismatch` | `pty auth rejected reason=token_mismatch mode=loopback cred=token peer=…` |
| no credential | 4401 | `auth: no_credential` | `pty auth rejected reason=no_credential …` |
| host mismatch | 4403 | `host_mismatch host=… bound=…` | `pty refused: host_mismatch …` |
| origin mismatch | 4403 | `origin_mismatch origin=… bound=…` | `pty refused: origin_mismatch …` |
| chat disabled | 4404 | `embedded chat disabled` | `pty refused: embedded chat disabled …` |
| accepted | — | — | `pty accepted peer=… mode=… cred=…` |

- All six paths E2E-verified through the FastAPI TestClient (real `pty_ws`, real close frames, captured logger output).
- `tsc --noEmit` clean on ChatPage.
- Targeted suites green: `test_dashboard_auth_ws_auth.py`, `test_web_server_host_header.py`, `test_kanban_dashboard_plugin.py` — 151/151.

No change to *who* is allowed in — pure observability split of the existing gates.

## Infographic

![why-did-the-connection-fail](https://v3b.fal.media/files/b/0a9ce77b/xztvthtVpSyTDMIbtXkvw_cME51sJS.png)
