### PR TITLE
fix(file-safety): read-deny external provider-CLI credential stores (Claude Code / Copilot / MiniMax)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -165,7 +165,7 @@ _BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets a denied Hermes path.
 
-    Three categories are blocked:
+    Four categories are blocked:
 
       * Internal Hermes cache files under ``HERMES_HOME/skills/.hub`` —
         readable metadata that an attacker could use as a prompt-injection
@@ -309,7 +309,12 @@ def get_read_block_error(path: str) -> Optional[str]:
     # stop touching it (single-use refresh-token race); it is external by design.
     home = Path(os.path.expanduser("~"))
     xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    config_home = Path(xdg) if xdg else (home / ".config")
+    # Normalize XDG_CONFIG_HOME the same way the input path is normalized above:
+    # users commonly set it to "~/.config" or "$HOME/.config", which must be
+    # expanded before comparison or the Copilot store would slip the denylist.
+    config_home = (
+        Path(os.path.expanduser(os.path.expandvars(xdg))) if xdg else (home / ".config")
+    )
     external_credential_paths = (
         home / ".claude" / ".credentials.json",        # Claude Code OAuth
         home / ".claude.json",                          # Claude Code creds (legacy)

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -184,6 +184,12 @@ def get_read_block_error(path: str) -> Optional[str]:
         own projects. The agent helping debug a project shouldn't normally
         need to read these — ``.env.example`` is the documented-shape
         substitute.
+      * External provider-CLI credential stores that Hermes imports OAuth
+        tokens from but which live OUTSIDE HERMES_HOME:
+        ``~/.claude/.credentials.json``, ``~/.claude.json``,
+        ``~/.config/github-copilot/{hosts,apps}.json`` (``XDG_CONFIG_HOME``
+        honored), and ``~/.minimax/credentials.json``. ``~/.codex/auth.json``
+        is intentionally excluded (#12360 made Hermes stop touching it).
 
     **This is NOT a security boundary.** The terminal tool runs as the
     same OS user with shell access; the agent can still ``cat auth.json``
@@ -291,6 +297,39 @@ def get_read_block_error(path: str) -> Optional[str]:
             "and cannot be read directly. (Defense-in-depth — not a "
             "security boundary; the terminal tool can still bypass.)"
         )
+
+    # External provider-CLI credential stores that Hermes imports tokens from.
+    # These live OUTSIDE HERMES_HOME (in the provider tool's own home), so the
+    # hermes_dirs loop above never reaches them — yet they hold plaintext OAuth /
+    # API-key material the agent's read_file can exfiltrate (same vector as the
+    # HERMES_HOME credential stores hardened in #17656 / #30721 / #30972).
+    # Hermes ACTIVELY reads several of these (e.g. ~/.claude/.credentials.json in
+    # the anthropic adapter), so they are live paths, not theoretical.
+    # NOTE: ~/.codex/auth.json is intentionally NOT listed — #12360 made Hermes
+    # stop touching it (single-use refresh-token race); it is external by design.
+    home = Path(os.path.expanduser("~"))
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    config_home = Path(xdg) if xdg else (home / ".config")
+    external_credential_paths = (
+        home / ".claude" / ".credentials.json",        # Claude Code OAuth
+        home / ".claude.json",                          # Claude Code creds (legacy)
+        config_home / "github-copilot" / "hosts.json",  # GitHub Copilot OAuth
+        config_home / "github-copilot" / "apps.json",   # GitHub Copilot OAuth (apps)
+        home / ".minimax" / "credentials.json",         # MiniMax OAuth
+    )
+    for ext in external_credential_paths:
+        try:
+            blocked = ext.resolve()
+        except Exception:
+            continue
+        if resolved == blocked:
+            return (
+                f"Access denied: {path} is an external provider credential "
+                "store (Claude Code / GitHub Copilot / MiniMax OAuth tokens) "
+                "and cannot be read directly. Hermes consumes these through its "
+                "credential pool. (Defense-in-depth — not a security boundary; "
+                "the terminal tool can still bypass.)"
+            )
 
     # Block common secret-bearing project-local .env files anywhere on disk.
     # The agent helping a user with their project rarely needs to read raw

--- a/tests/agent/test_file_safety.py
+++ b/tests/agent/test_file_safety.py
@@ -198,6 +198,18 @@ class TestExternalCredentialStoreReadBlocking:
 
         assert get_read_block_error(str(target)) is not None
 
+    def test_xdg_config_home_with_tilde_honored_for_copilot(self, monkeypatch, tmp_path):
+        """A tilde-containing XDG_CONFIG_HOME (e.g. "~/.config") is expanded."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        # User-style value that must be expanded against HOME before matching.
+        monkeypatch.setenv("XDG_CONFIG_HOME", "~/xdgconfig")
+        target = tmp_path / "xdgconfig" / "github-copilot" / "apps.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+
+        assert get_read_block_error(str(target)) is not None
+
     def test_codex_auth_not_read_denied(self, monkeypatch, tmp_path):
         """~/.codex/auth.json is intentionally external (#12360) — not denied here."""
         monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/agent/test_file_safety.py
+++ b/tests/agent/test_file_safety.py
@@ -146,3 +146,76 @@ class TestCombinedGuards:
             error = get_read_block_error(str(cache))
             assert error is not None
             assert "internal Hermes cache" in error
+
+
+# ---------------------------------------------------------------------------
+# External provider-CLI credential stores (sibling follow-up to #17656)
+#
+# #17656 / #30721 / #30972 only read-deny credential stores UNDER HERMES_HOME.
+# The provider-CLI stores Hermes imports OAuth tokens from live OUTSIDE
+# HERMES_HOME, so the hermes_dirs resolve-loop never reaches them — yet
+# read_file can exfiltrate them. ~/.codex/auth.json is intentionally excluded
+# (#12360 made Hermes stop touching it by design).
+# ---------------------------------------------------------------------------
+
+
+class TestExternalCredentialStoreReadBlocking:
+    """External provider-CLI credential stores must be read-denied."""
+
+    @pytest.mark.parametrize("rel", [
+        ".claude/.credentials.json",
+        ".claude.json",
+        ".config/github-copilot/hosts.json",
+        ".config/github-copilot/apps.json",
+        ".minimax/credentials.json",
+    ])
+    def test_external_credential_stores_read_denied(self, monkeypatch, tmp_path, rel):
+        """read_file on external provider-CLI credential stores is blocked."""
+        # Isolate OS home and HERMES_HOME at separate tmp dirs so the
+        # HERMES_HOME credential loop cannot coincidentally match (profile-safe
+        # rule: tests that mock home must also pin HERMES_HOME).
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+
+        error = get_read_block_error(str(target))
+        assert error is not None, f"{rel} should be read-denied"
+        assert "Access denied" in error
+        assert "credential" in error.lower()
+
+    def test_xdg_config_home_honored_for_copilot(self, monkeypatch, tmp_path):
+        """Copilot store under a custom XDG_CONFIG_HOME is still read-denied."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        target = xdg / "github-copilot" / "hosts.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+
+        assert get_read_block_error(str(target)) is not None
+
+    def test_codex_auth_not_read_denied(self, monkeypatch, tmp_path):
+        """~/.codex/auth.json is intentionally external (#12360) — not denied here."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        target = tmp_path / ".codex" / "auth.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+
+        assert get_read_block_error(str(target)) is None
+
+    def test_non_credential_file_in_claude_dir_readable(self, monkeypatch, tmp_path):
+        """Negative: a non-credential file under ~/.claude stays readable."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        target = tmp_path / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("hi")
+
+        assert get_read_block_error(str(target)) is None


### PR DESCRIPTION
## This is a sibling follow-up to #17656 (commits 056e00a7 / 567ea612, landed via #30721)

- #17656 / #30721 / #30972 covered: read-deny on credential stores UNDER HERMES_HOME / hermes_root (`auth.json`, `.anthropic_oauth.json`, `.env`, `webhook_subscriptions.json`, `auth/google_oauth.json`, `cache/bws_cache.json`, `mcp-tokens/`).
- Those PRs did NOT touch: the EXTERNAL provider-CLI credential stores Hermes imports OAuth tokens from, which live outside HERMES_HOME so the existing `hermes_dirs` resolve-loop in `get_read_block_error` never reaches them.
- This PR adds the same exact-path read-deny for `~/.claude/.credentials.json`, `~/.claude.json`, `~/.config/github-copilot/{hosts,apps}.json`, and `~/.minimax/credentials.json` (`XDG_CONFIG_HOME` honored). `~/.codex/auth.json` is intentionally excluded — #12360 made Hermes stop touching it by design.

## What does this PR do?

Extends `get_read_block_error` (`agent/file_safety.py`) to deny `read_file` on the external, well-known provider credential stores Hermes imports OAuth tokens from. These hold plaintext OAuth / API-key material and are reachable by the agent today because the existing denylist only resolves candidate paths against `hermes_dirs` (HERMES_HOME + the Hermes root) — external provider homes are never walked. Same prompt-injection exfiltration vector as #17656.

The stores are live paths, not theoretical:
- `~/.claude/.credentials.json` / `~/.claude.json` — Claude Code OAuth, read by the anthropic adapter.
- `~/.config/github-copilot/{hosts,apps}.json` — GitHub Copilot OAuth, enumerated by the model layer.
- `~/.minimax/credentials.json` — MiniMax credentials, enumerated by the model layer.

`~/.codex/auth.json` is deliberately left readable here: #12360 made Hermes stop owning/touching it (single-use refresh-token race), so it is external by design and out of scope for this guard. Calling that out so the exclusion reads as a conscious decision rather than an oversight.

Defense-in-depth, not a security boundary — the terminal tool runs as the same OS user and can still `cat` the file; the read-deny returns a clear error that models respecting tool denials honor, and leaves an audit trail.

## Related Issue

Sibling follow-up to #17656 — no separate issue.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/file_safety.py`: in `get_read_block_error`, add an external provider-CLI credential-store exact-path block after the `mcp-tokens/` check (Claude Code, GitHub Copilot, MiniMax; `XDG_CONFIG_HOME` honored; `~/.codex/auth.json` deliberately excluded per #12360). Reuses the function's existing `resolved` local; no new top-level imports (`os` / `Path` already imported). Docstring updated to list the new category.
- `tests/agent/test_file_safety.py`: new `TestExternalCredentialStoreReadBlocking` — parametrized deny tests for all five stores, an `XDG_CONFIG_HOME`-override case, a negative `~/.codex/auth.json`-stays-readable case, and a negative non-credential-file-under-`~/.claude`-stays-readable case. Tests pin both `HOME` and `HERMES_HOME` so the HERMES_HOME loop cannot coincidentally match.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_file_safety.py -v` → 26 passed (7 new).
2. Regression guard (verified both directions): revert only the `agent/file_safety.py` hunk → the 6 deny-assertions fail (`get_read_block_error` returns `None`); restore → all pass. The 2 negative tests pass both ways, so they are not tautological.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the focused suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on `get_read_block_error`) — or N/A
- [x] cli-config.yaml.example — N/A (no config keys)
- [x] CONTRIBUTING.md / AGENTS.md — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — paths built with `pathlib` and `XDG_CONFIG_HOME` is honored; only tested on macOS
- [x] Tool descriptions/schemas — N/A (no tool-behavior change)

## Related / Positioning

Disjoint from the open #35997 (generic OS/cloud user secrets: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.azure`, `~/.config/gh`, `~/.config/gcloud`, `~/.netrc`, etc.). This PR targets the narrower, Hermes-specific surface: the provider-CLI OAuth stores Hermes' own adapters read live and import tokens from. The two are complementary — neither covers the other's paths.

Disjoint from the open write-deny work (#37336 / Dusk1e's #38490–#38493), which adds `write_file`/`patch` denial on HERMES_HOME credential stores. This is read-deny on external stores.