### PR TITLE
feat: show retry/rate-limit messages progressively instead of deferred batch flush

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1484,11 +1484,11 @@ def run_conversation(
                     else:
                         _failure_hint = f"response time {api_duration:.1f}s"
 
-                    agent._buffer_vprint(f"⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
-                    agent._buffer_vprint(f"   🏢 Provider: {provider_name}")
+                    agent._vprint(f"{agent.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}", force=True)
+                    agent._vprint(f"{agent.log_prefix}   🏢 Provider: {provider_name}", force=True)
                     cleaned_provider_error = agent._clean_error_message(error_msg)
-                    agent._buffer_vprint(f"   📝 Provider message: {cleaned_provider_error}")
-                    agent._buffer_vprint(f"   ⏱️  {_failure_hint}")
+                    agent._vprint(f"{agent.log_prefix}   📝 Provider message: {cleaned_provider_error}", force=True)
+                    agent._vprint(f"{agent.log_prefix}   ⏱️  {_failure_hint}", force=True)
                     
                     if retry_count >= max_retries:
                         # Try fallback before giving up
@@ -1514,7 +1514,7 @@ def run_conversation(
                     
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
                     wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
-                    agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
+                    agent._vprint(f"{agent.log_prefix}⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...", force=True)
                     logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
                     # Sleep in small increments to stay responsive to interrupts
@@ -2609,16 +2609,16 @@ def run_conversation(
                 _base = getattr(agent, "base_url", "unknown")
                 _model = getattr(agent, "model", "unknown")
                 _status_code_str = f" [HTTP {status_code}]" if status_code else ""
-                agent._buffer_vprint(f"⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}")
-                agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
-                agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
-                agent._buffer_vprint(f"   📝 Error: {_error_summary}")
+                agent._vprint(f"{agent.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
+                agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
+                agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
+                agent._vprint(f"{agent.log_prefix}   📝 Error: {_error_summary}", force=True)
                 if status_code and status_code < 500:
                     _err_body = getattr(api_error, "body", None)
                     _err_body_str = str(_err_body)[:300] if _err_body else None
                     if _err_body_str:
-                        agent._buffer_vprint(f"   📋 Details: {_err_body_str}")
-                agent._buffer_vprint(f"   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
+                        agent._vprint(f"{agent.log_prefix}   📋 Details: {_err_body_str}", force=True)
+                agent._vprint(f"{agent.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens", force=True)
 
                 # Actionable hint for OpenRouter "no tool endpoints" error.
                 # Buffered like the rest of the retry trace — surfaced only
@@ -3393,9 +3393,9 @@ def run_conversation(
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 if is_rate_limited:
-                    agent._buffer_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
+                    agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                 else:
-                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    agent._emit_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
                 logger.warning(
                     "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                     wait_time,

--- a/cli.py
+++ b/cli.py
@@ -12236,6 +12236,20 @@ class HermesCLI:
                         # triggered by input events — on macOS this causes
                         # the CLI to appear frozen until the user types. (#1624)
                         self._invalidate(min_interval=0.15)
+                        # Process pending asyncio callbacks so cross-thread
+                        # _cprint messages (retry status, error lines) render
+                        # immediately instead of accumulating until the agent
+                        # thread exits.  _cprint uses call_soon_threadsafe to
+                        # schedule run_in_terminal on the app's event loop,
+                        # and without a periodic callback pump those callbacks
+                        # queue behind the synchronous polling loop. (#1624)
+                        try:
+                            import asyncio as _aio
+                            _loop = _aio.get_event_loop()
+                            if _loop.is_running() and hasattr(_loop, '_run_once'):
+                                _loop._run_once()
+                        except Exception:
+                            pass
                 else:
                     # Fallback for non-interactive mode (e.g., single-query)
                     agent_thread.join(0.1)


### PR DESCRIPTION
## Motivation

The current design intentionally buffers retry status messages via `_buffer_vprint` / `_buffer_status` and only flushes them once all retries fail (or silently drops them on success). This reduces noise for transient errors, but for multi-attempt retries — especially rate-limit backoffs that can take 80+ seconds — the user sees nothing until the very end, then gets a wall of messages all at once.

This PR changes the behavior to show retry messages **progressively** as each retry occurs, giving real-time feedback during long backoff waits.

## Changes

### 1. `agent/conversation_loop.py` — Stop buffering retry messages

Convert retry status messages from buffered to immediate emission:

- `_buffer_vprint()` → `_vprint(force=True)` for error detail lines (API call failed, provider info, etc.)
- `_buffer_status()` → `_emit_status()` for rate-limit/retry waiting messages

Pre-existing `_flush_status_buffer()` calls for OTHER buffered messages (OpenRouter hints, long-context tier messages, etc.) are preserved — only the retry-loop messages are unbuffered.

### 2. `cli.py` — Process event loop callbacks during agent polling

The agent runs in a daemon background thread. `_cprint()` routes cross-thread prints through `call_soon_threadsafe`, which schedules them on the prompt_toolkit event loop. However, the main thread blocks the event loop with a synchronous `while agent_thread.is_alive()` polling loop. The existing `_invalidate()` call marks the UI for redraw but does not process event loop callbacks.

After `_invalidate()`, add `asyncio.get_event_loop()._run_once()` to process one batch of pending callbacks every ~0.1s. Without this, even unbuffered messages accumulate and render all at once when the polling loop exits.

Safety: wrapped in try/except, guarded by `is_running()` and `hasattr(_run_once)`.

## Before / After

**Before:** All 5 retry messages appear simultaneously after ~80s of silent waiting.

**After:** Each retry message appears in real time as it happens — ⚠️ API call failed, ⏱️ Rate limited. Waiting Xs... — giving the user visibility into the retry progress.