### PR TITLE
fix: allow local cron jobs to self-post

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1091,12 +1091,24 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
+    if str(job.get("deliver") or "").strip().lower() == "local":
+        delivery_hint = (
+            "DELIVERY: This cron job is configured for local-only final delivery. "
+            "Your final response will be saved locally for audit, not automatically sent to the user. "
+            "If this job's prompt explicitly instructs you to send a message to a specific target, "
+            "you may use send_message for that requested notification; otherwise just produce your "
+            "report/output as your final response. "
+        )
+    else:
+        delivery_hint = (
+            "DELIVERY: Your final response will be automatically delivered "
+            "to the user — do NOT use send_message or try to deliver "
+            "the output yourself. Just produce your report/output as your "
+            "final response and the system handles the rest. "
+        )
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
+        f"{delivery_hint}"
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1909,16 +1909,24 @@ class TestBuildJobPromptSilentHint:
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
 
-    def test_delivery_guidance_present(self):
-        """Cron hint tells agents their final response is auto-delivered."""
-        job = {"prompt": "Generate a report"}
+    def test_delivery_guidance_present_for_auto_delivered_jobs(self):
+        """Cron hint tells agents not to self-deliver when scheduler has a target."""
+        job = {"prompt": "Generate a report", "deliver": "origin", "origin": {"platform": "slack", "chat_id": "C123"}}
         result = _build_job_prompt(job)
         assert "do NOT use send_message" in result
         assert "automatically delivered" in result
 
+    def test_local_delivery_guidance_allows_explicit_send_message_workflows(self):
+        """Local-only cron jobs may intentionally post elsewhere via send_message."""
+        job = {"prompt": "If needed, use send_message to post to slack:C123.", "deliver": "local"}
+        result = _build_job_prompt(job)
+        assert "local-only" in result
+        assert "If this job's prompt explicitly instructs you to send a message" in result
+        assert "do NOT use send_message" not in result
+
     def test_delivery_guidance_precedes_user_prompt(self):
         """System guidance appears before the user's prompt text."""
-        job = {"prompt": "My custom prompt"}
+        job = {"prompt": "My custom prompt", "deliver": "origin", "origin": {"platform": "slack", "chat_id": "C123"}}
         result = _build_job_prompt(job)
         system_pos = result.index("do NOT use send_message")
         prompt_pos = result.index("My custom prompt")


### PR DESCRIPTION
## Summary
- Allow deliver=local cron jobs to self-post via messaging tools instead of applying the generic no-send-message guidance
- Preserve the no-send-message guidance for auto-delivered cron jobs to avoid duplicate delivery
- Add scheduler tests for local vs non-local delivery guidance

## Test Plan
- python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='
