### PR TITLE
fix(gateway): make streaming transport off absolute

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -209,9 +209,10 @@ def resolve_display_setting(
 def resolve_gateway_streaming_enabled(streaming_config: Any, platform_override: Any) -> bool:
     """Resolve whether gateway token streaming should run.
 
-    ``streaming.transport: off`` is a global hard kill switch.  Per-platform
-    defaults/overrides (for example Telegram's streaming=true default) can opt
-    a platform in or out only when the transport itself is still enabled.
+    ``streaming.enabled: false`` and ``streaming.transport: off`` are global
+    hard kill switches. Per-platform defaults/overrides (for example
+    Telegram's streaming=true default) can opt a platform in or out only after
+    both global gates allow streaming.
     """
     transport = getattr(streaming_config, "transport", "auto")
     if isinstance(transport, str):
@@ -223,8 +224,11 @@ def resolve_gateway_streaming_enabled(streaming_config: Any, platform_override: 
     if transport_off:
         return False
 
+    if not bool(getattr(streaming_config, "enabled", False)):
+        return False
+
     if platform_override is None:
-        return bool(getattr(streaming_config, "enabled", False))
+        return True
     return bool(platform_override)
 
 

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -206,6 +206,28 @@ def resolve_display_setting(
     return fallback
 
 
+def resolve_gateway_streaming_enabled(streaming_config: Any, platform_override: Any) -> bool:
+    """Resolve whether gateway token streaming should run.
+
+    ``streaming.transport: off`` is a global hard kill switch.  Per-platform
+    defaults/overrides (for example Telegram's streaming=true default) can opt
+    a platform in or out only when the transport itself is still enabled.
+    """
+    transport = getattr(streaming_config, "transport", "auto")
+    if isinstance(transport, str):
+        transport_off = transport.strip().lower() in {"off", "false", "0", "no"}
+    else:
+        # YAML 1.1 parses bare ``off`` as boolean False; keep this defensive so
+        # already-loaded configs still obey the documented kill switch.
+        transport_off = transport is False
+    if transport_off:
+        return False
+
+    if platform_override is None:
+        return bool(getattr(streaming_config, "enabled", False))
+    return bool(platform_override)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16601,14 +16601,15 @@ class GatewayRunner:
 
         platform_key = _platform_config_key(source.platform)
         user_config = _load_gateway_config()
-        from gateway.display_config import resolve_display_setting
+        from gateway.display_config import (
+            resolve_display_setting,
+            resolve_gateway_streaming_enabled,
+        )
         _plat_streaming = resolve_display_setting(
             user_config, platform_key, "streaming"
         )
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
+        _streaming_enabled = resolve_gateway_streaming_enabled(
+            _scfg, _plat_streaming,
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
@@ -17553,16 +17554,20 @@ class GatewayRunner:
             # Per-platform streaming gate: display.platforms.<plat>.streaming
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
+            from gateway.display_config import (
+                resolve_display_setting,
+                resolve_gateway_streaming_enabled,
+            )
             _plat_streaming = resolve_display_setting(
                 user_config, platform_key, "streaming"
             )
-            # None = no per-platform override → follow global config
-            _streaming_enabled = (
-                _scfg.enabled and _scfg.transport != "off"
-                if _plat_streaming is None
-                else bool(_plat_streaming)
+            # None = no per-platform override → follow global config.
+            # transport=off is always a hard kill switch.
+            _streaming_enabled = resolve_gateway_streaming_enabled(
+                _scfg, _plat_streaming,
             )
             _want_stream_deltas = _streaming_enabled
+
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages
             if _want_stream_deltas or _want_interim_consumer:

--- a/tests/gateway/test_per_platform_streaming_defaults.py
+++ b/tests/gateway/test_per_platform_streaming_defaults.py
@@ -10,6 +10,8 @@ in the web UI.
 
 from __future__ import annotations
 
+import pytest
+
 
 def test_default_per_platform_streaming_flags():
     from hermes_cli.config import DEFAULT_CONFIG
@@ -22,15 +24,19 @@ def test_resolver_telegram_on_discord_off_when_global_enabled():
     """With global streaming on, the per-platform defaults make Telegram stream
     and Discord not — matching the platforms' actual streaming quality."""
     from hermes_cli.config import DEFAULT_CONFIG
-    from gateway.display_config import resolve_display_setting
+    from gateway.config import StreamingConfig
+    from gateway.display_config import (
+        resolve_display_setting,
+        resolve_gateway_streaming_enabled,
+    )
 
     cfg = dict(DEFAULT_CONFIG)
     cfg["streaming"] = {"enabled": True, "transport": "auto"}
+    scfg = StreamingConfig.from_dict(cfg["streaming"])
 
     def streams(plat):
         ov = resolve_display_setting(cfg, plat, "streaming")
-        # global enabled; None override = follow global (True)
-        return True if ov is None else bool(ov)
+        return resolve_gateway_streaming_enabled(scfg, ov)
 
     assert streams("telegram") is True
     assert streams("discord") is False
@@ -48,6 +54,55 @@ def test_user_override_wins_over_default():
     assert merged["display"]["platforms"]["discord"]["streaming"] is True
     # Partial override must not wipe the sibling telegram default.
     assert merged["display"]["platforms"]["telegram"]["streaming"] is True
+
+
+def _resolved_streaming_enabled(streaming_config, platform_override):
+    from gateway.config import StreamingConfig
+    from gateway.display_config import resolve_gateway_streaming_enabled
+
+    scfg = StreamingConfig.from_dict(streaming_config)
+    return resolve_gateway_streaming_enabled(scfg, platform_override)
+
+
+@pytest.mark.parametrize(
+    ("streaming_config", "platform_override", "expected"),
+    [
+        ({"enabled": False, "transport": "auto"}, True, False),
+        ({"enabled": False, "transport": "auto"}, False, False),
+        ({"enabled": False, "transport": "auto"}, None, False),
+        ({"enabled": True, "transport": "auto"}, True, True),
+        ({"enabled": True, "transport": "auto"}, False, False),
+        ({"enabled": True, "transport": "auto"}, None, True),
+        ({"enabled": True, "transport": "off"}, True, False),
+        ({"enabled": True, "transport": "off"}, None, False),
+        ({"enabled": True, "transport": False}, True, False),
+        ({"enabled": True, "transport": False}, None, False),
+    ],
+)
+def test_gateway_streaming_global_gate_truth_table(
+    streaming_config, platform_override, expected
+):
+    """Global streaming gates must be absolute; platform overrides only narrow."""
+    assert _resolved_streaming_enabled(streaming_config, platform_override) is expected
+
+
+def test_global_disabled_blocks_telegram_platform_default():
+    """Regression for #53697: Telegram's default true must not bypass enabled=false."""
+    from hermes_cli.config import DEFAULT_CONFIG, _deep_merge
+    from gateway.config import StreamingConfig
+    from gateway.display_config import (
+        resolve_display_setting,
+        resolve_gateway_streaming_enabled,
+    )
+
+    cfg = _deep_merge(
+        dict(DEFAULT_CONFIG), {"streaming": {"enabled": False, "transport": "auto"}}
+    )
+    scfg = StreamingConfig.from_dict(cfg["streaming"])
+    telegram_override = resolve_display_setting(cfg, "telegram", "streaming")
+
+    assert telegram_override is True
+    assert resolve_gateway_streaming_enabled(scfg, telegram_override) is False
 
 
 def test_global_transport_off_is_hard_kill_switch_for_platform_defaults():
@@ -76,7 +131,6 @@ def test_global_transport_off_is_hard_kill_switch_for_platform_defaults():
 def test_dashboard_schema_exposes_per_platform_streaming():
     """Because the web settings schema is built from DEFAULT_CONFIG, the
     per-platform streaming toggles surface in the dashboard automatically."""
-    import pytest
     pytest.importorskip("fastapi")  # web_server requires fastapi/uvicorn
     from hermes_cli.web_server import CONFIG_SCHEMA
 

--- a/tests/gateway/test_per_platform_streaming_defaults.py
+++ b/tests/gateway/test_per_platform_streaming_defaults.py
@@ -50,6 +50,29 @@ def test_user_override_wins_over_default():
     assert merged["display"]["platforms"]["telegram"]["streaming"] is True
 
 
+def test_global_transport_off_is_hard_kill_switch_for_platform_defaults():
+    """Global transport=off must disable streaming even when Telegram's
+    per-platform default says streaming=true."""
+    from hermes_cli.config import DEFAULT_CONFIG, _deep_merge
+    from gateway.config import StreamingConfig
+    from gateway.display_config import (
+        resolve_display_setting,
+        resolve_gateway_streaming_enabled,
+    )
+
+    cfg = _deep_merge(dict(DEFAULT_CONFIG), {"streaming": {"transport": "off"}})
+    scfg = StreamingConfig.from_dict(cfg["streaming"])
+    telegram_override = resolve_display_setting(cfg, "telegram", "streaming")
+
+    assert telegram_override is True
+    assert scfg.transport == "off"
+    assert resolve_gateway_streaming_enabled(scfg, telegram_override) is False
+
+    yaml_bool_cfg = _deep_merge(dict(DEFAULT_CONFIG), {"streaming": {"transport": False}})
+    yaml_bool_scfg = StreamingConfig.from_dict(yaml_bool_cfg["streaming"])
+    assert resolve_gateway_streaming_enabled(yaml_bool_scfg, telegram_override) is False
+
+
 def test_dashboard_schema_exposes_per_platform_streaming():
     """Because the web settings schema is built from DEFAULT_CONFIG, the
     per-platform streaming toggles surface in the dashboard automatically."""


### PR DESCRIPTION
## Summary
- make `streaming.transport: off` a hard kill switch before per-platform streaming defaults are applied
- share the gateway streaming enablement logic across both run paths
- add regression coverage for Telegram's `display.platforms.telegram.streaming: true` default and YAML-style boolean `off`

## Root cause
`display.platforms.telegram.streaming` defaults to `true`, so the gateway could take the platform override branch and bypass the global `streaming.transport != "off"` check. That meant `streaming.transport: off` did not reliably disable Telegram streaming.

## Test plan
- `python -m pytest tests/gateway/test_per_platform_streaming_defaults.py tests/gateway/test_display_config.py tests/gateway/test_stream_consumer_draft.py -q -o 'addopts='`

Fixes #6558
