### PR TITLE
Clear stale desktop onboarding errors

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -8,7 +8,8 @@ import {
   type OnboardingContext,
   refreshOnboarding,
   requestDesktopOnboarding,
-  saveOnboardingLocalEndpoint
+  saveOnboardingLocalEndpoint,
+  submitOnboardingCode
 } from './onboarding'
 
 function provider(id: string, name = id): OAuthProvider {
@@ -143,6 +144,100 @@ describe('refreshOnboarding', () => {
     await Promise.all([first, second])
 
     expect($desktopOnboarding.get().providers?.map(p => p.id)).toEqual(['shared'])
+  })
+})
+
+describe('OAuth onboarding', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+    vi.restoreAllMocks()
+  })
+
+  it('clears stale readiness errors after OAuth succeeds and model confirmation is shown', async () => {
+    const model = 'anthropic/claude-opus-4.8'
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/oauth/nous/submit') {
+        return { ok: true, status: 'approved' }
+      }
+
+      if (path === '/api/model/options') {
+        return {
+          providers: [
+            {
+              name: 'Nous Portal',
+              slug: 'nous',
+              models: [model]
+            }
+          ]
+        }
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'nous', model, free_tier: false }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'nous', model, gateway_tools: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async method => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        return { ok: true } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        flow: {
+          status: 'awaiting_user',
+          provider: provider('nous', 'Nous Portal'),
+          start: {
+            auth_url: 'https://portal.example/auth',
+            expires_in: 600,
+            flow: 'pkce',
+            session_id: 'portal-session'
+          },
+          code: 'fresh-code'
+        },
+        reason:
+          'No access token found for Nous Portal login. setup.status reports configured credentials, but runtime resolution still failed.',
+        requested: true
+      })
+    )
+
+    await submitOnboardingCode(onboardingContext(requestGateway))
+
+    const state = $desktopOnboarding.get()
+    expect(state.reason).toBeNull()
+    expect(state.flow.status).toBe('confirming_model')
+    if (state.flow.status === 'confirming_model') {
+      expect(state.flow.label).toBe('Nous Portal')
+      expect(state.flow.currentModel).toBe(model)
+    }
+    expect(calls.some(c => c.path === '/api/model/set')).toBe(true)
   })
 })
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -162,7 +162,8 @@ const errMessage = (e: unknown) => (e instanceof Error ? e.message : String(e))
 const patch = (update: Partial<DesktopOnboardingState>) =>
   $desktopOnboarding.set({ ...$desktopOnboarding.get(), ...update })
 
-const setFlow = (flow: OnboardingFlow) => patch({ flow })
+const setFlow = (flow: OnboardingFlow) =>
+  patch(flow.status === 'idle' ? { flow } : { flow, reason: null })
 
 const sessionIdFor = (flow: OnboardingFlow) => ('start' in flow && flow.start ? flow.start.session_id : undefined)
 


### PR DESCRIPTION
## Summary

- Clear stale desktop onboarding readiness errors when a new OAuth flow advances past idle.
- Add a regression test for the Nous Portal expired-session re-login path where auth succeeds and the model confirmation card is shown.

## Root Cause

Desktop onboarding stored the runtime readiness error separately from the active OAuth/model confirmation flow. After a user re-authenticated through Nous Portal successfully, the flow advanced to the connected/model-confirm state but the old `reason` still rendered as a red error notice above it.

## Validation

- `npm run test:ui -- src/store/onboarding.test.ts`
- `npm run type-check`
