### PR TITLE
fix(cli): erase live chrome on exit so it isn't stranded above the session summary

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14874,6 +14874,17 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
+            # Erase the live bottom chrome (status bar, input box, separator
+            # rules) on exit instead of freezing a final copy into scrollback.
+            # Without this, prompt_toolkit's render_as_done teardown repaints
+            # the chrome one last time and leaves it stranded above the exit
+            # summary — so a dead status bar + empty prompt sit between the
+            # conversation transcript and the "Resume this session" block, and
+            # stack with the next session's UI on resume (#38252). The actual
+            # conversation transcript is printed through patch_stdout into
+            # normal scrollback and is unaffected; only the managed chrome is
+            # erased. Applies to every exit path (/exit, /quit, EOF, Ctrl+C).
+            erase_when_done=True,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         _disable_prompt_toolkit_cpr_warning(app)


### PR DESCRIPTION
## Summary
On exit, the classic CLI no longer strands its live chrome (status bar, input box, separator rules) above the session summary. Fixes #38252.

Root cause: prompt_toolkit's `render_as_done` teardown repaints the bottom chrome one final time and leaves it on screen (`ESC[J` only erases *below* the cursor, not the chrome above). So a dead status bar + empty `❯` prompt + rules were left between the conversation transcript and the "Resume this session" block, and stacked with the next session's UI on resume. Reproduces on Linux and Windows.

## Changes
- `cli.py`: set `erase_when_done=True` on the classic REPL's prompt_toolkit `Application`. Teardown now routes through `renderer.erase()` (wipes exactly the managed chrome region) instead of repainting it. The conversation transcript prints through `patch_stdout` into normal scrollback and is untouched. Applies to every exit path (`/exit`, `/quit`, EOF, Ctrl+C).

## Validation
Rendered the real exit byte stream through a `pyte` terminal emulator (final on-screen grid, not frame history) before/after:

| Exit path | Before | After |
|---|---|---|
| `/exit` | dead status bar + `❯` + rules stranded above summary | chrome gone; transcript + summary clean |
| EOF (Ctrl+D) | same stranded chrome | chrome gone; clean |

- Transcript preserved after fix (conversation reply, welcome banner, and resume summary all still present in scrollback).
- `tests/cli/` — 888/888 pass.

## Infographic

![clean-exit-handoff](https://v3b.fal.media/files/b/0a9cedf2/C9Y41zt3Ovu-ocpud_nT-_wDeJPCQw.png)
