### PR TITLE
[codex] Disable compression in background review fork

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -449,6 +449,7 @@ def _run_review_in_thread(
             # if a future code path bypasses the cache.
             review_agent.session_start = agent.session_start
             review_agent.session_id = agent.session_id
+            review_agent.compression_enabled = False
 
             from model_tools import get_tool_definitions
             from hermes_cli.plugins import (

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -313,3 +313,47 @@ def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
         "the fork leaks harness prompts into the user's real memory "
         "namespace via on_turn_start / prefetch_all / sync_all."
     )
+
+
+def test_background_review_fork_disables_compression(monkeypatch):
+    """The review fork must not compress the foreground session_id.
+
+    The fork intentionally inherits the parent's session_id for prompt-cache
+    parity. If it also keeps compression enabled, the short-lived review agent
+    can rotate that shared parent session and leave the gateway holding a stale
+    parent, allowing the next foreground turn to create a sibling child.
+    """
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self.compression_enabled = True
+            self.session_id = None
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            observed["compression_enabled"] = self.compression_enabled
+            observed["session_id"] = self.session_id
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert observed["session_id"] == agent.session_id
+    assert observed["compression_enabled"] is False, (
+        "Background review forks share the foreground session_id, so they "
+        "must not be allowed to rotate it via context compression."
+    )


### PR DESCRIPTION
## Summary
- disable context compression for background review fork agents after they inherit the foreground session id
- add regression coverage that review forks keep prompt-cache session parity without rotating the shared session

## Root cause
Background review forks intentionally copy the foreground `session_id` for cache parity. Leaving `compression_enabled=True` lets the short-lived review agent rotate that shared session, which can leave the foreground gateway path holding a stale parent and create a sibling session on a later turn.

Fixes #38727.

## Validation
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_background_review.py::test_background_review_fork_disables_compression -q` -> `1 passed`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_toolset_restriction.py tests/agent/test_compression_concurrent_fork.py -q` -> `15 passed`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check agent/background_review.py tests/run_agent/test_background_review.py` -> `All checks passed!`
- `git diff --check` -> clean