### PR TITLE
fix: harden quick commands, plugin loading, and installer fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ cd hermes-agent
 ./hermes              # auto-detects the venv, no need to `source` first
 ```
 
+By default, `setup-hermes.sh` aborts if `uv.lock` is missing or `uv sync --locked` fails. Set `HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL=1` only as an explicit break-glass override if you temporarily need an unverified PyPI fallback.
+
 Manual path (equivalent to the above):
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,8 +169,10 @@ hermes claw migrate --overwrite  # 覆盖已有冲突
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 ./setup-hermes.sh     # 安装 uv、创建 venv、安装 .[all]、创建符号链接 ~/.local/bin/hermes
-./hermes              # 自动检测 venv，无需先 source
+./hermes              # 自动检测 venv，无需先 `source`
 ```
+
+默认情况下，`setup-hermes.sh` 会在 `uv.lock` 缺失或 `uv sync --locked` 失败时直接中止。仅在你需要临时使用未校验的 PyPI 回退路径时，才显式设置 `HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL=1`。
 
 手动安装（等效于上述命令）：
 

--- a/cli.py
+++ b/cli.py
@@ -9108,11 +9108,22 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
-                            # shell=True is intentional: quick_commands are user-defined
-                            # shell snippets from config.yaml — not agent/LLM controlled.
+                            # Default: split the command via shlex and run
+                            # without a shell so config-supplied commands can't
+                            # chain extra operators. Users who explicitly want
+                            # a shell can still opt in with shell: true.
+                            from gateway.config import _quick_command_shell_enabled
+                            import shlex
+                            use_shell = _quick_command_shell_enabled(qcmd.get("shell"))
+                            if use_shell:
+                                run_args = exec_cmd
+                                run_kwargs = {"shell": True}
+                            else:
+                                run_args = shlex.split(exec_cmd)
+                                run_kwargs = {"shell": False}
                             result = subprocess.run(
-                                exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30
+                                run_args, capture_output=True,
+                                text=True, timeout=30, **run_kwargs
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -36,6 +36,15 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return is_truthy_value(value, default=default)
 
 
+def _quick_command_shell_enabled(value: Any) -> bool:
+    """Return True only for explicit quick-command shell opt-in values."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
+
+
 def _coerce_float(value: Any, default: float) -> float:
     """Coerce numeric config values, falling back on malformed input."""
     if value is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1119,6 +1119,7 @@ from gateway.config import (
     GatewayConfig,
     HomeChannel,
     PlatformConfig,
+    _quick_command_shell_enabled,
     load_gateway_config,
 )
 from gateway.session import (
@@ -8245,8 +8246,19 @@ class GatewayRunner:
                             # has all API keys in os.environ.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
-                            proc = await asyncio.create_subprocess_shell(
-                                exec_cmd,
+                            # Default: run without a shell so config-supplied
+                            # commands can't chain extra operators. Users who
+                            # explicitly want a shell can still opt in with
+                            # shell: true.
+                            use_shell = _quick_command_shell_enabled(qcmd.get("shell"))
+                            if use_shell:
+                                exec_args = exec_cmd
+                                exec_fn = asyncio.create_subprocess_shell
+                            else:
+                                exec_args = shlex.split(exec_cmd)
+                                exec_fn = asyncio.create_subprocess_exec
+                            proc = await exec_fn(
+                                *exec_args,
                                 stdout=asyncio.subprocess.PIPE,
                                 stderr=asyncio.subprocess.PIPE,
                                 env=sanitized_env,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -179,6 +179,20 @@ def _env_enabled(name: str) -> bool:
     return env_var_enabled(name)
 
 
+def _path_within_resolved_root(candidate: Path, resolved_root: Path) -> bool:
+    """Return True when *candidate* stays inside *resolved_root*.
+
+    Both paths must already be resolved (or at least absolute) before calling
+    this helper. The loader uses it to reject symlink escapes without changing
+    the existing plugin layout or discovery semantics.
+    """
+    try:
+        candidate.relative_to(resolved_root)
+        return True
+    except ValueError:
+        return False
+
+
 def _get_disabled_plugins() -> set:
     """Read the disabled plugins list from config.yaml.
 
@@ -1220,8 +1234,14 @@ class PluginManager:
         top level (kept for back-compat; the current call sites no longer
         pass it now that categories are first-class).
         """
+        try:
+            root = path.resolve()
+        except (OSError, RuntimeError) as exc:
+            logger.warning("Skipping plugin root %s: %s", path, exc)
+            return []
+
         return self._scan_directory_level(
-            path, source, skip_names=skip_names, prefix="", depth=0
+            path, source, skip_names=skip_names, prefix="", depth=0, root=root
         )
 
     def _scan_directory_level(
@@ -1232,6 +1252,7 @@ class PluginManager:
         skip_names: Optional[Set[str]],
         prefix: str,
         depth: int,
+        root: Path,
     ) -> List[PluginManifest]:
         """Recursive implementation of :meth:`_scan_directory`.
 
@@ -1246,6 +1267,19 @@ class PluginManager:
         for child in sorted(path.iterdir()):
             if not child.is_dir():
                 continue
+            try:
+                child_real = child.resolve()
+            except (OSError, RuntimeError) as exc:
+                logger.warning("Skipping plugin directory %s: %s", child, exc)
+                continue
+            if not _path_within_resolved_root(child_real, root):
+                logger.warning(
+                    "Skipping plugin directory %s (resolved path %s escapes root %s)",
+                    child,
+                    child_real,
+                    root,
+                )
+                continue
             if depth == 0 and skip_names and child.name in skip_names:
                 continue
             manifest_file = child / "plugin.yaml"
@@ -1253,6 +1287,34 @@ class PluginManager:
                 manifest_file = child / "plugin.yml"
 
             if manifest_file.exists():
+                try:
+                    manifest_real = manifest_file.resolve()
+                except (OSError, RuntimeError) as exc:
+                    logger.warning("Skipping manifest %s: %s", manifest_file, exc)
+                    continue
+                if not _path_within_resolved_root(manifest_real, child_real):
+                    logger.warning(
+                        "Skipping manifest %s (resolved path %s escapes plugin dir %s)",
+                        manifest_file,
+                        manifest_real,
+                        child_real,
+                    )
+                    continue
+                init_file = child / "__init__.py"
+                if init_file.exists():
+                    try:
+                        init_real = init_file.resolve()
+                    except (OSError, RuntimeError) as exc:
+                        logger.warning("Skipping plugin directory %s: %s", child, exc)
+                        continue
+                    if not _path_within_resolved_root(init_real, child_real):
+                        logger.warning(
+                            "Skipping plugin directory %s (resolved init %s escapes plugin dir %s)",
+                            child,
+                            init_real,
+                            child_real,
+                        )
+                        continue
                 manifest = self._parse_manifest(
                     manifest_file, child, source, prefix
                 )
@@ -1275,6 +1337,7 @@ class PluginManager:
                     skip_names=None,
                     prefix=sub_prefix,
                     depth=depth + 1,
+                    root=root,
                 )
             )
 
@@ -1486,6 +1549,15 @@ class PluginManager:
         init_file = plugin_dir / "__init__.py"
         if not init_file.exists():
             raise FileNotFoundError(f"No __init__.py in {plugin_dir}")
+        try:
+            plugin_root = plugin_dir.resolve()
+            init_real = init_file.resolve()
+        except (OSError, RuntimeError) as exc:
+            raise ImportError(f"Cannot resolve plugin path {plugin_dir}: {exc}") from exc
+        if not _path_within_resolved_root(init_real, plugin_root):
+            raise ImportError(
+                f"Plugin init file {init_file} resolves outside plugin directory {plugin_dir}"
+            )
 
         # Ensure the namespace parent package exists
         if _NS_PARENT not in sys.modules:

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -204,8 +204,11 @@ if is_termux; then
     fi
     echo -e "${GREEN}✓${NC} Dependencies installed"
 else
-    # Prefer uv sync with lockfile (hash-verified installs) when available,
-    # fall back to pip install for compatibility or when lockfile is stale.
+    # Prefer uv sync with lockfile (hash-verified installs) when available.
+    # Default posture is fail-closed: if the lockfile is missing or the
+    # locked sync fails, abort instead of silently dropping to an
+    # unverified PyPI resolve. Set HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL=1
+    # only as an explicit break-glass override.
     #
     # Multi-tier pip fallback. Goal: ONE compromised PyPI package
     # (mistralai 2.4.6 in May 2026 → quarantined) shouldn't silently demote
@@ -227,6 +230,23 @@ else
         [ "$_skip" = false ] && _SAFE_EXTRAS+=("$_e")
     done
     _SAFE_SPEC=".[$(IFS=,; echo "${_SAFE_EXTRAS[*]}")]"
+    _allow_unverified_fallback() {
+        case "${HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL:-}" in
+            1|true|TRUE|yes|YES|on|ON)
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+    _refuse_unverified_install() {
+        local _reason="$1"
+        echo -e "${RED}✗${NC} ${_reason}"
+        echo -e "${RED}✗${NC} Refusing to continue with an unverified PyPI install."
+        echo -e "${RED}✗${NC} Fix uv.lock and rerun, or set HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL=1 to break glass temporarily."
+        exit 1
+    }
     _try_install() {
         $UV_CMD pip install -e ".[all]" \
             || $UV_CMD pip install -e "$_SAFE_SPEC" \
@@ -254,15 +274,23 @@ else
         if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra all --locked; then
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
         else
-            echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."
-            echo -e "${YELLOW}⚠${NC} Falling back to PyPI resolve — transitives will NOT be hash-verified."
-            _try_install
-            echo -e "${GREEN}✓${NC} Dependencies installed (transitives re-resolved, not hash-verified)"
+            if _allow_unverified_fallback; then
+                echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."
+                echo -e "${YELLOW}⚠${NC} Break-glass override enabled — falling back to PyPI resolve without hash verification."
+                _try_install
+                echo -e "${GREEN}✓${NC} Dependencies installed (transitives re-resolved, not hash-verified)"
+            else
+                _refuse_unverified_install "Lockfile sync failed (see uv output above)."
+            fi
         fi
     else
-        echo -e "${YELLOW}⚠${NC} uv.lock not found — installing without hash verification of transitives."
-        _try_install
-        echo -e "${GREEN}✓${NC} Dependencies installed (transitives re-resolved, not hash-verified)"
+        if _allow_unverified_fallback; then
+            echo -e "${YELLOW}⚠${NC} uv.lock not found — break-glass override enabled, installing without hash verification of transitives."
+            _try_install
+            echo -e "${GREEN}✓${NC} Dependencies installed (transitives re-resolved, not hash-verified)"
+        else
+            _refuse_unverified_install "uv.lock not found."
+        fi
     fi
 fi
 

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -1,7 +1,7 @@
 """Tests for user-defined quick commands that bypass the agent loop."""
 import os
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from rich.text import Text
 import pytest
 
@@ -38,6 +38,61 @@ class TestCLIQuickCommands:
         cli.console.print.assert_called_once()
         printed = self._printed_plain(cli.console.print.call_args[0][0])
         assert printed == "daily-note"
+
+    def test_exec_command_defaults_to_argv_mode_without_shell(self):
+        cli = self._make_cli({"dn": {"type": "exec", "command": "echo daily-note"}})
+
+        completed = subprocess.CompletedProcess(
+            args=["echo", "daily-note"], returncode=0, stdout="daily-note\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            result = cli.process_command("/dn")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["echo", "daily-note"],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_exec_command_string_false_does_not_enable_shell(self):
+        cli = self._make_cli({"dn": {"type": "exec", "shell": "false", "command": "echo daily-note"}})
+
+        completed = subprocess.CompletedProcess(
+            args=["echo", "daily-note"], returncode=0, stdout="daily-note\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            result = cli.process_command("/dn")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["echo", "daily-note"],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_exec_command_explicit_shell_true_still_works(self):
+        cli = self._make_cli({"dn": {"type": "exec", "shell": True, "command": "echo daily-note"}})
+
+        completed = subprocess.CompletedProcess(
+            args="echo daily-note", returncode=0, stdout="daily-note\n", stderr=""
+        )
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            result = cli.process_command("/dn")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            "echo daily-note",
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
 
     def test_exec_command_uses_chat_console_when_tui_is_live(self):
         cli = self._make_cli({"dn": {"type": "exec", "command": "echo daily-note"}})
@@ -159,6 +214,72 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_defaults_to_argv_mode_without_shell(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"limits": {"type": "exec", "command": "echo ok"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        proc = AsyncMock()
+        proc.communicate.return_value = (b"ok\n", b"")
+        event = self._make_event("limits")
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec:
+            result = await runner._handle_message(event)
+
+        assert result == "ok"
+        mock_exec.assert_awaited_once()
+        call_args = mock_exec.await_args
+        assert call_args.args[:2] == ("echo", "ok")
+        assert call_args.kwargs["stdout"] is not None
+        assert call_args.kwargs["stderr"] is not None
+        assert call_args.kwargs["env"] is not None
+
+    @pytest.mark.asyncio
+    async def test_exec_command_string_false_does_not_enable_shell(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"limits": {"type": "exec", "shell": "false", "command": "echo ok"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        proc = AsyncMock()
+        proc.communicate.return_value = (b"ok\n", b"")
+        event = self._make_event("limits")
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec:
+            result = await runner._handle_message(event)
+
+        assert result == "ok"
+        mock_exec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_exec_command_explicit_shell_true_still_works(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"limits": {"type": "exec", "shell": True, "command": "echo ok"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        proc = AsyncMock()
+        proc.communicate.return_value = (b"ok\n", b"")
+        event = self._make_event("limits")
+
+        with patch("asyncio.create_subprocess_shell", new=AsyncMock(return_value=proc)) as mock_shell:
+            result = await runner._handle_message(event)
+
+        assert result == "ok"
+        mock_shell.assert_awaited_once()
+
 
     @pytest.mark.asyncio
     async def test_exec_command_does_not_leak_credentials(self):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,6 +1,7 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
 
 import logging
+import os
 import sys
 import types
 from pathlib import Path
@@ -245,6 +246,58 @@ class TestPluginLoading:
         mgr.discover_and_load()
 
         assert "hermes_plugins.ns_plugin" in sys.modules
+
+    def test_symlinked_plugin_dir_outside_root_is_skipped(self, tmp_path, monkeypatch):
+        """Symlinked plugin directories must not escape the configured root."""
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        plugins_dir.mkdir(parents=True)
+
+        outside_plugin = tmp_path / "outside_plugin"
+        outside_plugin.mkdir()
+        (outside_plugin / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "symlink_dir_escape", "version": "0.1.0"})
+        )
+        (outside_plugin / "__init__.py").write_text(
+            "def register(ctx):\n    raise AssertionError('should not load')\n"
+        )
+        os.symlink(str(outside_plugin), str(plugins_dir / "symlink_dir_escape"))
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["symlink_dir_escape"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "symlink_dir_escape" not in mgr._plugins
+        assert "hermes_plugins.symlink_dir_escape" not in sys.modules
+
+    def test_symlinked_init_outside_plugin_dir_is_skipped(self, tmp_path, monkeypatch):
+        """The loader must reject ``__init__.py`` symlink escapes too."""
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "symlink_init_escape"
+        plugin_dir.mkdir(parents=True)
+
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "symlink_init_escape", "version": "0.1.0"})
+        )
+        outside_init = tmp_path / "outside_init.py"
+        outside_init.write_text(
+            "def register(ctx):\n    raise AssertionError('should not load')\n"
+        )
+        os.symlink(str(outside_init), str(plugin_dir / "__init__.py"))
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["symlink_init_escape"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "symlink_init_escape" not in mgr._plugins
+        assert "hermes_plugins.symlink_init_escape" not in sys.modules
 
     def test_user_memory_plugin_auto_coerced_to_exclusive(self, tmp_path, monkeypatch):
         """User-installed memory plugins must NOT be loaded by the general

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -18,3 +18,12 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
+
+
+def test_setup_hermes_script_fails_closed_on_unverified_fallback_by_default():
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL" in content
+    assert "Default posture is fail-closed" in content
+    assert "Refusing to continue with an unverified PyPI install." in content
+    assert "break glass temporarily" in content

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1440,6 +1440,7 @@ quick_commands:
     command: df -h /
   update:
     type: exec
+    shell: true
     command: cd ~/.hermes/hermes-agent && git pull && pip install -e .
   gpu:
     type: exec
@@ -1449,7 +1450,7 @@ quick_commands:
     target: /gateway restart
 ```
 
-Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or any messaging platform. `exec` commands run locally on the host and return the output directly — no LLM call, no tokens consumed. `alias` commands rewrite to the configured slash command target.
+Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or any messaging platform. `exec` commands run locally on the host and return the output directly — no LLM call, no tokens consumed. `alias` commands rewrite to the configured slash command target. `exec` entries run as argv by default; add `shell: true` only when you need shell syntax such as `&&`, pipes, redirects, or `cd` chains.
 
 - **30-second timeout** — long-running commands are killed with an error message
 - **Priority** — quick commands are checked before skill commands, so you can override skill names


### PR DESCRIPTION
## Summary
- default quick_commands exec path now uses argv/exec mode; shell execution requires explicit `shell: true` opt-in
- plugin discovery/loading now rejects resolved-path escapes outside the plugin root
- setup-hermes now fails closed on missing/broken `uv.lock` unless `HERMES_SETUP_ALLOW_UNVERIFIED_INSTALL=1` is set

## Test Plan
- `uv run pytest -q tests/cli/test_quick_commands.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_setup_hermes_script.py`