### PR TITLE
feat: add Telegram compact spacing option

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -46,6 +46,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Gateway text postprocessing.  When true, platform adapters may collapse
+    # markdown blank-line runs into single newlines for denser mobile chat
+    # output.  Off by default to preserve exact historical output.
+    "compact_spacing": False,
 }
 
 # ---------------------------------------------------------------------------
@@ -229,6 +233,10 @@ def _normalise(setting: str, value: Any) -> Any:
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
     if setting == "cleanup_progress":
+        if isinstance(value, str):
+            return value.lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+    if setting == "compact_spacing":
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -331,6 +331,31 @@ def _wrap_markdown_tables(text: str) -> str:
     return '\n'.join(out)
 
 
+_FENCED_CODE_BLOCK_RE = re.compile(r'(```(?:[^\n]*\n)?[\s\S]*?```)')
+_BLANK_LINE_RUN_RE = re.compile(r'\n[ \t]*(?:\n[ \t]*)+')
+
+
+def _compact_markdown_spacing_for_telegram(text: str) -> str:
+    """Collapse blank-line runs outside fenced code blocks for Telegram.
+
+    Telegram clients render every markdown blank line as a large vertical gap.
+    This opt-in postprocessor turns paragraph-separating blank lines into
+    single newlines while preserving fenced code blocks byte-for-byte so code,
+    logs, and preformatted examples keep their original spacing.
+    """
+    if not text or '\n\n' not in text:
+        return text
+
+    parts = _FENCED_CODE_BLOCK_RE.split(text)
+    compacted: list[str] = []
+    for idx, part in enumerate(parts):
+        if idx % 2 == 1:
+            compacted.append(part)
+        else:
+            compacted.append(_BLANK_LINE_RUN_RE.sub('\n', part))
+    return ''.join(compacted)
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -409,6 +434,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
+        self._compact_spacing: bool = self._coerce_bool_extra("compact_spacing", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -4360,6 +4386,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # 0) Rewrite GFM-style pipe tables into Telegram-friendly row groups
         #    before the normal MarkdownV2 conversions run.
         text = _wrap_markdown_tables(text)
+
+        # 0b) Optional Telegram-specific compact spacing.  Apply this before
+        #     MarkdownV2 escaping so the raw markdown structure is still visible
+        #     to the fenced-code protector.
+        if getattr(self, "_compact_spacing", False):
+            text = _compact_markdown_spacing_for_telegram(text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         #    Per MarkdownV2 spec, \ and ` inside pre/code must be escaped.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6762,6 +6762,24 @@ class GatewayRunner:
             if not check_telegram_requirements():
                 logger.warning("Telegram: python-telegram-bot not installed")
                 return None
+            # Bridge display.platforms.telegram.compact_spacing into the
+            # adapter's platform extra config.  The adapter owns MarkdownV2
+            # formatting, while the gateway owns user config resolution.
+            try:
+                if hasattr(config, "extra") and isinstance(config.extra, dict):
+                    _compact_spacing = os.getenv("HERMES_TELEGRAM_COMPACT_SPACING", "")
+                    if _compact_spacing in {"", None}:
+                        from gateway.display_config import resolve_display_setting
+
+                        _compact_spacing = resolve_display_setting(
+                            _load_gateway_config(),
+                            "telegram",
+                            "compact_spacing",
+                            False,
+                        )
+                    config.extra["compact_spacing"] = _compact_spacing
+            except Exception:
+                logger.debug("Telegram compact_spacing resolution failed", exc_info=True)
             adapter = TelegramAdapter(config)
             # Apply Telegram notification mode from config.  Controls whether
             # intermediate messages (tool progress, streaming, status) trigger

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1407,6 +1407,7 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "compact_spacing": False,  # Gateway: collapse blank markdown lines in text output (opt-in; per-platform overrideable)
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
         # that support message deletion (currently Telegram; other platforms

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -267,6 +267,25 @@ class TestPlatformDefaults:
         assert resolve_display_setting(config, "telegram", "long_running_notifications") is False
         assert resolve_display_setting(config, "telegram", "busy_ack_detail") is True
 
+    def test_telegram_compact_spacing_defaults_off(self):
+        """Telegram does not collapse final-answer blank lines unless opted in."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "compact_spacing") is False
+
+    def test_telegram_compact_spacing_can_opt_in(self):
+        """display.platforms.telegram.compact_spacing enables dense Telegram output."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {"compact_spacing": "yes"},
+                }
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "compact_spacing") is True
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -37,6 +37,7 @@ _ensure_telegram_mock()
 
 from gateway.platforms.telegram import (  # noqa: E402
     TelegramAdapter,
+    _compact_markdown_spacing_for_telegram,
     _escape_mdv2,
     _strip_mdv2,
     _wrap_markdown_tables,
@@ -109,6 +110,81 @@ class TestFormatMessageBasic:
     def test_plain_text_no_markdown(self, adapter):
         result = adapter.format_message("Hello world")
         assert result == "Hello world"
+
+
+# =========================================================================
+# format_message - compact spacing opt-in
+# =========================================================================
+
+
+class TestTelegramCompactSpacing:
+    def test_default_preserves_markdown_blank_lines(self, adapter):
+        text = "Intro\n\n## Heading\n\nSentence one.\n\nSentence two."
+
+        result = adapter.format_message(text)
+
+        assert "Intro\n\n*Heading*\n\nSentence one\\.\n\nSentence two\\." in result
+
+    def test_compact_spacing_collapses_blank_lines_outside_code_blocks(self):
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"compact_spacing": True},
+            )
+        )
+        text = (
+            "Intro\n\n"
+            "## Heading\n\n"
+            "Sentence one.\n\n"
+            "```\n"
+            "line 1\n\n"
+            "line 2\n"
+            "```\n\n"
+            "Sentence two."
+        )
+
+        result = adapter.format_message(text)
+
+        assert "Intro\n*Heading*\nSentence one\\.\n```\nline 1\n\nline 2\n```\nSentence two\\." in result
+        assert "Sentence one\\.\n\n```" not in result
+        assert "```\n\nSentence two" not in result
+
+    def test_compact_spacing_helper_preserves_fenced_code_verbatim(self):
+        text = "A\n\n```python\nprint('a')\n\nprint('b')\n```\n\nB"
+
+        result = _compact_markdown_spacing_for_telegram(text)
+
+        assert result == "A\n```python\nprint('a')\n\nprint('b')\n```\nB"
+
+    def test_gateway_create_adapter_applies_display_compact_spacing(self, monkeypatch):
+        import gateway.platforms.telegram as telegram_mod
+        import gateway.run as gateway_run
+        from gateway.config import GatewayConfig, Platform
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+        )
+        platform_config = PlatformConfig(enabled=True, token="fake-token")
+        monkeypatch.setattr(telegram_mod, "check_telegram_requirements", lambda: True)
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "platforms": {
+                        "telegram": {"compact_spacing": True},
+                    }
+                }
+            },
+        )
+
+        created = runner._create_adapter(Platform.TELEGRAM, platform_config)
+
+        assert isinstance(created, TelegramAdapter)
+        assert created._compact_spacing is True
 
 
 # =========================================================================

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1209,6 +1209,7 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+  compact_spacing: false  # Gateway: collapse blank markdown lines in text output (opt-in; per-platform overrideable)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
@@ -1286,11 +1287,14 @@ display:
       tool_progress: 'off'    # silence progress on Signal
     telegram:
       tool_progress: verbose  # detailed progress on Telegram
+      compact_spacing: true   # collapse Markdown blank lines for denser mobile replies
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
 ```
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
+
+`compact_spacing` is gateway-only and currently implemented by the Telegram adapter. When enabled, it collapses markdown blank-line runs (`\n\n`) into single newlines outside fenced code blocks before Telegram MarkdownV2 formatting. Use it when mobile chat replies feel too vertically spaced; leave it off when you want document-style Markdown spacing preserved.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 


### PR DESCRIPTION
## Summary
- Add opt-in Telegram `compact_spacing` display setting for denser mobile chat output.
- Collapse Markdown blank-line runs outside fenced code blocks before Telegram MarkdownV2 conversion.
- Keep default behavior unchanged unless `display.compact_spacing` or `display.platforms.telegram.compact_spacing` is enabled.
- Document the setting in the configuration guide and default config comments.

## Backward compatibility
- Strictly additive: 7 files, **+158 / -0**. Default output is unchanged unless the new opt-in flag is set.

Runtime opt-in example:

```yaml
display:
  platforms:
    telegram:
      compact_spacing: true
```

## Test plan
- **RED confirmed first**: compact-spacing tests failed with `ImportError: cannot import name '_compact_markdown_spacing_for_telegram'` before implementation.
- Targeted tests → `6 passed`:
  `python -m pytest tests/gateway/test_telegram_format.py::TestTelegramCompactSpacing tests/gateway/test_display_config.py::TestPlatformDefaults::test_telegram_compact_spacing_defaults_off tests/gateway/test_display_config.py::TestPlatformDefaults::test_telegram_compact_spacing_can_opt_in -q`
- Full Telegram/display suite → `604 passed, 0 failed`:
  `python scripts/run_tests_parallel.py -j 6 tests/gateway/test_telegram*.py tests/gateway/test_display_config.py`
- Lint → `All checks passed!`:
  `ruff check gateway/platforms/telegram.py gateway/display_config.py gateway/run.py hermes_cli/config.py tests/gateway/test_telegram_format.py tests/gateway/test_display_config.py`
