### PR TITLE
fix(dashboard_auth): allow any http:// host in OAuth redirect_uri

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -383,20 +383,16 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         """Surface obviously-broken redirect_uris before bouncing to Portal.
 
         The Portal-side check (``agent-redirect-uri.ts``) is authoritative;
-        this is a fast-fail for the common operator-error case.
+        this is a fast-fail for the common operator-error case. We allow any
+        ``http://`` host (not just localhost) so self-hosted dashboards reached
+        over plain HTTP — LAN IPs, internal hostnames, reverse proxies that
+        terminate TLS upstream — are not rejected here; Portal makes the final
+        call on which redirect_uris are permitted.
         """
         parsed = urllib.parse.urlparse(redirect_uri)
         if parsed.scheme not in ("https", "http"):
             raise ProviderError(
                 f"redirect_uri must be http(s), got {redirect_uri!r}"
-            )
-        if parsed.scheme == "http" and parsed.hostname not in (
-            "localhost",
-            "127.0.0.1",
-        ):
-            raise ProviderError(
-                "redirect_uri may only use http:// for localhost/127.0.0.1, "
-                f"got {redirect_uri!r}"
             )
         if not parsed.path or not parsed.path.endswith("/auth/callback"):
             raise ProviderError(

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -494,11 +494,15 @@ class TestStartLogin:
         with pytest.raises(ProviderError, match="http"):
             provider.start_login(redirect_uri="ftp://x/auth/callback")
 
-    def test_rejects_http_with_non_localhost(self, provider):
-        with pytest.raises(ProviderError, match="localhost"):
-            provider.start_login(
-                redirect_uri="http://hermes.fly.dev/auth/callback"
-            )
+    def test_allows_http_with_arbitrary_host(self, provider):
+        # http:// is permitted for any host now, not just localhost — the
+        # Portal-side check is authoritative on which redirect_uris are
+        # accepted; this client-side fast-fail must not reject self-hosted
+        # dashboards reached over plain HTTP (LAN IPs, internal hostnames,
+        # TLS-terminating reverse proxies). Should not raise.
+        provider.start_login(redirect_uri="http://hermes.fly.dev/auth/callback")
+        provider.start_login(redirect_uri="http://192.168.1.50:8080/auth/callback")
+        provider.start_login(redirect_uri="http://my-internal-host/auth/callback")
 
     def test_allows_http_localhost(self, provider):
         # Should not raise.


### PR DESCRIPTION
## Summary

The Nous dashboard OAuth login screen rejects any `http://` redirect URI whose host is not `localhost`/`127.0.0.1`, showing:

> redirect_uri may only use http:// for localhost/127.0.0.1

This breaks self-hosted dashboards reached over plain HTTP — LAN IPs, internal hostnames, and reverse proxies that terminate TLS upstream. Those are legitimate deployments that should be able to log in.

## Impact

Anyone running the dashboard behind plain HTTP on a non-loopback host (LAN IP, internal DNS name, or a TLS-terminating reverse proxy that forwards `http://` to the dashboard) cannot complete OAuth login — the client-side check rejects the redirect URI before it ever reaches Portal. Default Fly/`https://` deployments are unaffected; this only fires on self-hosted plain-HTTP setups.

## Change

`_validate_redirect_uri` in `plugins/dashboard_auth/nous/__init__.py` is only a **fast-fail for obvious operator error** — the Portal-side check (`agent-redirect-uri.ts`) is authoritative on which redirect URIs are actually permitted. It shouldn't be second-guessing valid `http://` deployments.

- Dropped the localhost-only branch on the `http` scheme.
- Validation now enforces only: scheme is `http(s)`, and path ends with `/auth/callback`.
- Updated the docstring to explain the relaxed contract.

## Test Plan

- Replaced `test_rejects_http_with_non_localhost` (which pinned the old behavior) with `test_allows_http_with_arbitrary_host`, covering a Fly hostname, a LAN IP, and an internal hostname.
- `test_allows_http_localhost`, `test_rejects_non_http_scheme`, and `test_rejects_wrong_callback_path` remain green.
- Full provider suite passes: `python -m pytest tests/plugins/dashboard_auth/test_nous_provider.py -q` → **55 passed**.

## Note for reviewers

This relaxes only the **client-side** check. If the authoritative Portal-side `agent-redirect-uri.ts` also rejects non-localhost `http://`, that would need a matching relaxation there for self-hosted plain-HTTP login to fully work end-to-end.