### PR TITLE
fix(gateway): finalize abandoned stream overflow chunks

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -530,7 +530,17 @@ class GatewayStreamConsumer:
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
+                        # This chunk is complete and will be abandoned when
+                        # _message_id is reset below, so platforms such as
+                        # Telegram that apply rich text on finalize must see a
+                        # final edit now. The assistant turn is still streaming
+                        # the overflow remainder, though, so do not mark the
+                        # whole turn final yet.
+                        ok = await self._send_or_edit(
+                            chunk,
+                            finalize=True,
+                            is_turn_final=False,
+                        )
                         if self._fallback_final_send or not ok:
                             # Edit failed (or backed off due to flood control)
                             # while attempting to split an oversized message.

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -13,6 +13,7 @@ import pytest
 
 from gateway.stream_consumer import (
     GatewayStreamConsumer,
+    StreamConsumerConfig,
 )
 
 
@@ -134,6 +135,33 @@ class TestOverflowFirstMessage:
         assert call_kwargs["reply_to"] == "om_user_msg_789", (
             "Overflow first chunk should use initial_reply_to_id"
         )
+
+
+class TestOverflowExistingMessage:
+    """Verify abandoned overflow chunks are finalized without ending the turn."""
+
+    @pytest.mark.asyncio
+    async def test_existing_message_overflow_finalizes_completed_chunk(self):
+        adapter = _make_adapter(max_length=620)
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+        consumer._message_id = "preview_msg"
+        consumer._already_sent = True
+        consumer._send_or_edit = AsyncMock(return_value=True)
+
+        consumer.on_delta("**bold** " + ("A" * 700))
+        consumer.finish()
+        await consumer.run()
+
+        assert consumer._send_or_edit.await_count >= 2
+        first_call = consumer._send_or_edit.await_args_list[0]
+        assert first_call.kwargs == {
+            "finalize": True,
+            "is_turn_final": False,
+        }
 
 
 class TestFeishuFallbackThreadRouting:


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram streaming overflow case where an existing editable preview is split into multiple messages and the completed first chunk is abandoned before receiving final platform formatting.

When `GatewayStreamConsumer` overflows an existing message, it edits the current `_message_id` with the first chunk and then resets `_message_id = None` so the remainder can continue as a new message. For platforms that require an explicit final edit for rich text formatting, especially Telegram with MarkdownV2 finalization, that first chunk can otherwise be left as raw streaming preview text.

This PR finalizes that completed chunk before resetting the message id, but passes `is_turn_final=False` because the assistant turn is still streaming the overflow remainder.

## Related Issue / PR

- Focused follow-up/salvage for the stream-consumer portion of #32609.
- Incorporates the distinction raised in https://github.com/NousResearch/hermes-agent/pull/32609#issuecomment-4620376518.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/stream_consumer.py`
  - Calls `_send_or_edit(chunk, finalize=True, is_turn_final=False)` for completed overflow chunks before `_message_id` is reset.
- `tests/gateway/test_stream_consumer_thread_routing.py`
  - Adds a regression covering overflow after an existing editable preview.
  - Verifies the abandoned first chunk is finalized but does not mark the full turn final.

## How to Test

```bash
python3 -m pytest tests/gateway/test_stream_consumer_thread_routing.py -q -o addopts=
python3 -m pytest tests/gateway/test_telegram_format.py::TestEditMessageStreamingSafety -q -o addopts=
python3 -m ruff check gateway/stream_consumer.py tests/gateway/test_stream_consumer_thread_routing.py
```

Observed locally:

```text
8 passed, 2 warnings in 1.87s
4 passed in 0.20s
All checks passed!
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and linked the related/conflicting PR
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.8

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] Config/example update is N/A
- [x] Cross-platform impact considered; this is platform-neutral stream-consumer logic with Telegram-specific motivation
