### PR TITLE
fix(voice): add WSL audio warmup to eliminate RDP crackling

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1039,6 +1039,16 @@ def stop_playback() -> None:
         pass
 
 
+def _is_wsl() -> bool:
+    """True when running inside Windows Subsystem for Linux."""
+    try:
+        with open("/proc/version", "r") as f:
+            return "microsoft" in f.read().lower()
+    except Exception:
+        return False
+    return False
+
+
 def play_audio_file(file_path: str) -> bool:
     """Play an audio file through the default output device.
 
@@ -1067,7 +1077,27 @@ def play_audio_file(file_path: str) -> bool:
                 audio_data = np.frombuffer(frames, dtype=np.int16)
                 sample_rate = wf.getframerate()
 
-            sd.play(audio_data, samplerate=sample_rate)
+            # WSLg RDP audio needs a warmup to avoid crackling at the start.
+            # The RDP virtual-channel connection takes ~100 ms to stabilise,
+            # and small default blocksize exasperates timing jitter caused by
+            # systemd-timesyncd clock adjustments (microsoft/wslg#1257).
+            if _is_wsl():
+                silence_samples = int(0.1 * sample_rate)
+                fade_samples = int(0.1 * sample_rate)
+                fade = np.linspace(0.0, 1.0, fade_samples, dtype=np.float64)
+                audio_float = audio_data.astype(np.float64)
+                audio_float[:fade_samples] *= fade
+                tail = np.zeros(int(0.05 * sample_rate), dtype=np.int16)
+                audio_data = np.concatenate([
+                    np.zeros(silence_samples, dtype=np.int16),
+                    audio_float.astype(np.int16),
+                    tail,
+                ])
+                blocksize = 4096
+            else:
+                blocksize = 0  # default (auto)
+
+            sd.play(audio_data, samplerate=sample_rate, blocksize=blocksize)
             # sd.wait() calls Event.wait() without timeout — hangs forever if
             # the audio device stalls.  Poll with a ceiling and force-stop.
             duration_secs = len(audio_data) / sample_rate


### PR DESCRIPTION
## Summary

WSLg RDP audio playback produces crackling/popping artifacts even when the generated WAV file is clean. Two interacting issues:

1. **`systemd-timesyncd` clock adjustments** — hyperv_clocksource drift causes PulseAudio RDP sink timing jitter → buffer underruns throughout playback ([microsoft/wslg#1257](https://github.com/microsoft/wslg/issues/1257))
2. **Cold-start RDP connection** — PortAudio opens a new PA stream on first `sd.play()`; the RDP virtual channel needs ~100ms to stabilise → first packets dropped

## Fix

In `play_audio_file()` (`tools/voice_mode.py`), WAV branch (sounddevice path):

- Detect WSL via `/proc/version` → `"microsoft"` marker
- Prepend 100ms silence + apply 100ms fade-in to audio + append 50ms silence tail
- Set `blocksize=4096` explicitly (default auto ~1024 is too small for RDP jitter)
- All in a single continuous `sd.play()` buffer — no stop/start gap

Gated behind `_is_wsl()` → Linux/macOS paths are unchanged.

## Testing

Empirical A/B tests on WSL2 Ubuntu 24.04 with RTX 4060:

| Condition | Result |
|---|---|
| timesyncd ON, no warmup | crackling throughout |
| timesyncd OFF, no warmup | mostly clean, beginning crackles |
| timesyncd OFF + warmup (this PR) | **clean from start to end** |

The timesyncd fix is a documented user action (`sudo systemctl stop systemd-timesyncd`). The warmup is automated in code.

## Related

- Closes #38893
- Companion to #38833 (CLI TTS auto-play — this PR fixes the actual playback quality that PR delivers)