### PR TITLE
test(toolsets): cover platform branch, alias loops, and exception fallbacks (#36609)

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -269,3 +269,261 @@ class TestResolveToolsetIncludeRegistry:
 
     def test_registry_only_toolset_static_view_is_empty(self):
         assert resolve_toolset("__definitely_not_a_real_toolset__", include_registry=False) == []
+
+class TestGetToolsetRegistryFailure:
+    """Cover get_toolset branches that require registry import or alias wiring."""
+
+    def test_registry_import_error_returns_static_toolset(self, monkeypatch):
+        # Lines 570-571: except Exception on registry import returns static entry.
+        import builtins
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("simulated missing registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+        ts = get_toolset("web")
+        assert ts is not None
+        assert "web_search" in ts["tools"]
+
+    def test_registry_import_error_returns_none_for_unknown(self, monkeypatch):
+        # Lines 570-571: except Exception path when toolset not in TOOLSETS.
+        import builtins
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("simulated missing registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+        assert get_toolset("nonexistent_xyz") is None
+
+    def test_alias_with_no_target_returns_none(self, monkeypatch):
+        # Line 587: name not in plugin toolsets and alias_target is falsy.
+        reg = ToolRegistry()
+        reg.register_toolset_alias("dangling-alias", "nonexistent-canonical")
+        monkeypatch.setattr("tools.registry.registry", reg)
+        # Patch get_toolset_alias_target on the live registry object to return None,
+        # so registry_toolset is falsy and the early return fires.
+        monkeypatch.setattr(reg, "get_toolset_alias_target", lambda name: None)
+        result = get_toolset("dangling-alias")
+        assert result is None
+
+    def test_canonical_with_reverse_alias_uses_alias_in_description(self, monkeypatch):
+        # Line 597: canonical toolset found in plugin names; reverse alias found,
+        # so description becomes "MCP server '<alias>' tools".
+        reg = ToolRegistry()
+        reg.register(
+            name="srv_ping",
+            toolset="mcp-myserver",
+            schema=_make_schema("srv_ping", "Ping"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("myserver", "mcp-myserver")
+        monkeypatch.setattr("tools.registry.registry", reg)
+        ts = get_toolset("mcp-myserver")
+        assert ts is not None
+        assert ts["description"] == "MCP server 'myserver' tools"
+
+
+class TestResolveToolsetHermesPlatform:
+    """Cover the hermes-<platform> dynamic resolution branch in resolve_toolset."""
+
+    def test_registered_platform_returns_core_tools(self, monkeypatch):
+        # Lines 647-663: platform_registry.is_registered is True; result includes
+        # _HERMES_CORE_TOOLS plus any tools the plugin registered under the platform name.
+        from unittest.mock import MagicMock
+
+        mock_registry = MagicMock()
+        mock_registry.is_registered.return_value = True
+
+        reg = ToolRegistry()
+        reg.register(
+            name="my_platform_tool",
+            toolset="myplatform",
+            schema=_make_schema("my_platform_tool", "Platform tool"),
+            handler=_dummy_handler,
+        )
+        monkeypatch.setattr("tools.registry.registry", reg)
+        monkeypatch.setattr(
+            "gateway.platform_registry.platform_registry", mock_registry
+        )
+
+        tools = resolve_toolset("hermes-myplatform")
+        assert "web_search" in tools       # from _HERMES_CORE_TOOLS
+        assert "my_platform_tool" in tools  # registered under the platform toolset
+
+    def test_unregistered_platform_returns_empty(self, monkeypatch):
+        # Lines 641-666: hermes-<platform> but is_registered is False; falls through to [].
+        from unittest.mock import MagicMock
+
+        mock_registry = MagicMock()
+        mock_registry.is_registered.return_value = False
+
+        monkeypatch.setattr(
+            "gateway.platform_registry.platform_registry", mock_registry
+        )
+
+        result = resolve_toolset("hermes-notregistered")
+        assert result == []
+
+    def test_platform_registry_import_error_returns_empty(self, monkeypatch):
+        # Lines 647-665: outer except Exception; platform_registry import fails.
+        import builtins
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "gateway.platform_registry":
+                raise ImportError("no gateway")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+        result = resolve_toolset("hermes-nomodule")
+        assert result == []
+
+    def test_platform_tool_registry_import_error_falls_back_to_core(self, monkeypatch):
+        # Lines 656-660: inner except Exception; tools.registry import fails but
+        # platform_registry import succeeds, so result is just _HERMES_CORE_TOOLS.
+        from unittest.mock import MagicMock
+        mock_pr = MagicMock()
+        mock_pr.is_registered.return_value = True
+
+        monkeypatch.setattr(
+            "gateway.platform_registry.platform_registry", mock_pr
+        )
+
+        import builtins
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("no registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+
+        tools = resolve_toolset("hermes-fallbackplatform")
+        assert "web_search" in tools
+
+
+class TestPrivateHelperExceptionPaths:
+    """Cover the except-fallback paths in _get_plugin_toolset_names and _get_registry_toolset_aliases."""
+
+    def test_get_plugin_toolset_names_import_error_returns_empty(self, monkeypatch):
+        # Lines 712-713: registry import raises -> returns set().
+        import builtins
+        import toolsets as ts_mod
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("no registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+        result = ts_mod._get_plugin_toolset_names()
+        assert result == set()
+
+    def test_get_registry_toolset_aliases_import_error_returns_empty(self, monkeypatch):
+        # Lines 721-722: registry import raises -> returns {}.
+        import builtins
+        import toolsets as ts_mod
+        real_import = builtins.__import__
+
+        def patched_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("no registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", patched_import)
+        result = ts_mod._get_registry_toolset_aliases()
+        assert result == {}
+
+
+class TestGetAllToolsetsAliasBranches:
+    """Cover the alias-display-name loop and duplicate-skip guard in get_all_toolsets."""
+
+    def test_plugin_toolset_shown_under_alias_name(self, monkeypatch):
+        # Lines 739-743: canonical name is mcp-srv2; alias is "srv2";
+        # get_all_toolsets should expose it as "srv2", not "mcp-srv2".
+        reg = ToolRegistry()
+        reg.register(
+            name="srv2_op",
+            toolset="mcp-srv2",
+            schema=_make_schema("srv2_op", "Op"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("srv2", "mcp-srv2")
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        all_ts = get_all_toolsets()
+        assert "srv2" in all_ts
+        assert "mcp-srv2" not in all_ts  # canonical hidden behind alias
+
+    def test_duplicate_display_name_skipped(self, monkeypatch):
+        # Lines 741-742: display_name matches an existing static toolset; must be skipped.
+        reg = ToolRegistry()
+        reg.register(
+            name="web_extra",
+            toolset="web",  # same name as the static "web" toolset
+            schema=_make_schema("web_extra", "Extra web"),
+            handler=_dummy_handler,
+        )
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        all_ts = get_all_toolsets()
+        # "web" is in TOOLSETS; the plugin entry should not overwrite it.
+        assert "web" in all_ts
+        assert "web_search" in all_ts["web"]["tools"]
+
+
+class TestGetToolsetNamesForElse:
+    """Cover the for/else else-branch in get_toolset_names."""
+
+    def test_unaliased_plugin_toolset_appears_under_canonical_name(self, monkeypatch):
+        # Lines 763-765: plugin toolset "mcp-rawplugin" has no alias; else branch
+        # adds "mcp-rawplugin" directly to names.
+        reg = ToolRegistry()
+        reg.register(
+            name="rawplugin_op",
+            toolset="mcp-rawplugin",
+            schema=_make_schema("rawplugin_op", "Raw op"),
+            handler=_dummy_handler,
+        )
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        import toolsets as ts_mod
+        names = ts_mod.get_toolset_names()
+        assert "mcp-rawplugin" in names
+
+
+class TestValidateToolsetPluginAndAlias:
+    """Cover the plugin-name and registry-alias paths in validate_toolset."""
+
+    def test_plugin_toolset_name_is_valid(self, monkeypatch):
+        # Line 787: name is in _get_plugin_toolset_names() -> True.
+        reg = ToolRegistry()
+        reg.register(
+            name="val_plugin_tool",
+            toolset="mcp-valplugin",
+            schema=_make_schema("val_plugin_tool", "Val"),
+            handler=_dummy_handler,
+        )
+        monkeypatch.setattr("tools.registry.registry", reg)
+        assert validate_toolset("mcp-valplugin") is True
+
+    def test_registry_alias_name_is_valid(self, monkeypatch):
+        # Line 789: name is in _get_registry_toolset_aliases() -> True.
+        reg = ToolRegistry()
+        reg.register(
+            name="val_alias_tool",
+            toolset="mcp-valcanon",
+            schema=_make_schema("val_alias_tool", "Val alias"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("val-alias", "mcp-valcanon")
+        monkeypatch.setattr("tools.registry.registry", reg)
+        assert validate_toolset("val-alias") is True

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -274,8 +274,7 @@ class TestGetAllToolsetsAliasBranches:
     """Cover the alias-display-name loop and duplicate-skip guard in get_all_toolsets."""
 
     def test_plugin_toolset_shown_under_alias_name(self, monkeypatch):
-        # Lines 739-743: canonical name is mcp-srv2; alias is "srv2";
-        # get_all_toolsets should expose it as "srv2", not "mcp-srv2".
+        # A registry-only canonical toolset is exposed under its non-static alias.
         reg = ToolRegistry()
         reg.register(
             name="srv2_op",
@@ -291,7 +290,7 @@ class TestGetAllToolsetsAliasBranches:
         assert "mcp-srv2" not in all_ts  # canonical hidden behind alias
 
     def test_duplicate_display_name_skipped(self, monkeypatch):
-        # Lines 741-742: alias display name matches an already-added plugin toolset.
+        # Two registry-only canonical names resolve to the same display key.
         reg = ToolRegistry()
         reg.register(
             name="alpha_op",
@@ -308,16 +307,37 @@ class TestGetAllToolsetsAliasBranches:
         reg.register_toolset_alias("alpha", "mcp-srv2")
         monkeypatch.setattr("tools.registry.registry", reg)
 
-        all_ts = get_all_toolsets()
+        import toolsets as ts_mod
+
+        assert set(ts_mod._get_plugin_toolset_names()) == {"alpha", "mcp-srv2"}
+        assert ts_mod._get_registry_toolset_aliases() == {"alpha": "mcp-srv2"}
+
+        real_get_tool_names = reg.get_tool_names_for_toolset
+        materializations = []
+
+        def record_materialization(toolset):
+            names = real_get_tool_names(toolset)
+            if toolset == "alpha":
+                marker = f"materialization_{len(materializations)}"
+                materializations.append((tuple(names), marker))
+                return [*names, marker]
+            return names
+
+        monkeypatch.setattr(reg, "get_tool_names_for_toolset", record_materialization)
+        all_ts = ts_mod.get_all_toolsets()
+
         assert "alpha" in all_ts
-        assert set(all_ts["alpha"]["tools"]) == {"alpha_op"}
         assert "mcp-srv2" not in all_ts
+        assert len(materializations) == 1
+        names, marker = materializations[0]
+        assert all_ts["alpha"]["tools"] == sorted([*names, marker])
+        assert "alpha_op" in all_ts["alpha"]["tools"]
 
 class TestGetToolsetRegistryFailure:
     """Cover get_toolset branches that require registry import or alias wiring."""
 
     def test_registry_import_error_returns_static_toolset(self, monkeypatch):
-        # Lines 570-571: except Exception on registry import returns static entry.
+        # A missing registry preserves the static toolset definition.
         import builtins
         real_import = builtins.__import__
 
@@ -332,7 +352,7 @@ class TestGetToolsetRegistryFailure:
         assert "web_search" in ts["tools"]
 
     def test_registry_import_error_returns_none_for_unknown(self, monkeypatch):
-        # Lines 570-571: except Exception path when toolset not in TOOLSETS.
+        # A missing registry leaves unknown names unresolved.
         import builtins
         real_import = builtins.__import__
 
@@ -345,19 +365,17 @@ class TestGetToolsetRegistryFailure:
         assert get_toolset("nonexistent_xyz") is None
 
     def test_alias_with_no_target_returns_none(self, monkeypatch):
-        # Line 587: name not in plugin toolsets and alias_target is falsy.
+        # An alias without a canonical target is unresolved.
         reg = ToolRegistry()
         reg.register_toolset_alias("dangling-alias", "nonexistent-canonical")
         monkeypatch.setattr("tools.registry.registry", reg)
-        # Patch get_toolset_alias_target on the live registry object to return None,
-        # so registry_toolset is falsy and the early return fires.
+        # The live registry reports that the alias has no target.
         monkeypatch.setattr(reg, "get_toolset_alias_target", lambda name: None)
         result = get_toolset("dangling-alias")
         assert result is None
 
     def test_canonical_with_reverse_alias_uses_alias_in_description(self, monkeypatch):
-        # Line 597: canonical toolset found in plugin names; reverse alias found,
-        # so description becomes "MCP server '<alias>' tools".
+        # A canonical registry toolset uses its reverse alias in the description.
         reg = ToolRegistry()
         reg.register(
             name="srv_ping",
@@ -376,8 +394,7 @@ class TestResolveToolsetHermesPlatform:
     """Cover the hermes-<platform> dynamic resolution branch in resolve_toolset."""
 
     def test_registered_platform_returns_core_tools(self, monkeypatch):
-        # Lines 647-663: platform_registry.is_registered is True; result includes
-        # _HERMES_CORE_TOOLS plus any tools the plugin registered under the platform name.
+        # A registered platform resolves core tools plus its registry tools.
         from unittest.mock import MagicMock
 
         mock_registry = MagicMock()
@@ -400,7 +417,7 @@ class TestResolveToolsetHermesPlatform:
         assert "my_platform_tool" in tools  # registered under the platform toolset
 
     def test_unregistered_platform_returns_empty(self, monkeypatch):
-        # Lines 641-666: hermes-<platform> but is_registered is False; falls through to [].
+        # An unregistered platform has no generated toolset.
         from unittest.mock import MagicMock
 
         mock_registry = MagicMock()
@@ -414,7 +431,7 @@ class TestResolveToolsetHermesPlatform:
         assert result == []
 
     def test_platform_registry_import_error_returns_empty(self, monkeypatch):
-        # Lines 647-665: outer except Exception; platform_registry import fails.
+        # An unavailable platform registry leaves the generated toolset empty.
         import builtins
         real_import = builtins.__import__
 
@@ -428,8 +445,7 @@ class TestResolveToolsetHermesPlatform:
         assert result == []
 
     def test_platform_tool_registry_import_error_falls_back_to_core(self, monkeypatch):
-        # Lines 656-660: inner except Exception; tools.registry import fails but
-        # platform_registry import succeeds, so result is just _HERMES_CORE_TOOLS.
+        # A registered platform keeps core tools when its tool registry is unavailable.
         from unittest.mock import MagicMock
         mock_pr = MagicMock()
         mock_pr.is_registered.return_value = True
@@ -456,7 +472,7 @@ class TestPrivateHelperExceptionPaths:
     """Cover the except-fallback paths in _get_plugin_toolset_names and _get_registry_toolset_aliases."""
 
     def test_get_plugin_toolset_names_import_error_returns_empty(self, monkeypatch):
-        # Lines 712-713: registry import raises -> returns set().
+        # An unavailable registry produces no plugin toolset names.
         import builtins
         import toolsets as ts_mod
         real_import = builtins.__import__
@@ -471,7 +487,7 @@ class TestPrivateHelperExceptionPaths:
         assert result == set()
 
     def test_get_registry_toolset_aliases_import_error_returns_empty(self, monkeypatch):
-        # Lines 721-722: registry import raises -> returns {}.
+        # An unavailable registry produces no registry aliases.
         import builtins
         import toolsets as ts_mod
         real_import = builtins.__import__
@@ -490,8 +506,7 @@ class TestGetToolsetNamesForElse:
     """Cover the for/else else-branch in get_toolset_names."""
 
     def test_unaliased_plugin_toolset_appears_under_canonical_name(self, monkeypatch):
-        # Lines 763-765: plugin toolset "mcp-rawplugin" has no alias; else branch
-        # adds "mcp-rawplugin" directly to names.
+        # An unaliased registry toolset appears under its canonical name.
         reg = ToolRegistry()
         reg.register(
             name="rawplugin_op",
@@ -510,7 +525,7 @@ class TestValidateToolsetPluginAndAlias:
     """Cover the plugin-name and registry-alias paths in validate_toolset."""
 
     def test_plugin_toolset_name_is_valid(self, monkeypatch):
-        # Line 787: name is in _get_plugin_toolset_names() -> True.
+        # A registry-only canonical name is valid.
         reg = ToolRegistry()
         reg.register(
             name="val_plugin_tool",
@@ -522,7 +537,7 @@ class TestValidateToolsetPluginAndAlias:
         assert validate_toolset("mcp-valplugin") is True
 
     def test_registry_alias_name_is_valid(self, monkeypatch):
-        # Line 789: name is in _get_registry_toolset_aliases() -> True.
+        # A registered alias is valid.
         reg = ToolRegistry()
         reg.register(
             name="val_alias_tool",

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -270,6 +270,49 @@ class TestResolveToolsetIncludeRegistry:
     def test_registry_only_toolset_static_view_is_empty(self):
         assert resolve_toolset("__definitely_not_a_real_toolset__", include_registry=False) == []
 
+class TestGetAllToolsetsAliasBranches:
+    """Cover the alias-display-name loop and duplicate-skip guard in get_all_toolsets."""
+
+    def test_plugin_toolset_shown_under_alias_name(self, monkeypatch):
+        # Lines 739-743: canonical name is mcp-srv2; alias is "srv2";
+        # get_all_toolsets should expose it as "srv2", not "mcp-srv2".
+        reg = ToolRegistry()
+        reg.register(
+            name="srv2_op",
+            toolset="mcp-srv2",
+            schema=_make_schema("srv2_op", "Op"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("srv2", "mcp-srv2")
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        all_ts = get_all_toolsets()
+        assert "srv2" in all_ts
+        assert "mcp-srv2" not in all_ts  # canonical hidden behind alias
+
+    def test_duplicate_display_name_skipped(self, monkeypatch):
+        # Lines 741-742: alias display name matches an already-added plugin toolset.
+        reg = ToolRegistry()
+        reg.register(
+            name="alpha_op",
+            toolset="alpha",
+            schema=_make_schema("alpha_op", "Alpha"),
+            handler=_dummy_handler,
+        )
+        reg.register(
+            name="srv2_op",
+            toolset="mcp-srv2",
+            schema=_make_schema("srv2_op", "Op"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("alpha", "mcp-srv2")
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        all_ts = get_all_toolsets()
+        assert "alpha" in all_ts
+        assert set(all_ts["alpha"]["tools"]) == {"alpha_op"}
+        assert "mcp-srv2" not in all_ts
+
 class TestGetToolsetRegistryFailure:
     """Cover get_toolset branches that require registry import or alias wiring."""
 
@@ -441,43 +484,6 @@ class TestPrivateHelperExceptionPaths:
         monkeypatch.setattr(builtins, "__import__", patched_import)
         result = ts_mod._get_registry_toolset_aliases()
         assert result == {}
-
-
-class TestGetAllToolsetsAliasBranches:
-    """Cover the alias-display-name loop and duplicate-skip guard in get_all_toolsets."""
-
-    def test_plugin_toolset_shown_under_alias_name(self, monkeypatch):
-        # Lines 739-743: canonical name is mcp-srv2; alias is "srv2";
-        # get_all_toolsets should expose it as "srv2", not "mcp-srv2".
-        reg = ToolRegistry()
-        reg.register(
-            name="srv2_op",
-            toolset="mcp-srv2",
-            schema=_make_schema("srv2_op", "Op"),
-            handler=_dummy_handler,
-        )
-        reg.register_toolset_alias("srv2", "mcp-srv2")
-        monkeypatch.setattr("tools.registry.registry", reg)
-
-        all_ts = get_all_toolsets()
-        assert "srv2" in all_ts
-        assert "mcp-srv2" not in all_ts  # canonical hidden behind alias
-
-    def test_duplicate_display_name_skipped(self, monkeypatch):
-        # Lines 741-742: display_name matches an existing static toolset; must be skipped.
-        reg = ToolRegistry()
-        reg.register(
-            name="web_extra",
-            toolset="web",  # same name as the static "web" toolset
-            schema=_make_schema("web_extra", "Extra web"),
-            handler=_dummy_handler,
-        )
-        monkeypatch.setattr("tools.registry.registry", reg)
-
-        all_ts = get_all_toolsets()
-        # "web" is in TOOLSETS; the plugin entry should not overwrite it.
-        assert "web" in all_ts
-        assert "web_search" in all_ts["web"]["tools"]
 
 
 class TestGetToolsetNamesForElse:


### PR DESCRIPTION
## Summary

`toolsets.py` resolves static toolsets, registry-only plugin toolsets, and registry aliases. This PR adds focused behavior coverage for the dynamic `hermes-<platform>` fallback, registry import fallbacks, alias projections, validation, and the duplicate-display-key guard in `get_all_toolsets()`.

The duplicate-display-key regression now uses two canonical toolsets that exist only in the live registry and project to the same display key. It records materialization through the real registry accessor, so the test requires one materialization and retains the first definition. Bypassing the guard makes the regression fail.

## Changes

- `tests/test_toolsets.py`: adds six focused test classes with 15 behavior tests for dynamic resolution, registry fallbacks, aliases, names, validation, and duplicate display keys.
- `tests/test_toolsets.py`: keeps the collision fixture registry-only and removes stale line-number comments from the added tests.

## Validation

| Scenario | Result |
|---|---|
| Registry-only canonical names collide on one display key | One materialization retains the first definition |
| Duplicate guard bypassed in the disposable worktree | Focused regression fails with two materializations |
| Duplicate guard restored | Focused regression passes |
| Complete toolset test file | 37 passed |

## Test plan

- `scripts/run_tests.sh tests/test_toolsets.py -k duplicate_display_name_skipped -v --timeout=0` — 1 passed
- `scripts/run_tests.sh tests/test_toolsets.py -v --timeout=0` — 37 passed

Fixes #36609
