### PR TITLE
fix(slack): add catch-all ack handler to prevent Slack auto-disabling Event Subscriptions at scale

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -892,6 +892,33 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
 
+            # Catch-all no-op handler for any other subscribed bot event that
+            # Hermes has no listener for (e.g. user_change, user_huddle_changed,
+            # reaction_added, member_joined_channel, etc.).
+            #
+            # Without this, slack-bolt returns HTTP 404 for every unhandled
+            # event envelope and never sends the Socket Mode ack. When the app
+            # is subscribed to high-volume events (user_change fires on every
+            # presence/status change for the whole org), the resulting flood of
+            # un-acked 404s pushes Slack's failure rate past its 95%/60-min
+            # threshold and it auto-disables the app's Event Subscriptions —
+            # silently killing all inbound delivery until manually re-enabled.
+            #
+            # Placing this AFTER the specific handlers means bolt's router
+            # matches those first; this handler only fires for truly unhandled
+            # types. The envelope is acked with 200, keeping the failure rate
+            # near 0% regardless of which events the Slack app manifest
+            # subscribes to.
+            import re as _re
+            @self._app.event(_re.compile(r".*"))
+            async def _ack_unhandled_event(event, logger):
+                logger.debug(
+                    "[Slack] Ignoring unhandled event type=%s (no listener registered; "
+                    "subscribed events not handled by Hermes should be removed from the "
+                    "Slack app manifest via `hermes slack manifest`)",
+                    (event or {}).get("type", "unknown"),
+                )
+
             # Register slash command handler(s)
             #
             # Every gateway command from COMMAND_REGISTRY is a native Slack


### PR DESCRIPTION
## Problem

Fixes #6572 — but extends the severity beyond the original report.

The original issue framed this as a **cosmetic/noise problem** (~9 unhandled events/hour → warnings look alarming but Hermes still responds). That is true at low event volume.

**At enterprise Slack workspace scale, this is a functional outage.** High-volume events like `user_change` (fires on every user presence/status change org-wide) and `user_huddle_changed` can arrive thousands of times per hour. Since `slack-bolt` returns HTTP 404 and never acks the Socket Mode envelope for unhandled events, this floods Slack with un-acked failed deliveries that cross its **>95% failure threshold in 60 minutes**, triggering automatic disabling of the app's Event Subscriptions — silently killing all inbound delivery until manually re-enabled in the Slack UI.

**Measured in a production AI Assistant deployment:**
| Event | Count (24h) |
|---|---|
| `user_change` | 6,590 un-acked 404s |
| `user_huddle_changed` | 4,514 un-acked 404s |
| Handled messages | 1 |
| **Failure rate** | **~99.98%** |

Result: Slack auto-disabled Event Subscriptions every ~24h. The gateway socket showed `hello` + PING/PONG but **zero `event_callback` frames** — confirmed with a raw sole-consumer WebSocket listener. The agent went completely silent with no error.

## Root cause

`slack_bolt/adapter/socket_mode/async_internals.py:26-45`:
```python
if bolt_resp.status == 200:
    await client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
else:
    client.logger.info(f"Unsuccessful Bolt execution result (status: {bolt_resp.status}, ...)")
    # ← envelope is NEVER acked for 404; Slack counts this as a failed delivery
```

## Fix

Add a catch-all `re.compile(r".*")` handler **after** the existing specific handlers. Bolt's router matches specific handlers first; this only fires for truly unhandled events. Every subscribed event now gets acked with 200, keeping the failure rate near 0% regardless of what the manifest subscribes to.

```python
import re as _re
@self._app.event(_re.compile(r".*"))
async def _ack_unhandled_event(event, logger):
    logger.debug(
        "[Slack] Ignoring unhandled event type=%s (no listener registered; "
        "subscribed events not handled by Hermes should be removed from the "
        "Slack app manifest via `hermes slack manifest`)",
        (event or {}).get("type", "unknown"),
    )
```

## Changes

- `gateway/platforms/slack.py`: add catch-all `_ack_unhandled_event` handler after the 7 specific event handlers

## Notes

- PR #6580 describes this exact fix in its summary but its actual diff does not touch `slack.py` — the implementation was never added.
- The workaround is to trim the Slack app manifest to only the events Hermes handles (`hermes slack manifest` generates the correct set). The catch-all is a better long-term fix since it is defensive against manifest drift.
- Tested against a production deployment: after trimming subscriptions + adding this handler, `grep "Unhandled request" gateway.log` returned 0 in a 90-second window where it previously returned hundreds.