### PR TITLE
docs: fix prefill messages config key

### DIFF
--- a/skills/red-teaming/godmode/SKILL.md
+++ b/skills/red-teaming/godmode/SKILL.md
@@ -90,7 +90,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Strategy order per model family:
@@ -171,8 +171,7 @@ Create `~/.hermes/prefill.json`:
 
 Then set in `~/.hermes/config.yaml`:
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are ephemeral — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/website/docs/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
+++ b/website/docs/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
@@ -108,7 +108,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Strategy order per model family:
@@ -189,8 +189,7 @@ Create `~/.hermes/prefill.json`:
 
 Then set in `~/.hermes/config.yaml`:
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are ephemeral — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/website/docs/user-guide/skills/godmode.md
+++ b/website/docs/user-guide/skills/godmode.md
@@ -94,7 +94,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Model-Specific Strategy Order
@@ -150,8 +150,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 Create `~/.hermes/prefill.json` and reference it in config:
 
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are **ephemeral** — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
@@ -108,7 +108,7 @@ undo_jailbreak()
 7. **若某策略有效**，则锁定：
    - 将胜出的系统 prompt 写入 `config.yaml` 的 `agent.system_prompt`
    - 将 prefill 消息写入 `~/.hermes/prefill.json`
-   - 在 `config.yaml` 中设置 `agent.prefill_messages_file: "prefill.json"`
+   - 在 `config.yaml` 中设置 `prefill_messages_file: "prefill.json"`
 8. **报告结果**——胜出策略、得分、合规响应预览
 
 ### 各模型系列的策略顺序：
@@ -189,8 +189,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 
 然后在 `~/.hermes/config.yaml` 中设置：
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill 消息在每次 API 调用时注入到系统 prompt 之后。它们是临时的——永远不会保存到会话或轨迹中。模型将其视为先前的对话上下文，从而建立合规模式。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/godmode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/godmode.md
@@ -94,7 +94,7 @@ undo_jailbreak()
 7. **若某策略有效**，将其锁定：
    - 将获胜的系统提示词写入 `config.yaml` 的 `agent.system_prompt`
    - 将预填充消息写入 `~/.hermes/prefill.json`
-   - 在 `config.yaml` 中设置 `agent.prefill_messages_file: "prefill.json"`
+   - 在 `config.yaml` 中设置 `prefill_messages_file: "prefill.json"`
 8. **报告结果**——哪种策略获胜、得分、合规响应预览
 
 ### 各模型系列的策略顺序
@@ -150,8 +150,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 创建 `~/.hermes/prefill.json` 并在配置中引用：
 
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 预填充消息在每次 API 调用时注入到系统提示词之后。它们是**临时的**——不会保存到会话或轨迹中。模型将其视为先前的对话上下文，从而建立合规模式。


### PR DESCRIPTION
## What does this PR do?

Updates the godmode prefill docs to use the config key that the gateway actually reads: top-level `prefill_messages_file`, not `agent.prefill_messages_file`.

The gateway loader reads `prefill_messages_file` from the runtime config and loads it as a JSON prefill message array. The affected godmode docs showed the key nested under `agent`, which would not be picked up by `GatewayRunner._load_prefill_messages()`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/red-teaming/godmode/SKILL.md` to document top-level `prefill_messages_file`.
- Updated the generated English godmode docs under `website/docs/user-guide/skills/`.
- Updated the matching Simplified Chinese docs under `website/i18n/zh-Hans/`.

## How to Test

1. Search the updated docs for `agent.prefill_messages_file`; it should not appear.
2. Search for `agent:\n  prefill_messages_file`; it should not appear in the godmode docs.
3. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run locally:

- `rg -n "agent\.prefill_messages_file" . -S --glob '!node_modules' --glob '!venv' --glob '!.venv'` -> no matches
- `rg -n -U "agent:\n\s+prefill_messages_file" skills website/docs website/i18n -S` -> no matches
- `git diff --check` -> passed
