### PR TITLE
[codex] Fix dashboard Host allowlist for loopback reverse proxies

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1531,6 +1531,15 @@ DEFAULT_CONFIG = {
         # falls through to request reconstruction rather than breaking
         # the login flow.
         "public_url": "",
+        # Extra Host headers to trust when the dashboard is bound to loopback.
+        # This is the safe path for trusted loopback reverse proxies such as
+        # Tailscale Serve or a local nginx/Caddy shim: keep ``--host`` on
+        # 127.0.0.1/localhost/::1, then explicitly allow only the proxy-facing
+        # hostname(s). This does NOT disable the DNS-rebinding guard and does
+        # NOT create general proxy trust; it is a narrow operator-supplied
+        # Host allowlist. CLI: ``hermes dashboard --allowed-host <host>``.
+        # Env override: ``HERMES_DASHBOARD_ALLOWED_HOSTS=host1,host2``.
+        "allowed_hosts": [],
     },
 
     # Privacy settings

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11937,6 +11937,40 @@ def _report_dashboard_status() -> int:
     return len(pids)
 
 
+def _split_dashboard_allowed_hosts(values) -> list[str]:
+    hosts: list[str] = []
+    for value in values or []:
+        if value is None:
+            continue
+        for chunk in str(value).split(","):
+            host = chunk.strip()
+            if host:
+                hosts.append(host)
+    return hosts
+
+
+def _resolve_dashboard_allowed_hosts(args) -> list[str]:
+    """Resolve dashboard Host allowlist from CLI, env, or config."""
+    from hermes_cli.config import load_config
+
+    cli_hosts = _split_dashboard_allowed_hosts(getattr(args, "allowed_host", None))
+    if cli_hosts:
+        return cli_hosts
+
+    env_hosts = _split_dashboard_allowed_hosts(
+        [os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")]
+    )
+    if env_hosts:
+        return env_hosts
+
+    cfg = load_config() or {}
+    dashboard_cfg = cfg.get("dashboard") or {}
+    configured = dashboard_cfg.get("allowed_hosts") or []
+    if isinstance(configured, str):
+        configured = [configured]
+    return _split_dashboard_allowed_hosts(configured)
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     # --status: report running dashboards and exit, no deps needed.
@@ -12025,11 +12059,13 @@ def cmd_dashboard(args):
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
+    allowed_hosts = _resolve_dashboard_allowed_hosts(args)
     start_server(
         host=args.host,
         port=args.port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
+        allowed_hosts=allowed_hosts,
     )
 
 
@@ -15306,6 +15342,18 @@ Examples:
     )
     dashboard_parser.add_argument(
         "--host", default="127.0.0.1", help="Host (default 127.0.0.1)"
+    )
+    dashboard_parser.add_argument(
+        "--allowed-host",
+        action="append",
+        default=[],
+        help=(
+            "Extra Host header to trust when bound to loopback. Repeat the flag "
+            "or pass a comma-separated list. Safe for trusted loopback reverse "
+            "proxies like Tailscale Serve; does not disable DNS-rebinding "
+            "protection. Also supports HERMES_DASHBOARD_ALLOWED_HOSTS and "
+            "dashboard.allowed_hosts."
+        ),
     )
     dashboard_parser.add_argument(
         "--no-open", action="store_true", help="Don't open browser automatically"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -214,6 +214,52 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _normalize_dashboard_host(value: str) -> str:
+    """Normalize a host / netloc / allowlist entry for comparison.
+
+    Matching is case-insensitive, strips ports, and understands bracketed
+    IPv6 notation. Bare IPv6 literals are treated as host-only values.
+    """
+    if not value:
+        return ""
+    raw = value.strip()
+    if not raw:
+        return ""
+
+    if "://" in raw:
+        return (urllib.parse.urlsplit(raw).hostname or "").lower()
+
+    if raw.startswith("["):
+        close = raw.find("]")
+        if close != -1:
+            return raw[1:close].strip().lower()
+        return raw.strip("[]").lower()
+
+    if raw.count(":") >= 2:
+        return raw.lower()
+
+    return (urllib.parse.urlsplit(f"//{raw}").hostname or "").lower()
+
+
+def _normalize_allowed_dashboard_hosts(
+    allowed_hosts: list[str] | tuple[str, ...] | set[str] | frozenset[str] | None,
+) -> frozenset[str]:
+    """Return the operator-supplied dashboard Host allowlist.
+
+    This is intentionally a narrow host allowlist, not a broad proxy-trust
+    toggle. It is consulted only for loopback binds.
+    """
+    if not allowed_hosts:
+        return frozenset()
+
+    normalized = {
+        host
+        for host in (_normalize_dashboard_host(value) for value in allowed_hosts)
+        if host
+    }
+    return frozenset(normalized)
+
+
 def should_require_auth(host: str, allow_public: bool) -> bool:
     """Return True iff the dashboard OAuth auth gate must be active.
 
@@ -230,45 +276,37 @@ def should_require_auth(host: str, allow_public: bool) -> bool:
     return (host not in _LOOPBACK_HOST_VALUES) and (not allow_public)
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(
+    host_header: str,
+    bound_host: str,
+    allowed_hosts: list[str] | tuple[str, ...] | set[str] | frozenset[str] | None = None,
+) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
+    - Operator-allowed extra hosts when bound to loopback
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
     """
-    if not host_header:
+    host_only = _normalize_dashboard_host(host_header)
+    if not host_only:
         return False
-    # Strip port suffix. IPv6 addresses use bracket notation:
-    #   [::1]         — no port
-    #   [::1]:9119    — with port
-    # Plain hosts/v4:
-    #   localhost:9119
-    #   127.0.0.1:9119
-    h = host_header.strip()
-    if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
-        close = h.find("]")
-        if close != -1:
-            host_only = h[1:close]  # strip brackets
-        else:
-            host_only = h.strip("[]")
-    else:
-        host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
+    bound_lc = _normalize_dashboard_host(bound_host)
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
     # defence can protect that mode; rely on operator network controls.
-    if bound_host in {"0.0.0.0", "::"}:
+    if bound_lc in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
-    bound_lc = bound_host.lower()
+    # Loopback bind: accept the loopback names plus the operator-supplied
+    # allowlist for trusted loopback reverse proxies such as Tailscale Serve.
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        accepted_hosts = set(_LOOPBACK_HOST_VALUES)
+        accepted_hosts.update(_normalize_allowed_dashboard_hosts(allowed_hosts))
+        return host_only in accepted_hosts
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc
@@ -291,13 +329,15 @@ async def host_header_middleware(request: Request, call_next):
     bound_host = getattr(app.state, "bound_host", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        allowed_hosts = getattr(app.state, "allowed_hosts", frozenset())
+        if not _is_accepted_host(host_header, bound_host, allowed_hosts):
             return JSONResponse(
                 status_code=400,
                 content={
                     "detail": (
                         "Invalid Host header. Dashboard requests must use "
-                        "the hostname the server was bound to."
+                        "the hostname the server was bound to or an "
+                        "operator-allowed host."
                     ),
                 },
             )
@@ -7092,7 +7132,8 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
         return None
 
     host_header = ws.headers.get("host", "")
-    if not _is_accepted_host(host_header, bound_host):
+    allowed_hosts = getattr(app.state, "allowed_hosts", frozenset())
+    if not _is_accepted_host(host_header, bound_host, allowed_hosts):
         return f"host_mismatch host={host_header or '?'} bound={bound_host}"
 
     origin = ws.headers.get("origin", "")
@@ -7109,7 +7150,7 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
-    if not _is_accepted_host(parsed.netloc, bound_host):
+    if not _is_accepted_host(parsed.netloc, bound_host, allowed_hosts):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 
@@ -7124,7 +7165,6 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
     same bound dashboard host.
     """
     return _ws_host_origin_reason(ws) is None
-
 
 def _ws_request_reason(ws: "WebSocket") -> Optional[str]:
     """First Host/Origin or peer-IP rejection reason, or None when allowed."""
@@ -8681,6 +8721,8 @@ def start_server(
     port: int = 9119,
     open_browser: bool = True,
     allow_public: bool = False,
+    *,
+    allowed_hosts: list[str] | tuple[str, ...] | set[str] | frozenset[str] | None = None,
 ):
     """Start the web UI server."""
     import uvicorn
@@ -8755,6 +8797,12 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    app.state.allowed_hosts = _normalize_allowed_dashboard_hosts(allowed_hosts)
+    if app.state.allowed_hosts and _normalize_dashboard_host(host) in _LOOPBACK_HOST_VALUES:
+        _log.info(
+            "Dashboard loopback Host allowlist enabled for: %s",
+            ", ".join(sorted(app.state.allowed_hosts)),
+        )
 
     if open_browser:
         import webbrowser

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -13,6 +13,7 @@ import pytest
 pytestmark = pytest.mark.xdist_group("dashboard_auth_app_state")
 from fastapi.testclient import TestClient
 
+from hermes_cli import main
 from hermes_cli import web_server
 
 
@@ -132,6 +133,25 @@ def test_start_server_loopback_sets_auth_required_false(monkeypatch):
     assert web_server.app.state.auth_required is False
 
 
+def test_start_server_loopback_normalizes_allowed_hosts(monkeypatch):
+    """Loopback allowlist entries are normalized once at server startup."""
+    _stub_uvicorn_run(monkeypatch)
+    web_server.start_server(
+        host="127.0.0.1",
+        port=9119,
+        open_browser=False,
+        allow_public=False,
+        allowed_hosts=[
+            "Hermes-Agent-VPS.Tail88A68B.TS.Net:443",
+            "[::1]:9119",
+        ],
+    )
+    assert web_server.app.state.allowed_hosts == frozenset({
+        "hermes-agent-vps.tail88a68b.ts.net",
+        "::1",
+    })
+
+
 def test_start_server_insecure_public_sets_auth_required_false(monkeypatch):
     """``--insecure`` (allow_public=True) on a public host: gate stays OFF."""
     _stub_uvicorn_run(monkeypatch)
@@ -141,6 +161,32 @@ def test_start_server_insecure_public_sets_auth_required_false(monkeypatch):
         open_browser=False, allow_public=True,
     )
     assert web_server.app.state.auth_required is False
+
+
+def test_resolve_dashboard_allowed_hosts_prefers_cli_then_env_then_config(monkeypatch):
+    from argparse import Namespace
+    from hermes_cli import config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"dashboard": {"allowed_hosts": ["cfg.example", "cfg2.example:443"]}},
+    )
+    monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "env.example,env2.example:443")
+
+    assert main._resolve_dashboard_allowed_hosts(
+        Namespace(allowed_host=["cli.example,cli2.example:443"])
+    ) == ["cli.example", "cli2.example:443"]
+    assert main._resolve_dashboard_allowed_hosts(Namespace(allowed_host=[])) == [
+        "env.example",
+        "env2.example:443",
+    ]
+
+    monkeypatch.delenv("HERMES_DASHBOARD_ALLOWED_HOSTS")
+    assert main._resolve_dashboard_allowed_hosts(Namespace(allowed_host=[])) == [
+        "cfg.example",
+        "cfg2.example:443",
+    ]
 
 
 def test_start_server_public_without_insecure_records_auth_required(monkeypatch):

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -54,6 +54,46 @@ class TestHostHeaderValidator:
                     f"bound={bound} must reject attacker host={attacker!r}"
                 )
 
+    def test_loopback_bind_accepts_explicitly_allowed_hosts(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        allowed = ["hermes-agent-vps.tail88a68b.ts.net"]
+        assert _is_accepted_host(
+            "hermes-agent-vps.tail88a68b.ts.net",
+            "127.0.0.1",
+            allowed,
+        )
+        assert _is_accepted_host(
+            "hermes-agent-vps.tail88a68b.ts.net:443",
+            "127.0.0.1",
+            allowed,
+        )
+
+    def test_loopback_allowed_host_matching_is_case_insensitive_and_strips_ports(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        allowed = ["Hermes-Agent-VPS.Tail88A68B.TS.Net:443"]
+        assert _is_accepted_host(
+            "HERMES-AGENT-VPS.TAIL88A68B.TS.NET",
+            "127.0.0.1",
+            allowed,
+        )
+        assert _is_accepted_host(
+            "hermes-agent-vps.tail88a68b.ts.net:9119",
+            "127.0.0.1",
+            allowed,
+        )
+
+    def test_loopback_bind_still_rejects_non_allowlisted_hosts(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        allowed = ["hermes-agent-vps.tail88a68b.ts.net"]
+        assert not _is_accepted_host(
+            "other.tail88a68b.ts.net",
+            "127.0.0.1",
+            allowed,
+        )
+
     def test_zero_zero_bind_accepts_anything(self):
         """0.0.0.0 means operator explicitly opted into all-interfaces
         (requires --insecure). No Host-layer defence is possible — rely
@@ -94,6 +134,7 @@ class TestHostHeaderMiddleware:
 
         # Simulate start_server having set the bound_host
         app.state.bound_host = "127.0.0.1"
+        app.state.allowed_hosts = frozenset()
         try:
             client = TestClient(app)
             # The TestClient sends Host: testserver by default — which is
@@ -108,12 +149,15 @@ class TestHostHeaderMiddleware:
             # Clean up so other tests don't inherit the bound_host
             if hasattr(app.state, "bound_host"):
                 del app.state.bound_host
+            if hasattr(app.state, "allowed_hosts"):
+                del app.state.allowed_hosts
 
     def test_legit_loopback_request_accepted(self):
         from fastapi.testclient import TestClient
         from hermes_cli.web_server import app
 
         app.state.bound_host = "127.0.0.1"
+        app.state.allowed_hosts = frozenset()
         try:
             client = TestClient(app)
             # /api/status is in _PUBLIC_API_PATHS — passes auth — so the
@@ -130,6 +174,29 @@ class TestHostHeaderMiddleware:
         finally:
             if hasattr(app.state, "bound_host"):
                 del app.state.bound_host
+            if hasattr(app.state, "allowed_hosts"):
+                del app.state.allowed_hosts
+
+    def test_allowlisted_loopback_request_is_accepted(self):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        app.state.bound_host = "127.0.0.1"
+        app.state.allowed_hosts = frozenset({"hermes-agent-vps.tail88a68b.ts.net"})
+        try:
+            client = TestClient(app)
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "Hermes-Agent-VPS.Tail88A68B.TS.Net:443"},
+            )
+            assert resp.status_code != 400 or (
+                "Invalid Host header" not in resp.json().get("detail", "")
+            )
+        finally:
+            if hasattr(app.state, "bound_host"):
+                del app.state.bound_host
+            if hasattr(app.state, "allowed_hosts"):
+                del app.state.allowed_hosts
 
     def test_no_bound_host_skips_validation(self):
         """If app.state.bound_host isn't set (e.g. running under test
@@ -141,6 +208,8 @@ class TestHostHeaderMiddleware:
         # Make sure bound_host isn't set
         if hasattr(app.state, "bound_host"):
             del app.state.bound_host
+        if hasattr(app.state, "allowed_hosts"):
+            del app.state.allowed_hosts
 
         client = TestClient(app)
         resp = client.get("/api/status")
@@ -158,6 +227,7 @@ class TestWebSocketHostOriginGuard:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws.app.state, "allowed_hosts", frozenset(), raising=False)
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
@@ -181,6 +251,7 @@ class TestWebSocketHostOriginGuard:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws.app.state, "allowed_hosts", frozenset(), raising=False)
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
@@ -203,6 +274,7 @@ class TestWebSocketHostOriginGuard:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws.app.state, "allowed_hosts", frozenset(), raising=False)
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
@@ -212,6 +284,31 @@ class TestWebSocketHostOriginGuard:
             headers={
                 "Host": "localhost:9119",
                 "Origin": "http://localhost:9119",
+            },
+        ):
+            pass
+
+    def test_allowlisted_websocket_host_and_origin_are_accepted(self, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(
+            ws.app.state,
+            "allowed_hosts",
+            frozenset({"hermes-agent-vps.tail88a68b.ts.net"}),
+            raising=False,
+        )
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "Hermes-Agent-VPS.Tail88A68B.TS.Net:443",
+                "Origin": "https://hermes-agent-vps.tail88a68b.ts.net",
             },
         ):
             pass


### PR DESCRIPTION
## Summary
- add an explicit loopback-only dashboard Host allowlist for trusted reverse proxies such as Tailscale Serve
- wire `hermes dashboard --allowed-host` plus `HERMES_DASHBOARD_ALLOWED_HOSTS` and `dashboard.allowed_hosts`
- extend the Host-header regression tests for HTTP, WebSocket, and config/env resolution

## Root cause
The dashboard's DNS-rebinding guard correctly rejected non-loopback `Host` headers when the backend was bound to `127.0.0.1`, but that also blocked legitimate requests arriving through a trusted loopback reverse proxy or Tailscale Serve MagicDNS hostname.

## What changed
- normalize Host / Origin / allowlist matching case-insensitively while stripping ports and handling IPv6 bracket notation
- keep the default loopback DNS-rebinding protection intact and only consult the operator allowlist for loopback binds
- leave explicit non-loopback and `0.0.0.0` behavior unchanged
- document the safe path in CLI help and config comments without broadening `--insecure`

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_auth_ws_auth.py`
- `ruff check hermes_cli/web_server.py hermes_cli/main.py hermes_cli/config.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_gate.py`
