### PR TITLE
fix(tools): make slash_confirm importable via package re-export

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -23,3 +23,14 @@ def check_file_requirements():
 
 
 __all__ = ["check_file_requirements"]
+
+
+def __getattr__(name):
+    # Lazy re-export so gateway code can keep using
+    # `from tools import slash_confirm` without forcing a full eager import
+    # at package load time. Resolves only the names actually requested.
+    if name == "slash_confirm":
+        import importlib
+
+        return importlib.import_module("tools.slash_confirm")
+    raise AttributeError(f"module 'tools' has no attribute {name!r}")


### PR DESCRIPTION
## Problem

`gateway/run.py` and several platform adapters (telegram, slack, discord) use
the form `from tools import slash_confirm as _slash_confirm_mod` (6 sites).
This fails with:

```
ImportError: cannot import name 'slash_confirm' from 'tools'
```

when those code paths execute, for example during the destructive
slash-confirm flow in `gateway/run.py::handle_quick_command`.

## Root cause

`tools/__init__.py` was redesigned to keep package import side effects
minimal — its docstring explicitly says callers should import concrete
submodules directly (e.g. `import tools.slash_confirm`).

A later feature commit (`4d7fc0f` — "feat(gateway,cli): confirm
/reload-mcp to warn about prompt cache invalidation") introduced the
`from tools import slash_confirm` import style in the gateway code
without a corresponding re-export in `tools/__init__.py`. The two
styles are now inconsistent, and the import above breaks at runtime
when the gateway process actually loads those modules.

## Fix

Add a minimal PEP 562 `__getattr__` to `tools/__init__.py` that lazily
resolves the few names gateway code reaches through the package.
This keeps the package's "no eager imports at load time" design
intact while making `from tools import slash_confirm` work.

Only the names actually reached via `from tools import ...` in the
gateway / platform adapters are whitelisted; the rest of the tools
package remains lazily loaded.

## Verification

```python
import tools
mod = tools.slash_confirm
assert callable(mod.get_pending)
assert callable(mod.clear)
assert callable(mod.resolve)
```

The original failing import sites in `gateway/run.py` and
`gateway/platforms/{telegram,slack,discord}.py` now succeed.

## Notes

- This is a minimal, non-behavior-changing fix. It does not touch any
  other module's import style.
- Alternative considered: change all `from tools import slash_confirm`
  to `import tools.slash_confirm as slash_confirm` at the call sites.
  This is more invasive and touches 6 unrelated files; the `__getattr__`
  approach is one-file, ~10 lines, and preserves the lazy-load design
  intent of `tools/__init__.py`.