### PR TITLE
fix(auxiliary): close evicted clients in cache to prevent fd leaks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2583,6 +2583,16 @@ def _evict_cached_client_instance(target: Any) -> bool:
                 continue
             real = getattr(cached, "_real_client", None)
             if cached is target or real is target:
+                # Close the evicted client's transport to release sockets/fds.
+                # _evict_cached_clients() (by-provider) already does this;
+                # the instance variant must match.  See #10200.
+                _force_close_async_httpx(cached)
+                try:
+                    close_fn = getattr(cached, "close", None)
+                    if callable(close_fn):
+                        close_fn()
+                except Exception:
+                    pass
                 del _client_cache[key]
                 evicted = True
     return evicted
@@ -4562,9 +4572,24 @@ def _get_cached_client(
                 while len(_client_cache) >= _CLIENT_CACHE_MAX_SIZE:
                     evict_key, evict_entry = next(iter(_client_cache.items()))
                     _force_close_async_httpx(evict_entry[0])
+                    try:
+                        close_fn = getattr(evict_entry[0], "close", None)
+                        if callable(close_fn):
+                            close_fn()
+                    except Exception:
+                        pass
                     del _client_cache[evict_key]
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
+                # Another thread won the race — close the redundant client
+                # to avoid leaking its httpx transport (sockets/fds).
+                _force_close_async_httpx(client)
+                try:
+                    close_fn = getattr(client, "close", None)
+                    if callable(close_fn):
+                        close_fn()
+                except Exception:
+                    pass
                 client, default_model, _ = _client_cache[cache_key]
     return client, model or default_model
 


### PR DESCRIPTION
## What does this PR do?

Fixes three resource leaks in the auxiliary client cache (`agent/auxiliary_client.py`) where evicted or discarded OpenAI/httpx clients are never closed, leaking sockets and file descriptors.

### Bug 1 — `_evict_cached_client_instance` skips cleanup (line 2585)

When a specific cached client is poisoned (connection error, timeout), `_evict_cached_client_instance` removes it from the cache dict but **never calls `.close()`** on the evicted client. The by-provider variant `_evict_cached_clients` correctly calls both `_force_close_async_httpx` and `.close()` — the instance variant must match.

**Impact:** Every connection-error eviction leaks one httpx transport (TCP connection pool + sockets). In long-running gateways with retry/fallback logic, this accumulates until fd exhaustion.

### Bug 2 — TOCTOU race in `_get_cached_client` (line 4567)

`resolve_provider_client()` runs **outside the cache lock** (line 4531 releases it). Two concurrent threads can both pass the `cache_key not in _client_cache` check, both create new clients, and the second thread's client is silently discarded without close at line 4568.

**Fix:** Close the redundant client before replacing the reference.

### Bug 3 — FIFO eviction skips sync `.close()` (line 4562)

The cache-size cap eviction calls `_force_close_async_httpx` (which only marks httpx state as `CLOSED`) but does NOT call `.close()` on sync `OpenAI` clients. Compare with `shutdown_cached_clients()` which correctly calls `.close()` on both sync and async clients.

## Testing

```bash
python3 -c "import ast; ast.parse(open('agent/auxiliary_client.py').read()); print('Syntax OK')"
```

## Related

- #10200 — original fd-exhaustion report that motivated the client cache
- #23432 — connection-error eviction path
- #23606 — async wrapper eviction (closed without merge, different scope)
