### PR TITLE
fix(mcp): never permanently abandon a once-healthy MCP server on reconnect

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -317,3 +317,130 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: a once-healthy MCP server is never permanently abandoned
+# ---------------------------------------------------------------------------
+
+class TestMCPReconnectNeverGivesUp:
+    """MCPServerTask.run() keeps reconnecting a previously-healthy server.
+
+    Regression for the failure mode observed 2026-06-02: a Home Assistant
+    SSE connection dropped in a long-lived gateway process, the 5 reconnect
+    attempts failed, and the run-loop ``return``-ed — permanently removing
+    the server's tools from every session started afterwards until a full
+    Hermes restart. A server that has been healthy at least once (``_ready``
+    set) must instead retry indefinitely at the capped backoff cadence and
+    re-register its tools the moment the server comes back.
+    """
+
+    def test_reconnect_exceeds_max_retries_then_recovers(self, monkeypatch):
+        """After > _MAX_RECONNECT_RETRIES failures the loop keeps going and
+        recovers, instead of returning and killing the task."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        # Don't actually wait out the (capped 60s) backoff sleeps. Capture the
+        # real sleep *before* patching so the shim doesn't recurse into itself.
+        _real_sleep = asyncio.sleep
+
+        async def _fast_sleep(_delay):
+            await _real_sleep(0)
+
+        monkeypatch.setattr("tools.mcp_tool.asyncio.sleep", _fast_sleep)
+
+        # Fail well past the old give-up point (which returned once
+        # retries > _MAX_RECONNECT_RETRIES), then succeed. If the old
+        # ``return`` were still there, the task would exit at
+        # _MAX_RECONNECT_RETRIES + 1 attempts and never reach recovery.
+        recover_on = _MAX_RECONNECT_RETRIES + 4
+        call_count = 0
+
+        async def _run():
+            nonlocal call_count
+            server = MCPServerTask("test-never-give-up")
+
+            async def fake_run_stdio(self_inner, config):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    # First connection is healthy: mark ready, then drop.
+                    self_inner._ready.set()
+                    raise ConnectionError("SSE stream dropped")
+                if call_count < recover_on:
+                    # Reconnect attempts keep failing past the old limit.
+                    raise ConnectionError("server still down")
+                # Server is back: stay up until shutdown.
+                self_inner._ready.set()
+                await self_inner._shutdown_event.wait()
+
+            with patch.object(MCPServerTask, "_run_stdio", fake_run_stdio):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+
+                # Wait for the loop to climb past the old give-up point and
+                # reach the recovery attempt.
+                for _ in range(2000):
+                    if call_count >= recover_on:
+                        break
+                    await asyncio.sleep(0)
+
+                assert call_count >= recover_on, (
+                    f"Run-loop gave up early after {call_count} attempts; "
+                    f"expected it to keep retrying past "
+                    f"{_MAX_RECONNECT_RETRIES} and recover on attempt "
+                    f"{recover_on}"
+                )
+                # The task must still be alive (recovered), not finished.
+                assert not task.done(), "Run-loop exited instead of recovering"
+                # No terminal error was latched on a recoverable drop.
+                assert server._error is None
+
+                server._shutdown_event.set()
+                await task
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_reconnect_loop_honors_shutdown_after_max_retries(self, monkeypatch):
+        """Even while retrying indefinitely, a shutdown request still stops
+        the loop (no busy-spin, no leaked task)."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        _real_sleep = asyncio.sleep
+        sleep_calls = 0
+
+        async def _fast_sleep(_delay):
+            nonlocal sleep_calls
+            sleep_calls += 1
+            await _real_sleep(0)
+
+        monkeypatch.setattr("tools.mcp_tool.asyncio.sleep", _fast_sleep)
+
+        async def _run():
+            server = MCPServerTask("test-shutdown-while-retrying")
+            call_count = 0
+
+            async def fake_run_stdio(self_inner, config):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    self_inner._ready.set()
+                # Always fail so the loop is perpetually reconnecting.
+                raise ConnectionError("permanently down")
+
+            with patch.object(MCPServerTask, "_run_stdio", fake_run_stdio):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+
+                # Let it churn past the old give-up threshold.
+                for _ in range(2000):
+                    if call_count > _MAX_RECONNECT_RETRIES + 1:
+                        break
+                    await asyncio.sleep(0)
+
+                assert call_count > _MAX_RECONNECT_RETRIES + 1
+
+                # Request shutdown — the loop must terminate promptly.
+                server._shutdown_event.set()
+                await asyncio.wait_for(task, timeout=5)
+                assert task.done()
+
+        asyncio.get_event_loop().run_until_complete(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1764,12 +1764,36 @@ class MCPServerTask:
 
                 retries += 1
                 if retries > _MAX_RECONNECT_RETRIES:
+                    # A server that was healthy at least once (``_ready`` set)
+                    # must NEVER be permanently abandoned. Returning here kills
+                    # the run-loop task forever, so a multi-hour SSE/network
+                    # outage silently drops the server until a full Hermes
+                    # restart — every session started afterwards is missing its
+                    # tools. Observed 2026-06-02: Home Assistant SSE dropped,
+                    # 5 reconnects failed, task returned, HA tools vanished from
+                    # the long-lived gateway process for days.
+                    #
+                    # Instead of giving up, reset the retry counter and keep
+                    # probing at the capped backoff cadence. The moment the
+                    # server comes back, the next loop iteration reconnects and
+                    # re-registers its tools via _discover_tools(). The circuit
+                    # breaker (_CIRCUIT_BREAKER_THRESHOLD) already shields the
+                    # model from hammering tool calls at a still-dead server, so
+                    # a quiet once-per-_MAX_BACKOFF_SECONDS reconnect probe is
+                    # cheap and safe.
                     logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
+                        "MCP server '%s' still failing after %d reconnection "
+                        "attempts; continuing to retry every %.0fs instead of "
                         "giving up: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
+                        self.name, _MAX_RECONNECT_RETRIES,
+                        _MAX_BACKOFF_SECONDS, exc,
                     )
-                    return
+                    retries = 0
+                    backoff = _MAX_BACKOFF_SECONDS
+                    await asyncio.sleep(backoff)
+                    if self._shutdown_event.is_set():
+                        return
+                    continue
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "


### PR DESCRIPTION
## Problem

A long-lived MCP server connection that was **once healthy** could be permanently abandoned by the gateway after a transient transport drop.

In `MCPServerTask.run()`, the reconnect loop gave up with a bare `return` once `_MAX_RECONNECT_RETRIES` (5) consecutive reconnect attempts failed. For a long-running gateway process this `return` killed the server's task for good: the tools silently disappeared and never came back until a full gateway restart.

### Observed failure (2026-06-02)

A HomeAssistant MCP server over **SSE transport** dropped its connection. After 5 failed reconnects the run-loop returned, and all ~31 HomeAssistant tools vanished from every session. They only reappeared after manually restarting the gateway — unacceptable for an always-on home-automation hub.

## Root cause

The retry ceiling was meant to bound *initial* connection attempts, but it was also applied to a server that had already proven healthy (`_ready` had been set at least once). A server that worked once should never be permanently given up on — transient drops (SSE idle timeouts, network blips, HA restarts) are expected and recoverable.

## Fix

In the reconnect path, instead of `return` after `_MAX_RECONNECT_RETRIES`:
- reset `retries = 0`
- back off for `_MAX_BACKOFF_SECONDS` (60s)
- honor shutdown if requested
- `continue` the loop

The result: a once-healthy server reconnects indefinitely with a bounded 60s backoff, while shutdown still exits cleanly. The initial-connect path (`_MAX_INITIAL_CONNECT_RETRIES`) is unchanged, so genuinely-unreachable servers at startup still fail fast.

## Tests

Added `TestMCPReconnectNeverGivesUp` to `tests/tools/test_mcp_stability.py`:
- `test_reconnect_exceeds_max_retries_then_recovers` — healthy → drop → >5 failures → recovery; asserts the task stays alive and no permanent error is latched.
- `test_reconnect_loop_honors_shutdown_after_max_retries` — shutdown after the retry ceiling still exits cleanly.

Full MCP suite: `459 passed, 1 skipped`. Verified live on a running gateway — HA MCP (31 tools) survives an SSE drop and reconnects without a restart.
