### PR TITLE
fix(background-review): use release_clients instead of close to avoid SIGTERMing user bg processes

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -497,7 +497,15 @@ def _run_review_in_thread(
             except Exception:
                 pass
             try:
-                review_agent.close()
+                # Use release_clients() rather than close(): the review_agent
+                # shares session_id with the parent (set explicitly above), so
+                # close() -> kill_all(task_id=session_id) would SIGTERM every
+                # background process the user launched in this session via
+                # terminal(background=True). release_clients() drops the LLM
+                # client + child subagents but leaves process_registry,
+                # terminal sandbox, and browser daemon untouched -- exactly the
+                # semantics we want for a background-review teardown.
+                review_agent.release_clients()
             except Exception:
                 pass
             review_agent = None
@@ -546,7 +554,8 @@ def _run_review_in_thread(
                     except Exception:
                         pass
                     try:
-                        review_agent.close()
+                        # See note above on the happy path.
+                        review_agent.release_clients()
                     except Exception:
                         pass
             except Exception:

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -40,7 +40,7 @@ class ImmediateThread:
         self._target()
 
 
-def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
+def test_background_review_shuts_down_memory_provider_before_release(monkeypatch):
     events = []
 
     class FakeReviewAgent:
@@ -54,7 +54,14 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         def shutdown_memory_provider(self):
             events.append(("shutdown_memory_provider", None))
 
+        def release_clients(self):
+            events.append(("release_clients", None))
+
         def close(self):
+            # Must NOT be called by background-review teardown: close()
+            # invokes kill_all(task_id=session_id), which the review_agent
+            # shares with its parent, so it would SIGTERM every background
+            # process the user launched in this session.
             events.append(("close", None))
 
     monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
@@ -72,15 +79,16 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         "init",
         "run_conversation",
         "shutdown_memory_provider",
-        "close",
+        "release_clients",
     ]
+    assert ("close", None) not in events
 
 
-def test_background_review_summarizer_receives_captured_messages_after_close(monkeypatch):
-    """The action summarizer must see review messages even after close cleanup.
+def test_background_review_summarizer_receives_captured_messages_after_release(monkeypatch):
+    """The action summarizer must see review messages even after teardown.
 
-    Regression for the bug where ``review_messages`` was snapshot AFTER
-    ``review_agent.close()``. close() is allowed to clean per-session state
+    Regression for the bug where ``review_messages`` was snapshot AFTER the
+    review_agent teardown. Teardown is allowed to clean per-session state
     (including ``_session_messages``), so the summarizer would receive an
     empty list and the user-visible self-improvement summary would silently
     disappear. The fix snapshots ``_session_messages`` before teardown.
@@ -109,10 +117,10 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
         def shutdown_memory_provider(self):
             events.append("shutdown_memory_provider")
 
-        def close(self):
-            events.append("close")
-            # close() is allowed to clean _session_messages — the fix
-            # must have snapshot them before this runs.
+        def release_clients(self):
+            events.append("release_clients")
+            # release_clients() is allowed to clean _session_messages — the
+            # fix must have snapshot them before this runs.
             self._session_messages = []
 
     def fake_summarize(review_messages, prior_snapshot):
@@ -141,7 +149,7 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
     assert events == [
         "run_conversation",
         "shutdown_memory_provider",
-        "close",
+        "release_clients",
         "summarize",
     ]
     assert captured["review_messages"] == [review_tool_message]


### PR DESCRIPTION
### Summary

The background-review thread's teardown calls `review_agent.close()`, which through `AIAgent.close()` invokes `process_registry.kill_all(task_id=session_id)`. Because the `review_agent` is spawned with `session_id` explicitly pinned to the parent agent's `session_id` (see `agent/background_review.py:451`), that `kill_all` sweeps up **every background process the user launched in the parent session** via `terminal(background=True, notify_on_complete=True)`.

The fix is a one-line swap to `release_clients()`, which already exists for exactly this scenario — its docstring (`run_agent.py:2567`) explicitly states:

> Used by the gateway when evicting this agent from `_agent_cache` for memory-management reasons (LRU cap or idle TTL) — the session may resume at any time with a freshly-built `AIAgent` that reuses the same `task_id` / `session_id`, so we must NOT kill:
> - `process_registry` entries for `task_id` (user's bg shells)
> - terminal sandbox for `task_id` (cwd, env, shell state)
> - browser daemon for `task_id` (open tabs, cookies)

That is precisely the contract the background-review teardown needs. The `review_agent` owns no terminal/browser/process state of its own; it's a short-lived inspector spawned to do memory/skill maintenance and then discarded.

### Symptom (how I hit this)

Doing a multi-stage orchestration with `cc-orchestrator` (which uses `terminal(background=True)` to launch `claude -p` subprocesses for planner/worker/reviewer phases), I observed ~5 SIGTERMs in one session across different long-running background processes. Each kill had:

- Exit code **`-15`** (SIGTERM) reported by Hermes's process registry.
- A clean `stream-json` log up to the last partial event — no `"type":"result"` line, no error from the child process itself.
- Esporadic timing — sometimes a few minutes in, sometimes 10+. Not deterministic, not tied to memory pressure.
- A second attempt with a fresh `terminal(background=True)` call always succeeded.

The pattern correlates 1:1 with the background-review thread completing. In some cases the agent log shows:

```
WARNING [<session>] agent.tool_executor: Tool patch returned error (0.00s): 
  {"error": "Background review denied non-whitelisted tool: patch. Only memory/skill tools are allowed."}
```

…shortly before the kill, but the kill happens just the same when the review used only whitelisted tools (in which case there's no warning to grep for).

### Root cause walkthrough

1. `AIAgent._spawn_background_review` creates a `review_agent` with `parent_session_id=agent.session_id` (line 412), then **explicitly pins** `review_agent.session_id = agent.session_id` (line 451) so the review's actions land under the parent's audit trail.
2. When the review finishes, the teardown at line 500 calls `review_agent.close()`.
3. `AIAgent.close()` (`run_agent.py:2614`) computes `task_id = getattr(self, "session_id", None) or ""` and calls `process_registry.kill_all(task_id=task_id)`.
4. `process_registry.kill_all(task_id)` (`tools/process_registry.py:1328`) terminates every session in `_running` whose `task_id == task_id` — which is the parent's `task_id`, and therefore matches every user-launched `terminal(background=True)` from this session.
5. Each killed session has its `exit_code` set to `-15`, which surfaces in the chat as `exit code -15` and looks indistinguishable from an external `SIGTERM`.

### Fix

Swap `close()` for `release_clients()` at both teardown sites in `agent/background_review.py`:

- The happy-path teardown at the end of `_spawn_background_review` (line ~500).
- The defensive teardown inside the outer exception handler (line ~549).

`release_clients()` already does exactly what we want for a transient inspector agent:

- Closes the OpenAI/httpx client pool (releases sockets, frees memory).
- Drops active child subagents.
- Leaves `process_registry`, terminal sandbox, and browser daemon **untouched**.

### Tests

Both existing tests in `tests/run_agent/test_background_review.py` are updated:

1. **`test_background_review_shuts_down_memory_provider_before_release`** (renamed from `..._before_close`):
   - Now expects the call sequence `init → run_conversation → shutdown_memory_provider → release_clients`.
   - Adds `assert ("close", None) not in events` so a future regression to `close()` fails this test loudly.
   - The fake review agent still has a `close()` method with an explanatory comment so the test fails meaningfully if anything calls it.

2. **`test_background_review_summarizer_receives_captured_messages_after_release`** (renamed from `..._after_close`):
   - Same scenario, but for the `_session_messages` snapshot regression. The teardown is still allowed to clear `_session_messages`; the test confirms the summarizer receives the pre-teardown snapshot.
   - Updated to use `release_clients()` instead of `close()` as the teardown step.

```
$ git diff --stat origin/main...HEAD
 agent/background_review.py                | 13 +++++++++++--
 tests/run_agent/test_background_review.py | 30 +++++++++++++++++++-----------
 2 files changed, 30 insertions(+), 13 deletions(-)
```

### Risks / things to double-check

- **`release_clients()` does close the LLM client** — the review_agent's HTTP/socket resources are still released. Only the cross-cutting `process_registry` / `terminal sandbox` / `browser` state is preserved. That's harmless here because the review_agent never owned those resources.
- **No change to `AIAgent.close()` itself.** It still kills `process_registry` for its `task_id`, which is correct for actual session boundaries (`/new`, `/reset`, gateway shutdown). Only the background-review teardown stopped (mis)using it.
- **Existing `release_clients` tests in `tests/gateway/test_agent_cache.py`** (`test_release_clients_does_not_touch_process_registry`, `test_release_clients_does_not_touch_terminal_or_browser`) already enforce the "must NOT kill process_registry" contract for the LRU-evict caller. By routing background-review through the same method, this PR inherits those guarantees.

### Alternative considered

The other obvious shape would be giving the `review_agent` a distinct `session_id` so its `close()` doesn't sweep up the parent's processes. I rejected it because:

- It would split the audit trail (the review's memory/skill writes would no longer trace back to the parent session in journals).
- It would diverge from the existing pinning at line 451, which is intentional.
- `release_clients()` is the documented mechanism for exactly this case ("session may resume… we must NOT kill"). Using the wrong teardown function and then patching around it is worse than calling the right one.

### Reproduction (for reviewers)

Any setup where the user runs:

```python
terminal(background=True, notify_on_complete=True,
         command="claude -p '...' --max-turns 30 ...")
```

…and the agent then continues to use tools enough that a background review fires before the background process completes. With this PR, the background process runs to completion. Without it, you'll see exit code `-15` somewhere between 30s and a few minutes in, reliably correlating with `'Self-improvement review' completing in the agent log.

### Related

- `tools/process_registry.py:1195` is where the `exit_code = -15` is set (the kill path).
- `run_agent.py:2567-2613` is the existing `release_clients()` whose docstring describes exactly this scenario.
- `agent/background_review.py:451` is the `session_id` pin that makes the parent and review_agent collide under `kill_all(task_id=…)`.

