### PR TITLE
fix(desktop): add explicit 'Allow once' option to approval dropdown (fixes #38966)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -145,6 +145,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="min-w-44">
+            <DropdownMenuItem onSelect={() => void respond('once')}>Allow once</DropdownMenuItem>
             <DropdownMenuItem onSelect={() => void respond('session')}>Allow this session</DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() => {


### PR DESCRIPTION
Adds an explicit "Allow once" entry to the desktop approval dropdown. The once-only choice existed as the default Run button but wasn't visible in the dropdown alongside the other options. TUI parity puts all four canonical choices in the menu.

One-line fix: a DropdownMenuItem for "once" before "session" in the dropdown.

Closes #38966