### PR TITLE
desktop+linux: auto-restart after in-app update on Linux

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1384,6 +1384,19 @@ function resolveHermesCliBinary(updateRoot) {
   return findOnPath('hermes') || null
 }
 
+// Resolve the rebuilt Linux Electron binary so the desktop can short-circuit
+// the "Restart Hermes" prompt.
+function findLinuxLaunchable(updateRoot) {
+  const binaries = [
+    path.join(updateRoot, 'apps', 'desktop', 'release', 'linux-unpacked', 'Hermes'),
+    path.join(updateRoot, 'apps', 'desktop', 'release', 'linux-unpacked', 'hermes'),
+  ]
+  for (const exe of binaries) {
+    if (fileExists(exe)) return exe
+  }
+  return null
+}
+
 // Spawn a command and stream each output line to the update progress channel.
 function runStreamedUpdate(command, args, { cwd, env, stage } = {}) {
   return new Promise(resolve => {
@@ -1498,20 +1511,33 @@ async function applyUpdatesPosixInApp(opts = {}) {
   }
 
   const rebuiltApp = [
+    path.join(updateRoot, 'apps', 'desktop', 'release', 'linux-unpacked', 'Hermes'),
     path.join(updateRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
-  ].find(directoryExists)
+    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app'),
+  ]
+  const linuxBinary = rebuiltApp.find(p => !p.endsWith('.app') && fileExists(p)) || null
+  const macBundle = rebuiltApp.find(p => p.endsWith('.app') && directoryExists(p)) || null
   const targetApp = runningAppBundle()
 
-  // No bundle to swap (dev run, Linux AppImage, or unresolved paths): the
-  // backend is updated; the next launch picks up the rebuilt GUI.
-  if (!rebuiltApp || !targetApp) {
+  // Linux: the rebuild produces a plain binary in linux-unpacked/, running
+  // alongside the live process. Re-launch it directly so the user never sees
+  // a "Restart Hermes" prompt. The old process can exit freely because the
+  // running instance is a child of the CLI (its own fd refs), not a file lock.
+  if (linuxBinary && !targetApp) {
+    emitUpdateProgress({ stage: 'restart', message: 'Restarting Hermes…', percent: 95 })
+    spawn(linuxBinary, [], { detached: true, stdio: 'ignore' }).unref()
+    setTimeout(() => app.quit(), 600)
+    return { ok: true, handedOff: true, rebuiltApp: linuxBinary }
+  }
+
+  // macOS: swap the .app bundle while we're gone
+  if (!macBundle || !targetApp) {
     emitUpdateProgress({
       stage: 'done',
       message: 'Backend updated. Restart Hermes to load the new version.',
       percent: 100
     })
-    return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
+    return { ok: true, backendUpdated: true, rebuiltApp: macBundle || linuxBinary || null }
   }
 
   emitUpdateProgress({ stage: 'restart', message: 'Installing the updated app and restarting…', percent: 95 })
@@ -1521,7 +1547,7 @@ async function applyUpdatesPosixInApp(opts = {}) {
   const swapScript = `#!/bin/bash
 set -u
 APP_PID=${process.pid}
-SRC=${shellQuote(rebuiltApp)}
+SRC=${shellQuote(macBundle)}
 DST=${shellQuote(targetApp)}
 for _ in $(seq 1 240); do
   kill -0 "$APP_PID" 2>/dev/null || break
@@ -1547,16 +1573,16 @@ fi
       message: 'Backend + app updated. Restart Hermes to load the new version.',
       percent: 100
     })
-    rememberLog(`[updates] could not write swap script: ${err.message}; rebuilt app at ${rebuiltApp}`)
-    return { ok: true, backendUpdated: true, rebuiltApp }
+    rememberLog(`[updates] could not write swap script: ${err.message}; rebuilt app at ${macBundle}`)
+    return { ok: true, backendUpdated: true, rebuiltApp: macBundle }
   }
 
   const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
   child.unref()
-  rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${rebuiltApp} -> ${targetApp})`)
+  rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${macBundle} -> ${targetApp})`)
 
   setTimeout(() => app.quit(), 600)
-  return { ok: true, handedOff: true, rebuiltApp, targetApp }
+  return { ok: true, handedOff: true, rebuiltApp: macBundle, targetApp }
 }
 
 function readJson(filePath) {


### PR DESCRIPTION
Linux desktop updates previously showed 'Backend updated. Restart Hermes to load the new version.' because applyUpdatesPosixInApp() only knew how to swap .app bundles (macOS). The rebuilt linux-unpacked/ binary was left on disk with the user responsible for relaunching.

Now the same function detects the new linux-unpacked/<exe> binary and spawns it detached before quitting, so the user sees a seamless restart instead of being stuck on the updating overlay.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

