### PR TITLE
Fix desktop IME composition submit handling

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime.test.ts
+++ b/apps/desktop/src/app/chat/composer/ime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { isImeComposing } from './ime'
+
+describe('isImeComposing', () => {
+  it('treats explicit composition state as active', () => {
+    expect(isImeComposing({}, true)).toBe(true)
+    expect(isImeComposing({ isComposing: true })).toBe(true)
+    expect(isImeComposing({ nativeEvent: { isComposing: true } })).toBe(true)
+  })
+
+  it('recognizes process-key events emitted while an IME owns Enter', () => {
+    expect(isImeComposing({ keyCode: 229 })).toBe(true)
+    expect(isImeComposing({ which: 229 })).toBe(true)
+    expect(isImeComposing({ nativeEvent: { keyCode: 229 } })).toBe(true)
+    expect(isImeComposing({ nativeEvent: { which: 229 } })).toBe(true)
+  })
+
+  it('leaves normal Enter key events alone', () => {
+    expect(isImeComposing({ keyCode: 13, nativeEvent: { keyCode: 13, isComposing: false } })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/ime.ts
+++ b/apps/desktop/src/app/chat/composer/ime.ts
@@ -1,0 +1,27 @@
+interface ImeKeyboardEventLike {
+  isComposing?: boolean
+  keyCode?: number
+  nativeEvent?: {
+    isComposing?: boolean
+    keyCode?: number
+    which?: number
+  }
+  which?: number
+}
+
+const IME_PROCESSING_KEY_CODE = 229
+
+export function isImeComposing(event: ImeKeyboardEventLike, composing = false) {
+  if (composing) {
+    return true
+  }
+
+  return (
+    event.isComposing === true ||
+    event.nativeEvent?.isComposing === true ||
+    event.keyCode === IME_PROCESSING_KEY_CODE ||
+    event.which === IME_PROCESSING_KEY_CODE ||
+    event.nativeEvent?.keyCode === IME_PROCESSING_KEY_CODE ||
+    event.nativeEvent?.which === IME_PROCESSING_KEY_CODE
+  )
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -3,6 +3,7 @@ import { ComposerPrimitive, useAui, useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import {
   type ClipboardEvent,
+  type CompositionEvent,
   type FormEvent,
   type KeyboardEvent,
   type DragEvent as ReactDragEvent,
@@ -55,6 +56,7 @@ import { useAtCompletions } from './hooks/use-at-completions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useVoiceConversation } from './hooks/use-voice-conversation'
 import { useVoiceRecorder } from './hooks/use-voice-recorder'
+import { isImeComposing } from './ime'
 import { dragHasAttachments, droppedFileInlineRef, insertInlineRefsIntoEditor } from './inline-refs'
 import { QueuePanel } from './queue-panel'
 import {
@@ -552,27 +554,39 @@ export function ChatBar({
     }
   }, [trigger])
 
+  const syncDraftFromEditor = useCallback(
+    (editor: HTMLDivElement) => {
+      if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
+        editor.replaceChildren()
+      }
+
+      const nextDraft = composerPlainText(editor)
+
+      if (nextDraft !== draftRef.current) {
+        draftRef.current = nextDraft
+        aui.composer().setText(nextDraft)
+      }
+
+      return nextDraft
+    },
+    [aui]
+  )
+
   const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
     // During IME composition the DOM contains uncommitted preedit text
-    // mixed with real content.  Skip state writes — compositionend will
-    // deliver the finalized text via a clean input event.
+    // mixed with real content. Skip state writes until compositionend,
+    // then sync the finalized text in one pass.
     if (composingRef.current) {
       return
     }
 
-    const editor = event.currentTarget
+    syncDraftFromEditor(event.currentTarget)
+    window.setTimeout(refreshTrigger, 0)
+  }
 
-    if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
-      editor.replaceChildren()
-    }
-
-    const nextDraft = composerPlainText(editor)
-
-    if (nextDraft !== draftRef.current) {
-      draftRef.current = nextDraft
-      aui.composer().setText(nextDraft)
-    }
-
+  const handleEditorCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
+    composingRef.current = false
+    syncDraftFromEditor(event.currentTarget)
     window.setTimeout(refreshTrigger, 0)
   }
 
@@ -664,7 +678,7 @@ export function ChatBar({
     // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
     // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
     // preedit fires submitDraft() and splits the message mid-word.
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    if (isImeComposing(event, composingRef.current)) {
       return
     }
 
@@ -1199,9 +1213,7 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
-        onCompositionEnd={() => {
-          composingRef.current = false
-        }}
+        onCompositionEnd={handleEditorCompositionEnd}
         onCompositionStart={() => {
           composingRef.current = true
         }}

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -13,6 +13,7 @@ import { useStore } from '@nanostores/react'
 import { IconPlayerStopFilled } from '@tabler/icons-react'
 import {
   type ClipboardEvent,
+  type CompositionEvent,
   type ComponentProps,
   type FC,
   type FocusEvent,
@@ -37,6 +38,7 @@ import {
 } from '@/app/chat/composer/focus'
 import { useAtCompletions } from '@/app/chat/composer/hooks/use-at-completions'
 import { useSlashCompletions } from '@/app/chat/composer/hooks/use-slash-completions'
+import { isImeComposing } from '@/app/chat/composer/ime'
 import { dragHasAttachments, droppedFileInlineRef, insertInlineRefsIntoEditor } from '@/app/chat/composer/inline-refs'
 import {
   composerPlainText,
@@ -875,6 +877,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   const rootRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef(draft)
+  const composingRef = useRef(false)
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
@@ -1187,6 +1190,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   }
 
   const handleInput = (event: FormEvent<HTMLDivElement>) => {
+    if (composingRef.current) {
+      return
+    }
+
     const editor = event.currentTarget
 
     if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
@@ -1194,6 +1201,12 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
     }
 
     syncDraftFromEditor(editor)
+    window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
+    composingRef.current = false
+    syncDraftFromEditor(event.currentTarget)
     window.setTimeout(refreshTrigger, 0)
   }
 
@@ -1246,6 +1259,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isImeComposing(event, composingRef.current)) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -1358,6 +1375,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               data-placeholder="Edit message"
               data-slot={RICH_INPUT_SLOT}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onCompositionEnd={handleCompositionEnd}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               onFocus={() => markActiveComposer('edit')}


### PR DESCRIPTION
## What changed

- Add a shared desktop composer IME detection helper.
- Prevent Enter from submitting while the main composer or edit composer is still composing IME text.
- Sync finalized contentEditable text on compositionend.
- Add focused tests for IME composition signals, including the process-key 229 fallback.

## Why

Chinese/Japanese/Korean IMEs use Enter to confirm candidate text. The desktop composer could treat that Enter as a submit action, sending the prompt before the user had finalized the intended text.

## Validation

- `npm -w apps/desktop run test:ui -- src/app/chat/composer/ime.test.ts src/app/chat/composer/slash-nav-dom-repro.test.tsx`
- `npm -w apps/desktop run type-check`
