### PR TITLE
fix: add direct API-key provider fallback to vision auto-detect

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -287,6 +287,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2.5",
     "zai": "glm-5v-turbo",
+    "gemini": "gemini-2.5-flash",
 }
 
 # Providers whose endpoint does not accept image input, even though the
@@ -3957,6 +3958,15 @@ _VISION_AUTO_PROVIDER_ORDER = (
     "nous",
 )
 
+# Vision-capable direct API-key providers, checked after aggregators fail.
+# These require only an API key in .env (no OAuth) and have known working
+# vision models.  Checked last because aggregators can use any key, while
+# direct providers need a provider-specific key the user may not have set.
+_VISION_DIRECT_PROVIDER_FALLBACK = (
+    "gemini",
+    "nvidia",
+)
+
 
 def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     """Return True when ``provider``/``model`` is known to accept image input.
@@ -4042,6 +4052,17 @@ def get_available_vision_backends() -> List[str]:
     for p in _VISION_AUTO_PROVIDER_ORDER:
         if p not in available and _strict_vision_backend_available(p):
             available.append(p)
+    # 4. Direct API-key providers with vision support — checked last
+    #    because they need a provider-specific API key, while aggregators
+    #    can route through any key the user has configured.
+    for p in _VISION_DIRECT_PROVIDER_FALLBACK:
+        if p not in available:
+            try:
+                client, _ = resolve_provider_client(p, is_vision=True)
+                if client is not None:
+                    available.append(p)
+            except Exception:
+                continue
     return available
 
 
@@ -4167,6 +4188,37 @@ def resolve_vision_provider_client(
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)
+
+        # 4. Fall back through direct API-key providers with vision support.
+        #    These are providers that require only an API key in .env (no OAuth)
+        #    and have known working vision models.  Checked after aggregators
+        #    because aggregators work with any provider's key, while direct
+        #    providers need a specific API key the user may not have configured.
+        for direct_provider in _VISION_DIRECT_PROVIDER_FALLBACK:
+            if direct_provider == main_provider:
+                continue
+            try:
+                # Use vision-specific model override if one exists for this
+                # provider; otherwise let resolve_provider_client pick the
+                # default aux model.
+                fallback_client, fallback_model = resolve_provider_client(
+                    direct_provider,
+                    model=_PROVIDER_VISION_MODELS.get(direct_provider, ""),
+                    is_vision=True,
+                )
+                if fallback_client is not None:
+                    logger.info(
+                        "Vision auto-detect: using direct provider %s (%s)",
+                        direct_provider,
+                        fallback_model or _get_aux_model_for_provider(direct_provider),
+                    )
+                    return _finalize(direct_provider, fallback_client, fallback_model)
+            except Exception as exc:
+                logger.debug(
+                    "Vision auto-detect: direct provider %s failed: %s",
+                    direct_provider, exc,
+                )
+                continue
 
         logger.debug("Auxiliary vision client: none available")
         return None, None, None


### PR DESCRIPTION
## Problem

When `auxiliary.vision.provider: auto`, the fallback chain was:
`main provider -> OpenRouter -> Nous -> stop`

Users with only direct API keys (Google Gemini / NVIDIA NIM) but no aggregator keys got "No LLM provider configured for task=vision" — even though they had valid `GOOGLE_API_KEY` or `NVIDIA_API_KEY` set in `.env`.

## Solution

Added `_VISION_DIRECT_PROVIDER_FALLBACK = ("gemini", "nvidia")` — checked after the OpenRouter/Nous aggregator chain in both `get_available_vision_backends()` and `resolve_vision_provider_client()`.

These providers need only an API key in `.env` and have known working vision models. They're checked last because aggregators can route through any key, while direct providers need a provider-specific key.

## New fallback chain

`main provider (if vision-capable) -> OpenRouter -> Nous -> Gemini (GOOGLE_API_KEY) -> NVIDIA (NVIDIA_API_KEY) -> None`

## Testing

- All 58 existing vision routing tests pass
- All 12 vision-specific tests in test_auxiliary_client.py pass
- Verified `get_available_vision_backends()` includes `gemini` when `GOOGLE_API_KEY` is set
- Manual test: `resolve_vision_provider_client(provider="auto")` returns Google Gemini client when configured