### PR TITLE
docs(guides): Run Nemotron 3 Ultra free in Hermes Agent (launch guide)

### DIFF
--- a/website/docs/guides/run-nemotron-3-ultra-free.md
+++ b/website/docs/guides/run-nemotron-3-ultra-free.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 0
+title: "Run Nemotron 3 Ultra free in Hermes Agent"
+description: "Try NVIDIA Nemotron 3 Ultra on Nous Portal — free June 4–18 — with day 0 support in Hermes Agent"
+---
+
+# Run Nemotron 3 Ultra free in Hermes Agent
+
+We partnered with **NVIDIA** and **Nebius** to put **Nemotron 3 Ultra** on [Nous Portal](https://portal.nousresearch.com) with day 0 support, free for two weeks (**June 4th – June 18th**). Follow the instructions below to try the model in your Hermes Agent today.
+
+:::info Limited-time offer
+The `nvidia/nemotron-3-ultra:free` tier is available from **June 4th to June 18th**. The `:free` tag is what keeps it on the no-cost plan — pick that exact variant.
+:::
+
+## Before you start
+
+You'll need a terminal (macOS, Linux, or Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) with `curl` installed. `curl` is preinstalled on most systems.
+
+## Steps
+
+### 1. Install Hermes Agent
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+Prefer to review first? Download [`install.sh`](https://hermes-agent.nousresearch.com/install.sh), inspect it, then run it.
+
+After it finishes, reload your shell:
+
+```bash
+source ~/.bashrc   # or source ~/.zshrc
+```
+
+### 2. Run Quick Setup
+
+```bash
+hermes setup
+```
+
+Select **Quick Setup**. Hermes opens a browser tab and waits for you to finish the next steps.
+
+### 3. Create a Nous Portal account
+
+In the browser, create a [Nous Portal](https://portal.nousresearch.com) account (or sign in) and choose the **Free** plan.
+
+### 4. Connect your account
+
+When prompted to connect your account to Hermes Agent, click **Connect**. You'll see a confirmation once it's linked.
+
+### 5. Select the free Nemotron 3 Ultra model
+
+Return to your terminal. From the model list, select:
+
+```
+nvidia/nemotron-3-ultra:free
+```
+
+The `:free` tag is what keeps it on the no-cost tier, so make sure you pick that variant.
+
+### 6. Start chatting
+
+Complete the remaining Quick Setup prompts, then run:
+
+```bash
+hermes
+```
+
+That's it — you're talking to Nemotron 3 Ultra, free.
+
+## Switching to it later
+
+Already set up with another model? Switch any time from inside a session:
+
+```bash
+/model nvidia/nemotron-3-ultra:free
+```
+
+Or open the picker and choose it from the list:
+
+```bash
+/model
+```
+
+## Troubleshooting
+
+- **Don't see the model in the list?** Make sure you finished the Nous Portal connection (step 4) and that you're on the **Free** plan. Run `hermes portal info` to confirm you're logged in and routing through Nous.
+- **Picked the wrong variant?** Re-select `nvidia/nemotron-3-ultra:free` with `/model` — the `:free` suffix is required to stay on the no-cost tier.
+- **Browser didn't open / you're on a remote host?** See [OAuth over SSH / Remote Hosts](/guides/oauth-over-ssh) for port-forwarding and manual-paste workarounds.
+
+## See also
+
+- **[Run Hermes Agent with Nous Portal](/guides/run-hermes-with-nous-portal)** — Full Portal walkthrough: models, Tool Gateway, and verification
+- **[Nous Portal integration](/integrations/nous-portal)** — What's in the subscription
+- **[Quickstart](/getting-started/quickstart)** — Install-to-chat in under 5 minutes

--- a/website/docs/guides/run-nemotron-3-ultra-free.md
+++ b/website/docs/guides/run-nemotron-3-ultra-free.md
@@ -12,11 +12,37 @@ Nous Research has been inducted into the **Nemotron Coalition** of leading AI la
 The `nvidia/nemotron-3-ultra:free` tier is available from **June 4th to June 18th**. The `:free` tag is what keeps it on the no-cost plan — pick that exact variant.
 :::
 
-## Before you start
+Pick whichever install fits you. The **desktop app** is the easiest — no terminal required. If you live in a terminal, the **command-line** install is right below it.
 
-You'll need a terminal (macOS, Linux, or Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) with `curl` installed. `curl` is preinstalled on most systems.
+## Option A — Desktop app (recommended)
 
-## Steps
+The simplest path: a one-click installer with a guided, point-and-click setup. No terminal needed.
+
+### 1. Download and install
+
+[Download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) for macOS or Windows, then open it. On first launch it finishes setting itself up (usually under a minute).
+
+### 2. Connect Nous Portal
+
+When the app opens, you'll see a "Let's get you set up" screen. Click **Nous Portal** (marked **Recommended**). Your browser opens — create a [Nous Portal](https://portal.nousresearch.com) account (or sign in), choose the **Free** plan, and authorize Hermes. The app connects automatically.
+
+### 3. Pick the free Nemotron 3 Ultra model
+
+After connecting, the app shows a **Default model** card. Click **Change**, search for **nemotron 3 ultra**, and select the variant tagged **Free tier**:
+
+```
+nvidia/nemotron-3-ultra:free
+```
+
+The `:free` tag is what keeps it on the no-cost tier — pick that variant.
+
+### 4. Start chatting
+
+Click **Start chatting**. That's it — you're talking to Nemotron 3 Ultra, free.
+
+## Option B — Command line
+
+Prefer the terminal? You'll need macOS, Linux, or Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) with `curl` installed (`curl` is preinstalled on most systems).
 
 ### 1. Install Hermes Agent
 
@@ -70,26 +96,20 @@ That's it — you're talking to Nemotron 3 Ultra, free.
 
 ## Switching to it later
 
-Already set up with another model? Switch any time from inside a session:
+Already set up with another model?
 
-```bash
-/model nvidia/nemotron-3-ultra:free
-```
-
-Or open the picker and choose it from the list:
-
-```bash
-/model
-```
+- **Desktop app:** open the model picker, search for **nemotron 3 ultra**, and select the **Free tier** variant.
+- **CLI / TUI:** switch any time from inside a session with `/model nvidia/nemotron-3-ultra:free`, or run `/model` to open the picker and choose it from the list.
 
 ## Troubleshooting
 
-- **Don't see the model in the list?** Make sure you finished the Nous Portal connection (step 4) and that you're on the **Free** plan. Run `hermes portal info` to confirm you're logged in and routing through Nous.
-- **Picked the wrong variant?** Re-select `nvidia/nemotron-3-ultra:free` with `/model` — the `:free` suffix is required to stay on the no-cost tier.
-- **Browser didn't open / you're on a remote host?** See [OAuth over SSH / Remote Hosts](/guides/oauth-over-ssh) for port-forwarding and manual-paste workarounds.
+- **Don't see the model in the list?** Make sure you finished the Nous Portal connection and that you're on the **Free** plan. In the CLI, `hermes portal info` confirms you're logged in and routing through Nous.
+- **Picked the wrong variant?** Re-select `nvidia/nemotron-3-ultra:free` — the `:free` suffix is required to stay on the no-cost tier.
+- **Browser didn't open / you're on a remote host (CLI)?** See [OAuth over SSH / Remote Hosts](/guides/oauth-over-ssh) for port-forwarding and manual-paste workarounds.
 
 ## See also
 
+- **[Desktop App](/user-guide/desktop)** — The native one-click app (macOS, Windows, Linux)
 - **[Run Hermes Agent with Nous Portal](/guides/run-hermes-with-nous-portal)** — Full Portal walkthrough: models, Tool Gateway, and verification
 - **[Nous Portal integration](/integrations/nous-portal)** — What's in the subscription
 - **[Quickstart](/getting-started/quickstart)** — Install-to-chat in under 5 minutes

--- a/website/docs/guides/run-nemotron-3-ultra-free.md
+++ b/website/docs/guides/run-nemotron-3-ultra-free.md
@@ -6,7 +6,7 @@ description: "Try NVIDIA Nemotron 3 Ultra on Nous Portal — free June 4–18 �
 
 # Run Nemotron 3 Ultra free in Hermes Agent
 
-We partnered with **NVIDIA** and **Nebius** to put **Nemotron 3 Ultra** on [Nous Portal](https://portal.nousresearch.com) with day 0 support, free for two weeks (**June 4th – June 18th**). Follow the instructions below to try the model in your Hermes Agent today.
+Nous Research has been inducted into the **Nemotron Coalition** of leading AI labs working with **NVIDIA** to advance open frontier foundation models. In honor of this, we've partnered with **Nebius** to provide **Nemotron 3 Ultra** free on [Nous Portal](https://portal.nousresearch.com) for two weeks (**June 4th – June 18th**). Follow the instructions below to try the model in your Hermes Agent today.
 
 :::info Limited-time offer
 The `nvidia/nemotron-3-ultra:free` tier is available from **June 4th to June 18th**. The `:free` tag is what keeps it on the no-cost plan — pick that exact variant.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -691,6 +691,7 @@ const sidebars: SidebarsConfig = {
       label: 'Guides & Tutorials',
       collapsed: true,
       items: [
+        'guides/run-nemotron-3-ultra-free',
         'guides/run-hermes-with-nous-portal',
         'guides/tips',
         'guides/local-llm-on-mac',


### PR DESCRIPTION
## Summary

- Adds a launch guide for the **Nemotron 3 Ultra** day-0 availability on Nous Portal — **free June 4th–18th**, in partnership with **NVIDIA** and **Nebius**.
- Walks users through Quick Setup and selecting the `nvidia/nemotron-3-ultra:free` tier, plus how to switch to it later and basic troubleshooting.
- Registers the page at the top of **Guides & Tutorials** (`sidebar_position: 0`).

Live URL once deployed: `https://hermes-agent.nousresearch.com/docs/guides/run-nemotron-3-ultra-free`

## Notes / launch coordination

- Model goes live **9am EST, June 4th**. This is a preemptive PR — hold the merge/deploy until launch since the model isn't announced yet.
- Partner attribution credits both NVIDIA and Nebius per the launch copy. Adjust if comms wants different wording.
- The `:free` tag is called out repeatedly — it's what keeps users on the no-cost tier.

## Test plan

- [ ] `cd website && npm run build` (or `npm start`) — confirm the new page renders and the sidebar entry appears at the top of Guides & Tutorials
- [ ] Verify all cross-links resolve (Nous Portal guide, integration page, Quickstart, OAuth over SSH)
- [ ] Confirm install command + `nvidia/nemotron-3-ultra:free` slug match the final launch config