### PR TITLE
fix: use thread-based timeouts for cross-platform compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,12 +277,14 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap with thread method.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
 # hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+# Thread method is used for cross-platform compatibility (signal method
+# requires SIGALRM which is POSIX-only and unavailable on Windows).
+addopts = "-m 'not integration' --timeout=30 --timeout-method=thread"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## What does this PR do?

Fixes Windows pytest compatibility by switching from signal-based to thread-based timeouts. The signal method uses `SIGALRM` which is POSIX-only and causes `AttributeError` on Windows. Thread method works cross-platform with negligible performance difference.

Root cause: `tests/conftest.py` line 448 mentions "The old SIGALRM-based fixture (POSIX-only, didn't work on Windows) is gone" but `pyproject.toml` still referenced signal method.

## Related Issue

No existing issue - discovered during Windows contributor environment setup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Changed `pytest-timeout` method from `signal` to `thread` in `pyproject.toml` line 287
- Updated comment to explain cross-platform compatibility rationale

## How to Test

**Before (main branch, Windows):**
```powershell
pytest tests/test_hermes_state.py::TestSessionLifecycle::test_create_and_get_session -v
# Error: AttributeError: module 'signal' has no attribute 'SIGALRM'
```

**After (this branch, Windows):**
```powershell
pytest tests/test_hermes_state.py::TestSessionLifecycle::test_create_and_get_session -v
# ✅ 1 passed in 0.86s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix:`)
- [x] I searched for existing PRs - this isn't a duplicate
- [x] My PR contains only related changes
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests - N/A (config change, existing 17K tests validate behavior)
- [x] I've tested on my platform: Windows 11, Python 3.11.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (added explanatory comment in pyproject.toml) — or N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — this IS the cross-platform fix!
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

**Before fix (main branch, Windows 11, Python 3.11.9):**
```
platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0
timeout: 30.0s
timeout method: signal
timeout func_only: False

INTERNALERROR> File "...\pytest_timeout.py", line 324, in pytest_timeout_set_timer
INTERNALERROR>     signal.signal(signal.SIGALRM, handler)
INTERNALERROR>                   ^^^^^^^^^^^^^^
INTERNALERROR> AttributeError: module 'signal' has no attribute 'SIGALRM'

==================================================== no tests ran in 0.40s ====================================================
```

**After fix (fix/windows-pytest-timeout branch, Windows 11, Python 3.11.9):**
```
platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0
timeout: 30.0s
timeout method: thread  ← Changed!
timeout func_only: False
collected 1 item

tests/test_hermes_state.py::TestSessionLifecycle::test_create_and_get_session PASSED [100%]

====================================================== 1 passed in 0.86s ======================================================
```

**Key difference:** `timeout method: signal` → `timeout method: thread` ✅
