### PR TITLE
fix(gateway): close ResponseStore connections on adapter disconnect/reconnect failure

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4204,6 +4204,9 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        if self._response_store:
+            self._response_store.close()
+            self._response_store = None
         logger.info("[%s] API server stopped", self.name)
 
     async def send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6224,6 +6224,10 @@ class GatewayRunner:
                             "Reconnect %s: non-retryable error (%s), removing from retry queue",
                             platform.value, adapter.fatal_error_message,
                         )
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
                         del self._failed_platforms[platform]
                     else:
                         self._update_platform_runtime_status(
@@ -6239,6 +6243,10 @@ class GatewayRunner:
                             "Reconnect %s failed, next retry in %ds",
                             platform.value, backoff,
                         )
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
                         # Retryable failures (network/DNS blips) keep retrying
                         # at the backoff cap indefinitely — they self-heal once
                         # connectivity returns. We do NOT auto-pause them: a
@@ -6248,6 +6256,12 @@ class GatewayRunner:
                         # `not fatal_error_retryable` branch above, so anything
                         # reaching here is by definition retryable.
                 except Exception as e:
+                    # Clean up adapter resources if it was created before the exception
+                    try:
+                        if 'adapter' in dir() and adapter is not None:
+                            await adapter.disconnect()
+                    except Exception:
+                        pass
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",


### PR DESCRIPTION
## Problem

`ResponseStore` SQLite connections leak when `ApiServerAdapter` fails to connect and the reconnect watcher retries.

Each reconnect cycle creates a new `ResponseStore()` (opening a SQLite connection to `response_store.db`), but when the adapter fails to start, `disconnect()` is never called — so the connection is never closed. After ~500 reconnect cycles the process hits the 1024 FD limit, causing cascading failures across all platforms (DingTalk websocket errors, kanban DB lock failures, etc.).

## Root Cause

`ApiServerAdapter.disconnect()` did not close `self._response_store`, and the reconnect watcher in `GatewayRunner._platform_reconnect_watcher` discarded failed adapters without calling `disconnect()`.

## Fix

1. **`api_server.py`**: `disconnect()` now calls `self._response_store.close()`
2. **`run.py`**: Reconnect watcher now calls `adapter.disconnect()` on all failure paths (non-retryable, retryable, and exception)

## Verification

Before fix: 995 FDs consumed by response_store.db (498 connections × 2 FDs each), total 1024 FDs.
After fix: 3 FDs (db + wal + shm), total 25 FDs. DingTalk reconnects successfully.