### PR TITLE
feat(approval): env-gated reboot/shutdown downgrade (HERMES_ALLOW_REBOOT)

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -374,3 +374,83 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# -------------------------------------------------------------------------
+# HERMES_ALLOW_REBOOT env-gated downgrade (reboot/shutdown only)
+# -------------------------------------------------------------------------
+
+_REBOOT_FAMILY = [
+    "reboot",
+    "sudo reboot",
+    "systemctl reboot",
+    "shutdown -h now",
+    "shutdown -r now",
+    "halt",
+    "poweroff",
+    "init 0",
+    "init 6",
+    "telinit 0",
+    "systemctl poweroff",
+]
+
+# Catastrophic commands that must NEVER downgrade, flag or no flag.
+_NEVER_DOWNGRADE = [
+    "rm -rf /",
+    "mkfs.ext4 /dev/sda1",
+    "dd if=/dev/zero of=/dev/sda",
+    ":(){ :|:& };:",
+    "kill -1",
+]
+
+
+@pytest.mark.parametrize("command", _REBOOT_FAMILY)
+def test_reboot_stays_hardline_when_flag_unset(command, monkeypatch):
+    """Default (HERMES_ALLOW_REBOOT unset): reboot/shutdown stay hardline."""
+    monkeypatch.delenv("HERMES_ALLOW_REBOOT", raising=False)
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"{command!r} must stay hardline when flag unset"
+    assert desc
+
+
+@pytest.mark.parametrize("command", _REBOOT_FAMILY)
+def test_reboot_downgrades_to_dangerous_when_flag_set(command, monkeypatch):
+    """HERMES_ALLOW_REBOOT=1: reboot/shutdown drop out of hardline but remain
+    dangerous (approval-gated; yolo can pass)."""
+    monkeypatch.setenv("HERMES_ALLOW_REBOOT", "1")
+    is_hl, _ = detect_hardline_command(command)
+    assert not is_hl, f"{command!r} must downgrade out of hardline when flag set"
+    is_dng, _, ddesc = detect_dangerous_command(command)
+    assert is_dng, f"{command!r} must remain dangerous (approval-gated) when downgraded"
+    assert ddesc
+
+
+@pytest.mark.parametrize("command", _NEVER_DOWNGRADE)
+def test_other_hardline_unaffected_by_reboot_flag(command, monkeypatch):
+    """The reboot flag must NOT loosen any other catastrophic pattern."""
+    monkeypatch.setenv("HERMES_ALLOW_REBOOT", "1")
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"{command!r} must stay hardline even with HERMES_ALLOW_REBOOT=1"
+    assert desc
+
+
+def test_reboot_flag_plus_yolo_approves(monkeypatch):
+    """Flag set + session yolo => reboot passes the full guard pipeline."""
+    monkeypatch.setenv("HERMES_ALLOW_REBOOT", "1")
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    token = set_current_session_key("reboot_flag_test")
+    try:
+        enable_session_yolo("reboot_flag_test")
+        res = check_all_command_guards("sudo reboot", "ssh")
+        assert res["approved"] is True, f"expected approval, got {res}"
+    finally:
+        disable_session_yolo("reboot_flag_test")
+        reset_current_session_key(token)
+
+
+def test_reboot_flag_falsey_values_stay_blocked(monkeypatch):
+    """Only truthy HERMES_ALLOW_REBOOT downgrades; falsey/empty stays blocked."""
+    for val in ["0", "false", "no", ""]:
+        monkeypatch.setenv("HERMES_ALLOW_REBOOT", val)
+        is_hl, _ = detect_hardline_command("reboot")
+        assert is_hl, f"HERMES_ALLOW_REBOOT={val!r} must NOT downgrade reboot"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -317,6 +317,31 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     return (False, None)
 
 
+# Reboot/shutdown hardline descriptions that may be downgraded to the
+# DANGEROUS layer when HERMES_ALLOW_REBOOT is opted into. Kept in sync with
+# the reboot/shutdown entries in HARDLINE_PATTERNS below.
+_REBOOT_HARDLINE_DESCS = {
+    "system shutdown/reboot",
+    "init 0/6 (shutdown/reboot)",
+    "systemctl poweroff/reboot",
+    "telinit 0/6 (shutdown/reboot)",
+}
+
+
+def _reboot_shutdown_allowed() -> bool:
+    """Whether the reboot/shutdown family is opted out of the hardline floor.
+
+    When ``HERMES_ALLOW_REBOOT`` is set truthy, reboot/shutdown commands
+    downgrade from the unconditional hardline block to the DANGEROUS layer
+    (approval-gated; yolo / approvals.mode=off can pass them). This is for
+    fleet/ops agents that legitimately need to reboot hosts they manage.
+    Default (unset) preserves the historical unconditional block — no other
+    catastrophic pattern is affected.
+    """
+    from utils import env_var_enabled
+    return env_var_enabled("HERMES_ALLOW_REBOOT")
+
+
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
 
@@ -324,8 +349,18 @@ def detect_hardline_command(command: str) -> tuple:
         (is_hardline, description) or (False, None)
     """
     normalized = _normalize_command_for_detection(command).lower()
+    allow_reboot = _reboot_shutdown_allowed()
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
         if pattern_re.search(normalized):
+            # Opt-in escape hatch: when HERMES_ALLOW_REBOOT is set, the
+            # reboot/shutdown family downgrades out of the hardline floor and
+            # is handled by the DANGEROUS_PATTERNS layer instead (approval-
+            # gated; yolo can pass it through). Every other catastrophic
+            # pattern (rm -rf /, mkfs, dd to raw device, fork bomb, kill -1)
+            # stays unconditionally hardline. Default (flag unset) is byte-
+            # identical to the historical always-block behavior.
+            if allow_reboot and description in _REBOOT_HARDLINE_DESCS:
+                continue
             return (True, description)
     return (False, None)
 
@@ -382,6 +417,14 @@ DANGEROUS_PATTERNS = [
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
     (rf'>\s*{_SYSTEM_CONFIG_PATH}', "overwrite system config"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
+    # Reboot/shutdown family — normally HARDLINE-blocked. They only reach this
+    # DANGEROUS layer when HERMES_ALLOW_REBOOT downgrades them (see
+    # detect_hardline_command). Listed here so that, once downgraded, they are
+    # still approval-gated (and yolo-bypassable) rather than silently allowed.
+    (_CMDPOS + r'(shutdown|reboot|halt|poweroff)\b', "system shutdown/reboot"),
+    (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
+    (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
+    (_CMDPOS + r'telinit\s+[06]\b', "telinit 0/6 (shutdown/reboot)"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
     # killall with SIGKILL (parallel to pkill -9). Catches -9 / -KILL /


### PR DESCRIPTION
## Summary

The reboot/shutdown family is on the unconditional **hardline** blocklist in `tools/approval.py` — blocked even under `--yolo`, `approvals.mode=off`, and cron approve mode. That's the right default for most agents, but it's a hard wall for **fleet/ops agents that legitimately manage Linux hosts** and need to restart them.

This adds a narrow, opt-in escape hatch.

## What changed

- New `HERMES_ALLOW_REBOOT` env flag (default unset).
- When **unset** → behavior is byte-identical to today: reboot/shutdown stay hardline-blocked.
- When **set truthy** → the reboot/shutdown family (`shutdown|reboot|halt|poweroff`, `init 0/6`, `systemctl poweroff/reboot`, `telinit 0/6`) **downgrades** out of the hardline floor into the existing `DANGEROUS_PATTERNS` layer. It is then approval-gated like any other dangerous command, and `--yolo` / `approvals.mode=off` can pass it through.
- **Every other catastrophic pattern stays unconditionally hardline** regardless of the flag: root recursive delete, filesystem format, raw block-device overwrite, fork bomb, `kill -1`. The flag only touches the reboot/shutdown family.

## Why this design

- **Safe default preserved** — opt-in only; no behavior change for anyone who doesn't set the flag.
- **Not a removal of the safety floor** — reboot stays a *dangerous* command (still prompts unless yolo). It just stops being *unconditional*.
- **Scoped** — a single explicit set of descriptions (`_REBOOT_HARDLINE_DESCS`) is downgraded; the rest of the hardline floor is untouched.

## Tests

`tests/tools/test_hardline_blocklist.py` — added:
- reboot/shutdown stays hardline when flag unset
- reboot/shutdown downgrades to dangerous (not free) when flag set
- other catastrophic patterns stay hardline even with the flag set
- flag + session yolo => full guard pipeline approves
- falsey flag values (`0`, `false`, `no`, empty) stay blocked

`129 passed` (existing hardline suite + new tests), no regressions.
