### PR TITLE
[codex] fix(api-server): advertise jobs admin capability

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1077,6 +1077,8 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        jobs_admin = bool(_CRON_AVAILABLE)
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -1112,7 +1114,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_streaming": True,
                 "session_fork": True,
                 "admin_config_rw": False,
-                "jobs_admin": False,
+                "jobs_admin": jobs_admin,
                 "memory_write_api": False,
                 "skills_api": True,
                 "audio_api": False,
@@ -1143,6 +1145,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                **(
+                    {
+                        "jobs": {"method": "GET", "path": "/api/jobs"},
+                        "job_create": {"method": "POST", "path": "/api/jobs"},
+                        "job": {"method": "GET", "path": "/api/jobs/{job_id}"},
+                        "job_update": {"method": "PATCH", "path": "/api/jobs/{job_id}"},
+                        "job_delete": {"method": "DELETE", "path": "/api/jobs/{job_id}"},
+                        "job_pause": {"method": "POST", "path": "/api/jobs/{job_id}/pause"},
+                        "job_resume": {"method": "POST", "path": "/api/jobs/{job_id}/resume"},
+                        "job_run": {"method": "POST", "path": "/api/jobs/{job_id}/run"},
+                    }
+                    if jobs_admin
+                    else {}
+                ),
             },
         })
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -662,6 +662,36 @@ class TestCapabilitiesEndpoint:
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 
     @pytest.mark.asyncio
+    async def test_capabilities_advertises_jobs_admin_when_cron_available(self, adapter):
+        with patch("gateway.platforms.api_server._CRON_AVAILABLE", True):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/capabilities")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["features"]["jobs_admin"] is True
+        assert data["endpoints"]["jobs"] == {"method": "GET", "path": "/api/jobs"}
+        assert data["endpoints"]["job_create"] == {"method": "POST", "path": "/api/jobs"}
+        assert data["endpoints"]["job_run"] == {
+            "method": "POST",
+            "path": "/api/jobs/{job_id}/run",
+        }
+
+    @pytest.mark.asyncio
+    async def test_capabilities_omits_jobs_admin_when_cron_unavailable(self, adapter):
+        with patch("gateway.platforms.api_server._CRON_AVAILABLE", False):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/capabilities")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["features"]["jobs_admin"] is False
+        assert "jobs" not in data["endpoints"]
+        assert "job_create" not in data["endpoints"]
+
+    @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
## Summary
- Make `/v1/capabilities` report `jobs_admin: true` when the cron jobs backend is available.
- Advertise the `/api/jobs` management endpoints only when that admin surface is usable.
- Add regression coverage for both cron-available and cron-unavailable capability responses.

Fixes #38782.

## Verification
- `uv run --extra dev --extra messaging pytest tests/gateway/test_api_server.py -q -k capabilities`
- `uv run --extra dev --extra messaging python -m py_compile gateway/platforms/api_server.py`
- `uv run --extra dev ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- `git diff --check`

## Duplicate check
- Final open/closed PR searches for #38782, `jobs_admin`, `/v1/capabilities`, `/api/jobs`, and `gateway/platforms/api_server.py` found no overlapping PR.
