### PR TITLE
feat(desktop): remote-mode image attach/display + per-profile gateway switching

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3393,6 +3393,52 @@ function decryptDesktopSecret(secret) {
   return value
 }
 
+function genConnectionId() {
+  return crypto.randomBytes(6).toString('hex')
+}
+
+// Normalize parsed connection.json into the multi-remote schema. Migrates the
+// legacy single-`remote` shape ({ mode, remote: { url, token, authMode } })
+// into a one-entry `remotes` list so older configs keep working transparently.
+// Each entry carries its own authMode ('oauth' cookie + ws-ticket, or 'token'
+// static session token); defaults to 'token' for backward compatibility.
+function normalizeConnectionConfig(parsed) {
+  const mode = parsed?.mode === 'remote' ? 'remote' : 'local'
+
+  const coerceEntry = r => ({
+    id: typeof r.id === 'string' && r.id ? r.id : genConnectionId(),
+    label: typeof r.label === 'string' ? r.label : '',
+    profile: typeof r.profile === 'string' && r.profile ? r.profile : null,
+    url: String(r.url || ''),
+    authMode: r.authMode === 'oauth' ? 'oauth' : 'token',
+    token: r.token && typeof r.token === 'object' ? r.token : undefined
+  })
+
+  let remotes = []
+
+  if (Array.isArray(parsed?.remotes)) {
+    remotes = parsed.remotes.filter(r => r && typeof r === 'object' && typeof r.url === 'string').map(coerceEntry)
+  } else if (parsed?.remote && typeof parsed.remote === 'object' && (parsed.remote.url || parsed.remote.token)) {
+    remotes = [
+      coerceEntry({
+        id: genConnectionId(),
+        label: 'Remote',
+        profile: null,
+        url: parsed.remote.url,
+        authMode: parsed.remote.authMode,
+        token: parsed.remote.token
+      })
+    ]
+  }
+
+  const activeRemoteId =
+    typeof parsed?.activeRemoteId === 'string' && remotes.some(r => r.id === parsed.activeRemoteId)
+      ? parsed.activeRemoteId
+      : (remotes[0]?.id ?? null)
+
+  return { mode, remotes, activeRemoteId }
+}
+
 function readDesktopConnectionConfig() {
   // Check if file changed on disk since last read (e.g. modified by another
   // process or an external tool).  Our own writes update the cache inline
@@ -3408,22 +3454,14 @@ function readDesktopConnectionConfig() {
     return connectionConfigCache
   }
 
-  let config = { mode: 'local', remote: {} }
+  let config = { mode: 'local', remotes: [], activeRemoteId: null }
 
   try {
     const raw = fs.readFileSync(DESKTOP_CONNECTION_CONFIG_PATH, 'utf8')
     const parsed = JSON.parse(raw)
 
     if (parsed && typeof parsed === 'object') {
-      const remote = parsed.remote && typeof parsed.remote === 'object' ? parsed.remote : {}
-      // authMode lives on the remote sub-object: 'oauth' (cookie + ws-ticket)
-      // or 'token' (legacy static session token). Default to 'token' for
-      // backward compatibility with configs written before OAuth support.
-      remote.authMode = remote.authMode === 'oauth' ? 'oauth' : 'token'
-      config = {
-        mode: parsed.mode === 'remote' ? 'remote' : 'local',
-        remote
-      }
+      config = normalizeConnectionConfig(parsed)
     }
   } catch {
     // Missing or malformed connection settings should fall back to local.
@@ -3435,6 +3473,16 @@ function readDesktopConnectionConfig() {
   return config
 }
 
+// The remote connection a remote-mode session will use: the entry matching
+// activeRemoteId, falling back to the first one.
+function getActiveRemote(config = readDesktopConnectionConfig()) {
+  if (!config.remotes.length) {
+    return null
+  }
+
+  return config.remotes.find(r => r.id === config.activeRemoteId) ?? config.remotes[0]
+}
+
 function writeDesktopConnectionConfig(config) {
   fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
   writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
@@ -3442,63 +3490,98 @@ function writeDesktopConnectionConfig(config) {
   connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
 }
 
-async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionConfig()) {
-  const remoteToken = decryptDesktopSecret(config.remote?.token)
-  const authMode = config.remote?.authMode === 'oauth' ? 'oauth' : 'token'
-  const remoteUrl = String(config.remote?.url || '')
+async function sanitizeRemoteEntry(remote) {
+  const token = decryptDesktopSecret(remote.token)
+  const authMode = remote.authMode === 'oauth' ? 'oauth' : 'token'
+  const url = String(remote.url || '')
 
-  let remoteOauthConnected = false
-  if (authMode === 'oauth' && remoteUrl) {
+  let oauthConnected = false
+  if (authMode === 'oauth' && url) {
     try {
-      remoteOauthConnected = await hasOauthSessionCookie(remoteUrl)
+      oauthConnected = await hasOauthSessionCookie(url)
     } catch {
-      remoteOauthConnected = false
+      oauthConnected = false
     }
   }
 
   return {
+    id: remote.id,
+    label: remote.label || '',
+    profile: remote.profile || null,
+    url,
+    authMode,
+    tokenPreview: tokenPreview(token),
+    tokenSet: Boolean(token),
+    oauthConnected
+  }
+}
+
+async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionConfig()) {
+  const active = getActiveRemote(config)
+  const remotes = []
+  for (const remote of config.remotes) {
+    remotes.push(await sanitizeRemoteEntry(remote))
+  }
+
+  const activeSanitized = active ? remotes.find(r => r.id === active.id) : null
+
+  return {
     mode: config.mode === 'remote' ? 'remote' : 'local',
-    remoteAuthMode: authMode,
-    remoteOauthConnected,
-    remoteUrl,
-    remoteTokenPreview: tokenPreview(remoteToken),
-    remoteTokenSet: Boolean(remoteToken),
-    envOverride: Boolean(process.env.HERMES_DESKTOP_REMOTE_URL)
+    activeRemoteId: config.activeRemoteId,
+    remotes,
+    envOverride: Boolean(process.env.HERMES_DESKTOP_REMOTE_URL),
+    // Legacy mirror of the active remote, kept so older callers (the existing
+    // single-connection gateway UI) keep working against the active remote.
+    remoteUrl: activeSanitized ? activeSanitized.url : '',
+    remoteAuthMode: activeSanitized ? activeSanitized.authMode : 'token',
+    remoteOauthConnected: activeSanitized ? activeSanitized.oauthConnected : false,
+    remoteTokenPreview: activeSanitized ? activeSanitized.tokenPreview : null,
+    remoteTokenSet: activeSanitized ? activeSanitized.tokenSet : false
   }
 }
 
 function coerceDesktopConnectionConfig(input = {}, existing = readDesktopConnectionConfig(), options = {}) {
   const persistToken = options.persistToken !== false
   const mode = input.mode === 'remote' ? 'remote' : 'local'
-  const remoteUrl = String(input.remoteUrl ?? existing.remote?.url ?? '').trim()
-  // authMode: explicit input wins; otherwise inherit the saved value, default 'token'.
-  const authMode = resolveAuthMode(input.remoteAuthMode, existing.remote?.authMode)
+  const existingActive = getActiveRemote(existing)
+  const remoteUrl = String(input.remoteUrl ?? existingActive?.url ?? '').trim()
+  // authMode: explicit input wins; otherwise inherit the active remote's saved
+  // value, default 'token'.
+  const authMode = resolveAuthMode(input.remoteAuthMode, existingActive?.authMode)
   const incomingToken = typeof input.remoteToken === 'string' ? input.remoteToken.trim() : ''
-  const existingToken = existing.remote?.token
-  const nextRemote = {
-    url: remoteUrl,
-    authMode,
-    token: incomingToken
-      ? persistToken
-        ? encryptDesktopSecret(incomingToken)
-        : { encoding: 'plain', value: incomingToken }
-      : existingToken
+
+  const remotes = existing.remotes.map(r => ({ ...r }))
+  let activeRemoteId = existing.activeRemoteId
+
+  // Update (or create) the active remote from the legacy single-remote payload.
+  let active = remotes.find(r => r.id === activeRemoteId) ?? remotes[0]
+
+  if (!active) {
+    active = { id: genConnectionId(), label: 'Remote', profile: null, url: '', authMode, token: undefined }
+    remotes.push(active)
+    activeRemoteId = active.id
+  }
+
+  active.authMode = authMode
+
+  if (incomingToken) {
+    active.token = persistToken ? encryptDesktopSecret(incomingToken) : { encoding: 'plain', value: incomingToken }
+  }
+
+  if (remoteUrl) {
+    active.url = normalizeRemoteBaseUrl(remoteUrl)
   }
 
   if (mode === 'remote') {
-    nextRemote.url = normalizeRemoteBaseUrl(remoteUrl)
-
     // OAuth gateways authenticate via the session cookie established by the
     // login window, NOT a static token — so no token is required here. The
     // cookie presence is verified at connect time (resolveRemoteBackend).
-    if (authMode !== 'oauth' && !decryptDesktopSecret(nextRemote.token)) {
+    if (authMode !== 'oauth' && !decryptDesktopSecret(active.token)) {
       throw new Error('Remote gateway session token is required.')
     }
-  } else if (remoteUrl) {
-    nextRemote.url = normalizeRemoteBaseUrl(remoteUrl)
   }
 
-  return { mode, remote: nextRemote }
+  return { mode, remotes, activeRemoteId }
 }
 
 async function resolveRemoteBackend() {
@@ -3531,8 +3614,17 @@ async function resolveRemoteBackend() {
     return null
   }
 
-  const baseUrl = normalizeRemoteBaseUrl(config.remote?.url)
-  const authMode = config.remote?.authMode === 'oauth' ? 'oauth' : 'token'
+  const active = getActiveRemote(config)
+
+  if (!active) {
+    throw new Error(
+      'Remote Hermes gateway is selected, but no connection is configured. ' +
+        'Open Settings → Gateway and add one, or switch back to Local.'
+    )
+  }
+
+  const baseUrl = normalizeRemoteBaseUrl(active.url)
+  const authMode = active.authMode === 'oauth' ? 'oauth' : 'token'
 
   if (authMode === 'oauth') {
     // OAuth gateway: auth comes from the session cookie in the OAuth partition.
@@ -3572,11 +3664,11 @@ async function resolveRemoteBackend() {
     }
   }
 
-  const token = decryptDesktopSecret(config.remote?.token)
+  const token = decryptDesktopSecret(active.token)
 
   if (!token) {
     throw new Error(
-      'Remote Hermes gateway is selected, but no session token is saved. ' +
+      'Remote Hermes gateway is selected, but no session token is saved for the active connection. ' +
         'Open Settings → Gateway and save a token, or switch back to Local.'
     )
   }
@@ -3650,6 +3742,22 @@ async function probeRemoteAuthMode(rawUrl) {
   }
 }
 
+// Derive the profile name a gateway is serving from its HERMES_HOME path:
+// ``…/profiles/<name>`` → ``<name>``; the bare hermes root → ``default``.
+function profileFromHermesHome(hermesHome) {
+  const home = String(hermesHome || '').replace(/[/\\]+$/, '')
+
+  if (!home) {
+    return null
+  }
+
+  const parts = home.split(/[/\\]/)
+  const base = parts[parts.length - 1]
+  const parent = parts[parts.length - 2]
+
+  return parent === 'profiles' && base ? base : 'default'
+}
+
 async function testDesktopConnectionConfig(input = {}) {
   const config = coerceDesktopConnectionConfig(input, readDesktopConnectionConfig(), { persistToken: false })
   // ``/api/status`` is public on every gateway (no creds needed), so a
@@ -3659,9 +3767,10 @@ async function testDesktopConnectionConfig(input = {}) {
   let baseUrl
   let token = null
   if (config.mode === 'remote') {
-    baseUrl = normalizeRemoteBaseUrl(config.remote.url)
-    if ((config.remote.authMode || 'token') !== 'oauth') {
-      token = decryptDesktopSecret(config.remote.token)
+    const active = getActiveRemote(config)
+    baseUrl = normalizeRemoteBaseUrl(active?.url)
+    if ((active?.authMode || 'token') !== 'oauth') {
+      token = decryptDesktopSecret(active?.token)
     }
   } else {
     const remote = (await resolveRemoteBackend()) || (await startHermes())
@@ -4068,6 +4177,140 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   setTimeout(() => mainWindow?.reload(), 150)
 
   return sanitizeDesktopConnectionConfig(config)
+})
+
+// --- Multi-connection (per-profile remote) management ---------------------
+// Each remote connection points at one gateway, which is bound to one Hermes
+// profile. Switching profiles = activating a different connection and
+// reconnecting. The profile is auto-detected from the gateway's /api/status,
+// and each entry carries its own authMode (token vs OAuth).
+
+function reconnectToActiveBackend() {
+  resetHermesConnection()
+  setTimeout(() => mainWindow?.reload(), 150)
+}
+
+// Best-effort: ask a token-authed gateway which profile it is bound to. OAuth
+// gateways may not have credentials at add-time, so callers pass null there.
+async function detectRemoteProfile(baseUrl, token) {
+  try {
+    const status = await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000 })
+
+    return profileFromHermesHome(status?.hermes_home)
+  } catch {
+    return null
+  }
+}
+
+ipcMain.handle('hermes:connections:get', async () => sanitizeDesktopConnectionConfig())
+
+ipcMain.handle('hermes:connections:add', async (_event, payload = {}) => {
+  const url = normalizeRemoteBaseUrl(String(payload.url || '').trim())
+
+  if (!url) {
+    throw new Error('A remote URL is required.')
+  }
+
+  const rawToken = typeof payload.token === 'string' ? payload.token.trim() : ''
+  // Probe how this gateway authenticates so the entry records the right mode.
+  const probe = await probeRemoteAuthMode(url)
+  const authMode = probe.authMode === 'oauth' ? 'oauth' : 'token'
+
+  if (authMode === 'token' && !rawToken) {
+    throw new Error('This gateway uses a session token — provide one to add it.')
+  }
+
+  // Token gateways can report their bound profile right away; OAuth gateways
+  // typically have no creds yet at add-time, so leave the profile null until a
+  // sign-in + reconnect detects it.
+  const profile = authMode === 'token' && rawToken ? await detectRemoteProfile(url, rawToken) : null
+
+  const config = readDesktopConnectionConfig()
+  const entry = {
+    id: genConnectionId(),
+    label: String(payload.label || '').trim() || profile || 'Remote',
+    profile,
+    url,
+    authMode,
+    token: rawToken ? encryptDesktopSecret(rawToken) : undefined
+  }
+  const next = {
+    mode: config.mode,
+    remotes: [...config.remotes, entry],
+    activeRemoteId: config.activeRemoteId ?? entry.id
+  }
+  writeDesktopConnectionConfig(next)
+
+  return sanitizeDesktopConnectionConfig(next)
+})
+
+ipcMain.handle('hermes:connections:remove', async (_event, id) => {
+  const config = readDesktopConnectionConfig()
+  const remotes = config.remotes.filter(r => r.id !== id)
+  const activeRemoteId = config.activeRemoteId === id ? (remotes[0]?.id ?? null) : config.activeRemoteId
+  const next = {
+    mode: remotes.length === 0 ? 'local' : config.mode,
+    remotes,
+    activeRemoteId
+  }
+  writeDesktopConnectionConfig(next)
+
+  return sanitizeDesktopConnectionConfig(next)
+})
+
+ipcMain.handle('hermes:connections:activate', async (_event, id) => {
+  const config = readDesktopConnectionConfig()
+  const target = config.remotes.find(r => r.id === id)
+
+  if (!target) {
+    throw new Error('Connection not found.')
+  }
+
+  const next = { mode: 'remote', remotes: config.remotes, activeRemoteId: id }
+  writeDesktopConnectionConfig(next)
+  reconnectToActiveBackend()
+
+  return sanitizeDesktopConnectionConfig(next)
+})
+
+// NOTE: not named `useLocal` — eslint treats `use*` as a React hook.
+ipcMain.handle('hermes:connections:activateLocal', async () => {
+  const config = readDesktopConnectionConfig()
+  const next = { mode: 'local', remotes: config.remotes, activeRemoteId: config.activeRemoteId }
+  writeDesktopConnectionConfig(next)
+  reconnectToActiveBackend()
+
+  return sanitizeDesktopConnectionConfig(next)
+})
+
+ipcMain.handle('hermes:connections:test', async (_event, payload = {}) => {
+  const rawUrl = String(payload.url || '').trim()
+  const saved = payload.id ? readDesktopConnectionConfig().remotes.find(r => r.id === payload.id) : null
+  const url = normalizeRemoteBaseUrl(rawUrl || saved?.url || '')
+
+  if (!url) {
+    throw new Error('A remote URL is required to test.')
+  }
+
+  const authMode = saved?.authMode === 'oauth' ? 'oauth' : 'token'
+  const rawToken = typeof payload.token === 'string' && payload.token.trim() ? payload.token.trim() : ''
+  // OAuth gateways are cookie-authed and need no token for the public status
+  // probe; token gateways use the supplied or saved token.
+  const token = authMode === 'oauth' ? '' : rawToken || decryptDesktopSecret(saved?.token)
+
+  // ``/api/status`` is public on every gateway, so when we have no token (OAuth
+  // entries, or a brand-new URL) we probe it credential-free.
+  const status = token
+    ? await fetchJson(`${url}/api/status`, token, { timeoutMs: 8_000 })
+    : await fetchPublicJson(`${url}/api/status`, { timeoutMs: 8_000 })
+
+  return {
+    ok: true,
+    baseUrl: url,
+    version: status?.version || null,
+    profile: profileFromHermesHome(status?.hermes_home),
+    authMode
+  }
 })
 
 ipcMain.on('hermes:previewShortcutActive', (_event, active) => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -11,6 +11,17 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   probeConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:probe', remoteUrl),
   oauthLoginConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-login', remoteUrl),
   oauthLogoutConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-logout', remoteUrl),
+  connections: {
+    get: () => ipcRenderer.invoke('hermes:connections:get'),
+    add: payload => ipcRenderer.invoke('hermes:connections:add', payload),
+    remove: id => ipcRenderer.invoke('hermes:connections:remove', id),
+    activate: id => ipcRenderer.invoke('hermes:connections:activate', id),
+    activateLocal: () => ipcRenderer.invoke('hermes:connections:activateLocal'),
+    test: payload => ipcRenderer.invoke('hermes:connections:test', payload),
+    probe: url => ipcRenderer.invoke('hermes:connection-config:probe', url),
+    oauthLogin: url => ipcRenderer.invoke('hermes:connection-config:oauth-login', url),
+    oauthLogout: url => ipcRenderer.invoke('hermes:connection-config:oauth-logout', url)
+  },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -31,6 +31,7 @@ import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import {
   $busy,
+  $connection,
   $messages,
   $yoloActive,
   setAwaitingResponse,
@@ -67,6 +68,27 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
 
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
+}
+
+function base64FromDataUrl(dataUrl: string): string {
+  const comma = dataUrl.indexOf(',')
+
+  return comma >= 0 ? dataUrl.slice(comma + 1) : ''
+}
+
+function imageExtFromPath(filePath: string): string {
+  const match = /\.([a-z0-9]+)$/i.exec(filePath)
+
+  return match ? `.${match[1].toLowerCase()}` : '.png'
+}
+
+// Remote gateway: the local composer-images file does not exist on the gateway
+// machine, so read the bytes here and upload them via image.attach_bytes.
+async function readImageForRemoteAttach(filePath: string): Promise<{ data: string; ext: string } | null> {
+  const dataUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
+  const data = dataUrl ? base64FromDataUrl(dataUrl) : ''
+
+  return data ? { data, ext: imageExtFromPath(filePath) } : null
 }
 
 interface PromptActionsOptions {
@@ -181,16 +203,34 @@ export function usePromptActions({
     ) => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
       const images = attachments.filter(attachment => attachment.kind === 'image' && attachment.path)
+      const remote = $connection.get()?.mode === 'remote'
 
       for (const attachment of images) {
         if (attachment.attachedSessionId === sessionId) {
           continue
         }
 
-        const result = await requestGateway<ImageAttachResponse>('image.attach', {
-          session_id: sessionId,
-          path: attachment.path
-        })
+        let result: ImageAttachResponse
+
+        if (remote) {
+          const payload = attachment.path ? await readImageForRemoteAttach(attachment.path) : null
+
+          if (!payload) {
+            const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')
+            throw new Error(`Could not read ${label}`)
+          }
+
+          result = await requestGateway<ImageAttachResponse>('image.attach_bytes', {
+            session_id: sessionId,
+            data: payload.data,
+            ext: payload.ext
+          })
+        } else {
+          result = await requestGateway<ImageAttachResponse>('image.attach', {
+            session_id: sessionId,
+            path: attachment.path
+          })
+        }
 
         if (!result.attached) {
           const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1,38 +1,25 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import type { DesktopAuthProvider, DesktopConnectionProbeResult } from '@/global'
-import { AlertCircle, Check, FileText, Globe, Loader2, LogIn, Monitor } from '@/lib/icons'
+import type { DesktopAuthProvider, DesktopConnectionConfig, DesktopConnectionProbeResult, DesktopRemoteConnection } from '@/global'
+import { AlertCircle, Check, FileText, Globe, Loader2, LogIn, Monitor, Plus, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 
 import { CONTROL_TEXT } from './constants'
 import { EmptyState, ListRow, LoadingState, Pill, SettingsContent } from './primitives'
 
-type Mode = 'local' | 'remote'
 type AuthMode = 'oauth' | 'token'
 type ProbeStatus = 'idle' | 'probing' | 'done' | 'error'
 
-interface GatewaySettingsState {
-  envOverride: boolean
-  mode: Mode
-  remoteAuthMode: AuthMode
-  remoteOauthConnected: boolean
-  remoteTokenPreview: string | null
-  remoteTokenSet: boolean
-  remoteUrl: string
+interface AddForm {
+  label: string
+  token: string
+  url: string
 }
 
-const EMPTY_STATE: GatewaySettingsState = {
-  envOverride: false,
-  mode: 'local',
-  remoteAuthMode: 'token',
-  remoteOauthConnected: false,
-  remoteTokenPreview: null,
-  remoteTokenSet: false,
-  remoteUrl: ''
-}
+const EMPTY_FORM: AddForm = { label: '', token: '', url: '' }
 
 function ModeCard({
   active,
@@ -52,7 +39,7 @@ function ModeCard({
   return (
     <button
       className={cn(
-        'rounded-xl border p-3 text-left transition',
+        'w-full rounded-xl border p-3 text-left transition',
         active
           ? 'border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary)'
           : 'border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) hover:bg-(--chrome-action-hover)',
@@ -74,58 +61,125 @@ function ModeCard({
   )
 }
 
+// A remote connection a gateway is bound to. Token entries can connect once a
+// token is saved; OAuth entries surface a "Sign in" affordance until the
+// session cookie is established, then a "Connect" button.
+function ConnectionRow({
+  active,
+  busy,
+  connection,
+  envOverride,
+  onActivate,
+  onRemove,
+  onSignIn
+}: {
+  active: boolean
+  busy: boolean
+  connection: DesktopRemoteConnection
+  envOverride: boolean
+  onActivate: () => void
+  onRemove: () => void
+  onSignIn: () => void
+}) {
+  const title = connection.label || connection.profile || connection.url
+  const isOauth = connection.authMode === 'oauth'
+  const needsSignIn = isOauth && !connection.oauthConnected
+  // Token entries need a saved token; OAuth entries need a live session cookie.
+  const ready = isOauth ? Boolean(connection.oauthConnected) : connection.tokenSet
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-xl border px-3 py-2.5',
+        active ? 'border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary)' : 'border-(--ui-stroke-tertiary)'
+      )}
+    >
+      <Globe className="size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-[length:var(--conversation-text-font-size)] font-medium">
+          <span className="truncate">{title}</span>
+          {connection.profile ? <Pill tone="primary">{connection.profile}</Pill> : null}
+          <Pill tone="muted">{isOauth ? 'OAuth' : 'token'}</Pill>
+          {active ? <Pill tone="primary">connected</Pill> : null}
+        </div>
+        <p className="mt-0.5 truncate font-mono text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+          {connection.url}
+          {ready ? '' : isOauth ? ' · not signed in' : ' · no token'}
+        </p>
+      </div>
+      {needsSignIn ? (
+        <Button disabled={envOverride || busy} onClick={onSignIn} size="sm" variant="outline">
+          <LogIn className="size-4" />
+          Sign in
+        </Button>
+      ) : null}
+      <Button
+        disabled={envOverride || busy || active || !ready}
+        onClick={onActivate}
+        size="sm"
+        variant={active ? 'outline' : 'default'}
+      >
+        {active ? 'Connected' : 'Connect'}
+      </Button>
+      <Button
+        aria-label={`Remove ${title}`}
+        className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+        disabled={envOverride || busy}
+        onClick={onRemove}
+        size="sm"
+        variant="ghost"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  )
+}
+
 export function GatewaySettings() {
   const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
+  const [busy, setBusy] = useState(false)
   const [testing, setTesting] = useState(false)
-  const [signingIn, setSigningIn] = useState(false)
-  const [state, setState] = useState<GatewaySettingsState>(EMPTY_STATE)
-  const [remoteToken, setRemoteToken] = useState('')
+  const [config, setConfig] = useState<DesktopConnectionConfig | null>(null)
+  const [form, setForm] = useState<AddForm>(EMPTY_FORM)
   const [lastTest, setLastTest] = useState<null | string>(null)
 
   // Auth-mode probe: as the user types a remote URL we ask the gateway (via
   // its public /api/status) whether it gates with OAuth or a static session
-  // token, so we can show the right control (login button vs token box).
+  // token, so the add form can show the right control (token box vs OAuth note).
   const [probeStatus, setProbeStatus] = useState<ProbeStatus>('idle')
   const [probe, setProbe] = useState<DesktopConnectionProbeResult | null>(null)
   const probeSeq = useRef(0)
 
-  useEffect(() => {
-    let cancelled = false
+  const reload = useCallback(async () => {
     const desktop = window.hermesDesktop
 
-    if (!desktop?.getConnectionConfig) {
+    if (!desktop?.connections) {
       setLoading(false)
 
-      return () => void (cancelled = true)
+      return
     }
 
-    desktop
-      .getConnectionConfig()
-      .then(config => {
-        if (cancelled) {
-          return
-        }
-
-        setState(config)
-      })
-      .catch(err => notifyError(err, 'Gateway settings failed to load'))
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false)
-        }
-      })
-
-    return () => void (cancelled = true)
+    try {
+      setConfig(await desktop.connections.get())
+    } catch (err) {
+      notifyError(err, 'Gateway settings failed to load')
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
-  // Debounced probe of the entered remote URL. Only runs in remote mode with a
-  // syntactically plausible URL. The probe result drives whether we render the
-  // OAuth login button or the session-token entry box. The effective auth mode
-  // prefers a fresh probe result over the saved value.
-  const trimmedUrl = state.remoteUrl.trim()
   useEffect(() => {
-    if (state.mode !== 'remote' || !trimmedUrl || !/^https?:\/\//i.test(trimmedUrl)) {
+    void reload()
+  }, [reload])
+
+  const envOverride = Boolean(config?.envOverride)
+  const localActive = config?.mode === 'local'
+
+  // Debounced probe of the entered remote URL. The probe result drives whether
+  // the add form shows a session-token box or an OAuth note.
+  const trimmedUrl = form.url.trim()
+  useEffect(() => {
+    if (!trimmedUrl || !/^https?:\/\//i.test(trimmedUrl)) {
       setProbeStatus('idle')
       setProbe(null)
 
@@ -134,7 +188,7 @@ export function GatewaySettings() {
 
     const desktop = window.hermesDesktop
 
-    if (!desktop?.probeConnectionConfig) {
+    if (!desktop?.connections?.probe) {
       return
     }
 
@@ -142,8 +196,8 @@ export function GatewaySettings() {
     setProbeStatus('probing')
 
     const timer = setTimeout(() => {
-      desktop
-        .probeConnectionConfig(trimmedUrl)
+      desktop.connections
+        .probe(trimmedUrl)
         .then(result => {
           if (seq !== probeSeq.current) {
             return
@@ -163,37 +217,15 @@ export function GatewaySettings() {
     }, 500)
 
     return () => clearTimeout(timer)
-  }, [state.mode, trimmedUrl])
+  }, [trimmedUrl])
 
-  // Effective auth mode: a reachable probe wins; otherwise fall back to the
-  // saved config's mode so a re-open of settings doesn't flicker.
-  const authMode: AuthMode = useMemo(() => {
+  const formAuthMode: AuthMode = useMemo(() => {
     if (probeStatus === 'done' && probe && probe.authMode !== 'unknown') {
       return probe.authMode
     }
 
-    return state.remoteAuthMode
-  }, [probe, probeStatus, state.remoteAuthMode])
-
-  // Whether we actually KNOW how this gateway authenticates yet. Until we do,
-  // neither the OAuth button nor the session-token box should render —
-  // `authMode` defaults to 'token', so without this gate the token box flashes
-  // for every gateway (including OAuth ones) during the idle/probing window
-  // before the first probe lands. The scheme is known when either:
-  //   * the live probe finished (probeStatus 'done'), or
-  //   * we're idle but showing a previously-saved remote config (re-opening
-  //     settings for a gateway already signed-in or with a saved token), so
-  //     its control appears immediately with no flicker.
-  // While probing (or after a probe error), the scheme is unknown and we show
-  // the probe status row instead of a control.
-  const hasSavedRemote = state.remoteTokenSet || state.remoteOauthConnected
-  const authResolved = useMemo(() => {
-    if (probeStatus === 'done') {
-      return true
-    }
-
-    return probeStatus === 'idle' && hasSavedRemote
-  }, [probeStatus, hasSavedRemote])
+    return 'token'
+  }, [probe, probeStatus])
 
   const providerLabel = useMemo(() => {
     const providers: DesktopAuthProvider[] = probe?.providers ?? []
@@ -209,130 +241,79 @@ export function GatewaySettings() {
     return 'your identity provider'
   }, [probe])
 
-  const oauthConnected = state.remoteOauthConnected
-
-  const canUseRemote = useMemo(() => {
-    if (!trimmedUrl) {
-      return false
-    }
-
-    if (authMode === 'oauth') {
-      return oauthConnected
-    }
-
-    return Boolean(remoteToken.trim()) || state.remoteTokenSet
-  }, [authMode, oauthConnected, remoteToken, state.remoteTokenSet, trimmedUrl])
-
-  const payload = () => ({
-    mode: state.mode,
-    remoteAuthMode: authMode,
-    remoteToken: authMode === 'token' ? remoteToken.trim() || undefined : undefined,
-    remoteUrl: trimmedUrl
-  })
-
-  const save = async (apply: boolean) => {
-    if (state.mode === 'remote' && !canUseRemote) {
-      notify({
-        kind: 'warning',
-        title: 'Remote gateway incomplete',
-        message:
-          authMode === 'oauth'
-            ? 'Enter a remote URL and sign in before switching to remote.'
-            : 'Enter a remote URL and session token before switching to remote.'
-      })
-
-      return
-    }
-
-    setSaving(true)
+  const switchToLocal = useCallback(async () => {
+    setBusy(true)
 
     try {
-      const next = apply
-        ? await window.hermesDesktop.applyConnectionConfig(payload())
-        : await window.hermesDesktop.saveConnectionConfig(payload())
+      await window.hermesDesktop.connections.activateLocal()
+      notify({ kind: 'success', title: 'Switching to local gateway', message: 'Hermes Desktop will reconnect.' })
+    } catch (err) {
+      notifyError(err, 'Could not switch to local gateway')
+      setBusy(false)
+    }
+  }, [])
 
-      setState(next)
-      setRemoteToken('')
+  const activate = useCallback(async (connection: DesktopRemoteConnection) => {
+    setBusy(true)
+
+    try {
+      await window.hermesDesktop.connections.activate(connection.id)
       notify({
         kind: 'success',
-        title: apply ? 'Gateway connection restarting' : 'Gateway settings saved',
-        message: apply ? 'Hermes Desktop will reconnect using the saved settings.' : 'Saved for the next restart.'
+        title: 'Switching connection',
+        message: `Reconnecting to ${connection.label || connection.profile || connection.url}.`
       })
     } catch (err) {
-      notifyError(err, apply ? 'Could not apply gateway settings' : 'Could not save gateway settings')
-    } finally {
-      setSaving(false)
+      notifyError(err, 'Could not switch connection')
+      setBusy(false)
     }
-  }
+  }, [])
 
-  // OAuth sign-in: persist the URL + oauth mode first (so the saved config has
-  // the URL the login window needs), then open the gateway login window and
-  // refresh the connection status from the saved config once it completes.
-  const signIn = async () => {
-    if (!trimmedUrl) {
-      notify({ kind: 'warning', title: 'Remote gateway incomplete', message: 'Enter a remote URL first.' })
-
-      return
-    }
-
-    setSigningIn(true)
+  const remove = useCallback(async (connection: DesktopRemoteConnection) => {
+    setBusy(true)
 
     try {
-      // Save (don't apply/restart) so the login window has a URL to use and the
-      // oauth mode is persisted, without yet flipping the live connection.
-      const saved = await window.hermesDesktop.saveConnectionConfig({
-        mode: state.mode,
-        remoteAuthMode: 'oauth',
-        remoteUrl: trimmedUrl
-      })
+      setConfig(await window.hermesDesktop.connections.remove(connection.id))
+      notify({ kind: 'success', title: 'Connection removed', message: connection.label || connection.url })
+    } catch (err) {
+      notifyError(err, 'Could not remove connection')
+    } finally {
+      setBusy(false)
+    }
+  }, [])
 
-      setState(saved)
+  // OAuth sign-in for an existing entry: open the gateway login window for its
+  // URL, then refresh so the row reflects the new cookie state.
+  const signIn = useCallback(
+    async (connection: DesktopRemoteConnection) => {
+      setBusy(true)
 
-      const result = await window.hermesDesktop.oauthLoginConnectionConfig(trimmedUrl)
+      try {
+        const result = await window.hermesDesktop.connections.oauthLogin(connection.url)
 
-      if (result.connected) {
-        const refreshed = await window.hermesDesktop.getConnectionConfig()
-        setState(refreshed)
-        notify({ kind: 'success', title: 'Signed in', message: `Connected to ${providerLabel}.` })
-      } else {
-        notify({
-          kind: 'warning',
-          title: 'Sign-in incomplete',
-          message: 'The login window closed before authentication finished.'
-        })
+        if (result.connected) {
+          notify({ kind: 'success', title: 'Signed in', message: `Connected to ${connection.label || connection.url}.` })
+        } else {
+          notify({
+            kind: 'warning',
+            title: 'Sign-in incomplete',
+            message: 'The login window closed before authentication finished.'
+          })
+        }
+
+        await reload()
+      } catch (err) {
+        notifyError(err, 'Sign-in failed')
+      } finally {
+        setBusy(false)
       }
-    } catch (err) {
-      notifyError(err, 'Sign-in failed')
-    } finally {
-      setSigningIn(false)
-    }
-  }
+    },
+    [reload]
+  )
 
-  const signOut = async () => {
-    setSigningIn(true)
-
-    try {
-      await window.hermesDesktop.oauthLogoutConnectionConfig(trimmedUrl || undefined)
-      const refreshed = await window.hermesDesktop.getConnectionConfig()
-      setState(refreshed)
-      notify({ kind: 'success', title: 'Signed out', message: 'Cleared the remote gateway session.' })
-    } catch (err) {
-      notifyError(err, 'Sign-out failed')
-    } finally {
-      setSigningIn(false)
-    }
-  }
-
-  const testRemote = async () => {
-    if (!canUseRemote) {
-      notify({
-        kind: 'warning',
-        title: 'Remote gateway incomplete',
-        message:
-          authMode === 'oauth'
-            ? 'Enter a remote URL and sign in before testing.'
-            : 'Enter a remote URL and session token before testing.'
-      })
+  const testForm = useCallback(async () => {
+    if (!trimmedUrl) {
+      notify({ kind: 'warning', title: 'Connection incomplete', message: 'Enter a URL to test.' })
 
       return
     }
@@ -341,28 +322,73 @@ export function GatewaySettings() {
     setLastTest(null)
 
     try {
-      const result = await window.hermesDesktop.testConnectionConfig({
-        mode: 'remote',
-        remoteAuthMode: authMode,
-        remoteToken: authMode === 'token' ? remoteToken.trim() || undefined : undefined,
-        remoteUrl: trimmedUrl
+      const result = await window.hermesDesktop.connections.test({
+        token: form.token.trim() || undefined,
+        url: trimmedUrl
       })
 
-      const message = `Connected to ${result.baseUrl}${result.version ? ` · Hermes ${result.version}` : ''}`
+      const profile = result.profile ? ` · profile "${result.profile}"` : ''
+      const message = `Reachable${result.version ? ` · Hermes ${result.version}` : ''}${profile}`
       setLastTest(message)
-      notify({ kind: 'success', title: 'Remote gateway reachable', message })
+      notify({ kind: 'success', title: 'Gateway reachable', message })
     } catch (err) {
-      notifyError(err, 'Remote gateway test failed')
+      notifyError(err, 'Connection test failed')
     } finally {
       setTesting(false)
     }
-  }
+  }, [form.token, trimmedUrl])
+
+  const add = useCallback(async () => {
+    if (!trimmedUrl) {
+      notify({ kind: 'warning', title: 'Connection incomplete', message: 'Enter a URL to add a connection.' })
+
+      return
+    }
+
+    if (formAuthMode === 'token' && !form.token.trim()) {
+      notify({
+        kind: 'warning',
+        title: 'Session token required',
+        message: 'This gateway uses a session token — paste one to add it.'
+      })
+
+      return
+    }
+
+    setBusy(true)
+
+    try {
+      const next = await window.hermesDesktop.connections.add({
+        label: form.label.trim() || undefined,
+        token: form.token.trim() || undefined,
+        url: trimmedUrl
+      })
+
+      setConfig(next)
+      setForm(EMPTY_FORM)
+      setLastTest(null)
+      const added = next.remotes[next.remotes.length - 1]
+      notify({
+        kind: 'success',
+        title: 'Connection added',
+        message: added?.profile
+          ? `Detected profile "${added.profile}".`
+          : added?.authMode === 'oauth'
+            ? 'OAuth gateway added — sign in to connect.'
+            : 'Profile could not be auto-detected.'
+      })
+    } catch (err) {
+      notifyError(err, 'Could not add connection')
+    } finally {
+      setBusy(false)
+    }
+  }, [form.label, form.token, formAuthMode, trimmedUrl])
 
   if (loading) {
     return <LoadingState label="Loading gateway settings..." />
   }
 
-  if (!window.hermesDesktop?.getConnectionConfig) {
+  if (!window.hermesDesktop?.connections || !config) {
     return (
       <EmptyState
         description="The desktop IPC bridge does not expose gateway settings."
@@ -377,153 +403,157 @@ export function GatewaySettings() {
         <div className="flex items-center gap-2 text-[length:var(--conversation-text-font-size)] font-medium">
           <Globe className="size-4 text-muted-foreground" />
           Gateway Connection
-          {state.envOverride ? <Pill tone="primary">env override</Pill> : null}
+          {envOverride ? <Pill tone="primary">env override</Pill> : null}
         </div>
         <p className="mt-2 max-w-2xl text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
-          Hermes Desktop starts its own local gateway by default. Use a remote gateway when you want this app to control
-          an already-running Hermes backend on another machine or behind a trusted proxy.
+          Hermes Desktop starts its own local gateway by default. Add a remote connection for each Hermes profile you run
+          elsewhere — each points at one gateway, the profile is detected automatically, and hosted gateways use OAuth
+          while self-hosted ones may use a session token. Switch between them here or from the Profiles menu.
         </p>
       </div>
 
-      {state.envOverride ? (
+      {envOverride ? (
         <div className="mb-5 flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-[length:var(--conversation-caption-font-size)] text-destructive">
           <AlertCircle className="mt-0.5 size-4 shrink-0" />
           <div>
             <div className="font-medium">Environment variables are controlling this desktop session.</div>
             <div className="mt-1 leading-5">
-              Unset <code>HERMES_DESKTOP_REMOTE_URL</code> and <code>HERMES_DESKTOP_REMOTE_TOKEN</code> to use the saved
-              setting below.
+              Unset <code>HERMES_DESKTOP_REMOTE_URL</code> and <code>HERMES_DESKTOP_REMOTE_TOKEN</code> to manage
+              connections below.
             </div>
           </div>
         </div>
       ) : null}
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <ModeCard
-          active={state.mode === 'local'}
-          description="Start a private Hermes backend on localhost. This is the default and works offline."
-          disabled={state.envOverride}
-          icon={Monitor}
-          onSelect={() => setState(current => ({ ...current, mode: 'local' }))}
-          title="Local gateway"
-        />
-        <ModeCard
-          active={state.mode === 'remote'}
-          description="Connect this desktop shell to a remote Hermes backend. Hosted gateways use OAuth; self-hosted ones may use a session token."
-          disabled={state.envOverride}
-          icon={Globe}
-          onSelect={() => setState(current => ({ ...current, mode: 'remote' }))}
-          title="Remote gateway"
-        />
+      <ModeCard
+        active={Boolean(localActive)}
+        description="Start a private Hermes backend on localhost. This is the default and works offline."
+        disabled={envOverride || busy}
+        icon={Monitor}
+        onSelect={() => void switchToLocal()}
+        title="Local gateway"
+      />
+
+      <div className="mt-5 mb-2 text-[length:var(--conversation-caption-font-size)] font-medium uppercase tracking-[0.12em] text-(--ui-text-tertiary)">
+        Remote connections
       </div>
 
-      <div className="mt-5 grid gap-1">
-        <ListRow
-          action={
-            <Input
-              className={cn('h-8', CONTROL_TEXT)}
-              disabled={state.envOverride}
-              onChange={event => setState(current => ({ ...current, remoteUrl: event.target.value }))}
-              placeholder="https://gateway.example.com/hermes"
-              value={state.remoteUrl}
+      {config.remotes.length === 0 ? (
+        <p className="rounded-xl border border-(--ui-stroke-tertiary) px-3 py-4 text-center text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+          No remote connections yet. Add one below to connect to a profile running on another machine.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {config.remotes.map(connection => (
+            <ConnectionRow
+              active={config.mode === 'remote' && config.activeRemoteId === connection.id}
+              busy={busy}
+              connection={connection}
+              envOverride={envOverride}
+              key={connection.id}
+              onActivate={() => void activate(connection)}
+              onRemove={() => void remove(connection)}
+              onSignIn={() => void signIn(connection)}
             />
-          }
-          description="Base URL for the remote dashboard backend. Path prefixes are supported, for example /hermes."
-          title="Remote URL"
-        />
+          ))}
+        </div>
+      )}
 
-        {state.mode === 'remote' && probeStatus === 'probing' ? (
-          <div className="flex items-center gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
-            <Loader2 className="size-4 animate-spin" />
-            Checking how this gateway authenticates…
-          </div>
-        ) : null}
-
-        {state.mode === 'remote' && probeStatus === 'error' ? (
-          <div className="flex items-start gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
-            <AlertCircle className="mt-0.5 size-4 shrink-0" />
-            Could not reach this gateway yet. Check the URL — the auth method will appear once it responds.
-          </div>
-        ) : null}
-
-        {/* OAuth gateways: present a sign-in button + connection status. */}
-        {state.mode === 'remote' && authResolved && authMode === 'oauth' ? (
-          <ListRow
-            action={
-              oauthConnected ? (
-                <div className="flex items-center gap-2">
-                  <Pill tone="primary">
-                    <Check className="size-3" /> Signed in
-                  </Pill>
-                  <Button disabled={signingIn || state.envOverride} onClick={() => void signOut()} variant="outline">
-                    {signingIn ? <Loader2 className="size-4 animate-spin" /> : null}
-                    Sign out
-                  </Button>
-                </div>
-              ) : (
-                <Button disabled={signingIn || state.envOverride || !trimmedUrl} onClick={() => void signIn()}>
-                  {signingIn ? <Loader2 className="size-4 animate-spin" /> : <LogIn className="size-4" />}
-                  Sign in with {providerLabel}
-                </Button>
-              )
-            }
-            description={
-              oauthConnected
-                ? 'This gateway uses OAuth. You are signed in; the session refreshes automatically.'
-                : `This gateway uses OAuth. Sign in with ${providerLabel} to authorize this desktop app.`
-            }
-            title="Authentication"
-          />
-        ) : null}
-
-        {/* Session-token gateways: keep the existing token entry box. */}
-        {state.mode === 'remote' && authResolved && authMode === 'token' ? (
+      <div className="mt-6 rounded-xl border border-(--ui-stroke-tertiary) p-3">
+        <div className="mb-2 flex items-center gap-2 text-[length:var(--conversation-text-font-size)] font-medium">
+          <Plus className="size-4 text-muted-foreground" />
+          Add a connection
+        </div>
+        <div className="divide-y divide-border/40">
           <ListRow
             action={
               <Input
-                autoComplete="off"
-                className={cn('h-8 font-mono', CONTROL_TEXT)}
-                disabled={state.envOverride}
-                onChange={event => setRemoteToken(event.target.value)}
-                placeholder={
-                  state.remoteTokenSet ? `Existing token ${state.remoteTokenPreview ?? 'saved'}` : 'Paste session token'
-                }
-                type="password"
-                value={remoteToken}
+                className={cn('h-8', CONTROL_TEXT)}
+                disabled={envOverride}
+                onChange={event => setForm(current => ({ ...current, url: event.target.value }))}
+                placeholder="https://gateway.example.com/profile"
+                value={form.url}
               />
             }
-            description="The dashboard session token used for REST and WebSocket access. Leave blank to keep the saved token."
-            title="Session token"
+            description="Base URL for the remote dashboard. Path prefixes are supported, e.g. /coder."
+            title="Remote URL"
           />
-        ) : null}
+
+          {probeStatus === 'probing' ? (
+            <div className="flex items-center gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              <Loader2 className="size-4 animate-spin" />
+              Checking how this gateway authenticates…
+            </div>
+          ) : null}
+
+          {probeStatus === 'error' ? (
+            <div className="flex items-start gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              Could not reach this gateway yet. Check the URL — the auth method will appear once it responds.
+            </div>
+          ) : null}
+
+          {/* OAuth gateways: no token needed at add-time; sign in from the row. */}
+          {probeStatus === 'done' && formAuthMode === 'oauth' ? (
+            <div className="flex items-start gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              <LogIn className="mt-0.5 size-4 shrink-0" />
+              This gateway uses OAuth ({providerLabel}). Add it, then click "Sign in" on its row to authorize this
+              desktop app.
+            </div>
+          ) : null}
+
+          {/* Session-token gateways: collect the token up front. */}
+          {formAuthMode === 'token' ? (
+            <ListRow
+              action={
+                <Input
+                  autoComplete="off"
+                  className={cn('h-8 font-mono', CONTROL_TEXT)}
+                  disabled={envOverride}
+                  onChange={event => setForm(current => ({ ...current, token: event.target.value }))}
+                  placeholder="Paste session token"
+                  type="password"
+                  value={form.token}
+                />
+              }
+              description="The dashboard session token (HERMES_DASHBOARD_SESSION_TOKEN) for that gateway."
+              title="Session token"
+            />
+          ) : null}
+
+          <ListRow
+            action={
+              <Input
+                className={cn('h-8', CONTROL_TEXT)}
+                disabled={envOverride}
+                onChange={event => setForm(current => ({ ...current, label: event.target.value }))}
+                placeholder="Defaults to the detected profile"
+                value={form.label}
+              />
+            }
+            description="Optional friendly name for this connection."
+            title="Label"
+          />
+        </div>
+
+        {lastTest ? <div className="mt-3 text-xs text-primary">{lastTest}</div> : null}
+
+        <div className="mt-4 flex flex-wrap justify-end gap-3">
+          <Button disabled={envOverride || testing} onClick={() => void testForm()} variant="outline">
+            {testing ? <Loader2 className="size-4 animate-spin" /> : null}
+            Test
+          </Button>
+          <Button disabled={envOverride || busy} onClick={() => void add()}>
+            {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+            Add connection
+          </Button>
+        </div>
       </div>
 
-      {lastTest ? <div className="mt-4 text-xs text-primary">{lastTest}</div> : null}
-
-      <div className="mt-6 flex flex-wrap items-center justify-end gap-4">
-        <Button
-          className="mr-auto"
-          disabled={state.envOverride || testing || !canUseRemote}
-          onClick={() => void testRemote()}
-          size="sm"
-          variant="text"
-        >
-          {testing ? <Loader2 className="size-4 animate-spin" /> : null}
-          Test remote
-        </Button>
-        <Button disabled={state.envOverride || saving} onClick={() => void save(false)} size="sm" variant="textStrong">
-          Save for next restart
-        </Button>
-        <Button disabled={state.envOverride || saving} onClick={() => void save(true)} size="sm">
-          {saving ? <Loader2 className="size-4 animate-spin" /> : null}
-          Save and reconnect
-        </Button>
-      </div>
-
-      <div className="mt-6 grid gap-1">
+      <div className="mt-6 divide-y divide-border/40">
         <ListRow
           action={
-            <Button onClick={() => void window.hermesDesktop?.revealLogs()} size="sm" variant="textStrong">
+            <Button onClick={() => void window.hermesDesktop?.revealLogs()} variant="outline">
               <FileText className="size-4" />
               Open logs
             </Button>

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { ComponentProps, ReactNode } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button'
@@ -12,7 +13,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import type { DesktopConnectionConfig } from '@/global'
 import { triggerHaptic } from '@/lib/haptics'
+import { Check, Globe, Monitor } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import {
@@ -194,8 +197,37 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 }
 
 function ProfilesMenuButton({ navigate }: { navigate: ReturnType<typeof useNavigate> }) {
+  const [config, setConfig] = useState<DesktopConnectionConfig | null>(null)
+
+  const refresh = useCallback(() => {
+    void window.hermesDesktop?.connections
+      ?.get()
+      .then(setConfig)
+      .catch(() => undefined)
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const localActive = config?.mode === 'local'
+
+  const switchLocal = () => {
+    if (localActive) {
+      return
+    }
+
+    triggerHaptic('open')
+    void window.hermesDesktop?.connections?.activateLocal().catch(() => undefined)
+  }
+
+  const switchRemote = (id: string) => {
+    triggerHaptic('open')
+    void window.hermesDesktop?.connections?.activate(id).catch(() => undefined)
+  }
+
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={open => open && refresh()}>
       <DropdownMenuTrigger asChild>
         <Button
           aria-label="Profiles"
@@ -216,9 +248,26 @@ function ProfilesMenuButton({ navigate }: { navigate: ReturnType<typeof useNavig
         <DropdownMenuLabel>
           <div className="text-sm font-medium text-foreground">Profiles</div>
           <div className="mt-1 text-xs font-normal leading-4 text-muted-foreground">
-            Advanced Hermes environments for separate personas, config, skills, and SOUL.md.
+            Switch the active Hermes profile, or manage personas, config, skills, and SOUL.md.
           </div>
         </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => switchLocal()}>
+          <Monitor className="size-4" />
+          <span>Local gateway</span>
+          {localActive ? <Check className="ml-auto size-4 text-primary" /> : null}
+        </DropdownMenuItem>
+        {config?.remotes.map(remote => {
+          const active = config.mode === 'remote' && config.activeRemoteId === remote.id
+
+          return (
+            <DropdownMenuItem disabled={!remote.tokenSet} key={remote.id} onSelect={() => switchRemote(remote.id)}>
+              <Globe className="size-4" />
+              <span className="truncate">{remote.label || remote.profile || remote.url}</span>
+              {active ? <Check className="ml-auto size-4 text-primary" /> : null}
+            </DropdownMenuItem>
+          )
+        })}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => {

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -13,6 +13,12 @@ export interface ImageAttachResponse {
   path?: string
   text?: string
   message?: string
+  // Returned by the byte-upload variant (image.attach_bytes) used in remote mode.
+  count?: number
+  name?: string
+  width?: number
+  height?: number
+  token_estimate?: number
 }
 
 export interface ImageDetachResponse {

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -7,6 +7,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { extractEmbeddedImages } from '@/lib/embedded-images'
+import { gatewayMediaDataUrl, isRemoteGateway } from '@/lib/media'
 
 const HERMES_REF_TYPES = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal'] as const
 type HermesRefType = (typeof HERMES_REF_TYPES)[number]
@@ -324,9 +325,16 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
     }
 
     let alive = true
-    void window.hermesDesktop
-      ?.readFileDataUrl(id)
-      .then(url => alive && setSrc(url))
+
+    // Remote gateway: fetch the image over the API (it's on the gateway's disk,
+    // not ours). Local: read it straight off disk.
+    const load =
+      window.hermesDesktop && isRemoteGateway()
+        ? gatewayMediaDataUrl(id)
+        : window.hermesDesktop?.readFileDataUrl(id)
+
+    void Promise.resolve(load)
+      .then(url => alive && url && setSrc(url))
       .catch(() => alive && setFailed(true))
 
     return () => {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -17,6 +17,8 @@ import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   filePathFromMediaPath,
+  gatewayMediaDataUrl,
+  isRemoteGateway,
   mediaExternalUrl,
   mediaKind,
   mediaName,
@@ -49,6 +51,12 @@ async function mediaSrc(path: string): Promise<string> {
   // load the whole file into memory, which broke playback for larger videos.
   if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
     return mediaStreamUrl(path)
+  }
+
+  // Remote gateway: the file lives on the gateway machine, so read it over the
+  // API rather than this machine's disk.
+  if (window.hermesDesktop && isRemoteGateway()) {
+    return gatewayMediaDataUrl(path)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -13,6 +13,17 @@ declare global {
       probeConnectionConfig: (remoteUrl: string) => Promise<DesktopConnectionProbeResult>
       oauthLoginConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLoginResult>
       oauthLogoutConnectionConfig: (remoteUrl?: string) => Promise<DesktopOauthLogoutResult>
+      connections: {
+        get: () => Promise<DesktopConnectionConfig>
+        add: (payload: { url: string; token?: string; label?: string }) => Promise<DesktopConnectionConfig>
+        remove: (id: string) => Promise<DesktopConnectionConfig>
+        activate: (id: string) => Promise<DesktopConnectionConfig>
+        activateLocal: () => Promise<DesktopConnectionConfig>
+        test: (payload: { url?: string; token?: string; id?: string }) => Promise<DesktopConnectionTestResult>
+        probe: (url: string) => Promise<DesktopConnectionProbeResult>
+        oauthLogin: (url: string) => Promise<DesktopOauthLoginResult>
+        oauthLogout: (url?: string) => Promise<DesktopOauthLogoutResult>
+      }
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
@@ -165,9 +176,23 @@ export interface HermesWindowState {
   windowButtonPosition: { x: number; y: number } | null
 }
 
+export interface DesktopRemoteConnection {
+  id: string
+  label: string
+  profile: string | null
+  url: string
+  authMode: 'oauth' | 'token'
+  tokenPreview: string | null
+  tokenSet: boolean
+  oauthConnected?: boolean
+}
+
 export interface DesktopConnectionConfig {
   envOverride: boolean
   mode: 'local' | 'remote'
+  activeRemoteId: string | null
+  remotes: DesktopRemoteConnection[]
+  // Legacy mirror of the active remote, kept for older callers.
   remoteAuthMode: 'oauth' | 'token'
   remoteOauthConnected: boolean
   remoteTokenPreview: string | null
@@ -186,6 +211,8 @@ export interface DesktopConnectionTestResult {
   baseUrl: string
   ok: boolean
   version: string | null
+  profile?: string | null
+  authMode?: 'oauth' | 'token'
 }
 
 export interface DesktopAuthProvider {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,3 +1,5 @@
+import { $connection } from '@/store/session'
+
 export type MediaKind = 'audio' | 'image' | 'video' | 'file'
 
 interface MediaInfo {
@@ -75,6 +77,26 @@ export function mediaPathFromMarkdownHref(href?: string): string | null {
   } catch {
     return null
   }
+}
+
+// True when this desktop shell is wired to a remote gateway. Local media paths
+// then live on the gateway machine, not this disk, so we fetch them over the API.
+export function isRemoteGateway(): boolean {
+  return $connection.get()?.mode === 'remote'
+}
+
+// Fetch a gateway-local image as a data URL via the authenticated REST bridge.
+// Used in remote mode where readFileDataUrl (which reads THIS machine's disk)
+// can't see files the agent wrote on the gateway. Requires the gateway to
+// expose GET /api/media (added in hermes_cli/web_server.py).
+export async function gatewayMediaDataUrl(path: string): Promise<string> {
+  const file = filePathFromMediaPath(path)
+
+  const result = await window.hermesDesktop!.api<{ data_url: string }>({
+    path: `/api/media?path=${encodeURIComponent(file)}`
+  })
+
+  return result.data_url
 }
 
 export function filePathFromMediaPath(path: string): string {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -703,6 +703,50 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+# Image MIME types this endpoint will serve. Extension-allowlisted so an
+# authenticated caller can't bulk-exfiltrate source/secrets through it.
+_MEDIA_CONTENT_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".bmp": "image/bmp",
+    ".ico": "image/x-icon",
+}
+_MEDIA_MAX_BYTES = 25 * 1024 * 1024
+
+
+@app.get("/api/media")
+async def get_media(path: str):
+    """Return a local image file as a base64 data URL.
+
+    Lets remote clients (the desktop app connected over the network, or the
+    web dashboard in a browser) display images the agent wrote to *this*
+    machine's filesystem — they can't read the gateway's local disk directly.
+
+    Auth-gated by the session token like every other /api route. Restricted to
+    an image-extension allowlist and a size cap so it can't be used to read
+    arbitrary source files or secrets in bulk.
+    """
+    try:
+        target = Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    suffix = target.suffix.lower()
+    if suffix not in _MEDIA_CONTENT_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported media type")
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    if target.stat().st_size > _MEDIA_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    encoded = base64.b64encode(target.read_bytes()).decode("ascii")
+    return {"data_url": f"data:{_MEDIA_CONTENT_TYPES[suffix]};base64,{encoded}"}
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4630,6 +4630,73 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5027, str(e))
 
 
+@method("image.attach_bytes")
+def _(rid, params: dict) -> dict:
+    # Remote-client image attach. A desktop app (or web dashboard) running on a
+    # DIFFERENT machine than the gateway can't hand us a local path — that file
+    # only exists on the client's disk. So it uploads the raw image bytes
+    # (base64) and we write them into the gateway's own images dir. The response
+    # shape mirrors ``image.attach`` so the client treats both identically.
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    import base64
+
+    data = str(params.get("data", "") or "")
+    if not data:
+        return _err(rid, 4015, "data required")
+    # Strip a data-URL prefix if the client sent one (data:image/png;base64,…).
+    if data.startswith("data:"):
+        comma = data.find(",")
+        if comma != -1:
+            data = data[comma + 1 :]
+    try:
+        raw_bytes = base64.b64decode(data, validate=True)
+    except Exception:
+        return _err(rid, 4016, "data is not valid base64")
+    if not raw_bytes:
+        return _err(rid, 4016, "image is empty")
+    if len(raw_bytes) > 25 * 1024 * 1024:
+        return _err(rid, 4016, "image too large (max 25 MB)")
+
+    try:
+        from cli import _IMAGE_EXTENSIONS
+    except Exception:
+        _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+    ext = str(params.get("ext", "") or "").strip().lower()
+    if ext and not ext.startswith("."):
+        ext = "." + ext
+    if ext not in _IMAGE_EXTENSIONS:
+        ext = ".png"
+
+    session["image_counter"] = session.get("image_counter", 0) + 1
+    img_dir = _hermes_home / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    img_path = (
+        img_dir
+        / f"attach_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{session['image_counter']}{ext}"
+    )
+    try:
+        img_path.write_bytes(raw_bytes)
+    except Exception as e:
+        session["image_counter"] = max(0, session["image_counter"] - 1)
+        return _err(rid, 5027, str(e))
+
+    session.setdefault("attached_images", []).append(str(img_path))
+    return _ok(
+        rid,
+        {
+            "attached": True,
+            "path": str(img_path),
+            "count": len(session["attached_images"]),
+            "text": f"[User attached image: {img_path.name}]",
+            **_image_meta(img_path),
+        },
+    )
+
+
 @method("image.detach")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)


### PR DESCRIPTION
Three remote-mode improvements for the desktop app, each shipped with the gateway endpoint it needs so the feature works on a fresh deploy (no out-of-tree dependencies).

## 1. Remote image attach
When the desktop is connected to a **remote** gateway, attaching an image used to send a local file *path* — which doesn't exist on the gateway machine (the gateway then split the path on the first space, e.g. `…/Library/Application`). Now, in remote mode, the client uploads the image **bytes** via a new `image.attach_bytes` RPC (`tui_gateway/server.py`); local same-machine mode keeps the path-based `image.attach` untouched. The new RPC decodes base64, strips any data-URL prefix, sanitizes the extension, caps at 25 MB, writes into the gateway's own images dir, and returns the same response shape as `image.attach`.

## 2. Remote image display
Images the agent writes to the gateway's disk can't be read by a remote client, so they rendered as dead "Open …png" links. New **`GET /api/media`** (`hermes_cli/web_server.py`) returns an image file as a base64 data URL — auth-gated by the session token like every `/api` route, restricted to an image-extension allowlist, size-capped. The desktop fetches via it in remote mode (`media.ts`, `markdown-text.tsx`, `directive-text.tsx`), with graceful fallback to the existing chip when unavailable. Also fixes inline images in the web dashboard when viewed remotely.

## 3. Per-profile gateway switching
`connection.json` now holds a **`remotes[]`** list (+ `activeRemoteId`), auto-migrated from the single `remote`, each entry carrying its **auth mode** (`token` or `oauth`). **Settings → Gateway** manages the list (add / remove / connect), and the **titlebar Profiles menu** switches between them with one click (reconnects). Profile name and auth mode are **auto-detected** from the gateway's `/api/status` (`hermes_home` → profile; `auth_required` → oauth). Integrates with the existing OAuth connection layer — token gateways and OAuth-gated gateways are both supported per connection.

## Notes
- All three are independent; happy to split into separate PRs if preferred.
- Verified: `tsc -b` clean, eslint clean (no new findings), `py_compile` clean on both gateway files, full desktop build succeeds, and the running build exercises all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)