### PR TITLE
fix(cron): treat confirmation timeout as delivered to prevent duplicate messages #38922

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -786,6 +786,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
+                send_result = None
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
@@ -798,8 +799,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
+                            # The send was already dispatched on the gateway
+                            # event loop; future.cancel() cannot un-send it.
+                            # Treat as delivered to avoid duplicate messages.
                             future.cancel()
-                            raise
+                            logger.warning(
+                                "Job '%s': live adapter send to %s:%s timed "
+                                "out after 60s; message was already "
+                                "dispatched, assuming delivered",
+                                job["id"], platform_name, chat_id,
+                            )
+                            delivered = True
                         if send_result and not getattr(send_result, "success", True):
                             err = getattr(send_result, "error", "unknown")
                             logger.warning(

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2441,10 +2441,11 @@ class TestDeliverResultTimeoutCancelsFuture:
     coroutine so it cannot duplicate-send after the standalone fallback.
     """
 
-    def test_live_adapter_timeout_cancels_future_and_falls_back(self):
+    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
         """End-to-end: live adapter hangs past the 60s budget, _deliver_result
-        patches the timeout down to a fast value, confirms future.cancel() fires,
-        and verifies the standalone fallback path still delivers."""
+        cancels the orphan future, assumes the message was already dispatched,
+        and does NOT fall through to the standalone path (which would cause a
+        duplicate)."""
         from gateway.config import Platform
         from concurrent.futures import Future
 
@@ -2497,11 +2498,12 @@ class TestDeliverResultTimeoutCancelsFuture:
                 loop=loop,
             )
 
-        # 1. The orphan future was cancelled on timeout (the bug fix)
+        # 1. The orphan future was cancelled on timeout
         assert cancel_calls == [True], "future.cancel() must fire on TimeoutError"
-        # 2. The standalone fallback delivered — no double send, no silent drop
+        # 2. Delivery succeeded (no error returned)
         assert result is None, f"expected successful delivery, got error: {result!r}"
-        standalone_send.assert_awaited_once()
+        # 3. Standalone path was NOT called — avoids duplicate messages
+        standalone_send.assert_not_awaited()
 
     def test_live_adapter_thread_fallback_records_delivery_error(self):
         """A cron target with an explicit topic must not be marked clean if


### PR DESCRIPTION
## Summary

When the live-adapter send succeeds on the wire but its confirmation times out after 60s, the send was already dispatched and cannot be undone. Previously, the  propagated to the fallback handler, which re-sent the message via the standalone path, producing a duplicate.

Now, on confirmation ,  logs a warning and treats the message as delivered. The orphan future is still cancelled to free resources, but no standalone fallback is triggered.

## Changes

- ****: On  from , set  and log a warning instead of re-raising. Initialize  before the try block to avoid unbound variable issues.
- ****: Updated  →  to verify standalone path is NOT called on timeout.

## Testing

All 14  tests pass. The updated test confirms:
1.  fires on timeout
2. No error is returned (delivery assumed successful)
3. Standalone path is NOT called (no duplicate)

Fixes #38922