### PR TITLE
fix(cron): prevent one-shot jobs from re-firing after gateway death (#38758)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -929,13 +929,27 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
                 
-                # Increment completed count
+                # Increment completed count.  One-shot jobs with a finite
+                # repeat limit are pre-claimed by claim_dispatch() before the
+                # side effect runs, so do not double-count them here.  Direct
+                # mark_job_run() callers (no pre-run claim) still get the
+                # legacy increment because completed will still be zero.
                 if job.get("repeat"):
-                    job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
-                    
+                    repeat = job["repeat"]
+                    times = repeat.get("times")
+                    completed = repeat.get("completed", 0)
+                    kind = job.get("schedule", {}).get("kind")
+                    preclaimed_oneshot = (
+                        kind == "once"
+                        and times is not None
+                        and times > 0
+                        and completed > 0
+                    )
+                    if not preclaimed_oneshot:
+                        completed += 1
+                        repeat["completed"] = completed
+
                     # Check if we've hit the repeat limit
-                    times = job["repeat"].get("times")
-                    completed = job["repeat"]["completed"]
                     if times is not None and times > 0 and completed >= times:
                         # Remove the job (limit reached)
                         jobs.pop(i)
@@ -978,6 +992,64 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 return
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+
+
+def claim_dispatch(job_id: str) -> bool:
+    """Atomically claim a one-shot job dispatch BEFORE execution.
+
+    Increments ``repeat.completed`` under lock and persists the claim
+    immediately so that if the gateway process dies mid-execution the
+    dispatch is not lost.  Returns ``True`` if the claim succeeded
+    (completed < times), ``False`` if the job has already been
+    dispatched the maximum number of times.
+
+    This converts one-shot jobs from *at-least-once* to *at-most-times*
+    semantics — a job that self-destructs (gateway kill, OOM, segfault)
+    will fire at most ``repeat.times`` times instead of infinitely.
+
+    Only acts on jobs that have ``repeat.times > 0`` and
+    ``schedule.kind == "once"``.  Recurring jobs and infinite-repeat
+    jobs are left unchanged.
+    """
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] == job_id:
+                if job.get("schedule", {}).get("kind") != "once":
+                    return True  # recurring jobs use advance_next_run(), not dispatch claims
+                repeat = job.get("repeat")
+                if not repeat:
+                    return True  # no repeat limit — always dispatch
+                times = repeat.get("times")
+                if times is None or times <= 0:
+                    return True  # infinite — always dispatch
+                completed = repeat.get("completed", 0)
+                if completed >= times:
+                    # Already dispatched the max number of times.
+                    # Clean up: remove the job so it doesn't keep
+                    # appearing as due on every tick.
+                    jobs.pop(i)
+                    save_jobs(jobs)
+                    logger.info(
+                        "Job '%s': dispatch limit reached (%d/%d) — removing",
+                        job.get("name", job["id"]),
+                        completed,
+                        times,
+                    )
+                    return False
+                # Claim this dispatch
+                repeat["completed"] = completed + 1
+                save_jobs(jobs)
+                logger.debug(
+                    "Job '%s': claimed dispatch %d/%d",
+                    job.get("name", job["id"]),
+                    repeat["completed"],
+                    times,
+                )
+                return True
+
+        logger.warning("claim_dispatch: job_id %s not found", job_id)
+        return False
 
 
 def advance_next_run(job_id: str) -> bool:
@@ -1102,6 +1174,33 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
                     continue  # Skip this run
+
+            # ── One-shot dispatch limit guard (issue #38758) ──────────
+            # A one-shot that was dispatched (via claim_dispatch) but
+            # whose gateway died before mark_job_run could clean it up
+            # will have repeat.completed >= repeat.times.  Skip it and
+            # remove it so it doesn't keep appearing as due on every
+            # tick.
+            if kind == "once":
+                repeat = job.get("repeat")
+                if repeat:
+                    times = repeat.get("times")
+                    if times is not None and times > 0:
+                        completed = repeat.get("completed", 0)
+                        if completed >= times:
+                            logger.info(
+                                "Job '%s': one-shot dispatch limit reached "
+                                "(%d/%d) — removing stale due entry",
+                                job.get("name", job["id"]),
+                                completed,
+                                times,
+                            )
+                            for rj in raw_jobs:
+                                if rj["id"] == job["id"]:
+                                    raw_jobs.pop(raw_jobs.index(rj))
+                                    needs_save = True
+                                    break
+                            continue
 
             due.append(job)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -147,7 +147,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1970,8 +1970,28 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             )
 
         def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end: execute, save, deliver, mark."""
+            """Run one due job end-to-end: claim, execute, save, deliver, mark."""
             try:
+                # ── Pre-run dispatch claim (issue #38758) ──────────────
+                # Atomically claim finite one-shot executions BEFORE running
+                # the job. If the gateway dies mid-execution (kill, OOM,
+                # segfault), the claim persists so the job won't re-fire
+                # infinitely. Recurring jobs use advance_next_run() instead.
+                repeat = job.get("repeat") or {}
+                times = repeat.get("times")
+                schedule = job.get("schedule") if isinstance(job.get("schedule"), dict) else {}
+                should_claim_dispatch = (
+                    schedule.get("kind") == "once"
+                    and times is not None
+                    and times > 0
+                )
+                if should_claim_dispatch and not claim_dispatch(job["id"]):
+                    logger.info(
+                        "Job '%s': dispatch already claimed — skipping",
+                        job.get("name", job["id"]),
+                    )
+                    return True  # not an error — already handled
+
                 success, output, final_response, error = run_job(job)
 
                 output_file = save_job_output(job["id"], output)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -19,6 +19,7 @@ from cron.jobs import (
     remove_job,
     mark_job_run,
     advance_next_run,
+    claim_dispatch,
     get_due_jobs,
     save_job_output,
 )
@@ -669,6 +670,115 @@ class TestAdvanceNextRun:
         assert len(due_after) == 0, "Job should not be due after advance_next_run"
 
 
+class TestClaimDispatch:
+    """Tests for claim_dispatch — pre-run dispatch claim for one-shot jobs."""
+
+    def test_increments_completed(self, tmp_cron_dir):
+        """claim_dispatch atomically increments repeat.completed for a one-shot."""
+        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        assert job["repeat"]["completed"] == 0
+
+        result = claim_dispatch(job["id"])
+        assert result is True
+
+        updated = get_job(job["id"])
+        assert updated["repeat"]["completed"] == 1
+
+    def test_rejects_when_at_limit(self, tmp_cron_dir):
+        """claim_dispatch returns False when repeat.completed >= repeat.times."""
+        job = create_job(prompt="Once", schedule="30m", repeat=2)
+        # First dispatch
+        assert claim_dispatch(job["id"]) is True
+        # Second dispatch
+        assert claim_dispatch(job["id"]) is True
+        # Third dispatch — should be rejected and job removed
+        assert claim_dispatch(job["id"]) is False
+        # Job should be cleaned up
+        assert get_job(job["id"]) is None
+
+    def test_no_repeat_always_dispatches(self, tmp_cron_dir):
+        """Jobs without repeat limits always return True."""
+        job = create_job(prompt="Forever", schedule="every 1h")
+        # No repeat limit set
+        for _ in range(5):
+            assert claim_dispatch(job["id"]) is True
+        # Job still exists
+        assert get_job(job["id"]) is not None
+
+    def test_infinite_repeat_always_dispatches(self, tmp_cron_dir):
+        """Jobs with repeat=-1 or repeat=0 always return True."""
+        job = create_job(prompt="Forever", schedule="every 1h", repeat=-1)
+        assert claim_dispatch(job["id"]) is True
+        assert claim_dispatch(job["id"]) is True
+        assert get_job(job["id"]) is not None
+
+        job2 = create_job(prompt="Forever2", schedule="every 1h", repeat=0)
+        assert claim_dispatch(job2["id"]) is True
+        assert get_job(job2["id"]) is not None
+
+    def test_recurring_repeat_limit_not_mutated(self, tmp_cron_dir):
+        """Finite recurring jobs use advance_next_run, not one-shot dispatch claims."""
+        job = create_job(prompt="Every hour", schedule="every 1h", repeat=2)
+
+        assert claim_dispatch(job["id"]) is True
+        assert claim_dispatch(job["id"]) is True
+
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["repeat"]["completed"] == 0
+
+    def test_mark_job_run_does_not_double_count_preclaimed_oneshot(self, tmp_cron_dir):
+        """A successful pre-claimed one-shot records status without a second increment."""
+        job = create_job(prompt="Once", schedule="30m", repeat=2)
+
+        assert claim_dispatch(job["id"]) is True
+        assert get_job(job["id"])["repeat"]["completed"] == 1
+
+        mark_job_run(job["id"], success=True)
+
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["repeat"]["completed"] == 1
+        assert updated["last_status"] == "ok"
+
+    def test_claim_persists_without_mark_job_run(self, tmp_cron_dir):
+        """The claim survives even if mark_job_run never runs (simulates gateway death).
+
+        This is the core fix for #38758: if the gateway dies mid-execution,
+        the pre-run claim ensures the job won't re-fire infinitely.
+        """
+        job = create_job(prompt="Suicide", schedule="30m", repeat=1)
+        assert job["repeat"]["completed"] == 0
+
+        # Claim the dispatch (simulates pre-run claim)
+        assert claim_dispatch(job["id"]) is True
+
+        # Simulate gateway death — never call mark_job_run.
+        # On restart, the job is still present with completed=1
+        updated = get_job(job["id"])
+        assert updated is not None, "Job should still exist after claim"
+        assert updated["repeat"]["completed"] == 1
+
+        # Next claim attempt should reject (already dispatched)
+        assert claim_dispatch(job["id"]) is False
+        # Job should be cleaned up by the rejection path
+        assert get_job(job["id"]) is None
+
+    def test_unknown_job_id_returns_false(self, tmp_cron_dir):
+        """claim_dispatch for a non-existent job returns False."""
+        assert claim_dispatch("nonexistent-job-id") is False
+
+    def test_does_not_mark_status(self, tmp_cron_dir):
+        """claim_dispatch only touches repeat.completed; it does NOT set
+        last_run_at or last_status — those are mark_job_run's job."""
+        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        claim_dispatch(job["id"])
+        updated = get_job(job["id"])
+        assert updated["last_run_at"] is None
+        assert updated["last_status"] is None
+        assert updated["repeat"]["completed"] == 1
+
+
 class TestGetDueJobs:
     def test_past_due_within_window_returned(self, tmp_cron_dir):
         """Jobs within the dynamic grace window are still considered due (not stale).
@@ -847,6 +957,46 @@ class TestGetDueJobs:
         if recovered_dt.tzinfo is None:
             recovered_dt = recovered_dt.replace(tzinfo=timezone.utc)
         assert recovered_dt > now
+
+    def test_oneshot_at_dispatch_limit_not_due(self, tmp_cron_dir, monkeypatch):
+        """A one-shot with repeat.completed >= repeat.times is not returned as due.
+
+        This is the post-restart guard for #38758: if the gateway died
+        after claim_dispatch but before mark_job_run could remove the
+        job, get_due_jobs must skip (and clean up) the stale job.
+        """
+        now = datetime(2026, 3, 18, 4, 22, 5, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        run_at = "2026-03-18T04:22:00+00:00"
+        save_jobs(
+            [{
+                "id": "oneshot-dispatched",
+                "name": "Already dispatched",
+                "prompt": "Word of the day",
+                "schedule": {"kind": "once", "run_at": run_at, "display": "once at 2026-03-18 04:22"},
+                "schedule_display": "once at 2026-03-18 04:22",
+                "repeat": {"times": 1, "completed": 1},  # already dispatched!
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T04:21:00+00:00",
+                "next_run_at": run_at,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        # Job is past-due but already at dispatch limit
+        due = get_due_jobs()
+        assert due == [], "One-shot at dispatch limit should not be due"
+
+        # Job should be cleaned up
+        assert get_job("oneshot-dispatched") is None, "Stale dispatched job should be removed"
 
 
 class TestEnabledToolsets:


### PR DESCRIPTION
## What changed

Fixes #38758 by making finite one-shot cron jobs crash-safe before their side effects run.

- Adds a pre-run dispatch claim for `schedule.kind == "once"` jobs with a finite `repeat.times` limit.
- Persists `repeat.completed` before executing the job, so a self-restarting / gateway-killing `no_agent` script cannot re-fire forever after supervisor relaunch.
- Adds a due-job guard that removes stale one-shots already at their dispatch limit after a restart.
- Keeps recurring jobs on the existing `advance_next_run()` crash-safety path, avoiding accidental repeat-count mutation for interval/cron jobs.
- Avoids double-counting pre-claimed one-shots when `mark_job_run()` later records successful status.

## Verification

Focused regression tests:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py -v -o "addopts=" --tb=short
# 226 passed, 1 warning in 3.32s
```

Builder proof:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_jobs.py -v -o "addopts=" --tb=short
# 95 passed before review revision; 97 passed after review hardening
```

The new tests cover:

- pre-run one-shot claim increments and persists;
- already-dispatched one-shots are skipped/removed after restart;
- claims do not set status fields;
- finite recurring jobs are not mutated by one-shot dispatch claims;
- successful pre-claimed one-shots are not double-counted by `mark_job_run()`.

## Duplicate / competitor check

No open PRs found for:

- `38758 in:title,body state:open`
- `Tranquil-Flow:fix/38758*`
- `cron one-shot gateway restart loop state:open type:pr`

Auto-published by Moonsong via Path B automated pipeline.
