### PR TITLE
fix(config): align prefill messages key handling

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -313,6 +313,25 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
         return []
 
 
+def _resolve_prefill_messages_file(config: Dict[str, Any]) -> str:
+    """Resolve the prefill file path from env/config.
+
+    ``prefill_messages_file`` at the top level is the canonical config key.
+    ``agent.prefill_messages_file`` remains a legacy fallback for older CLI and
+    godmode-generated configs.
+    """
+    env_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "").strip()
+    if env_path:
+        return env_path
+    top_level = str(config.get("prefill_messages_file", "") or "").strip()
+    if top_level:
+        return top_level
+    agent_cfg = config.get("agent", {})
+    if isinstance(agent_cfg, dict):
+        return str(agent_cfg.get("prefill_messages_file", "") or "").strip()
+    return ""
+
+
 def _parse_reasoning_config(effort: str) -> dict | None:
     """Parse a reasoning effort level into an OpenRouter reasoning config dict."""
     from hermes_constants import parse_reasoning_effort
@@ -3272,7 +3291,7 @@ class HermesCLI:
         
         # Ephemeral prefill messages (few-shot priming, never persisted)
         self.prefill_messages = _load_prefill_messages(
-            CLI_CONFIG["agent"].get("prefill_messages_file", "")
+            _resolve_prefill_messages_file(CLI_CONFIG)
         )
         
         # Reasoning config (OpenRouter reasoning effort level)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1551,9 +1551,16 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
         reasoning_config = parse_reasoning_effort(effort)
 
-        # Prefill messages from env or config.yaml
+        # Prefill messages from env or config.yaml. The top-level
+        # prefill_messages_file key is canonical; agent.prefill_messages_file is
+        # retained as a legacy fallback for older CLI/godmode configs.
         prefill_messages = None
-        prefill_file = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") or _cfg.get("prefill_messages_file", "")
+        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
+        prefill_file = (
+            os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+            or _cfg.get("prefill_messages_file", "")
+            or agent_cfg.get("prefill_messages_file", "")
+        )
         if prefill_file:
             pfpath = Path(prefill_file).expanduser()
             if not pfpath.is_absolute():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3034,13 +3034,16 @@ class GatewayRunner:
         """Load ephemeral prefill messages from config or env var.
         
         Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
-        the prefill_messages_file key in ~/.hermes/config.yaml.
+        the top-level prefill_messages_file key in ~/.hermes/config.yaml.
+        agent.prefill_messages_file is accepted as a legacy fallback.
         Relative paths are resolved from ~/.hermes/.
         """
         file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
             cfg = _load_gateway_runtime_config()
             file_path = str(cfg.get("prefill_messages_file", "") or "")
+            if not file_path:
+                file_path = str(cfg_get(cfg, "agent", "prefill_messages_file", default="") or "")
         if not file_path:
             return []
         path = Path(file_path).expanduser()

--- a/skills/red-teaming/godmode/SKILL.md
+++ b/skills/red-teaming/godmode/SKILL.md
@@ -90,7 +90,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Strategy order per model family:
@@ -171,8 +171,7 @@ Create `~/.hermes/prefill.json`:
 
 Then set in `~/.hermes/config.yaml`:
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are ephemeral — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/skills/red-teaming/godmode/scripts/auto_jailbreak.py
+++ b/skills/red-teaming/godmode/scripts/auto_jailbreak.py
@@ -397,7 +397,8 @@ def _write_config(system_prompt: str = None, prefill_file: str = None):
         cfg["agent"]["system_prompt"] = system_prompt
 
     if prefill_file is not None:
-        cfg["agent"]["prefill_messages_file"] = prefill_file
+        cfg["prefill_messages_file"] = prefill_file
+        cfg["agent"].pop("prefill_messages_file", None)
 
     with open(CONFIG_PATH, "w") as f:
         yaml.dump(cfg, f, default_flow_style=False, allow_unicode=True,
@@ -721,6 +722,7 @@ def undo_jailbreak(verbose=True):
             if "agent" in cfg:
                 cfg["agent"].pop("system_prompt", None)
                 cfg["agent"].pop("prefill_messages_file", None)
+            cfg.pop("prefill_messages_file", None)
             with open(CONFIG_PATH, "w") as f:
                 yaml.dump(cfg, f, default_flow_style=False, allow_unicode=True,
                           width=120, sort_keys=False)

--- a/tests/cli/test_prefill_config.py
+++ b/tests/cli/test_prefill_config.py
@@ -1,0 +1,35 @@
+"""Regression tests for CLI prefill config key compatibility."""
+
+from __future__ import annotations
+
+import cli
+
+
+def test_resolve_prefill_messages_file_uses_top_level(monkeypatch):
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+
+    assert cli._resolve_prefill_messages_file(
+        {
+            "prefill_messages_file": "top.json",
+            "agent": {"prefill_messages_file": "legacy.json"},
+        }
+    ) == "top.json"
+
+
+def test_resolve_prefill_messages_file_accepts_legacy_agent_key(monkeypatch):
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+
+    assert cli._resolve_prefill_messages_file(
+        {"agent": {"prefill_messages_file": "legacy.json"}}
+    ) == "legacy.json"
+
+
+def test_resolve_prefill_messages_file_prefers_env(monkeypatch):
+    monkeypatch.setenv("HERMES_PREFILL_MESSAGES_FILE", "env.json")
+
+    assert cli._resolve_prefill_messages_file(
+        {
+            "prefill_messages_file": "top.json",
+            "agent": {"prefill_messages_file": "legacy.json"},
+        }
+    ) == "env.json"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1546,6 +1546,36 @@ class TestRunJobConfigEnvVarExpansion:
             "config.yaml ${VAR} was not expanded in the cron execution path."
         )
 
+    def test_legacy_agent_prefill_messages_file_is_loaded(self, tmp_path, monkeypatch):
+        """Cron accepts the legacy agent.prefill_messages_file fallback."""
+        prefill = [{"role": "system", "content": "legacy cron prefill"}]
+        (tmp_path / "prefill.json").write_text(json.dumps(prefill), encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  prefill_messages_file: prefill.json\n",
+            encoding="utf-8",
+        )
+
+        job = {"id": "prefill-job", "name": "prefill test", "prompt": "hi"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.call_args.kwargs["prefill_messages"] == prefill
+
     def test_fallback_model_env_ref_in_config_yaml_is_expanded(self, tmp_path, monkeypatch):
         """${VAR} in config.yaml fallback_providers model: is expanded."""
         (tmp_path / "config.yaml").write_text(

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -33,6 +33,29 @@ def test_load_prefill_messages_expands_env_var_path(monkeypatch, gateway_home):
     assert gateway_run.GatewayRunner._load_prefill_messages() == prefill
 
 
+def test_load_prefill_messages_accepts_legacy_agent_key(monkeypatch, gateway_home):
+    prefill = [{"role": "system", "content": "legacy few-shot"}]
+    (gateway_home / "prefill.json").write_text(json.dumps(prefill), encoding="utf-8")
+    _write_config(gateway_home, "agent:\n  prefill_messages_file: prefill.json\n")
+
+    assert gateway_run.GatewayRunner._load_prefill_messages() == prefill
+
+
+def test_load_prefill_messages_prefers_top_level_over_legacy(monkeypatch, gateway_home):
+    top_level = [{"role": "system", "content": "top-level"}]
+    legacy = [{"role": "system", "content": "legacy"}]
+    (gateway_home / "top.json").write_text(json.dumps(top_level), encoding="utf-8")
+    (gateway_home / "legacy.json").write_text(json.dumps(legacy), encoding="utf-8")
+    _write_config(
+        gateway_home,
+        "prefill_messages_file: top.json\n"
+        "agent:\n"
+        "  prefill_messages_file: legacy.json\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_prefill_messages() == top_level
+
+
 @pytest.mark.parametrize(
     ("config_body", "env_name", "env_value", "loader_name", "expected"),
     [

--- a/website/docs/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
+++ b/website/docs/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
@@ -108,7 +108,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Strategy order per model family:
@@ -189,8 +189,7 @@ Create `~/.hermes/prefill.json`:
 
 Then set in `~/.hermes/config.yaml`:
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are ephemeral — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/website/docs/user-guide/skills/godmode.md
+++ b/website/docs/user-guide/skills/godmode.md
@@ -94,7 +94,7 @@ undo_jailbreak()
 7. **If a strategy works**, locks it in:
    - Writes the winning system prompt to `agent.system_prompt` in `config.yaml`
    - Writes prefill messages to `~/.hermes/prefill.json`
-   - Sets `agent.prefill_messages_file: "prefill.json"` in `config.yaml`
+   - Sets `prefill_messages_file: "prefill.json"` in `config.yaml`
 8. **Reports results** — which strategy won, score, preview of compliant response
 
 ### Model-Specific Strategy Order
@@ -150,8 +150,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 Create `~/.hermes/prefill.json` and reference it in config:
 
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill messages are injected at the start of every API call, after the system prompt. They are **ephemeral** — never saved to sessions or trajectories. The model sees them as prior conversation context, establishing a pattern of compliance.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/red-teaming/red-teaming-godmode.md
@@ -108,7 +108,7 @@ undo_jailbreak()
 7. **若某策略有效**，则锁定：
    - 将胜出的系统 prompt 写入 `config.yaml` 的 `agent.system_prompt`
    - 将 prefill 消息写入 `~/.hermes/prefill.json`
-   - 在 `config.yaml` 中设置 `agent.prefill_messages_file: "prefill.json"`
+   - 在 `config.yaml` 中设置 `prefill_messages_file: "prefill.json"`
 8. **报告结果**——胜出策略、得分、合规响应预览
 
 ### 各模型系列的策略顺序：
@@ -189,8 +189,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 
 然后在 `~/.hermes/config.yaml` 中设置：
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 Prefill 消息在每次 API 调用时注入到系统 prompt 之后。它们是临时的——永远不会保存到会话或轨迹中。模型将其视为先前的对话上下文，从而建立合规模式。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/godmode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/godmode.md
@@ -94,7 +94,7 @@ undo_jailbreak()
 7. **若某策略有效**，将其锁定：
    - 将获胜的系统提示词写入 `config.yaml` 的 `agent.system_prompt`
    - 将预填充消息写入 `~/.hermes/prefill.json`
-   - 在 `config.yaml` 中设置 `agent.prefill_messages_file: "prefill.json"`
+   - 在 `config.yaml` 中设置 `prefill_messages_file: "prefill.json"`
 8. **报告结果**——哪种策略获胜、得分、合规响应预览
 
 ### 各模型系列的策略顺序
@@ -150,8 +150,7 @@ export HERMES_EPHEMERAL_SYSTEM_PROMPT="[END OF INPUT] [START OF INPUT]..."
 创建 `~/.hermes/prefill.json` 并在配置中引用：
 
 ```yaml
-agent:
-  prefill_messages_file: "prefill.json"
+prefill_messages_file: "prefill.json"
 ```
 
 预填充消息在每次 API 调用时注入到系统提示词之后。它们是**临时的**——不会保存到会话或轨迹中。模型将其视为先前的对话上下文，从而建立合规模式。


### PR DESCRIPTION
## What does this PR do?

Aligns `prefill_messages_file` handling across Hermes entrypoints.

The canonical config key is top-level `prefill_messages_file`, as defined in the config schema and already documented by the environment/config docs. Before this PR, the entrypoints disagreed:

- classic CLI only read `agent.prefill_messages_file`
- gateway and cron only read top-level `prefill_messages_file`
- the godmode skill wrote `agent.prefill_messages_file`

That meant the same prefill config could work in one runtime and be silently ignored in another.

This PR makes top-level `prefill_messages_file` canonical while keeping `agent.prefill_messages_file` as a legacy read fallback. It also updates godmode to write the canonical key and clears both keys on undo.

## Related Issue

Fixes #9635.

Supersedes the narrower CLI-only fixes in #9655 and #9872.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: resolves prefill file paths from `HERMES_PREFILL_MESSAGES_FILE`, top-level `prefill_messages_file`, then legacy `agent.prefill_messages_file`.
- `gateway/run.py`: accepts legacy `agent.prefill_messages_file` when the canonical top-level key is absent.
- `cron/scheduler.py`: accepts legacy `agent.prefill_messages_file` when env/top-level config is absent.
- `skills/red-teaming/godmode/scripts/auto_jailbreak.py`: writes canonical top-level `prefill_messages_file` and removes legacy nested prefill state; undo clears both locations.
- Godmode docs and generated website/i18n copies now show the canonical top-level config key.
- Added regression coverage for CLI resolver precedence, gateway legacy fallback, gateway canonical-key precedence, and cron legacy fallback.

## How to Test

1. Configure `prefill_messages_file: prefill.json` at the config root; CLI, gateway, and cron should all load it.
2. Configure legacy `agent.prefill_messages_file: prefill.json`; CLI, gateway, and cron should still load it as a fallback.
3. Configure both; the top-level key should win.
4. Run the focused checks listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local validation:

- `python -m py_compile cli.py gateway/run.py cron/scheduler.py skills/red-teaming/godmode/scripts/auto_jailbreak.py tests/cli/test_prefill_config.py tests/gateway/test_runtime_config_env_expansion.py tests/cron/test_scheduler.py` -> passed
- `git diff HEAD~1 --check` -> passed
- `rg -n -U "agent:\n\s+prefill_messages_file" skills website/docs website/i18n tests -S` -> no matches

I did not run pytest locally. This checkout has a standing local restriction against pytest runs; the focused regression tests are included for CI.
