### PR TITLE
fix(desktop): re-mint OAuth WS ticket on gateway reconnect

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 
 import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
-import { resolveGatewayWsUrl } from '@/lib/gateway-ws-url'
+import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@/lib/gateway-ws-url'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -104,7 +104,15 @@ export function useGatewayBoot({
         }
 
         publish(conn)
-        await gateway.connect(conn.wsUrl)
+        // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
+        // with a short TTL, so the ticket baked into the cached conn.wsUrl is
+        // dead on every reconnect after the initial boot — reusing it surfaces
+        // as an opaque "Could not connect to Hermes gateway". resolveGatewayWsUrl
+        // mints a fresh ticket (or throws a reauth error in OAuth mode rather
+        // than connecting with a stale one). For local/token gateways the URL
+        // carries a long-lived token and the re-mint is a cheap no-op.
+        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        await gateway.connect(wsUrl)
 
         if (cancelled) {
           return
@@ -114,8 +122,14 @@ export function useGatewayBoot({
         // Resync state that may have moved on the backend while we were asleep.
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
-      } catch {
-        // Fall through to scheduleReconnect's backoff below.
+      } catch (err) {
+        // OAuth session expired mid-reconnect: surface the actionable "sign in
+        // again" message once instead of silently looping the backoff against a
+        // ticket that can never succeed. Transport failures fall through to the
+        // backoff in the finally block below.
+        if (!cancelled && isGatewayReauthRequired(err)) {
+          notifyError(err, 'Gateway sign-in required')
+        }
       } finally {
         reconnecting = false
 


### PR DESCRIPTION
## Summary
OAuth-gated remote desktop gateways now reconnect successfully instead of failing with "Could not connect to Hermes gateway" after the first sign-in.

Root cause: `attemptReconnect()` connected with the stale cached `conn.wsUrl`. OAuth WS tickets are single-use with a ~30s TTL — the first sign-in goes through `boot()`, which re-mints a fresh ticket via `resolveGatewayWsUrl()`, but every reconnect (sleep/wake, network online, window refocus, socket-drop-after-boot, app restart) reused a dead ticket. The WS upgrade was rejected even though backend resolution (cookie + REST) reported "Remote Hermes backend is ready" — the WebSocket was the only thing dying.

## Changes
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`:
  - `attemptReconnect()` now mints a fresh WS URL via `resolveGatewayWsUrl(desktop, conn)` before connecting, mirroring the already-shipped pattern in `use-gateway-request.ts`.
  - On an OAuth reauth-required error, surfaces the actionable "sign in again" notification once instead of silently looping the backoff against a ticket that can never succeed.
  - Local/token gateways are unaffected — the re-mint is a cheap no-op over a long-lived token.

## Validation
| | Before | After |
|---|---|---|
| First sign-in (OAuth remote) | works | works |
| Reconnect after sleep/restart (OAuth remote) | "Could not connect to Hermes gateway" | re-mints ticket, connects |
| OAuth session expired on reconnect | silent backoff loop | one "sign in again" notification |
| Local / token gateway | works | works (re-mint no-op) |

`tsc -b` passes clean. This was the lone remaining `.connect(conn.wsUrl)` site in the renderer; `use-gateway-request.ts` already used the re-mint helper.

## Infographic

![oauth-ws-ticket-remint](https://v3b.fal.media/files/b/0a9cece3/UXN0ACX5OjmmBTyNF9qHC_mwANjBoz.png)
