### PR TITLE
fix(dashboard): enable embedded chat by default so the GUI connects

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12022,7 +12022,19 @@ def cmd_dashboard(args):
 
     from hermes_cli.web_server import start_server
 
-    embedded_chat = args.tui or os.environ.get("HERMES_DASHBOARD_TUI") == "1"
+    # Embedded chat (the /api/ws JSON-RPC transport the desktop GUI connects
+    # to, plus the in-browser /chat PTY tab) is ON BY DEFAULT — plain
+    # `hermes dashboard` must produce a dashboard the GUI can actually talk to.
+    # Explicit opt-out for hardened public binds: `--no-tui` or
+    # HERMES_DASHBOARD_TUI=0/false/off.  `--tui` / HERMES_DASHBOARD_TUI=1 remain
+    # as explicit-on (and win over a stale =0 env) for backward compatibility.
+    _tui_env = os.environ.get("HERMES_DASHBOARD_TUI", "").strip().lower()
+    if args.tui or _tui_env in ("1", "true", "yes", "on"):
+        embedded_chat = True
+    elif getattr(args, "no_tui", False) or _tui_env in ("0", "false", "no", "off"):
+        embedded_chat = False
+    else:
+        embedded_chat = True
     start_server(
         host=args.host,
         port=args.port,
@@ -15318,8 +15330,18 @@ Examples:
         "--tui",
         action="store_true",
         help=(
-            "Expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket). "
-            "Alternatively set HERMES_DASHBOARD_TUI=1."
+            "Force the in-browser Chat tab on (embedded `hermes --tui` via "
+            "PTY/WebSocket). On by default; this flag is only needed to override "
+            "HERMES_DASHBOARD_TUI=0. Alternatively set HERMES_DASHBOARD_TUI=1."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--no-tui",
+        action="store_true",
+        help=(
+            "Disable the in-browser Chat tab and its WebSocket transport. Use "
+            "for hardened public binds where the shell-capable embedded agent "
+            "should not be reachable. Alternatively set HERMES_DASHBOARD_TUI=0."
         ),
     )
     dashboard_parser.add_argument(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8678,7 +8678,7 @@ def start_server(
     open_browser: bool = True,
     allow_public: bool = False,
     *,
-    embedded_chat: bool = False,
+    embedded_chat: bool = True,
 ):
     """Start the web UI server."""
     import uvicorn


### PR DESCRIPTION
## Summary
Plain `hermes dashboard` now produces a dashboard the GUI can actually connect to — embedded chat is on by default instead of requiring `--tui`.

Root cause: `cmd_dashboard` minted `embedded_chat = args.tui or HERMES_DASHBOARD_TUI==1`, so with no flag the chat WebSocket (`/api/ws`, `/api/pty`) closed every upgrade with 4403/4404 before the auth ticket was ever consumed. The desktop GUI needs that socket, so it could never connect unless the operator knew to pass `--tui`. PR #38743 improved the *refusal messaging* (split close codes, log reasons) but never flipped the default — so the connection blocker survived.

## Changes
- `hermes_cli/main.py`: embedded chat is ON by default. `--no-tui` (or `HERMES_DASHBOARD_TUI=0/false/off`) is the explicit opt-out for hardened public binds. `--tui` / `=1` remain as explicit-on and win over a stale `=0` env.
- `hermes_cli/web_server.py`: `start_server(embedded_chat=...)` default flipped `False → True` so programmatic callers (desktop app) match the CLI default.
- Added `--no-tui` arg; `--tui` help updated to note default-on.

## Security note
The embedded `/chat` PTY tab spawns a shell-capable agent. With this change it's reachable by default on any bind that passes the auth gate (ticket/internal credential + host/origin + dashboard basic-auth). Operators who bind `0.0.0.0` for a hardened deployment and don't want the in-browser shell should pass `--no-tui` or set `HERMES_DASHBOARD_TUI=0`.

## Validation
| Scenario | embedded_chat |
|---|---|
| `hermes dashboard` (no flag) | **True** (was False — the bug) |
| `--host 0.0.0.0`, no flag | True |
| `--tui` | True |
| `--no-tui` | False |
| `HERMES_DASHBOARD_TUI=0` / `false` / `off` | False |
| `--tui` + stale `HERMES_DASHBOARD_TUI=0` | True (explicit-on wins) |

10-case argparse E2E all pass. `tests/hermes_cli/test_web_server.py` + `test_web_server_host_header.py`: 238 passed (incl. `test_rejects_when_embedded_chat_disabled`, the explicit-disable path).

## Infographic

![dashboard-chat-on-by-default](https://v3b.fal.media/files/b/0a9cee1c/T4b8NX18nDj9M8SG5eUnq_COByetkx.png)
