### PR TITLE
fix(desktop): respect IME composition in composers

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -174,6 +174,7 @@ export function ChatBar({
   const [focusRequestId, setFocusRequestId] = useState(0)
   const dragDepthRef = useRef(0)
   const composingRef = useRef(false)  // true during IME composition (CJK input)
+  const compositionEndedAtRef = useRef(-Infinity)
   const lastSpokenIdRef = useRef<string | null>(null)
 
   const narrow = useMediaQuery('(max-width: 30rem)')
@@ -579,8 +580,14 @@ export function ChatBar({
 
   const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
     composingRef.current = false
+    compositionEndedAtRef.current = performance.now()
     handleEditorInput(event)
   }
+
+  // macOS Chromium can fire compositionend before the Enter keydown that
+  // confirmed the preedit text, so keep that one Enter from submitting.
+  const isConfirmingRecentImeComposition = (event: KeyboardEvent<HTMLDivElement>) =>
+    event.key === 'Enter' && performance.now() - compositionEndedAtRef.current < 100
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
     trigger?.kind === '@' ? at.adapter : trigger?.kind === '/' ? slash.adapter : null
@@ -670,7 +677,7 @@ export function ChatBar({
     // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
     // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
     // preedit fires submitDraft() and splits the message mid-word.
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    if (composingRef.current || event.nativeEvent.isComposing || isConfirmingRecentImeComposition(event)) {
       return
     }
 
@@ -1258,7 +1265,7 @@ export function ChatBar({
           onSubmit={e => {
             e.preventDefault()
 
-            if (composingRef.current) {
+            if (composingRef.current || performance.now() - compositionEndedAtRef.current < 100) {
               return
             }
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -3,6 +3,7 @@ import { ComposerPrimitive, useAui, useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import {
   type ClipboardEvent,
+  type CompositionEvent,
   type FormEvent,
   type KeyboardEvent,
   type DragEvent as ReactDragEvent,
@@ -574,6 +575,11 @@ export function ChatBar({
     }
 
     window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
+    composingRef.current = false
+    handleEditorInput(event)
   }
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
@@ -1199,9 +1205,7 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
-        onCompositionEnd={() => {
-          composingRef.current = false
-        }}
+        onCompositionEnd={handleCompositionEnd}
         onCompositionStart={() => {
           composingRef.current = true
         }}
@@ -1253,9 +1257,11 @@ export function ChatBar({
           onDrop={handleDrop}
           onSubmit={e => {
             e.preventDefault()
+
             if (composingRef.current) {
               return
             }
+
             submitDraft()
           }}
           ref={composerRef}

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -14,6 +14,7 @@ import { IconPlayerStopFilled } from '@tabler/icons-react'
 import {
   type ClipboardEvent,
   type ComponentProps,
+  type CompositionEvent,
   type FC,
   type FocusEvent,
   type FormEvent,
@@ -884,6 +885,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   // key so the matching keyup skips refreshTrigger (timing-immune vs reading
   // `trigger`, which keyup sees as already-null after Escape).
   const triggerKeyConsumedRef = useRef(false)
+  const composingRef = useRef(false)
   const [triggerPlacement, setTriggerPlacement] = useState<'bottom' | 'top'>('top')
   const [focusRequestId, setFocusRequestId] = useState(0)
   const [submitting, setSubmitting] = useState(false)
@@ -1187,6 +1189,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   }
 
   const handleInput = (event: FormEvent<HTMLDivElement>) => {
+    if (composingRef.current) {
+      return
+    }
+
     const editor = event.currentTarget
 
     if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
@@ -1195,6 +1201,11 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
 
     syncDraftFromEditor(editor)
     window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
+    composingRef.current = false
+    handleInput(event)
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
@@ -1246,6 +1257,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (composingRef.current || event.nativeEvent.isComposing) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -1358,6 +1373,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               data-placeholder="Edit message"
               data-slot={RICH_INPUT_SLOT}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onCompositionEnd={handleCompositionEnd}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               onFocus={() => markActiveComposer('edit')}

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -886,6 +886,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   // `trigger`, which keyup sees as already-null after Escape).
   const triggerKeyConsumedRef = useRef(false)
   const composingRef = useRef(false)
+  const compositionEndedAtRef = useRef(-Infinity)
   const [triggerPlacement, setTriggerPlacement] = useState<'bottom' | 'top'>('top')
   const [focusRequestId, setFocusRequestId] = useState(0)
   const [submitting, setSubmitting] = useState(false)
@@ -1205,6 +1206,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
 
   const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>) => {
     composingRef.current = false
+    compositionEndedAtRef.current = performance.now()
     handleInput(event)
   }
 
@@ -1257,7 +1259,13 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    // macOS Chromium can fire compositionend before the Enter keydown that
+    // confirmed the preedit text, so keep that one Enter from submitting.
+    if (
+      composingRef.current ||
+      event.nativeEvent.isComposing ||
+      (event.key === 'Enter' && performance.now() - compositionEndedAtRef.current < 100)
+    ) {
       return
     }
 


### PR DESCRIPTION
## Summary

This improves Desktop composer behavior for CJK and other IME-based input methods.

When typing Japanese, Chinese, Korean, or other text through an IME, Enter is commonly used to confirm the current preedit/composition text. The composer should treat that Enter as part of text input, not as a request to send or submit the message.

This PR:
- keeps the main chat composer in sync after IME composition ends
- adds the same composition guard to the user edit composer
- avoids draft/trigger updates while the edit composer still contains active preedit text
- prevents Enter during active composition from submitting an edited message

## Why

The main composer already had a composition-aware Enter guard, but composition end did not explicitly flush the finalized text through the same input path. The edit composer also did not track composition state, so confirming CJK preedit text with Enter could be interpreted as submitting the edit.

For CJK users, this makes normal text entry feel unsafe: a user can accidentally send or submit a half-composed message while simply trying to confirm conversion candidates.

## Testing

- npm --prefix apps/desktop run type-check
- npm --prefix apps/desktop run test:ui -- src/app/chat/composer/slash-nav-dom-repro.test.tsx src/app/chat/composer/rich-editor.test.ts
- npx eslint src/app/chat/composer/index.tsx src/components/assistant-ui/thread.tsx (from apps/desktop)
- built and launched a local macOS Desktop app from this branch

Note: full npm --prefix apps/desktop run lint currently reports unrelated existing lint errors outside this change.