### PR TITLE
docs(claude-code): add bypassPermissions, VS Code limits, git-init pitfall, /yolo mode

### DIFF
--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-code
 description: "Delegate coding to Claude Code CLI (features, PRs)."
-version: 2.3.0
+version: 2.2.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-code
 description: "Delegate coding to Claude Code CLI (features, PRs)."
-version: 2.2.0
+version: 2.3.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
@@ -44,6 +44,19 @@ terminal(command="claude -p 'Add error handling to all API calls in src/' --allo
 - Structured data extraction with `--json-schema`
 - Piped input processing (`cat file | claude -p "analyze this"`)
 - Any task where you don't need multi-turn conversation
+
+
+> ✅ **PREFERRED permission flag: `--permission-mode bypassPermissions`**
+>
+> Use `--permission-mode bypassPermissions` instead of `--dangerously-skip-permissions`. It bypasses all confirmation dialogs at the flag level — no dialog appears, no PTY needed, no `Down+Enter` dance. Clean for automation.
+>
+> ```bash
+> # ✅ Clean — no dialog, no PTY
+> claude --permission-mode bypassPermissions --print 'Your task'
+>
+> # ❌ Fragile — triggers dialog that defaults to "No, exit", needs PTY + Down+Enter
+> claude --dangerously-skip-permissions 'task'
+> ```
 
 **Print mode skips ALL interactive dialogs** — no workspace trust prompt, no permission confirmations. This makes it ideal for automation.
 
@@ -351,6 +364,15 @@ mcp__<server>__<tool>   # Specific MCP tool
   }
 }
 ```
+
+> ⚠️ **`defaultMode` must be at the top level** — placing it inside the `permissions` object is silently ignored (no error, no effect). This is a common misconfiguration.
+>
+> ```json
+> {
+>   "defaultMode": "bypassPermissions",
+>   "permissions": { ... }
+> }
+> ```
 
 ### Memory Files (CLAUDE.md) Hierarchy
 1. **Global:** `~/.claude/CLAUDE.md` — applies to all projects
@@ -716,6 +738,35 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 10. **Start new sessions for distinct tasks** — sessions last 5 hours; fresh context is more efficient.
 11. **Use `--no-session-persistence`** in CI to avoid accumulating saved sessions on disk.
 
+## VS Code Extension — Permission Behavior & Hard Limits
+
+The VS Code extension has **fundamentally different permission behavior** from the CLI — understand this before debugging.
+
+### What works
+- Settings file: `.claude/settings.local.json` (dot prefix, project root — `claude/` without dot is NOT read)
+- `Shift+Tab` cycles: Normal → Auto-accept edits only
+- `permissions.allow` list is respected for most tools
+
+### What does NOT work (extension hard limits)
+- **`defaultMode: "bypassPermissions"`** — silently ignored everywhere in the file (top-level or inside `permissions`). CLI-only flag.
+- **`"*"` wildcard** — unreliable in extension context; dialogs may persist even with full wildcard
+- **Bypass mode** — the extension has NO bypass mode at all. Anthropic intentionally restricts this.
+- **PowerShell dialogs** — persist even with `["Bash", "Bash(powershell *)", "*"]` in allow list and correct file path. This is intentional by Anthropic. **No settings combination removes these dialogs in the VS Code extension.**
+
+**Only real bypass: use CLI**
+```bash
+claude --dangerously-skip-permissions
+# or (preferred)
+claude --permission-mode bypassPermissions
+```
+
+### Debugging checklist (before concluding it's the extension)
+1. File at `.claude/settings.local.json` (with dot, project root)?
+2. `Ctrl+Shift+P → Reload Window` after every settings change?
+3. Try `["Bash", "Bash(powershell *)", "Read", "Write", "Edit"]` explicitly
+4. If still failing after above → it's the extension limit, not your config
+
+
 ## Pitfalls & Gotchas
 
 1. **Interactive mode REQUIRES tmux** — Claude Code is a full TUI app. Using `pty=true` alone in Hermes terminal works but tmux gives you `capture-pane` for monitoring and `send-keys` for input, which is essential for orchestration.
@@ -730,6 +781,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 10. **Slash commands (like `/commit`) only work in interactive mode** — in `-p` mode, describe the task in natural language instead.
 11. **`--bare` skips OAuth** — requires `ANTHROPIC_API_KEY` env var or an `apiKeyHelper` in settings.
 12. **Context degradation is real** — AI output quality measurably degrades above 70% context window usage. Monitor with `/context` and proactively `/compact`.
+13. **`git init` defaults to `master` branch** — modern convention (and GitHub default) is `main`. When initializing any Claude Code project repo or `~/.claude` dotfiles, always use `git init -b main`. If you've already pushed the wrong branch: `git checkout -b main --track origin/main` then `git branch -D master`.
 
 ## Rules for Hermes Agents
 
@@ -743,3 +795,4 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 8. **Report results to user** — after completion, summarize what Claude did and what changed
 9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
 10. **Use `--allowedTools`** — restrict capabilities to what the task actually needs
+11. **Use `/yolo` in interactive sessions for long autonomous tasks** — enables session-level bypass permissions (equivalent to `--dangerously-skip-permissions`), so all tool calls execute without confirmation prompts for the duration of the session.


### PR DESCRIPTION
## Summary

Five production-discovered improvements to the `claude-code` skill based on real orchestration experience.

### Changes

**1. Preferred permission flag: `--permission-mode bypassPermissions`**

`--dangerously-skip-permissions` in interactive/PTY mode triggers a confirmation dialog that defaults to *"No, exit"* — silently failing automations. `--permission-mode bypassPermissions` bypasses at the flag level with no dialog, no PTY required, no `Down+Enter` timing dance.

```bash
# ✅ Clean
claude --permission-mode bypassPermissions --print 'Your task'

# ❌ Fragile (needs PTY + tmux dialog handling)
claude --dangerously-skip-permissions 'task'
```

**2. `defaultMode` top-level placement trap**

Placing `defaultMode: "bypassPermissions"` inside the `permissions` object is silently ignored — no error, just no effect. Must be at the outermost level of the settings JSON. A common misconfiguration that wastes hours.

**3. VS Code Extension hard limits**

- `defaultMode: "bypassPermissions"` is CLI-only — silently ignored in the extension everywhere
- PowerShell dialogs cannot be suppressed via any settings combination — intentional by Anthropic
- The extension has no bypass mode at all
- Added a debugging checklist to distinguish "my config is wrong" from "this is an extension limit"

**4. `git init -b main` pitfall**

`git init` defaults to `master` on older systems. When initializing Claude Code project repos or `~/.claude` dotfiles, always use `git init -b main` to match GitHub's default. Without this, branch mismatches cause silent failures in push/pull workflows.

**5. `/yolo` in interactive sessions**

Documents the `/yolo` slash command as the interactive-session equivalent of `--dangerously-skip-permissions` — enables session-level bypass permissions for long autonomous tasks without relying on CLI flags.

---

All five points are confirmed production pitfalls, not theoretical.