### PR TITLE
feat(desktop): Multitask view — multi-session sidebar with live tiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -60,7 +60,7 @@ import {
   sessionPinId
 } from '@/store/session'
 
-import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
+import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, MULTITASK_ROUTE, SKILLS_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
@@ -89,7 +89,8 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     route: SKILLS_ROUTE
   },
   { id: 'messaging', label: 'Messaging', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
-  { id: 'artifacts', label: 'Artifacts', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
+  { id: 'artifacts', label: 'Artifacts', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE },
+  { id: 'multitask', label: 'Multitask', icon: props => <Codicon name="split-horizontal" {...props} />, route: MULTITASK_ROUTE }
 ]
 
 const WORKSPACE_PAGE = 5
@@ -447,7 +448,8 @@ export function ChatSidebar({
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
-                  (item.id === 'artifacts' && currentView === 'artifacts')
+                  (item.id === 'artifacts' && currentView === 'artifacts') ||
+                  (item.id === 'multitask' && currentView === 'multitask')
 
                 return (
                   <SidebarMenuItem key={item.id}>

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -94,6 +94,7 @@ const ArtifactsView = lazy(async () => ({ default: (await import('./artifacts'))
 const CommandCenterView = lazy(async () => ({ default: (await import('./command-center')).CommandCenterView }))
 const CronView = lazy(async () => ({ default: (await import('./cron')).CronView }))
 const MessagingView = lazy(async () => ({ default: (await import('./messaging')).MessagingView }))
+const MultitaskView = lazy(async () => ({ default: (await import('./multitask')).MultitaskView }))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
@@ -775,6 +776,14 @@ export function DesktopController() {
               </Suspense>
             }
             path="artifacts"
+          />
+          <Route
+            element={
+              <Suspense fallback={null}>
+                <MultitaskView gateway={gatewayRef.current} />
+              </Suspense>
+            }
+            path="multitask"
           />
           <Route element={null} path="cron" />
           <Route element={null} path="profiles" />

--- a/apps/desktop/src/app/multitask/add-session-modal.tsx
+++ b/apps/desktop/src/app/multitask/add-session-modal.tsx
@@ -1,0 +1,87 @@
+import { useStore } from '@nanostores/react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+
+import { $sessions } from '@/store/session'
+import { $multitaskSessionIds, addMultitaskSession } from '@/store/multitask'
+
+export interface AddSessionModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function AddSessionModal({ open, onOpenChange }: AddSessionModalProps) {
+  const sessions = useStore($sessions)
+  const multitaskIds = useStore($multitaskSessionIds)
+  const [search, setSearch] = useState('')
+
+  const filtered = sessions.filter(s => {
+    if (multitaskIds.includes(s.id)) return false
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    return (
+      (s.title?.toLowerCase().includes(q) ?? false) ||
+      s.id.toLowerCase().includes(q) ||
+      (s.preview?.toLowerCase().includes(q) ?? false)
+    )
+  })
+
+  const handleAdd = (sessionId: string) => {
+    addMultitaskSession(sessionId)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-h-[70vh] max-w-md overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add Session to Multitask</DialogTitle>
+        </DialogHeader>
+
+        <div className="relative mb-2">
+          <Codicon
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-(--ui-text-tertiary)"
+            name="search"
+            size="0.75rem"
+          />
+          <input
+            className="w-full rounded-md border border-(--ui-stroke-tertiary) bg-transparent py-1.5 pl-7 pr-2.5 text-[0.8125rem] text-foreground outline-none placeholder:text-(--ui-text-tertiary) focus:border-(--ui-stroke-focus)"
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search sessions…"
+            value={search}
+          />
+        </div>
+
+        {filtered.length === 0 && (
+          <p className="py-4 text-center text-[0.8125rem] text-(--ui-text-tertiary)">
+            {sessions.length === 0 ? 'No sessions yet' : 'No matching sessions'}
+          </p>
+        )}
+
+        <div className="space-y-0.5">
+          {filtered.map(session => (
+            <button
+              key={session.id}
+              className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left hover:bg-(--ui-control-hover-background)"
+              onClick={() => handleAdd(session.id)}
+              type="button"
+            >
+              <Codicon className="size-4 shrink-0 text-(--ui-text-tertiary)" name="comment" />
+              <span className="min-w-0 flex-1 truncate text-[0.8125rem] text-foreground">
+                {session.title || session.id.slice(0, 12) + '…'}
+              </span>
+              {session.model && (
+                <span className="shrink-0 text-[0.6875rem] text-(--ui-text-tertiary)">
+                  {session.model}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/multitask/index.tsx
+++ b/apps/desktop/src/app/multitask/index.tsx
@@ -1,0 +1,278 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { SidebarPanelLabel } from '../shell/sidebar-label'
+import { cn } from '@/lib/utils'
+import { toChatMessages } from '@/lib/chat-messages'
+
+import {
+  $multitaskLayout,
+  $multitaskSessionIds,
+  $multitaskTileStates,
+  clearAllMultitaskSessions,
+  updateTileState
+} from '@/store/multitask'
+
+import { AddSessionModal } from './add-session-modal'
+import { LayoutSwitcher } from './layout-switcher'
+import { MultitaskTile } from './tile'
+
+import type { RpcEvent, SessionResumeResponse } from '@/types/hermes'
+import type { HermesGateway } from '@/hermes'
+import type { ChatMessage } from '@/lib/chat-messages'
+
+export interface MultitaskViewProps {
+  gateway: HermesGateway | null | undefined
+}
+
+function makeAssistantMessage(text: string): ChatMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    role: 'assistant',
+    parts: [{ type: 'text', text: '' + text }],
+    timestamp: Date.now() / 1000
+  }
+}
+
+function makeToolMessage(name: string): ChatMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    role: 'assistant',
+    parts: [{ type: 'text' as const, text: `[Tool: ${name}]` }],
+    timestamp: Date.now() / 1000
+  }
+}
+
+// Fallback noop request for when gateway is not ready yet
+const NOOP_REQUEST = async <T,>(_method: string, _params?: Record<string, unknown>): Promise<T> =>
+  Promise.reject(new Error('Gateway not connected'))
+
+export function MultitaskView({ gateway }: MultitaskViewProps) {
+  const sessionIds = useStore($multitaskSessionIds)
+  const layout = useStore($multitaskLayout)
+  const tileStates = useStore($multitaskTileStates)
+  const [modalOpen, setModalOpen] = useState(false)
+  const gatewayConnected = gateway?.connectionState === 'open'
+
+  // ── Resume sessions when gateway connects ─────────────────────────
+  useEffect(() => {
+    if (!gateway || gateway.connectionState !== 'open') return
+    if (!sessionIds.length) return
+
+    let cancelled = false
+
+    for (const storedId of sessionIds) {
+      // Read fresh state from store instead of captured closure
+      const currentState = $multitaskTileStates.get().get(storedId)
+      if (currentState?.runtimeSessionId) continue
+
+      gateway
+        .request<SessionResumeResponse>('session.resume', { session_id: storedId, cols: 96 })
+        .then(res => {
+          if (cancelled) return
+          updateTileState(storedId, s => ({
+            ...s,
+            runtimeSessionId: res.session_id,
+            model: res.info?.model ?? null,
+            cwd: res.info?.cwd ?? null,
+            messages: toChatMessages(res.messages),
+            busy: false,
+            awaitingResponse: false
+          }))
+        })
+        .catch(err => {
+          if (cancelled) return
+          updateTileState(storedId, s => ({
+            ...s,
+            error: err instanceof Error ? err.message : 'Failed to resume session'
+          }))
+        })
+    }
+
+    return () => void (cancelled = true)
+  }, [gatewayConnected ? 'connected' : 'disconnected', sessionIds.join(',')])
+
+  // ── Subscribe to gateway events ───────────────────────────────────
+  useEffect(() => {
+    if (!gateway || gateway.connectionState !== 'open') return
+
+    const unsub = gateway.onAny((event: RpcEvent) => {
+      const sid = event.session_id
+      if (!sid) return
+
+      // Match runtime session id → stored session id via fresh store read
+      let storedId: string | null = null
+      for (const [stored, state] of $multitaskTileStates.get()) {
+        if (state.runtimeSessionId === sid) {
+          storedId = stored
+          break
+        }
+      }
+      if (!storedId) return
+
+      switch (event.type) {
+        case 'message.delta': {
+          const payload = event.payload as { text?: string } | undefined
+          if (payload?.text) {
+            updateTileState(storedId, state => {
+              const msgs = state.messages.map(m => ({ ...m }))
+              const last = msgs[msgs.length - 1]
+              if (last?.role === 'assistant' && last.parts?.length) {
+                const parts = last.parts.map(p => ({ ...p }))
+                const lastPart = parts[parts.length - 1]
+                if ('text' in lastPart) {
+                  parts[parts.length - 1] = { ...lastPart, text: lastPart.text + payload.text! }
+                } else {
+                  parts.push({ type: 'text', text: payload.text! })
+                }
+                msgs[msgs.length - 1] = { ...last, parts }
+              } else {
+                msgs.push(makeAssistantMessage(payload.text!))
+              }
+              return { ...state, messages: msgs }
+            })
+          }
+          break
+        }
+        case 'message.complete': {
+          updateTileState(storedId, state => ({
+            ...state,
+            busy: false,
+            awaitingResponse: false,
+            streamId: null
+          }))
+          break
+        }
+        case 'message.start': {
+          updateTileState(storedId, state => ({
+            ...state,
+            busy: true,
+            awaitingResponse: true
+          }))
+          break
+        }
+        case 'tool.start': {
+          const payload = event.payload as { name?: string } | undefined
+          if (payload?.name) {
+            updateTileState(storedId, state => ({
+              ...state,
+              messages: [...state.messages, makeToolMessage(payload.name!)]
+            }))
+          }
+          break
+        }
+        case 'error': {
+          const errPayload = event.payload as { message?: string } | undefined
+          updateTileState(storedId, state => ({
+            ...state,
+            busy: false,
+            awaitingResponse: false,
+            error: errPayload?.message ?? 'Gateway error'
+          }))
+          break
+        }
+      }
+    })
+
+    return () => unsub()
+  }, [gatewayConnected ? 'connected' : 'disconnected'])
+
+  // ── Grid class by layout ────────────────────────────────────────
+  const gridClass = useMemo(() => {
+    switch (layout) {
+      case 'grid-2':
+        return 'grid-cols-1 sm:grid-cols-2'
+      case 'grid-3':
+        return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+      case 'horizontal':
+        return 'grid-cols-1'
+      case 'vertical':
+        return 'grid-cols-1 sm:grid-cols-2'
+      default:
+        return 'grid-cols-1 sm:grid-cols-2'
+    }
+  }, [layout])
+
+  const tileHeightClass = layout === 'horizontal' ? 'min-h-[30vh]' : 'min-h-[40vh]'
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-(--ui-app-background)">
+      {/* Toolbar */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-(--ui-stroke-tertiary) px-4 py-2">
+        <div className="flex items-center gap-2">
+          <Codicon className="text-(--theme-primary)" name="split-horizontal" size="1rem" />
+          <SidebarPanelLabel>Multitask</SidebarPanelLabel>
+        </div>
+
+        <div className="mx-2 h-4 w-px bg-(--ui-stroke-tertiary)" />
+
+        <LayoutSwitcher />
+
+        <div className="flex-1" />
+
+        <div className="flex items-center gap-1">
+          <Button
+            className="flex h-7 items-center gap-1 rounded-md px-2 text-[0.75rem] font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+            onClick={() => setModalOpen(true)}
+            title="Add a session to the multitask view"
+            type="button"
+            variant="ghost"
+          >
+            <Codicon name="add" className="size-3.5" />
+            <span>Add Session</span>
+          </Button>
+
+          {sessionIds.length > 0 && (
+            <Button
+              className="flex h-7 items-center gap-1 rounded-md px-2 text-[0.75rem] text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-red-400"
+              onClick={() => clearAllMultitaskSessions()}
+              title="Remove all sessions"
+              type="button"
+              variant="ghost"
+            >
+              <Codicon name="close" className="size-3.5" />
+              <span>Clear All</span>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 overflow-auto">
+        {sessionIds.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-4">
+            <Codicon className="text-(--ui-text-tertiary)" name="split-horizontal" size="2rem" />
+            <p className="text-center text-[0.875rem] text-(--ui-text-secondary)">
+              Monitor and interact with multiple sessions at once
+            </p>
+            <Button
+              className="flex h-8 items-center gap-1.5 rounded-md px-3 text-[0.8125rem] font-medium text-foreground hover:bg-(--ui-control-hover-background)"
+              onClick={() => setModalOpen(true)}
+              title="Add a session"
+              type="button"
+              variant="ghost"
+            >
+              <Codicon name="add" className="size-4" />
+              <span>Add Session</span>
+            </Button>
+          </div>
+        ) : (
+          <div className={cn('grid auto-rows-fr gap-2 p-3', gridClass)}>
+            {sessionIds.map(sid => (
+              <div key={sid} className={cn('flex flex-col overflow-hidden rounded-lg', tileHeightClass)}>
+                <MultitaskTile
+                  requestGateway={gateway?.request.bind(gateway) ?? NOOP_REQUEST}
+                  storedSessionId={sid}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <AddSessionModal onOpenChange={setModalOpen} open={modalOpen} />
+    </div>
+  )
+}

--- a/apps/desktop/src/app/multitask/layout-switcher.tsx
+++ b/apps/desktop/src/app/multitask/layout-switcher.tsx
@@ -1,0 +1,42 @@
+import { useStore } from '@nanostores/react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+import { $multitaskLayout, setMultitaskLayout, type MultitaskLayout } from '@/store/multitask'
+
+const LAYOUTS: { id: MultitaskLayout; label: string; icon: string }[] = [
+  { id: 'grid-2', label: '2×2', icon: 'layout-sidebar-left' },
+  { id: 'grid-3', label: '3×3', icon: 'layout-sidebar-left' },
+  { id: 'horizontal', label: 'Horizontal', icon: 'split-horizontal' },
+  { id: 'vertical', label: 'Vertical', icon: 'layout-sidebar-right' }
+]
+
+export function LayoutSwitcher({ className }: { className?: string }) {
+  const currentLayout = useStore($multitaskLayout)
+
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      {LAYOUTS.map(layout => (
+        <Button
+          key={layout.id}
+          aria-pressed={currentLayout === layout.id}
+          className={cn(
+            'flex h-7 items-center gap-1 rounded-md px-2 text-[0.75rem] font-medium transition-colors',
+            currentLayout === layout.id
+              ? 'bg-(--ui-control-active-background) text-foreground'
+              : 'text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground'
+          )}
+          onClick={() => setMultitaskLayout(layout.id)}
+          title={layout.label}
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name={layout.icon} className="size-3.5" />
+          <span className="hidden sm:inline">{layout.label}</span>
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/multitask/tile-composer.tsx
+++ b/apps/desktop/src/app/multitask/tile-composer.tsx
@@ -1,0 +1,119 @@
+import { type FormEvent, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+
+import { updateTileState } from '@/store/multitask'
+
+export interface MultitaskComposerProps {
+  busy: boolean
+  runtimeSessionId: string | null
+  storedSessionId: string
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+export function MultitaskComposer({
+  busy,
+  runtimeSessionId,
+  storedSessionId,
+  requestGateway
+}: MultitaskComposerProps) {
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  const handleSend = async (e: FormEvent) => {
+    e.preventDefault()
+    const text = value.trim()
+    if (!text || !runtimeSessionId || busy) return
+
+    setValue('')
+
+    // Optimistic: add user message
+    updateTileState(storedSessionId, state => ({
+      ...state,
+      busy: true,
+      awaitingResponse: true,
+      messages: [
+        ...state.messages,
+        {
+          id: `optimistic-${Date.now()}`,
+          role: 'user',
+          parts: [{ type: 'text', text }],
+          created_at: Date.now() / 1000
+        }
+      ]
+    }))
+
+    try {
+      await requestGateway('session.send', {
+        session_id: runtimeSessionId,
+        message: text
+      })
+    } catch (err) {
+      updateTileState(storedSessionId, state => ({
+        ...state,
+        busy: false,
+        awaitingResponse: false,
+        error: err instanceof Error ? err.message : 'Send failed'
+      }))
+    }
+  }
+
+  const handleCancel = async () => {
+    if (!runtimeSessionId) return
+    try {
+      await requestGateway('session.cancel', { session_id: runtimeSessionId })
+    } catch {
+      // best-effort
+    }
+    updateTileState(storedSessionId, state => ({
+      ...state,
+      busy: false,
+      awaitingResponse: false
+    }))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend(e as unknown as FormEvent)
+    }
+  }
+
+  return (
+    <form className="flex items-center gap-1 border-t border-(--ui-stroke-tertiary) p-1.5" onSubmit={handleSend}>
+      <textarea
+        ref={inputRef}
+        className="min-h-0 flex-1 resize-none rounded bg-transparent px-2 py-1 text-[0.75rem] text-foreground outline-none placeholder:text-(--ui-text-tertiary)"
+        disabled={busy || !runtimeSessionId}
+        onKeyDown={handleKeyDown}
+        placeholder={busy ? 'Waiting for response…' : !runtimeSessionId ? 'Resuming…' : 'Send a message…'}
+        rows={1}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+
+      {busy ? (
+        <Button
+          className="size-6 rounded p-0 text-(--ui-text-secondary) hover:text-red-400"
+          onClick={handleCancel}
+          title="Cancel"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="close" className="size-3.5" />
+        </Button>
+      ) : (
+        <Button
+          className="size-6 rounded p-0 text-(--ui-text-secondary) hover:text-foreground disabled:opacity-30"
+          disabled={!value.trim() || !runtimeSessionId}
+          title="Send"
+          type="submit"
+          variant="ghost"
+        >
+          <Codicon name="arrow-up" className="size-3.5" />
+        </Button>
+      )}
+    </form>
+  )
+}

--- a/apps/desktop/src/app/multitask/tile.tsx
+++ b/apps/desktop/src/app/multitask/tile.tsx
@@ -1,0 +1,108 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+import { $multitaskTileStates, removeMultitaskSession } from '@/store/multitask'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import { MultitaskComposer } from './tile-composer'
+
+export interface MultitaskTileProps {
+  storedSessionId: string
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+export function MultitaskTile({ storedSessionId, requestGateway }: MultitaskTileProps) {
+  const state = useStore($multitaskTileStates).get(storedSessionId)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [state?.messages.length])
+
+  if (!state) return null
+
+  const title = state.title || state.storedSessionId.slice(0, 10) + '…'
+  const msgCount = state.messages.length
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-(--ui-stroke-tertiary) px-3 py-1.5">
+        <Codicon name="comment" className="size-3.5 shrink-0 text-(--ui-text-tertiary)" />
+        <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium text-foreground" title={title}>
+          {title}
+        </span>
+        {state.busy && (
+          <Codicon name="loading" className="size-3.5 animate-spin text-(--ui-text-secondary)" />
+        )}
+        <span className="shrink-0 text-[0.6875rem] text-(--ui-text-tertiary)">
+          {msgCount} msgs
+        </span>
+        <Button
+          className="size-5 rounded p-0 text-(--ui-text-tertiary) hover:text-foreground"
+          onClick={() => removeMultitaskSession(storedSessionId)}
+          title="Remove this session from the multitask view"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="close" className="size-3.5" />
+        </Button>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-3 py-2">
+        {state.messages.length === 0 && (
+          <p className="pt-4 text-center text-[0.75rem] text-(--ui-text-tertiary)">
+            {state.busy ? 'Streaming…' : 'No messages yet'}
+          </p>
+        )}
+        <div className="space-y-1.5">
+          {state.messages.map((msg, i) => (
+            <TileMessage key={msg.id ?? i} message={msg} />
+          ))}
+        </div>
+        {state.error && (
+          <div className="mt-2 rounded bg-red-500/10 px-2 py-1 text-[0.75rem] text-red-400">
+            {state.error}
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Composer */}
+      <MultitaskComposer
+        busy={state.busy}
+        requestGateway={requestGateway}
+        runtimeSessionId={state.runtimeSessionId}
+        storedSessionId={storedSessionId}
+      />
+    </div>
+  )
+}
+
+function TileMessage({ message }: { message: ChatMessage }) {
+  const text = message.parts?.map(p => ('text' in p ? p.text : '')).join('') || ''
+  const isUser = message.role === 'user'
+
+  return (
+    <div className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={cn(
+          'max-w-[85%] rounded-lg px-2.5 py-1 text-[0.75rem] leading-relaxed',
+          isUser
+            ? 'bg-(--ui-control-active-background) text-foreground'
+            : 'bg-(--ui-control-hover-background) text-(--ui-text-secondary)'
+        )}
+      >
+        {text || (
+          <span className="italic text-(--ui-text-tertiary)">[{message.role} message]</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -5,6 +5,7 @@ export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
+export const MULTITASK_ROUTE = '/multitask'
 export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
@@ -16,6 +17,7 @@ export type AppView =
   | 'command-center'
   | 'cron'
   | 'messaging'
+  | 'multitask'
   | 'profiles'
   | 'settings'
   | 'skills'
@@ -26,6 +28,7 @@ export type AppRouteId =
   | 'command-center'
   | 'cron'
   | 'messaging'
+  | 'multitask'
   | 'new'
   | 'profiles'
   | 'settings'
@@ -44,6 +47,7 @@ export const APP_ROUTES = [
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
+  { id: 'multitask', path: MULTITASK_ROUTE, view: 'multitask' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -52,7 +52,7 @@ export type CommandDispatchResponse =
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'multitask' | 'new-session' | 'settings' | 'skills'
 
 export interface SidebarNavItem {
   id: SidebarNavId

--- a/apps/desktop/src/store/multitask.ts
+++ b/apps/desktop/src/store/multitask.ts
@@ -1,0 +1,99 @@
+import { atom } from 'nanostores'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+import { persistStringArray, storedStringArray } from '@/lib/storage'
+
+export type MultitaskLayout = 'grid-2' | 'grid-3' | 'horizontal' | 'vertical'
+
+export interface MultitaskTileState {
+  storedSessionId: string
+  runtimeSessionId: string | null
+  title: string | null
+  model: string | null
+  messages: ChatMessage[]
+  busy: boolean
+  awaitingResponse: boolean
+  cwd: string | null
+  streamId: string | null
+  error: string | null
+}
+
+const MULTITASK_STORAGE_KEY = 'hermes:multitask:sessionIds'
+const MULTITASK_LAYOUT_KEY = 'hermes:multitask:layout'
+
+// ─── Atoms ───────────────────────────────────────────────────────────
+
+export const $multitaskSessionIds = atom<string[]>(storedStringArray(MULTITASK_STORAGE_KEY))
+
+export const $multitaskTileStates = atom<Map<string, MultitaskTileState>>(new Map())
+
+export const $multitaskLayout = atom<MultitaskLayout>(
+  (typeof localStorage !== 'undefined'
+    ? (localStorage.getItem(MULTITASK_LAYOUT_KEY) as MultitaskLayout | null)
+    : null) ?? 'grid-2'
+)
+
+// ─── Actions ─────────────────────────────────────────────────────────
+
+export function persistMultitaskSessionIds(ids: string[]): void {
+  persistStringArray(MULTITASK_STORAGE_KEY, ids)
+}
+
+export function addMultitaskSession(storedSessionId: string): void {
+  const ids = $multitaskSessionIds.get()
+  if (ids.includes(storedSessionId)) return
+  const next = [...ids, storedSessionId]
+  $multitaskSessionIds.set(next)
+  persistMultitaskSessionIds(next)
+
+  const states = $multitaskTileStates.get()
+  if (!states.has(storedSessionId)) {
+    states.set(storedSessionId, {
+      storedSessionId,
+      runtimeSessionId: null,
+      title: null,
+      model: null,
+      messages: [],
+      busy: false,
+      awaitingResponse: false,
+      cwd: null,
+      streamId: null,
+      error: null
+    })
+    $multitaskTileStates.set(new Map(states))
+  }
+}
+
+export function removeMultitaskSession(storedSessionId: string): void {
+  const ids = $multitaskSessionIds.get().filter(id => id !== storedSessionId)
+  $multitaskSessionIds.set(ids)
+  persistMultitaskSessionIds(ids)
+
+  const states = $multitaskTileStates.get()
+  states.delete(storedSessionId)
+  $multitaskTileStates.set(new Map(states))
+}
+
+export function clearAllMultitaskSessions(): void {
+  $multitaskSessionIds.set([])
+  persistMultitaskSessionIds([])
+  $multitaskTileStates.set(new Map())
+}
+
+export function updateTileState(
+  storedSessionId: string,
+  updater: (state: MultitaskTileState) => MultitaskTileState
+): void {
+  const states = $multitaskTileStates.get()
+  const current = states.get(storedSessionId)
+  if (!current) return
+  states.set(storedSessionId, updater({ ...current }))
+  $multitaskTileStates.set(new Map(states))
+}
+
+export function setMultitaskLayout(layout: MultitaskLayout): void {
+  $multitaskLayout.set(layout)
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(MULTITASK_LAYOUT_KEY, layout)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,9 @@
         "vite": "^8.0.10",
         "vitest": "^4.1.5",
         "wait-on": "^9.0.5"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "apps/desktop/node_modules/@nous-research/ui": {


### PR DESCRIPTION
## Summary

Adds a new **Multitask** view to the Hermes Desktop app sidebar (below Artifacts) for monitoring and interacting with multiple chat sessions simultaneously.

## Changes

**10 files, +755 / -4 lines**

### New files
- `apps/desktop/src/store/multitask.ts` — nanostore atoms + localStorage persistence
- `apps/desktop/src/app/multitask/index.tsx` — MultitaskView: grid layout, session resume on mount, gateway event bridge
- `apps/desktop/src/app/multitask/tile.tsx` — per-session tile with message history
- `apps/desktop/src/app/multitask/tile-composer.tsx` — mini input with Send (Enter) / Cancel
- `apps/desktop/src/app/multitask/add-session-modal.tsx` — session picker dialog
- `apps/desktop/src/app/multitask/layout-switcher.tsx` — 2×2 / 3×3 / Horizontal / Vertical

### Modified files
- `types.ts` — added `'multitask'` to `SidebarNavId`
- `routes.ts` — added `MULTITASK_ROUTE`, `'multitask'` to `AppView` / `AppRouteId`
- `sidebar/index.tsx` — nav item in `SIDEBAR_NAV` array
- `desktop-controller.tsx` — lazy import, Route, gateway prop

## Architecture

```
MultitaskView
├── Toolbar: LayoutSwitcher + Add/Clear buttons
├── CSS Grid (responsive columns by layout)
│   └── MultitaskTile (per stored session)
│       ├── Header: title, model, close button
│       ├── Messages: scrollable chat bubbles
│       └── Composer: textarea + send (Enter) / cancel
└── AddSessionModal: searchable session picker
```

- Each tile runs `session.resume` independently → gets its own `runtimeSessionId`
- Gateway WebSocket events are routed to the correct tile via `gateway.onAny()`, matching `event.session_id` against tile runtime IDs
- Message delta streaming, tool.start, and error events are all handled per-tile
- Session list and layout are persisted in localStorage
- Rebased on upstream/main — zero conflicts, build passes

## Testing
- `tsc -b`: ✅ 0 errors
- `npm run build`: ✅ passes
- `npm run dev:renderer`: ✅ server starts clean