### PR TITLE
Add SkillOpt-style skill promotion gate

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -12,6 +12,7 @@ handler are thin wrappers that parse args and delegate.
 
 import json
 import re
+import shlex
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -1511,6 +1512,63 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
         c.print(f"[bold red]Unknown target:[/] {target}. Use 'github' or 'clawhub'.\n")
 
 
+def do_optimize(
+    skill_path: str,
+    candidate_path: str,
+    baseline_score: float,
+    candidate_score: float,
+    *,
+    validator: str = "",
+    allow_equal: bool = False,
+    dry_run: bool = False,
+    console: Optional[Console] = None,
+    invalidate_cache: bool = False,
+) -> None:
+    """Run the SkillOpt-style validation gate for a candidate SKILL.md."""
+    from tools.skillopt import promote_skill_candidate
+
+    c = console or _console
+    result = promote_skill_candidate(
+        skill_path,
+        candidate_path,
+        baseline_score=baseline_score,
+        candidate_score=candidate_score,
+        validator=validator or None,
+        allow_equal=allow_equal,
+        dry_run=dry_run,
+        metadata={"entrypoint": "hermes skills optimize"},
+    )
+
+    style = "green" if result.accepted else "yellow"
+    title = "SkillOpt gate accepted" if result.accepted else "SkillOpt gate rejected"
+    lines = [
+        f"[bold]Skill:[/] {result.skill_path}",
+        f"[bold]Candidate:[/] {result.candidate_path}",
+        f"[bold]Score:[/] {result.baseline_score:g} → {result.candidate_score:g} ({result.delta:+g})",
+        f"[bold]Reason:[/] {result.reason}",
+    ]
+    if result.backup_path:
+        lines.append(f"[bold]Backup:[/] {result.backup_path}")
+    if result.history_path:
+        lines.append(f"[bold]History:[/] {result.history_path}")
+    if result.rejected_path:
+        lines.append(f"[bold]Rejected buffer:[/] {result.rejected_path}")
+    if dry_run:
+        lines.append("[dim]Dry run: no skill file was changed.[/]")
+    c.print(Panel("\n".join(lines), title=f"[{style}]{title}[/]", border_style=style))
+
+    if result.accepted and not dry_run:
+        if invalidate_cache:
+            try:
+                from agent.prompt_builder import clear_skills_system_prompt_cache
+                clear_skills_system_prompt_cache(clear_snapshot=True)
+            except Exception:
+                pass
+        else:
+            c.print("[dim]Optimized skill will be available in your next session.[/]")
+            c.print("[dim]Use /reset to start a new session now, or --now to activate immediately (invalidates prompt cache).[/]\n")
+
+
 def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
                     auth) -> tuple:
     """Create a PR to a GitHub repo with the skill. Returns (success, message)."""
@@ -1749,6 +1807,17 @@ def skills_command(args) -> None:
             target=getattr(args, "to", "github"),
             repo=getattr(args, "repo", ""),
         )
+    elif action == "optimize":
+        do_optimize(
+            args.skill_path,
+            getattr(args, "candidate"),
+            getattr(args, "baseline_score"),
+            getattr(args, "candidate_score"),
+            validator=getattr(args, "validator", ""),
+            allow_equal=getattr(args, "allow_equal", False),
+            dry_run=getattr(args, "dry_run", False),
+            invalidate_cache=getattr(args, "now", False),
+        )
     elif action == "snapshot":
         snap_action = getattr(args, "snapshot_action", None)
         if snap_action == "export":
@@ -1765,7 +1834,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|repair-official|publish|optimize|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1797,7 +1866,11 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         /skills tap remove owner/repo
     """
     c = console or _console
-    parts = cmd.strip().split()
+    try:
+        parts = shlex.split(cmd.strip())
+    except ValueError as exc:
+        c.print(f"[bold red]Could not parse /skills command:[/] {exc}\n")
+        return
 
     # Strip the leading "/skills" if present
     if parts and parts[0].lower() == "/skills":
@@ -1960,6 +2033,49 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                 repo = args[i + 1]
         do_publish(skill_path, target=target, repo=repo, console=c)
 
+    elif action == "optimize":
+        if not args:
+            c.print("[bold red]Usage:[/] /skills optimize <skill-path> --candidate <SKILL.md> --baseline-score N --candidate-score N [--validator 'cmd'] [--dry-run] [--now]\n")
+            return
+        skill_path = args[0]
+        candidate = ""
+        baseline_score = None
+        candidate_score = None
+        validator = ""
+        allow_equal = "--allow-equal" in args
+        dry_run = "--dry-run" in args
+        invalidate_cache = "--now" in args
+        i = 1
+        while i < len(args):
+            a = args[i]
+            if a == "--candidate" and i + 1 < len(args):
+                candidate = args[i + 1]
+                i += 2
+            elif a == "--baseline-score" and i + 1 < len(args):
+                try:
+                    baseline_score = float(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif a == "--candidate-score" and i + 1 < len(args):
+                try:
+                    candidate_score = float(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif a == "--validator" and i + 1 < len(args):
+                validator = args[i + 1]
+                i += 2
+            else:
+                i += 1
+        if not candidate or baseline_score is None or candidate_score is None:
+            c.print("[bold red]Usage:[/] /skills optimize <skill-path> --candidate <SKILL.md> --baseline-score N --candidate-score N [--validator 'cmd'] [--dry-run] [--now]\n")
+            return
+        do_optimize(skill_path, candidate, baseline_score, candidate_score,
+                    validator=validator, allow_equal=allow_equal,
+                    dry_run=dry_run, invalidate_cache=invalidate_cache,
+                    console=c)
+
     elif action == "snapshot":
         if not args:
             c.print("[bold red]Usage:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
@@ -2007,6 +2123,8 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]diff[/] <name>                 Diff your copy of a bundled skill vs the stock version\n"
         "  [cyan]reset[/] <name> [--restore]    Reset bundled-skill tracking (fix 'user-modified' flag)\n"
         "  [cyan]publish[/] <path> --repo <r>   Publish a skill to GitHub via PR\n"
+        "  [cyan]optimize[/] <path> --candidate <SKILL.md> --baseline-score N --candidate-score N\n"
+        "       Promote candidate only if it passes the SkillOpt-style validation gate; add --now to refresh this session\n"
         "  [cyan]snapshot[/] export|import      Export/import skill configurations\n"
         "  [cyan]tap[/] list|add|remove         Manage skill sources\n",
         title="/skills",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -283,6 +283,45 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "--repo", default="", help="Target GitHub repo (e.g. openai/skills)"
     )
 
+    skills_optimize = skills_subparsers.add_parser(
+        "optimize",
+        help="Promote a candidate SKILL.md through a SkillOpt-style validation gate",
+        description=(
+            "Compare a candidate SKILL.md against the current skill and only "
+            "promote it when it is valid, passes the optional validator command, "
+            "preserves the current skill identity, and strictly improves the "
+            "held-out score."
+        ),
+    )
+    skills_optimize.add_argument("skill_path", help="Skill directory or SKILL.md to update")
+    skills_optimize.add_argument("--candidate", required=True, help="Candidate SKILL.md file")
+    skills_optimize.add_argument(
+        "--baseline-score", required=True, type=float, help="Held-out score of the current skill"
+    )
+    skills_optimize.add_argument(
+        "--candidate-score", required=True, type=float, help="Held-out score of the candidate skill"
+    )
+    skills_optimize.add_argument(
+        "--validator",
+        default="",
+        help="Optional shell command that must exit 0 before promotion; runs in the skill directory",
+    )
+    skills_optimize.add_argument(
+        "--allow-equal",
+        action="store_true",
+        help="Allow equal scores to promote (default requires strict improvement)",
+    )
+    skills_optimize.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Evaluate and record the gate decision without replacing SKILL.md",
+    )
+    skills_optimize.add_argument(
+        "--now",
+        action="store_true",
+        help="Invalidate the skills prompt cache immediately instead of waiting for the next session",
+    )
+
     skills_snapshot = skills_subparsers.add_parser(
         "snapshot", help="Export/import skill configurations"
     )

--- a/tests/hermes_cli/test_skills_skip_confirm.py
+++ b/tests/hermes_cli/test_skills_skip_confirm.py
@@ -11,6 +11,7 @@ Updated for PR #3586 (cache-aware install/uninstall).
 """
 
 from unittest.mock import patch
+from types import SimpleNamespace
 
 
 
@@ -117,6 +118,75 @@ class TestHandleSkillsSlashUninstallFlags:
             handle_skills_slash("/skills uninstall test-skill --now")
             mock_uninstall.assert_called_once()
             _, kwargs = mock_uninstall.call_args
+            assert kwargs.get("invalidate_cache") is True
+
+
+class TestHandleSkillsSlashOptimizeFlags:
+    """Test cache-invalidation flag parsing in handle_skills_slash for optimize."""
+
+    def test_default_defers_cache_invalidation(self):
+        from hermes_cli.skills_hub import handle_skills_slash
+        with patch("hermes_cli.skills_hub.do_optimize") as mock_optimize:
+            handle_skills_slash(
+                "/skills optimize demo --candidate /tmp/candidate.md "
+                "--baseline-score 0.2 --candidate-score 0.9"
+            )
+            mock_optimize.assert_called_once()
+            args, kwargs = mock_optimize.call_args
+            assert args[:4] == ("demo", "/tmp/candidate.md", 0.2, 0.9)
+            assert kwargs.get("invalidate_cache") is False
+
+    def test_now_flag_invalidates_cache(self):
+        from hermes_cli.skills_hub import handle_skills_slash
+        with patch("hermes_cli.skills_hub.do_optimize") as mock_optimize:
+            handle_skills_slash(
+                "/skills optimize demo --candidate /tmp/candidate.md "
+                "--baseline-score 0.2 --candidate-score 0.9 --now"
+            )
+            mock_optimize.assert_called_once()
+            _, kwargs = mock_optimize.call_args
+            assert kwargs.get("invalidate_cache") is True
+
+
+class TestCmdSkillsOptimizeFlags:
+    """Test cache-invalidation flag propagation in `hermes skills optimize`."""
+
+    def test_default_defers_cache_invalidation(self):
+        from hermes_cli.main import cmd_skills
+        args = SimpleNamespace(
+            skills_action="optimize",
+            skill_path="demo",
+            candidate="/tmp/candidate.md",
+            baseline_score=0.2,
+            candidate_score=0.9,
+            validator="",
+            allow_equal=False,
+            dry_run=False,
+            now=False,
+        )
+        with patch("hermes_cli.skills_hub.do_optimize") as mock_optimize:
+            cmd_skills(args)
+            mock_optimize.assert_called_once()
+            _, kwargs = mock_optimize.call_args
+            assert kwargs.get("invalidate_cache") is False
+
+    def test_now_flag_invalidates_cache(self):
+        from hermes_cli.main import cmd_skills
+        args = SimpleNamespace(
+            skills_action="optimize",
+            skill_path="demo",
+            candidate="/tmp/candidate.md",
+            baseline_score=0.2,
+            candidate_score=0.9,
+            validator="",
+            allow_equal=False,
+            dry_run=False,
+            now=True,
+        )
+        with patch("hermes_cli.skills_hub.do_optimize") as mock_optimize:
+            cmd_skills(args)
+            mock_optimize.assert_called_once()
+            _, kwargs = mock_optimize.call_args
             assert kwargs.get("invalidate_cache") is True
 
 

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,39 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_skills_optimize_parser_dispatches_to_skills_handler():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("skills")
+    build_skills_parser(sub, cmd_skills=handler)
+
+    ns = parser.parse_args([
+        "skills",
+        "optimize",
+        "skills/demo",
+        "--candidate",
+        "/tmp/candidate-SKILL.md",
+        "--baseline-score",
+        "0.72",
+        "--candidate-score",
+        "0.81",
+        "--validator",
+        "python eval.py",
+        "--allow-equal",
+        "--dry-run",
+        "--now",
+    ])
+
+    assert ns.command == "skills"
+    assert ns.skills_action == "optimize"
+    assert ns.func is handler
+    assert ns.skill_path == "skills/demo"
+    assert ns.candidate == "/tmp/candidate-SKILL.md"
+    assert ns.baseline_score == 0.72
+    assert ns.candidate_score == 0.81
+    assert ns.validator == "python eval.py"
+    assert ns.allow_equal is True
+    assert ns.dry_run is True
+    assert ns.now is True

--- a/tests/tools/test_skillopt.py
+++ b/tests/tools/test_skillopt.py
@@ -1,0 +1,178 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.skillopt import SkillOptError, promote_skill_candidate
+
+
+BASE_SKILL = """---
+name: demo-skill
+description: Demo skill for tests.
+---
+
+# Demo
+
+Do the old thing.
+"""
+
+BETTER_SKILL = """---
+name: demo-skill
+description: Demo skill for tests.
+---
+
+# Demo
+
+Do the better thing with a concrete verification step.
+"""
+
+INVALID_SKILL = """# Missing frontmatter
+
+Nope.
+"""
+
+RENAMED_SKILL = """---
+name: other-skill
+description: Renamed skill for tests.
+---
+
+# Demo
+
+Do the renamed thing.
+"""
+
+
+def _make_skill(tmp_path: Path) -> Path:
+    skill_dir = tmp_path / "demo-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE_SKILL, encoding="utf-8")
+    return skill_dir
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_promotes_candidate_when_score_strictly_improves(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(BETTER_SKILL, encoding="utf-8")
+
+    result = promote_skill_candidate(
+        skill_dir,
+        candidate,
+        baseline_score=0.72,
+        candidate_score=0.81,
+    )
+
+    assert result.accepted is True
+    assert result.decision == "accepted"
+    assert "better thing" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert Path(result.backup_path).exists()
+    history = _read_jsonl(skill_dir / ".skillopt" / "history.jsonl")
+    assert history[-1]["candidate_score"] == 0.81
+    assert history[-1]["baseline_score"] == 0.72
+
+
+def test_rejects_candidate_when_score_does_not_improve(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(BETTER_SKILL, encoding="utf-8")
+
+    result = promote_skill_candidate(
+        skill_dir,
+        candidate,
+        baseline_score=0.81,
+        candidate_score=0.81,
+    )
+
+    assert result.accepted is False
+    assert result.decision == "rejected"
+    assert "old thing" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    rejected = _read_jsonl(skill_dir / ".skillopt" / "rejected.jsonl")
+    assert "did not beat baseline" in rejected[-1]["reason"]
+
+
+def test_rejects_invalid_skill_document_before_score_gate(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "invalid.md"
+    candidate.write_text(INVALID_SKILL, encoding="utf-8")
+
+    result = promote_skill_candidate(
+        skill_dir,
+        candidate,
+        baseline_score=0.1,
+        candidate_score=0.9,
+    )
+
+    assert result.accepted is False
+    assert "candidate validation failed" in result.reason
+    assert "old thing" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_rejects_candidate_when_validator_fails(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(BETTER_SKILL, encoding="utf-8")
+
+    result = promote_skill_candidate(
+        skill_dir,
+        candidate,
+        baseline_score=0.2,
+        candidate_score=0.9,
+        validator="python -c 'import os; print(os.environ[\"HERMES_SKILLOPT_CANDIDATE\"]); raise SystemExit(3)'",
+    )
+
+    assert result.accepted is False
+    assert result.validator_exit_code == 3
+    assert "validator failed" in result.reason
+
+
+def test_rejects_candidate_that_renames_skill_identity(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "renamed.md"
+    candidate.write_text(RENAMED_SKILL, encoding="utf-8")
+
+    result = promote_skill_candidate(
+        skill_dir,
+        candidate,
+        baseline_score=0.2,
+        candidate_score=0.9,
+    )
+
+    assert result.accepted is False
+    assert "name mismatch" in result.reason
+    assert "old thing" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    rejected = _read_jsonl(skill_dir / ".skillopt" / "rejected.jsonl")
+    assert "other-skill" in rejected[-1]["reason"]
+
+
+def test_rejects_candidate_that_is_live_skill_file(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+
+    result = promote_skill_candidate(
+        skill_dir,
+        skill_dir / "SKILL.md",
+        baseline_score=0.2,
+        candidate_score=0.9,
+    )
+
+    assert result.accepted is False
+    assert "quarantined file distinct" in result.reason
+    assert not (skill_dir / ".skillopt" / "backups").exists()
+
+
+def test_rejects_non_finite_scores_before_history_write(tmp_path):
+    skill_dir = _make_skill(tmp_path)
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(BETTER_SKILL, encoding="utf-8")
+
+    with pytest.raises(SkillOptError, match="finite numbers"):
+        promote_skill_candidate(
+            skill_dir,
+            candidate,
+            baseline_score=0.2,
+            candidate_score=float("nan"),
+        )
+
+    assert not (skill_dir / ".skillopt").exists()

--- a/tools/skillopt.py
+++ b/tools/skillopt.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""SkillOpt-style validation gate for Hermes skills.
+
+This is not a paper reimplementation. It is the small, boring piece Hermes
+needs in core: keep candidate skill edits quarantined, validate them, and only
+promote a candidate when it strictly improves a held-out score.
+
+Inspired by: Yang et al., "SkillOpt: Executive Strategy for Self-Evolving
+Agent Skills" (arXiv:2605.23904, 2026).
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import math
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from utils import atomic_replace
+
+Decision = Literal["accepted", "rejected"]
+
+
+@dataclass(frozen=True)
+class SkillOptResult:
+    """Outcome returned by :func:`promote_skill_candidate`."""
+
+    decision: Decision
+    reason: str
+    skill_path: str
+    candidate_path: str
+    baseline_score: float
+    candidate_score: float
+    delta: float
+    accepted: bool
+    dry_run: bool = False
+    validator_exit_code: int | None = None
+    validator_output: str = ""
+    skill_sha256_before: str = ""
+    candidate_sha256: str = ""
+    backup_path: str | None = None
+    history_path: str | None = None
+    rejected_path: str | None = None
+    diff_preview: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class SkillOptError(ValueError):
+    """Raised for malformed SkillOpt inputs."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _read_text(path: Path, label: str) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SkillOptError(f"{label} does not exist: {path}") from exc
+    except UnicodeDecodeError as exc:
+        raise SkillOptError(f"{label} must be UTF-8 text: {path}") from exc
+
+
+def _skill_md_path(skill_path: Path) -> Path:
+    """Resolve either a skill directory or a SKILL.md path to SKILL.md."""
+    path = skill_path.expanduser()
+    if path.is_dir():
+        path = path / "SKILL.md"
+    return path
+
+
+def _validate_skill_document(content: str) -> str | None:
+    # Reuse the same frontmatter/body validation as skill_manage. Import lazily
+    # to avoid making every CLI startup pay for PyYAML before skills are touched.
+    from tools.skill_manager_tool import _validate_frontmatter, _validate_content_size
+
+    size_error = _validate_content_size(content, "SKILL.md")
+    if size_error:
+        return size_error
+    return _validate_frontmatter(content)
+
+
+def _frontmatter_name(content: str, label: str) -> str:
+    """Return the YAML frontmatter ``name`` value for a validated SKILL.md."""
+    import yaml
+
+    end_match = re.search(r"\n---\s*\n", content[3:])
+    if not end_match:
+        raise SkillOptError(f"{label} frontmatter is not closed")
+    parsed = yaml.safe_load(content[3 : end_match.start() + 3]) or {}
+    name = parsed.get("name") if isinstance(parsed, dict) else None
+    if not isinstance(name, str) or not name.strip():
+        raise SkillOptError(f"{label} frontmatter name must be a non-empty string")
+    return name.strip()
+
+
+def _run_validator(command: str, skill_file: Path, candidate_file: Path) -> tuple[int, str]:
+    env = os.environ.copy()
+    env["HERMES_SKILLOPT_SKILL"] = str(skill_file)
+    env["HERMES_SKILLOPT_CANDIDATE"] = str(candidate_file)
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(skill_file.parent),
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout if isinstance(exc.stdout, str) else ""
+        return 124, (output + "\nvalidator timed out after 600s").strip()
+    return completed.returncode, (completed.stdout or "").strip()
+
+
+def _diff_preview(before: str, after: str, *, max_lines: int = 80) -> str:
+    lines = list(
+        difflib.unified_diff(
+            before.splitlines(),
+            after.splitlines(),
+            fromfile="current/SKILL.md",
+            tofile="candidate/SKILL.md",
+            lineterm="",
+        )
+    )
+    if len(lines) > max_lines:
+        lines = lines[:max_lines] + [f"... diff truncated after {max_lines} lines"]
+    return "\n".join(lines)
+
+
+def _record_result(skill_dir: Path, result: SkillOptResult) -> SkillOptResult:
+    payload = asdict(result) | {"timestamp": _utc_now()}
+    if result.accepted:
+        history_path = skill_dir / ".skillopt" / "history.jsonl"
+        _append_jsonl(history_path, payload)
+        return SkillOptResult(**(asdict(result) | {"history_path": str(history_path)}))
+    rejected_path = skill_dir / ".skillopt" / "rejected.jsonl"
+    _append_jsonl(rejected_path, payload)
+    return SkillOptResult(**(asdict(result) | {"rejected_path": str(rejected_path)}))
+
+
+def promote_skill_candidate(
+    skill_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    baseline_score: float,
+    candidate_score: float,
+    validator: str | None = None,
+    allow_equal: bool = False,
+    dry_run: bool = False,
+    metadata: dict[str, Any] | None = None,
+) -> SkillOptResult:
+    """Promote a candidate SKILL.md only when it passes the validation gate.
+
+    The gate intentionally mirrors the most important production lesson from
+    SkillOpt: skills may self-edit, but promotion is conservative. A candidate
+    must be valid, pass any external validator, and beat the held-out baseline
+    score unless ``allow_equal`` is explicitly set.
+    """
+
+    baseline_score = float(baseline_score)
+    candidate_score = float(candidate_score)
+    if not math.isfinite(baseline_score) or not math.isfinite(candidate_score):
+        raise SkillOptError("baseline_score and candidate_score must be finite numbers")
+
+    skill_file = _skill_md_path(Path(skill_path))
+    candidate_file = Path(candidate_path).expanduser()
+    current = _read_text(skill_file, "skill")
+    candidate = _read_text(candidate_file, "candidate")
+    skill_dir = skill_file.parent
+
+    base_payload = {
+        "skill_path": str(skill_file),
+        "candidate_path": str(candidate_file),
+        "baseline_score": baseline_score,
+        "candidate_score": candidate_score,
+        "delta": candidate_score - baseline_score,
+        "dry_run": dry_run,
+        "skill_sha256_before": _sha256_text(current),
+        "candidate_sha256": _sha256_text(candidate),
+        "diff_preview": _diff_preview(current, candidate),
+        "metadata": metadata or {},
+    }
+
+    if skill_file.resolve() == candidate_file.resolve():
+        result = SkillOptResult(
+            decision="rejected",
+            accepted=False,
+            reason="candidate must be a quarantined file distinct from the live SKILL.md",
+            **base_payload,
+        )
+        return _record_result(skill_dir, result)
+
+    current_validation_error = _validate_skill_document(current)
+    if current_validation_error:
+        result = SkillOptResult(
+            decision="rejected",
+            accepted=False,
+            reason=f"current skill validation failed: {current_validation_error}",
+            **base_payload,
+        )
+        return _record_result(skill_dir, result)
+
+    validation_error = _validate_skill_document(candidate)
+    if validation_error:
+        result = SkillOptResult(
+            decision="rejected",
+            accepted=False,
+            reason=f"candidate validation failed: {validation_error}",
+            **base_payload,
+        )
+        return _record_result(skill_dir, result)
+
+    current_name = _frontmatter_name(current, "skill")
+    candidate_name = _frontmatter_name(candidate, "candidate")
+    if candidate_name != current_name:
+        result = SkillOptResult(
+            decision="rejected",
+            accepted=False,
+            reason=(
+                f"candidate skill name mismatch: expected {current_name!r}, "
+                f"got {candidate_name!r}"
+            ),
+            **base_payload,
+        )
+        return _record_result(skill_dir, result)
+
+    validator_exit_code = None
+    validator_output = ""
+    if validator:
+        validator_exit_code, validator_output = _run_validator(
+            validator, skill_file, candidate_file
+        )
+        if validator_exit_code != 0:
+            result = SkillOptResult(
+                decision="rejected",
+                accepted=False,
+                reason=f"validator failed: {shlex.quote(validator)} exited {validator_exit_code}",
+                validator_exit_code=validator_exit_code,
+                validator_output=validator_output,
+                **base_payload,
+            )
+            return _record_result(skill_dir, result)
+
+    improved = candidate_score > baseline_score or (
+        allow_equal and candidate_score == baseline_score
+    )
+    if not improved:
+        comparator = "meet" if allow_equal else "beat"
+        result = SkillOptResult(
+            decision="rejected",
+            accepted=False,
+            reason=(
+                f"candidate score {candidate_score:g} did not {comparator} "
+                f"baseline {baseline_score:g}"
+            ),
+            validator_exit_code=validator_exit_code,
+            validator_output=validator_output,
+            **base_payload,
+        )
+        return _record_result(skill_dir, result)
+
+    backup_path = None
+    if not dry_run:
+        backup_dir = skill_dir / ".skillopt" / "backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup_file = backup_dir / f"SKILL.{stamp}.{_sha256_text(current)[:12]}.md"
+        backup_file.write_text(current, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=str(skill_file.parent),
+            prefix=".skillopt-promote-",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(candidate)
+            tmp_path = Path(handle.name)
+        atomic_replace(tmp_path, skill_file)
+        backup_path = str(backup_file)
+
+    result = SkillOptResult(
+        decision="accepted",
+        accepted=True,
+        reason="candidate passed validation and improved held-out score",
+        validator_exit_code=validator_exit_code,
+        validator_output=validator_output,
+        backup_path=backup_path,
+        **base_payload,
+    )
+    return _record_result(skill_dir, result)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1050,6 +1050,7 @@ Subcommands:
 | `opt-out` | Stop bundled skills from being seeded into the active profile. Writes a `.no-bundled-skills` marker so the installer, `hermes update`, and any sync skip bundled-skill seeding. Safe by default — nothing on disk is touched. With `--remove`, also deletes already-present bundled skills that are **unmodified** (user-edited, hub-installed, and hand-written skills are never removed; previews and confirms first, `--yes` to skip). |
 | `opt-in` | Undo `opt-out` by removing the `.no-bundled-skills` marker so bundled skills are seeded again on the next `hermes update`. With `--sync`, re-seed immediately. |
 | `publish` | Publish a skill to a registry. |
+| `optimize` | Promote a candidate `SKILL.md` through the SkillOpt validation gate. |
 | `snapshot` | Export/import skill configurations. |
 | `tap` | Manage custom skill sources. |
 | `config` | Interactive enable/disable configuration for skills by platform. |
@@ -1075,6 +1076,7 @@ hermes skills reset google-workspace --restore --yes
 hermes skills opt-out                  # stop future bundled-skill seeding (nothing deleted)
 hermes skills opt-out --remove --yes   # also delete UNMODIFIED bundled skills
 hermes skills opt-in --sync            # undo: remove marker and re-seed now
+hermes skills optimize ~/.hermes/skills/my-skill --candidate /tmp/candidate-SKILL.md --baseline-score 0.72 --candidate-score 0.81
 ```
 
 Notes:

--- a/website/docs/user-guide/features/skillopt.md
+++ b/website/docs/user-guide/features/skillopt.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 3
+title: "SkillOpt Promotion Gate"
+description: "Promote candidate SKILL.md edits only after validation, identity checks, and held-out score improvement"
+---
+
+# SkillOpt Promotion Gate
+
+Hermes can promote skill edits through a conservative gate inspired by:
+
+> Yifan Yang et al. **"SkillOpt: Executive Strategy for Self-Evolving Agent Skills."** arXiv:2605.23904, 2026. [arXiv:2605.23904](https://arxiv.org/abs/2605.23904)
+
+This is not a full research-system clone. It is the practical production piece Hermes needs: keep candidate skill edits quarantined, validate them, and only replace the live skill when the candidate proves better on a held-out evaluator.
+
+## What the gate enforces
+
+`hermes skills optimize` promotes a candidate only when all of these are true:
+
+- the current skill and candidate are valid `SKILL.md` documents;
+- the candidate is a separate quarantined file, not the live `SKILL.md` itself;
+- the candidate preserves the current skill's frontmatter `name:` identity;
+- baseline and candidate scores are finite numbers;
+- an optional validator command exits `0`;
+- the candidate score strictly beats the baseline score, unless `--allow-equal` is set.
+
+If the gate accepts, Hermes backs up the previous `SKILL.md`, atomically replaces it with the candidate, and records the promotion. If it rejects, the live skill is left untouched and the rejection is recorded for later analysis.
+
+## CLI usage
+
+```bash
+hermes skills optimize ~/.hermes/skills/my-skill \
+  --candidate /tmp/candidate-SKILL.md \
+  --baseline-score 0.72 \
+  --candidate-score 0.81 \
+  --validator 'python tests/evaluate_skill.py'
+```
+
+The validator runs in the live skill directory and receives:
+
+- `HERMES_SKILLOPT_SKILL` - path to the current live `SKILL.md`
+- `HERMES_SKILLOPT_CANDIDATE` - path to the candidate `SKILL.md`
+
+Useful flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--allow-equal` | Permit equal scores when the evaluator is noisy. Default requires strict improvement. |
+| `--dry-run` | Evaluate and record the decision without replacing the live skill. |
+| `--validator '<cmd>'` | Require a project-specific command to pass before promotion. |
+
+## Slash usage inside chat
+
+Inside a running Hermes session:
+
+```bash
+/skills optimize ~/.hermes/skills/my-skill \
+  --candidate /tmp/candidate-SKILL.md \
+  --baseline-score 0.72 \
+  --candidate-score 0.81
+```
+
+By default, slash-command mutations preserve the current prompt cache and activate on the next session. Pass `--now` only when you explicitly want immediate cache invalidation in the current session:
+
+```bash
+/skills optimize ~/.hermes/skills/my-skill \
+  --candidate /tmp/candidate-SKILL.md \
+  --baseline-score 0.72 \
+  --candidate-score 0.81 \
+  --now
+```
+
+## Files written
+
+For a skill at `~/.hermes/skills/my-skill/SKILL.md`, optimization metadata lives beside the skill:
+
+```text
+~/.hermes/skills/my-skill/.skillopt/
+├── backups/
+│   └── SKILL.<timestamp>.<sha>.md
+├── history.jsonl
+└── rejected.jsonl
+```
+
+This keeps the live skill simple while preserving enough audit trail for future autonomous optimizers and human review.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -64,6 +64,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/tools',
             'user-guide/features/tool-search',
             'user-guide/features/skills',
+            'user-guide/features/skillopt',
             'user-guide/features/lsp',
             'user-guide/features/curator',
             'user-guide/features/memory',


### PR DESCRIPTION
## What changed

This adds a small SkillOpt-style promotion gate for Hermes skills:

- `hermes skills optimize <skill> --candidate <SKILL.md> --baseline-score N --candidate-score N`
- candidate validation reuses the existing `SKILL.md` frontmatter/body checks
- optional validator command support before promotion
- strict held-out score improvement by default
- accepted candidates get backed up and recorded in `.skillopt/history.jsonl`
- rejected candidates land in `.skillopt/rejected.jsonl` instead of disappearing
- docs for the workflow and audit files

The intent is intentionally modest: not a full autonomous optimizer yet, just the safe promotion layer that makes autonomous skill improvement possible without letting random self-edits mutate live skills.

## Credit / inspiration

Inspired by Yang et al., **“SkillOpt: Executive Strategy for Self-Evolving Agent Skills”** (arXiv:2605.23904, 2026):
https://arxiv.org/abs/2605.23904

The paper’s key idea I pulled into Hermes is the operational discipline: keep skill edits bounded, validate against held-out feedback, promote only when the candidate actually improves, and retain rejected edits as useful negative signal.

## Verified

- `python -m pytest tests/tools/test_skillopt.py tests/hermes_cli/test_skills_subparser.py -q`
- `python -m pytest tests/tools/test_skillopt.py tests/tools/test_skill_manager_tool.py tests/hermes_cli/test_skills_subparser.py tests/hermes_cli/test_skills_hub.py -q`
- `python -m ruff check tools/skillopt.py hermes_cli/skills_hub.py tests/tools/test_skillopt.py`
- smoke-tested `python -m hermes_cli.main skills optimize ...` with a real temp skill, candidate file, and validator command
