### PR TITLE
fix(hindsight): auto-install hindsight-all for local_embedded mode (closes #7718)

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,6 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.4.22`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client >= 0.4.22` (cloud / local external modes). The plugin auto-upgrades on session start if an older version is detected.
+
+For `local_embedded` mode, the `hindsight-all` package is required (provides the embedded daemon, PostgreSQL, and local embedding pipeline). The setup wizard (`hermes memory setup hindsight`) installs it automatically. If the package is missing (e.g. after a `hermes update`), the plugin will attempt to auto-install it on session start.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -99,6 +99,61 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _ensure_hindsight_installed() -> bool:
+    """Auto-install hindsight-all for local_embedded mode if missing.
+
+    Called when ``_check_local_runtime()`` fails.  Uses ``uv pip install``
+    (the same mechanism the setup wizard uses in ``post_setup()``) to
+    install ``hindsight-all`` into the active venv.  Returns True if
+    the install succeeded (or the package was already present).
+    """
+    import shutil
+    import subprocess
+    import sys
+
+    # Quick check — already importable?
+    try:
+        importlib.import_module("hindsight")
+        return True
+    except Exception as exc:
+        # ImportError = package missing (auto-install may help)
+        # RuntimeError/other = incompatible hardware or other issue
+        # — auto-install won't help, return False immediately
+        if not isinstance(exc, ImportError):
+            return False
+
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        logger.warning(
+            "hindsight-all not installed and uv not found. "
+            "Install manually: pip install hindsight-all"
+        )
+        return False
+
+    logger.info("Auto-installing hindsight-all for local_embedded mode...")
+    try:
+        subprocess.run(
+            [uv_path, "pip", "install", "--python", sys.executable,
+             "--quiet", "hindsight-all"],
+            check=True, timeout=180, capture_output=True,
+        )
+        logger.info("hindsight-all installed successfully")
+        return True
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode(errors="replace").strip()
+        logger.warning(
+            "Auto-install of hindsight-all failed. "
+            "Run: hermes memory setup hindsight\n"
+            "Or manually: uv pip install --python %s hindsight-all\n"
+            "Error: %s",
+            sys.executable, stderr[-500:] if stderr else exc,
+        )
+        return False
+    except Exception as exc:
+        logger.warning("Auto-install of hindsight-all failed: %s", exc)
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
@@ -1133,11 +1188,22 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._mode == "local":
             self._mode = "local_embedded"
         if self._mode == "local_embedded":
+            # Auto-install hindsight-all if missing (e.g. after hermes update
+            # removed it from the venv).  Only fires for local_embedded mode
+            # so cloud/self-hosted users are never affected.
             available, reason = _check_local_runtime()
             if not available:
+                installed = _ensure_hindsight_installed()
+                if installed:
+                    available, reason = _check_local_runtime()
+            if not available:
+                import sys
                 logger.warning(
-                    "Hindsight local mode disabled because its runtime could not be imported: %s",
-                    reason,
+                    "Hindsight local_embedded mode requires the 'hindsight-all' "
+                    "package. Run: hermes memory setup hindsight\n"
+                    "Or manually: uv pip install --python %s hindsight-all\n"
+                    "Error: %s",
+                    sys.executable, reason,
                 )
                 self._mode = "disabled"
                 return


### PR DESCRIPTION
## What does this PR do?

Fixes the silent failure when `hindsight-all` is missing from the venv in `local_embedded` mode (e.g. after `hermes update` removes it during dependency resolution). The plugin now auto-installs `hindsight-all` on session start when needed, using the same `uv pip install` mechanism as the setup wizard.

## Related Issue

Fixes #7718

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`:
  - Added `_ensure_hindsight_installed()` helper that auto-installs `hindsight-all` using `uv pip install` (same mechanism as the setup wizard)
  - Modified `initialize()` to call this helper when `_check_local_runtime()` fails for `local_embedded` mode
  - Only fires for `local_embedded` mode — cloud/self-hosted users are never affected
  - Improved warning message with actionable install instructions
  - Handles non-ImportError failures (e.g. incompatible hardware) by returning False immediately without attempting auto-install

- `plugins/memory/hindsight/README.md`:
  - Updated "Client Version" section to document `hindsight-all` requirement for `local_embedded` mode
  - Added note about auto-install behavior

## How to Test

1. Configure hindsight in `local_embedded` mode
2. Run `hermes update` (which may remove `hindsight-all` from venv)
3. Start a new hermes session
4. Verify the plugin auto-installs `hindsight-all` and works correctly
5. Check logs for "Auto-installing hindsight-all for local_embedded mode..."

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#7745, #17851, #13101 were related but didn't land)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/plugins/memory/test_hindsight_provider.py -q` and all 101 tests pass
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README.md in hindsight plugin)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — uses `uv pip install --python sys.executable` which works on macOS, Linux, Windows
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
