### PR TITLE
fix(desktop): ignore IME composition Enter shortcuts

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -20,6 +20,7 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { chatMessageText } from '@/lib/chat-messages'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
+import { isImeComposing } from '@/lib/keyboard'
 import { cn } from '@/lib/utils'
 import {
   $composerAttachments,
@@ -664,7 +665,7 @@ export function ChatBar({
     // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
     // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
     // preedit fires submitDraft() and splits the message mid-word.
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    if (composingRef.current || isImeComposing(event.nativeEvent)) {
       return
     }
 

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -17,6 +17,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Input } from '@/components/ui/input'
 import { renameSession } from '@/hermes'
 import { triggerHaptic } from '@/lib/haptics'
+import { isImeComposing } from '@/lib/keyboard'
 import { exportSession } from '@/lib/session-export'
 import { notify, notifyError } from '@/store/notifications'
 import { setSessions } from '@/store/session'
@@ -224,7 +225,7 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle }: Re
           disabled={submitting}
           onChange={event => setValue(event.target.value)}
           onKeyDown={event => {
-            if (event.key === 'Enter') {
+            if (event.key === 'Enter' && !isImeComposing(event.nativeEvent)) {
               event.preventDefault()
               void submit()
             } else if (event.key === 'Escape') {

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -78,6 +78,7 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, Volume2Icon, VolumeXIcon } from '@/lib/icons'
+import { isImeComposing } from '@/lib/keyboard'
 import { extractPreviewTargets } from '@/lib/preview-targets'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
@@ -1246,6 +1247,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isImeComposing(event.nativeEvent)) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ModelPickerDialog } from '@/components/model-picker'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,7 @@ import {
   Sparkles,
   Terminal
 } from '@/lib/icons'
+import { isImeComposing } from '@/lib/keyboard'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { cn } from '@/lib/utils'
 import { $desktopBoot, type DesktopBootState } from '@/store/boot'
@@ -102,6 +103,10 @@ const API_KEY_OPTIONS: ApiKeyOption[] = [
     placeholder: 'http://127.0.0.1:8000/v1'
   }
 ]
+
+function shouldSubmitOnEnter(event: KeyboardEvent<HTMLInputElement>): boolean {
+  return event.key === 'Enter' && !isImeComposing(event.nativeEvent)
+}
 
 const PROVIDER_DISPLAY: Record<string, { order: number; title: string }> = {
   nous: { order: 0, title: 'Nous Portal' },
@@ -583,7 +588,7 @@ export function ApiKeyForm({
           autoFocus
           className="font-mono"
           onChange={e => setValue(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submit()}
+          onKeyDown={e => shouldSubmitOnEnter(e) && void submit()}
           placeholder={currentRedacted ?? (alreadySet ? 'Replace current value' : option.placeholder || 'Paste API key')}
           type={isLocal ? 'text' : 'password'}
           value={value}
@@ -658,7 +663,7 @@ function FlowPanel({ ctx, flow }: { ctx: OnboardingContext; flow: OnboardingFlow
         <Input
           autoFocus
           onChange={e => setOnboardingCode(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submitOnboardingCode(ctx)}
+          onKeyDown={e => shouldSubmitOnEnter(e) && void submitOnboardingCode(ctx)}
           placeholder="Paste authorization code"
           value={flow.code}
         />

--- a/apps/desktop/src/lib/keyboard.test.ts
+++ b/apps/desktop/src/lib/keyboard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isImeComposing } from './keyboard'
+
+describe('isImeComposing', () => {
+  it('matches active IME composition events', () => {
+    expect(isImeComposing({ isComposing: true, keyCode: 13 } as KeyboardEvent)).toBe(true)
+  })
+
+  it('matches the legacy Chromium process key fallback', () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 229 } as KeyboardEvent)).toBe(true)
+  })
+
+  it('does not match a plain Enter key press', () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 13 } as KeyboardEvent)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -1,0 +1,5 @@
+export function isImeComposing(event: KeyboardEvent): boolean {
+  // Chromium/Electron sets isComposing for modern IMEs. keyCode 229 is the
+  // legacy "Process" fallback still seen with some CJK composition flows.
+  return event.isComposing || event.keyCode === 229
+}


### PR DESCRIPTION
## Summary
Fixes Desktop Enter-key handlers so Enter used to commit IME composition does not also trigger submit/save actions.

This is a narrow macOS/CJK input quality fix and does not overlap with the larger Desktop i18n/localization work.

## Changes
- Add `isImeComposing()` helper for `KeyboardEvent.isComposing` plus legacy `keyCode === 229`
- Apply it to:
  - main chat composer submit path
  - message edit composer submit path
  - onboarding API key / OAuth code inputs
  - session rename input

## Why
Chinese/Japanese/Korean IMEs use Enter to commit the current candidate. Without this guard, Hermes Desktop can submit or save while the user is still composing text.

## Test plan
- [ ] macOS: enable a Chinese/Japanese/Korean IME
- [ ] In the chat composer, type a preedit string and press Enter to commit candidate; message should remain in the composer
- [ ] Press Enter again after composition ends; message should submit normally
- [ ] Repeat for message edit mode, onboarding code/API-key inputs, and session rename

Fixes #37483