### PR TITLE
feat(i18n): localize gateway provider error replies (zh + zh-hant)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -230,21 +230,12 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
+        return t("gateway.provider_errors.auth_failed")
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
-        )
+        return t("gateway.provider_errors.policy_rejected")
     if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
-    )
+        return t("gateway.provider_errors.rate_limited")
+    return t("gateway.provider_errors.failed_after_retries")
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ YOLO-modus **AF** vir hierdie sessie — gevaarlike opdragte sal goedkeuring vereis."
     enabled:                    "⚡ YOLO-modus **AAN** vir hierdie sessie — alle opdragte word outomaties goedgekeur. Gebruik versigtig."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Sessie-databasis is nie beskikbaar nie."
     session_db_unavailable_prefix: "Sessie-databasis is nie beskikbaar"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ YOLO-Modus für diese Sitzung **AUS** — gefährliche Befehle benötigen eine Genehmigung."
     enabled:                    "⚡ YOLO-Modus für diese Sitzung **AN** — alle Befehle werden automatisch genehmigt. Mit Vorsicht verwenden."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Session-Datenbank nicht verfügbar."
     session_db_unavailable_prefix: "Session-Datenbank nicht verfügbar"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -363,6 +363,12 @@ gateway:
     disabled:                   "⚠️ YOLO mode **OFF** for this session — dangerous commands will require approval."
     enabled:                    "⚡ YOLO mode **ON** for this session — all commands auto-approved. Use with caution."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
+
   shared:
     session_db_unavailable:      "Session database not available."
     session_db_unavailable_prefix: "Session database not available"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Modo YOLO **DESACTIVADO** en esta sesión — los comandos peligrosos requerirán aprobación."
     enabled:                    "⚡ Modo YOLO **ACTIVADO** en esta sesión — todos los comandos se aprueban automáticamente. Úsalo con precaución."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Base de datos de sesiones no disponible."
     session_db_unavailable_prefix: "Base de datos de sesiones no disponible"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Mode YOLO **DÉSACTIVÉ** pour cette session — les commandes dangereuses nécessiteront une approbation."
     enabled:                    "⚡ Mode YOLO **ACTIVÉ** pour cette session — toutes les commandes sont auto-approuvées. À utiliser avec prudence."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Base de données de sessions indisponible."
     session_db_unavailable_prefix: "Base de données de sessions indisponible"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -352,6 +352,11 @@ gateway:
     disabled:                   "⚠️ Mód YOLO **AS** don seisiún seo — beidh cead de dhíth d'orduithe contúirteacha."
     enabled:                    "⚡ Mód YOLO **AR** don seisiún seo — gach ordú ceadaithe go huathoibríoch. Úsáid go cúramach."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Níl bunachar sonraí na seisiún ar fáil."
     session_db_unavailable_prefix: "Níl bunachar sonraí na seisiún ar fáil"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ YOLO mód **KI** ebben a munkamenetben — a veszélyes parancsok jóváhagyást igényelnek."
     enabled:                    "⚡ YOLO mód **BE** ebben a munkamenetben — minden parancs automatikusan jóváhagyva. Óvatosan használd."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "A munkamenet-adatbázis nem érhető el."
     session_db_unavailable_prefix: "A munkamenet-adatbázis nem érhető el"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Modalità YOLO **OFF** per questa sessione — i comandi pericolosi richiederanno approvazione."
     enabled:                    "⚡ Modalità YOLO **ON** per questa sessione — tutti i comandi auto-approvati. Usa con cautela."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Database delle sessioni non disponibile."
     session_db_unavailable_prefix: "Database delle sessioni non disponibile"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ このセッションの YOLO モードは **OFF** — 危険なコマンドには承認が必要です。"
     enabled:                    "⚡ このセッションの YOLO モードは **ON** — すべてのコマンドが自動承認されます。注意して使用してください。"
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "セッションデータベースが利用できません。"
     session_db_unavailable_prefix: "セッションデータベースが利用できません"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ 이 세션에서 YOLO 모드 **꺼짐** — 위험한 명령은 승인이 필요합니다."
     enabled:                    "⚡ 이 세션에서 YOLO 모드 **켜짐** — 모든 명령이 자동 승인됩니다. 주의해서 사용하세요."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "세션 데이터베이스를 사용할 수 없습니다."
     session_db_unavailable_prefix: "세션 데이터베이스를 사용할 수 없습니다"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Modo YOLO **DESATIVADO** nesta sessão — comandos perigosos exigirão aprovação."
     enabled:                    "⚡ Modo YOLO **ATIVADO** nesta sessão — todos os comandos são aprovados automaticamente. Usa com precaução."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Base de dados de sessões indisponível."
     session_db_unavailable_prefix: "Base de dados de sessões indisponível"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Режим YOLO для этого сеанса **ОТКЛЮЧЁН** — опасные команды потребуют одобрения."
     enabled:                    "⚡ Режим YOLO для этого сеанса **ВКЛЮЧЁН** — все команды одобряются автоматически. Используйте с осторожностью."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "База данных сеансов недоступна."
     session_db_unavailable_prefix: "База данных сеансов недоступна"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Bu oturumda YOLO modu **KAPALI** — tehlikeli komutlar onay gerektirecek."
     enabled:                    "⚡ Bu oturumda YOLO modu **AÇIK** — tüm komutlar otomatik onaylanır. Dikkatli kullanın."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "Oturum veritabanı kullanılamıyor."
     session_db_unavailable_prefix: "Oturum veritabanı kullanılamıyor"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -348,6 +348,11 @@ gateway:
     disabled:                   "⚠️ Режим YOLO для цього сеансу **ВИМКНЕНО** — небезпечні команди потребуватимуть схвалення."
     enabled:                    "⚡ Режим YOLO для цього сеансу **УВІМКНЕНО** — усі команди схвалюються автоматично. Використовуйте з обережністю."
 
+  provider_errors:
+    auth_failed:               "⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs."
+    policy_rejected:           "⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing."
+    rate_limited:              "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    failed_after_retries:      "⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics."
   shared:
     session_db_unavailable:      "База даних сеансів недоступна."
     session_db_unavailable_prefix: "База даних сеансів недоступна"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -348,6 +348,12 @@ gateway:
     disabled:                   "⚠️ 本工作階段 YOLO 模式 **已關閉** — 危險指令將需要批准。"
     enabled:                    "⚡ 本工作階段 YOLO 模式 **已開啟** — 所有指令自動批准。請謹慎使用。"
 
+  provider_errors:
+    auth_failed:               "⚠️ 模型提供方驗證失敗。請檢查已設定的憑證；原始提供方詳情請見閘道日誌。"
+    policy_rejected:           "⚠️ 模型提供方拒絕了此請求。對話中已隱藏原始錯誤；請查看閘道日誌或嘗試改寫請求。"
+    rate_limited:              "⏱️ 模型提供方正在限速。請稍候片刻後再試。"
+    failed_after_retries:      "⚠️ 模型提供方在重試後仍失敗。對話中已隱藏原始詳情；請查看閘道日誌進行診斷。"
+
   shared:
     session_db_unavailable:      "工作階段資料庫無法使用。"
     session_db_unavailable_prefix: "工作階段資料庫無法使用"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -348,6 +348,12 @@ gateway:
     disabled:                   "⚠️ 本会话 YOLO 模式 **已关闭** — 危险命令将需要批准。"
     enabled:                    "⚡ 本会话 YOLO 模式 **已开启** — 所有命令自动批准。请谨慎使用。"
 
+  provider_errors:
+    auth_failed:               "⚠️ 模型提供商认证失败。请检查已配置的凭据；原始提供商详情见网关日志。"
+    policy_rejected:           "⚠️ 模型提供商拒绝了该请求。聊天中已隐藏原始错误；请查看网关日志或尝试改写请求。"
+    rate_limited:              "⏱️ 模型提供商正在限流。请稍等片刻后重试。"
+    failed_after_retries:      "⚠️ 模型提供商在重试后仍失败。聊天中已隐藏原始详情；请查看网关日志进行诊断。"
+
   shared:
     session_db_unavailable:      "会话数据库不可用。"
     session_db_unavailable_prefix: "会话数据库不可用"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -169,6 +169,35 @@ def test_t_unknown_language_uses_english():
     assert i18n.t("approval.denied", lang="klingon") == i18n.t("approval.denied", lang="en")
 
 
+def test_gateway_provider_error_replies_use_i18n_keys(monkeypatch):
+    """Gateway provider error categories must resolve through i18n keys.
+
+    This keeps Telegram-safe provider failures localizable without exercising
+    the full gateway runner or platform adapters.
+    """
+    from gateway import run as gateway_run
+
+    seen_keys = []
+
+    def fake_t(key: str, **kwargs):
+        seen_keys.append(key)
+        return f"translated:{key}"
+
+    monkeypatch.setattr(gateway_run, "t", fake_t)
+
+    cases = [
+        ("Provider authentication failed: invalid API key", "gateway.provider_errors.auth_failed"),
+        ("Request blocked by provider security policy", "gateway.provider_errors.policy_rejected"),
+        ("HTTP 429 rate limit exceeded", "gateway.provider_errors.rate_limited"),
+        ("API call failed after retries", "gateway.provider_errors.failed_after_retries"),
+    ]
+
+    for raw_error, expected_key in cases:
+        assert gateway_run._gateway_provider_error_reply(raw_error) == f"translated:{expected_key}"
+
+    assert seen_keys == [expected_key for _, expected_key in cases]
+
+
 # ---------------------------------------------------------------------------
 # _locales_dir resolution ladder -- regression for #23943 / #27632 / #35374.
 # Sealed installs (Nix store venv, pip wheel) have no source tree next to


### PR DESCRIPTION
## Summary
Localizes the four user-facing **provider/API error** replies shown in messaging gateways when auth fails, policy blocks, rate limits hit, or retries exhaust.

Previously these were hardcoded English strings in `_gateway_provider_error_reply()` (`gateway/run.py`).

## Changes
- Add `gateway.provider_errors.*` (4 keys) to **all** locale catalogs (parity tests)
- Route `gateway/run.py` through `t()`
- **zh** and **zh-hant**: full translations
- Other locales: English mirror (catalog parity; community can refine later)

## Test plan
- [ ] `scripts/run_tests.sh tests/agent/test_i18n.py -q`
- [ ] `display.language: zh` + trigger rate-limit/auth error path in gateway → Chinese reply

## Related (Chinese localization effort)
- #38703 — Web dashboard zh key parity
- #38735 — Web dashboard zh-hant key parity
- #38747 — README.zh-CN language settings docs

Made with [Cursor](https://cursor.com)