### PR TITLE
fix(web ui): prevent global background color change on sidebar overlay

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -531,7 +531,7 @@ export default function App() {
           onClick={closeMobile}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
-            "bg-black/70",
+            "bg-black/70 hover:bg-black/70",
           )}
         />
       )}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1307,7 +1307,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             onClick={closeMobilePanel}
             className={cn(
               "fixed inset-0 z-[55] p-0 block",
-              "bg-black/60",
+              "bg-black/60 hover:bg-black/60",
             )}
           />
         )}


### PR DESCRIPTION
## What does this PR do?

This PR fixes ghost-button hover regressions on full-screen mobile backdrops in the web console. Explicit hover background classes now match each backdrop's base color, preventing the default `ghost` Button hover style (`hover:bg-midground/10`) from changing the overlay opacity.

## Related Issue

Fixes #38850

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hover:bg-black/70` to the full-screen mobile navigation overlay in `web/src/App.tsx`.
- Added `hover:bg-black/60` to the mobile model/tools overlay in `web/src/pages/ChatPage.tsx`.
- Both hover overrides now match their corresponding base background colors, preventing opacity changes on hover.

## How to Test

1. Open the Hermes Web UI and resize the browser window to trigger the narrow-screen/mobile layout.
2. Open the left navigation sidebar and hover over its backdrop.
3. Verify that the navigation backdrop remains stable at `bg-black/70`.
4. Open the mobile model/tools panel in ChatPage and hover over its backdrop.
5. Verify that the model/tools backdrop remains stable at `bg-black/60`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(Note: Frontend CSS fix only, backend unaffected)*
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) *(N/A: Purely visual Tailwind CSS fix)*
- [x] I've tested on my platform: Windows 11 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

before:
<img width="1047" height="1234" alt="image" src="https://github.com/user-attachments/assets/ed866faa-55a0-4b76-bc89-810be5eea4d0" />

now:
<img width="1047" height="1234" alt="image" src="https://github.com/user-attachments/assets/170e98ee-11fe-4c6d-9ad8-c790a305ef84" />