### PR TITLE
fix(api_server): mark missing/placeholder API_SERVER_KEY as non-retry…

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4144,11 +4144,12 @@ class APIServerAdapter(BasePlatformAdapter):
             # dispatch terminal-capable agent work, so every deployment needs
             # an explicit API_SERVER_KEY regardless of bind address.
             if not self._api_key:
-                logger.error(
-                    "[%s] Refusing to start: API_SERVER_KEY is required for the API server, "
-                    "including loopback-only binds on %s.",
-                    self.name, self._host,
+                message = (
+                    f"API_SERVER_KEY is required for the API server, "
+                    f"including loopback-only binds on {self._host}"
                 )
+                logger.error("[%s] Refusing to start: %s", self.name, message)
+                self._set_fatal_error("api_server_missing_key", message, retryable=False)
                 return False
 
             # Refuse to start network-accessible with a placeholder key.
@@ -4157,13 +4158,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 try:
                     from hermes_cli.auth import has_usable_secret
                     if not has_usable_secret(self._api_key, min_length=8):
-                        logger.error(
-                            "[%s] Refusing to start: API_SERVER_KEY is set to a "
-                            "placeholder value. Generate a real secret "
-                            "(e.g. `openssl rand -hex 32`) and set API_SERVER_KEY "
-                            "before exposing the API server on %s.",
-                            self.name, self._host,
+                        message = (
+                            f"API_SERVER_KEY is set to a placeholder value. "
+                            f"Generate a real secret (e.g. `openssl rand -hex 32`) "
+                            f"and set API_SERVER_KEY before exposing the API server on {self._host}"
                         )
+                        logger.error("[%s] Refusing to start: %s", self.name, message)
+                        self._set_fatal_error("api_server_placeholder_key", message, retryable=False)
                         return False
                 except ImportError:
                     pass

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3495,3 +3495,77 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
+
+
+# ---------------------------------------------------------------------------
+# connect() — fatal-error signalling on missing / placeholder API_SERVER_KEY
+# ---------------------------------------------------------------------------
+
+
+class TestConnectFatalErrors:
+    """Verify that APIServerAdapter.connect() marks non-retryable fatal errors
+    when API_SERVER_KEY is missing or a placeholder, instead of returning
+    False silently (which causes infinite reconnect loops — #37011).
+    """
+
+    @pytest.fixture
+    def config_no_key(self, tmp_path, monkeypatch):
+        """PlatformConfig with no API_SERVER_KEY set."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
+        return PlatformConfig(enabled=True)
+
+    @pytest.fixture
+    def config_placeholder_key(self, tmp_path, monkeypatch):
+        """PlatformConfig with a placeholder API_SERVER_KEY.
+
+        The placeholder check only fires when the bind host is
+        network-accessible, so bind 0.0.0.0 (loopback would skip the
+        branch entirely).  "test" is 4 chars < min_length=8, so
+        has_usable_secret() rejects it as a placeholder.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("API_SERVER_KEY", "test")
+        return PlatformConfig(
+            enabled=True,
+            extra={"key": "test", "host": "0.0.0.0"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_key_sets_fatal_error(self, config_no_key):
+        adapter = APIServerAdapter(config_no_key)
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error
+        assert not adapter.fatal_error_retryable
+        assert "api_server_missing_key" in adapter.fatal_error_code
+
+    @pytest.mark.asyncio
+    async def test_connect_placeholder_key_sets_fatal_error(self, config_placeholder_key):
+        adapter = APIServerAdapter(config_placeholder_key)
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error
+        assert not adapter.fatal_error_retryable
+        assert "api_server_placeholder_key" in adapter.fatal_error_code
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_response_store(self, config_no_key):
+        """A failed connect() leaves the adapter in a disposable, fatal state
+        and disconnect() must close the ResponseStore SQLite connection so the
+        gateway's _dispose_unused_adapter cleanup reclaims the FD (#37011)."""
+        adapter = APIServerAdapter(config_no_key)
+        store = adapter._response_store
+        # The store is open before connect().
+        assert store._conn is not None
+        await adapter.connect()
+        # The fatal-error state is what signals the gateway to dispose this
+        # adapter (instead of retrying and leaking another connection).
+        assert adapter.has_fatal_error
+        # disconnect() — invoked by _dispose_unused_adapter in production —
+        # must close the SQLite connection.
+        await adapter.disconnect()
+        # After disconnect the connection is closed; using it raises.
+        import sqlite3
+        with pytest.raises(sqlite3.ProgrammingError):
+            store._conn.execute("SELECT 1")


### PR DESCRIPTION
…able fatal error

When API_SERVER_KEY is absent or set to a placeholder value, the APIServerAdapter.connect() method returned False without setting has_fatal_error. This caused the gateway reconnect loop to treat it as a transient retryable failure, retrying every 300s indefinitely.

Each retry created a new APIServerAdapter (which opens a SQLite connection via ResponseStore) but never disconnected the failed instance. Over ~2.5 days this leaked ~501 sqlite connections (1002 FDs), exhausting the default 1024 soft limit and making the entire gateway unresponsive (OSError: [Errno 24] Too many open files).

Fix: call _set_fatal_error(..., retryable=False) before returning False, matching how weixin handles missing credentials. The gateway's _dispose_unused_adapter cleanup (already merged) handles FD reclamation from here.

Test: TestConnectFatalErrors covers both the missing-key and placeholder-key paths (fatal_error set, non-retryable) and verifies disconnect() closes the ResponseStore SQLite connection.

Refs: #37011

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

