### PR TITLE
fix(matrix): propagate room name to session source via get_chat_info()

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1857,8 +1857,10 @@ class MatrixAdapter(BasePlatformAdapter):
             self._threads.mark(thread_id)
 
         display_name = await self._get_display_name(room_id, sender)
+        room_info = await self.get_chat_info(room_id)
         source = self.build_source(
             chat_id=room_id,
+            chat_name=room_info["name"],
             chat_type=chat_type,
             user_id=sender,
             user_name=display_name,

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2160,6 +2160,7 @@ class TestMatrixReadReceipts:
     async def test_accepted_message_schedules_read_receipt(self):
         self.adapter._is_dm_room = AsyncMock(return_value=True)
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter.get_chat_info = AsyncMock(return_value={"name": "Room Alpha", "type": "dm"})
         self.adapter._background_read_receipt = MagicMock()
 
         ctx = await self.adapter._resolve_message_context(
@@ -2732,6 +2733,7 @@ class TestMatrixDmAutoThread:
         self.adapter = _make_adapter()
         self.adapter._is_dm_room = AsyncMock(return_value=True)
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter.get_chat_info = AsyncMock(return_value={"name": "DM Chat", "type": "dm"})
         self.adapter._background_read_receipt = MagicMock()
         # Disable require_mention so DMs pass gating
         self.adapter._require_mention = False


### PR DESCRIPTION
## Summary

Fixes #38805 — the Matrix adapter was building session sources without a `chat_name`, causing every Matrix room to appear with the sender display name (e.g. "AVP") in `channel_directory.json` instead of the actual Matrix room name.

## Changes

**`gateway/platforms/matrix.py`:**
- Added `room_info = await self.get_chat_info(room_id)` call in `_resolve_message_context()`
- Passed `chat_name=room_info["name"]` to `build_source()`

**`tests/gateway/test_matrix.py`:**
- Added `get_chat_info` mock to `TestMatrixReadReceipts.test_accepted_message_schedules_read_receipt`
- Added `get_chat_info` mock to `TestMatrixDmAutoThread.setup_method`

## Design

Matches the WhatsApp and Telegram adapter pattern — the room name is resolved at ingestion time and passed through to the session source.

## Testing

All 16 related tests pass (TestMatrixReadReceipts, TestMatrixDmAutoThread, TestMatrixOnRoomMessageFilter, TestMatrixClockSkewWarning).