### PR TITLE
fix(auxiliary): guard vision main-agent fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2933,6 +2933,40 @@ def _try_payment_fallback(
     return None, None, ""
 
 
+def _main_agent_vision_fallback_allowed(client: Any, model: str) -> bool:
+    """Return True when the resolved main-agent endpoint can accept images.
+
+    A custom or aliased main provider can resolve to a concrete backend after
+    ``resolve_provider_client``.  For vision fallback, use that actual endpoint
+    to verify model capabilities before handing image payloads to the main
+    model.  This keeps an auxiliary vision timeout from turning into a
+    misleading provider-side model/API mismatch.
+    """
+    base_url = str(getattr(client, "base_url", "") or "").strip()
+    if not base_url:
+        return True
+
+    try:
+        from agent.model_metadata import _infer_provider_from_url
+
+        inferred_provider = _infer_provider_from_url(base_url)
+    except Exception:
+        inferred_provider = None
+
+    if not inferred_provider:
+        return True
+
+    try:
+        from agent.image_routing import _lookup_supports_vision
+        from hermes_cli.config import load_config
+
+        supports = _lookup_supports_vision(inferred_provider, model, load_config())
+    except Exception:
+        supports = None
+
+    return supports is True
+
+
 def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
@@ -2974,12 +3008,21 @@ def _try_main_agent_model_fallback(
     if client is None:
         return None, None, ""
 
+    fallback_model = resolved_model or main_model
+    if task == "vision" and not _main_agent_vision_fallback_allowed(client, fallback_model):
+        logger.info(
+            "Auxiliary vision: skipping main agent model fallback %s (%s) "
+            "because the resolved endpoint does not report vision support",
+            main_provider, fallback_model,
+        )
+        return None, None, ""
+
     label = f"main-agent({main_provider})"
     logger.info(
         "Auxiliary %s: %s on %s — falling back to main agent model %s (%s)",
-        task or "call", reason, failed_provider, label, resolved_model or main_model,
+        task or "call", reason, failed_provider, label, fallback_model,
     )
-    return client, resolved_model or main_model, label
+    return client, fallback_model, label
 
 
 def _try_configured_fallback_chain(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,7 @@ from agent.auxiliary_client import (
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
+    _try_main_agent_model_fallback,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
@@ -1543,6 +1544,73 @@ class TestTryPaymentFallback:
         assert client is None
         assert model is None
         assert label == ""
+
+
+class TestTryMainAgentModelFallback:
+    """Main-agent fallback should preserve task capability boundaries."""
+
+    def _patch_main_model(self, client, model="mimo-v2.5-pro"):
+        return (
+            patch("agent.auxiliary_client._read_main_provider", return_value="custom"),
+            patch("agent.auxiliary_client._read_main_model", return_value=model),
+            patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(client, model)),
+        )
+
+    def test_vision_skips_main_agent_when_resolved_model_is_not_vision_capable(self):
+        main_client = MagicMock()
+        main_client.base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+
+        patches = self._patch_main_model(main_client)
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch("agent.image_routing._lookup_supports_vision", return_value=False) as lookup:
+            client, model, label = _try_main_agent_model_fallback(
+                "gemini",
+                task="vision",
+                reason="connection error",
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
+        lookup.assert_called_once_with("xiaomi", "mimo-v2.5-pro", {})
+
+    def test_vision_allows_main_agent_when_resolved_model_supports_vision(self):
+        main_client = MagicMock()
+        main_client.base_url = "https://api.openai.com/v1"
+
+        patches = self._patch_main_model(main_client, model="gpt-4o")
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            client, model, label = _try_main_agent_model_fallback(
+                "gemini",
+                task="vision",
+                reason="connection error",
+            )
+
+        assert client is main_client
+        assert model == "gpt-4o"
+        assert label == "main-agent(custom)"
+
+    def test_non_vision_still_uses_main_agent_without_vision_lookup(self):
+        main_client = MagicMock()
+        main_client.base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+
+        patches = self._patch_main_model(main_client)
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("agent.image_routing._lookup_supports_vision") as lookup:
+            client, model, label = _try_main_agent_model_fallback(
+                "gemini",
+                task="compression",
+                reason="connection error",
+            )
+
+        assert client is main_client
+        assert model == "mimo-v2.5-pro"
+        assert label == "main-agent(custom)"
+        lookup.assert_not_called()
 
 
 class TestCallLlmPaymentFallback:


### PR DESCRIPTION
When an explicitly configured auxiliary vision provider times out or fails after the configured fallback chain is exhausted, Hermes currently tries the user's main agent model as a last-resort fallback. That is fine for text auxiliary tasks, but for vision it can route image payloads to a resolved main-agent endpoint/model that does not actually support images, producing a misleading provider-side model/API mismatch instead of preserving the real vision failure.

This patch checks the resolved main-agent client's actual endpoint before allowing vision fallback. If the endpoint can be mapped to a known backend, the fallback only proceeds when that backend + model explicitly reports vision support. Unknown/local endpoints keep the previous behavior.

## What does this PR do?

- Adds a guard for last-resort main-agent fallback on `task="vision"`.
- Infers the concrete provider from the resolved client's `base_url` before checking vision capability.
- Leaves non-vision auxiliary main-agent fallback unchanged.
- Adds regression coverage for non-vision-capable, vision-capable, and non-vision fallback paths.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py`: require resolved main-agent endpoint/model vision support before using it as a vision fallback.
- `tests/agent/test_auxiliary_client.py`: add fallback boundary tests.

## How to Test

1. `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
2. `python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py -q -k "TryMainAgentModelFallback"`
3. `python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py -q`

Local results:

- Targeted tests: `4 passed, 199 deselected`
- Full file: `203 passed`

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 / Python pytest local checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A