### PR TITLE
fix(gateway): finalize oversize-split stream chunk so it gets final platform markup

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -530,7 +530,19 @@ class GatewayStreamConsumer:
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
+                        # finalize=True so the adapter applies platform-specific
+                        # rich-text markup (e.g. Telegram MarkdownV2). This chunk
+                        # is surrendered immediately below (_message_id is reset to
+                        # None), so it can never be edited again and must receive
+                        # its final formatting now. is_turn_final=False because the
+                        # remainder (_accumulated[split_at:]) is still the real
+                        # answer: it keeps _try_fresh_final from setting
+                        # _final_response_sent on this mid-stream chunk, which would
+                        # otherwise let a cancel/timeout before got_done suppress
+                        # the final send and strand the continuation.
+                        ok = await self._send_or_edit(
+                            chunk, finalize=True, is_turn_final=False,
+                        )
                         if self._fallback_final_send or not ok:
                             # Edit failed (or backed off due to flood control)
                             # while attempting to split an oversized message.

--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -158,6 +158,100 @@ class TestFreshFinalForLongLivedPreviews:
         adapter.edit_message.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_oversize_split_chunk_finalizes_without_marking_final(self):
+        """Oversize-split first chunk finalizes for formatting but stays non-final.
+
+        The overflow loop in the run cycle finalizes the first half of an
+        oversized message (so the adapter applies platform markup) and then
+        resets ``_message_id`` so a fresh message carries the remainder.  That
+        finalize must pass ``is_turn_final=False``: the chunk is not the
+        turn-final answer.  If it set ``_final_response_sent`` (what a bare
+        ``finalize=True`` does on a long-lived preview), a cancel/timeout
+        before ``got_done`` would let the gateway suppress the real final send
+        and strand the continuation.
+        """
+        adapter = _make_adapter()
+        adapter.send.side_effect = [
+            SimpleNamespace(success=True, message_id="initial_preview"),
+            SimpleNamespace(success=True, message_id="fresh_final"),
+        ]
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            config=StreamConsumerConfig(fresh_final_after_seconds=60.0),
+        )
+        await consumer._send_or_edit("first part so far")
+        consumer._message_created_ts = 0.0  # preview is stale → fresh-final path
+        # Mirror the overflow split call site: finalize the (distinct) chunk for
+        # markup, but the remainder is still the real answer, so
+        # is_turn_final=False.  Text must differ from the prior send or the
+        # skip-if-same guard short-circuits before fresh-final runs.
+        ok = await consumer._send_or_edit(
+            "first part of an oversized answer", finalize=True, is_turn_final=False,
+        )
+        assert ok is True
+        # Fresh-final still fired (formatting/cleanup happened) ...
+        assert adapter.send.call_count == 2
+        # ... but the chunk was NOT recorded as the turn-final response.
+        assert consumer._final_response_sent is False
+        assert consumer.final_response_sent is False
+
+    @pytest.mark.asyncio
+    async def test_run_loop_overflow_split_passes_is_turn_final_false(self):
+        """End-to-end guard for the overflow-split call site.
+
+        Drives the real run() loop with an oversized accumulation so the
+        ``while ... _message_id is not None`` overflow branch fires, and asserts
+        the split chunk is delivered via ``_send_or_edit(finalize=True,
+        is_turn_final=False)``.  With no segment break in the stream, that is the
+        only call carrying ``is_turn_final=False`` (got_done passes
+        ``is_turn_final=got_done``), so reverting the call site to a bare
+        ``finalize=True`` makes this assertion fail.
+        """
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096  # cursor="" -> _safe_limit = 3996
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="m1"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="m1"),
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            config=StreamConsumerConfig(
+                edit_interval=0.01, buffer_threshold=5, cursor="",
+            ),
+        )
+
+        captured: list[dict] = []
+        original = consumer._send_or_edit
+
+        async def _spy(text, **kwargs):
+            captured.append(kwargs)
+            return await original(text, **kwargs)
+
+        consumer._send_or_edit = _spy  # type: ignore[assignment]
+
+        consumer.on_delta("Start. ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)  # first send establishes _message_id
+        consumer.on_delta("X" * 5000)  # accumulation now exceeds _safe_limit
+        await asyncio.sleep(0.08)  # overflow while-loop fires the split
+        consumer.finish()
+        await task
+
+        finalize_nonfinal = [
+            kw for kw in captured
+            if kw.get("finalize") is True and kw.get("is_turn_final") is False
+        ]
+        assert finalize_nonfinal, (
+            "overflow-split chunk must be sent with finalize=True, "
+            f"is_turn_final=False; captured kwargs={captured}"
+        )
+
+    @pytest.mark.asyncio
     async def test_no_edit_sentinel_is_not_affected(self):
         """Platforms with the ``__no_edit__`` sentinel never go fresh-final."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

When a streamed message grows past the platform safe limit mid-stream, the consumer splits it: the first chunk is sent and then `_message_id` is reset to `None` so the remainder starts a fresh message. That first chunk was sent with the default `finalize=False`, so it never received the adapter's final rich-text markup (raw MarkdownV2 on Telegram) and could never be edited again.

This sends the split chunk with `finalize=True` so it gets its final platform formatting before it is surrendered, and with `is_turn_final=False` so it is not mistaken for the turn-final answer.

## Why `is_turn_final=False` matters

The split chunk enters the `_message_id is not None` edit branch, where `finalize=True` can trigger `_try_fresh_final`. That path is enabled by default on Telegram (`fresh_final_after_seconds=60`). If it fired with the default `is_turn_final=True`, it would set `_final_response_sent=True` on a mid-stream chunk. A cancel or timeout before `got_done` would then let the gateway suppress the real final send and strand the continuation (the remainder is still the real answer). The sibling segment-break send already passes `is_turn_final=got_done` for the same reason (#29346).

## Changes

- `gateway/stream_consumer.py`: oversize-split first chunk now sent via `_send_or_edit(chunk, finalize=True, is_turn_final=False)`.
- `tests/gateway/test_stream_consumer_fresh_final.py`: two regression tests.
  - A unit check that `_send_or_edit(finalize=True, is_turn_final=False)` runs fresh-final without setting `_final_response_sent`.
  - An end-to-end test that drives the real run loop into the overflow branch and asserts the call site passes `is_turn_final=False`. It fails if the call site is reverted to a bare `finalize=True`.

## Test plan

```
scripts/run_tests.sh tests/gateway/test_stream_consumer.py \
  tests/gateway/test_stream_consumer_fresh_final.py \
  tests/gateway/test_stream_consumer_draft.py \
  tests/gateway/test_stream_consumer_thread_routing.py
```

Result: 133 passed, 0 failed.

## Context

This is the one salvageable change observed in #32609, rebased onto current `main` and hardened with the `is_turn_final` fix and regression coverage. The other changes in that PR are already on `main` (draft MarkdownV2 parity via #37250, sanitized skip-path logging) or broaden the media-delivery allowlist in a way that bypasses the credential denylist, so they are intentionally not carried here.
