### PR TITLE
docs(skills): fix 8 broken related_skills references in bundled SKILL.md (#37338)

### DIFF
--- a/skills/creative/architecture-diagram/SKILL.md
+++ b/skills/creative/architecture-diagram/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [architecture, diagrams, SVG, HTML, visualization, infrastructure, cloud]
-    related_skills: [concept-diagrams, excalidraw]
+    related_skills: [excalidraw]
 ---
 
 # Architecture Diagram Skill

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -23,7 +23,7 @@ metadata:
       - creative
       - generative-ai
       - video-generation
-    related_skills: [stable-diffusion-image-generation, image_gen]
+    related_skills: []
     category: creative
 ---
 

--- a/skills/creative/touchdesigner-mcp/SKILL.md
+++ b/skills/creative/touchdesigner-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [TouchDesigner, MCP, twozero, creative-coding, real-time-visuals, generative-art, audio-reactive, VJ, installation, GLSL]
-    related_skills: [native-mcp, ascii-video, manim-video, hermes-video]
+    related_skills: [native-mcp, ascii-video, manim-video]
 
 ---
 

--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Tools, Integrations]
-    related_skills: [mcporter]
+    related_skills: []
 ---
 
 # Native MCP Client

--- a/skills/media/heartmula/SKILL.md
+++ b/skills/media/heartmula/SKILL.md
@@ -6,7 +6,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [music, audio, generation, ai, heartmula, heartcodec, lyrics, songs]
-    related_skills: [audiocraft]
+    related_skills: [audiocraft-audio-generation]
 ---
 
 # HeartMuLa - Open-Source Music Generation

--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos]
 metadata:
   hermes:
     tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
-    related_skills: [vllm, gguf, huggingface-tokenizers]
+    related_skills: [serving-llms-vllm, llama-cpp]
 ---
 
 # OBLITERATUS Skill

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   hermes:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]
     category: research
-    related_skills: [arxiv, ml-paper-writing, subagent-driven-development, plan]
+    related_skills: [arxiv, subagent-driven-development, plan]
     requires_toolsets: [terminal, files]
 
 ---

--- a/skills/software-development/hermes-s6-container-supervision/SKILL.md
+++ b/skills/software-development/hermes-s6-container-supervision/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   hermes:
     tags: [docker, s6, supervision, gateway, profiles]
-    related_skills: [hermes-agent, hermes-agent-dev]
+    related_skills: [hermes-agent]
 ---
 
 # Hermes s6-overlay Container Supervision


### PR DESCRIPTION
## What does this PR do?

Fixes 8 bundled SKILL.md files whose YAML frontmatter `related_skills` entries pointed at skill names that **never existed**, were **renamed**, or were **toolset names** (not skill names). Each replacement was verified by extracting the canonical `name:` field from every `skills/**/SKILL.md` and checking that the new references resolve.

This is **Part 1 of 3** from the audit in #37338. The other two parts (body-text references in 3 files, and empty category directories) are deliberately deferred to keep this PR review-friendly and reversible.

## Related Issue

Fixes #37338

## Type of Change

- [x] 📝 Documentation update

## Changes Made

| Skill | Path | Before | After |
|---|---|---|---|
| `obliteratus` | `mlops/inference/` | `[vllm, gguf, huggingface-tokenizers]` | `[serving-llms-vllm, llama-cpp]` |
| `native-mcp` | `mcp/` | `[mcporter]` | `[]` |
| `architecture-diagram` | `creative/` | `[concept-diagrams, excalidraw]` | `[excalidraw]` |
| `comfyui` | `creative/` | `[stable-diffusion-image-generation, image_gen]` | `[]` |
| `research-paper-writing` | `research/` | `[arxiv, ml-paper-writing, subagent-driven-development, plan]` | `[arxiv, subagent-driven-development, plan]` |
| `hermes-s6-container-supervision` | `software-development/` | `[hermes-agent, hermes-agent-dev]` | `[hermes-agent]` |
| `touchdesigner-mcp` | `creative/` | `[native-mcp, ascii-video, manim-video, hermes-video]` | `[native-mcp, ascii-video, manim-video]` |
| `heartmula` | `media/` | `[audiocraft]` | `[audiocraft-audio-generation]` |

8 files, +8 / -8 lines, one targeted edit per file. No prose touched, no scripts changed.

### Out of scope (deferred)

- **Part 2 (issue §2)** — body-text references to non-existent skills in 3 files (`native-mcp`, `hermes-s6-container-supervision`, `research-paper-writing`). Touches free-text prose, so I'd rather get review feedback on this PR first before editing narrative sections.
- **Part 3 (issue §3)** — empty category directories. Potentially destructive (removing `mlops/training/`, `mlops/vector-databases/`, `diagramming/`, `gifs/`, `domain/`, `inference-sh/`). Deserves explicit maintainer alignment; tracked separately at `agentskills/agentskills#1` per @duruonanni's comment.
- **`macos-computer-use` "suspect" entry** — the issue itself flags this as needing clarification rather than a confirmed broken ref, so I'm leaving it alone.

## How to Test

1. **Verify each replacement is a real skill name** (already done locally, results below):
   ```bash
   find skills -name SKILL.md -exec grep -h "^name:" {} \; \
     | awk '{print $2}' | sort -u > /tmp/valid.txt
   for n in serving-llms-vllm llama-cpp excalidraw arxiv \
            subagent-driven-development plan hermes-agent \
            native-mcp ascii-video manim-video \
            audiocraft-audio-generation; do
     grep -qx "$n" /tmp/valid.txt && echo "✓ $n" || echo "✗ $n MISSING"
   done
   ```
   All 11 replacement names resolve.

2. **Re-run the audit pattern** the issue describes to confirm no `related_skills` entry in this PR's 8 files points at an unknown name after the edit.

3. Optional: build the docs site (`cd website && npm run build`) — this PR doesn't change anything Docusaurus renders, but the build will at least confirm no surrounding YAML was broken.

## Checklist

- [x] Single-purpose PR (docs only — `related_skills` YAML field fixes)
- [x] Conventional Commits title (`docs(skills): …`)
- [x] No dependencies added
- [x] No code changes (no tests required)
- [x] Every replacement skill name verified to exist in the current tree
- [x] Stake comment posted on #37338 explaining scope before opening
- [x] Scope deliberately narrowed to the lowest-risk subset of the audit
