### PR TITLE
fix(install): scope npm installs/audits to avoid pulling in apps/desktop

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1454,18 +1454,29 @@ def run_doctor(args):
     # npm audit for all Node.js packages
     _npm_bin = _safe_which("npm")
     if _npm_bin:
-        npm_dirs = [
-            (PROJECT_ROOT, "Browser tools (agent-browser)"),
-            (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge"),
+        # Each entry: (cwd, label, extra_audit_args)
+        # PROJECT_ROOT is audited with --workspaces=false so that the apps/*
+        # glob (which pulls in Electron, node-pty, etc.) is never resolved
+        # for a routine security check. The web and ui-tui workspaces are
+        # audited separately via --workspace flags. See #38772.
+        npm_audit_targets = [
+            (PROJECT_ROOT, "Browser tools (agent-browser)", ["--workspaces=false"]),
+            (PROJECT_ROOT, "web workspace", ["--workspace", "web"]),
+            (PROJECT_ROOT, "ui-tui workspace", ["--workspace", "ui-tui"]),
+            (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge", []),
         ]
-        for npm_dir, label in npm_dirs:
-            if not (npm_dir / "node_modules").exists():
+        for npm_dir, label, audit_extra in npm_audit_targets:
+            # For workspace-scoped audits run from PROJECT_ROOT the
+            # node_modules check must use the workspace root; standalone dirs
+            # (whatsapp-bridge) check their own node_modules.
+            check_dir = npm_dir if audit_extra else npm_dir
+            if not (check_dir / "node_modules").exists():
                 continue
             try:
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).
                 audit_result = subprocess.run(
-                    [_npm_bin, "audit", "--json"],
+                    [_npm_bin, "audit", "--json", *audit_extra],
                     cwd=str(npm_dir),
                     capture_output=True, text=True, timeout=30,
                 )
@@ -1476,12 +1487,20 @@ def run_doctor(args):
                 high = vuln_count.get("high", 0)
                 moderate = vuln_count.get("moderate", 0)
                 total = critical + high + moderate
+                # Determine a scoped fix command for the remediation hint.
+                if audit_extra and audit_extra[0] == "--workspace":
+                    fix_scope = " ".join(audit_extra)
+                    fix_cmd = f"cd {npm_dir} && npm audit fix {fix_scope}"
+                elif audit_extra == ["--workspaces=false"]:
+                    fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
+                else:
+                    fix_cmd = f"cd {npm_dir} && npm audit fix"
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
                     check_warn(
                         f"{label} deps",
-                        f"({critical} critical, {high} high, {moderate} moderate — run: cd {npm_dir} && npm audit fix)"
+                        f"({critical} critical, {high} high, {moderate} moderate — run: {fix_cmd})"
                     )
                     issues.append(
                         f"{label} has {total} npm "

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1469,7 +1469,7 @@ def run_doctor(args):
             # For workspace-scoped audits run from PROJECT_ROOT the
             # node_modules check must use the workspace root; standalone dirs
             # (whatsapp-bridge) check their own node_modules.
-            check_dir = npm_dir if audit_extra else npm_dir
+            check_dir = PROJECT_ROOT if audit_extra else npm_dir
             if not (check_dir / "node_modules").exists():
                 continue
             try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7007,7 +7007,11 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     r1 = _run_npm_install_deterministic(
         npm,
         _workspace_root(web_dir),
-        extra_args=("--silent",),
+        # Scope install to the web workspace only so that the full workspace
+        # graph (including apps/desktop with its Electron + node-pty deps) is
+        # never resolved here.  Without --workspace the root package.json's
+        # apps/* glob would pull in desktop on every web build. See #38772.
+        extra_args=("--silent", "--workspace", "web"),
     )
     if r1.returncode != 0:
         _say(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1532,7 +1532,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
         result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+            # --workspace ui-tui avoids resolving apps/desktop. See #38772.
+            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false",
+             "--workspace", "ui-tui"],
             cwd=str(_workspace_root(tui_dir)),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -7020,7 +7022,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         )
         _relay(r1)
         if fatal:
-            _say("  Run manually:  cd web && npm install && npm run build")
+            _say("  Run manually:  npm install --workspace web && npm run build -w web")
         return False
     # First attempt — stream output via idle-timeout helper (issue #33788).
     # capture_output=True on a long Vite build looks identical to a hang;
@@ -7062,7 +7064,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         )
         _relay(r2)
         if fatal:
-            _say("  Run manually:  cd web && npm install && npm run build")
+            _say("  Run manually:  npm install --workspace web && npm run build -w web")
         return False
     _say("  ✓ Web UI built")
     return True

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12354,7 +12354,7 @@ def cmd_dashboard(args):
         )
         if not (_dist_root / "index.html").exists():
             print(f"✗ --skip-build was passed but no web dist found at: {_dist_root}")
-            print("  Pre-build first:  cd web && npm install && npm run build")
+            print("  Pre-build first:  npm install --workspace web && npm run build -w web")
             print("  Or drop --skip-build to build automatically.")
             sys.exit(1)
         print(f"→ Skipping web UI build (--skip-build); using dist at {_dist_root}")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -846,14 +846,17 @@ def _run_post_setup(post_setup_key: str):
             # batch shims).  On POSIX npm_bin is the plain path — same
             # behaviour as before.
             result = subprocess.run(
-                [npm_bin, "install", "--silent"],
+                # --workspaces=false restricts the install to the repo root
+                # only, avoiding the apps/* glob which would pull in
+                # apps/desktop (Electron + node-pty) unnecessarily. See #38772.
+                [npm_bin, "install", "--silent", "--workspaces=false"],
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT)
             )
             if result.returncode == 0:
                 _print_success("    Node.js dependencies installed")
             else:
                 from hermes_constants import display_hermes_home
-                _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install")
+                _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
                 if result.stderr:
                     _print_info(f"      {result.stderr.strip()[:200]}")
         elif not node_modules.exists():
@@ -951,13 +954,14 @@ def _run_post_setup(post_setup_key: str):
             import subprocess
             # Absolute npm path so .cmd shim executes on Windows.
             result = subprocess.run(
-                [_npm_bin, "install", "--silent"],
+                # --workspaces=false avoids resolving apps/desktop. See #38772.
+                [_npm_bin, "install", "--silent", "--workspaces=false"],
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT)
             )
             if result.returncode == 0:
                 _print_success("    Camofox installed")
             else:
-                _print_warning("    npm install failed - run manually: npm install")
+                _print_warning("    npm install failed - run manually: npm install --workspaces=false")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")

--- a/package.json
+++ b/package.json
@@ -10,7 +10,17 @@
     "web"
   ],
   "scripts": {
-    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'"
+    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'",
+    "install:root": "npm install --workspaces=false",
+    "install:web": "npm install --workspace web",
+    "install:tui": "npm install --workspace ui-tui",
+    "install:desktop": "npm install --workspace apps/desktop",
+    "audit:root": "npm audit --workspaces=false",
+    "audit:web": "npm audit --workspace web",
+    "audit:tui": "npm audit --workspace ui-tui",
+    "audit:fix:root": "npm audit fix --workspaces=false",
+    "audit:fix:web": "npm audit fix --workspace web",
+    "audit:fix:tui": "npm audit fix --workspace ui-tui"
   },
   "repository": {
     "type": "git",

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -277,7 +277,7 @@ class TestCmdUpdateBranchFallback:
             # The web/ install runs from the workspace root when the root
             # lockfile exists (npm workspaces hoist node_modules upward).
             assert npm_calls[2:] == [
-                (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT),
+                (["/usr/bin/npm", "ci", "--silent", "--workspace", "web"], PROJECT_ROOT),
             ]
 
         # The web UI build itself went through the streaming helper.

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -299,3 +299,36 @@ def test_no_stray_lockfiles_in_workspace_subdirs(main_mod) -> None:
         "delete them and run `npm install` from the repo root instead: "
         + ", ".join(str(d / "package-lock.json") for d in stray)
     )
+
+
+def test_tui_launch_install_uses_workspace_scope(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """TUI launch npm install must pass --workspace ui-tui to avoid pulling apps/desktop."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist" / "entry.js").parent.mkdir(parents=True)
+    (tui_dir / "dist" / "entry.js").write_text("console.log('tui')")
+    # workspace root: parent has lockfile, tui_dir does not
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    npm_calls = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0].endswith("npm"):
+            npm_calls.append(cmd)
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert npm_calls, "expected npm install to be called"
+    install_cmd = npm_calls[0]
+    assert "--workspace" in install_cmd
+    assert "ui-tui" in install_cmd

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -140,6 +140,19 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["encoding"] == "utf-8"
         assert kwargs["errors"] == "replace"
 
+    def test_npm_install_uses_workspace_web_scope(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        build_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run, \
+             patch("hermes_cli.main._run_with_idle_timeout", return_value=build_ok):
+            result = _build_web_ui(web_dir)
+        assert result is True
+        install_cmd = mock_run.call_args[0][0]
+        assert "--workspace" in install_cmd
+        assert install_cmd[install_cmd.index("--workspace") + 1] == "web"
+
     def test_web_build_uses_idle_timeout_helper(self, tmp_path):
         """npm run build now goes through _run_with_idle_timeout (issue #33788).
 


### PR DESCRIPTION
## Summary

Fixes #38772.

The root `package.json` `workspaces: ["apps/*", ...]` glob unconditionally pulls `apps/desktop` (Electron + `node-pty@1.1.0`, ~200 MB, requires `make`/`g++` to build from source) into every unscoped `npm` command run from the repo root. This patch adds explicit workspace scoping to every internal `npm install` / `npm audit` call in the codebase, and adds convenience scripts to `package.json` so developers don't have to remember the right flags.

## Changes

### `hermes_cli/main.py` — `_build_web_ui`
- Add `--workspace web` to the `npm ci` / `npm install` call inside `_build_web_ui()`, so only the `web` workspace deps are resolved when building the dashboard frontend. Previously the call ran against the workspace root without scoping, triggering full `apps/*` resolution on every web rebuild.
- Update all manual-recovery hints to use the scoped form `npm install --workspace web && npm run build -w web` so users following the hint don't accidentally trigger a desktop rebuild.

### `hermes_cli/main.py` — TUI launch path
- Add `--workspace ui-tui` to the inline `npm install` that runs when launching `hermes tui` with missing deps. Previously this ran unscoped from `PROJECT_ROOT`, resolving `apps/*` including desktop.

### `hermes_cli/tools_config.py`
- Add `--workspaces=false` to the `npm install --silent` calls that install root-level browser tool deps (agent-browser, Camofox). Root deps live in the root `package.json` and don't need any workspace to be resolved.

### `hermes_cli/doctor.py` — `run_doctor` npm audit block
- Replace the single unscoped `npm audit --json` at `PROJECT_ROOT` with three scoped invocations: `--workspaces=false` for root deps, `--workspace web` for the web workspace, and `--workspace ui-tui` for the TUI workspace.
- Update the remediation hint in each warning to use the matching scoped `npm audit fix` command, so users aren't directed to run an unscoped fix that would rebuild `node-pty`.
- Fix `check_dir` tautology: `npm_dir if audit_extra else npm_dir` always evaluated to `npm_dir`; corrected to `PROJECT_ROOT if audit_extra else npm_dir` so workspace-scoped audits check the workspace root's `node_modules`.

### `package.json`
Add convenience npm scripts for the most common scoped operations:

| Script | What it does |
|--------|-------------|
| `npm run install:root` | `npm install --workspaces=false` |
| `npm run install:web` | `npm install --workspace web` |
| `npm run install:tui` | `npm install --workspace ui-tui` |
| `npm run install:desktop` | `npm install --workspace apps/desktop` |
| `npm run audit:root` | `npm audit --workspaces=false` |
| `npm run audit:web` | `npm audit --workspace web` |
| `npm run audit:tui` | `npm audit --workspace ui-tui` |
| `npm run audit:fix:root` | `npm audit fix --workspaces=false` |
| `npm run audit:fix:web` | `npm audit fix --workspace web` |
| `npm run audit:fix:tui` | `npm audit fix --workspace ui-tui` |

### `tests/hermes_cli/test_cmd_update.py`
- Update the stale assertion for the `_build_web_ui` npm ci call to expect `--workspace web`.

### `tests/hermes_cli/test_tui_npm_install.py`
- Add `test_tui_launch_install_uses_workspace_scope` to assert that the TUI launch npm install carries `--workspace ui-tui`.

### `tests/hermes_cli/test_web_ui_build.py`
- Add `test_npm_install_uses_workspace_web_scope` to assert that `_build_web_ui` passes `--workspace web` adjacently in the npm install invocation, directly covering the most critical call site.

## What this does NOT change

- The `workspaces` array in `package.json` itself — `apps/desktop` stays in the workspace graph so the single shared lockfile and hoisted `node_modules/` continue to work for desktop developers.
- The `_update_node_dependencies()` function already correctly used `--workspaces=false` + `--workspace ui-tui --workspace web` (the fix from #38358); this PR only fixes the remaining unscoped call sites.

## Test Plan
- [ ] `hermes dashboard` still builds the dashboard (`_build_web_ui` path)
- [ ] `hermes --tui` does not pull desktop deps on first launch
- [ ] `hermes update` does not pull desktop deps (`_update_node_dependencies` unchanged)
- [ ] `hermes doctor` reports separate audit results for root / web / ui-tui workspaces
- [ ] `npm run audit:fix:web` can be run on a minimal Linux box without `make`/`g++`