### PR TITLE
fix(codex): seed app-server sessions with configured cwd

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -622,6 +622,10 @@ class SessionManager:
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+        # Codex app-server sessions are spawned lazily on the first turn. Stamp
+        # the ACP workspace onto the agent so the Codex runtime starts from the
+        # editor/session cwd instead of the Hermes daemon's process cwd.
+        agent.session_cwd = cwd
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -47,7 +47,9 @@ def run_codex_app_server_turn(
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
     if not hasattr(agent, "_codex_session") or agent._codex_session is None:
-        cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
         # Approval callback: defer to Hermes' standard prompt flow if a
         # CLI thread has installed one. Gateway / cron contexts get the
         # codex-side fail-closed default.

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -77,6 +77,50 @@ class TestCreateSession:
     def test_get_nonexistent_session_returns_none(self, manager):
         assert manager.get_session("does-not-exist") is None
 
+    def test_make_agent_stamps_session_cwd_for_codex_runtime(self, monkeypatch):
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "acp_adapter.session.load_config",
+            lambda: {
+                "model": {
+                    "default": "fake-model",
+                    "provider": "fake-provider",
+                },
+                "mcp_servers": {},
+            },
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "default": "fake-model",
+                    "provider": "fake-provider",
+                },
+                "mcp_servers": {},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "codex_app_server",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert state.agent.session_cwd == "/tmp/project"
+
 
 
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -232,6 +232,39 @@ class TestRunConversationCodexPath:
             agent.run_conversation("hi")
         assert not client_mock.chat.completions.create.called
 
+    def test_gateway_terminal_cwd_seeds_codex_thread_cwd(self, monkeypatch, tmp_path):
+        """Gateway sessions set TERMINAL_CWD without stamping agent.session_cwd.
+        Codex app-server must still start in that configured workspace instead
+        of falling back to the Hermes daemon process cwd."""
+        from agent.transports.codex_app_server_session import (
+            CodexAppServerSession, TurnResult,
+        )
+
+        captured: dict[str, str] = {}
+
+        def fake_init(self, **kwargs):
+            captured["cwd"] = kwargs["cwd"]
+            self._thread_id = "thread-stub-1"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+
+        agent = _make_codex_agent()
+        assert not hasattr(agent, "session_cwd")
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["cwd"] == str(tmp_path)
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background


### PR DESCRIPTION
## What does this PR do?

Fixes Codex app-server sessions starting from the Hermes daemon cwd instead of the active Hermes workspace cwd.

There are two affected launch paths:

- ACP/editor sessions already store and register the session cwd for Hermes terminal/file tool overrides, but did not stamp that cwd onto the `AIAgent` instance for the Codex app-server runtime.
- Gateway/messaging sessions already bridge `terminal.cwd` to `TERMINAL_CWD`, but the Codex app-server runtime ignored that helper path and fell back directly to `os.getcwd()`.

This PR stamps ACP-created agents with `agent.session_cwd` and updates the Codex app-server runtime fallback to use `agent.runtime_cwd.resolve_agent_cwd()`, so gateway sessions honor `TERMINAL_CWD` while ACP sessions still prefer the explicit session cwd.

## Related Issue

Fixes #38775

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/session.py`
  - Set `agent.session_cwd = cwd` after ACP constructs the `AIAgent`.
  - This gives `agent/codex_runtime.py` the correct cwd when it lazily creates `CodexAppServerSession`.
- `agent/codex_runtime.py`
  - Use `resolve_agent_cwd()` instead of raw `os.getcwd()` when `agent.session_cwd` is absent.
  - This makes gateway/messaging Codex app-server sessions honor `terminal.cwd` as bridged to `TERMINAL_CWD`.
- `tests/acp/test_session.py`
  - Added regression coverage proving ACP agent creation stamps the session cwd onto the agent for the Codex runtime.
- `tests/run_agent/test_codex_app_server_integration.py`
  - Added regression coverage proving `TERMINAL_CWD` seeds the Codex app-server thread cwd when no ACP `session_cwd` is present.

## How to Test

1. Run the focused ACP session tests:

   ```sh
   python -m pytest tests/acp/test_session.py -q
   ```

2. Verify the focused suite passes:

   ```text
   42 passed, 1 warning
   ```

3. Run the focused Codex app-server runtime tests:

   ```sh
   python -m pytest tests/run_agent/test_codex_app_server_integration.py -q
   ```

4. Verify the focused suite passes:

   ```text
   16 passed, 1 warning
   ```

5. Manual reproduction check:

   Configure ACP/gateway with a cwd outside Hermes home, for example:

   ```yaml
   terminal:
     cwd: /home/nrsimha/Sites/athabasca
     docker_mount_cwd_to_workspace: true
   ```

   Start a new ACP Codex app-server session and confirm the Codex environment context uses that project path as `cwd`/workspace root instead of `/home/nrsimha/.hermes`.

   For gateway/messaging, restart the gateway after applying this patch and start a fresh session. The Codex app-server log should show:

   ```text
   codex app-server thread started: ... cwd=/home/nrsimha/Sites/athabasca
   ```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
$ python -m pytest tests/acp/test_session.py -q
..........................................                               [100%]
=============================== warnings summary ===============================
tests/acp/test_session.py::TestCreateSession::test_make_agent_stamps_session_cwd_for_codex_runtime
  /home/nrsimha/.hermes/hermes-agent/venv/lib/python3.11/site-packages/discord/player.py:30: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
42 passed, 1 warning in 2.97s
```

```text
$ python -m pytest tests/run_agent/test_codex_app_server_integration.py -q
................                                                         [100%]
=============================== warnings summary ===============================
venv/lib/python3.11/site-packages/discord/player.py:30
  /home/nrsimha/.hermes/hermes-agent/venv/lib/python3.11/site-packages/discord/player.py:30: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
16 passed, 1 warning in 2.41s
```

Relevant pre-fix runtime symptom:

```text
<cwd>/home/nrsimha/.hermes</cwd>
<workspace_roots><root>/home/nrsimha/.hermes</root></workspace_roots>
<entry access="write"><path>/home/nrsimha/.hermes</path></entry>
```

Expected post-fix behavior for an ACP session whose cwd is `/home/nrsimha/Sites/athabasca`:

```text
<cwd>/home/nrsimha/Sites/athabasca</cwd>
```

Relevant gateway log from the pre-fix reproduction:

```text
agent.transports.codex_app_server_session: codex app-server thread started: ... cwd=/home/nrsimha/.hermes
```
