### PR TITLE
fix(i18n): keep /usage readable without locale catalog

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -46,6 +46,29 @@ SUPPORTED_LANGUAGES: tuple[str, ...] = (
 )
 DEFAULT_LANGUAGE = "en"
 
+# Last-resort strings for high-traffic gateway commands that should stay
+# readable even when a packaged install cannot find the locale catalog.
+_BUILTIN_EN_FALLBACKS: dict[str, str] = {
+    "gateway.usage.rate_limits": "Rate Limits: {state}",
+    "gateway.usage.header_session": "**Session Token Usage**",
+    "gateway.usage.label_model": "Model: `{model}`",
+    "gateway.usage.label_input_tokens": "Input tokens: {count}",
+    "gateway.usage.label_cache_read": "Cache read tokens: {count}",
+    "gateway.usage.label_cache_write": "Cache write tokens: {count}",
+    "gateway.usage.label_output_tokens": "Output tokens: {count}",
+    "gateway.usage.label_total": "Total: {count}",
+    "gateway.usage.label_api_calls": "API calls: {count}",
+    "gateway.usage.label_cost": "Cost: {prefix}${amount}",
+    "gateway.usage.label_cost_included": "Cost: included",
+    "gateway.usage.label_context": "Context: {used} / {total} ({pct}%)",
+    "gateway.usage.label_compressions": "Compressions: {count}",
+    "gateway.usage.header_session_info": "**Session Info**",
+    "gateway.usage.label_messages": "Messages: {count}",
+    "gateway.usage.label_estimated_context": "Estimated context: ~{count} tokens",
+    "gateway.usage.detailed_after_first": "(Detailed usage available after the first agent response)",
+    "gateway.usage.no_data": "No usage data available for this session.",
+}
+
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
 # get the right catalog instead of silently falling back to English.
 _LANGUAGE_ALIASES: dict[str, str] = {
@@ -274,6 +297,9 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     if value is None and target != DEFAULT_LANGUAGE:
         # Fall through to English rather than showing a key path to the user.
         value = _load_catalog(DEFAULT_LANGUAGE).get(key)
+
+    if value is None:
+        value = _BUILTIN_EN_FALLBACKS.get(key)
 
     if value is None:
         # Last-ditch: return the key itself.  A broken catalog should not

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -92,6 +92,34 @@ class TestUsageCachedAgent:
         assert "Compressions: 1" in result
 
     @pytest.mark.asyncio
+    async def test_usage_command_has_readable_fallback_when_catalog_missing(self, tmp_path, monkeypatch):
+        from agent import i18n
+
+        fake_locales = tmp_path / "empty-locales"
+        fake_locales.mkdir()
+        monkeypatch.setattr(i18n, "_locales_dir", lambda: fake_locales)
+        i18n.reset_language_cache()
+
+        agent = _make_mock_agent()
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+        monkeypatch.setattr("gateway.run.fetch_account_usage", lambda *args, **kwargs: None)
+
+        try:
+            with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+                 patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+                mock_cost.return_value = MagicMock(amount_usd=None, status="unknown")
+                result = await runner._handle_usage_command(event)
+        finally:
+            i18n.reset_language_cache()
+
+        assert "gateway.usage." not in result
+        assert "Session Token Usage" in result
+        assert "Rate Limits: RPM: 50/60" in result
+        assert "Input tokens: 35,000" in result
+        assert "API calls: 5" in result
+
+    @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):
         """When agent is in both dicts, the running one wins."""
         running = _make_mock_agent(session_api_calls=10, session_total_tokens=80_000)


### PR DESCRIPTION
## Summary

- add built-in English fallback strings for the gateway `/usage` i18n keys
- keep `/usage` readable when a packaged/runtime environment cannot resolve `locales/en.yaml`
- add a regression test that simulates a missing locale catalog and asserts raw `gateway.usage.*` keys are not returned

Fixes #38840

## Validation

- `bash scripts/run_tests.sh tests/gateway/test_usage_command.py::TestUsageCachedAgent::test_usage_command_has_readable_fallback_when_catalog_missing -q` (blocked in this Windows checkout: script has CRLF line endings and bash reports `set: pipefail\r: invalid option name`)
- `uv run --extra dev python -m pytest -q tests/gateway/test_usage_command.py::TestUsageCachedAgent::test_usage_command_has_readable_fallback_when_catalog_missing -o addopts=''`
- `uv run --extra dev python -m pytest -q tests/gateway/test_usage_command.py -o addopts=''`
- `uv run --extra dev python -m pytest -q tests/agent/test_i18n.py -o addopts=''`
- `uv run --extra dev ruff check agent/i18n.py tests/gateway/test_usage_command.py`
- `git diff --check`
- `uv run --extra dev python -m py_compile agent/i18n.py gateway/run.py tests/gateway/test_usage_command.py`