### PR TITLE
fix(auxiliary): preserve custom vision async client config (#38679)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3224,6 +3224,16 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
     }
+
+    # Propagate httpx-level configuration from the sync client so the
+    # async client uses the same connection parameters (query params,
+    # custom headers) as the sync client.  Without this, custom endpoints
+    # with query-param auth or custom headers silently lose their
+    # configuration during sync→async conversion (#38679).
+    _sync_default_query = getattr(sync_client, "default_query", None)
+    if _sync_default_query:
+        async_kwargs["default_query"] = _sync_default_query
+
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()
@@ -3251,6 +3261,15 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
+
+    # Merge any default_headers from the sync client (set during OpenAI
+    # construction) on top of the provider-inferred headers. The sync
+    # client's explicit headers take precedence.
+    _sync_default_headers = getattr(sync_client, "default_headers", None)
+    if _sync_default_headers:
+        _existing = async_kwargs.get("default_headers", {}) or {}
+        _merged = {**_existing, **_sync_default_headers}
+        async_kwargs["default_headers"] = _merged
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -4085,6 +4104,7 @@ def resolve_vision_provider_client(
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            is_vision=True,
         )
         if client is None:
             return provider_for_base_override, None, None

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -491,3 +491,90 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestCustomVisionAsyncClient:
+    """#38679: custom vision provider must create a properly configured async client."""
+
+    def test_async_custom_vision_passes_is_vision_flag_to_provider_client(self):
+        """resolve_vision_provider_client must pass is_vision=True to resolve_provider_client."""
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        fake_sync = MagicMock()
+        fake_async = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(
+                "custom", "vision-model",
+                "https://custom.test/v1", "test-key", None,
+            ),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_async, "vision-model"),
+        ) as mock_resolve:
+            provider, client, model = resolve_vision_provider_client(
+                provider="custom",
+                model="vision-model",
+                base_url="https://custom.test/v1",
+                api_key="test-key",
+                async_mode=True,
+            )
+
+        # The resolve_provider_client call must include is_vision=True
+        call_kwargs = mock_resolve.call_args.kwargs
+        assert call_kwargs.get("is_vision") is True, (
+            f"resolve_provider_client must receive is_vision=True for vision tasks, "
+            f"got {call_kwargs.get('is_vision')!r}"
+        )
+        assert provider == "custom"
+        assert client is fake_async
+        assert model == "vision-model"
+
+    def test_default_query_preserved_in_async_conversion(self):
+        """_to_async_client must propagate default_query from sync to async client."""
+        from agent.auxiliary_client import _to_async_client
+
+        sync_client = MagicMock()
+        sync_client.api_key = "test-key"
+        sync_client.base_url = "https://custom.test/v1"
+        sync_client.default_query = {"api-version": "2024-02-01"}
+
+        with patch(
+            "openai.AsyncOpenAI"
+        ) as mock_async_openai:
+            fake_async = MagicMock()
+            mock_async_openai.return_value = fake_async
+
+            client, model = _to_async_client(sync_client, "test-model", is_vision=True)
+
+            call_kwargs = mock_async_openai.call_args.kwargs
+            assert call_kwargs.get("default_query") == {"api-version": "2024-02-01"}, (
+                f"AsyncOpenAI must receive default_query from sync client, "
+                f"got {call_kwargs.get('default_query')!r}"
+            )
+            assert client is fake_async
+            assert model == "test-model"
+
+    def test_default_headers_preserved_in_async_conversion(self):
+        """_to_async_client must propagate default_headers from sync to async client."""
+        from agent.auxiliary_client import _to_async_client
+
+        sync_client = MagicMock()
+        sync_client.api_key = "test-key"
+        sync_client.base_url = "https://custom.test/v1"
+        sync_client.default_headers = {"X-Custom-Header": "value"}
+
+        with patch(
+            "openai.AsyncOpenAI"
+        ) as mock_async_openai:
+            fake_async = MagicMock()
+            mock_async_openai.return_value = fake_async
+
+            client, model = _to_async_client(sync_client, "test-model", is_vision=False)
+
+            call_kwargs = mock_async_openai.call_args.kwargs
+            assert call_kwargs.get("default_headers") == {"X-Custom-Header": "value"}, (
+                f"AsyncOpenAI must receive default_headers from sync client, "
+                f"got {call_kwargs.get('default_headers')!r}"
+            )


### PR DESCRIPTION
## Summary

Fixes #38679.

`vision_analyze` could fail with a generic connection error when `auxiliary.vision.provider: custom` used an explicit OpenAI-compatible `base_url`/`api_key`. The async custom vision path diverged from the sync/main model path in two ways:

- `_to_async_client()` recreated `AsyncOpenAI` with only `api_key` and `base_url`, dropping `default_query` and `default_headers` from the sync client.
- `resolve_vision_provider_client()` did not pass `is_vision=True` through the explicit-base-url path, so vision-specific client configuration was skipped.

This PR propagates the sync client's query/header configuration during async conversion and preserves the vision flag for explicit custom vision endpoints.

## Verification

Red proof from upstream/main was captured in the automation artifacts:

- `test_async_custom_vision_passes_is_vision_flag_to_provider_client`: failed because `is_vision` was not passed.
- `test_default_query_preserved_in_async_conversion`: failed because `default_query` was dropped.
- `test_default_headers_preserved_in_async_conversion`: failed because `default_headers` was dropped.

After the fix and rebase onto current `upstream/main`:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_auxiliary_named_custom_providers.py::TestCustomVisionAsyncClient -v -o addopts= --tb=short
# 3 passed in 0.29s

/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_auxiliary_named_custom_providers.py -v -o addopts= --tb=short
# 32 passed, 1 warning in 1.10s
```

Branch state verified as exactly one focused commit ahead of `upstream/main` (`0 1`).

## Duplicate / competitor check

No same-author open PR found for issue #38679 or branch `fix/38679*`. No open competitor PRs found for the issue number or distinctive keywords (`vision_analyze custom provider`, `auxiliary vision custom base_url`, `auxiliary_client custom vision async`).

Auto-published by Moonsong via Path B automated pipeline.
