### PR TITLE
feat(gateway): paginate /api/sessions/{id}/messages and /api/jobs (#38370)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -64,29 +64,6 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
-
-def _hermes_version() -> str:
-    """Return the hermes-agent version string, or "dev" if it can't be resolved.
-
-    Tries the installed package metadata first (authoritative for a pip/uv
-    install), then the in-tree ``hermes_cli.__version__`` (covers editable /
-    source checkouts where metadata may be stale or absent). Never raises —
-    a version probe must not be able to break the health endpoint.
-    """
-    try:
-        from importlib.metadata import version
-
-        return version("hermes-agent")
-    except Exception:
-        pass
-    try:
-        from hermes_cli import __version__
-
-        return __version__
-    except Exception:
-        return "dev"
-
-
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -455,19 +432,7 @@ class ResponseStore:
             (time.time(), response_id),
         )
         self._conn.commit()
-        try:
-            return json.loads(row[0])
-        except (json.JSONDecodeError, TypeError):
-            logger.warning(
-                "Corrupted JSON in response store for id=%s, evicting entry",
-                response_id,
-            )
-            self._conn.execute(
-                "DELETE FROM responses WHERE response_id = ?",
-                (response_id,),
-            )
-            self._conn.commit()
-            return None
+        return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
@@ -800,7 +765,6 @@ except ImportError:
     _cron_resume = None
     _cron_trigger = None
 
-
 def _notify_cron_provider_jobs_changed() -> None:
     """Tell the active cron scheduler provider the job set changed after a REST
     mutation (no-op for the built-in). Best-effort — never breaks the handler."""
@@ -822,7 +786,6 @@ try:
     from tools.cronjob_tools import _scan_cron_prompt as _scan_cron_prompt
 except Exception:  # pragma: no cover - scanner is optional hardening
     _scan_cron_prompt = None
-
 
 class APIServerAdapter(BasePlatformAdapter):
     """
@@ -1369,9 +1332,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response(
-            {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
-        )
+        return web.json_response({"status": "ok", "platform": "hermes-agent"})
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -1818,12 +1779,19 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = self._ensure_session_db()
-        resolved_id = db.resolve_resume_session_id(session_id)
-        messages = db.get_messages(resolved_id)
+        limit = self._parse_nonnegative_int(request.query.get("limit"), default=200, maximum=1000)
+        offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
+        messages = db.get_messages(session_id)
+        total = len(messages)
+        page = messages[offset:offset + limit]
         return web.json_response({
             "object": "list",
-            "session_id": resolved_id,
-            "data": [self._message_response(m) for m in messages],
+            "session_id": session_id,
+            "data": [self._message_response(m) for m in page],
+            "limit": limit,
+            "offset": offset,
+            "total": total,
+            "has_more": offset + len(page) < total,
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
@@ -3561,8 +3529,18 @@ class APIServerAdapter(BasePlatformAdapter):
             return cron_err
         try:
             include_disabled = request.query.get("include_disabled", "").lower() in {"true", "1"}
+            limit = self._parse_nonnegative_int(request.query.get("limit"), default=200, maximum=1000)
+            offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
             jobs = _cron_list(include_disabled=include_disabled)
-            return web.json_response({"jobs": jobs})
+            total = len(jobs)
+            page = jobs[offset:offset + limit]
+            return web.json_response({
+                "jobs": page,
+                "limit": limit,
+                "offset": offset,
+                "total": total,
+                "has_more": offset + len(page) < total,
+            })
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -3595,10 +3573,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
-            if prompt and _scan_cron_prompt is not None:
-                scan_error = _scan_cron_prompt(prompt)
-                if scan_error:
-                    return web.json_response({"error": scan_error}, status=400)
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
 
@@ -3665,10 +3639,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
-            if sanitized.get("prompt") and _scan_cron_prompt is not None:
-                scan_error = _scan_cron_prompt(sanitized["prompt"])
-                if scan_error:
-                    return web.json_response({"error": scan_error}, status=400)
             job = _cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -64,6 +64,22 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+
+def _hermes_version() -> str:
+    """Return the hermes-agent version string, or "dev" if it can't be resolved."""
+    try:
+        from importlib.metadata import version
+
+        return version("hermes-agent")
+    except Exception:
+        pass
+    try:
+        from hermes_cli import __version__
+
+        return __version__
+    except Exception:
+        return "dev"
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -432,7 +448,19 @@ class ResponseStore:
             (time.time(), response_id),
         )
         self._conn.commit()
-        return json.loads(row[0])
+        try:
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Corrupted JSON in response store for id=%s, evicting entry",
+                response_id,
+            )
+            self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?",
+                (response_id,),
+            )
+            self._conn.commit()
+            return None
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
@@ -1332,7 +1360,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        return web.json_response(
+            {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
+        )
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -1779,14 +1809,15 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = self._ensure_session_db()
+        resolved_id = db.resolve_resume_session_id(session_id)
         limit = self._parse_nonnegative_int(request.query.get("limit"), default=200, maximum=1000)
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
-        messages = db.get_messages(session_id)
+        messages = db.get_messages(resolved_id)
         total = len(messages)
         page = messages[offset:offset + limit]
         return web.json_response({
             "object": "list",
-            "session_id": session_id,
+            "session_id": resolved_id,
             "data": [self._message_response(m) for m in page],
             "limit": limit,
             "offset": offset,
@@ -3573,6 +3604,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
+            if prompt and _scan_cron_prompt is not None:
+                scan_error = _scan_cron_prompt(prompt)
+                if scan_error:
+                    return web.json_response({"error": scan_error}, status=400)
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
 
@@ -3639,6 +3674,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
+            if sanitized.get("prompt") and _scan_cron_prompt is not None:
+                scan_error = _scan_cron_prompt(sanitized["prompt"])
+                if scan_error:
+                    return web.json_response({"error": scan_error}, status=400)
             job = _cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -130,6 +130,57 @@ class TestListJobs:
                 assert resp.status == 200
                 mock_list.assert_called_once_with(include_disabled=False)
 
+    @pytest.mark.asyncio
+    async def test_list_jobs_pagination_slices_and_reports_total(self, adapter):
+        """GET /api/jobs with limit/offset returns the correct page and metadata."""
+        all_jobs = [{**SAMPLE_JOB, "id": f"aabbccddeef{i}", "name": f"job-{i}"} for i in range(5)]
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_list", return_value=all_jobs
+            ):
+                # First page
+                resp = await cli.get("/api/jobs?limit=2&offset=0")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == all_jobs[:2]
+                assert data["limit"] == 2
+                assert data["offset"] == 0
+                assert data["total"] == 5
+                assert data["has_more"] is True
+
+                # Second page
+                resp = await cli.get("/api/jobs?limit=2&offset=2")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == all_jobs[2:4]
+                assert data["has_more"] is True
+
+                # Last page (1 item)
+                resp = await cli.get("/api/jobs?limit=2&offset=4")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == all_jobs[4:]
+                assert data["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_list_jobs_default_limit_returns_all(self, adapter):
+        """GET /api/jobs with no limit param returns all jobs with has_more=False."""
+        all_jobs = [{**SAMPLE_JOB, "id": f"aabbccddeef{i}", "name": f"job-{i}"} for i in range(3)]
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_list", return_value=all_jobs
+            ):
+                resp = await cli.get("/api/jobs")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == all_jobs
+                assert data["limit"] == 200
+                assert data["offset"] == 0
+                assert data["total"] == 3
+                assert data["has_more"] is False
+
 
 # ---------------------------------------------------------------------------
 # 3-7. test_create_job and validation

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -410,6 +410,53 @@ async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter
 
 
 @pytest.mark.asyncio
+async def test_session_messages_pagination(adapter, session_db):
+    session_id = session_db.create_session("page-session", "api_server")
+    for i in range(5):
+        session_db.append_message(session_id, "user", f"msg {i}")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        # Default: all 5, limit=200, offset=0, has_more=False
+        resp = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 5
+        assert data["limit"] == 200
+        assert data["offset"] == 0
+        assert data["total"] == 5
+        assert data["has_more"] is False
+
+        # First page of 2, has_more=True
+        resp = await cli.get(f"/api/sessions/{session_id}/messages?limit=2&offset=0")
+        assert resp.status == 200
+        data = await resp.json()
+        assert len(data["data"]) == 2
+        assert data["limit"] == 2
+        assert data["offset"] == 0
+        assert data["total"] == 5
+        assert data["has_more"] is True
+
+        # Last page: offset=4, limit=2, 1 item, has_more=False
+        resp = await cli.get(f"/api/sessions/{session_id}/messages?limit=2&offset=4")
+        assert resp.status == 200
+        data = await resp.json()
+        assert len(data["data"]) == 1
+        assert data["offset"] == 4
+        assert data["total"] == 5
+        assert data["has_more"] is False
+
+        # Malformed params fall back to defaults, no 400
+        resp = await cli.get(f"/api/sessions/{session_id}/messages?limit=bad&offset=-1")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["limit"] == 200
+        assert data["offset"] == 0
+        assert len(data["data"]) == 5
+
+
+@pytest.mark.asyncio
 async def test_session_endpoints_require_auth_when_key_configured(auth_adapter):
     app = _create_session_app(auth_adapter)
     async with TestClient(TestServer(app)) as cli:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -282,7 +282,7 @@ The server exposes a lightweight jobs CRUD surface for managing scheduled / back
 
 ### GET /api/jobs
 
-List all scheduled jobs.
+List scheduled jobs. Supports `limit`, `offset`, and `include_disabled=1|true`. The response includes the current page in `jobs`, plus `limit`, `offset`, `total`, and `has_more` so clients can keep paginating without re-counting locally.
 
 ### POST /api/jobs
 
@@ -323,12 +323,14 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}` | Read session metadata |
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
-| `GET` | `/api/sessions/{id}/messages` | Message history for a session |
+| `GET` | `/api/sessions/{id}/messages` | Message history for a session, paginated with `limit` and `offset` |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+`GET /api/sessions/{id}/messages` accepts `limit` and `offset`, then returns `object: "list"`, the resolved `session_id`, the current page in `data`, and the same pagination metadata fields the jobs endpoint uses: `limit`, `offset`, `total`, and `has_more`.
 
 ```bash
 # fork a session and run one turn


### PR DESCRIPTION
## Summary

`GET /api/sessions/{session_id}/messages` and `GET /api/jobs` returned their entire backing collection with no way to request a page. A long session can carry thousands of messages, and the client pays for the full payload with no cursor to scroll.

Both now accept `limit`/`offset` query params and return `{limit, offset, total, has_more}`, mirroring the existing `GET /api/sessions` paging contract and its `_parse_nonnegative_int` helper. Defaults (`limit=200`) preserve current behavior for typical callers; only collections longer than the page size change shape, and those gain a deterministic cursor. `has_more` is computed against the real `total` count rather than a heuristic, so paging never reports a spurious extra page. Malformed params fall back to defaults (no 400).

The issue suggested reusing `get_messages_around`, but that primitive anchors on a message id for symmetric windowed scrolling, not offset/limit paging. The fix keeps the slicing in the handlers (single file, same pattern as the existing list sessions endpoint) rather than pushing `LIMIT/OFFSET` into `SessionDB` and `cron.jobs`.

Fixes #38370

## Changes

- `gateway/platforms/api_server.py`: parse `limit`/`offset` in `_handle_session_messages` and `_handle_list_jobs` via existing `_parse_nonnegative_int`; slice and add `{limit, offset, total, has_more}` (+16 lines)
- `tests/gateway/test_session_api.py`: `test_session_messages_pagination` covering default, first page, short last page, malformed-param fallback (+47 lines)
- `tests/gateway/test_api_server_jobs.py`: `test_list_jobs_pagination_slices_and_reports_total`, `test_list_jobs_default_limit_returns_all` (+51 lines)

## Test plan

- `pytest tests/gateway/test_session_api.py tests/gateway/test_api_server_jobs.py -v --timeout=0` -- 49 passed
- Existing `test_session_crud_and_message_history`, `test_list_jobs`, `test_list_jobs_include_disabled`, `test_list_jobs_default_excludes_disabled` all pass unchanged