### PR TITLE
feat(whatsapp): add emoji reaction support

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -264,7 +264,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
-from gateway.whatsapp_identity import to_whatsapp_jid
+from gateway.whatsapp_identity import canonical_whatsapp_identifier, to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -388,6 +388,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     # Default bridge location resolved via shared helper
     _DEFAULT_BRIDGE_DIR = None  # resolved in __init__
     splits_long_messages = True  # send() chunks via truncate_message()
+    _LAST_INBOUND_CHATS_MAX = 200
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
@@ -441,6 +442,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # Latest inbound (message_id, from_me) per chat (bounded). Lets the
+        # react action default to "the message that triggered me".
+        self._last_inbound_by_chat: Dict[str, tuple] = {}
 
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
@@ -931,6 +935,133 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     return SendResult(success=False, error=error)
         except Exception as e:
             return SendResult(success=False, error=str(e))
+
+    @staticmethod
+    def _reaction_chat_key(chat_id: str) -> str:
+        """Key the last-inbound map by identity, not by JID form.
+
+        The bridge may surface the same DM as a phone JID or a LID; keying on
+        either alone makes a react-by-phone miss a LID-recorded message.
+        """
+        return canonical_whatsapp_identifier(chat_id) or to_whatsapp_jid(chat_id)
+
+    def _record_last_inbound(
+        self,
+        chat_id: Optional[str],
+        message_id: Optional[str],
+        from_me: bool = False,
+    ) -> None:
+        if not chat_id or not message_id:
+            return
+        key = self._reaction_chat_key(chat_id)
+        last = self._last_inbound_by_chat
+        if key in last:
+            del last[key]  # refresh insertion order
+        # from_me rides along: a reaction key must match the target's own
+        # fromMe flag, and owner-typed messages arrive with fromMe=true.
+        last[key] = (message_id, from_me)
+        if len(last) > self._LAST_INBOUND_CHATS_MAX:
+            for old in list(last.keys())[
+                : len(last) - self._LAST_INBOUND_CHATS_MAX
+            ]:
+                del last[old]
+
+    def _last_inbound_target(
+        self, chat_id: str, message_id: Optional[str]
+    ) -> Optional[tuple]:
+        """Resolve the (message_id, from_me) a reaction should target."""
+        if message_id:
+            # Caller-supplied ids are assumed to be someone else's message.
+            return (message_id, False)
+        return self._last_inbound_by_chat.get(self._reaction_chat_key(chat_id))
+
+    async def send_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        *,
+        from_me: bool = False,
+    ) -> SendResult:
+        """React to a message via the bridge's ``/react`` endpoint.
+
+        An empty ``emoji`` retracts our reaction — WhatsApp's native unreact.
+        """
+        if not self._running or not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        bridge_exit = await self._check_managed_bridge_exit()
+        if bridge_exit:
+            return SendResult(success=False, error=bridge_exit)
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json={
+                    "chatId": to_whatsapp_jid(chat_id),
+                    "messageId": message_id,
+                    "emoji": emoji,
+                    "fromMe": from_me,
+                },
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                if resp.status == 200:
+                    return SendResult(success=True, message_id=message_id)
+                else:
+                    error = await resp.text()
+                    return SendResult(success=False, error=error)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    # -- Agent-facing reactions (send_message action="react") ---------------
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """React with ``emoji`` to a message in ``chat_id``.
+
+        Without ``message_id``, targets the chat's most recent inbound message
+        (typically the one the agent is responding to).
+        """
+        target = self._last_inbound_target(chat_id, message_id)
+        if not target:
+            return {
+                "success": False,
+                "error": "no message to react to — pass message_id (no "
+                "inbound message seen in this chat since the gateway started)",
+            }
+        msg_id, from_me = target
+        result = await self.send_reaction(chat_id, msg_id, emoji, from_me=from_me)
+        if not result.success:
+            return {
+                "success": False,
+                "error": result.error or "reaction failed",
+            }
+        return {"success": True, "message_id": msg_id}
+
+    async def remove_reaction(
+        self, chat_id: str, message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Retract our reaction from a message.
+
+        WhatsApp models an unreact as re-reacting with an empty emoji.
+        """
+        target = self._last_inbound_target(chat_id, message_id)
+        if not target:
+            return {
+                "success": False,
+                "error": "no message to unreact — pass message_id",
+            }
+        msg_id, from_me = target
+        result = await self.send_reaction(chat_id, msg_id, "", from_me=from_me)
+        if not result.success:
+            return {
+                "success": False,
+                "error": result.error or "unreact failed",
+            }
+        return {"success": True, "message_id": msg_id}
 
     async def _send_media_to_bridge(
         self,
@@ -1501,6 +1632,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 metadata["whatsapp_from_owner"] = True
                 if not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
+
+            # Lets add_reaction()/remove_reaction() default to the message the
+            # agent is currently responding to. fromOwner ⇒ the bridge forwarded
+            # one of our own (fromMe) messages, which the reaction key must match.
+            # Skip reaction events: a reaction is not itself a reactable target.
+            if native_type != "reactionMessage":
+                self._record_last_inbound(
+                    data.get("chatId"),
+                    data.get("messageId"),
+                    from_me=bool(data.get("fromOwner")),
+                )
 
             return MessageEvent(
                 text=body,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -9,6 +9,7 @@
  *   GET  /messages       - Long-poll for new incoming messages
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
+ *   POST /react          - React to a message { chatId, messageId, emoji, fromMe? } (emoji "" unreacts)
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
  *   POST /typing         - Send typing indicator { chatId }
@@ -36,6 +37,7 @@ import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
   buildLocationPayload,
+  buildReactionPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
   extractBridgeEvent,
@@ -875,6 +877,31 @@ app.post('/edit', async (req, res) => {
     }
 
     res.json({ success: true, messageIds });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// React to a message (emoji "" retracts an existing reaction)
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, messageId, emoji, fromMe } = req.body;
+  let payload;
+  try {
+    payload = buildReactionPayload({ chatId, messageId, emoji, fromMe });
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  try {
+    const sent = await sendWithTimeout(chatId, payload);
+    // Same as every other outbound route: without this our own reaction echoes
+    // back as a fromMe inbound message and can be misread as owner-typed.
+    trackSentMessageId(sent);
+    res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/scripts/whatsapp-bridge/bridge.react.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.react.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the WhatsApp reaction payload helper (POST /react).
+ *
+ * These tests avoid importing bridge.js because that file starts an HTTP
+ * server and Baileys socket at module load. Keep the helper module pure.
+ */
+
+import { strict as assert } from 'node:assert';
+
+import { buildReactionPayload } from './bridge_helpers.js';
+
+{
+  const payload = buildReactionPayload({
+    chatId: '15551234567@s.whatsapp.net',
+    messageId: 'msg-1',
+    emoji: '👍',
+  });
+  assert.deepEqual(payload, {
+    react: {
+      text: '👍',
+      key: {
+        remoteJid: '15551234567@s.whatsapp.net',
+        fromMe: false,
+        id: 'msg-1',
+      },
+    },
+  });
+  console.log('  ✓ builds a native Baileys reaction payload');
+}
+
+{
+  // WhatsApp retracts a reaction when the react text is '' — an empty emoji
+  // is the unreact path, not a validation error.
+  const payload = buildReactionPayload({
+    chatId: '15551234567@s.whatsapp.net',
+    messageId: 'msg-1',
+    emoji: '',
+  });
+  assert.equal(payload.react.text, '');
+  assert.equal(payload.react.key.id, 'msg-1');
+  console.log('  ✓ empty emoji builds an unreact payload');
+}
+
+{
+  const payload = buildReactionPayload({
+    chatId: '15551234567@s.whatsapp.net',
+    messageId: 'msg-1',
+    emoji: '👍',
+    fromMe: true,
+  });
+  assert.equal(payload.react.key.fromMe, true);
+
+  const coerced = buildReactionPayload({
+    chatId: '15551234567@s.whatsapp.net',
+    messageId: 'msg-1',
+    emoji: '👍',
+    fromMe: 'true',
+  });
+  assert.equal(coerced.react.key.fromMe, true);
+  console.log('  ✓ fromMe targets our own message (accepts bool or "true")');
+}
+
+{
+  assert.throws(
+    () => buildReactionPayload({ messageId: 'msg-1', emoji: '👍' }),
+    /chatId is required/,
+  );
+  assert.throws(
+    () => buildReactionPayload({ chatId: 'c@s.whatsapp.net', emoji: '👍' }),
+    /messageId is required/,
+  );
+  assert.throws(
+    () => buildReactionPayload({ chatId: 'c@s.whatsapp.net', messageId: 'msg-1' }),
+    /emoji is required/,
+  );
+  console.log('  ✓ missing chatId/messageId/emoji are rejected');
+}
+
+console.log('\n✅ All WhatsApp reaction bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -170,6 +170,26 @@ export function buildTextSendPayload(text, { replyTo, messageStore } = {}) {
   return { content, options };
 }
 
+export function buildReactionPayload({ chatId, messageId, emoji, fromMe = false } = {}) {
+  if (!chatId) throw new Error('chatId is required');
+  if (!messageId) throw new Error('messageId is required');
+  // An empty string is a valid emoji here: WhatsApp retracts an existing
+  // reaction when the react text is ''. Only a missing field is an error.
+  if (emoji === undefined || emoji === null) {
+    throw new Error('emoji is required (use "" to remove a reaction)');
+  }
+  return {
+    react: {
+      text: String(emoji),
+      key: {
+        remoteJid: chatId,
+        fromMe: fromMe === true || fromMe === 'true',
+        id: messageId,
+      },
+    },
+  };
+}
+
 export function buildLocationPayload({ latitude, longitude, name, address } = {}) {
   const lat = Number(latitude);
   const lon = Number(longitude);

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -61,6 +61,7 @@ def _make_adapter():
     adapter._allow_from = set()
     adapter._group_policy = "open"
     adapter._group_allow_from = set()
+    adapter._last_inbound_by_chat = {}
     return adapter
 
 

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -43,6 +43,7 @@ def _make_adapter():
     adapter._mention_patterns = []
     adapter._free_response_chats = set()
     adapter._whatsapp_free_response_chats = lambda: set()
+    adapter._last_inbound_by_chat = {}
     return adapter
 
 

--- a/tests/gateway/test_whatsapp_reactions.py
+++ b/tests/gateway/test_whatsapp_reactions.py
@@ -1,0 +1,205 @@
+"""Tests for WhatsApp emoji reactions (send_message action='react'/'unreact').
+
+Covers the adapter → bridge `/react` dispatch, the "default to the message the
+agent is replying to" behavior, and WhatsApp's empty-emoji unreact.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.gateway.test_whatsapp_formatting import _AsyncCM, _make_adapter
+
+
+@pytest.fixture(autouse=True)
+def _whatsapp_open_optin(monkeypatch):
+    """Opt into WhatsApp allow-all so inbound dispatch reaches the event builder.
+
+    The adapter fails closed on ``dm_policy: open`` without this (SECURITY.md
+    2.6), which would otherwise drop the message before it is recorded as the
+    chat's last inbound.
+    """
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+
+
+def _ok_response(adapter, status=200, text=""):
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value={"success": True})
+    resp.text = AsyncMock(return_value=text)
+    adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_posts_to_bridge_react_endpoint():
+    adapter = _make_adapter()
+    _ok_response(adapter)
+
+    result = await adapter.add_reaction("15551234567", "👍", message_id="msg-1")
+
+    assert result == {"success": True, "message_id": "msg-1"}
+    call = adapter._http_session.post.call_args
+    assert call.args[0] == "http://127.0.0.1:3000/react"
+    assert call.kwargs["json"] == {
+        "chatId": "15551234567@s.whatsapp.net",
+        "messageId": "msg-1",
+        "emoji": "👍",
+        "fromMe": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_defaults_to_last_inbound_message():
+    adapter = _make_adapter()
+    await adapter._build_message_event({
+        "messageId": "inbound-9",
+        "chatId": "15551234567@s.whatsapp.net",
+        "senderId": "15551234567@s.whatsapp.net",
+        "senderName": "Tester",
+        "chatName": "Tester",
+        "isGroup": False,
+        "body": "ship it",
+        "hasMedia": False,
+        "mediaUrls": [],
+    })
+    _ok_response(adapter)
+
+    result = await adapter.add_reaction("15551234567", "❤️")
+
+    assert result == {"success": True, "message_id": "inbound-9"}
+    assert adapter._http_session.post.call_args.kwargs["json"]["messageId"] == "inbound-9"
+
+
+@pytest.mark.asyncio
+async def test_remove_reaction_sends_empty_emoji():
+    adapter = _make_adapter()
+    adapter._record_last_inbound("15551234567@s.whatsapp.net", "inbound-9")
+    _ok_response(adapter)
+
+    result = await adapter.remove_reaction("15551234567")
+
+    assert result == {"success": True, "message_id": "inbound-9"}
+    # WhatsApp models an unreact as re-reacting with an empty emoji.
+    assert adapter._http_session.post.call_args.kwargs["json"]["emoji"] == ""
+
+
+@pytest.mark.asyncio
+async def test_react_by_phone_finds_message_recorded_under_lid():
+    """The bridge surfaces a DM as a LID; a react addressed by phone must still
+    resolve it — both forms canonicalize to the same identity."""
+    aliases = {"195794724511942@lid": "94768741618", "94768741618": "94768741618"}
+
+    adapter = _make_adapter()
+    _ok_response(adapter)
+
+    with patch(
+        "plugins.platforms.whatsapp.adapter.canonical_whatsapp_identifier",
+        side_effect=lambda cid: aliases.get(cid, cid),
+    ):
+        adapter._record_last_inbound("195794724511942@lid", "inbound-lid")
+        result = await adapter.add_reaction("94768741618", "👍")
+
+    assert result == {"success": True, "message_id": "inbound-lid"}
+    assert adapter._http_session.post.call_args.kwargs["json"]["messageId"] == "inbound-lid"
+
+
+@pytest.mark.asyncio
+async def test_reacting_to_owner_message_sets_from_me():
+    """fromOwner messages are our own (fromMe=true); the reaction key must match
+    or WhatsApp resolves it to no message at all."""
+    adapter = _make_adapter()
+    await adapter._build_message_event({
+        "messageId": "owner-1",
+        "chatId": "15551234567@s.whatsapp.net",
+        "senderId": "15551234567@s.whatsapp.net",
+        "senderName": "Owner",
+        "chatName": "Owner",
+        "isGroup": False,
+        "body": "handling this myself",
+        "hasMedia": False,
+        "mediaUrls": [],
+        "fromOwner": True,
+    })
+    _ok_response(adapter)
+
+    result = await adapter.add_reaction("15551234567", "👍")
+
+    assert result == {"success": True, "message_id": "owner-1"}
+    assert adapter._http_session.post.call_args.kwargs["json"]["fromMe"] is True
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_does_not_become_the_react_target():
+    """A reaction is not itself a reactable message — reacting to one resolves to
+    no target at all, so it must not displace the real last inbound message."""
+    adapter = _make_adapter()
+    base = {
+        "chatId": "15551234567@s.whatsapp.net",
+        "senderId": "15551234567@s.whatsapp.net",
+        "senderName": "Tester",
+        "chatName": "Tester",
+        "isGroup": False,
+        "hasMedia": False,
+        "mediaUrls": [],
+    }
+    await adapter._build_message_event({**base, "messageId": "real-msg", "body": "ship it"})
+    await adapter._build_message_event({
+        **base,
+        "messageId": "reaction-evt",
+        "body": "[Reaction: ❤️ to real-msg]",
+        "nativeType": "reactionMessage",
+    })
+    _ok_response(adapter)
+
+    result = await adapter.add_reaction("15551234567", "👍")
+
+    assert result == {"success": True, "message_id": "real-msg"}
+
+
+@pytest.mark.asyncio
+async def test_reacting_to_inbound_message_does_not_set_from_me():
+    adapter = _make_adapter()
+    adapter._record_last_inbound("15551234567@s.whatsapp.net", "inbound-9")
+    _ok_response(adapter)
+
+    await adapter.add_reaction("15551234567", "👍")
+
+    assert adapter._http_session.post.call_args.kwargs["json"]["fromMe"] is False
+
+
+@pytest.mark.asyncio
+async def test_reaction_without_target_or_inbound_message_errors():
+    adapter = _make_adapter()
+    adapter._http_session.post = MagicMock()
+
+    result = await adapter.add_reaction("15551234567", "👍")
+
+    assert result["success"] is False
+    assert "pass message_id" in result["error"]
+    adapter._http_session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reaction_surfaces_bridge_error():
+    adapter = _make_adapter()
+    _ok_response(adapter, status=500, text="Not connected to WhatsApp")
+
+    result = await adapter.add_reaction("15551234567", "👍", message_id="msg-1")
+
+    assert result == {"success": False, "error": "Not connected to WhatsApp"}
+
+
+@pytest.mark.asyncio
+async def test_last_inbound_map_is_bounded():
+    adapter = _make_adapter()
+    for i in range(adapter._LAST_INBOUND_CHATS_MAX + 25):
+        adapter._record_last_inbound(f"1555{i:07d}@s.whatsapp.net", f"msg-{i}")
+
+    assert len(adapter._last_inbound_by_chat) == adapter._LAST_INBOUND_CHATS_MAX
+    # Oldest chats evicted, newest retained.
+    n = adapter._LAST_INBOUND_CHATS_MAX + 24
+    assert adapter._reaction_chat_key("15550000000@s.whatsapp.net") not in (
+        adapter._last_inbound_by_chat
+    )
+    newest = adapter._reaction_chat_key(f"1555{n:07d}@s.whatsapp.net")
+    assert adapter._last_inbound_by_chat[newest] == (f"msg-{n}", False)

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -95,3 +95,59 @@ def test_react_without_live_gateway():
         )
     assert result.get("success") is not True
     assert "live" in json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp
+#
+# Exercised through the real adapter (not a fake) so the tool's keyword-arg
+# call convention stays pinned to the adapter's actual signature.
+# ---------------------------------------------------------------------------
+
+def _whatsapp_runner():
+    from gateway.config import Platform
+    from tests.gateway.test_whatsapp_formatting import _AsyncCM, _make_adapter
+    from unittest.mock import AsyncMock, MagicMock
+
+    adapter = _make_adapter()
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value={"success": True})
+    resp.text = AsyncMock(return_value="")
+    adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+    return SimpleNamespace(adapters={Platform.WHATSAPP: adapter}), adapter
+
+
+def test_react_dispatches_to_whatsapp_adapter():
+    runner, adapter = _whatsapp_runner()
+    with patch("gateway.run._gateway_runner_ref", lambda: runner):
+        result = _call(
+            {
+                "action": "react",
+                "target": "whatsapp:15551234567",
+                "emoji": "👍",
+                "message_id": "msg-1",
+            }
+        )
+    assert result["success"] is True
+    call = adapter._http_session.post.call_args
+    assert call.args[0].endswith("/react")
+    assert call.kwargs["json"] == {
+        "chatId": "15551234567@s.whatsapp.net",
+        "messageId": "msg-1",
+        "emoji": "👍",
+        "fromMe": False,
+    }
+
+
+def test_unreact_dispatches_to_whatsapp_adapter_with_empty_emoji():
+    runner, adapter = _whatsapp_runner()
+    adapter._record_last_inbound("15551234567@s.whatsapp.net", "inbound-9")
+    with patch("gateway.run._gateway_runner_ref", lambda: runner):
+        result = _call({"action": "unreact", "target": "whatsapp:15551234567"})
+    assert result["success"] is True
+    assert adapter._http_session.post.call_args.kwargs["json"] == {
+        "chatId": "15551234567@s.whatsapp.net",
+        "messageId": "inbound-9",
+        "emoji": "",
+        "fromMe": False,
+    }

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -210,7 +210,7 @@ SEND_MESSAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["send", "list", "react", "unreact"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction."
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. WhatsApp, photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction."
             },
             "target": {
                 "type": "string",


### PR DESCRIPTION
Closes #38868

## Summary

Implements WhatsApp emoji reactions. `send_message` already dispatches `action='react'` / `'unreact'` to an adapter's `add_reaction` / `remove_reaction`, but the WhatsApp plugin and bridge never implemented them — so the capability was missing on WhatsApp specifically.

Rebased onto current `main` and re-scoped after review.

## Changes

### `plugins/platforms/whatsapp/adapter.py`
- `add_reaction(chat_id, emoji, message_id=None)` / `remove_reaction(chat_id, message_id=None)` matching the interface `_handle_react` dispatches to, backed by `send_reaction()` → the bridge's `/react` endpoint.
- Tracks the latest inbound message id per chat (bounded at 200, insertion-order eviction — mirrors the photon adapter's `_record_last_inbound`), so `react`/`unreact` default to the message the agent is responding to when no `message_id` is given.
- Chat ids are normalized with `to_whatsapp_jid()`, consistent with every other bridge call.

### `scripts/whatsapp-bridge/`
- New `POST /react` route. WhatsApp models an unreact as re-reacting with an empty emoji, so `emoji: ""` is valid and only a *missing* field is rejected.
- Payload construction lives in a pure `buildReactionPayload()` in `bridge_helpers.js` — the `.mjs` tests can't import `bridge.js` (it starts an HTTP server and Baileys socket at module load), so keeping it in the helper module is what makes the route testable at all.
- The route calls `trackSentMessageId()` like every other outbound route, so our own reaction doesn't echo back as a `fromMe` inbound and get misread as owner-typed.

### `tools/send_message_tool.py`
- One-line schema description update: the reaction copy previously named only photon/iMessage.

## Testing

- `tests/gateway/test_whatsapp_reactions.py` — adapter → bridge dispatch: explicit `message_id`, defaulting to last inbound, unreact sending an empty emoji, the no-inbound-seen error, bridge error propagation, and the bounded-map eviction.
- `tests/tools/test_send_message_react.py` — WhatsApp cases driven through the **real** adapter (not a fake), so the tool's keyword-arg call convention stays pinned to the adapter's actual signature.
- `scripts/whatsapp-bridge/bridge.react.test.mjs` — payload builder, including the empty-emoji unreact.
- Verified live against a real WhatsApp bridge: the reaction renders as a native WhatsApp reaction.

## Notes for reviewers

- The previous revision edited `gateway/platforms/whatsapp.py`, which `560010547` relocated to `plugins/platforms/whatsapp/adapter.py`. That's fixed — this is rebased onto current `main` and touches only the bundled plugin path.
- The earlier revision also carried quoted-reply changes (`getQuotedText`, `quotedText`, `reply_to_*`). `main` has since implemented that independently and more completely (`textFromQuotedMessage()` covers polls/location/contacts; the adapter also sets `reply_to_author_id` / `reply_to_is_own_message`), so that work is **dropped** — this PR is reactions only.
- Scope: this makes reactions available on WhatsApp through the surfaces that already reach `send_message` (MCP server, cron delivery). It does **not** register `send_message` as an agent-callable tool — that guardrail is untouched.
