### PR TITLE
feat(google-workspace): add gmail trash and permanent-delete commands

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.1.0
+version: 1.2.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -196,7 +196,18 @@ $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "T
 $GAPI gmail labels
 $GAPI gmail modify MESSAGE_ID --add-labels LABEL_ID
 $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
+
+# Trash / delete
+$GAPI gmail trash MESSAGE_ID                 # move to Trash (reversible, auto-purged after 30 days)
+$GAPI gmail delete MESSAGE_ID                # safe default — also just trashes
+$GAPI gmail delete MESSAGE_ID --permanent    # bypass Trash, irreversible (requires mail.google.com scope)
 ```
+
+> **Permanent delete needs the full `https://mail.google.com/` scope.** The
+> default `gmail.modify` scope can only move messages to Trash. If
+> `gmail delete --permanent` returns `HttpError 403: Insufficient Permission`,
+> re-run setup Steps 3-5 to grant the upgraded scope (`$GSETUP --revoke` first
+> if the consent screen doesn't re-prompt).
 
 ### Calendar
 
@@ -293,6 +304,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Gmail search**: `[{id, threadId, from, to, subject, date, snippet, labels}]`
 - **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
+- **Gmail trash/delete**: `{status: "trashed" | "deleted", id, permanent}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
 - **Calendar create**: `{status: "created", id, summary, htmlLink}`
 - **Drive search**: `[{id, name, mimeType, modifiedTime, webViewLink}]`
@@ -310,7 +322,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, permanently delete email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `gmail delete` and `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -456,6 +456,41 @@ def gmail_modify(args):
     print(json.dumps({"id": result["id"], "labels": result.get("labelIds", [])}, indent=2))
 
 
+def gmail_trash(args):
+    """Move a message to Trash (reversible; auto-purged after 30 days)."""
+    if _gws_binary():
+        result = _run_gws(
+            ["gmail", "users", "messages", "trash"],
+            params={"userId": "me", "id": args.message_id},
+        )
+        print(json.dumps({"status": "trashed", "id": result.get("id", args.message_id), "permanent": False}, indent=2))
+        return
+
+    service = build_service("gmail", "v1")
+    result = service.users().messages().trash(userId="me", id=args.message_id).execute()
+    print(json.dumps({"status": "trashed", "id": result.get("id", args.message_id), "permanent": False}, indent=2))
+
+
+def gmail_delete(args):
+    """Permanently delete a message (bypasses Trash). Requires the full
+    https://mail.google.com/ scope; gmail.modify can only trash."""
+    if not args.permanent:
+        # Safety: default to trash unless --permanent is explicitly passed.
+        return gmail_trash(args)
+
+    if _gws_binary():
+        _run_gws(
+            ["gmail", "users", "messages", "delete"],
+            params={"userId": "me", "id": args.message_id},
+        )
+        print(json.dumps({"status": "deleted", "id": args.message_id, "permanent": True}, indent=2))
+        return
+
+    service = build_service("gmail", "v1")
+    service.users().messages().delete(userId="me", id=args.message_id).execute()
+    print(json.dumps({"status": "deleted", "id": args.message_id, "permanent": True}, indent=2))
+
+
 # =========================================================================
 # Calendar
 # =========================================================================
@@ -1092,6 +1127,15 @@ def main():
     p.add_argument("--add-labels", default="", help="Comma-separated label IDs to add")
     p.add_argument("--remove-labels", default="", help="Comma-separated label IDs to remove")
     p.set_defaults(func=gmail_modify)
+
+    p = gmail_sub.add_parser("trash")
+    p.add_argument("message_id")
+    p.set_defaults(func=gmail_trash)
+
+    p = gmail_sub.add_parser("delete")
+    p.add_argument("message_id")
+    p.add_argument("--permanent", action="store_true", help="Permanently delete (default is trash, which is reversible)")
+    p.set_defaults(func=gmail_delete)
 
     # --- Calendar ---
     cal = sub.add_parser("calendar")

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -46,6 +46,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://mail.google.com/",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/contacts.readonly",


### PR DESCRIPTION
Gmail had no delete command while Calendar and Drive both did. Adds:
- gmail trash <id>         move to Trash (reversible, gmail.modify scope)
- gmail delete <id>        safe default, also just trashes
- gmail delete --permanent bypass Trash, irreversible

Adds the https://mail.google.com/ scope to setup.py (required for permanent delete; gmail.modify can only trash). Documents the commands, output shapes, and scope requirement in SKILL.md; bumps to 1.2.0.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

