### PR TITLE
feat(desktop): username/password login for remote gateways

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3624,15 +3624,21 @@ async function probeRemoteAuthMode(rawUrl) {
   let providers = []
 
   if (authRequired) {
-    // Best-effort: a gated gateway exposes the registered OAuth providers so
-    // the button can read "Log in with Nous Research" instead of a generic
-    // label. A failure here doesn't change the auth mode, so swallow it.
+    // Best-effort: a gated gateway exposes the registered providers so the
+    // button can read "Sign in with Nous Research" instead of a generic
+    // label, and so a username/password provider can be distinguished from
+    // an OAuth-redirect one (``supports_password``). A failure here doesn't
+    // change the auth mode, so swallow it.
     try {
       const body = await fetchPublicJson(`${baseUrl}/api/auth/providers`, { timeoutMs: 8_000 })
       if (Array.isArray(body?.providers)) {
         providers = body.providers
           .filter(p => p && typeof p === 'object')
-          .map(p => ({ name: String(p.name || ''), displayName: String(p.display_name || p.name || '') }))
+          .map(p => ({
+            name: String(p.name || ''),
+            displayName: String(p.display_name || p.name || ''),
+            supportsPassword: Boolean(p.supports_password)
+          }))
           .filter(p => p.name)
       }
     } catch {

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -209,6 +209,19 @@ export function GatewaySettings() {
     return 'your identity provider'
   }, [probe])
 
+  // A username/password gateway authenticates through a credential form on the
+  // gateway's /login page (POST /auth/password-login) rather than an OAuth
+  // redirect. Everything downstream — the session cookie, the ws-ticket mint,
+  // the persistent partition — is identical, so the desktop drives it through
+  // the same sign-in window; only the button copy changes. We treat the
+  // gateway as password-style only when EVERY advertised provider supports
+  // password, so a mixed deployment keeps the generic OAuth copy.
+  const isPasswordProvider = useMemo(() => {
+    const providers: DesktopAuthProvider[] = probe?.providers ?? []
+
+    return providers.length > 0 && providers.every(p => p.supportsPassword)
+  }, [probe])
+
   const oauthConnected = state.remoteOauthConnected
 
   const canUseRemote = useMemo(() => {
@@ -409,7 +422,7 @@ export function GatewaySettings() {
         />
         <ModeCard
           active={state.mode === 'remote'}
-          description="Connect this desktop shell to a remote Hermes backend. Hosted gateways use OAuth; self-hosted ones may use a session token."
+          description="Connect this desktop shell to a remote Hermes backend. Hosted gateways use OAuth or a username and password; self-hosted ones may use a session token."
           disabled={state.envOverride}
           icon={Globe}
           onSelect={() => setState(current => ({ ...current, mode: 'remote' }))}
@@ -446,7 +459,7 @@ export function GatewaySettings() {
           </div>
         ) : null}
 
-        {/* OAuth gateways: present a sign-in button + connection status. */}
+        {/* OAuth / password gateways: present a sign-in button + connection status. */}
         {state.mode === 'remote' && authResolved && authMode === 'oauth' ? (
           <ListRow
             action={
@@ -463,14 +476,18 @@ export function GatewaySettings() {
               ) : (
                 <Button disabled={signingIn || state.envOverride || !trimmedUrl} onClick={() => void signIn()}>
                   {signingIn ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
-                  Sign in with {providerLabel}
+                  {isPasswordProvider ? 'Sign in' : `Sign in with ${providerLabel}`}
                 </Button>
               )
             }
             description={
               oauthConnected
-                ? 'This gateway uses OAuth. You are signed in; the session refreshes automatically.'
-                : `This gateway uses OAuth. Sign in with ${providerLabel} to authorize this desktop app.`
+                ? isPasswordProvider
+                  ? 'This gateway uses a username and password. You are signed in; the session refreshes automatically.'
+                  : 'This gateway uses OAuth. You are signed in; the session refreshes automatically.'
+                : isPasswordProvider
+                  ? 'This gateway uses a username and password. Sign in to authorize this desktop app.'
+                  : `This gateway uses OAuth. Sign in with ${providerLabel} to authorize this desktop app.`
             }
             title="Authentication"
           />

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -191,6 +191,11 @@ export interface DesktopConnectionTestResult {
 export interface DesktopAuthProvider {
   name: string
   displayName: string
+  // True when this provider authenticates with a username + password
+  // (the gateway's /login page renders a credential form) rather than an
+  // OAuth redirect. The session/cookie/ws-ticket machinery is identical;
+  // only the login-page form and the desktop's button copy differ.
+  supportsPassword?: boolean
 }
 
 export interface DesktopConnectionProbeResult {


### PR DESCRIPTION
## Summary
Hermes Desktop can now connect to a remote gateway protected by a **username and password**, not just OAuth or a static session token.

A password-gated gateway authenticates the same way an OAuth one does — `auth_required: true` on `/api/status`, an HttpOnly session cookie for REST, and a single-use WebSocket ticket. So the desktop already drove it correctly through the existing sign-in window; the only gaps were that the connection probe dropped the `supports_password` flag and the UI always described the gateway as "OAuth".

## Changes
- `electron/main.cjs` — the `/api/auth/providers` probe now captures `supports_password` into `supportsPassword`.
- `src/global.d.ts` — `DesktopAuthProvider` gains an optional `supportsPassword` field.
- `src/app/settings/gateway-settings.tsx` — derives `isPasswordProvider` (true only when *every* advertised provider is password-based, so mixed deployments keep the OAuth copy). A password gateway renders a plain **"Sign in"** button and "username and password" copy instead of an OAuth provider label.

Login still flows through the gateway's existing `/login` credential form (which POSTs to `/auth/password-login` and sets the session cookie) — the desktop's sign-in window and cookie-poll are unchanged and provider-agnostic. No new IPC, no new connection mechanism, no duplicated credential handling.

## Background
This is the desktop GUI half of the username/password dashboard-auth provider. The gateway-side machinery (the `supports_password` protocol extension, `BasicAuthProvider`, and the `/auth/password-login` route + credential-form rendering on `/login`) shipped in #38819. The OAuth-gated desktop connect flow this builds on shipped in #37888.

## Validation
| Check | Result |
|---|---|
| `tsc -b` (desktop typecheck) | PASS |
| `node --test connection-config.test.cjs` | 26/26 PASS |
| eslint (changed files) | clean (1 pre-existing warning unrelated to this change) |
| Live login end-to-end | PASS |

Live end-to-end (real `BasicAuthProvider` + real auth routes): `/api/auth/providers` returns `supports_password: true`; `/login` renders the credential form wired to `/auth/password-login`; wrong password **and** unknown user both return an identical generic `401` (no enumeration oracle); correct credentials return `200` and mint the `hermes_session_at` + `hermes_session_rt` cookies — exactly the cookie the desktop's sign-in window polls for.

## Infographic

![username-password-login](https://v3b.fal.media/files/b/0a9ceb9d/YyOkvM0RTauKIX9-Mdaf7_gWNRrrwO.png)
