### PR TITLE
fix(agent): drop Gemini-illegal `items` on non-array tool schemas

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -87,6 +87,26 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
         if any(not isinstance(item, str) for item in enum_val):
             cleaned.pop("enum", None)
 
+    # Gemini's Schema validator enforces that ``items`` (and the array-only
+    # ``minItems`` / ``maxItems`` constraints) may appear ONLY when ``type`` is
+    # ``ARRAY``.  Some MCP tool schemas are sloppy here -- e.g. ClickUp's
+    # ``clickup_filter_tasks`` declares a polymorphic ``value`` field as
+    # ``{type: "string", items: {type: "string"}, ...}`` to hint that the RANGE
+    # operator also accepts a two-element array.  OpenAI / Anthropic ignore the
+    # contradiction; Gemini rejects the ENTIRE tool catalog with HTTP 400
+    # INVALID_ARGUMENT ("field predicate failed: $type == Type.ARRAY"), so every
+    # request dies.  When ``type`` is an explicit non-array scalar, trust the
+    # scalar and drop the array-only keys -- the description still documents the
+    # array case.  When ``items`` is present but ``type`` is absent, the field is
+    # really an array that forgot to declare itself, so pin ``type: "array"``.
+    if "items" in cleaned and type_val != "array":
+        if type_val is None:
+            cleaned["type"] = "array"
+        else:
+            cleaned.pop("items", None)
+            cleaned.pop("minItems", None)
+            cleaned.pop("maxItems", None)
+
     return cleaned
 
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -107,6 +107,86 @@ class TestSanitizeGeminiSchema:
         assert sanitize_gemini_schema("not a schema") == {}
         assert sanitize_gemini_schema([1, 2, 3]) == {}
 
+    def test_drops_items_on_non_array_scalar(self):
+        """Gemini: ``items`` is legal only when ``type == array``.
+
+        Regression for ClickUp's ``clickup_filter_tasks``: its ``value`` field
+        ships ``{type: string, items: {type: string}, description: ...}`` and
+        triggered Gemini HTTP 400 INVALID_ARGUMENT
+        "field predicate failed: $type == Type.ARRAY", rejecting the whole
+        tool catalog on every request.
+        """
+        schema = {
+            "type": "string",
+            "items": {"type": "string"},
+            "description": "Value; for RANGE provide an array of two strings.",
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert "items" not in cleaned
+        # description survives so the model still learns about the array case
+        assert "RANGE" in cleaned["description"]
+
+    def test_drops_array_only_constraints_on_non_array(self):
+        """minItems / maxItems share the array-only predicate."""
+        schema = {
+            "type": "string",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "maxItems": 2,
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert "items" not in cleaned
+        assert "minItems" not in cleaned
+        assert "maxItems" not in cleaned
+
+    def test_keeps_items_on_real_array(self):
+        """A legitimate array schema must keep its ``items``."""
+        schema = {"type": "array", "items": {"type": "string"}}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "array"
+        assert cleaned["items"] == {"type": "string"}
+
+    def test_pins_array_type_when_items_present_without_type(self):
+        """``items`` with no ``type`` is an array that forgot to say so."""
+        schema = {"items": {"type": "string"}, "description": "tags"}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "array"
+        assert cleaned["items"] == {"type": "string"}
+
+    def test_clickup_filter_tasks_value_no_longer_trips_gemini(self):
+        """End-to-end: the exact ``custom_fields`` shape rejected in prod."""
+        params = {
+            "type": "object",
+            "properties": {
+                "custom_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field_id": {"type": "string"},
+                            "operator": {"type": "string"},
+                            "value": {
+                                "type": "string",
+                                "items": {"type": "string"},
+                                "description": "Value; RANGE takes two strings.",
+                            },
+                        },
+                        "required": ["field_id", "operator"],
+                    },
+                },
+            },
+        }
+        cleaned = sanitize_gemini_tool_parameters(params)
+        value = cleaned["properties"]["custom_fields"]["items"]["properties"][
+            "value"
+        ]
+        assert value["type"] == "string"
+        assert "items" not in value
+        # The outer custom_fields array keeps its items (it really is an array).
+        assert cleaned["properties"]["custom_fields"]["type"] == "array"
+        assert "items" in cleaned["properties"]["custom_fields"]
+
 
 class TestSanitizeGeminiToolParameters:
     def test_empty_parameters_return_valid_object_schema(self):


### PR DESCRIPTION
# fix(agent): drop Gemini-illegal `items` on non-array tool schemas

## What & why

Gemini's `Schema` validator enforces that `items` (and the array-only
`minItems` / `maxItems` constraints) may appear **only** when `type` is
`ARRAY`. Some MCP tool schemas violate this. The concrete trigger is ClickUp's
`clickup_filter_tasks`, whose `value` field is declared as:

```json
{
  "type": "string",
  "items": { "type": "string" },
  "description": "The value to compare against. Use a string for most operators. For RANGE, provide an array of two strings (e.g., [\"yesterday\", \"tomorrow\"])."
}
```

`type` is `"string"` but the schema also carries `items` to hint that the
`RANGE` operator accepts a two-element array.

OpenAI and Anthropic silently ignore the contradiction. Gemini does not — it
rejects the **entire** tool catalog with:

```
HTTP 400 (INVALID_ARGUMENT): * GenerateContentRequest.tools[0].function_declarations[101]
.parameters.properties[custom_fields].items.properties[value].items:
field predicate failed: $type == Type.ARRAY
```

Because the whole `tools` payload is refused, **every** request to
`generativelanguage.googleapis.com` fails as soon as a tool like this is in
scope — not just calls that actually use the offending tool. The error is
non-retryable, so the agent aborts.

## The fix

`sanitize_gemini_schema` (in `agent/gemini_schema.py`) already strips other
Gemini-illegal constructs (e.g. integer-typed enums). This adds one more
invariant, applied after each node is cleaned:

| Node | Action |
|------|--------|
| explicit non-array `type` + `items` | drop `items` / `minItems` / `maxItems` (trust the scalar type; the description still documents the array case) |
| `items` present, no `type` | pin `type: "array"` (an array that forgot to declare itself) |
| `type: "array"` + `items` | untouched |

Both Gemini tool-translation paths (`gemini_native_adapter.py` and
`gemini_cloudcode_adapter.py`) route through this function, so one fix covers
both.

## How to test

Unit/regression tests added in `tests/agent/test_gemini_schema.py`:

```
scripts/run_tests.sh tests/agent/test_gemini_schema.py
# 16 tests passed
```

End-to-end verification against a real 173-tool catalog (ClickUp + others):

- Feeding the catalog through `build_gemini_request` leaves **0** illegal
  `items` nodes (was failing at `function_declarations[101]`).
- A live `gemini-flash-lite-latest:generateContent` call with that catalog
  returns **HTTP 200** instead of HTTP 400.

## Platforms tested

- Linux (Python 3.11)
