### PR TITLE
chore(desktop): silence Vite chunk-size warning for intentional single bundle

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   build: {
     // Keep desktop packaging stable: Shiki ships many dynamic chunks by
     // default, and electron-builder can OOM scanning thousands of files.
+    // Collapsing to a single chunk is intentional, so the renderer bundle is
+    // large by design (~22 MB). Raise the warning ceiling above that so the
+    // cosmetic "chunk larger than 500 kB" nag stays quiet, while still acting
+    // as a regression alarm if the bundle balloons well past today's size.
+    chunkSizeWarningLimit: 25000,
     rolldownOptions: {
       output: {
         codeSplitting: false


### PR DESCRIPTION
## Summary
Builds of the desktop app no longer print the spurious "Some chunks are larger than 500 kB" warning — the single fat bundle is by design, so the warning was pure noise.

The renderer is bundled into one chunk on purpose (`codeSplitting: false`) because Shiki ships many dynamic chunks that make `electron-builder` OOM scanning thousands of files. That makes the ~22 MB `index-*.js` expected, but Vite warned on every build anyway.

## Changes
- `apps/desktop/vite.config.ts`: add `build.chunkSizeWarningLimit: 25000` (kB), above the current ~22 MB bundle. Comment explains why. `codeSplitting: false` untouched.

## Validation
- `vite.resolveConfig(..., 'build')` against the edited config resolves `chunkSizeWarningLimit` to `25000` and keeps `rolldownOptions.output.codeSplitting === false`.
- Config-only, additive change — no effect on the bundle itself; still alarms if the bundle ever grows past ~25 MB.

## Infographic
![desktop-quiet-chunk-warning](https://v3b.fal.media/files/b/0a9cecf7/ZeROsHF7AE982vTAFEyrc_uD7lL4V7.png)
