### PR TITLE
fix(desktop): prevent thinking block from closing mid-streaming

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -438,7 +438,7 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
       s.thread.isRunning &&
       s.message.status?.type === 'running' &&
       s.message.parts
-        .slice(Math.max(0, startIndex), Math.min(s.message.parts.length, endIndex))
+        .slice(Math.max(0, startIndex))
         .some(p => p?.type === 'reasoning' && p.status?.type !== 'complete')
   )
 


### PR DESCRIPTION
## Summary

Fixes a bug where the Thinking/Reasoning disclosure block auto-closes while reasoning text is still actively streaming. Reported as: block closes suddenly when thinking text gets long enough, during active streaming.

## Root Cause

`ReasoningAccordionGroup` checks whether any reasoning part in a fixed range `[startIndex, endIndex)` is still pending:

```tsx
s.message.parts
  .slice(startIndex, Math.min(s.message.parts.length, endIndex))
  .some(p => p?.type === 'reasoning' && p.status?.type !== 'complete')
```

During streaming, new reasoning parts can be appended to `s.message.parts` **beyond `endIndex`** (which was fixed at component mount time). When the original part completes and a new part starts beyond the range, `.some()` returns false → `pending = false` → block closes.

## Fix

Remove the `endIndex` cap from `slice()` — check all parts from `startIndex` onward:

```tsx
s.message.parts
  .slice(Math.max(0, startIndex))  // no endIndex cap
  .some(p => p?.type === 'reasoning' && p.status?.type !== 'complete')
```

Since `startIndex` still scopes to this reasoning group's beginning, and the `p?.type === 'reasoning'` filter excludes non-reasoning parts (tool calls, etc.), removing the end bound is safe — newly appended reasoning parts are now correctly detected.

## Verification
- TypeScript compiles cleanly
- Existing behavior unchanged when no new parts are appended
