### PR TITLE
docs(desktop): add i18n localization guidelines

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -81,6 +81,8 @@ HERMES_HOME=/tmp/throwaway npm run dev
 npm run dev:fake-boot   # exercise the startup overlay with deterministic delays
 ```
 
+For Desktop localization work, see [Desktop i18n guidelines](docs/i18n.md).
+
 ### Building installers
 
 ```bash

--- a/apps/desktop/docs/i18n.md
+++ b/apps/desktop/docs/i18n.md
@@ -1,0 +1,78 @@
+# Desktop i18n guidelines
+
+Hermes Desktop can support localized UI chrome while keeping agent output and
+developer-facing identifiers stable. This guide defines the review expectations
+for Desktop localization work.
+
+## Scope
+
+Translate user-facing Desktop UI surfaces:
+
+- First-run onboarding and provider setup.
+- App shell labels, titlebar controls, sidebar labels, and status text.
+- Settings panels, including models, keys, MCP, sessions, appearance, and about.
+- Confirmation dialogs, destructive-action prompts, empty states, and toasts.
+- Gateway and boot status messages shown by the Desktop renderer.
+
+Do not translate content that can change program behavior or pollute model
+context:
+
+- Tool output, shell commands, code blocks, JSON, diffs, tracebacks, and logs.
+- Provider IDs, model IDs, plugin IDs, skill IDs, environment variable names, and
+  file paths.
+- Text written back into session history or sent to the agent as user/model
+  context.
+
+## Glossary
+
+Keep stable product and developer terms in English unless a maintainer approves
+a different project-wide glossary.
+
+| Term | Preferred UI text |
+| --- | --- |
+| Toolset | Toolset |
+| Skill | Skill |
+| MCP | MCP |
+| Provider | Provider |
+| Gateway | Gateway |
+| Profile | Profile |
+| Session | Session |
+| SOUL.md | SOUL.md |
+
+Short explanatory copy can add localized context around these terms, but the
+term itself should remain recognizable to users following English docs,
+provider setup instructions, or skill references.
+
+## Chinese locales
+
+Chinese localization should support both Simplified and Traditional Chinese:
+
+- `zh-CN` for Simplified Chinese.
+- `zh-Hant` for Traditional Chinese.
+
+System locale detection should map `zh-TW`, `zh-HK`, and `zh-MO` to `zh-Hant`.
+Other `zh` locales can fall back to `zh-CN` unless a more specific catalog is
+available.
+
+## Runtime expectations
+
+Desktop localization should preserve these behavior guarantees:
+
+- English remains the default fallback.
+- Missing locale keys fall back to English instead of showing raw keys.
+- All locale catalogs keep key parity with the English catalog.
+- Switching language updates visible React UI without requiring an app restart.
+- Language persistence should use the same config path as other Hermes surfaces
+  when possible, such as `display.language`, instead of introducing a separate
+  Desktop-only preference.
+
+## Review checklist
+
+Before opening or merging a Desktop localization PR:
+
+- Run a key-parity check between each locale catalog and English.
+- Spot-check onboarding, settings, sidebar, and gateway/error toasts.
+- Verify `zh-CN` and `zh-Hant` system-locale detection on macOS.
+- Confirm that commands, code, JSON, logs, provider IDs, model IDs, and skill IDs
+  remain untranslated.
+- Confirm that language changes repaint visible UI immediately.


### PR DESCRIPTION
## Summary

- Add Desktop i18n review guidelines covering scope, glossary, Chinese locale mapping, and runtime expectations.
- Link the guide from the Desktop README development section.

## Why

Desktop localization PRs are starting to land, and Chinese support needs clear boundaries so UI chrome can be translated without changing tool output, code, provider/model IDs, or model context.

The guide also documents zh-CN / zh-Hant expectations, including `zh-TW`, `zh-HK`, and `zh-MO` mapping to Traditional Chinese.

## Validation

- Markdown-only change.
- New `apps/desktop/docs/i18n.md` content is ASCII.
- README change is a single link to the new guide.

Closes #37897? No, this is guidance only; runtime i18n still needs implementation.
