### PR TITLE
fix: stop Nous JWT from overriding custom provider API keys

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -100,6 +100,45 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _is_nous_inference_base_url(base_url: str) -> bool:
+    hostname = base_url_hostname(base_url)
+    if not hostname:
+        return False
+
+    allowed_hosts = {
+        str(host).strip().lower().rstrip(".")
+        for host in getattr(auth_mod, "_ALLOWED_NOUS_INFERENCE_HOSTS", frozenset())
+        if isinstance(host, str) and host.strip()
+    }
+    default_host = base_url_hostname(getattr(auth_mod, "DEFAULT_NOUS_INFERENCE_URL", ""))
+    if default_host:
+        allowed_hosts.add(default_host)
+    return hostname in allowed_hosts
+
+
+def _is_nous_invoke_jwt(value: Any) -> bool:
+    status_fn = getattr(auth_mod, "_nous_invoke_jwt_status", None)
+    if not callable(status_fn) or not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        status = status_fn(value, min_ttl_seconds=0)
+    except Exception:
+        return False
+    return status in {None, "invoke_jwt_expiring", "invoke_jwt_expiry_unknown_or_expiring"}
+
+
+def _custom_explicit_api_key_candidate(explicit_api_key: Optional[str], base_url: str) -> str:
+    candidate = str(explicit_api_key or "").strip()
+    if candidate and _is_nous_invoke_jwt(candidate) and not _is_nous_inference_base_url(base_url):
+        logger.debug(
+            "Ignoring Nous invoke JWT for custom provider endpoint %s; "
+            "using custom provider credentials instead",
+            base_url,
+        )
+        return ""
+    return candidate
+
+
 def _host_derived_api_key(base_url: str) -> str:
     """Look up `<VENDOR>_API_KEY` in the env, derived from the base URL host.
 
@@ -658,7 +697,7 @@ def _resolve_named_custom_runtime(
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [
-            (explicit_api_key or "").strip(),
+            _custom_explicit_api_key_candidate(explicit_api_key, base_url),
             # Gate env key fallbacks on authoritative hosts (#28660)
             (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
@@ -710,7 +749,7 @@ def _resolve_named_custom_runtime(
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
     api_key_candidates = [
-        (explicit_api_key or "").strip(),
+        _custom_explicit_api_key_candidate(explicit_api_key, base_url),
         str(custom_provider.get("api_key", "") or "").strip(),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
@@ -833,7 +872,7 @@ def _resolve_openrouter_runtime(
         # Mistral, …) leaks credentials and causes 401s (issue #28660).
         # Mirrors the OLLAMA_API_KEY host-gate added in GHSA-76xc-57q6-vm5m.
         api_key_candidates = [
-            explicit_api_key,
+            _custom_explicit_api_key_candidate(explicit_api_key, base_url),
             (cfg_api_key if use_config_base_url else ""),
             (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,6 +1,30 @@
+import base64
+import json
+import time
 from types import SimpleNamespace
 
 from agent.agent_init import _merge_custom_provider_extra_body
+from hermes_cli import runtime_provider as rp
+
+
+def _encode_jwt_part(payload):
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _nous_invoke_jwt():
+    return ".".join(
+        [
+            _encode_jwt_part({"alg": "none", "typ": "JWT"}),
+            _encode_jwt_part(
+                {
+                    "scope": rp.auth_mod.NOUS_INFERENCE_INVOKE_SCOPE,
+                    "exp": int(time.time()) + 3600,
+                }
+            ),
+            "signature",
+        ]
+    )
 
 
 def test_custom_provider_extra_body_merges_into_request_overrides():
@@ -91,3 +115,177 @@ def test_custom_provider_extra_body_ignores_other_custom_models():
     )
 
     assert agent.request_overrides == {}
+
+
+def test_named_custom_provider_key_wins_over_nous_invoke_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "third-party",
+                    "base_url": "https://api.thirdparty.example/v1",
+                    "api_key": "custom-provider-key",
+                }
+            ]
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:third-party",
+        explicit_api_key=nous_jwt,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.thirdparty.example/v1"
+    assert resolved["api_key"] == "custom-provider-key"
+
+
+def test_bare_custom_model_key_wins_over_nous_invoke_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://api.thirdparty.example/v1",
+                "api_key": "model-custom-key",
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_api_key=nous_jwt,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.thirdparty.example/v1"
+    assert resolved["api_key"] == "model-custom-key"
+
+
+def test_named_custom_provider_pool_key_wins_over_nous_invoke_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "pooled",
+                    "base_url": "https://api.pooled.example/v1",
+                    "api_key": "config-key",
+                }
+            ]
+        },
+    )
+
+    def fake_pool_result(base_url, provider_label, api_mode_override=None, provider_name=None):
+        return {
+            "provider": provider_label,
+            "api_mode": api_mode_override or "chat_completions",
+            "base_url": base_url,
+            "api_key": "pool-key",
+            "source": f"pool:custom:{provider_name}",
+        }
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", fake_pool_result)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:pooled",
+        explicit_api_key=nous_jwt,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.pooled.example/v1"
+    assert resolved["api_key"] == "pool-key"
+
+
+def test_custom_provider_without_key_does_not_substitute_nous_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "third-party",
+                    "base_url": "https://api.thirdparty.example/v1",
+                }
+            ]
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:third-party",
+        explicit_api_key=nous_jwt,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.thirdparty.example/v1"
+    assert resolved["api_key"] == "no-key-required"
+
+
+def test_custom_provider_nous_host_can_use_nous_invoke_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "nous-compatible",
+                    "base_url": "https://inference-api.nousresearch.com/v1",
+                    "api_key": "custom-provider-key",
+                }
+            ]
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:nous-compatible",
+        explicit_api_key=nous_jwt,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
+    assert resolved["api_key"] == nous_jwt
+
+
+def test_nous_provider_still_resolves_nous_invoke_jwt(monkeypatch):
+    nous_jwt = _nous_invoke_jwt()
+    monkeypatch.setattr(rp, "load_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_nous_runtime_credentials",
+        lambda **kwargs: {
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": nous_jwt,
+            "source": "portal",
+            "expires_at": None,
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous")
+
+    assert resolved["provider"] == "nous"
+    assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
+    assert resolved["api_key"] == nous_jwt


### PR DESCRIPTION
## What does this PR do?

A user who configures a third-party OpenAI-compatible endpoint through `custom_providers` in `~/.hermes/config.yaml` while also logged in to Nous would have the Nous device-code "NAS invoke" JWT injected as the `Authorization: Bearer` key, overriding their own `custom_providers[].api_key`. The third-party endpoint rejected that JWT with HTTP 403, a non-retryable client error. This restores the user-supplied key for `custom` providers and only applies the Nous JWT when the resolved provider is Nous-native or its `base_url` matches a recognized Nous inference host. The existing base_url-trust logic from #14676 / #27132 is left intact.

## Related Issue

Fixes #38694

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/runtime_provider.py`: guard Nous JWT substitution so a `custom`-resolved provider with a user key or non-Nous `base_url` keeps the user key; the credential-pool mismatch safety log is preserved.
- `tests/agent/test_custom_provider_extra_body.py`: cover the custom-key, Nous-native, Nous-matching-base_url, and no-key cases.

## How to Test

1. Configure a `custom_providers` entry with an explicit `api_key` and a non-Nous `base_url`, and log in to Nous via device code.
2. Resolve the runtime provider and confirm the outgoing key equals the custom key, not the Nous JWT.
3. Repeat with `provider: nous` and confirm the JWT still applies.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.3

### Documentation & Housekeeping

- [x] N/A
- [x] N/A
- [x] N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] N/A
