### PR TITLE
[codex] Add WhatsApp observed group context

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -894,7 +894,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
-                if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
+                if plat in {Platform.TELEGRAM, Platform.WHATSAPP} and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
@@ -1101,6 +1101,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(whatsapp_cfg, dict):
                 if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
                     os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
+                if "observe_unmentioned_group_messages" in whatsapp_cfg and not os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
+                    os.environ["WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] = str(whatsapp_cfg["observe_unmentioned_group_messages"]).lower()
                 if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
                     os.environ["WHATSAPP_MENTION_PATTERNS"] = json.dumps(whatsapp_cfg["mention_patterns"])
                 frc = whatsapp_cfg.get("free_response_chats")

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -537,8 +537,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(data)
 
-    def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
-        """Return True when a group message should be stored but not dispatched."""
+    def _whatsapp_group_observe_mode_enabled(self, data: Dict[str, Any]) -> bool:
+        """Return True when group observe mode applies to this message."""
         if not self._whatsapp_observe_unmentioned_group_messages():
             return False
         chat_id = str(data.get("chatId") or "")
@@ -551,6 +551,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if chat_id in self._whatsapp_free_response_chats():
             return False
         if not self._whatsapp_require_mention():
+            return False
+        return True
+
+    def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
+        """Return True when a group message should be stored but not dispatched."""
+        if not self._whatsapp_group_observe_mode_enabled(data):
             return False
         body = str(data.get("body") or "").strip()
         if body.startswith("/"):
@@ -575,13 +581,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         return f"[{sender}|{user_id}]\n{event.text or ''}"
 
     def _apply_whatsapp_group_observe_attribution(self, event: MessageEvent) -> MessageEvent:
-        if not self._whatsapp_observe_unmentioned_group_messages():
-            return event
         raw_message = event.raw_message if isinstance(event.raw_message, dict) else {}
-        if not raw_message.get("isGroup", False):
-            return event
-        chat_id = str(raw_message.get("chatId") or "")
-        if not self._is_group_allowed(chat_id):
+        if not self._whatsapp_group_observe_mode_enabled(raw_message):
             return event
         return dataclasses.replace(
             event,

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import dataclasses
 import json
 import logging
 import os
@@ -24,6 +25,7 @@ import re
 import shutil
 import signal
 import subprocess
+from datetime import datetime, timezone
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -342,6 +344,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("WHATSAPP_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _whatsapp_observe_unmentioned_group_messages(self) -> bool:
+        configured = self.config.extra.get("observe_unmentioned_group_messages")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
+
     def _whatsapp_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
@@ -526,6 +536,88 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if self._message_mentions_bot(data):
             return True
         return self._message_matches_mention_patterns(data)
+
+    def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
+        """Return True when a group message should be stored but not dispatched."""
+        if not self._whatsapp_observe_unmentioned_group_messages():
+            return False
+        chat_id = str(data.get("chatId") or "")
+        if self._is_broadcast_chat(chat_id):
+            return False
+        if not data.get("isGroup", False):
+            return False
+        if not self._is_group_allowed(chat_id):
+            return False
+        if chat_id in self._whatsapp_free_response_chats():
+            return False
+        if not self._whatsapp_require_mention():
+            return False
+        body = str(data.get("body") or "").strip()
+        if body.startswith("/"):
+            return False
+        if self._message_is_reply_to_bot(data):
+            return False
+        if self._message_mentions_bot(data):
+            return False
+        if self._message_matches_mention_patterns(data):
+            return False
+        return True
+
+    @staticmethod
+    def _whatsapp_group_observe_shared_source(source):
+        """Return a chat-scoped source for observed WhatsApp group context."""
+        return dataclasses.replace(source, user_id=None, user_name=None, user_id_alt=None)
+
+    @staticmethod
+    def _whatsapp_group_observe_attributed_text(event: MessageEvent) -> str:
+        user_id = event.source.user_id or "unknown"
+        sender = event.source.user_name or user_id
+        return f"[{sender}|{user_id}]\n{event.text or ''}"
+
+    def _apply_whatsapp_group_observe_attribution(self, event: MessageEvent) -> MessageEvent:
+        if not self._whatsapp_observe_unmentioned_group_messages():
+            return event
+        raw_message = event.raw_message if isinstance(event.raw_message, dict) else {}
+        if not raw_message.get("isGroup", False):
+            return event
+        chat_id = str(raw_message.get("chatId") or "")
+        if not self._is_group_allowed(chat_id):
+            return event
+        return dataclasses.replace(
+            event,
+            text=self._whatsapp_group_observe_attributed_text(event),
+            source=self._whatsapp_group_observe_shared_source(event.source),
+        )
+
+    async def _observe_unmentioned_group_message(self, data: Dict[str, Any]) -> None:
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            event = await self._build_message_event(data, skip_gate=True)
+            if not event:
+                return
+            shared_source = self._whatsapp_group_observe_shared_source(event.source)
+            session_entry = store.get_or_create_session(shared_source)
+            entry = {
+                "role": "user",
+                "content": self._whatsapp_group_observe_attributed_text(event),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = str(event.message_id)
+            store.append_to_transcript(session_entry.session_id, entry)
+            adapter_name = getattr(self, "name", "whatsapp")
+            logger.info(
+                "[%s] WhatsApp group message observed (no bot trigger): chat=%s from=%s",
+                adapter_name,
+                data.get("chatId") or "unknown",
+                event.source.user_id or "unknown",
+            )
+        except Exception as exc:
+            adapter_name = getattr(self, "name", "whatsapp")
+            logger.warning("[%s] Failed to observe WhatsApp group message: %s", adapter_name, exc)
     
     async def connect(self) -> bool:
         """
@@ -1257,10 +1349,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
-    async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
+    async def _build_message_event(self, data: Dict[str, Any], *, skip_gate: bool = False) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
-            if not self._should_process_message(data):
+            if not skip_gate and not self._should_process_message(data):
+                if self._should_observe_unmentioned_group_message(data):
+                    await self._observe_unmentioned_group_message(data)
                 return None
 
             # Determine message type
@@ -1373,7 +1467,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
-            return MessageEvent(
+            event = MessageEvent(
                 text=body,
                 message_type=msg_type,
                 source=source,
@@ -1382,6 +1476,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 media_urls=cached_urls,
                 media_types=media_types,
             )
+            if not skip_gate:
+                event = self._apply_whatsapp_group_observe_attribution(event)
+            return event
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")
             return None

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -172,6 +172,53 @@ def test_observed_group_context_uses_shared_source_for_later_mentions():
     asyncio.run(_run())
 
 
+def test_observe_flag_without_mention_gating_keeps_normal_group_event_source():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=False,
+            observe_unmentioned_group_messages=True,
+        )
+
+        event = await adapter._build_message_event(
+            _group_message(
+                "hello everyone",
+                senderId="6281234567890@s.whatsapp.net",
+                senderName="Alice Example",
+            )
+        )
+
+        assert event is not None
+        assert event.source.user_id == "6281234567890@s.whatsapp.net"
+        assert event.source.user_name == "Alice Example"
+        assert event.text == "hello everyone"
+
+    asyncio.run(_run())
+
+
+def test_observe_flag_keeps_free_response_group_event_source():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            free_response_chats=["120363001234567890@g.us"],
+            observe_unmentioned_group_messages=True,
+        )
+
+        event = await adapter._build_message_event(
+            _group_message(
+                "hello everyone",
+                senderId="6281234567890@s.whatsapp.net",
+                senderName="Alice Example",
+            )
+        )
+
+        assert event is not None
+        assert event.source.user_id == "6281234567890@s.whatsapp.net"
+        assert event.source.user_name == "Alice Example"
+        assert event.text == "hello everyone"
+
+    asyncio.run(_run())
+
+
 def test_regex_mention_patterns_allow_custom_wake_words():
     adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*chompy\b"])
 

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,11 +1,13 @@
 import json
+import asyncio
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  observe_unmentioned_group_messages=None):
     from gateway.platforms.whatsapp import WhatsAppAdapter
 
     extra = {}
@@ -23,6 +25,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if observe_unmentioned_group_messages is not None:
+        extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -63,6 +67,23 @@ def _dm_message(body="hello", **overrides):
     return data
 
 
+class _FakeSessionEntry:
+    session_id = "whatsapp-group-session"
+
+
+class _FakeSessionStore:
+    def __init__(self):
+        self.sources = []
+        self.messages = []
+
+    def get_or_create_session(self, source):
+        self.sources.append(source)
+        return _FakeSessionEntry()
+
+    def append_to_transcript(self, session_id, message, skip_db=False):
+        self.messages.append((session_id, message, skip_db))
+
+
 # --- Existing tests (unchanged logic, updated helper) ---
 
 def test_group_messages_can_be_opened_via_config():
@@ -90,6 +111,67 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("/status")) is True
 
 
+def test_unmentioned_group_messages_can_be_observed_without_dispatching():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+
+        event = await adapter._build_message_event(
+            _group_message(
+                "side chatter",
+                senderId="6281234567890@s.whatsapp.net",
+                senderName="Alice Example",
+                messageId="msg-42",
+            )
+        )
+
+        assert event is None
+        assert len(store.messages) == 1
+        session_id, message, skip_db = store.messages[0]
+        assert session_id == "whatsapp-group-session"
+        assert skip_db is False
+        assert message["role"] == "user"
+        assert message["content"] == "[Alice Example|6281234567890@s.whatsapp.net]\nside chatter"
+        assert message["observed"] is True
+        assert message["message_id"] == "msg-42"
+        assert store.sources[0].chat_id == "120363001234567890@g.us"
+        assert store.sources[0].chat_type == "group"
+        assert store.sources[0].user_id is None
+        assert store.sources[0].user_name is None
+
+    asyncio.run(_run())
+
+
+def test_observed_group_context_uses_shared_source_for_later_mentions():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            observe_unmentioned_group_messages=True,
+        )
+
+        event = await adapter._build_message_event(
+            _group_message(
+                "@15551230000 what did Alice say?",
+                mentionedIds=["15551230000@s.whatsapp.net"],
+                senderId="6289999999999@s.whatsapp.net",
+                senderName="Bob Example",
+            )
+        )
+
+        assert event is not None
+        assert event.source.chat_id == "120363001234567890@g.us"
+        assert event.source.chat_type == "group"
+        assert event.source.user_id is None
+        assert event.source.user_name is None
+        assert event.text == "[Bob Example|6289999999999@s.whatsapp.net]\nwhat did Alice say?"
+
+    asyncio.run(_run())
+
+
 def test_regex_mention_patterns_allow_custom_wake_words():
     adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*chompy\b"])
 
@@ -111,6 +193,7 @@ def test_config_bridges_whatsapp_group_settings(monkeypatch, tmp_path):
     (hermes_home / "config.yaml").write_text(
         "whatsapp:\n"
         "  require_mention: true\n"
+        "  observe_unmentioned_group_messages: true\n"
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n",
         encoding="utf-8",
@@ -118,14 +201,17 @@ def test_config_bridges_whatsapp_group_settings(monkeypatch, tmp_path):
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("WHATSAPP_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", raising=False)
     monkeypatch.delenv("WHATSAPP_MENTION_PATTERNS", raising=False)
 
     config = load_gateway_config()
 
     assert config is not None
     assert config.platforms[Platform.WHATSAPP].extra["require_mention"] is True
+    assert config.platforms[Platform.WHATSAPP].extra["observe_unmentioned_group_messages"] is True
     assert config.platforms[Platform.WHATSAPP].extra["mention_patterns"] == [r"^\s*chompy\b"]
     assert __import__("os").environ["WHATSAPP_REQUIRE_MENTION"] == "true"
+    assert __import__("os").environ["WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] == "true"
     assert json.loads(__import__("os").environ["WHATSAPP_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
 
 


### PR DESCRIPTION
## Summary
- add WhatsApp `observe_unmentioned_group_messages` config/env bridging
- store unmentioned WhatsApp group chatter as observed context when mention-gating skips dispatch
- align later mentioned group turns to the shared group source so they can see observed context
- preserve normal group sender attribution when observe mode is enabled but mention gating does not apply

## Root cause
WhatsApp mention-gated group messages were dropped at intake when `_should_process_message()` returned false. Unlike Telegram, there was no observe-only path to append skipped group chatter to the shared group transcript for a later direct mention.

Post-audit, the observe attribution path also needed to be scoped to the same mention-gated observe mode. Without that, open groups and `free_response_chats` could lose the sender `user_id` / `user_name` and receive observed-context text prefixes even though they are normal dispatching conversations.

Fixes #38710.

## Validation
- `.venv\\Scripts\\python.exe -m pytest -o addopts='' tests/gateway/test_whatsapp_group_gating.py -q --timeout-method=thread` -> `30 passed`
- `.venv\\Scripts\\python.exe -m ruff check gateway/config.py gateway/platforms/whatsapp.py tests/gateway/test_whatsapp_group_gating.py` -> `All checks passed!`
- `.venv\\Scripts\\python.exe -m py_compile gateway/config.py gateway/platforms/whatsapp.py tests/gateway/test_whatsapp_group_gating.py` -> passed
- `git diff --check` -> passed