### PR TITLE
fix: bridge Codex app-server progress events

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -24,6 +24,65 @@ from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
+def _codex_note_to_tool_progress(note: dict) -> tuple[str, str, dict] | None:
+    """Map Codex app-server item starts to Hermes tool-progress events."""
+    if not isinstance(note, dict) or note.get("method") != "item/started":
+        return None
+    params = note.get("params") or {}
+    item = params.get("item") or {}
+    if not isinstance(item, dict):
+        return None
+
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        args = {
+            "command": item.get("command") or "",
+            "cwd": item.get("cwd") or "",
+        }
+        return "exec_command", args["command"], args
+
+    if item_type == "fileChange":
+        changes = item.get("changes") or []
+        preview = "file changes"
+        if isinstance(changes, list) and changes:
+            paths = [
+                str(change.get("path"))
+                for change in changes
+                if isinstance(change, dict) and change.get("path")
+            ]
+            if paths:
+                preview = ", ".join(paths[:3])
+                if len(paths) > 3:
+                    preview += f", +{len(paths) - 3} more"
+        return "apply_patch", preview, {"changes": changes}
+
+    if item_type == "mcpToolCall":
+        server = item.get("server") or "mcp"
+        tool = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return f"mcp.{server}.{tool}", tool, args
+
+    if item_type == "dynamicToolCall":
+        tool = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return tool, tool, args
+
+    return None
+
+
+def _last_projected_reasoning(projected_messages: list[dict]) -> str | None:
+    for msg in reversed(projected_messages or []):
+        if not isinstance(msg, dict):
+            continue
+        reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning.strip():
+            return reasoning
+    return None
+
 
 def run_codex_app_server_turn(
     agent,
@@ -56,9 +115,29 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+
+        def _on_codex_event(note: dict) -> None:
+            progress_callback = getattr(agent, "tool_progress_callback", None)
+            if progress_callback is None:
+                return
+            mapped = _codex_note_to_tool_progress(note)
+            if mapped is None:
+                return
+            tool_name, preview, args = mapped
+            try:
+                progress_callback(
+                    "tool.started",
+                    tool_name,
+                    preview,
+                    args,
+                )
+            except Exception:
+                logger.debug("codex tool-progress callback raised", exc_info=True)
+
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            on_event=_on_codex_event,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -109,6 +188,7 @@ def run_codex_app_server_turn(
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
+    last_reasoning = _last_projected_reasoning(turn.projected_messages)
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -170,6 +250,7 @@ def run_codex_app_server_turn(
         "error": turn.error,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
+        "last_reasoning": last_reasoning,
     }
 
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 
 import run_agent
+from agent import codex_runtime
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -83,6 +84,103 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+        assert result["last_reasoning"] is None
+
+    def test_last_reasoning_is_returned_for_gateway_display(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[
+                    {"role": "assistant", "content": "done", "reasoning": "planned the work"},
+                ],
+                turn_id="t1",
+                thread_id="th1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th1"
+        )
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+        assert result["last_reasoning"] == "planned the work"
+
+    def test_codex_app_server_wires_tool_progress_callback(self, monkeypatch):
+        captured_init = {}
+        progress_events = []
+
+        def fake_init(self, **kwargs):
+            captured_init.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured_init["on_event"]({
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "type": "commandExecution",
+                        "command": "sed -n '1,5p' README.md",
+                        "cwd": "/repo",
+                    }
+                },
+            })
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="t1",
+                thread_id="th1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th1"
+        )
+
+        agent = _make_codex_agent()
+        agent.tool_progress_callback = lambda *args, **kwargs: progress_events.append((args, kwargs))
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("inspect")
+
+        assert callable(captured_init["on_event"])
+        assert progress_events == [
+            (
+                (
+                    "tool.started",
+                    "exec_command",
+                    "sed -n '1,5p' README.md",
+                    {"command": "sed -n '1,5p' README.md", "cwd": "/repo"},
+                ),
+                {},
+            )
+        ]
+
+    def test_codex_tool_progress_mapper_handles_native_item_types(self):
+        assert codex_runtime._codex_note_to_tool_progress({
+            "method": "item/started",
+            "params": {"item": {"type": "fileChange", "changes": [{"path": "a.py"}]}},
+        }) == ("apply_patch", "a.py", {"changes": [{"path": "a.py"}]})
+        assert codex_runtime._codex_note_to_tool_progress({
+            "method": "item/started",
+            "params": {
+                "item": {
+                    "type": "mcpToolCall",
+                    "server": "hermes-tools",
+                    "tool": "browser_snapshot",
+                    "arguments": {"full": True},
+                }
+            },
+        }) == ("mcp.hermes-tools.browser_snapshot", "browser_snapshot", {"full": True})
+        assert codex_runtime._codex_note_to_tool_progress({
+            "method": "item/started",
+            "params": {
+                "item": {
+                    "type": "dynamicToolCall",
+                    "tool": "todo",
+                    "arguments": {"items": ["one"]},
+                }
+            },
+        }) == ("todo", "todo", {"items": ["one"]})
 
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()


### PR DESCRIPTION
## Summary

- Bridge Codex app-server `item/started` notifications into Hermes `tool.started` progress callbacks
- Map Codex command execution, file changes, MCP tool calls, and dynamic tool calls into verbose-friendly progress previews
- Return the latest projected Codex reasoning summary as `last_reasoning` when available
- Add regression tests for progress callback wiring, mapper coverage, and reasoning propagation

## Test Plan

- `python -m pytest tests/run_agent/test_codex_app_server_integration.py -q`

Closes #38835
