### PR TITLE
mem0: add MEM0_CAPTURE recall-only mode (skip per-turn auto-capture)

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -127,6 +127,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
+        self._capture = "auto"
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
@@ -164,6 +165,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
+            {"key": "capture", "description": "Per-turn auto-capture mode (auto=capture every turn; off=recall-only, no per-turn writes)", "default": "auto", "choices": ["auto", "off"], "env_var": "MEM0_CAPTURE"},
         ]
 
     def _get_client(self):
@@ -209,6 +211,15 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
         self._agent_id = self._config.get("agent_id", "hermes")
         self._rerank = self._config.get("rerank", True)
+        # Capture mode: "auto" (default) syncs every completed turn to Mem0 for
+        # server-side extraction. "off"/"manual" keeps recall (prefetch + search)
+        # and explicit mem0_conclude writes, but skips per-turn auto-capture —
+        # used for latency-sensitive / high-traffic agents (e.g. voice agents)
+        # where we want shared recall without paying a write on every turn.
+        self._capture = str(
+            os.environ.get("MEM0_CAPTURE")
+            or self._config.get("capture", "auto")
+        ).strip().lower()
 
     def _read_filters(self) -> Dict[str, Any]:
         """Filters for search/get_all — scoped to user only for cross-session recall."""
@@ -272,6 +283,10 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
+        # Recall-only mode: skip per-turn auto-capture. Explicit mem0_conclude
+        # writes and prefetch/search recall still work.
+        if self._capture not in ("auto", "on", "true", "1"):
+            return
         if self._is_breaker_open():
             return
 


### PR DESCRIPTION
## Summary

Adds a per-turn capture-mode gate (`MEM0_CAPTURE`) to the Mem0 memory provider so an agent can use Mem0 for **recall** without paying a Mem0 write on **every** turn.

- **Default `auto`** — unchanged behaviour: `sync_turn` fires every completed turn (server-side extraction).
- **`MEM0_CAPTURE=off`** (or `capture: off` in `mem0.json`) — recall (prefetch + `mem0_search`) and explicit `mem0_conclude` writes still work, but per-turn auto-capture is skipped.

## Motivation

The harness calls `sync_all` unconditionally on every completed turn, so today the only way to get shared cross-agent recall is to also auto-capture every turn. For **latency-sensitive / high-traffic agents** (e.g. always-on voice agents) that's an unwanted cloud round-trip + write on every spoken turn. This gives those agents read-mostly access to a shared Mem0 pool (`user_id` shared, per-agent `agent_id`) while keeping writes deliberate.

## Changes

Single file, additive, backward-compatible (`plugins/memory/mem0/__init__.py`):
- Read `MEM0_CAPTURE` (env) / `capture` (config) in `initialize()`, default `"auto"`.
- Early-return in `sync_turn()` when capture is not enabled.
- Expose `capture` in the config schema for discoverability.

## Testing

Unit-tested the gate matrix (provider instantiated, fake client, threaded sync joined):

| `MEM0_CAPTURE` | per-turn write |
|---|---|
| `auto` / `on` / `true` / `1` | ✅ writes |
| `off` / `manual` | ⛔ skipped |

Default (`initialize` not setting it) resolves to `auto`. Recall path (`prefetch`/`search`) and `mem0_conclude` are untouched.
