### PR TITLE
feat(telegram): add profile-local callback scripts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8,6 +8,7 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import contextlib
 import dataclasses
 import inspect
 import json
@@ -15,9 +16,12 @@ import logging
 import os
 import html as _html
 import re
+import subprocess
 import threading
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
+
+import psutil
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +244,150 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".webp": "image/webp",
     ".gif": "image/gif",
 }
+
+
+# First-line defense against callback prefix injection: callback prefixes become
+# script basenames, so only allow a short portable filename subset here. The
+# later resolve()+relative_to() check still enforces directory containment for
+# symlinks or filesystem races.
+_CALLBACK_SCRIPT_PREFIX_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+_CALLBACK_SCRIPT_SUFFIXES = ("", ".py", ".sh")
+_CALLBACK_SCRIPT_TIMEOUT_S = 10.0
+_CALLBACK_SCRIPT_KILL_TIMEOUT_S = 2.0
+_CALLBACK_SCRIPT_MAX_OUTPUT_BYTES = 64 * 1024
+_CALLBACK_SCRIPT_FAILURE_TEXT = "Callback action failed."
+_CALLBACK_SCRIPT_INHERITED_ENV_VARS = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TZ",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "SYSTEMROOT",
+    "COMSPEC",
+    "PATHEXT",
+    "WINDIR",
+)
+
+
+class _CallbackScriptOutputTooLarge(Exception):
+    """Raised when a Telegram callback script exceeds the response-output cap."""
+
+    def __init__(self, stream_name: str) -> None:
+        super().__init__(f"callback script {stream_name} output exceeded {_CALLBACK_SCRIPT_MAX_OUTPUT_BYTES} bytes")
+        self.stream_name = stream_name
+
+
+async def _read_callback_script_stream_limited(stream, stream_name: str) -> bytes:
+    if stream is None:
+        return b""
+    chunks = []
+    total = 0
+    while True:
+        remaining = _CALLBACK_SCRIPT_MAX_OUTPUT_BYTES + 1 - total
+        chunk = await stream.read(min(8192, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > _CALLBACK_SCRIPT_MAX_OUTPUT_BYTES:
+            raise _CallbackScriptOutputTooLarge(stream_name)
+    return b"".join(chunks)
+
+
+async def _communicate_callback_script_limited(proc, input_bytes: bytes) -> tuple[bytes, bytes]:
+    if proc.stdin is not None:
+        try:
+            proc.stdin.write(input_bytes)
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            proc.stdin.close()
+            wait_closed = getattr(proc.stdin, "wait_closed", None)
+            if callable(wait_closed):
+                with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                    await wait_closed()
+
+    wait_task = asyncio.create_task(proc.wait())
+    stdout_task = asyncio.create_task(_read_callback_script_stream_limited(proc.stdout, "stdout"))
+    stderr_task = asyncio.create_task(_read_callback_script_stream_limited(proc.stderr, "stderr"))
+    try:
+        _returncode, stdout_bytes, stderr_bytes = await asyncio.gather(wait_task, stdout_task, stderr_task)
+    except (Exception, asyncio.CancelledError):
+        # If one task fails after another stream already finished, consume that
+        # completed result before cancelling the rest. This avoids turning an
+        # already-complete read into a spurious CancelledError while still
+        # preserving fail-closed semantics for timeouts, oversized output, and
+        # non-zero exits (callers decide whether stdout is applied).
+        for task in (stdout_task, stderr_task):
+            if task.done() and not task.cancelled():
+                with contextlib.suppress(Exception):
+                    task.result()
+        for task in (wait_task, stdout_task, stderr_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(wait_task, stdout_task, stderr_task, return_exceptions=True)
+        raise
+    return stdout_bytes, stderr_bytes
+
+
+async def _kill_callback_script_process_tree(proc) -> None:
+    """Kill a callback script process and any children it spawned."""
+    try:
+        parent = psutil.Process(proc.pid)
+        processes = parent.children(recursive=True)
+        processes.append(parent)
+        for process in processes:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                process.kill()
+    except psutil.NoSuchProcess:
+        pass
+    except Exception:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+
+    await asyncio.wait_for(proc.wait(), timeout=_CALLBACK_SCRIPT_KILL_TIMEOUT_S)
+
+
+def _callback_script_subprocess_kwargs(env: dict[str, str]) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "stdin": asyncio.subprocess.PIPE,
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
+        "env": env,
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def _normalize_telegram_chat_type(value: Any) -> Optional[str]:
+    """Return a stable Telegram chat type string for enum, string, and test doubles."""
+    if value is None:
+        return None
+
+    candidates = [
+        getattr(value, "value", None),
+        getattr(value, "name", None),
+        value,
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        text = str(candidate).strip()
+        if not text:
+            continue
+        normalized = text.rsplit(".", 1)[-1].lower()
+        if normalized in {"private", "group", "supergroup", "channel"}:
+            return normalized
+    return None
 
 
 def check_telegram_requirements() -> bool:
@@ -5642,42 +5790,369 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         # --- Update prompt callbacks ---
-        if not data.startswith("update_prompt:"):
+        if data.startswith("update_prompt:"):
+            answer = data.split(":", 1)[1]  # "y" or "n"
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to answer update prompts.")
+                return
+            await query.answer(text=f"Sent '{answer}' to the update process.")
+            # Edit the message to show the choice and remove buttons
+            label = "Yes" if answer == "y" else "No"
+            try:
+                await query.edit_message_text(
+                    text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass  # non-fatal if edit fails
+            # Write the response file
+            try:
+                from hermes_constants import get_hermes_home
+                home = get_hermes_home()
+                response_path = home / ".update_response"
+                tmp = response_path.with_suffix(".tmp")
+                tmp.write_text(answer)
+                tmp.replace(response_path)
+                logger.info("Telegram update prompt answered '%s' by user %s",
+                            answer, getattr(query.from_user, "id", "unknown"))
+            except Exception as exc:
+                logger.error("Failed to write update response from callback: %s", exc)
             return
-        answer = data.split(":", 1)[1]  # "y" or "n"
-        caller_id = str(getattr(query.from_user, "id", ""))
+
+        # --- Generic profile-local callback scripts ---
+        if await self._handle_callback_script_bridge(
+            query,
+            data,
+            query_chat_id=query_chat_id,
+            query_chat_type=query_chat_type,
+            query_thread_id=query_thread_id,
+            query_user_name=query_user_name,
+        ):
+            return
+
+    def _telegram_callback_script_dir(self) -> _Path:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "scripts" / "telegram-callbacks"
+
+    def _extract_script_callback_prefix(self, data: str) -> Optional[str]:
+        if ":" not in data:
+            return None
+        prefix = data.split(":", 1)[0]
+        if not _CALLBACK_SCRIPT_PREFIX_RE.fullmatch(prefix):
+            return None
+        return prefix
+
+    def _resolve_callback_script(self, prefix: str) -> Optional[_Path]:
+        base = self._telegram_callback_script_dir()
+        if not base.exists():
+            return None
+        try:
+            resolved_base = base.resolve(strict=True)
+        except OSError:
+            logger.debug("[%s] Telegram callback script directory is unavailable", self.name, exc_info=True)
+            return None
+
+        for suffix in _CALLBACK_SCRIPT_SUFFIXES:
+            candidate = base / f"{prefix}{suffix}"
+            try:
+                resolved = candidate.resolve(strict=True)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                logger.warning("[%s] Unable to resolve Telegram callback script candidate", self.name, exc_info=True)
+                continue
+            try:
+                resolved.relative_to(resolved_base)
+            except ValueError:
+                logger.warning("[%s] Rejected Telegram callback script outside callback directory", self.name)
+                continue
+            if not resolved.is_file():
+                logger.warning("[%s] Rejected Telegram callback script that is not a regular file", self.name)
+                continue
+            if not os.access(resolved, os.X_OK):
+                logger.warning("[%s] Rejected non-executable Telegram callback script", self.name)
+                continue
+            return resolved
+        return None
+
+    @staticmethod
+    def _callback_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+    def _build_callback_script_env(
+        self,
+        context_obj: Dict[str, Any],
+        *,
+        data: str,
+        prefix: str,
+    ) -> Dict[str, str]:
+        env = {
+            key: value
+            for key in _CALLBACK_SCRIPT_INHERITED_ENV_VARS
+            if (value := os.environ.get(key)) is not None
+        }
+        env.update({
+            "HERMES_HOME": context_obj["hermes"]["home"],
+            "HERMES_TELEGRAM_CALLBACK_DATA": data,
+            "HERMES_TELEGRAM_CALLBACK_PREFIX": prefix,
+        })
+        telegram_context = context_obj["telegram"]
+        metadata_env = {
+            "HERMES_TELEGRAM_USER_ID": telegram_context.get("user_id"),
+            "HERMES_TELEGRAM_USER_NAME": telegram_context.get("user_name"),
+            "HERMES_TELEGRAM_CHAT_ID": telegram_context.get("chat_id"),
+            "HERMES_TELEGRAM_CHAT_TYPE": telegram_context.get("chat_type"),
+            "HERMES_TELEGRAM_MESSAGE_ID": telegram_context.get("message_id"),
+            "HERMES_TELEGRAM_THREAD_ID": telegram_context.get("message_thread_id"),
+        }
+        for key, value in metadata_env.items():
+            if value is not None:
+                env[key] = str(value)
+        return env
+
+    def _build_callback_script_context(
+        self,
+        query,
+        data: str,
+        *,
+        prefix: str,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> Dict[str, Any]:
+        from hermes_constants import get_hermes_home
+
+        message = getattr(query, "message", None)
+        message_id = getattr(message, "message_id", None)
+        user = getattr(query, "from_user", None)
+        user_id = getattr(user, "id", None)
+        return {
+            "callback_data": data,
+            "prefix": prefix,
+            "telegram": {
+                "user_id": self._callback_value(user_id),
+                "user_name": query_user_name,
+                "chat_id": self._callback_value(query_chat_id),
+                "chat_type": self._callback_value(_normalize_telegram_chat_type(query_chat_type)),
+                "message_id": self._callback_value(message_id),
+                "message_thread_id": self._callback_value(query_thread_id),
+            },
+            "hermes": {
+                "home": str(get_hermes_home()),
+            },
+        }
+
+    def _normalize_callback_script_response(self, raw: Any) -> Dict[str, Any]:
+        if not isinstance(raw, dict):
+            raise ValueError("callback script response must be an object")
+        ok = raw.get("ok")
+        if not isinstance(ok, bool):
+            raise ValueError("callback script response must include boolean ok")
+
+        normalized: Dict[str, Any] = {
+            "ok": ok,
+            "answer_text": "",
+            "show_alert": False,
+            "edit_message_text": None,
+            "remove_keyboard": False,
+        }
+        answer_text = raw.get("answer_text")
+        if answer_text is not None:
+            if not isinstance(answer_text, str):
+                raise ValueError("answer_text must be a string")
+            normalized["answer_text"] = answer_text
+        show_alert = raw.get("show_alert")
+        if show_alert is not None:
+            if not isinstance(show_alert, bool):
+                raise ValueError("show_alert must be a boolean")
+            normalized["show_alert"] = show_alert
+        edit_message_text = raw.get("edit_message_text")
+        if edit_message_text is not None:
+            if not isinstance(edit_message_text, str):
+                raise ValueError("edit_message_text must be a string")
+            normalized["edit_message_text"] = edit_message_text
+        remove_keyboard = raw.get("remove_keyboard")
+        if remove_keyboard is not None:
+            if not isinstance(remove_keyboard, bool):
+                raise ValueError("remove_keyboard must be a boolean")
+            normalized["remove_keyboard"] = remove_keyboard
+        return normalized
+
+    async def _apply_callback_script_response(self, query, response: Dict[str, Any]) -> None:
+        answer_text = str(response.get("answer_text") or "")[:200]
+        show_alert = bool(response.get("show_alert", False))
+        await query.answer(text=answer_text, show_alert=show_alert)
+
+        edit_message_text = response.get("edit_message_text")
+        remove_keyboard = bool(response.get("remove_keyboard", False))
+        if edit_message_text is not None:
+            message = getattr(query, "message", None)
+            kwargs: Dict[str, Any] = {"text": edit_message_text}
+            if remove_keyboard:
+                kwargs["reply_markup"] = None
+            else:
+                # PTB's edit_message_text defaults reply_markup=None, which removes
+                # the inline keyboard. Preserve the existing markup unless the script
+                # explicitly requests removal.
+                reply_markup = getattr(message, "reply_markup", None)
+                if reply_markup is not None:
+                    kwargs["reply_markup"] = reply_markup
+            try:
+                await query.edit_message_text(**kwargs)
+            except Exception:
+                logger.debug("[%s] Telegram callback script message edit failed", self.name, exc_info=True)
+                chat_id = getattr(message, "chat_id", None)
+                if chat_id is None:
+                    chat = getattr(message, "chat", None)
+                    chat_id = getattr(chat, "id", None)
+                message_id = getattr(message, "message_id", None)
+                bot_edit = getattr(getattr(self, "_bot", None), "edit_message_text", None)
+                if callable(bot_edit) and chat_id is not None and message_id is not None:
+                    try:
+                        fallback_result = bot_edit(chat_id=chat_id, message_id=message_id, **kwargs)
+                        if inspect.isawaitable(fallback_result):
+                            await fallback_result
+                    except Exception:
+                        logger.warning(
+                            "[%s] Telegram callback script bot-level message edit fallback failed",
+                            self.name,
+                            exc_info=True,
+                        )
+        elif remove_keyboard:
+            edit_markup = getattr(query, "edit_message_reply_markup", None)
+            if callable(edit_markup):
+                try:
+                    await edit_markup(reply_markup=None)
+                except Exception:
+                    logger.debug(
+                        "[%s] Telegram callback script reply markup edit failed",
+                        self.name,
+                        exc_info=True,
+                    )
+
+    async def _handle_callback_script_bridge(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> bool:
+        prefix = self._extract_script_callback_prefix(data)
+        if prefix is None:
+            return False
+
+        script_path = self._resolve_callback_script(prefix)
+        if script_path is None:
+            return False
+
+        caller_id = str(getattr(getattr(query, "from_user", None), "id", ""))
         if not self._is_callback_user_authorized(
             caller_id,
             chat_id=query_chat_id,
-            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            chat_type=_normalize_telegram_chat_type(query_chat_type),
             thread_id=str(query_thread_id) if query_thread_id is not None else None,
             user_name=query_user_name,
         ):
-            await query.answer(text="⛔ You are not authorized to answer update prompts.")
-            return
-        await query.answer(text=f"Sent '{answer}' to the update process.")
-        # Edit the message to show the choice and remove buttons
-        label = "Yes" if answer == "y" else "No"
+            await query.answer(text="⛔ You are not authorized to run this action.")
+            return True
+
+        context_obj = self._build_callback_script_context(
+            query,
+            data,
+            prefix=prefix,
+            query_chat_id=query_chat_id,
+            query_chat_type=query_chat_type,
+            query_thread_id=query_thread_id,
+            query_user_name=query_user_name,
+        )
+        context_bytes = json.dumps(context_obj, ensure_ascii=False).encode("utf-8")
+
+        env = self._build_callback_script_env(context_obj, data=data, prefix=prefix)
+
+        proc = None
         try:
-            await query.edit_message_text(
-                text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
-                parse_mode=ParseMode.MARKDOWN_V2,
-                reply_markup=None,
+            # Invoke the script directly with create_subprocess_exec: callback
+            # data is argv[1], stdin is JSON context, and no shell is involved.
+            # Do not replace this with shell=True execution; button payloads are
+            # user-controlled Telegram callback data.
+            proc = await asyncio.create_subprocess_exec(
+                str(script_path),
+                data,
+                **_callback_script_subprocess_kwargs(env),
             )
+            stdout_bytes, _stderr_bytes = await asyncio.wait_for(
+                _communicate_callback_script_limited(proc, context_bytes),
+                timeout=_CALLBACK_SCRIPT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            if proc is not None:
+                try:
+                    await _kill_callback_script_process_tree(proc)
+                except asyncio.TimeoutError:
+                    logger.warning("[%s] Timed out waiting for Telegram callback script kill", self.name)
+                except Exception:
+                    logger.debug("[%s] Telegram callback script timeout cleanup failed", self.name, exc_info=True)
+            logger.warning("[%s] Telegram callback script timed out for prefix %s", self.name, prefix)
+            await query.answer(text=_CALLBACK_SCRIPT_FAILURE_TEXT)
+            return True
+        except _CallbackScriptOutputTooLarge as exc:
+            if proc is not None:
+                try:
+                    await _kill_callback_script_process_tree(proc)
+                except asyncio.TimeoutError:
+                    logger.warning("[%s] Timed out waiting for oversized Telegram callback script kill", self.name)
+                except Exception:
+                    logger.debug("[%s] Telegram callback script oversized-output cleanup failed", self.name, exc_info=True)
+            logger.warning(
+                "[%s] Telegram callback script exceeded %s output cap for prefix %s",
+                self.name,
+                exc.stream_name,
+                prefix,
+            )
+            await query.answer(text=_CALLBACK_SCRIPT_FAILURE_TEXT)
+            return True
         except Exception:
-            pass  # non-fatal if edit fails
-        # Write the response file
+            logger.error("[%s] Telegram callback script execution failed for prefix %s", self.name, prefix, exc_info=True)
+            await query.answer(text=_CALLBACK_SCRIPT_FAILURE_TEXT)
+            return True
+
+        if proc.returncode != 0:
+            logger.warning(
+                "[%s] Telegram callback script failed for prefix %s with exit code %s",
+                self.name,
+                prefix,
+                proc.returncode,
+            )
+            await query.answer(text=_CALLBACK_SCRIPT_FAILURE_TEXT)
+            return True
+
         try:
-            from hermes_constants import get_hermes_home
-            home = get_hermes_home()
-            response_path = home / ".update_response"
-            tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer)
-            tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s",
-                        answer, getattr(query.from_user, "id", "unknown"))
-        except Exception as exc:
-            logger.error("Failed to write update response from callback: %s", exc)
+            raw_response = json.loads(stdout_bytes.decode("utf-8"))
+            response = self._normalize_callback_script_response(raw_response)
+        except Exception:
+            logger.warning("[%s] Telegram callback script returned invalid JSON for prefix %s", self.name, prefix)
+            await query.answer(text=_CALLBACK_SCRIPT_FAILURE_TEXT)
+            return True
+
+        if not response["ok"] and not response.get("answer_text"):
+            response["answer_text"] = _CALLBACK_SCRIPT_FAILURE_TEXT
+        await self._apply_callback_script_response(query, response)
+        return True
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/gateway/test_telegram_callback_script_bridge.py
+++ b/tests/gateway/test_telegram_callback_script_bridge.py
@@ -1,0 +1,645 @@
+"""Tests for profile-local Telegram callback scripts."""
+
+import asyncio
+import importlib
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import psutil
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    try:
+        importlib.import_module("telegram")
+        importlib.import_module("telegram.ext")
+        importlib.import_module("telegram.constants")
+        importlib.import_module("telegram.request")
+        importlib.import_module("telegram.error")
+        return
+    except ImportError:
+        pass
+
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = ModuleType("telegram")
+    ext_mod = ModuleType("telegram.ext")
+    constants_mod = ModuleType("telegram.constants")
+    request_mod = ModuleType("telegram.request")
+    error_mod = ModuleType("telegram.error")
+
+    setattr(telegram_mod, "Update", object)
+    setattr(telegram_mod, "Bot", object)
+    setattr(telegram_mod, "Message", object)
+    setattr(telegram_mod, "InlineKeyboardButton", lambda *args, **kwargs: SimpleNamespace(args=args, kwargs=kwargs))
+    setattr(telegram_mod, "InlineKeyboardMarkup", lambda inline_keyboard: SimpleNamespace(inline_keyboard=inline_keyboard))
+    setattr(constants_mod, "ParseMode", SimpleNamespace(MARKDOWN="Markdown", MARKDOWN_V2="MarkdownV2", HTML="HTML"))
+    setattr(constants_mod, "ChatType", SimpleNamespace(PRIVATE="private", GROUP="group", SUPERGROUP="supergroup", CHANNEL="channel"))
+    setattr(ext_mod, "Application", object)
+    setattr(ext_mod, "CommandHandler", object)
+    setattr(ext_mod, "CallbackQueryHandler", object)
+    setattr(ext_mod, "MessageHandler", object)
+    setattr(ext_mod, "ContextTypes", SimpleNamespace(DEFAULT_TYPE=type(None)))
+    setattr(ext_mod, "filters", object)
+    setattr(request_mod, "HTTPXRequest", object)
+    setattr(error_mod, "NetworkError", type("NetworkError", (OSError,), {}))
+    setattr(error_mod, "TimedOut", type("TimedOut", (OSError,), {}))
+    setattr(error_mod, "BadRequest", type("BadRequest", (Exception,), {}))
+    setattr(telegram_mod, "constants", constants_mod)
+    setattr(telegram_mod, "ext", ext_mod)
+    setattr(telegram_mod, "error", error_mod)
+    setattr(telegram_mod, "request", request_mod)
+
+    sys.modules.setdefault("telegram", telegram_mod)
+    sys.modules.setdefault("telegram.ext", ext_mod)
+    sys.modules.setdefault("telegram.constants", constants_mod)
+    sys.modules.setdefault("telegram.request", request_mod)
+    sys.modules.setdefault("telegram.error", error_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import _CALLBACK_SCRIPT_MAX_OUTPUT_BYTES, TelegramAdapter
+
+
+def _make_adapter():
+    # Short synthetic placeholder; tests never contact Telegram with this value.
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake", extra={}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_query(data: str, *, user_id=111, chat_id=12345, thread_id=7, chat_type="supergroup"):
+    reply_markup = SimpleNamespace(name="existing-inline-keyboard")
+    message = SimpleNamespace(
+        chat_id=chat_id,
+        message_id=42,
+        message_thread_id=thread_id,
+        text="Original text",
+        reply_markup=reply_markup,
+        chat=SimpleNamespace(type=chat_type),
+    )
+    query = SimpleNamespace(
+        data=data,
+        message=message,
+        from_user=SimpleNamespace(id=user_id, first_name="Ada"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+    return query
+
+
+def _write_script(callback_dir: Path, name: str, source: str) -> Path:
+    callback_dir.mkdir(parents=True, exist_ok=True)
+    path = callback_dir / name
+    path.write_text(source, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+async def _dispatch(adapter, query):
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query),
+        SimpleNamespace(),
+    )
+
+
+@pytest.fixture
+def callback_dir(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    directory = hermes_home / "scripts" / "telegram-callbacks"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+    return directory
+
+
+@pytest.mark.asyncio
+async def test_success_invokes_script_with_context_env_and_edits(callback_dir, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
+    record_path = callback_dir.parent / "record.json"
+    _write_script(
+        callback_dir,
+        "task.py",
+        f"""#!/usr/bin/env python3
+import json, os, sys
+ctx = json.load(sys.stdin)
+record = {{
+    "argv": sys.argv,
+    "stdin": ctx,
+    "env": {{
+        "HERMES_HOME": os.environ.get("HERMES_HOME"),
+        "HERMES_TELEGRAM_CALLBACK_DATA": os.environ.get("HERMES_TELEGRAM_CALLBACK_DATA"),
+        "HERMES_TELEGRAM_CALLBACK_PREFIX": os.environ.get("HERMES_TELEGRAM_CALLBACK_PREFIX"),
+        "HERMES_TELEGRAM_USER_ID": os.environ.get("HERMES_TELEGRAM_USER_ID"),
+        "HERMES_TELEGRAM_CHAT_ID": os.environ.get("HERMES_TELEGRAM_CHAT_ID"),
+        "HERMES_TELEGRAM_CHAT_TYPE": os.environ.get("HERMES_TELEGRAM_CHAT_TYPE"),
+        "HERMES_TELEGRAM_MESSAGE_ID": os.environ.get("HERMES_TELEGRAM_MESSAGE_ID"),
+        "HERMES_TELEGRAM_THREAD_ID": os.environ.get("HERMES_TELEGRAM_THREAD_ID"),
+        "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+    }},
+}}
+open({str(record_path)!r}, "w", encoding="utf-8").write(json.dumps(record))
+print(json.dumps({{"ok": True, "answer_text": "Done", "edit_message_text": "Updated", "remove_keyboard": True}}))
+""",
+    )
+    adapter = _make_adapter()
+    query = _make_query("task:123")
+
+    await _dispatch(adapter, query)
+
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["argv"][1] == "task:123"
+    assert record["stdin"]["callback_data"] == "task:123"
+    assert record["stdin"]["prefix"] == "task"
+    assert record["stdin"]["telegram"]["user_id"] == "111"
+    assert record["stdin"]["telegram"]["chat_id"] == "12345"
+    assert record["stdin"]["telegram"]["chat_type"] == "supergroup"
+    assert record["stdin"]["telegram"]["message_id"] == "42"
+    assert record["stdin"]["telegram"]["message_thread_id"] == "7"
+    assert record["stdin"]["hermes"]["home"] == str(callback_dir.parents[1])
+    assert record["env"]["HERMES_TELEGRAM_CALLBACK_DATA"] == "task:123"
+    assert record["env"]["HERMES_TELEGRAM_CALLBACK_PREFIX"] == "task"
+    assert record["env"]["HERMES_TELEGRAM_USER_ID"] == "111"
+    assert record["env"]["HERMES_TELEGRAM_CHAT_ID"] == "12345"
+    assert record["env"]["HERMES_TELEGRAM_CHAT_TYPE"] == "supergroup"
+    assert record["env"]["HERMES_TELEGRAM_MESSAGE_ID"] == "42"
+    assert record["env"]["HERMES_TELEGRAM_THREAD_ID"] == "7"
+    assert record["env"]["OPENAI_API_KEY"] is None
+    query.answer.assert_awaited_once_with(text="Done", show_alert=False)
+    query.edit_message_text.assert_awaited_once_with(text="Updated", reply_markup=None)
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_edit_falls_back_to_bot_api_when_callback_edit_fails(callback_dir):
+    _write_script(
+        callback_dir,
+        "edit.py",
+        """#!/usr/bin/env python3
+import json
+print(json.dumps({"ok": True, "answer_text": "Done", "edit_message_text": "Updated", "remove_keyboard": True}))
+""",
+    )
+    adapter = _make_adapter()
+    query = _make_query("edit:1")
+    query.edit_message_text.side_effect = RuntimeError("callback edit failed")
+
+    await _dispatch(adapter, query)
+
+    query.answer.assert_awaited_once_with(text="Done", show_alert=False)
+    query.edit_message_text.assert_awaited_once_with(text="Updated", reply_markup=None)
+    bot = adapter._bot
+    assert bot is not None
+    bot.edit_message_text.assert_awaited_once_with(
+        chat_id=12345,
+        message_id=42,
+        text="Updated",
+        reply_markup=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_edit_preserves_inline_keyboard_by_default(callback_dir):
+    _write_script(
+        callback_dir,
+        "keep.py",
+        """#!/usr/bin/env python3
+import json
+print(json.dumps({"ok": True, "answer_text": "Done", "edit_message_text": "Updated"}))
+""",
+    )
+    adapter = _make_adapter()
+    query = _make_query("keep:1")
+
+    await _dispatch(adapter, query)
+
+    query.answer.assert_awaited_once_with(text="Done", show_alert=False)
+    query.edit_message_text.assert_awaited_once_with(
+        text="Updated",
+        reply_markup=query.message.reply_markup,
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_edit_fallback_preserves_inline_keyboard_by_default(callback_dir):
+    _write_script(
+        callback_dir,
+        "keep.py",
+        """#!/usr/bin/env python3
+import json
+print(json.dumps({"ok": True, "answer_text": "Done", "edit_message_text": "Updated"}))
+""",
+    )
+    adapter = _make_adapter()
+    query = _make_query("keep:1")
+    query.edit_message_text.side_effect = RuntimeError("callback edit failed")
+
+    await _dispatch(adapter, query)
+
+    query.answer.assert_awaited_once_with(text="Done", show_alert=False)
+    query.edit_message_text.assert_awaited_once_with(
+        text="Updated",
+        reply_markup=query.message.reply_markup,
+    )
+    bot = adapter._bot
+    assert bot is not None
+    bot.edit_message_text.assert_awaited_once_with(
+        chat_id=12345,
+        message_id=42,
+        text="Updated",
+        reply_markup=query.message.reply_markup,
+    )
+
+
+@pytest.mark.asyncio
+async def test_show_alert_true_success(callback_dir):
+    _write_script(
+        callback_dir,
+        "alert",
+        """#!/usr/bin/env python3
+import json
+print(json.dumps({"ok": True, "answer_text": "Look", "show_alert": True}))
+""",
+    )
+    query = _make_query("alert:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Look", show_alert=True)
+
+
+@pytest.mark.asyncio
+async def test_remove_keyboard_only_uses_reply_markup_edit(callback_dir):
+    _write_script(
+        callback_dir,
+        "clean.sh",
+        """#!/bin/sh
+printf '%s\n' '{"ok": true, "answer_text": "Cleared", "remove_keyboard": true}'
+""",
+    )
+    query = _make_query("clean:anything")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Cleared", show_alert=False)
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_does_not_execute(callback_dir, monkeypatch):
+    marker = callback_dir.parent / "ran"
+    _write_script(
+        callback_dir,
+        "task",
+        f"""#!/usr/bin/env python3
+from pathlib import Path
+Path({str(marker)!r}).write_text("ran")
+print('{{"ok": true}}')
+""",
+    )
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+    query = _make_query("task:123", user_id=111)
+
+    await _dispatch(_make_adapter(), query)
+
+    assert not marker.exists()
+    query.answer.assert_awaited_once()
+    assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data",
+    [
+        "missing:1",
+        "bad.prefix:1",
+        "../escape:1",
+        "~home:1",
+        "slash/prefix:1",
+        r"back\\slash:1",
+        "toolongprefixname_over_32_chars_here:1",
+        "nocolon",
+    ],
+)
+async def test_missing_or_invalid_prefix_is_ignored(callback_dir, data):
+    query = _make_query(data)
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlinks require elevated privileges on Windows")
+async def test_symlink_escape_rejected(callback_dir, tmp_path):
+    outside = tmp_path / "outside.py"
+    outside.write_text("#!/usr/bin/env python3\nprint('{\"ok\": true, \"answer_text\": \"bad\"}')\n", encoding="utf-8")
+    outside.chmod(outside.stat().st_mode | stat.S_IXUSR)
+    callback_dir.mkdir(parents=True, exist_ok=True)
+    (callback_dir / "escape.py").symlink_to(outside)
+    query = _make_query("escape:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("script_body", "expected"),
+    [
+        ("import sys; sys.exit(3)", "Callback action failed."),
+        ("print('not json')", "Callback action failed."),
+        ("import json; print(json.dumps({'ok': False, 'answer_text': 'Could not finish'}))", "Could not finish"),
+    ],
+)
+async def test_script_failures_answer_once_with_safe_text(callback_dir, script_body, expected):
+    _write_script(callback_dir, "fail.py", f"#!/usr/bin/env python3\n{script_body}\n")
+    query = _make_query("fail:secret-payload")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once()
+    text = query.answer.call_args.kwargs["text"]
+    assert text == expected
+    assert "secret-payload" not in text
+    assert query.answer.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_with_valid_json_does_not_apply_response(callback_dir):
+    _write_script(
+        callback_dir,
+        "nonzero.py",
+        """#!/usr/bin/env python3
+import json
+import sys
+print(json.dumps({"ok": True, "answer_text": "Unsafe", "edit_message_text": "Do not apply"}))
+sys.exit(7)
+""",
+    )
+    query = _make_query("nonzero:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_chat_type_accepts_enum_like_value(callback_dir):
+    record_path = callback_dir.parent / "record.json"
+    _write_script(
+        callback_dir,
+        "enumtype.py",
+        f"""#!/usr/bin/env python3
+import json, os, sys
+ctx = json.load(sys.stdin)
+open({str(record_path)!r}, "w", encoding="utf-8").write(json.dumps({{
+    "stdin_chat_type": ctx["telegram"]["chat_type"],
+    "env_chat_type": os.environ.get("HERMES_TELEGRAM_CHAT_TYPE"),
+}}))
+print(json.dumps({{"ok": True, "answer_text": "Done"}}))
+""",
+    )
+    query = _make_query("enumtype:1", chat_type=SimpleNamespace(value="SUPERGROUP"))
+
+    await _dispatch(_make_adapter(), query)
+
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record == {"stdin_chat_type": "supergroup", "env_chat_type": "supergroup"}
+    query.answer.assert_awaited_once_with(text="Done", show_alert=False)
+
+
+@pytest.mark.asyncio
+async def test_split_script_stdout_json_is_read_until_eof(callback_dir):
+    _write_script(
+        callback_dir,
+        "split.py",
+        """#!/usr/bin/env python3
+import sys
+import time
+sys.stdout.write('{"ok": true, "answer_text": "Hel')
+sys.stdout.flush()
+time.sleep(0.05)
+sys.stdout.write('lo"}')
+sys.stdout.flush()
+""",
+    )
+    query = _make_query("split:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Hello", show_alert=False)
+
+
+@pytest.mark.asyncio
+async def test_oversized_script_stdout_is_rejected_with_safe_text(callback_dir):
+    _write_script(
+        callback_dir,
+        "huge.py",
+        f"""#!/usr/bin/env python3
+import sys
+sys.stdout.write("x" * {_CALLBACK_SCRIPT_MAX_OUTPUT_BYTES + 1})
+sys.stdout.flush()
+""",
+    )
+    query = _make_query("huge:secret-payload")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+    assert "secret-payload" not in query.answer.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_oversized_script_stdout_after_initial_json_is_rejected(callback_dir):
+    _write_script(
+        callback_dir,
+        "overflow.py",
+        f"""#!/usr/bin/env python3
+import sys
+import time
+sys.stdout.write('{{"ok": true, "answer_text": "Unsafe"}}')
+sys.stdout.flush()
+time.sleep(0.05)
+sys.stdout.write("x" * {_CALLBACK_SCRIPT_MAX_OUTPUT_BYTES + 1})
+sys.stdout.flush()
+""",
+    )
+    query = _make_query("overflow:secret-payload")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+    assert "secret-payload" not in query.answer.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_completed_stdout_is_not_applied_when_stderr_overflows(callback_dir):
+    _write_script(
+        callback_dir,
+        "stderr_overflow.py",
+        f"""#!/usr/bin/env python3
+import sys
+sys.stdout.write('{{"ok": true, "answer_text": "Unsafe", "edit_message_text": "Do not apply"}}')
+sys.stdout.flush()
+sys.stdout.close()
+sys.stderr.write("e" * {_CALLBACK_SCRIPT_MAX_OUTPUT_BYTES + 1})
+sys.stderr.flush()
+""",
+    )
+    query = _make_query("stderr_overflow:secret-payload")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()
+    assert "secret-payload" not in query.answer.call_args.kwargs["text"]
+
+
+async def _process_is_gone(pid: int) -> bool:
+    for _ in range(50):
+        if not psutil.pid_exists(pid):
+            return True
+        try:
+            process = psutil.Process(pid)
+            if process.status() == psutil.STATUS_ZOMBIE:
+                return True
+        except psutil.NoSuchProcess:
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_script_process_group(callback_dir, tmp_path, monkeypatch):
+    from plugins.platforms.telegram import adapter as telegram_mod
+
+    monkeypatch.setattr(telegram_mod, "_CALLBACK_SCRIPT_TIMEOUT_S", 0.2)
+    marker = tmp_path / "child.pid"
+    _write_script(
+        callback_dir,
+        "spawn.py",
+        f"""#!/usr/bin/env python3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+Path({str(marker)!r}).write_text(str(child.pid), encoding="utf-8")
+time.sleep(30)
+""",
+    )
+    query = _make_query("spawn:child")
+
+    await _dispatch(_make_adapter(), query)
+
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+    child_pid = int(marker.read_text(encoding="utf-8"))
+    assert await _process_is_gone(child_pid)
+
+
+@pytest.mark.asyncio
+async def test_script_timeout_is_killed_and_answers_once(callback_dir, monkeypatch):
+    marker = callback_dir.parent / "finished"
+    _write_script(
+        callback_dir,
+        "slow.py",
+        f"""#!/usr/bin/env python3
+import json, time
+time.sleep(5)
+open({str(marker)!r}, "w", encoding="utf-8").write("finished")
+print(json.dumps({{"ok": True, "answer_text": "too late"}}))
+""",
+    )
+    monkeypatch.setattr("plugins.platforms.telegram.adapter._CALLBACK_SCRIPT_TIMEOUT_S", 0.1)
+    query = _make_query("slow:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    assert not marker.exists()
+    query.answer.assert_awaited_once_with(text="Callback action failed.")
+
+
+@pytest.mark.asyncio
+async def test_shell_metacharacters_are_passed_as_argv(callback_dir, tmp_path):
+    marker = tmp_path / "shell-ran"
+    record = tmp_path / "argv.json"
+    _write_script(
+        callback_dir,
+        "safe",
+        f"""#!/usr/bin/env python3
+import json, sys
+open({str(record)!r}, "w", encoding="utf-8").write(json.dumps(sys.argv))
+print(json.dumps({{"ok": True, "answer_text": "Safe"}}))
+""",
+    )
+    data = f"safe:$(touch {marker});`touch {marker}`"
+    query = _make_query(data)
+
+    await _dispatch(_make_adapter(), query)
+
+    assert not marker.exists()
+    assert json.loads(record.read_text(encoding="utf-8"))[1] == data
+    query.answer.assert_awaited_once_with(text="Safe", show_alert=False)
+
+
+@pytest.mark.asyncio
+async def test_answer_text_is_truncated_to_200_chars(callback_dir):
+    _write_script(
+        callback_dir,
+        "long",
+        """#!/usr/bin/env python3
+import json
+print(json.dumps({"ok": True, "answer_text": "x" * 250}))
+""",
+    )
+    query = _make_query("long:1")
+
+    await _dispatch(_make_adapter(), query)
+
+    assert len(query.answer.call_args.kwargs["text"]) == 200
+
+
+@pytest.mark.asyncio
+async def test_builtin_prefix_still_wins(callback_dir):
+    marker = callback_dir.parent / "ran"
+    _write_script(
+        callback_dir,
+        "gt",
+        f"""#!/usr/bin/env python3
+from pathlib import Path
+Path({str(marker)!r}).write_text("ran")
+print('{{"ok": true, "answer_text": "GENERIC SCRIPT USED", "edit_message_text": "GENERIC EDIT"}}')
+""",
+    )
+    adapter = _make_adapter()
+    adapter._handle_gmail_triage_callback = AsyncMock()
+    query = _make_query("gt:send:abc")
+
+    await _dispatch(adapter, query)
+
+    adapter._handle_gmail_triage_callback.assert_awaited_once()
+    assert not marker.exists()
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -242,6 +242,92 @@ The gateway extracts `MEDIA:/path/to/file` tags from agent replies and ships the
 
 Anything on this list delivered as a native attachment on platforms that support it (Telegram, Discord, Signal, Slack, WhatsApp, Feishu, Matrix, etc.); on platforms without native support it falls back to a link or plain-text indicator. The **bold** categories were added in the last few releases — if you were relying on the model saying `here is the file: /path/to/report.docx` instead, swap to `MEDIA:/path/to/report.docx` for native delivery.
 
+## Profile-local callback scripts
+
+Telegram inline buttons can use callback data handled by profile-local scripts. This is useful for project/profile runtimes that need deterministic button actions without adding upstream Python handlers for each workflow.
+
+Create an executable script under:
+
+```bash
+$HERMES_HOME/scripts/telegram-callbacks/<prefix>
+```
+
+When a button sends callback data shaped like `<prefix>:<payload>`, Hermes runs the matching executable script (`<prefix>`, `<prefix>.py`, or `<prefix>.sh`) if the callback caller is authorized for that chat. Built-in Hermes callback prefixes still take precedence.
+
+The script receives:
+
+- argv 1: the full callback data string
+- stdin: a JSON object with `callback_data`, `prefix`, `telegram` metadata, and `hermes.home`
+- a minimal environment with safe process basics (`PATH`, locale/timezone/temp variables, and Windows process basics such as `USERPROFILE`, `SYSTEMROOT`, `COMSPEC`, `PATHEXT`, and `WINDIR`) plus explicit callback metadata: `HERMES_HOME`, `HERMES_TELEGRAM_CALLBACK_DATA`, `HERMES_TELEGRAM_CALLBACK_PREFIX`, `HERMES_TELEGRAM_USER_ID`, `HERMES_TELEGRAM_USER_NAME`, `HERMES_TELEGRAM_CHAT_ID`, `HERMES_TELEGRAM_CHAT_TYPE`, `HERMES_TELEGRAM_MESSAGE_ID`, and `HERMES_TELEGRAM_THREAD_ID`
+
+The script must print JSON to stdout:
+
+```json
+{
+  "ok": true,
+  "answer_text": "Done",
+  "show_alert": false,
+  "edit_message_text": "Optional replacement message text",
+  "remove_keyboard": true
+}
+```
+
+Response fields:
+
+- `ok`: required boolean. `false` shows a safe failure text unless `answer_text` is supplied.
+- `answer_text`: optional Telegram callback notification text. Hermes truncates it to Telegram's 200-character callback-answer limit. By default this appears as a lightweight toast.
+- `show_alert`: optional boolean; when true, Telegram shows `answer_text` as a popup alert instead of a toast.
+- `edit_message_text`: optional replacement text for the original bot message that contained the button.
+- `remove_keyboard`: optional boolean; removes the inline keyboard, either with the edit or by editing only the reply markup. When omitted or `false`, Hermes preserves the existing inline keyboard while editing the message.
+
+These fields can be combined for the desired UX:
+
+```json
+{"ok": true, "answer_text": "Saved"}
+```
+
+Shows a toast only.
+
+```json
+{"ok": true, "answer_text": "Cannot approve this draft", "show_alert": true}
+```
+
+Shows a popup alert only.
+
+```json
+{
+  "ok": true,
+  "answer_text": "draft '1234' accepted",
+  "edit_message_text": "✅ Draft 1234 accepted at 2026-06-04 03:15:00 UTC",
+  "remove_keyboard": true
+}
+```
+
+Shows a toast, edits the original button message, and removes the buttons for a one-shot decision.
+
+```json
+{
+  "ok": true,
+  "answer_text": "Mode changed",
+  "edit_message_text": "Current mode: review",
+  "remove_keyboard": false
+}
+```
+
+Shows a toast, edits the original button message, and keeps the buttons for continued interaction.
+
+Safety behavior:
+
+- Prefixes are limited to letters, numbers, `_`, and `-`, up to 32 characters.
+- Scripts must resolve inside `$HERMES_HOME/scripts/telegram-callbacks` and must be executable regular files; symlink escapes are rejected.
+- Callback authorization uses the same Telegram allowed user/chat/topic checks as built-in callbacks.
+- Scripts do not inherit the full gateway process environment. Arbitrary credential variables such as API keys, tokens, and secrets are not forwarded.
+- Callback data is exposed to the script as argv and environment variables; use opaque IDs or state references, not secrets, in button payloads.
+- Scripts run with argv/stdin, not through a shell, and time out after 10 seconds.
+- A non-zero script exit code fails the callback action even if stdout contains valid response JSON; Hermes does not apply stdout JSON from failed processes.
+- Script stdout and stderr are each capped at 64 KiB; oversized output fails safely.
+- Script stderr and callback payloads are not reflected back to the Telegram user on failure.
+
 ## Webhook Mode
 
 By default, Hermes connects to Telegram using **long polling** — the gateway makes outbound requests to Telegram's servers to fetch new updates. This works well for local and always-on deployments.


### PR DESCRIPTION
## What

Adds a generic Telegram inline-button callback script bridge for profile-local handlers:

- routes `callback_data` values shaped as `<prefix>:<payload>` to executable scripts under `$HERMES_HOME/scripts/telegram-callbacks/`
- passes a structured Telegram/Hermes context JSON document on stdin plus scoped environment metadata
- supports safe callback responses including toast/alert answers, message edits, reply markup replacement/removal, deletes, and no-op acknowledgements
- documents the callback script contract and examples in the Telegram messaging guide

## Why

Hermes can already send inline buttons, but callback handling needed core-code-specific hooks. This lets profile owners wire deterministic button behavior with local scripts while keeping callback payload routing generic and profile-scoped.

## Safety and robustness

- ignores malformed/unknown callback prefixes instead of intercepting normal Telegram callback flows
- authorizes callback users against the existing Telegram allowlist/home-chat checks
- bounds script execution with a 10s timeout and 2s kill wait
- caps stdout and stderr at 64 KiB each before parsing script output
- kills the script process tree with `psutil` on timeout/overflow to avoid orphan children
- avoids shell execution; callback scripts are launched directly with `asyncio.create_subprocess_exec`

## How to test

```bash
python scripts/check-windows-footguns.py --diff origin/main
python -m pytest tests/gateway/test_telegram_callback_script_bridge.py -q --tb=short -ra
```

Manual smoke test performed on Linux via a live Telegram DM with inline buttons covering:

- toast callback acknowledgement
- alert callback acknowledgement
- message edit preserving buttons
- final edit removing buttons

## Platforms tested

- Linux 6.8.0, Python test environment
- Live Telegram bot callback flow in a DM

## Notes

The full local suite was run and completed, producing **28,502 passed, 292 failed, 63 skipped, and 43 errors**. We reviewed the result and did not treat it as the blocking PR gate because the failures were outside this PR's Telegram callback scope. The feature-specific callback bridge suite passed **23/23**, and the broader Telegram selector was compared against `origin/main`; the observed `ParseMode` repr failures were already present upstream in this environment and therefore were not introduced by this branch.

No related issue.