### PR TITLE
fix(desktop): skip sandbox SUID fixup when ELECTRON_DISABLE_SANDBOX is set

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5552,6 +5552,11 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     if sys.platform != "linux":
         return True
 
+    # When sandbox is explicitly disabled we don't need the SUID helper.
+    # Accepted values match sandboxFallbackFromEnv in update-relaunch.ts.
+    if os.environ.get("ELECTRON_DISABLE_SANDBOX", "").strip().lower() in ("1", "true"):
+        return True
+
     sandbox = packaged_executable.parent / "chrome-sandbox"
     if not sandbox.exists():
         print(f"✗ Hermes Desktop is missing Electron's Linux sandbox helper: {sandbox}")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -257,6 +257,51 @@ def test_gui_linux_exits_when_sandbox_fixup_fails_without_safe_fallback(tmp_path
     mock_run.assert_not_called()
 
 
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", " 1 ", " True "])
+def test_gui_linux_skips_sandbox_fixup_when_disabled(tmp_path, monkeypatch, value):
+    """ELECTRON_DISABLE_SANDBOX=1/true skips the SUID helper check."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    monkeypatch.setenv("ELECTRON_DISABLE_SANDBOX", value)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    # Only the launch call — no sudo chown/chmod
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "yes", "on"])
+def test_gui_linux_runs_sandbox_fixup_when_not_disabled(tmp_path, monkeypatch, value):
+    """Values outside (1, true) don't skip the SUID helper check."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    sandbox = packaged_exe.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    sandbox.chmod(0o755)
+    monkeypatch.setenv("ELECTRON_DISABLE_SANDBOX", value)
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    # sudo chown + chmod + launch = 3 calls
+    assert mock_run.call_count == 3
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/sudo", "chown", "root:root", str(sandbox)]
+    assert mock_run.call_args_list[1].args[0] == ["/usr/bin/sudo", "chmod", "4755", str(sandbox)]
+
+
 def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch):
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"


### PR DESCRIPTION
## What does this PR do?

Short-circuits `_desktop_linux_sandbox_fixup()` to return `True` early when the Electron sandbox is explicitly disabled via `ELECTRON_DISABLE_SANDBOX`, skipping the unnecessary `chrome-sandbox` SUID helper check.

Previously, the helper always ran — even when the user had already opted out of sandboxing — and would exit with a fatal error if `sudo chown/chmod` failed.

## Accepted Values

Only `"1"` and `"true"` (case-insensitive, whitespace-trimmed) skip the check — aligned with `sandboxFallbackFromEnv` in `apps/desktop/electron/update-relaunch.ts` to avoid drift between the launcher and relaunch safety check.

Values like `"0"`, `"false"`, `"yes"`, `"on"`, and empty string do **not** skip the check.

## Related Issue

No open issue — discovered during desktop troubleshooting on Linux systems where the env var was set to `0` but the sandbox check was still bypassed (Python truthy string behavior).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — added early return in `_desktop_linux_sandbox_fixup()` when `ELECTRON_DISABLE_SANDBOX` is set to `1` or `true`
- `tests/hermes_cli/test_gui_command.py` — two parametrized tests:
  - `test_gui_linux_skips_sandbox_fixup_when_disabled` — verifies `1`, `true`, `TRUE`, and padded variants skip the SUID helper
  - `test_gui_linux_runs_sandbox_fixup_when_not_disabled` — verifies `0`, `false`, `no`, `off`, `""`, `yes`, `on` do **not** skip the check

## How to Test

1. Set `ELECTRON_DISABLE_SANDBOX=1` and run `hermes desktop` — sandbox check is correctly bypassed
2. Set `ELECTRON_DISABLE_SANDBOX=true` — same as above
3. Set `ELECTRON_DISABLE_SANDBOX=0` — sandbox check still runs (no silent skip)
4. Unset `ELECTRON_DISABLE_SANDBOX` — sandbox check runs normally
5. `pytest tests/hermes_cli/test_gui_command.py` — all 35 tests pass

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched existing PRs — this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04
- [x] N/A — no docs update needed (fixing existing behavior, not adding new)
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — no tool behavior changes