### PR TITLE
fix(tools): stop hermes tools reporting kanban as removed

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -181,6 +181,30 @@ def _get_plugin_toolset_keys() -> set:
     except Exception:
         return set()
 
+
+def _checklist_toolset_keys(platform: str) -> Set[str]:
+    """Return the toolset keys the ``hermes tools`` checklist actually offers
+    for ``platform``.
+
+    This mirrors exactly what ``_prompt_toolset_checklist`` renders:
+    ``_get_effective_configurable_toolsets()`` (built-in + plugin toolsets),
+    filtered by ``_toolset_allowed_for_platform``. The checklist's returned
+    selection can therefore only ever be a subset of this universe.
+
+    Non-configurable toolsets that ``_get_platform_tools`` resolves at read
+    time — ``kanban`` and other check_fn-gated toolsets, recovered platform
+    composites, MCP server names — are NOT in this set because the checklist
+    never shows them. Use this to scope the added/removed diff the UI prints,
+    so ``hermes tools`` never claims to add or remove a toolset the user was
+    never given a checkbox for. The underlying config is unaffected — those
+    entries are preserved by ``_save_platform_tools`` regardless.
+    """
+    return {
+        ts_key
+        for ts_key, _, _ in _get_effective_configurable_toolsets()
+        if _toolset_allowed_for_platform(ts_key, platform)
+    }
+
 # Platform display config — derived from the canonical registry so every
 # module shares the same data.  Kept as dict-of-dicts for backward
 # compatibility with existing ``PLATFORMS[key]["label"]`` access patterns.
@@ -3317,8 +3341,15 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             # Show checklist
             new_enabled = _prompt_toolset_checklist(pinfo["label"], checklist_preselected, pkey)
 
-            added = new_enabled - current_enabled
-            removed = current_enabled - new_enabled
+            # Only diff against toolsets the checklist actually offered. The
+            # resolved ``current_enabled`` can include non-configurable toolsets
+            # (e.g. ``kanban``, recovered platform composites) the user was
+            # never shown a checkbox for; without this scope the summary would
+            # print spurious ``- kanban`` removals even though the config keeps
+            # them. See _checklist_toolset_keys.
+            _diff_universe = _checklist_toolset_keys(pkey)
+            added = (new_enabled - current_enabled) & _diff_universe
+            removed = (current_enabled - new_enabled) & _diff_universe
             if added:
                 for ts in sorted(added):
                     label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
@@ -3427,8 +3458,12 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             if new_enabled != all_current:
                 for pk in platform_keys:
                     prev = _get_platform_tools(config, pk, include_default_mcp_servers=False)
-                    added = new_enabled - prev
-                    removed = prev - new_enabled
+                    # Scope the printed diff to the checklist's universe (see
+                    # _checklist_toolset_keys) so non-configurable toolsets like
+                    # ``kanban`` aren't reported as added/removed.
+                    _diff_universe = _checklist_toolset_keys(pk)
+                    added = (new_enabled - prev) & _diff_universe
+                    removed = (prev - new_enabled) & _diff_universe
                     pinfo_inner = PLATFORMS[pk]
                     if added or removed:
                         print(color(f"  {pinfo_inner['label']}:", Colors.DIM))
@@ -3474,8 +3509,12 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         )
 
         if new_enabled != current_enabled:
-            added = new_enabled - current_enabled
-            removed = current_enabled - new_enabled
+            # Scope the printed diff to the checklist's universe (see
+            # _checklist_toolset_keys) so non-configurable toolsets like
+            # ``kanban`` aren't reported as added/removed.
+            _diff_universe = _checklist_toolset_keys(pkey)
+            added = (new_enabled - current_enabled) & _diff_universe
+            removed = (current_enabled - new_enabled) & _diff_universe
 
             if added:
                 for ts in sorted(added):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -9,6 +9,7 @@ from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _apply_toolset_change,
+    _checklist_toolset_keys,
     _configure_provider,
     _reconfigure_provider,
     _get_platform_tools,
@@ -1487,4 +1488,59 @@ def test_apply_provider_selection_does_not_prompt_or_post_setup(monkeypatch):
     config = {}
     tools_config.apply_provider_selection("tts", "Microsoft Edge TTS", config)
     assert config["tts"]["provider"] == "edge"
+
+
+# ── Checklist diff scope: non-configurable toolsets (kanban) must not be
+#    reported as added/removed by `hermes tools` ──────────────────────────
+
+
+def test_checklist_toolset_keys_excludes_kanban():
+    """``kanban`` is check_fn-gated and never appears in the checklist, so it
+    must not be in the checklist's offered universe for any platform."""
+    for plat in ("cli", "telegram", "discord"):
+        keys = _checklist_toolset_keys(plat)
+        assert "kanban" not in keys
+        # Configurable toolsets that ARE offered must be present.
+        assert "web" in keys
+
+
+def test_kanban_not_reported_as_removed_in_diff():
+    """Reproduces the false-signal bug: `hermes tools` printed ``- kanban``
+    when saving a platform that resolves kanban as enabled, even though the
+    checklist never offered kanban as a toggle.
+
+    The printed diff must be scoped to ``_checklist_toolset_keys`` so a tool
+    the user could not deselect is never reported as removed. The persisted
+    config still keeps kanban (verified separately by _save_platform_tools).
+    """
+    config = {"platform_toolsets": {"telegram": ["kanban", "web", "terminal"]}}
+    current = _get_platform_tools(config, "telegram", include_default_mcp_servers=False)
+    assert "kanban" in current  # resolved as enabled at read time
+
+    # The checklist can only return configurable keys it was shown; kanban
+    # is never one of them.
+    universe = _checklist_toolset_keys("telegram")
+    new_enabled = {t for t in current if t != "kanban"}
+
+    # Unscoped (old, buggy) diff would surface kanban.
+    assert (current - new_enabled) == {"kanban"}
+    # Scoped (fixed) diff drops it.
+    assert ((current - new_enabled) & universe) == set()
+
+
+def test_real_configurable_changes_still_reported_in_diff():
+    """Scoping the diff to the checklist universe must NOT swallow genuine
+    add/remove of configurable toolsets."""
+    config = {"platform_toolsets": {"cli": ["kanban", "web", "terminal", "skills"]}}
+    current = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    universe = _checklist_toolset_keys("cli")
+
+    # User unticks 'terminal' (configurable) — must still report as removed.
+    new_enabled = {t for t in current if t not in ("kanban", "terminal")}
+    assert ((current - new_enabled) & universe) == {"terminal"}
+
+    # User adds 'vision' (configurable) — must still report as added.
+    new_enabled2 = (current - {"kanban"}) | {"vision"}
+    assert ((new_enabled2 - current) & universe) == {"vision"}
+
 


### PR DESCRIPTION
## Summary
`hermes tools` no longer reports `kanban` as added/removed when saving a platform — it was a false signal, never a real config change.

Root cause: `kanban` is a `check_fn`-gated toolset whose tools are a subset of the platform composite, so `_get_platform_tools()` resolves it as enabled. But `_prompt_toolset_checklist()` only renders `CONFIGURABLE_TOOLSETS`, so `kanban` is never a checkbox and can't survive into the returned selection. The diff `current_enabled - new_enabled` then surfaced `kanban`, printing `- kanban` in red — for a tool the user was never given the ability to toggle.

The persisted config was always correct (`_save_platform_tools` keeps non-configurable entries via `preserved_entries`); this was purely a misleading summary.

## Changes
- `hermes_cli/tools_config.py`: new `_checklist_toolset_keys(platform)` helper returning exactly what the checklist offers (configurable + plugin toolsets, filtered by `_toolset_allowed_for_platform`). Scope the printed added/removed diff to that universe at all three sites (first-install, all-platforms, per-platform).
- `tests/hermes_cli/test_tools_config.py`: 3 regression tests — kanban excluded from the checklist universe, kanban not reported removed, and genuine configurable add/remove still reported.

## Validation
| | Before | After |
|---|---|---|
| Save platform with kanban resolved-enabled | prints `- kanban` (red) | no spurious diff line |
| Untick a real configurable toolset | reported removed | reported removed |
| Tick a real configurable toolset | reported added | reported added |
| Persisted `platform_toolsets` | kanban preserved | kanban preserved |

`tests/hermes_cli/test_tools_config.py`: 98/98 passing (95 existing + 3 new).

Reported by @austinbv.

## Infographic

![hermes-tools-phantom-kanban-removal-fix](https://v3b.fal.media/files/b/0a9cee6a/t2OwFrkrcbew9jEKrFn4r_GAD6zTwC.png)
