### PR TITLE
fix(tui): read terminal.cwd from config.yaml in _completion_cwd()

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -647,6 +647,7 @@ def _completion_cwd(params: dict | None = None) -> str:
         (params or {}).get("cwd")
         or _sessions.get((params or {}).get("session_id") or "", {}).get("cwd")
         or os.environ.get("TERMINAL_CWD")
+        or (_load_cfg().get("terminal") or {}).get("cwd")
         or os.getcwd()
     )
     try:


### PR DESCRIPTION
The TUI's _completion_cwd() function resolves the working directory for new sessions and completions, but its priority chain falls through to os.getcwd() without ever checking the profile's terminal.cwd setting in config.yaml. This means that regardless of what the user configured, the TUI always uses the directory from which `hermes --tui` was launched.

In contrast, the WebUI bypasses this by injecting a [Workspace::v1: ...] tag into every user message, overriding the cwd at the agent level.

Fix: insert a config.yaml terminal.cwd read into the _completion_cwd() priority chain, between TERMINAL_CWD and os.getcwd(). This makes the TUI respect the configured workspace automatically, while preserving all existing priorities (explicit user choice > session cwd > TERMINAL_CWD env > config > fallback).

Priority chain after this change:
1. params['cwd'] (explicit user/workspace choice from frontend)
2. session['cwd'] (existing session's cwd)
3. TERMINAL_CWD env var (worktree mode)
4. config.yaml terminal.cwd (profile-configured workspace)  <-- NEW
5. os.getcwd() (final fallback)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

