### PR TITLE
feat: add cross-PR conflict detection to github-code-review skill

### DIFF
--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -467,6 +467,10 @@ EOF
 )"
 ```
 
+### Step 8b: Cross-PR Conflict Check (Optional)
+
+Run the cross-PR conflict check (see Section 6).
+
 ### Step 9: Clean up
 
 ```bash
@@ -479,3 +483,67 @@ git branch -D pr-$PR_NUMBER
 - **Approve** — no critical or warning-level issues, only minor suggestions or all clear
 - **Request Changes** — any critical or warning-level issue that should be fixed before merge
 - **Comment** — observations and suggestions, but nothing blocking (use when you're unsure or the PR is a draft)
+
+---
+
+## 6. Cross-PR Conflict Analysis (Optional)
+
+Check whether the current PR modifies functions also changed by other open PRs.
+
+### During PR Review — Conflict Check
+
+After posting your code review (Steps 7-8), run the cross-PR conflict check:
+
+```bash
+# Install codegraph if not present
+if ! command -v codegraph &>/dev/null; then
+  pip install codegraph-ai
+fi
+
+# Build index if not present (one-time, takes a few minutes)
+if [ ! -d ".codegraph" ]; then
+  codegraph init --repo . --db .codegraph
+  # Re-run periodically (e.g. weekly) to keep the index fresh
+  codegraph pr-review prepare --db .codegraph --limit 500
+  echo ".codegraph/" >> .gitignore
+fi
+
+# Ensure this PR is in the index (idempotent — safe to re-run on existing PRs)
+codegraph pr-review update --db .codegraph --pr $PR_NUMBER
+
+# Check for conflicts (dry-run to preview)
+codegraph pr-review label --db .codegraph --pr $PR_NUMBER --comment-only --dry-run
+```
+
+If conflicts are found, post the conflict comment:
+
+```bash
+codegraph pr-review label --db .codegraph --pr $PR_NUMBER --comment-only
+```
+
+If no conflicts are found, skip — no comment needed.
+
+The conflict comment looks like:
+
+```markdown
+### :warning: Cross-PR Conflict Detected
+
+This PR shares modified code with #37398, #37442, #37966.
+
+**Shared functions:**
+
+| Function | File | Also modified by |
+|----------|------|-----------------|
+| `_run_single_child` | `tools/delegate_tool.py` | #37633, #37724 |
+| `delegate_task` | `tools/delegate_tool.py` | #37398, #37442, #37966 |
+
+**Recommendation:** Coordinate with #37398, #37442, #37633, #37724, #37966 before merging.
+```
+
+### Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Database locked` after interrupted `prepare` | `rm .codegraph/graph.db/neugdb.lock` |
+| `prepare`/`update` fails to fetch PR diffs | Run `gh auth login` first — codegraph uses `gh` CLI for GitHub access |
+| `prepare` seems stuck | Normal — indexing 500 PRs takes a few minutes. Let it finish |


### PR DESCRIPTION
## Summary

- Add **Section 6: Cross-PR Conflict Analysis** to `github-code-review` skill — detects when the current PR modifies functions also changed by other open PRs
- Add **Step 8b** to the PR review workflow (Section 5) to integrate the conflict check into the existing review flow
- Uses [codegraph](https://github.com/alibaba/neug/tree/main/skills/codegraph) (`pip install codegraph-ai`) for function-level conflict detection across open PRs

## Motivation

Repos with many concurrent PRs often have multiple PRs modifying the same functions. Reviewing them independently wastes effort — merging one invalidates the diffs of the others. This extension gives the reviewer visibility into cross-PR dependencies so they can coordinate merge order.

Related issue: #38054

## How it works

[codegraph](https://github.com/alibaba/neug/tree/main/skills/codegraph) builds a **code knowledge graph** using [tree-sitter](https://tree-sitter.github.io/) to parse source code into function-level nodes and call edges, stored in a [NeuG](https://github.com/alibaba/neug) graph database.

For cross-PR conflict detection, the pipeline works in three steps:

1. **Index**: Parse each open PR's diff (`gh pr diff`) and resolve changed hunks to function-level granularity. For each PR, create a `PR` node and `CHANGES` edges to the `Function` nodes it modifies — verified against the existing code graph to distinguish modified functions from newly added ones.

2. **Detect**: Query the graph for functions with incoming `CHANGES` edges from multiple PRs:
   ```cypher
   MATCH (pr1:PR)-[:CHANGES]->(f:Function)<-[:CHANGES]-(pr2:PR)
   WHERE pr1.id < pr2.id
   RETURN pr1.id, pr2.id, f.name, f.file_path
   ```
   Then compute connected components (union-find) to group all transitively conflicting PRs.

3. **Report**: For each PR in a conflict group, post a comment listing the shared functions and the other PRs that touch them.

This catches conflicts that git cannot — git only detects merge conflicts between two branches at merge time, and has no awareness of other open PRs. codegraph compares all open PRs simultaneously at the function level, surfacing semantic overlaps before any merge is attempted.

## What changed

`skills/github/github-code-review/SKILL.md`:
- **Step 8b** (Section 5): cross-reference to Section 6
- **Section 6**: self-contained conflict detection workflow — auto-installs codegraph if not present, builds index on first run, then runs incremental update + conflict check for the current PR
- **Troubleshooting** table for common issues (database lock, gh auth, slow prepare)

## Verification

Tested the full workflow (`init` → `prepare` → `update` → `label --comment-only`) against open PRs in this repo. Confirmed conflict detection, idempotent update, and comment posting all work correctly. Detailed analysis results will be posted as a follow-up comment.
