### PR TITLE
fix(test): expect 4404 close code for disabled embedded chat

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3528,7 +3528,7 @@ class TestPtyWebSocket:
         with pytest.raises(WebSocketDisconnect) as exc:
             with self.client.websocket_connect(self._url()):
                 pass
-        assert exc.value.code == 4403
+        assert exc.value.code == 4404
 
     def test_rejects_missing_token(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Fixes the red `test (2)` / `test (4)` shards on main — the disabled-embedded-chat test now expects the correct WebSocket close code.

PR #38743 split the dashboard PTY WebSocket refusal codes — `4404` = embedded chat disabled, `4403` = host/origin mismatch (documented at the refusal site in `hermes_cli/web_server.py`) — but left `test_rejects_when_embedded_chat_disabled` asserting the old `4403`. The server now sends `4404` for that path, so the test fails `assert 4404 == 4403`. Main CI has been red since `6717914e0`.

## Changes
- `tests/hermes_cli/test_web_server.py`: update the disabled-chat assertion `4403` → `4404` to match the server's current close code.

## Validation
| | Before | After |
|---|---|---|
| `TestPtyWebSocket::test_rejects_when_embedded_chat_disabled` | `assert 4404 == 4403` fail | pass |
| `TestPtyWebSocket` class (12 tests) | 1 failed | 12 passed |

## Infographic

![web-server-close-code-fix](https://v3b.fal.media/files/b/0a9ceb4b/WWFk_2dfTihVa_uenrOZz_qTJKIRZ5.png)
