### PR TITLE
fix(qqbot): reconnect when heartbeat ACKs stop

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -224,6 +224,14 @@ class QQAdapter(BasePlatformAdapter):
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
+        # Heartbeat-ACK watchdog state. QQ replies to every op 1 heartbeat with
+        # an op 11 HEARTBEAT_ACK. We track the last ACK time so the heartbeat
+        # loop can detect a half-open ("zombie") connection — e.g. after the
+        # host sleeps/resumes and the TCP socket is silently dead — and force a
+        # reconnect instead of waiting for the server-side session timeout
+        # (~30 min, close code 4009).
+        self._last_heartbeat_ack: float = 0.0
+        self._heartbeat_pending: bool = False
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
@@ -697,21 +705,42 @@ class QQAdapter(BasePlatformAdapter):
                 raise RuntimeError("WebSocket closed")
 
     async def _heartbeat_loop(self) -> None:
-        """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
+        """Send periodic heartbeats and reconnect when ACKs stop arriving.
 
-        The interval is set from the Hello (op 10) event's heartbeat_interval.
-        QQ's default is ~41s; we send at 80% of the interval to stay safe.
+        QQ Gateway expects op 1 heartbeat with the latest seq and replies with
+        op 11 HEARTBEAT_ACK. Without an ACK watchdog, a half-open WebSocket can
+        look connected forever after host sleep/resume because receive() blocks
+        and writes may disappear into a dead TCP socket. If a previous heartbeat
+        is still unacknowledged after one full interval, close the socket so the
+        read loop enters the normal reconnect path.
         """
         try:
             while self._running:
                 await asyncio.sleep(self._heartbeat_interval)
                 if not self._ws or self._ws.closed:
+                    self._heartbeat_pending = False
                     continue
+
+                if self._heartbeat_pending:
+                    age = time.monotonic() - self._last_heartbeat_ack
+                    logger.warning(
+                        "[%s] Heartbeat ACK timeout after %.1fs; closing WebSocket to reconnect",
+                        self._log_tag,
+                        age,
+                    )
+                    await self._ws.close()
+                    self._heartbeat_pending = False
+                    continue
+
                 try:
                     # d should be the latest sequence number received, or null
                     await self._ws.send_json({"op": 1, "d": self._last_seq})
+                    self._heartbeat_pending = True
                 except Exception as exc:
-                    logger.debug("[%s] Heartbeat failed: %s", self._log_tag, exc)
+                    logger.warning("[%s] Heartbeat failed: %s", self._log_tag, exc)
+                    self._heartbeat_pending = False
+                    if self._ws and not self._ws.closed:
+                        await self._ws.close()
         except asyncio.CancelledError:
             pass
 
@@ -813,6 +842,8 @@ class QQAdapter(BasePlatformAdapter):
             interval_ms = d_data.get("heartbeat_interval", 30000)
             # Send heartbeats at 80% of the server interval to stay safe
             self._heartbeat_interval = interval_ms / 1000.0 * 0.8
+            self._last_heartbeat_ack = time.monotonic()
+            self._heartbeat_pending = False
             logger.debug(
                 "[%s] Hello received, heartbeat_interval=%dms (sending every %.1fs)",
                 self._log_tag,
@@ -849,6 +880,8 @@ class QQAdapter(BasePlatformAdapter):
 
         # op 11 = Heartbeat ACK
         if op == 11:
+            self._last_heartbeat_ack = time.monotonic()
+            self._heartbeat_pending = False
             return
 
         # op 7 = Server Reconnect — server asks client to reconnect (e.g.

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -430,10 +430,17 @@ class TestDispatchPayload:
         # Should be 50000 / 1000 * 0.8 = 40.0
         assert adapter._heartbeat_interval == 40.0
 
-    def test_op11_heartbeat_ack(self):
+    def test_op11_heartbeat_ack(self, monkeypatch):
+        from gateway.platforms.qqbot import adapter as qq_adapter_module
+
         adapter = self._make_adapter(app_id="a", client_secret="b")
-        # Should not raise
+        adapter._heartbeat_pending = True
+        monkeypatch.setattr(qq_adapter_module.time, "monotonic", lambda: 123.0)
+
         adapter._dispatch_payload({"op": 11, "t": "HEARTBEAT_ACK", "s": 42})
+
+        assert adapter._last_heartbeat_ack == 123.0
+        assert adapter._heartbeat_pending is False
 
     def test_seq_tracking(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
@@ -445,6 +452,77 @@ class TestDispatchPayload:
         adapter._dispatch_payload({"op": 0, "t": "READY", "s": 5, "d": {}})
         adapter._dispatch_payload({"op": 0, "t": "SOME_EVENT", "s": 10, "d": {}})
         assert adapter._last_seq == 10
+
+
+class TestHeartbeatWatchdog:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_sets_pending_until_ack(self, monkeypatch):
+        from gateway.platforms.qqbot import adapter as qq_adapter_module
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._last_seq = 42
+        adapter._heartbeat_interval = 0.01
+
+        class FakeWS:
+            closed = False
+
+            def __init__(self):
+                self.sent = []
+
+            async def send_json(self, payload):
+                self.sent.append(payload)
+                adapter._running = False
+
+        async def no_sleep(_delay):
+            return None
+
+        fake_ws = FakeWS()
+        adapter._ws = fake_ws
+        monkeypatch.setattr(qq_adapter_module.asyncio, "sleep", no_sleep)
+
+        await adapter._heartbeat_loop()
+
+        assert fake_ws.sent == [{"op": 1, "d": 42}]
+        assert adapter._heartbeat_pending is True
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_closes_ws_when_previous_ack_missing(self, monkeypatch):
+        from gateway.platforms.qqbot import adapter as qq_adapter_module
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._heartbeat_interval = 0.01
+        adapter._last_heartbeat_ack = 100.0
+        adapter._heartbeat_pending = True
+
+        class FakeWS:
+            closed = False
+
+            def __init__(self):
+                self.closed_by_watchdog = False
+
+            async def close(self):
+                self.closed = True
+                self.closed_by_watchdog = True
+                adapter._running = False
+
+        async def no_sleep(_delay):
+            return None
+
+        fake_ws = FakeWS()
+        adapter._ws = fake_ws
+        monkeypatch.setattr(qq_adapter_module.asyncio, "sleep", no_sleep)
+        monkeypatch.setattr(qq_adapter_module.time, "monotonic", lambda: 130.0)
+
+        await adapter._heartbeat_loop()
+
+        assert fake_ws.closed_by_watchdog is True
+        assert adapter._heartbeat_pending is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Track QQ Gateway heartbeat ACKs (op 11) instead of discarding them.
- Close the WebSocket when a previous heartbeat remains unacknowledged for a full heartbeat interval, so the existing reconnect loop can resume/re-identify.
- Add unit tests for ACK state tracking and the watchdog close path.

## Why
QQBot currently sends application-level heartbeats but does not verify that the gateway acknowledges them. After host sleep/resume (commonly WSL on Windows), the TCP/WebSocket connection can become half-open: `receive()` waits forever and writes can appear to succeed even though the server will no longer deliver events. The adapter then looks connected until the server-side session timeout eventually closes the session (observed as long delays and 4009/session-timeout style recovery).

QQ Gateway replies to heartbeat op 1 with op 11 HEARTBEAT_ACK, so the adapter can detect this condition locally. If an ACK is missing for one full heartbeat interval, closing the WebSocket hands control back to the existing reconnect logic, preserving session state for Resume where possible.

## Test plan
- `python -m pytest tests/gateway/test_qqbot.py -q -o 'addopts='`
- `python -m compileall -q gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`

Target test result: `161 passed`.
