### PR TITLE
fix(file-safety): deny writes to Google Workspace and Bitwarden credential stores

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -59,6 +59,30 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
+            # Bitwarden plaintext disk cache — still live alongside the
+            # encrypted one (agent.secret_sources.bitwarden._DISK_CACHE), and
+            # read-blocked by get_read_block_error(). Left writable, a
+            # prompt-injected write could seed cached secret VALUES that the
+            # next process reads back as if they came from BSM.
+            str(hermes_home / "cache" / "bws_cache.json"),
+            str(hermes_root / "cache" / "bws_cache.json"),
+            # Google Workspace OAuth token store, also read-blocked by
+            # get_read_block_error(): overwriting it plants attacker-controlled
+            # refresh tokens that get loaded on the next run.
+            str(hermes_home / "auth" / "google_oauth.json"),
+            str(hermes_root / "auth" / "google_oauth.json"),
+            # LIVE Google Workspace OAuth token + in-flight exchange state,
+            # stored at the HERMES_HOME root (not under auth/) by the
+            # google-workspace skill: setup.py writes both, google_api.py
+            # rewrites the token on refresh, gws_bridge.py consumes it. Those
+            # trusted writes are direct file IO inside the skill's own scripts
+            # and never route through this guard, so denying model-facing
+            # writes here does not break setup/refresh. Same per-file set as
+            # gateway.platforms.base._ROOT_CREDENTIAL_FILES.
+            str(hermes_home / "google_token.json"),
+            str(hermes_root / "google_token.json"),
+            str(hermes_home / "google_oauth_pending.json"),
+            str(hermes_root / "google_oauth_pending.json"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -49,6 +49,18 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
+            # Bitwarden plaintext disk cache — still live alongside the
+            # encrypted one (agent.secret_sources.bitwarden._DISK_CACHE), and
+            # read-blocked by get_read_block_error(). Left writable, a
+            # prompt-injected write could seed cached secret VALUES that the
+            # next process reads back as if they came from BSM.
+            str(hermes_home / "cache" / "bws_cache.json"),
+            str(hermes_root / "cache" / "bws_cache.json"),
+            # Google Workspace OAuth token store, also read-blocked by
+            # get_read_block_error(): overwriting it plants attacker-controlled
+            # refresh tokens that get loaded on the next run.
+            str(hermes_home / "auth" / "google_oauth.json"),
+            str(hermes_root / "auth" / "google_oauth.json"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -5,7 +5,32 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.file_operations import _is_write_denied
+
+# Credential stores that get_read_block_error() refuses to read, and which
+# must therefore also be write-denied — a writable read-blocked credential
+# file lets a prompt-injected write plant tokens it can never be caught
+# reading back.
+READ_BLOCKED_CREDENTIAL_FILES = [
+    os.path.join("auth", "google_oauth.json"),
+    os.path.join("cache", "bws_cache.json"),
+]
+
+# LIVE Google Workspace OAuth stores at the HERMES_HOME root: the token
+# consumed by gws_bridge.py/google_api.py and the in-flight exchange state
+# consumed by setup.py. Written by the skill's own scripts via direct file
+# IO (never through the model-facing guard), so denying them here cannot
+# break the trusted setup/refresh flow.
+GOOGLE_WORKSPACE_TOKEN_FILES = [
+    "google_token.json",
+    "google_oauth_pending.json",
+]
+
+WRITE_DENIED_CREDENTIAL_FILES = (
+    READ_BLOCKED_CREDENTIAL_FILES + GOOGLE_WORKSPACE_TOKEN_FILES
+)
 
 
 class TestWriteDenyExactPaths:
@@ -46,6 +71,51 @@ class TestWriteDenyExactPaths:
         assert get_default_hermes_root() == root
 
         assert _is_write_denied(str(global_env)) is True
+
+    @pytest.mark.parametrize("rel_path", WRITE_DENIED_CREDENTIAL_FILES)
+    def test_active_home_credential_stores_denied(
+        self, tmp_path, monkeypatch, rel_path
+    ):
+        """Credential stores under the active ``HERMES_HOME`` are write-denied.
+
+        ``auth/google_oauth.json`` and ``cache/bws_cache.json`` are
+        read-blocked by ``get_read_block_error()``; the write side only
+        covered the encrypted Bitwarden cache (``cache/bws_cache.enc.json``),
+        leaving the plaintext cache (still live — see
+        ``agent.secret_sources.bitwarden._DISK_CACHE``) overwritable.
+        ``google_token.json`` and ``google_oauth_pending.json`` are the LIVE
+        Google Workspace token and pending-exchange state: left writable, a
+        model-directed write can plant attacker-controlled token material
+        that gws_bridge.py/google_api.py consume on the next run.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert _is_write_denied(str(home / rel_path)) is True
+
+    @pytest.mark.parametrize("rel_path", WRITE_DENIED_CREDENTIAL_FILES)
+    def test_hermes_root_credential_stores_when_running_under_profile(
+        self, tmp_path, monkeypatch, rel_path
+    ):
+        """The same stores stay write-denied at ``<root>/`` while a profile
+        is active — same shape as the ``<root>/.env`` widening above (#15981).
+
+        Every profile inherits the root credentials, so a root-level write is
+        strictly worse than a per-profile one.
+        """
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        from hermes_constants import get_hermes_home, get_default_hermes_root
+
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        assert _is_write_denied(str(root / rel_path)) is True
+        assert _is_write_denied(str(profile_home / rel_path)) is True
 
     def test_shell_profiles_are_writable(self):
         home = str(Path.home())

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -5,7 +5,18 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.file_operations import _is_write_denied
+
+# Credential stores that get_read_block_error() refuses to read, and which
+# must therefore also be write-denied — a writable read-blocked credential
+# file lets a prompt-injected write plant tokens it can never be caught
+# reading back.
+READ_BLOCKED_CREDENTIAL_FILES = [
+    os.path.join("auth", "google_oauth.json"),
+    os.path.join("cache", "bws_cache.json"),
+]
 
 
 class TestWriteDenyExactPaths:
@@ -46,6 +57,45 @@ class TestWriteDenyExactPaths:
         assert get_default_hermes_root() == root
 
         assert _is_write_denied(str(global_env)) is True
+
+    @pytest.mark.parametrize("rel_path", READ_BLOCKED_CREDENTIAL_FILES)
+    def test_active_home_credential_stores_denied(self, tmp_path, monkeypatch, rel_path):
+        """``<HERMES_HOME>/auth/google_oauth.json`` and
+        ``<HERMES_HOME>/cache/bws_cache.json`` are write-denied.
+
+        Both are read-blocked by ``get_read_block_error()``; the write side
+        only covered the encrypted Bitwarden cache
+        (``cache/bws_cache.enc.json``), leaving the Google OAuth token store
+        and the plaintext Bitwarden cache (still live — see
+        ``agent.secret_sources.bitwarden._DISK_CACHE``) overwritable.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert _is_write_denied(str(home / rel_path)) is True
+
+    @pytest.mark.parametrize("rel_path", READ_BLOCKED_CREDENTIAL_FILES)
+    def test_hermes_root_credential_stores_when_running_under_profile(
+        self, tmp_path, monkeypatch, rel_path
+    ):
+        """The same two stores stay write-denied at ``<root>/`` while a profile
+        is active — same shape as the ``<root>/.env`` widening above (#15981).
+
+        Every profile inherits the root credentials, so a root-level write is
+        strictly worse than a per-profile one.
+        """
+        root = tmp_path / "hermes_root"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        from hermes_constants import get_hermes_home, get_default_hermes_root
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        assert _is_write_denied(str(root / rel_path)) is True
+        assert _is_write_denied(str(profile_home / rel_path)) is True
 
     def test_shell_profiles_are_writable(self):
         home = str(Path.home())


### PR DESCRIPTION
## What does this PR do?

`get_read_block_error()` blocks *reads* of `<hermes>/auth/google_oauth.json` (Google Workspace OAuth token store) and `<hermes>/cache/bws_cache.json` (Bitwarden Secrets Manager plaintext disk cache), but `build_write_denied_paths()` only covers the *encrypted* cache variant (`cache/bws_cache.enc.json`), so neither read-blocked path was write-denied.

The plaintext Bitwarden cache is still live alongside the encrypted one (`agent/secret_sources/bitwarden.py`, `_DISK_CACHE`), so both files remained overwritable by `write_file`. A prompt-injected write can plant attacker-controlled OAuth refresh tokens or seed cached secret *values* that the next process reads back as if they came from BSM.

Per review (thanks @egilewski), the fix also covers the **live** Google Workspace stores at the `HERMES_HOME` root, which the original patch missed: `google_token.json` (written by the skill's `setup.py`, rewritten on refresh by `google_api.py`, consumed by `gws_bridge.py`) and `google_oauth_pending.json` (in-flight exchange state). Trusted setup/refresh writes are direct file IO inside the skill's own scripts and never route through the model-facing guard, so they keep working unchanged.

All paths are added to the exact-path write denylist under **both** the active profile's `HERMES_HOME` and the global Hermes root, the same widening already applied to `.env` and `.anthropic_oauth.json` (#15981), since every profile inherits root credentials.

Note: `gateway/platforms/base.py` (`_ROOT_CREDENTIAL_FILES`) and `hermes_cli/web_server.py` (`_SENSITIVE_MANAGED_FILE_BASENAMES`) already list all four filenames; `agent/file_safety.py`'s write denylist was the only one of the three lagging behind.

## Related Issue

None. Discovered by diffing the read-deny and write-deny lists in `agent/file_safety.py`; live-token coverage added per review.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/file_safety.py`: added `auth/google_oauth.json`, `cache/bws_cache.json`, `google_token.json`, and `google_oauth_pending.json`, each under both `hermes_home` and `hermes_root`, to the exact-path set returned by `build_write_denied_paths()`.
- `tests/tools/test_write_deny.py`: two parametrized tests over all four filenames, one for the active `HERMES_HOME` and one for `<root>/` while a profile is active (which also asserts the profile view stays denied). Both use `tmp_path` + `monkeypatch`, mirroring the existing `test_hermes_root_env_when_running_under_profile`.

The diff is purely additive: `+94 / -0`, two files, no reformatting of surrounding code. An earlier revision of this branch carried incidental `ruff format` churn in `agent/file_safety.py` and `tests/tools/test_write_deny.py`; that has been stripped, since `main` is not `ruff format`-clean on those files and the churn was unrelated to the fix.

Deliberately out of scope, both now tracked: the model-facing *read* guard for the same live token files is #89072, and folding the four hand-maintained credential lists (`file_safety.py` read + write, `_ROOT_CREDENTIAL_FILES`, `_SENSITIVE_MANAGED_FILE_BASENAMES`) into one shared constant is #89064. #89072 applies cleanly on top of this branch — they touch different functions of the same module.

## How to Test

```bash
uv run --extra dev pytest tests/tools/test_write_deny.py tests/tools/test_credential_files.py tests/agent/test_file_safety.py tests/agent/test_file_safety_credentials.py tests/agent/test_file_safety_cross_profile.py -q
```

The eight parametrized write-deny cases fail before the `file_safety.py` change and pass after it. On the current rebase this is **97 passed**.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the file-safety suites listed above (97 passed) — not the full `pytest tests/ -q`. I also ran the two blocking lint jobs in full on this head: repo-wide `ruff check .` ("All checks passed") and `python scripts/check-windows-footguns.py --all` (clean, 1003 files scanned)
- [x] Rebased onto current `main` (`14c59f0b`); single commit, no merge commit
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 + Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — paths are built with `pathlib` / `os.path.join` and compared via `realpath`, as the surrounding entries already do
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A


