### PR TITLE
fix(checkpoint): only record dir in _checkpointed_dirs after successful snapshot

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -1049,3 +1049,97 @@ class TestClearFunctions:
         result = clear_all()
         assert result["deleted"] is False
         assert result["bytes_freed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #38891 — checkpoint dirs polluted on failed snapshot
+# ---------------------------------------------------------------------------
+
+class TestEnsureCheckpointDirPollution:
+    """When ``_take()`` fails, the dir must NOT be added to ``_checkpointed_dirs``.
+
+    Before the fix, ``ensure_checkpoint`` called
+    ``self._checkpointed_dirs.add(abs_dir)`` *before* ``_take()``.  If
+    ``_take()`` returned ``False`` or raised, the dir was permanently
+    recorded and all future calls short-circuited — preventing retries.
+    """
+
+    def test_dir_not_added_on_take_failure(self, tmp_path):
+        """_take() returns False → dir must not be in _checkpointed_dirs."""
+        m = CheckpointManager(enabled=True)
+        work_dir = str(tmp_path / "bad_project")
+        tmp_path.joinpath("bad_project").mkdir()
+
+        original_take = m._take
+        m._take = lambda wd, reason: False
+
+        try:
+            result = m.ensure_checkpoint(work_dir, reason="test")
+            assert result is False
+            assert work_dir not in m._checkpointed_dirs
+            # Retry should actually call _take again (not short-circuit)
+            result2 = m.ensure_checkpoint(work_dir, reason="retry")
+            assert result2 is False
+        finally:
+            m._take = original_take
+
+    def test_dir_not_added_on_take_exception(self, tmp_path):
+        """_take() raises → dir must not be in _checkpointed_dirs."""
+        m = CheckpointManager(enabled=True)
+        work_dir = str(tmp_path / "crash_project")
+        tmp_path.joinpath("crash_project").mkdir()
+
+        call_count = 0
+
+        def _take_that_raises(wd, reason):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("simulated failure")
+
+        m._take = _take_that_raises
+
+        result = m.ensure_checkpoint(work_dir, reason="test")
+        assert result is False
+        assert work_dir not in m._checkpointed_dirs
+        # Second call should retry, not skip
+        result2 = m.ensure_checkpoint(work_dir, reason="retry")
+        assert result2 is False
+        assert call_count == 2  # Both calls reached _take
+
+    def test_dir_added_on_success_then_skipped(self, tmp_path):
+        """_take() succeeds → dir is recorded → second call is a no-op."""
+        m = CheckpointManager(enabled=True)
+        work_dir = str(tmp_path / "good_project")
+        tmp_path.joinpath("good_project").mkdir()
+
+        m._take = lambda wd, reason: True
+
+        result1 = m.ensure_checkpoint(work_dir, reason="test")
+        assert result1 is True
+        assert work_dir in m._checkpointed_dirs
+
+        result2 = m.ensure_checkpoint(work_dir, reason="test")
+        assert result2 is False  # Already checkpointed
+
+    def test_false_then_success_retry(self, tmp_path):
+        """After _take() returns False, a later success should record the dir."""
+        m = CheckpointManager(enabled=True)
+        work_dir = str(tmp_path / "retry_project")
+        tmp_path.joinpath("retry_project").mkdir()
+
+        call_count = 0
+
+        def _take_selective(wd, reason):
+            nonlocal call_count
+            call_count += 1
+            return call_count >= 2  # Fail first, succeed second
+
+        m._take = _take_selective
+
+        result1 = m.ensure_checkpoint(work_dir, reason="first")
+        assert result1 is False
+        assert work_dir not in m._checkpointed_dirs
+
+        result2 = m.ensure_checkpoint(work_dir, reason="second")
+        assert result2 is True
+        assert work_dir in m._checkpointed_dirs

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -646,13 +646,15 @@ class CheckpointManager:
         if abs_dir in self._checkpointed_dirs:
             return False
 
-        self._checkpointed_dirs.add(abs_dir)
-
         try:
-            return self._take(abs_dir, reason)
+            result = self._take(abs_dir, reason)
         except Exception as e:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
             return False
+
+        if result:
+            self._checkpointed_dirs.add(abs_dir)
+        return result
 
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
         """List available checkpoints for a directory (most recent first)."""


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `CheckpointManager.ensure_checkpoint()` where a failed snapshot permanently prevented retries for that directory. When `_take()` returned `False` or raised an exception, the working directory was already added to `_checkpointed_dirs`, causing all future calls to short-circuit with "already checkpointed."

## Related Issue

Fixes #38891

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/checkpoint_manager.py`: Move `_checkpointed_dirs.add(abs_dir)` to after `_take()` returns `True`, so failed snapshots can be retried on subsequent calls
- `tests/tools/test_checkpoint_manager.py`: Add 4 regression tests covering `_take()` returning False, raising an exception, succeeding, and the fail-then-succeed retry path

## How to Test

1. Run `pytest tests/tools/test_checkpoint_manager.py::TestEnsureCheckpointDirPollution -v` — all 4 tests should pass
2. Verify the fix: when `_take()` returns False, the dir is NOT in `_checkpointed_dirs`; when it returns True, the dir IS recorded and subsequent calls skip

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/checkpoint_manager.py:ensure_checkpoint` (callers: agent tool dispatch, flows: checkpoint-before-mutation)
- Blast radius: LOW — `_checkpointed_dirs` is an in-memory per-turn dedup set; moving the `.add()` after `_take()` only affects retry behavior within the same turn
- Related patterns: fail-closed guard pattern — record success, not attempt
