### PR TITLE
fix(cli): use os.replace to safely rebuild venv when hermes.exe is running (#37881)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -105,19 +105,56 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
     old venv may point to a Python without FTS5, so we rebuild it with a
     fresh interpreter from the current managed uv.  Returns ``True`` on
     success.
+
+    The old venv is moved aside *atomically* before recreating, never deleted
+    in place.  On Windows a still-running ``hermes.exe`` (gateway/desktop) holds
+    ``venv\\Scripts\\python.exe`` open; ``shutil.rmtree(ignore_errors=True)``
+    would delete everything it *can* (site-packages, certifi's cert bundle) and
+    silently leave a half-gutted venv that the following ``uv venv`` then refuses
+    to overwrite ("directory already exists") — bricking the install.
+    ``os.replace`` fails fast and cleanly when the venv is in use, leaving it
+    untouched; and if the rebuild itself fails we move the old venv back so we
+    never leave Hermes with no venv at all.
     """
+    backup: Optional[Path] = None
     if venv_dir.exists():
         print(f"  → Rebuilding venv (old Python may lack FTS5)...")
-        shutil.rmtree(venv_dir, ignore_errors=True)
+        backup = venv_dir.with_name(venv_dir.name + ".old")
+        shutil.rmtree(backup, ignore_errors=True)  # clear any stale backup
+        try:
+            # Atomic move — fails (without partial deletion) if a process still
+            # holds files inside the venv, which is exactly the Windows file-lock
+            # case that previously bricked the install.
+            os.replace(venv_dir, backup)
+        except OSError as exc:
+            logger.warning("venv rebuild aborted — venv in use: %s", exc)
+            print(
+                "  ✗ venv rebuild aborted — the venv is in use; stop the "
+                f"gateway/desktop and retry ({exc})"
+            )
+            return False
 
     result = subprocess.run(
-        [uv_bin, "venv", str(venv_dir), "--python", python_version],
+        [uv_bin, "venv", str(venv_dir), "--python", python_version, "--clear"],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode == 0:
         venv_python = venv_dir / ("Scripts" if platform.system() == "Windows" else "bin") / "python"
+        if not venv_python.exists():
+            logger.warning("venv rebuild reported success but %s is missing", venv_python)
+            print(f"  ✗ venv rebuild failed: Python interpreter missing at {venv_python}")
+            if backup is not None:
+                shutil.rmtree(venv_dir, ignore_errors=True)
+                try:
+                    os.replace(backup, venv_dir)
+                    print("  ↩ Restored previous venv.")
+                except OSError:
+                    pass
+            return False
+        if backup is not None:
+            shutil.rmtree(backup, ignore_errors=True)
         py_ver = subprocess.run(
             [str(venv_python), "--version"],
             capture_output=True,
@@ -127,6 +164,12 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
         print(f"  ✓ venv rebuilt ({py_ver})")
         return True
     else:
+        if backup is not None and not venv_dir.exists():
+            try:
+                os.replace(backup, venv_dir)
+                print("  ↩ Restored previous venv after failed rebuild.")
+            except OSError:
+                pass
         logger.warning("venv rebuild failed: %s", result.stderr)
         print(f"  ✗ venv rebuild failed: {result.stderr.strip()}")
         return False

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -108,38 +108,80 @@ class TestEnsureUv:
 # ---------------------------------------------------------------------------
 
 class TestRebuildVenv:
-    def test_removes_old_venv_and_creates_new(self, tmp_path):
+    def test_moves_old_venv_aside_and_creates_new(self, tmp_path):
         venv_dir = tmp_path / "venv"
         venv_dir.mkdir()
         (venv_dir / "old_file").write_text("stale")
 
         uv_bin = str(tmp_path / "bin" / "uv")
+        seen_cmds = []
 
         def fake_run(cmd, **kwargs):
+            seen_cmds.append(cmd)
             m = MagicMock(returncode=0)
             if cmd[1] == "venv":
-                # Simulate uv creating the venv dir
                 venv_dir.mkdir(exist_ok=True)
-                bin_dir = venv_dir / "bin"
-                bin_dir.mkdir(parents=True, exist_ok=True)
-                (bin_dir / "python").write_text("#!/bin/sh\necho Python 3.11.0")
+                for sub in ("bin", "Scripts"):
+                    bin_dir = venv_dir / sub
+                    bin_dir.mkdir(parents=True, exist_ok=True)
+                    (bin_dir / "python").write_text("#!/bin/sh\necho Python 3.11.0")
             elif "--version" in cmd:
                 m.stdout = "Python 3.11.0"
             return m
 
-        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
-             patch("hermes_cli.managed_uv.shutil.rmtree") as mock_rmtree:
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run):
             from hermes_cli.managed_uv import rebuild_venv
             result = rebuild_venv(uv_bin, venv_dir)
             assert result is True
-            mock_rmtree.assert_called_once_with(venv_dir, ignore_errors=True)
+            assert venv_dir.exists()
+            assert not (venv_dir / "old_file").exists()
+            # backup cleaned up after success
+            assert not (tmp_path / "venv.old").exists()
+            # uv venv called with --clear
+            venv_cmd = next(c for c in seen_cmds if c[1] == "venv")
+            assert "--clear" in venv_cmd
+
+    def test_aborts_without_deleting_when_venv_in_use(self, tmp_path):
+        """Regression: venv in use (Windows file lock) must be left intact.
+
+        Previously shutil.rmtree(ignore_errors=True) deleted what it could
+        and left a gutted venv.  Now os.replace fails fast and the venv is
+        untouched, with no uv venv attempted.
+        """
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        marker = venv_dir / "site-packages-marker"
+        marker.write_text("do not delete me")
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch("hermes_cli.managed_uv.os.replace", side_effect=OSError("in use")), \
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is False
+            mock_run.assert_not_called()
+            assert marker.exists()
+
+    def test_restores_backup_on_rebuild_failure(self, tmp_path):
+        """If uv venv fails, the moved-aside venv is restored."""
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        (venv_dir / "good_site_packages").write_text("intact")
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="uv error")
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is False
+            assert venv_dir.exists()
+            assert (venv_dir / "good_site_packages").exists()
 
     def test_rebuild_failure_returns_false(self, tmp_path):
         venv_dir = tmp_path / "venv"
         uv_bin = str(tmp_path / "bin" / "uv")
 
-        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
-             patch("hermes_cli.managed_uv.shutil.rmtree"):
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="nope")
             from hermes_cli.managed_uv import rebuild_venv
             result = rebuild_venv(uv_bin, venv_dir)


### PR DESCRIPTION
## Summary

Replace `shutil.rmtree(ignore_errors=True)` in `rebuild_venv()` with an atomic `os.replace()` move-aside before recreating the venv.

## Root cause (fixes #37881)

When `hermes.exe` / `python.exe` is running, Windows holds an exclusive lock on `venv\Scripts\python.exe`. `shutil.rmtree(ignore_errors=True)` deletes everything it *can* (site-packages, certifi's cert bundle) but silently fails on the locked interpreter, leaving a half-gutted venv. The following `uv venv` then refuses to overwrite ("directory already exists") — bricking the install. Every later HTTPS call dies with `FileNotFoundError` for the missing cert bundle. No automatic recovery: the venv must be rebuilt by hand.

## Fix

`os.replace(venv_dir, backup)` atomically renames the venv directory. On Windows, renaming a directory containing a running exe **succeeds** (only deletion fails with `ERROR_SHARING_VIOLATION`). If the rename fails (venv is locked by an open handle on the dir itself), `rebuild_venv` aborts cleanly without touching the existing venv and tells the user to stop the gateway/desktop. If the rebuild fails, the backup is restored.

> Note: this supersedes the `--clear`-only approach — `uv venv --clear` still cannot delete a locked `python.exe`, so it hits the same `ERROR_SHARING_VIOLATION` as `rmtree`. The move-aside is what actually prevents the brick.

## Test plan
- [ ] `test_moves_old_venv_aside_and_creates_new` — happy path, backup cleaned up
- [ ] `test_aborts_without_deleting_when_venv_in_use` — `os.replace` raises OSError → `False` returned, existing venv intact, `uv venv` never called
- [ ] `test_restores_backup_on_rebuild_failure` — `uv venv` exits non-zero → backup restored, `False` returned
- [ ] `test_rebuild_failure_returns_false` — no existing venv, `uv venv` fails → `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
