### PR TITLE
docs(install): warn that VPS browser consoles mangle special chars (#36279)

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -17,6 +17,19 @@ This page covers option 1. The container stores all user data (config, API keys,
 
 If this is your first time running Hermes Agent, create a data directory on the host and start the container interactively to run the setup wizard:
 
+:::caution Avoid browser-based VPS consoles for the install commands
+Some VPS providers (Hetzner Cloud, and several others) offer a browser-based
+console for managing hosts. These consoles transmit special characters
+incorrectly — `:` may arrive as `;`, `@` may be mis-rendered, and non-English
+keyboard layouts fare worse — which silently corrupts `docker run` arguments
+like `-v ~/.hermes:/opt/data`, `-e KEY=value`, and pasted API keys / tokens.
+
+**Connect over SSH instead** (`ssh root@<host>`) for copy-paste-safe command
+entry. If you must use the browser console, type the commands manually
+instead of pasting, and double-check every `:`, `@`, `=`, and `/` in the
+result before hitting Enter.
+:::
+
 ```sh
 mkdir -p ~/.hermes
 docker run -it --rm \


### PR DESCRIPTION
## What does this PR do?

Adds a `:::caution` admonition above the Quick start `docker run` block in `website/docs/user-guide/docker.md` warning that browser-based VPS consoles (Hetzner Cloud and similar) transmit special characters incorrectly, which silently corrupts `docker run` arguments and pasted secrets. Recommends SSH for copy-paste-safe command entry.

Pure docs change, no code touched.

## Related Issue

Fixes #36279

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/docker.md` — inserted a `:::caution Avoid browser-based VPS consoles for the install commands` block after the Quick start intro paragraph and before the first `docker run` invocation. The block lists the affected providers (Hetzner Cloud et al.), the concrete failure modes (`:` → `;`, `@` mis-render, non-English keyboard layouts), the impact on `-v`/`-e` args and pasted API keys, and gives two mitigations (SSH preferred; manual typing + character double-check as fallback).

## How to Test

1. `cd website && npm install && npm run build` — Docusaurus build succeeds and the admonition renders on `/docs/user-guide/docker`.
2. Visually verify the caution block appears above the `mkdir -p ~/.hermes / docker run -it --rm ...` snippet in the Quick start section.
3. Confirm no other content on the page shifted unexpectedly.

## Checklist

- [x] Single-purpose PR (docs only)
- [x] Conventional Commits title (`docs(install): …`)
- [x] No dependencies added
- [x] No code changes (no tests required)
- [x] Stake comment posted on #36279 before opening
