### PR TITLE
fix(desktop): read composer text from DOM on Enter submit to avoid stale state

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -881,6 +881,13 @@ export function ChatBar({
   }, [activeQueueSessionKey, editingQueuedPrompt, queueEdit]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const submitDraft = () => {
+    // Resolve the current draft text from the DOM rather than from React
+    // state. The React draft may be stale when Enter fires synchronously
+    // from the keydown handler, before the latest onInput has committed
+    // (see #38923).
+    const editor = editorRef.current
+    const currentText = editor ? composerPlainText(editor).trim() : ''
+
     if (queueEdit) {
       exitQueuedEdit('save')
     } else if (busy) {
@@ -894,8 +901,8 @@ export function ChatBar({
       }
     } else if (!hasComposerPayload && queuedPrompts.length > 0) {
       void drainNextQueued()
-    } else if (draft.trim() || attachments.length > 0) {
-      const submitted = draft
+    } else if (currentText || attachments.length > 0) {
+      const submitted = currentText
       triggerHaptic('submit')
       clearDraft()
       void onSubmit(submitted)


### PR DESCRIPTION

## What does this PR do?

Fixes a bug where pressing Enter in the Desktop composer does not submit the message on the first press. The user must first press Shift+Enter (to insert a newline) and then press Enter to successfully submit.

The root cause is that `submitDraft()` reads the `draft` React state to check whether the composer has content. However, the `keydown` event fires before React has committed the latest `onInput` batch update, so `draft` can still be empty at the time of the check. The fix reads the current text synchronously from the DOM using the existing `composerPlainText()` helper, which is guaranteed to reflect the latest editor content.

## Related Issue

Fixes #38923

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`: In `submitDraft()`, read composer text directly from the DOM via `composerPlainText(editorRef.current)` instead of relying on the `draft` React state. Use the DOM value for both the emptiness check and the submitted content.

## How to Test

1. Open Hermes Desktop
2. Type a single-line message in the composer (e.g., "hello world")
3. Press Enter
4. Verify the message is submitted immediately, without needing Shift+Enter first

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no documentation, config, or schema changes needed
