### PR TITLE
fix(tui_gateway): close slash_worker on transport disconnect + reap orphans

### DIFF
--- a/tests/tui_gateway/test_slash_worker_leak.py
+++ b/tests/tui_gateway/test_slash_worker_leak.py
@@ -1,0 +1,202 @@
+"""Regression tests for the slash_worker subprocess leak.
+
+A long-lived dashboard accumulated orphaned ``tui_gateway.slash_worker``
+subprocesses (live + ``<defunct>`` zombies) because sessions whose WebSocket
+transport dropped were never finalized and their workers never closed/reaped.
+
+These tests pin the three lifecycle guarantees of the fix:
+
+* a transport disconnect terminates the session's slash worker (no live leak),
+  while keeping the session warm for in-place resume;
+* a worker's drain thread reaps the child on death (no ``<defunct>`` zombies);
+* terminal ``_finalize_session`` closes the worker (unified teardown).
+"""
+
+import asyncio
+import queue
+import types
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        import importlib
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+
+
+class _FakeWorker:
+    """Stand-in for ``_SlashWorker`` exposing the bits the lifecycle touches."""
+
+    def __init__(self):
+        self.closed = 0
+        # Starts "alive"; close() flips poll() to a return code, like the real one.
+        self._rc = None
+        self.proc = types.SimpleNamespace(poll=lambda: self._rc)
+
+    def close(self):
+        self.closed += 1
+        self._rc = -15  # terminated
+
+
+# ── 1. transport disconnect must terminate the worker (live-leak fix) ────────
+
+
+def test_detach_transport_terminates_and_nulls_worker(server):
+    worker = _FakeWorker()
+    transport = object()
+    server._sessions["sid"] = {
+        "session_key": "sid",
+        "transport": transport,
+        "slash_worker": worker,
+    }
+
+    detached = server._detach_transport(transport)
+
+    assert detached == 1
+    # Worker subprocess torn down — this is the leak that was accumulating.
+    assert worker.closed == 1
+    assert server._sessions["sid"]["slash_worker"] is None
+    # Session stays warm (transport falls back to stdio) so resume still works.
+    assert server._sessions["sid"]["transport"] is server._stdio_transport
+    assert "sid" in server._sessions
+
+
+def test_detach_transport_ignores_other_sessions(server):
+    mine = _FakeWorker()
+    theirs = _FakeWorker()
+    dropped = object()
+    other = object()
+    server._sessions["a"] = {"session_key": "a", "transport": dropped, "slash_worker": mine}
+    server._sessions["b"] = {"session_key": "b", "transport": other, "slash_worker": theirs}
+
+    server._detach_transport(dropped)
+
+    assert mine.closed == 1
+    assert theirs.closed == 0  # untouched — its socket is still live
+    assert server._sessions["b"]["slash_worker"] is theirs
+
+
+def test_handle_ws_disconnect_terminates_session_worker(server):
+    """End-to-end: a session whose WebSocket drops must have its worker closed."""
+    from tui_gateway import ws as ws_mod
+
+    captured = {}
+    real_transport_cls = ws_mod.WSTransport
+
+    class _CapturingTransport(real_transport_cls):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            captured["t"] = self
+
+    worker = _FakeWorker()
+    state = {"step": 0}
+
+    class _FakeWS:
+        client = types.SimpleNamespace(host="t", port=1)
+
+        async def accept(self):
+            return None
+
+        async def send_text(self, _line):
+            return None
+
+        async def receive_text(self):
+            if state["step"] == 0:
+                state["step"] = 1
+                # Bind a session to the live transport, then disconnect next read.
+                server._sessions["sid"] = {
+                    "session_key": "sid",
+                    "transport": captured["t"],
+                    "slash_worker": worker,
+                }
+                return ""  # blank line → loop continues without dispatch
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            return None
+
+    with patch.object(ws_mod, "WSTransport", _CapturingTransport):
+        asyncio.run(ws_mod.handle_ws(_FakeWS()))
+
+    assert worker.closed == 1
+    assert server._sessions["sid"]["slash_worker"] is None
+    assert server._sessions["sid"]["transport"] is server._stdio_transport
+
+
+# ── 2. drain thread must reap the child on death (zombie fix) ────────────────
+
+
+def test_drain_stdout_reaps_worker_on_eof(server):
+    """When the worker's stdout EOFs (child exited), the drain thread must
+    ``wait()`` the child so it is reaped instead of left as ``<defunct>``."""
+    worker = server._SlashWorker.__new__(server._SlashWorker)
+    worker.stdout_queue = queue.Queue()
+
+    waited = {"n": 0}
+
+    class _Proc:
+        stdout = iter(['{"id": 1, "ok": true, "output": "hi"}\n'])
+
+        def wait(self):
+            waited["n"] += 1
+            return 0
+
+    worker.proc = _Proc()
+
+    worker._drain_stdout()
+
+    # Message parsed and forwarded, then the None sentinel.
+    assert worker.stdout_queue.get_nowait() == {"id": 1, "ok": True, "output": "hi"}
+    assert worker.stdout_queue.get_nowait() is None
+    # Child reaped exactly once — the missing piece that produced zombies.
+    assert waited["n"] == 1
+
+
+# ── 3. terminal finalize must close the worker (unified teardown) ────────────
+
+
+def test_finalize_session_closes_worker(server, monkeypatch):
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    worker = _FakeWorker()
+    session = {
+        "session_key": "sid",
+        "agent": types.SimpleNamespace(session_id="sid"),
+        "history": [],
+        "slash_worker": worker,
+    }
+
+    server._finalize_session(session)
+
+    assert worker.closed == 1
+    assert session["slash_worker"] is None
+
+
+def test_finalize_session_is_idempotent(server, monkeypatch):
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    worker = _FakeWorker()
+    session = {
+        "session_key": "sid",
+        "agent": types.SimpleNamespace(session_id="sid"),
+        "history": [],
+        "slash_worker": worker,
+    }
+
+    server._finalize_session(session)
+    server._finalize_session(session)  # second call must be a no-op
+
+    assert worker.closed == 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -221,6 +221,14 @@ class _SlashWorker:
             except json.JSONDecodeError:
                 continue
         self.stdout_queue.put(None)
+        # stdout EOF means the child closed its pipe (i.e. exited). Reap it so a
+        # worker that dies on its own is never left as a <defunct> zombie, even
+        # if nobody ever calls close(). Popen.wait() is thread-safe, so this
+        # composes with close()'s own terminate()+wait().
+        try:
+            self.proc.wait()
+        except Exception:
+            pass
 
     def _drain_stderr(self):
         for line in self.proc.stderr or []:
@@ -284,11 +292,27 @@ def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
         pass
 
 
+def _close_slash_worker(session: dict) -> None:
+    """Idempotently tear down a session's slash worker subprocess."""
+    worker = session.get("slash_worker")
+    if worker is None:
+        return
+    try:
+        worker.close()
+    except Exception:
+        pass
+    session["slash_worker"] = None
+
+
 def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> None:
     """Best-effort finalize hook + memory commit for a session."""
     if not session or session.get("_finalized"):
         return
     session["_finalized"] = True
+    # Terminal teardown — close the slash worker here so every finalize path
+    # (session.close RPC, atexit shutdown) frees the subprocess. The _finalized
+    # guard above makes this run exactly once per session.
+    _close_slash_worker(session)
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
@@ -326,15 +350,26 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 def _shutdown_sessions() -> None:
     for session in list(_sessions.values()):
         _finalize_session(session, end_reason="tui_shutdown")
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
 
 
 atexit.register(_shutdown_sessions)
+
+
+def _detach_transport(transport) -> int:
+    """A client transport went away. For every session it owned, re-point the
+    transport to stdio so late event emits fall back to a harmless sink instead
+    of crashing into a closed socket, and close its slash worker so the ~45 MB
+    subprocess is freed (and reaped) immediately rather than orphaned until the
+    whole dashboard exits. The session itself stays warm: history/agent survive
+    for in-place resume and ``slash.exec`` re-spawns the worker on demand.
+    Returns the number of sessions detached."""
+    detached = 0
+    for sess in list(_sessions.values()):
+        if sess.get("transport") is transport:
+            sess["transport"] = _stdio_transport
+            _close_slash_worker(sess)
+            detached += 1
+    return detached
 
 
 # ── Plumbing ──────────────────────────────────────────────────────────
@@ -3561,7 +3596,7 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
-    _finalize_session(session)
+    _finalize_session(session)  # also closes the slash worker
     try:
         from tools.approval import unregister_gateway_notify
 
@@ -3572,12 +3607,6 @@ def _(rid, params: dict) -> dict:
         agent = session.get("agent")
         if agent and hasattr(agent, "close"):
             agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
     except Exception:
         pass
     return _ok(rid, {"closed": True})

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -266,11 +266,10 @@ async def handle_ws(ws: Any) -> None:
             transport.close()
 
             # Detach the transport from any sessions it owned so later emits
-            # fall back to stdio instead of crashing into a closed socket.
-            for _, sess in list(server._sessions.items()):
-                if sess.get("transport") is transport:
-                    sess["transport"] = server._stdio_transport
-                    detached_sessions += 1
+            # fall back to stdio instead of crashing into a closed socket, and
+            # tear down each session's slash worker so the subprocess is freed
+            # rather than orphaned until the whole dashboard exits.
+            detached_sessions = server._detach_transport(transport)
         try:
             await ws.close()
         except Exception as exc:


### PR DESCRIPTION
## Problem
A long-lived dashboard (`hermes dashboard --tui`) accumulates orphaned `tui_gateway.slash_worker` subprocesses. On a real deployment after ~3 days: **96 live workers** (each ~45 MB RSS, ≈4.2 GB total) plus **71 `<defunct>` zombies**, all parented to the dashboard PID. Restarting the dashboard clears them (via `atexit`), but they return with continued use.

## Root cause
A session's `_SlashWorker` (persistent `subprocess.Popen` child) was only closed on three paths: the `session.close` RPC, `_restart_slash_worker`, and `_shutdown_sessions` (atexit). But the most common abandonment path — a **dashboard WebSocket dropping** — was not covered: `handle_ws`'s `finally` block (`ws.py`) only re-pointed each owned session's transport to stdio and never finalized the session or closed its worker, so the subprocess leaked until the whole dashboard exited. Separately, `_drain_stdout` never called `proc.wait()`, so any orphaned worker that later died was left `<defunct>`.

## Fix (minimal, idempotent)
1. **`_detach_transport()`** — extracted from `handle_ws`; on transport drop it re-points transport→stdio **and** closes the session's worker, while keeping the session warm (history/agent survive; `slash.exec` lazily respawns the worker on demand, so in-place resume still works).
2. **`_drain_stdout`** reaps the child on stdout EOF (`proc.wait()`), so a worker that dies on its own is never left a zombie regardless of who called `close()`. `Popen.wait()` is thread-safe.
3. **`_finalize_session`** now owns worker teardown via a shared `_close_slash_worker` helper, guarded by the existing `_finalized` flag — letting us delete the now-redundant `worker.close()` blocks in `session.close` and `_shutdown_sessions`.

`_restart_slash_worker` and the atexit shutdown are untouched and still respawn/close correctly.

## Tests
New `tests/tui_gateway/test_slash_worker_leak.py` (6 tests): detach terminates + nulls the worker, detach ignores other sessions, ws-disconnect terminates the session worker, `_drain_stdout` reaps on EOF, finalize closes the worker, finalize is idempotent. RED against current code (workers never closed), GREEN with the fix. Full suite: `tests/tui_gateway/` 106 passed, `tests/test_tui_gateway_server.py` 199 passed.
