### PR TITLE
perf(dashboard): skip full InsightsEngine on /api/analytics/usage (#18511)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -164,17 +164,23 @@ class InsightsEngine:
             "top_sessions": top_sessions,
         }
 
-    def get_skill_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
-        """Return only the skills section without running a full generate().
+    def get_usage_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+        """Return the analytics-usage payload without running a full generate().
 
         Uses the instr()-prefiltered _get_skill_usage query so only messages
-        that reference skill_view or skill_manage are loaded from SQLite,
-        avoiding the cost of _get_sessions, _get_tool_usage, and the other
-        compute passes that generate() performs.
+        that reference skill_view or skill_manage are loaded from SQLite, while
+        still preserving the per-tool breakdown used by the dashboard route.
         """
         cutoff = time.time() - (days * 86400)
+        tool_usage = self._get_tool_usage(cutoff, source)
         skill_usage = self._get_skill_usage(cutoff, source)
-        return self._compute_skill_breakdown(skill_usage)
+        return {
+            "tools": self._compute_tool_breakdown(tool_usage),
+            "skills": self._compute_skill_breakdown(skill_usage),
+        }
+
+    def get_skill_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+        return self.get_usage_breakdown(days=days, source=source)["skills"]
 
     # =========================================================================
     # Data gathering (SQL queries)

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -164,6 +164,18 @@ class InsightsEngine:
             "top_sessions": top_sessions,
         }
 
+    def get_skill_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+        """Return only the skills section without running a full generate().
+
+        Uses the instr()-prefiltered _get_skill_usage query so only messages
+        that reference skill_view or skill_manage are loaded from SQLite,
+        avoiding the cost of _get_sessions, _get_tool_usage, and the other
+        compute passes that generate() performs.
+        """
+        cutoff = time.time() - (days * 86400)
+        skill_usage = self._get_skill_usage(cutoff, source)
+        return self._compute_skill_breakdown(skill_usage)
+
     # =========================================================================
     # Data gathering (SQL queries)
     # =========================================================================
@@ -298,7 +310,9 @@ class InsightsEngine:
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ? AND s.source = ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
+                     AND (instr(m.tool_calls, 'skill_view') > 0
+                          OR instr(m.tool_calls, 'skill_manage') > 0)""",
                 (cutoff, source),
             )
         else:
@@ -307,7 +321,9 @@ class InsightsEngine:
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
+                     AND (instr(m.tool_calls, 'skill_view') > 0
+                          OR instr(m.tool_calls, 'skill_manage') > 0)""",
                 (cutoff,),
             )
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14037,17 +14037,17 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
-        skills = InsightsEngine(db).get_skill_breakdown(days=days)
+        usage = InsightsEngine(db).get_usage_breakdown(days=days)
 
         return {
             "daily": daily,
             "by_model": by_model,
             "totals": totals,
             "period_days": days,
-            "skills": skills,
+            "skills": usage["skills"],
             # Per-tool-name call counts (already computed by InsightsEngine);
             # the desktop Capabilities page aggregates these per toolset.
-            "tools": insights_report.get("tools", []),
+            "tools": usage["tools"],
         }
     finally:
         db.close()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14037,16 +14037,7 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
-        insights_report = InsightsEngine(db).generate(days=days)
-        skills = insights_report.get("skills", {
-            "summary": {
-                "total_skill_loads": 0,
-                "total_skill_edits": 0,
-                "total_skill_actions": 0,
-                "distinct_skills_used": 0,
-            },
-            "top_skills": [],
-        })
+        skills = InsightsEngine(db).get_skill_breakdown(days=days)
 
         return {
             "daily": daily,

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -506,6 +506,49 @@ class TestInsightsPopulated:
         # All 5 sessions should be included
         assert report["overview"]["total_sessions"] == 5
 
+    def test_get_skill_breakdown_matches_full_generate(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        full = engine.generate(days=30)
+        focused = engine.get_skill_breakdown(days=30)
+        assert focused == full["skills"]
+
+    def test_get_skill_breakdown_respects_source_filter(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        # Only s1 (cli) has skill_view "github-pr-workflow"
+        focused = engine.get_skill_breakdown(days=30, source="cli")
+        skill_names = [s["skill"] for s in focused["top_skills"]]
+        assert "github-pr-workflow" in skill_names
+        # github-code-review was in discord (s4), not cli
+        assert "github-code-review" not in skill_names
+
+    def test_get_skill_breakdown_empty_db(self, db):
+        focused = InsightsEngine(db).get_skill_breakdown(days=30)
+        assert focused == {
+            "summary": {
+                "total_skill_loads": 0,
+                "total_skill_edits": 0,
+                "total_skill_actions": 0,
+                "distinct_skills_used": 0,
+            },
+            "top_skills": [],
+        }
+
+    def test_get_skill_usage_prefilter_ignores_non_skill_substring(self, db):
+        # "my_skill_view_helper" contains "skill_view" as a substring; instr()
+        # will match but the Python-side name check keeps the set clean.
+        # More importantly, messages with no skill_* tools must be excluded.
+        db.create_session(session_id="sx", source="cli", model="gpt-4o")
+        db.append_message(
+            "sx",
+            role="assistant",
+            content="Just using read_file.",
+            tool_calls=[{"function": {"name": "read_file", "arguments": '{"path":"/tmp/x"}'}}],
+        )
+        db._conn.commit()
+        focused = InsightsEngine(db).get_skill_breakdown(days=30)
+        assert focused["summary"]["total_skill_actions"] == 0
+        assert focused["top_skills"] == []
+
 
 # =========================================================================
 # Formatting

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -512,6 +512,13 @@ class TestInsightsPopulated:
         focused = engine.get_skill_breakdown(days=30)
         assert focused == full["skills"]
 
+    def test_get_usage_breakdown_matches_full_generate(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        full = engine.generate(days=30)
+        focused = engine.get_usage_breakdown(days=30)
+        assert focused["skills"] == full["skills"]
+        assert focused["tools"] == full["tools"]
+
     def test_get_skill_breakdown_respects_source_filter(self, populated_db):
         engine = InsightsEngine(populated_db)
         # Only s1 (cli) has skill_view "github-pr-workflow"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4949,11 +4949,34 @@ class TestNewEndpoints:
         """get_usage_analytics must call get_skill_breakdown, not generate()."""
         from unittest.mock import patch
         from agent.insights import InsightsEngine
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="usage-tools-test",
+                source="cli",
+                model="anthropic/claude-sonnet-4",
+            )
+            db.update_token_counts(
+                "usage-tools-test",
+                input_tokens=10,
+                output_tokens=5,
+            )
+            db.append_message(
+                "usage-tools-test",
+                role="tool",
+                content="read output",
+                tool_name="read_file",
+            )
+        finally:
+            db.close()
 
         with patch.object(InsightsEngine, "generate") as mock_generate:
             resp = self.client.get("/api/analytics/usage?days=7")
         assert resp.status_code == 200
         mock_generate.assert_not_called()
+        assert any(tool["tool"] == "read_file" for tool in resp.json()["tools"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4945,6 +4945,16 @@ class TestNewEndpoints:
         except Exception:
             pass
 
+    def test_analytics_usage_skips_full_insights_generate(self):
+        """get_usage_analytics must call get_skill_breakdown, not generate()."""
+        from unittest.mock import patch
+        from agent.insights import InsightsEngine
+
+        with patch.object(InsightsEngine, "generate") as mock_generate:
+            resp = self.client.get("/api/analytics/usage?days=7")
+        assert resp.status_code == 200
+        mock_generate.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Model context length: normalize/denormalize + /api/model/info


### PR DESCRIPTION
## Summary

`/api/analytics/usage` reused `InsightsEngine.generate()` only to read its `skills` and `tools` sections, then discarded overview, models, platforms, activity, and top_sessions. `generate()` scans and JSON-parses every assistant `tool_calls` row in the window twice and computes several report sections the route does not return. On the reporter's database, that left the route taking 6 to 16 seconds and blocking unrelated async dashboard requests such as `/api/status`.

The first revision of this PR replaced the route with a skills-only helper, but current main now also returns per-tool usage from `/api/analytics/usage`. This update keeps the performance improvement while preserving the current response shape by adding a focused `InsightsEngine.get_usage_breakdown(days, source=None)` helper that computes only `skills` and `tools`.

The `instr()` prefilter on `_get_skill_usage()` stays in place, so the skill-side optimization remains intact while the route keeps the existing tool breakdown used by the desktop Capabilities page.

Picks up #18642 (self-closed for branch staleness), rebased on current main with the design the follow-up review converged on.

Fixes #18511

## Changes

- `agent/insights.py`: add `get_usage_breakdown(days, source=None)` for the route-level `skills` and `tools` payload, keep `get_skill_breakdown()` as a wrapper, and retain the `instr()` prefilter on `_get_skill_usage()`.
- `hermes_cli/web_server.py`: replace the full `generate()` call with `get_usage_breakdown(days=days)` and keep both `skills` and `tools` in the `/api/analytics/usage` response.
- `tests/agent/test_insights.py`: add parity coverage for the new focused helper against `generate()`.
- `tests/hermes_cli/test_web_server.py`: assert `/api/analytics/usage` still returns `tools` and still avoids `InsightsEngine.generate()`.

## Validation

| Scenario | Before | After |
|---|---|---|
| `/api/analytics/usage?days=30` on a large DB | 6 to 16s, full `generate()` | focused `skills` + `tools` helper only |
| `skills` payload shape | `{summary, top_skills}` | identical |
| `tools` payload for Capabilities | present on current main | preserved |
| non-skill row with literal `skill_view` text in args | not counted | unchanged |
| other `InsightsEngine.generate()` callers | unchanged | unchanged |

## Test plan

- `pytest tests/agent/test_insights.py tests/hermes_cli/test_web_server.py -v --timeout=0` — 376 passed, 17 skipped, 4 warnings