### PR TITLE
fix(mcp): omit mcp-protocol-version header on initialize request (#27569)

### DIFF
--- a/tests/tools/test_mcp_sse_transport.py
+++ b/tests/tools/test_mcp_sse_transport.py
@@ -207,3 +207,55 @@ class TestSSEOAuthForwarding:
             f"sse_client was called with auth= when no OAuth was configured: "
             f"{patch_sse_client!r}"
         )
+
+
+class TestSSEProtocolVersionForwarding:
+    def test_sse_client_receives_default_protocol_header_when_unpinned(self, patch_sse_client):
+        from tools.mcp_tool import MCPServerTask, LATEST_PROTOCOL_VERSION
+
+        server = _build_server_with_sse()
+
+        async def drive():
+            with patch.object(MCPServerTask, "_wait_for_lifecycle_event", new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+                try:
+                    await asyncio.wait_for(
+                        server._run_http({
+                            "url": "https://example.com/mcp/sse",
+                            "transport": "sse",
+                            "timeout": 60,
+                        }),
+                        timeout=2.0,
+                    )
+                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                    pass
+
+        asyncio.run(drive())
+
+        assert patch_sse_client["headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
+    def test_sse_client_preserves_user_pinned_protocol_header(self, patch_sse_client):
+        from tools.mcp_tool import MCPServerTask
+
+        server = _build_server_with_sse()
+
+        async def drive():
+            with patch.object(MCPServerTask, "_wait_for_lifecycle_event", new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
+                try:
+                    await asyncio.wait_for(
+                        server._run_http({
+                            "url": "https://example.com/mcp/sse",
+                            "transport": "sse",
+                            "timeout": 60,
+                            "headers": {"MCP-Protocol-Version": "custom-version"},
+                        }),
+                        timeout=2.0,
+                    )
+                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                    pass
+
+        asyncio.run(drive())
+
+        assert patch_sse_client["headers"]["MCP-Protocol-Version"] == "custom-version"
+        assert "mcp-protocol-version" not in patch_sse_client["headers"]

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1223,6 +1223,196 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_http_protocol_version_hook_behavior(self):
+        """The new-SDK path injects mcp-protocol-version via a request hook,
+        skipping the header on the initialize request and adding it on all
+        subsequent requests. User-pinned versions are never overwritten.
+        """
+        import json as _json
+        from tools.mcp_tool import LATEST_PROTOCOL_VERSION, MCPServerTask
+
+        server = MCPServerTask("remote")
+        captured = {}
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummyTransportCtx:
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return None
+
+        class DummyLegacyTransportCtx:
+            def __init__(self, **kwargs):
+                captured["legacy_headers"] = kwargs.get("headers")
+
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def _discover_tools(self):
+            self._shutdown_event.set()
+
+        async def _run(config, *, new_http):
+            captured.clear()
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", new_http), \
+                 patch("httpx.AsyncClient", DummyAsyncClient), \
+                 patch("tools.mcp_tool.streamable_http_client", return_value=DummyTransportCtx()), \
+                 patch("tools.mcp_tool.streamablehttp_client", side_effect=lambda url, **kwargs: DummyLegacyTransportCtx(**kwargs)), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", _discover_tools):
+                await server._run_http(config)
+
+        # --- new-SDK path: hook is registered, no static header in client_kwargs ---
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=True))
+        hooks = captured.get("event_hooks", {})
+        request_hooks = hooks.get("request", [])
+        # One hook added when user hasn't pinned a version.
+        assert len(request_hooks) == 1, "expected exactly one request hook"
+        hook = request_hooks[0]
+        # Static client-level header must NOT be present.
+        client_headers = captured.get("headers", {})
+        assert "mcp-protocol-version" not in client_headers
+
+        # Hook skips initialize requests.
+        init_body = _json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        tools_body = _json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}).encode()
+
+        class _FakeHeaders(dict):
+            pass
+
+        class _FakeRequest:
+            def __init__(self, body):
+                self.content = body
+                self.headers = _FakeHeaders()
+
+        init_req = _FakeRequest(init_body)
+        asyncio.run(hook(init_req))
+        assert "mcp-protocol-version" not in init_req.headers, \
+            "hook must not add header to initialize request"
+
+        tools_req = _FakeRequest(tools_body)
+        asyncio.run(hook(tools_req))
+        assert tools_req.headers.get("mcp-protocol-version") == LATEST_PROTOCOL_VERSION, \
+            "hook must add header to non-initialize requests"
+
+        # User-pinned version: no hook registered, caller's header preserved as-is.
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"mcp-protocol-version": "custom-version"},
+        }, new_http=True))
+        hooks = captured.get("event_hooks", {})
+        assert hooks.get("request", []) == [], "no hook when user pins version"
+        assert captured["headers"]["mcp-protocol-version"] == "custom-version"
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"MCP-Protocol-Version": "custom-version"},
+        }, new_http=True))
+        hooks = captured.get("event_hooks", {})
+        assert hooks.get("request", []) == [], "no hook when user pins version (alt casing)"
+        assert captured["headers"]["MCP-Protocol-Version"] == "custom-version"
+        assert "mcp-protocol-version" not in captured["headers"]
+
+        # --- legacy path: header seeded statically (no per-request hook available) ---
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=False))
+        assert captured["legacy_headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"MCP-Protocol-Version": "custom-version"},
+        }, new_http=False))
+        assert captured["legacy_headers"]["MCP-Protocol-Version"] == "custom-version"
+        assert "mcp-protocol-version" not in captured["legacy_headers"]
+
+
+# ---------------------------------------------------------------------------
+# _is_initialize_request helper
+# ---------------------------------------------------------------------------
+
+class TestIsInitializeRequest:
+    """Unit tests for the _is_initialize_request helper."""
+
+    def test_falsy_bodies(self):
+        from tools.mcp_tool import _is_initialize_request
+        assert _is_initialize_request(None) is False
+        assert _is_initialize_request(b"") is False
+        assert _is_initialize_request("") is False
+
+    def test_non_json_body(self):
+        from tools.mcp_tool import _is_initialize_request
+        assert _is_initialize_request(b"not json") is False
+        assert _is_initialize_request("not json") is False
+
+    def test_initialize_method_dict(self):
+        import json as _json
+        from tools.mcp_tool import _is_initialize_request
+        body = _json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        assert _is_initialize_request(body) is True
+        assert _is_initialize_request(body.encode()) is True
+
+    def test_non_initialize_method(self):
+        import json as _json
+        from tools.mcp_tool import _is_initialize_request
+        body = _json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        assert _is_initialize_request(body) is False
+        assert _is_initialize_request(body.encode()) is False
+
+    def test_batch_with_initialize(self):
+        import json as _json
+        from tools.mcp_tool import _is_initialize_request
+        batch = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        ]
+        assert _is_initialize_request(_json.dumps(batch)) is True
+
+    def test_batch_without_initialize(self):
+        import json as _json
+        from tools.mcp_tool import _is_initialize_request
+        batch = [
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "resources/list", "params": {}},
+        ]
+        assert _is_initialize_request(_json.dumps(batch)) is False
+
+    def test_invalid_utf8_bytes(self):
+        from tools.mcp_tool import _is_initialize_request
+        assert _is_initialize_request(b"\xff\xfe") is False
+
+    def test_non_dict_non_list_json(self):
+        from tools.mcp_tool import _is_initialize_request
+        assert _is_initialize_request(b'"initialize"') is False
+        assert _is_initialize_request(b"42") is False
+
+
 # ---------------------------------------------------------------------------
 # Reconnection logic
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2831,6 +2831,9 @@ class MCPServerTask:
                     "mcp.client.sse.sse_client is not available. "
                     "Upgrade the mcp package to get SSE support."
                 )
+            _sse_headers = dict(headers)
+            if not _user_set_protocol_version:
+                _sse_headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
             # sse_read_timeout governs how long sse_client will wait between
             # events on the SSE stream. Using the tool_timeout (default 60s)
             # here is wrong: SSE servers commonly hold the stream idle for
@@ -2841,7 +2844,7 @@ class MCPServerTask:
             # Supermemory on Cloudflare Workers idle-disconnect at ~60s).
             _sse_kwargs: dict = {
                 "url": url,
-                "headers": headers or None,
+                "headers": _sse_headers or None,
                 "timeout": float(connect_timeout),
                 "sse_read_timeout": 300.0,
             }

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1818,6 +1818,33 @@ class ElicitationHandler:
 # Server task -- each MCP server lives in one long-lived asyncio Task
 # ---------------------------------------------------------------------------
 
+def _is_initialize_request(body) -> bool:
+    """Return True when *body* is a JSON-RPC request whose method is 'initialize'.
+
+    Handles bytes, str, and batch (list) payloads. Returns False for anything
+    that cannot be decoded or parsed as JSON-RPC.
+    """
+    if not body:
+        return False
+    if isinstance(body, (bytes, bytearray)):
+        try:
+            body = body.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return False
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        return False
+    if isinstance(payload, dict):
+        return payload.get("method") == "initialize"
+    if isinstance(payload, list):
+        return any(
+            isinstance(item, dict) and item.get("method") == "initialize"
+            for item in payload
+        )
+    return False
+
+
 class MCPServerTask:
     """Manages a single MCP server connection in a dedicated asyncio Task.
 
@@ -2760,12 +2787,11 @@ class MCPServerTask:
 
         url = config["url"]
         headers = dict(config.get("headers") or {})
-        # Some MCP servers require MCP-Protocol-Version on the initial
-        # initialize request and reject session-less POSTs otherwise.
-        # Seed it as a client-level default, but treat user overrides as
-        # case-insensitive so conventional casing is preserved.
-        if not any(key.lower() == "mcp-protocol-version" for key in headers):
-            headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
+        # Track whether the caller pinned a protocol version so hook and legacy
+        # path can both respect it without adding a duplicate.
+        _user_set_protocol_version = any(
+            key.lower() == "mcp-protocol-version" for key in headers
+        )
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
@@ -2905,11 +2931,26 @@ class MCPServerTask:
                         response.next_request.headers.pop("authorization", None)
                         response.next_request.headers.pop("Authorization", None)
 
+            async def _add_protocol_version_after_initialize(request):
+                # Skip the initialize request: the MCP spec requires the header
+                # only on requests AFTER initialization, not on initialize itself.
+                if _is_initialize_request(request.content):
+                    return
+                if "mcp-protocol-version" not in request.headers:
+                    request.headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
+
+            _request_hooks = []
+            if not _user_set_protocol_version:
+                _request_hooks.append(_add_protocol_version_after_initialize)
+
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
-                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                "event_hooks": {
+                    "request": _request_hooks,
+                    "response": [_strip_auth_on_cross_origin_redirect],
+                },
             }
             if headers:
                 client_kwargs["headers"] = headers
@@ -2952,6 +2993,11 @@ class MCPServerTask:
             return reason
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
+            # The legacy transport has no per-request hook support, so seed the
+            # header at the client level for all requests. This is best-effort:
+            # the spec violation on initialize is unavoidable on this code path.
+            if not _user_set_protocol_version:
+                headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
             _http_kwargs: dict = {
                 "headers": headers,
                 "timeout": float(connect_timeout),


### PR DESCRIPTION
## Summary

Hermes injects the `mcp-protocol-version` HTTP header on every new Streamable HTTP request to an MCP server, including the `initialize` request. The MCP spec negotiates the version through `params.protocolVersion` in the `initialize` body and requires the header only on subsequent requests; a compliant server such as Graylog 7.1.1 rejects the `initialize` POST when Hermes sends the header early.

Root cause: `MCPServerTask._run_http()` seeded `mcp-protocol-version` as a client-level default header, so httpx attached it to every outgoing Streamable HTTP request. The first revision of this PR moved that default into a request hook for new Streamable HTTP, but it also dropped the shared default that current main still passes into `sse_client(..., headers=...)`.

The fix keeps the request-hook approach for new Streamable HTTP so `initialize` stays header-free, preserves caller-pinned protocol versions, restores the default header on the SSE transport when the caller did not pin one, and leaves the deprecated legacy HTTP path unchanged.

Fixes #27569

## Changes

- `tools/mcp_tool.py`: add `_is_initialize_request()` to classify JSON-RPC bodies, keep the new Streamable HTTP request hook, and restore the default protocol header on the SSE branch when no caller pin exists.
- `tests/tools/test_mcp_tool.py`: keep the hook-behavior regression coverage around `initialize` and later requests.
- `tests/tools/test_mcp_sse_transport.py`: add SSE regression coverage for the default protocol header and caller-pinned overrides.

## Validation

| Scenario | Before | After |
|---|---|---|
| Streamable HTTP `initialize`, no user pin | header sent, compliant server returns 400 | header omitted, handshake succeeds |
| later Streamable HTTP request, no user pin | header sent | header still sent |
| SSE transport, no user pin | default header lost after the first revision of this PR | default header forwarded to `sse_client` again |
| caller-pinned version on HTTP or SSE | sent verbatim | sent verbatim |
| legacy `_MCP_NEW_HTTP is False` | seeded at client level | unchanged |

## Test plan

- `pytest tests/tools/test_mcp_tool.py::TestHTTPConfig::test_http_protocol_version_hook_behavior tests/tools/test_mcp_tool.py::TestIsInitializeRequest tests/tools/test_mcp_sse_transport.py -v --timeout=0` — 15 passed