### PR TITLE
feat: add multilingual slang/laughter endings to natural response detector

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1276,8 +1276,31 @@ class AIAgent:
         from agent.agent_runtime_helpers import strip_think_blocks
         return strip_think_blocks(self, content)
 
-    @staticmethod
-    def _has_natural_response_ending(content: str) -> bool:
+    # Common internet slang / laughter abbreviations across languages.
+    # A response ending with one of these (case-insensitive, optional trailing
+    # punctuation/emoji) is considered intentionally finished, not truncated.
+    _SLANG_ENDINGS = frozenset({
+        # French
+        "mdr", "ptdr", "xptdr", "lol",
+        # English
+        "lmao", "rofl", "lmaf", "lmfao", "kek", "kekw", "iykyk",
+        # Spanish / Portuguese
+        "jaja", "jeje", "jiji", "rsrs", "kkk", "huehue",
+        # German
+        "lel", "mfl",
+        # Japanese (romaji)
+        "w", "ww", "www", "kusa",
+        # Chinese (pinyin slang)
+        "233", "666", "888",
+        # Korean
+        "kkk", "keke",
+        # General
+        "haha", "hahaha", "heh", "brb", "tbh", "nvm", "smh", "thx", "ty",
+        "gg", "wp", "gl", "hf", "afk", "idk", "imo", "fyi", "tldr",
+    })
+
+    @classmethod
+    def _has_natural_response_ending(cls, content: str) -> bool:
         """Heuristic: does visible assistant text look intentionally finished?"""
         if not content:
             return False
@@ -1291,8 +1314,19 @@ class AIAgent:
         last = stripped[-1]
         if last in '.!?:)"\']}。！？：）】」』》^':
             return True
-        # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
-        if ord(last) >= 0x1F300:
+        # Emoji / symbol ranges: Misc Symbols (0x2600+), Dingbats (0x2700+),
+        # Emoticons (0x1F300+), Supplemental, Transport, etc.
+        # Covers common symbols like ⚡ (U+26A1), ❤️ (U+2764), etc.
+        cp = ord(last)
+        if (0x2600 <= cp <= 0x27BF) or cp >= 0x1F300:
+            return True
+        # Slang / laughter ending: check if last word (stripped of trailing
+        # punctuation) matches a known abbreviation.
+        # Handles: "mdr", "mdr ^^", "lmao!!!", "www", etc.
+        last_token = stripped.split()[-1].lower()
+        # Strip trailing punctuation/emoji from the token for matching
+        last_token = re.sub(r'[^a-zA-Z0-9]+$', '', last_token)
+        if last_token in cls._SLANG_ENDINGS:
             return True
         return False
 

--- a/tests/agent/test_natural_response_ending.py
+++ b/tests/agent/test_natural_response_ending.py
@@ -1,0 +1,173 @@
+"""Tests for AIAgent._has_natural_response_ending heuristic."""
+
+import pytest
+from run_agent import AIAgent
+
+
+cls = AIAgent
+
+
+class TestNaturalResponseEnding:
+    """Cover punctuation, emoji, caret, slang, and edge cases."""
+
+    # --- Punctuation endings (existing behavior) ---
+
+    def test_period(self):
+        assert cls._has_natural_response_ending("Hello world.")
+
+    def test_exclamation(self):
+        assert cls._has_natural_response_ending("Cool!")
+
+    def test_question_mark(self):
+        assert cls._has_natural_response_ending("Really?")
+
+    def test_colon(self):
+        assert cls._has_natural_response_ending("Here:")
+
+    def test_closing_paren(self):
+        assert cls._has_natural_response_ending("(done)")
+
+    def test_closing_bracket(self):
+        assert cls._has_natural_response_ending("[ok]")
+
+    def test_cjk_punctuation(self):
+        assert cls._has_natural_response_ending("こんにちは。")
+
+    # --- Code block endings ---
+
+    def test_triple_backtick(self):
+        assert cls._has_natural_response_ending("```\ncode\n```")
+
+    # --- Caret endings (PR #28168) ---
+
+    def test_caret_single(self):
+        assert cls._has_natural_response_ending("Voila ^")
+
+    def test_caret_double(self):
+        assert cls._has_natural_response_ending("C'est cool ^^")
+
+    # --- Emoji / symbol endings ---
+
+    def test_emoji_emoticons(self):
+        assert cls._has_natural_response_ending("Génial 😊")
+
+    def test_symbol_misc(self):
+        """⚡ (U+26A1) is in Misc Symbols, below U+1F300."""
+        assert cls._has_natural_response_ending("C'est cool ⚡")
+
+    def test_symbol_dingbats(self):
+        """❤ (U+2764) is in Dingbats."""
+        assert cls._has_natural_response_ending("Merci ❤")
+
+    def test_symbol_check_mark(self):
+        """✅ (U+2705) is in Dingbats."""
+        assert cls._has_natural_response_ending("Done ✅")
+
+    # --- Slang / laughter endings ---
+
+    class TestFrenchSlang:
+        def test_mdr(self):
+            assert cls._has_natural_response_ending("Trop drôle mdr")
+
+        def test_ptdr(self):
+            assert cls._has_natural_response_ending("N'importe quoi ptdr")
+
+        def test_xptdr(self):
+            assert cls._has_natural_response_ending("C'est ouf xptdr")
+
+        def test_lol(self):
+            assert cls._has_natural_response_ending("ok lol")
+
+    class TestEnglishSlang:
+        def test_lmao(self):
+            assert cls._has_natural_response_ending("That's hilarious lmao")
+
+        def test_rofl(self):
+            assert cls._has_natural_response_ending("Classic rofl")
+
+        def test_kek(self):
+            assert cls._has_natural_response_ending("kek")
+
+        def test_brb(self):
+            assert cls._has_natural_response_ending("brb")
+
+        def test_smh(self):
+            assert cls._has_natural_response_ending("smh")
+
+    class TestSpanishPortugueseSlang:
+        def test_jaja(self):
+            assert cls._has_natural_response_ending("jaja")
+
+        def test_rsrs(self):
+            assert cls._has_natural_response_ending("rsrs")
+
+        def test_kkk(self):
+            assert cls._has_natural_response_ending("kkk")
+
+    class TestJapaneseSlang:
+        def test_w(self):
+            assert cls._has_natural_response_ending("w")
+
+        def test_www(self):
+            assert cls._has_natural_response_ending("www")
+
+        def test_kusa(self):
+            assert cls._has_natural_response_ending("kusa")
+
+    class TestChineseSlang:
+        def test_233(self):
+            assert cls._has_natural_response_ending("233")
+
+        def test_666(self):
+            assert cls._has_natural_response_ending("666")
+
+    class TestGamingGeneralSlang:
+        def test_gg(self):
+            assert cls._has_natural_response_ending("gg")
+
+        def test_gg_wp(self):
+            assert cls._has_natural_response_ending("gg wp")
+
+        def test_thx(self):
+            assert cls._has_natural_response_ending("thx")
+
+        def test_tldr(self):
+            assert cls._has_natural_response_ending("tldr")
+
+    # --- Slang with trailing punctuation/emoji ---
+
+    def test_slang_with_emoji(self):
+        """'mdr ^^' — slang followed by caret (already handled by caret)."""
+        assert cls._has_natural_response_ending("mdr ^^")
+
+    def test_slang_with_exclamation(self):
+        """'lmao!!!' — slang with trailing punctuation."""
+        assert cls._has_natural_response_ending("lmao!!!")
+
+    def test_slang_case_insensitive(self):
+        """Slang matching is case-insensitive."""
+        assert cls._has_natural_response_ending("LMAO")
+
+    # --- Negative cases (should NOT be detected as natural ending) ---
+
+    def test_mid_sentence(self):
+        """'mdr' in the middle of a sentence is NOT an ending."""
+        assert not cls._has_natural_response_ending("Le mot mdr existe dans le dico")
+
+    def test_empty_string(self):
+        assert not cls._has_natural_response_ending("")
+
+    def test_whitespace_only(self):
+        assert not cls._has_natural_response_ending("   ")
+
+    def test_no_ending(self):
+        """Bare text ending with a letter (no punctuation/emoji/slang)."""
+        assert not cls._has_natural_response_ending("Je pense donc")
+
+    def test_number_not_slang(self):
+        """A random number is not slang."""
+        assert not cls._has_natural_response_ending("The answer is 42")
+
+    def test_regular_word_ending(self):
+        """A regular word ending in 'r' is not slang."""
+        assert not cls._has_natural_response_ending("C'est un ordinateur")


### PR DESCRIPTION
## Summary

Fixes false truncation reports when responses end with common internet abbreviations (mdr, lmao, www, 233, etc.) that GLM/Ollama backends misidentify as incomplete output.

## Changes

- Add `_SLANG_ENDINGS` frozenset covering 45 abbreviations across 7 languages:
  - **French**: mdr, ptdr, xptdr, lol
  - **English**: lmao, rofl, lmaf, lmfao, kek, kekw, iykyk
  - **Spanish/Portuguese**: jaja, jeje, jiji, rsrs, kkk, huehue
  - **German**: lel, mfl
  - **Japanese** (romaji): w, ww, www, kusa
  - **Chinese** (pinyin slang): 233, 666, 888
  - **Korean**: kkk, keke
  - **Gaming/General**: haha, hahaha, heh, brb, tbh, nvm, smh, thx, ty, gg, wp, gl, hf, afk, idk, imo, fyi, tldr
- Match last token case-insensitively, stripping trailing punctuation/emoji before matching
- Extend emoji/symbol detection to Misc Symbols (U+2600+) and Dingbats (U+2700+), fixing ⚡ (U+26A1), ❤ (U+2764), ✅ (U+2705) etc. being missed as natural endings
- Change `_has_natural_response_ending` from `@staticmethod` to `@classmethod` for `_SLANG_ENDINGS` access
- Add 44 tests covering all categories and edge cases

## Context

This closes the "mdr incident" of June 2026. GLM models served via Ollama report `stop` as `length` (truncated) when the last token is not standard punctuation. Responses ending in slang like `mdr` or `lmao` were being falsely continued, causing silent agent conditioning (responses shrinking from 137→0 chars over 50+ false truncations).

The emoji range fix is independent and benefits all backends — symbols like ⚡, ❤, ✅ are common in agent output and should be recognized as natural endings.

## Test plan

- [x] 44 new tests pass (`tests/agent/test_natural_response_ending.py`)
- [x] Existing test suite unaffected
- [x] `python -c "import run_agent; print(\"OK\")"` passes