### PR TITLE
fix(matrix): propagate room name from room state to session source

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1857,9 +1857,11 @@ class MatrixAdapter(BasePlatformAdapter):
             self._threads.mark(thread_id)
 
         display_name = await self._get_display_name(room_id, sender)
+        room_info = await self.get_chat_info(room_id)
         source = self.build_source(
             chat_id=room_id,
-            chat_type=chat_type,
+            chat_name=room_info["name"],
+            chat_type=room_info["type"],
             user_id=sender,
             user_name=display_name,
             thread_id=thread_id,

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1858,11 +1858,11 @@ class MatrixAdapter(BasePlatformAdapter):
             self._threads.mark(thread_id)
 
         display_name = await self._get_display_name(room_id, sender)
-        room_info = await self.get_chat_info(room_id)
+        chat_info = await self.get_chat_info(room_id)
         source = self.build_source(
             chat_id=room_id,
-            chat_name=room_info["name"],
-            chat_type=room_info["type"],
+            chat_name=chat_info.get("name"),
+            chat_type=chat_info.get("type", chat_type),
             user_id=sender,
             user_name=display_name,
             thread_id=thread_id,

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1157,6 +1157,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
                 if name_evt and hasattr(name_evt, "name") and name_evt.name:
                     name = name_evt.name
+                    chat_type = "group"  # Named rooms are workspaces, not DMs
             except Exception:
                 pass
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2160,6 +2160,7 @@ class TestMatrixReadReceipts:
     async def test_accepted_message_schedules_read_receipt(self):
         self.adapter._is_dm_room = AsyncMock(return_value=True)
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter.get_chat_info = AsyncMock(return_value={"name": "Room Alpha", "type": "dm"})
         self.adapter._background_read_receipt = MagicMock()
 
         ctx = await self.adapter._resolve_message_context(
@@ -2732,6 +2733,7 @@ class TestMatrixDmAutoThread:
         self.adapter = _make_adapter()
         self.adapter._is_dm_room = AsyncMock(return_value=True)
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter.get_chat_info = AsyncMock(return_value={"name": "DM Chat", "type": "dm"})
         self.adapter._background_read_receipt = MagicMock()
         # Disable require_mention so DMs pass gating
         self.adapter._require_mention = False


### PR DESCRIPTION
## Summary

Two one-line fixes in `gateway/platforms/matrix.py` to ensure Matrix rooms are identifiable in session context:

**Fix 1** (first commit): `_resolve_message_context()` now calls `get_chat_info()` to resolve the Matrix room name from `m.room.name` state and passes `chat_name` + `chat_type` to `build_source()`. Previously these were omitted — every room showed as the sender display name.

**Fix 2** (second commit): `get_chat_info()` now overrides `chat_type` to `"group"` when a room has `m.room.name`. A named Matrix room is semantically a workspace, not a personal DM, regardless of member count.

Together these ensure named rooms appear as `"group: RoomName"` in session source descriptions instead of the generic `"DM with AVP"`.

## Problem

The Matrix adapter was omitting `chat_name` when building session sources. Even after fix 1 propagated the room name, `session.py` ignored `chat_name` for `chat_type="dm"` rooms. Since all self-hosted Matrix rooms are 2-person (user + bot), `_is_dm_room()` returned True for every room — making all rooms appear identical in the system prompt.

## Data flow (after both fixes)

```
Matrix message arrives in "Development" room
  → _resolve_message_context()
    → get_chat_info(room_id)
      → _is_dm_room() → True → chat_type = "dm"
      → get_state_event(m.room.name) → "Development"
      → name = "Development"
      → chat_type = "group"  ← FIX 2: named room = workspace
    → build_source(chat_name="Development", chat_type="group")
  → SessionSource.description → "group: Development"
  → Agent prompt: "Source: Matrix (group: Development)"
```

| Room | Members | Has m.room.name? | chat_type | Prompt shows |
|---|---|---|---|---|
| Actual DM with user | 2 | No | `"dm"` | `"DM with AVP"` (unchanged) |
| Development | 2 | Yes | `"group"` | `"group: Development"` |
| Homeassistant | 2 | Yes | `"group"` | `"group: Homeassistant"` |

## Design consistency

| Adapter | `chat_name` source |
|---|---|
| WhatsApp | `data.get("chatName")` |
| Telegram | `chat.title` |
| Matrix (before) | *(omitted)* |
| Matrix (after) | `get_chat_info()` → `m.room.name` |

## Session migration

- **New sessions:** Immediately correct — `chat_type` is `"group"` for named rooms.
- **Existing sessions:** Have `chat_type="dm"` baked into the session key and data. They must be deleted for the fix to take effect. `sessions.json` and `channel_directory.json` will auto-rebuild on next messages.
- **No data loss:** Honcho memory, local memory, skills, config, and cron jobs are untouched.

To apply on an existing deployment:
```bash
systemctl --user stop hermes-gateway
rm ~/.hermes/sessions/sessions.json
rm ~/.hermes/sessions/session_*.json    # optional: individual session traces
rm ~/.hermes/channel_directory.json
systemctl --user start hermes-gateway
```

## Verification

1. Send a message from a named Matrix room (Development, Homeassistant, etc.)
2. Check `~/.hermes/sessions/sessions.json` — origin should show `chat_type: "group"` and correct `display_name`
3. Agent system prompt should show `"Source: Matrix (group: Development)"` instead of `"Source: Matrix (DM with AVP)"`

Closes #38805