### PR TITLE
fix(desktop): reap detached TUI sessions so session.active_list can't leak

### DIFF
--- a/tests/tui_gateway/test_session_reaper.py
+++ b/tests/tui_gateway/test_session_reaper.py
@@ -1,0 +1,205 @@
+"""Detached-session liveness filter + reaper.
+
+Regression coverage for the "N sessions" footer leak: ws disconnects used to
+rebind a session's transport to stdio but never remove the ``_sessions`` entry,
+so ``session.active_list`` counted every session ever opened against the gateway
+and the count only reset on a gateway restart. The fix stamps ``detached_at`` on
+disconnect, filters disconnected-idle sessions out of ``active_list`` after a
+short grace, and reaps them — running the full ``session.close`` teardown
+(finalize + unregister notify + ``AIAgent.close`` + slash worker) to reclaim the
+agent's subprocesses/sandbox/browser/httpx resources.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sessions():
+    """Run each test against an empty, restored ``_sessions`` registry."""
+    saved = dict(server._sessions)
+    server._sessions.clear()
+    try:
+        yield
+    finally:
+        server._sessions.clear()
+        server._sessions.update(saved)
+
+
+def _mk(
+    sid: str,
+    *,
+    running: bool = False,
+    detached_at: float | None = None,
+    last_active: float | None = None,
+    **extra,
+):
+    if last_active is None:
+        # A detached session went idle when its client left, so model
+        # last_active as tracking detached_at unless a test overrides it (to
+        # exercise the "detached but still running autonomous turns" guard).
+        last_active = detached_at if detached_at is not None else time.time()
+    session = {
+        "session_key": sid,
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": running,
+        "created_at": time.time(),
+        "last_active": last_active,
+        "detached_at": detached_at,
+        "slash_worker": None,
+    }
+    session.update(extra)
+    server._sessions[sid] = session
+    return session
+
+
+def _old() -> float:
+    return time.time() - (server._SESSION_REAP_AFTER_S + 60)
+
+
+# ── _session_is_live ──────────────────────────────────────────────────────
+
+
+def test_attached_session_is_live():
+    assert server._session_is_live(_mk("a")) is True  # detached_at None == attached
+
+
+def test_running_session_is_live_even_if_detached():
+    s = _mk("a", running=True, detached_at=time.time() - 10_000)
+    assert server._session_is_live(s) is True
+
+
+def test_recently_detached_session_is_live_within_grace():
+    s = _mk("a", detached_at=time.time() - 1)
+    assert server._session_is_live(s) is True
+
+
+def test_long_detached_idle_session_is_not_live():
+    s = _mk("a", detached_at=time.time() - (server._SESSION_LIVE_GRACE_S + 5))
+    assert server._session_is_live(s) is False
+
+
+# ── session.active_list filtering ─────────────────────────────────────────
+
+
+def test_active_list_drops_detached_idle_but_keeps_current(monkeypatch):
+    # Keep the test independent of the heavy per-row builder (DB/agent/title).
+    monkeypatch.setattr(
+        server,
+        "_session_live_item",
+        lambda sid, sess, cur="": {"id": sid, "current": sid == cur},
+    )
+
+    _mk("live")  # attached
+    _mk("run", running=True, detached_at=time.time() - 9_999)  # running
+    _mk("fresh", detached_at=time.time() - 1)  # within grace
+    _mk("stale", detached_at=_old())
+
+    # 'stale' is the focused session -> must be kept despite being idle/detached.
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.active_list",
+            "params": {"current_session_id": "stale"},
+        }
+    )
+    ids = {row["id"] for row in resp["result"]["sessions"]}
+    assert ids == {"live", "run", "fresh", "stale"}
+
+    # Not focused -> the long-detached idle session drops out of the count.
+    resp2 = server.handle_request(
+        {"id": "2", "method": "session.active_list", "params": {}}
+    )
+    ids2 = {row["id"] for row in resp2["result"]["sessions"]}
+    assert ids2 == {"live", "run", "fresh"}
+    assert "stale" not in ids2
+
+
+# ── _reap_detached_sessions ───────────────────────────────────────────────
+
+
+def test_reaper_tears_down_only_idle_detached_sessions(monkeypatch):
+    torn: list[str] = []
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda sess, end_reason="": torn.append(sess.get("session_key")),
+    )
+
+    _mk("live")  # attached -> keep
+    _mk("run", running=True, detached_at=_old())  # running -> keep
+    _mk("fresh", detached_at=time.time() - 1)  # detached but recent -> keep
+    _mk("stale", detached_at=_old())  # detached + idle -> reap
+
+    assert server._reap_detached_sessions() == 1
+    assert set(server._sessions) == {"live", "run", "fresh"}
+    assert torn == ["stale"]
+
+
+def test_reaper_keeps_detached_session_running_autonomous_turns(monkeypatch):
+    # Finding-3 guard: a detached session whose notification poller / goal loop
+    # keeps last_active fresh must NOT be reaped even though detached_at is old.
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda *a, **k: pytest.fail("must not reap an actively-progressing session"),
+    )
+    _mk("auto", detached_at=_old(), last_active=time.time())
+    assert server._reap_detached_sessions() == 0
+    assert "auto" in server._sessions
+
+
+def test_reaper_skips_session_that_reattached_before_sweep(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda *a, **k: pytest.fail("must not reap a re-attached session"),
+    )
+    _mk("x", detached_at=_old())
+    # Simulate a client re-attaching (prompt.submit/activate clears detached_at).
+    server._sessions["x"]["detached_at"] = None
+
+    assert server._reap_detached_sessions() == 0
+    assert "x" in server._sessions
+
+
+def test_reaper_closes_agent_worker_and_unregisters_notify(monkeypatch):
+    # The whole point of the reaper is to reclaim the OS resources the agent
+    # holds — assert it runs the full teardown, not just a DB finalize.
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    unregistered: list[str] = []
+    monkeypatch.setattr(
+        "tools.approval.unregister_gateway_notify",
+        lambda key: unregistered.append(key),
+    )
+    closed = {"agent": 0, "worker": 0}
+
+    class _Agent:
+        def close(self):
+            closed["agent"] += 1
+
+    class _Worker:
+        def close(self):
+            closed["worker"] += 1
+
+    _mk("stale", detached_at=_old(), agent=_Agent(), slash_worker=_Worker())
+
+    assert server._reap_detached_sessions() == 1
+    assert "stale" not in server._sessions
+    assert closed == {"agent": 1, "worker": 1}
+    assert unregistered == ["stale"]
+
+
+def test_reap_window_is_at_least_the_live_grace():
+    # A session must stop counting as live (grace window) before it becomes
+    # reapable, otherwise active_list could still show a session the reaper is
+    # about to remove.
+    assert server._SESSION_REAP_AFTER_S >= server._SESSION_LIVE_GRACE_S

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -324,6 +324,7 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
 
 def _shutdown_sessions() -> None:
+    _reaper_stop.set()
     for session in list(_sessions.values()):
         _finalize_session(session, end_reason="tui_shutdown")
         try:
@@ -335,6 +336,171 @@ def _shutdown_sessions() -> None:
 
 
 atexit.register(_shutdown_sessions)
+
+
+# ── Detached-session reaper ───────────────────────────────────────────────
+#
+# A TUI/dashboard session whose client socket drops is kept warm briefly so a
+# reconnect can re-attach (prompt.submit / session.activate rebind the transport
+# and clear ``detached_at``). If no client comes back, the reaper finalizes the
+# session — freeing the AIAgent, the slash-command worker, and the
+# notification-poller thread it held — and drops it from ``_sessions``. The
+# transcript is already persisted, so the session stays resumable from disk.
+#
+# Before this, ws disconnects only rebound the transport to stdio and never
+# removed the entry, so every dashboard tab / PTY / reconnect leaked a permanent
+# "active" session: the footer "N sessions" climbed without bound and only reset
+# when the gateway process restarted.
+
+
+# Detached sessions still count as live in active_list for this long, so a quick
+# reconnect/refresh doesn't flicker the footer to a lower number.
+_SESSION_LIVE_GRACE_S = 12.0
+# After a client disconnects, an idle session is kept warm in memory this long
+# (so a reconnect can re-attach without a disk reload) before the reaper
+# finalizes it. Must be >= the live-grace window above.
+_SESSION_REAP_AFTER_S = 300.0
+# How often the reaper sweeps for idle, detached sessions.
+_SESSION_REAP_INTERVAL_S = 60.0
+
+_reaper_stop = threading.Event()
+_reaper_started = False
+_reaper_lock = threading.Lock()
+
+
+def _teardown_session(session: dict, end_reason: str = "tui_close") -> None:
+    """Fully release a finished session and every OS resource it held.
+
+    Runs the same teardown as the ``session.close`` RPC, in the same order:
+    finalize (commit memory + mark the DB row ended), unregister the
+    gateway-notify callback (a process-global closure), close the ``AIAgent``
+    (background processes, terminal sandbox VMs, browser daemon sessions, child
+    agents, httpx client), then close the slash-command worker. ``session.close``
+    and the idle reaper both call this so the two teardown paths can never drift.
+    Idempotent and individually guarded — safe to call from the reaper thread.
+    """
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        key = session.get("session_key")
+        if key:
+            unregister_gateway_notify(key)
+    except Exception:
+        logger.debug("teardown: unregister_gateway_notify failed", exc_info=True)
+    try:
+        agent = session.get("agent")
+        if agent is not None and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        logger.debug("teardown: agent.close failed", exc_info=True)
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        logger.debug("teardown: slash_worker close failed", exc_info=True)
+
+
+def _reap_detached_sessions(now: float | None = None) -> int:
+    """Finalize and drop sessions whose client disconnected and went idle.
+
+    A session is reaped only when it is (a) not running, (b) detached
+    (``detached_at`` set) for at least ``_SESSION_REAP_AFTER_S``, AND (c) has had
+    no turn activity (``last_active``) for the same window. The ``last_active``
+    guard matters because the notification poller and the /goal continuation loop
+    run autonomous turns on a *detached* session without a client re-attach;
+    those keep ``last_active`` fresh, so such a session is never reaped mid-loop.
+
+    The final "still reapable?" check, the busy-tombstone, and the ``_sessions``
+    removal are done under the session's ``history_lock`` — the same lock every
+    worker path takes to flip ``running`` between turns — so the reaper cannot
+    interleave with a turn starting. Setting ``running = True`` before removal
+    means any worker blocked on the lock (poller / goal / drain) sees the session
+    as busy and won't start a turn on what we're about to finalize. Finalize and
+    ``AIAgent.close`` run after the lock is released (``_finalize_session`` takes
+    that lock itself; ``close`` may block on subprocess/network teardown).
+
+    Unlike ``session.active_list`` (which always keeps the focused session
+    listed), the reaper has no focused-session exception on purpose: a session
+    detached + idle this long has a dead socket regardless of focus, reattach
+    clears ``detached_at`` first, and the transcript persists for
+    ``session.resume``.
+
+    Safe to call from any thread; returns the number of sessions reaped.
+    """
+    if now is None:
+        now = time.time()
+    reaped = 0
+    for sid, session in list(_sessions.items()):
+        detached_at = session.get("detached_at")
+        if detached_at is None or (now - detached_at) < _SESSION_REAP_AFTER_S:
+            continue
+        if session.get("running"):
+            continue
+        last_active = session.get("last_active") or session.get("created_at") or 0.0
+        if (now - last_active) < _SESSION_REAP_AFTER_S:
+            continue
+        live = _sessions.get(sid)
+        if live is not session:
+            continue
+        lock = live.get("history_lock")
+        if lock is not None and not lock.acquire(blocking=False):
+            continue  # a turn is actively holding the lock → not idle
+        try:
+            last_active = live.get("last_active") or live.get("created_at") or 0.0
+            if (
+                live.get("running")
+                or live.get("detached_at") is None
+                or (now - last_active) < _SESSION_REAP_AFTER_S
+            ):
+                # Re-check failed under the lock (a worker started a turn, a
+                # client re-attached, or fresh activity landed) → not reapable.
+                # The ``finally`` releases the lock and the loop moves on.
+                continue
+            # Tombstone as busy (under the lock) so any worker path blocked on
+            # this lock won't fire a fresh turn on a session we're finalizing,
+            # then remove it from the registry. Never cleared — the pop below
+            # drops the entry in this same locked section.
+            live["running"] = True
+            _sessions.pop(sid, None)
+        finally:
+            if lock is not None:
+                lock.release()
+        _teardown_session(session, end_reason="idle_reap")
+        reaped += 1
+        logger.info(
+            "session reaper: finalized idle detached session sid=%s (idle %.0fs)",
+            sid,
+            now - detached_at,
+        )
+    return reaped
+
+
+def _reaper_loop() -> None:
+    while not _reaper_stop.wait(_SESSION_REAP_INTERVAL_S):
+        try:
+            _reap_detached_sessions()
+        except Exception:
+            logger.exception("session reaper sweep failed")
+
+
+def _ensure_reaper_started() -> None:
+    """Start the reaper thread once, lazily, on first session creation.
+
+    Lazy start keeps the thread out of unit tests that never create a session
+    and guarantees it only runs inside a live gateway process.
+    """
+    global _reaper_started
+    if _reaper_started:
+        return
+    with _reaper_lock:
+        if _reaper_started:
+            return
+        threading.Thread(
+            target=_reaper_loop, name="tui-session-reaper", daemon=True
+        ).start()
+        _reaper_started = True
 
 
 # ── Plumbing ──────────────────────────────────────────────────────────
@@ -2409,6 +2575,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "history_version": 0,
         "inflight_turn": None,
         "created_at": now,
+        "detached_at": None,
         "last_active": now,
         "running": False,
         "attached_images": [],
@@ -2424,6 +2591,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
         "transport": current_transport() or _stdio_transport,
     }
+    _ensure_reaper_started()
     db = _get_db()
     if db is not None:
         row = db.get_session(key)
@@ -2824,6 +2992,7 @@ def _(rid, params: dict) -> dict:
         "attached_images": [],
         "cols": cols,
         "created_at": now,
+        "detached_at": None,
         "edit_snapshots": {},
         "explicit_cwd": explicit_cwd,
         "history": history,
@@ -2843,6 +3012,7 @@ def _(rid, params: dict) -> dict:
         "transport": current_transport() or _stdio_transport,
     }
     _register_session_cwd(_sessions[sid])
+    _ensure_reaper_started()
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop
     # launch (and every "New agent" / draft) opens a session here just to paint
     # the composer, so eagerly creating a row left an "Untitled" empty session
@@ -3062,6 +3232,27 @@ def _session_live_status(sid: str, session: dict) -> str:
     return "idle"
 
 
+def _session_is_live(session: dict, now: float | None = None) -> bool:
+    """Whether a session should count as a live, switchable TUI session.
+
+    Running sessions and sessions with a client attached are live. When the
+    client socket drops, ``ws.py`` stamps ``detached_at``; the session then
+    stays "live" only for the short ``_SESSION_LIVE_GRACE_S`` window (so a quick
+    reconnect/refresh doesn't flicker the count) before it becomes resumable
+    history. This is what keeps ``session.active_list`` — and the TUI footer's
+    "N sessions" — honest instead of counting every session ever opened against
+    this gateway process.
+    """
+    if session.get("running"):
+        return True
+    detached_at = session.get("detached_at")
+    if detached_at is None:
+        return True
+    if now is None:
+        now = time.time()
+    return (now - detached_at) <= _SESSION_LIVE_GRACE_S
+
+
 def _message_preview(history: list) -> str:
     for msg in reversed(history or []):
         text = _content_display_text(msg.get("content", msg.get("text", ""))).strip()
@@ -3136,7 +3327,18 @@ def _(rid, params: dict) -> dict:
     # Keep the natural creation/insertion order from ``_sessions``.  The
     # frontend marks the focused session with ``current``; it should not jump to
     # the top just because the user switched to it.
-    rows = [_session_live_item(sid, session, current) for sid, session in snapshot]
+    # Drop sessions whose client disconnected and didn't re-attach within the
+    # grace window — they're resumable history, not live sessions — but always
+    # keep the currently focused session so the user never sees their own
+    # session vanish. Together with the reaper this is the fix for the footer
+    # "N sessions" count that only ever climbed because disconnects never
+    # removed their _sessions entry.
+    now = time.time()
+    rows = [
+        _session_live_item(sid, session, current)
+        for sid, session in snapshot
+        if sid == current or _session_is_live(session, now)
+    ]
     return _ok(rid, {"sessions": rows})
 
 
@@ -3154,6 +3356,8 @@ def _(rid, params: dict) -> dict:
 
     with session["history_lock"]:
         session["last_active"] = time.time()
+        # The frontend just attached to this session — clear any detach mark.
+        session["detached_at"] = None
         history = list(session.get("display_history") or session.get("history") or [])
         inflight = _inflight_snapshot(session)
         running = bool(session.get("running"))
@@ -3561,25 +3765,7 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
+    _teardown_session(session)
     return _ok(rid, {"closed": True})
 
 
@@ -3934,6 +4120,9 @@ def _(rid, params: dict) -> dict:
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
         session["transport"] = t
+        # A live client just (re)bound to this session — clear any detach mark
+        # so the liveness filter/reaper don't treat it as abandoned.
+        session["detached_at"] = None
     with session["history_lock"]:
         if session.get("running"):
             return _err(rid, 4009, "session busy")

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 from tui_gateway import server
@@ -267,9 +268,16 @@ async def handle_ws(ws: Any) -> None:
 
             # Detach the transport from any sessions it owned so later emits
             # fall back to stdio instead of crashing into a closed socket.
+            detach_ts = time.time()
             for _, sess in list(server._sessions.items()):
                 if sess.get("transport") is transport:
                     sess["transport"] = server._stdio_transport
+                    # Stamp the disconnect time so session.active_list stops
+                    # counting this session after a short grace, and the reaper
+                    # can finalize it if no client re-attaches. Without this,
+                    # every dashboard tab / PTY / reconnect leaked a permanent
+                    # "active" session (the footer "N sessions" inflation bug).
+                    sess["detached_at"] = detach_ts
                     detached_sessions += 1
         try:
             await ws.close()


### PR DESCRIPTION
## What does this PR do?

Fixes a session-registry leak in the `tui_gateway` JSON-RPC server. The in-memory
`_sessions` dict is never pruned when a WebSocket client disconnects, so the
TUI/dashboard footer's **"N sessions"** count (which is `len(_sessions)` via
`session.active_list`) climbs without bound on a long-lived gateway and only
resets on a gateway restart. Each leaked entry also retains a live `AIAgent`,
slash worker, and notification-poller thread, so it's a real memory/thread leak.

The disconnect path is *intentionally* non-destructive — `prompt.submit` re-binds
the transport so a session survives a transient drop and re-attaches on the next
prompt — so the fix can't simply pop on disconnect. Instead it:

- stamps `detached_at` on disconnect,
- filters disconnected-idle sessions out of `session.active_list` after a short
  grace window (always keeping the focused session), and
- adds a lazily-started daemon reaper (mirroring `gateway/memory_monitor`) that
  finalizes detached + idle, not-running sessions via the existing `session.close`
  teardown — extracted into a shared `_teardown_session()` so the two paths can't
  drift.

The reaper's final re-check + busy-tombstone + pop run under `history_lock` (the
lock every `running=True` transition takes), with a `last_active` guard so a
detached session running autonomous `/goal` or notification turns is never reaped
mid-turn. The reaper starts lazily on first session creation (no import-time
thread, none in unit tests) and stops on `atexit`.

## Related Issue

Fixes #38950

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/ws.py` — stamp `sess["detached_at"]` on WS disconnect, beside the existing stdio-rebind.
- `tui_gateway/server.py`:
  - seed `detached_at: None` in both session builders; clear it on re-attach (`prompt.submit` rebind, `session.activate`).
  - `_session_is_live()` + filter in `session.active_list` (keeps the focused session).
  - `_teardown_session()` — the `session.close` teardown order (`_finalize_session` → `unregister_gateway_notify` → `agent.close()` → `worker.close()`), now shared by `session.close` and the reaper.
  - `_reap_detached_sessions()` / `_reaper_loop()` / `_ensure_reaper_started()` — the lazily-started daemon reaper.
- `tests/tui_gateway/test_session_reaper.py` — new regression tests.

## How to Test

**Repro (before this PR):**
1. `hermes gateway run` (long-lived), then `hermes dashboard --tui` → `http://127.0.0.1:9119/chat`.
2. Hard-refresh the chat tab a few times → the footer "N sessions" increments each
   time and never drops, despite a single live socket; only a gateway restart resets it.

**Proof it's fixed:**
- `scripts/run_tests.sh tests/tui_gateway/` — the new `test_session_reaper.py` covers
  the grace-window liveness filter, `active_list` dropping detached-idle sessions
  while keeping the focused one, the reaper running the full teardown
  (agent/worker/notify) on idle-detached sessions only, a detached session running
  autonomous turns *not* being reaped, and the reattach race.
- Manually: with the patch, refreshing the dashboard tab keeps the count at ~1; a
  detached session drops out of the count after the grace window and is reclaimed
  after the idle window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tests and all pass (`scripts/run_tests.sh tests/tui_gateway/` green; `ruff check .` and `scripts/check-windows-footguns.py --all` clean)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal session lifecycle; no public API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys; module constants)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — pure-Python stdlib `threading`/`time`, no POSIX-only primitives (windows-footguns clean)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
