### PR TITLE
fix: cron list crash when job repeat is null

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -81,7 +81,7 @@ def cron_list(show_all: bool = False):
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
+        repeat_info = job.get("repeat") or {}
         repeat_times = repeat_info.get("times")
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"


### PR DESCRIPTION
## Bug

hermes cron list crashes when any job has "repeat": null in jobs.json.

## Root Cause

hermes_cli/cron.py line 84:
```python
repeat_info = job.get("repeat", {})
repeat_times = repeat_info.get("times")   # AttributeError when repeat_info is None
```

dict.get(key, default) only returns the default when the key is missing. When the JSON value is null, job.get("repeat", {}) returns None.

## Fix

```python
repeat_info = job.get("repeat") or {}
```

or {} handles both missing keys and null values.

## Steps to Reproduce

1. Create a cron job where "repeat": null in jobs.json
2. Run hermes cron list  
3. Crashes: AttributeError: NoneType object has no attribute get

## Environment

Hermes Agent v0.15.1, Python 3.11.15, Linux (Kylin V10)