### PR TITLE
fix(desktop): support JIS keyboard zoom shortcut

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2930,23 +2930,27 @@ function installPreviewShortcut(window) {
 
 function installZoomShortcuts(window) {
   // Override Ctrl/Cmd + +/-/0 with half the default zoom step (0.1 vs 0.2).
-  // The menu items handle this on macOS (where the menu is always present),
-  // but on Linux/Windows the menu is null and Chromium's default handler
-  // would use the full 0.2 step, so we intercept here for consistency.
+  // On Japanese/JIS keyboards, typing "+" normally includes Shift, and Electron
+  // may surface the physical key as "+", "=", ";", or ":" depending on layout.
+  // Do not reject Shift globally; only require it to be absent for reset/zoom-out.
   const ZOOM_STEP = 0.1
   window.webContents.on('before-input-event', (event, input) => {
     const mod = IS_MAC ? input.meta : input.control
-    if (!mod || input.alt || input.shift) return
+    if (!mod || input.alt) return
 
-    const key = input.key
-    if (key === '0') {
+    const key = String(input.key || '')
+    const isZoomReset = key === '0' && !input.shift
+    const isZoomIn = key === '=' || key === '+' || key === 'Add' || (input.shift && (key === ';' || key === ':'))
+    const isZoomOut = key === '-' && !input.shift
+
+    if (isZoomReset) {
       event.preventDefault()
       window.webContents.setZoomLevel(0)
-    } else if (key === '=' || key === '+') {
+    } else if (isZoomIn) {
       event.preventDefault()
       const next = Math.min(window.webContents.getZoomLevel() + ZOOM_STEP, 9)
       window.webContents.setZoomLevel(next)
-    } else if (key === '-') {
+    } else if (isZoomOut) {
       event.preventDefault()
       const next = Math.max(window.webContents.getZoomLevel() - ZOOM_STEP, -9)
       window.webContents.setZoomLevel(next)


### PR DESCRIPTION
## Summary

Adds JIS/Japanese keyboard-friendly zoom-in handling to the desktop zoom shortcut fallback.

The existing desktop zoom shortcut handler (from #37894) rejects all shifted inputs. On JIS keyboards, typing `+` commonly requires Shift, and Electron can surface that physical key path as `;` or `:` depending on the layout/input state. This means Windows users on Japanese keyboards can still miss the zoom-in shortcut even though `Ctrl+-` and `Ctrl+0` work.

This PR keeps the existing zoom behavior and only broadens zoom-in recognition:

- keep requiring Ctrl/Cmd
- keep ignoring Alt-modified shortcuts
- keep `Ctrl+=`, `Ctrl++`, and numpad `Add` as zoom-in
- add shifted `;` / `:` as zoom-in for JIS/Japanese keyboards
- keep zoom-out as unshifted `-`
- keep reset as unshifted `0`

## Related

Follow-up to #37894 and related to #37917 / #37619. I also checked for existing Japanese/JIS-specific issues or PRs and did not find a duplicate.

## Validation

- `node --check apps/desktop/electron/main.cjs`
- Built the Windows desktop package locally with `python -m hermes_cli.main desktop --build-only`
- Confirmed `apps/desktop/release/win-unpacked/Hermes.exe` exists and launches on Windows
