### PR TITLE
fix(gateway): run agent turns on a dedicated thread pool to prevent HITL-approval starvation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -580,6 +580,15 @@ agent:
   # 0 = no drain, interrupt immediately.
   # restart_drain_timeout: 60
 
+  # Size of the dedicated thread pool that runs gateway agent turns.
+  # Each session's turn occupies one worker for its whole duration — including
+  # while it is parked waiting for a HITL approval (up to gateway_timeout). This
+  # pool is separate from asyncio's default executor, so parked approvals can't
+  # starve other sessions or compression / MCP discovery. Raise it if you run
+  # many concurrent sessions that frequently sit on approvals. Must be >= 1;
+  # invalid values fall back to the default.
+  # gateway_max_concurrent_turns: 64
+
   # Max app-level retry attempts for API errors (connection drops, provider
   # timeouts, 5xx, etc.) before the agent surfaces the failure. Lower this
   # to 1 if you use fallback providers and want fast failover on flaky

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,6 +39,7 @@ import threading
 import time
 import sqlite3
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
@@ -65,6 +66,16 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+# Agent turns run on a dedicated thread pool (see _run_in_executor_with_context)
+# instead of asyncio's default executor. A turn that is parked waiting for a
+# gateway HITL approval (tools/approval.py _await_gateway_decision) blocks its
+# worker thread for up to the approval timeout (default 300s). On the shared
+# default pool (min(32, cpu+4) threads, also used by compression/MCP discovery)
+# enough concurrent pending approvals starve every other session's new turn.
+# A dedicated, larger pool isolates agent turns and gives parked-approval
+# headroom. Override via agent.gateway_max_concurrent_turns / env
+# HERMES_GATEWAY_MAX_CONCURRENT_TURNS.
+_GATEWAY_AGENT_WORKERS_DEFAULT = 64
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -1876,6 +1887,16 @@ class GatewayRunner:
         self._restart_command_source: Optional[SessionSource] = None
         self._stop_task: Optional[asyncio.Task] = None
         
+        # Dedicated thread pool for agent turns. Kept separate from asyncio's
+        # default executor so a turn parked on a HITL approval (which blocks its
+        # worker thread for up to the approval timeout) cannot starve other
+        # sessions' turns — nor compete with compression / MCP discovery, which
+        # stay on the default pool. See _run_in_executor_with_context.
+        self._agent_executor = ThreadPoolExecutor(
+            max_workers=self._load_agent_executor_workers(),
+            thread_name_prefix="hermes-agent-turn",
+        )
+
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
@@ -3179,6 +3200,41 @@ class GatewayRunner:
             cfg_get(cfg, "display", "show_reasoning"),
             default=False,
         )
+
+    @staticmethod
+    def _load_agent_executor_workers() -> int:
+        """Load the dedicated agent-turn thread pool size from config/env.
+
+        Precedence: env HERMES_GATEWAY_MAX_CONCURRENT_TURNS, then config
+        agent.gateway_max_concurrent_turns, then _GATEWAY_AGENT_WORKERS_DEFAULT.
+        Invalid or non-positive values fall back to the default (with a warning),
+        so a misconfiguration can never produce a 0-worker (deadlocked) pool.
+        """
+        raw = os.getenv("HERMES_GATEWAY_MAX_CONCURRENT_TURNS", "").strip()
+        if not raw:
+            cfg = _load_gateway_runtime_config()
+            raw = str(
+                cfg_get(cfg, "agent", "gateway_max_concurrent_turns", default="") or ""
+            ).strip()
+        if not raw:
+            return _GATEWAY_AGENT_WORKERS_DEFAULT
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid agent.gateway_max_concurrent_turns '%s', using default %d",
+                raw,
+                _GATEWAY_AGENT_WORKERS_DEFAULT,
+            )
+            return _GATEWAY_AGENT_WORKERS_DEFAULT
+        if value < 1:
+            logger.warning(
+                "agent.gateway_max_concurrent_turns must be >= 1 (got %d), using default %d",
+                value,
+                _GATEWAY_AGENT_WORKERS_DEFAULT,
+            )
+            return _GATEWAY_AGENT_WORKERS_DEFAULT
+        return value
 
     @staticmethod
     def _load_busy_input_mode() -> str:
@@ -6703,6 +6759,14 @@ class GatewayRunner:
                     else 0
                 )
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
+
+            # Tear down the dedicated agent thread pool. Don't block teardown on
+            # in-flight turns (they've already been interrupted above); cancel
+            # any still-queued work so shutdown stays bounded.
+            try:
+                self._agent_executor.shutdown(wait=False, cancel_futures=True)
+            except Exception as e:
+                logger.debug("Agent executor shutdown error: %s", e)
 
             self._draining = False
             self._update_runtime_status("stopped", self._exit_reason)
@@ -15483,10 +15547,18 @@ class GatewayRunner:
         clear_session_vars(tokens)
 
     async def _run_in_executor_with_context(self, func, *args):
-        """Run blocking work in the thread pool while preserving session contextvars."""
+        """Run an agent turn in the dedicated agent thread pool while preserving
+        session contextvars.
+
+        Uses ``self._agent_executor`` (not asyncio's default executor) so a turn
+        parked on a HITL approval can't starve other sessions or contend with
+        compression / MCP discovery. Falls back to the default pool if the
+        executor isn't set up yet (defensive; both call sites run post-__init__).
+        """
         loop = asyncio.get_running_loop()
         ctx = copy_context()
-        return await loop.run_in_executor(None, ctx.run, func, *args)
+        executor = getattr(self, "_agent_executor", None)
+        return await loop.run_in_executor(executor, ctx.run, func, *args)
 
     def _decide_image_input_mode(self) -> str:
         """Resolve the image-input routing for the currently active model.

--- a/tests/gateway/test_agent_executor.py
+++ b/tests/gateway/test_agent_executor.py
@@ -1,0 +1,109 @@
+"""Tests for the dedicated gateway agent thread pool.
+
+Agent turns run on ``GatewayRunner._agent_executor`` instead of asyncio's
+default executor so that a turn parked on a HITL approval (which blocks its
+worker thread for up to the approval timeout) cannot starve other sessions'
+turns or contend with compression / MCP discovery on the shared default pool.
+"""
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+
+DEFAULT = gateway_run._GATEWAY_AGENT_WORKERS_DEFAULT
+
+
+def test_load_agent_executor_workers_prefers_env_then_config_then_default(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("HERMES_GATEWAY_MAX_CONCURRENT_TURNS", raising=False)
+
+    # Nothing configured -> default.
+    assert gateway_run.GatewayRunner._load_agent_executor_workers() == DEFAULT
+
+    # config.yaml wins over the default.
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  gateway_max_concurrent_turns: 8\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_agent_executor_workers() == 8
+
+    # env wins over config.yaml.
+    monkeypatch.setenv("HERMES_GATEWAY_MAX_CONCURRENT_TURNS", "16")
+    assert gateway_run.GatewayRunner._load_agent_executor_workers() == 16
+
+
+@pytest.mark.parametrize("bad", ["not-a-number", "0", "-4"])
+def test_load_agent_executor_workers_falls_back_on_invalid(tmp_path, monkeypatch, bad):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_GATEWAY_MAX_CONCURRENT_TURNS", bad)
+    # Invalid / non-positive must never yield a 0-worker (deadlocked) pool.
+    assert gateway_run.GatewayRunner._load_agent_executor_workers() == DEFAULT
+
+
+@pytest.mark.asyncio
+async def test_run_in_executor_with_context_uses_dedicated_pool():
+    """An agent turn must run on the dedicated 'hermes-agent-turn' pool, not
+    the default executor."""
+    executor = ThreadPoolExecutor(
+        max_workers=2, thread_name_prefix="hermes-agent-turn"
+    )
+    try:
+        fake_self = SimpleNamespace(_agent_executor=executor)
+
+        def _turn() -> str:
+            return threading.current_thread().name
+
+        # Call the unbound coroutine with a minimal fake self — the method only
+        # touches self._agent_executor.
+        thread_name = await gateway_run.GatewayRunner._run_in_executor_with_context(
+            fake_self, _turn
+        )
+        assert thread_name.startswith("hermes-agent-turn")
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+
+@pytest.mark.asyncio
+async def test_dedicated_pool_isolates_parked_turn_from_other_sessions():
+    """A turn blocked (parked on approval) holds one worker but does not block a
+    turn for another session on the same dedicated pool."""
+    executor = ThreadPoolExecutor(
+        max_workers=2, thread_name_prefix="hermes-agent-turn"
+    )
+    try:
+        fake_self = SimpleNamespace(_agent_executor=executor)
+        release = threading.Event()
+
+        def _parked_turn() -> str:
+            # Simulates _await_gateway_decision blocking on the approval event.
+            release.wait(timeout=5)
+            return "parked-done"
+
+        def _other_turn() -> str:
+            return "other-done"
+
+        parked = asyncio.ensure_future(
+            gateway_run.GatewayRunner._run_in_executor_with_context(
+                fake_self, _parked_turn
+            )
+        )
+        # The other session's turn must complete while the first is still parked.
+        other = await asyncio.wait_for(
+            gateway_run.GatewayRunner._run_in_executor_with_context(
+                fake_self, _other_turn
+            ),
+            timeout=5,
+        )
+        assert other == "other-done"
+        assert not parked.done()  # still parked, unaffected
+
+        release.set()
+        assert await asyncio.wait_for(parked, timeout=5) == "parked-done"
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)


### PR DESCRIPTION
## What does this PR do?

Gateway agent turns are submitted to asyncio's **default** `ThreadPoolExecutor` (`min(32, cpu+4)` workers, shared with trajectory compression and MCP discovery). When a turn hits a gateway HITL approval, `tools/approval.py::_await_gateway_decision` **blocks its worker thread** (polling the per-session approval `Event`) for up to the approval timeout (`agent.gateway_timeout`, default **300s**).

The approval queue itself is per-session and holds no global lock, so the *logic* is isolated — but the parked turn still **pins a scarce worker** in the shared pool. If enough sessions are simultaneously parked on approvals (plus other blocking executor work), the pool saturates and **other sessions' new turns can't acquire a worker and stall** until one frees. It doesn't hard-deadlock (`/approve` and `/deny` resolve on the event loop and the timeout eventually fires), but it degrades whole-gateway concurrency.

**Fix:** run agent turns on a **dedicated** `ThreadPoolExecutor` owned by `GatewayRunner`, separate from the default pool. This isolates turns from compression/MCP work and gives parked-approval headroom. Size is configurable; invalid/non-positive values fall back to the default so a misconfiguration can never produce a 0-worker (deadlocked) pool. The pool is torn down in the gateway stop path.

This raises the practical ceiling and decouples agent turns from other executor work. It does **not** make waiting fully thread-free (each parked turn still holds one worker) — a structural suspend-and-resume of HITL waits would remove the last bound and is noted as follow-up.

## Related Issue

No existing tracking issue. Found while reviewing gateway session isolation under pending approvals. Happy to file an issue if preferred.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`:
  - New dedicated `self._agent_executor` (`ThreadPoolExecutor`, `thread_name_prefix="hermes-agent-turn"`) created in `GatewayRunner.__init__`.
  - `_run_in_executor_with_context` (the sole wrapper for agent turns — both call sites run `run_conversation`) now dispatches to `self._agent_executor` instead of the default executor.
  - `_load_agent_executor_workers()` config helper (env `HERMES_GATEWAY_MAX_CONCURRENT_TURNS` → `agent.gateway_max_concurrent_turns` → default `64`; invalid/`<1` → default, with a warning).
  - Pool shutdown (`shutdown(wait=False, cancel_futures=True)`) added to the gateway stop/teardown path.
- `cli-config.yaml.example`: document `agent.gateway_max_concurrent_turns`.
- `tests/gateway/test_agent_executor.py`: new tests.

## How to Test

1. Unit tests:
   ```
   scripts/run_tests.sh tests/gateway/test_agent_executor.py
   ```
   Covers: config precedence (env > config.yaml > default), invalid/non-positive fallback, that agent turns run on the `hermes-agent-turn` pool, and that a turn parked (blocked) on one session does **not** block another session's turn on the dedicated pool.
2. Manual: with two gateway sessions, trigger a dangerous command in session A (so it parks on approval, holding a worker), then message session B — B's turn proceeds normally. Without this change, enough concurrent parked approvals to exhaust the default pool would delay B.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the gateway test subset locally (`tests/gateway/test_agent_executor.py` + `test_restart_drain.py` + `test_background_process_notifications.py`, 54 passed) and `ruff check`; full `pytest tests/ -q` left to CI (local env lacks some optional webhook/api test deps)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin, Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings added; — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (internal threading detail; config documented in `cli-config.yaml.example`)
- [x] I've considered cross-platform impact (Windows, macOS) — `ThreadPoolExecutor` is stdlib/cross-platform; no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)