### PR TITLE
fix(slack): include bot's own prior replies in cold-start thread context

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -3096,18 +3096,23 @@ class SlackAdapter(BasePlatformAdapter):
                     self._team_bot_user_ids.get(msg_team) if msg_team else None
                 ) or self._bot_user_id
 
-                # Exclude only our own prior bot replies (circular context).
-                # Keep:
-                #   - the thread parent even if it was posted by a bot
-                #     (e.g. a cron job summary we are now replying to);
-                #   - other bots' child messages (useful third-party context).
-                if (
+                # Identify our own prior bot replies. These are kept on the
+                # cold-start path (the only path that reaches this method —
+                # the call site is guarded by _has_active_session_for_thread)
+                # so the agent can reconstruct its own prior turns. When an
+                # active session exists, this method is not called and the
+                # session history already carries those replies — so there
+                # is no risk of circular duplication.
+                #
+                # Self-bot replies are labelled with an explicit ``[assistant]``
+                # prefix so the agent can distinguish its own prior turns
+                # from user messages and from third-party bot posts.
+                is_self_bot_reply = (
                     is_bot
                     and not is_parent
                     and self_bot_uid
                     and msg_user == self_bot_uid
-                ):
-                    continue
+                )
 
                 msg_text = msg.get("text", "").strip()
                 if not msg_text:
@@ -3117,13 +3122,24 @@ class SlackAdapter(BasePlatformAdapter):
                 if bot_uid:
                     msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
 
-                prefix = "[thread parent] " if is_parent else ""
+                if is_parent:
+                    prefix = "[thread parent] "
+                elif is_self_bot_reply:
+                    prefix = "[assistant] "
+                else:
+                    prefix = ""
                 display_user = msg_user or "unknown"
                 # Prefer the bot's own name when the message is a bot post.
                 if is_bot and not display_user:
                     display_user = msg.get("username") or "bot"
-                name = await self._resolve_user_name(display_user, chat_id=channel_id)
-                context_parts.append(f"{prefix}{name}: {msg_text}")
+                if is_self_bot_reply:
+                    # Skip user-name resolution for self-bot replies — the
+                    # ``[assistant]`` prefix already communicates authorship,
+                    # and the resolved name would just be our own bot handle.
+                    context_parts.append(f"{prefix}{msg_text}")
+                else:
+                    name = await self._resolve_user_name(display_user, chat_id=channel_id)
+                    context_parts.append(f"{prefix}{name}: {msg_text}")
                 if is_parent:
                     parent_text = msg_text
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -273,24 +273,28 @@ class TestSlackThreadContext:
         assert "<@U_BOT>" not in context
 
     @pytest.mark.asyncio
-    async def test_skips_bot_messages(self):
-        """Self-bot child replies are skipped to avoid circular context,
-        but non-self bots (e.g. cron posts, third-party integrations) are kept.
+    async def test_includes_self_bot_replies_as_assistant_on_cold_start(self):
+        """Cold-start contract (issue #38861): self-bot replies in the thread
+        must be included in the context, labelled with an ``[assistant]``
+        prefix so the agent can reconstruct its own prior turns. This method
+        only runs on the cold-start path (guarded at the call site by
+        ``_has_active_session_for_thread``) — when an active session exists,
+        the session history already carries those replies, so there is no
+        risk of circular duplication.
 
-        Regression guard for the fix in _fetch_thread_context: previously ALL
-        bot messages were dropped, which lost context when the bot was replying
-        to a cron-posted thread parent."""
+        Third-party bots (e.g. deploy notifications) must still be kept,
+        attributed to their display name."""
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]
         mock_client.conversations_replies = AsyncMock(return_value={
             "messages": [
                 {"ts": "1000.0", "user": "U1", "text": "Parent"},
-                # Self-bot reply -> must be skipped (circular)
+                # Self-bot reply -> kept on cold-start, prefixed [assistant]
                 {
                     "ts": "1000.1",
                     "bot_id": "B_SELF",
                     "user": "U_BOT",
-                    "text": "Previous bot self-reply (should be skipped)",
+                    "text": "Previous bot self-reply",
                 },
                 # Third-party bot child -> kept (useful context)
                 {
@@ -308,10 +312,13 @@ class TestSlackThreadContext:
             channel_id="C1", thread_ts="1000.0", current_ts="1000.2", team_id="T1"
         )
 
-        assert "Previous bot self-reply" not in context
         assert "Alice: Parent" in context
-        # Third-party bot message must now be included
+        # Self-bot reply must now be included with [assistant] label
+        assert "[assistant] Previous bot self-reply" in context
+        # Third-party bot message must still be included
         assert "Deploy succeeded" in context
+        # The [assistant] label must NOT leak to user messages
+        assert "[assistant] Alice" not in context
 
     @pytest.mark.asyncio
     async def test_empty_thread(self):
@@ -368,9 +375,11 @@ class TestSlackThreadContext:
         assert "メール要約: 本日の新着3件" in context
 
     @pytest.mark.asyncio
-    async def test_fetch_thread_context_excludes_self_bot_replies(self):
-        """Parent (non-self bot) is kept, self-bot child replies are dropped,
-        user replies are kept."""
+    async def test_fetch_thread_context_includes_self_bot_replies_with_assistant_label(self):
+        """Cold-start: parent (non-self bot) kept with [thread parent],
+        self-bot child replies kept with [assistant] label, user replies
+        kept unchanged. The cold-start path is the ONLY caller of this
+        method; circular-context risk does not apply here (see #38861)."""
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]
         mock_client.conversations_replies = AsyncMock(return_value={
@@ -397,7 +406,8 @@ class TestSlackThreadContext:
 
         assert "Cron summary" in context
         assert "[thread parent]" in context
-        assert "Previous self reply" not in context
+        # Self-bot child reply is now kept with the [assistant] label
+        assert "[assistant] Previous self reply" in context
         assert "Follow-up question" in context
         assert "Current" not in context
 
@@ -445,7 +455,12 @@ class TestSlackThreadContext:
 
         assert "Parent T2" in context
         assert "Cross-workspace bot reply" in context
-        assert "Own T2 bot reply" not in context
+        # T2's own self-bot reply is kept with the [assistant] label
+        # (cold-start path includes self-replies; see #38861). The
+        # per-workspace filter still applies: this assertion confirms
+        # we use T2's bot id, not T1's, when deciding what counts as
+        # self-bot.
+        assert "[assistant] Own T2 bot reply" in context
 
     @pytest.mark.asyncio
     async def test_fetch_thread_context_current_ts_excluded(self):


### PR DESCRIPTION
## Why

In `_fetch_thread_context` (`gateway/platforms/slack.py`), the bot's own prior
replies in a thread were unconditionally filtered out before injection. The
guard was sound for the *active-session* path (where the session history
already carries those replies and re-injecting them would be circular), but
`_fetch_thread_context` is **only** called when there is no active session for
the thread — the call site at line 2361 is wrapped in
`if not self._has_active_session_for_thread(...)`. On that cold-start path,
dropping the bot's prior replies leaves the agent with only user messages and
no way to reconstruct what it (or a sibling cron session that posted the
thread parent) already said.

Concrete failure mode: a cron job posts a thread parent → a user replies in
the thread → a different agent session warms up → the agent sees user turns
only, has to guess at the prior conversation, and often re-asks for
information the bot already provided.

Fixes #38861.

## What

`gateway/platforms/slack.py` — `_fetch_thread_context` now keeps self-bot
child replies and labels them with an explicit `[assistant]` prefix instead of
`continue`-ing past them. The per-workspace bot-id resolution
(`self._team_bot_user_ids.get(msg_team) or self._bot_user_id`) is preserved
verbatim, so the existing multi-workspace correctness (only *our* bot in
*this* workspace is treated as self) still holds.

Detection logic moves into a single boolean (`is_self_bot_reply`); the prefix
ladder becomes `[thread parent] | [assistant] | ""`; user-name resolution is
skipped for self-bot turns (the `[assistant]` label already communicates
authorship and the resolved name would just be our own bot handle).

## Behaviour change footprint

| Path | Before | After |
|------|--------|-------|
| Cold-start cache miss, self-bot child reply present | Dropped | Kept, prefixed `[assistant]` |
| Cold-start, third-party bot child reply | Kept (unchanged) | Kept (unchanged) |
| Cold-start, bot-posted parent | Kept, prefixed `[thread parent]` (unchanged) | Kept, prefixed `[thread parent]` (unchanged) |
| Cold-start, user message | Kept (unchanged) | Kept (unchanged) |
| Active session path (`_has_active_session_for_thread` true) | Not called (unchanged) | Not called (unchanged) |
| Per-workspace self-bot detection | Uses `self._team_bot_user_ids` per `msg_team` (unchanged) | Uses `self._team_bot_user_ids` per `msg_team` (unchanged) |

The active-session circular-context concern that originally motivated the
filter does not apply here — that path simply never reaches this method.

## Test coverage

`tests/gateway/test_slack_approval_buttons.py`:

| Test | Covers |
|------|--------|
| `test_includes_self_bot_replies_as_assistant_on_cold_start` (new behaviour) | Self-bot reply kept with `[assistant]` prefix, third-party bot kept, `[assistant]` label does not leak to user lines |
| `test_fetch_thread_context_includes_self_bot_replies_with_assistant_label` (renamed/updated from `_excludes_self_bot_replies`) | Bot-posted parent kept with `[thread parent]`, self-bot child kept with `[assistant]`, user replies kept |
| `test_fetch_thread_context_multi_workspace` (updated) | Per-workspace self-bot detection still uses T2's bot id (not T1's); T2's self-bot reply is included with `[assistant]` rather than dropped; T1's bot id appearing in a T2 message is treated as third-party and kept by its display name |
| `test_fetches_and_formats_context` (unchanged, regression guard) | User messages and bot-mention stripping still work |
| `test_fetch_thread_context_includes_bot_parent` (unchanged, regression guard) | Bot-posted parent still labelled `[thread parent]` |
| `test_fetch_thread_context_current_ts_excluded` (unchanged, regression guard) | The currently-triggering message is still excluded |
| `test_empty_thread`, `test_api_failure_returns_empty` (unchanged) | Boundary cases unchanged |

Verification on this branch:
```
pytest tests/gateway/test_slack_approval_buttons.py
  23 passed in 0.44s
pytest tests/gateway/
  6156 passed, 38 failed, 76 skipped
```

The 38 failures are all pre-existing on `upstream/main` (telegram/whatsapp
adapters, status-command onboarding) — diffed against a pristine
`upstream/main` baseline run, the set of failures is bit-for-bit identical.
No new failures introduced by this change.

## Out of scope

- The active-session path (`_thread_context_cache` reuse during a live
  session) — not touched; that path was already correct.
- `_fetch_thread_parent_text` — same cache, but only ever returns the parent
  text; the self-bot filter never applied there.
- Restructuring the thread-context cache or the per-workspace bot-id store.
- Other platform adapters (discord, slack-via-events-only paths, etc.) —
  out of scope; the issue and its repro are Slack-specific.
- Treating `[assistant]` lines as actual assistant-role messages in the
  agent's message list. Cold-start context is injected as a single user-role
  preamble today; promoting individual lines back into typed turns would be
  a broader gateway refactor and a separate change.
