### PR TITLE
fix(feishu): remove outdated markdown table fallback, always use post format #38755

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -154,9 +154,6 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4308,16 +4305,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post-type 'md' elements natively support all markdown syntax
+        # including pipe tables, code blocks, headings, lists, etc.
+        # Always use post format for proper markdown rendering.
+        return "post", _build_markdown_post_payload(content)
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -367,11 +367,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
-        self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
-        )
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_message_falls_back_to_text_when_post_update_is_rejected(self):


### PR DESCRIPTION
## Problem

When Hermes sends Markdown messages containing pipe tables to Feishu, the message content is displayed as raw Markdown source code instead of rendered output.

## Root Cause

In `gateway/platforms/feishu.py`, the `_build_outbound_payload()` method had an outdated fallback logic that detected pipe tables via `_MARKDOWN_TABLE_RE` and forced the message type to `text` (plain text):

This was originally a workaround for an older Feishu version where the Post format with `"tag": "md"` elements did not support tables. Feishu now supports all Markdown syntax natively in Post format.

## Fix

Always use Feishu's Post format (`msg_type: "post"`) with `{"tag": "md"}` elements for all outbound messages. This removes the `_MARKDOWN_TABLE_RE` fallback check and the plain-text fallback, ensuring all Markdown content (tables, headings, code blocks, lists, etc.) is properly rendered by Feishu.

## Testing

- All 160 Feishu tests pass
- Updated test `test_edit_message_updates_existing_feishu_message` to expect `post` format instead of `text`

Fixes #38755