### PR TITLE
fix(model): use catalog fallback for proxied Anthropic contexts

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -254,6 +254,18 @@ DEFAULT_CONTEXT_LENGTHS = {
     "zai-org/GLM-5": 202752,
 }
 
+
+def _lookup_default_context_length(model: str) -> Optional[int]:
+    """Return the hardcoded catalog match for a model, if any."""
+    model_lower = model.lower()
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if default_model in model_lower:
+            return length
+    return None
+
+
 # xAI Grok models that ACCEPT the `reasoning.effort` parameter on
 # api.x.ai. Verified live against /v1/responses 2026-05-10:
 #
@@ -1657,6 +1669,18 @@ def get_model_context_length(
                     if provider != "lmstudio":
                         save_context_length(model, base_url, local_ctx)
                     return local_ctx
+            catalog_ctx = (
+                _lookup_default_context_length(model)
+                if provider == "anthropic"
+                else None
+            )
+            if catalog_ctx is not None:
+                logger.info(
+                    "Could not detect context length for model %r at %s; "
+                    "using hardcoded catalog default %s tokens.",
+                    model, base_url, f"{catalog_ctx:,}",
+                )
+                return catalog_ctx
             logger.info(
                 "Could not detect context length for model %r at %s — "
                 "defaulting to %s tokens (probe-down). Set model.context_length "
@@ -1773,12 +1797,9 @@ def get_model_context_length(
     # Only check `default_model in model` (is the key a substring of the input).
     # The reverse (`model in default_model`) causes shorter names like
     # "claude-sonnet-4" to incorrectly match "claude-sonnet-4-6" and return 1M.
-    model_lower = model.lower()
-    for default_model, length in sorted(
-        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
-    ):
-        if default_model in model_lower:
-            return length
+    catalog_ctx = _lookup_default_context_length(model)
+    if catalog_ctx is not None:
+        return catalog_ctx
 
     # 9. Query local server as last resort
     if base_url and is_local_endpoint(base_url):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -785,6 +785,30 @@ class TestGetModelContextLength:
 
         assert result == CONTEXT_PROBE_TIERS[0]
 
+    @patch("agent.model_metadata._query_anthropic_context_length", return_value=None)
+    @patch("agent.model_metadata._query_ollama_api_show", return_value=None)
+    @patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    def test_custom_anthropic_endpoint_falls_through_to_catalog_default(
+        self,
+        mock_cache,
+        mock_fetch,
+        mock_endpoint_ctx,
+        mock_ollama,
+        mock_anthropic,
+    ):
+        """A proxied Anthropic base URL should not stop before catalog defaults."""
+        with patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            result = get_model_context_length(
+                "claude-opus-4-8",
+                provider="anthropic",
+                base_url="https://gateway.example.com/v1/claude",
+                api_key="sk-ant-test",
+            )
+
+        assert result == 1_000_000
+
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     def test_custom_endpoint_single_model_fallback(self, mock_endpoint_fetch, mock_fetch):


### PR DESCRIPTION
## Summary
- factor the hardcoded context catalog lookup into a shared helper
- let `provider="anthropic"` custom gateway URLs use that catalog before falling back to 256K when endpoint probes fail
- add regression coverage for proxied Claude models that should resolve to 1M from `DEFAULT_CONTEXT_LENGTHS`

## Root cause
The custom-endpoint branch in `get_model_context_length()` returned `DEFAULT_FALLBACK_CONTEXT` immediately after failed endpoint/Ollama/local probes. For Anthropic models behind custom gateway base URLs, that short-circuited before the resolver could reach known Claude catalog entries such as `claude-opus-4-8: 1_000_000`.

Fixes #38865.

## Validation
- `.venv\\Scripts\\python.exe -m pytest -o addopts='' tests/agent/test_model_metadata.py -q --timeout-method=thread` -> `98 passed`
- `.venv\\Scripts\\python.exe -m ruff check agent/model_metadata.py tests/agent/test_model_metadata.py` -> `All checks passed!`
- `.venv\\Scripts\\python.exe -m py_compile agent/model_metadata.py tests/agent/test_model_metadata.py` -> passed
- `git diff --check` -> passed