### PR TITLE
fix(approval): catch Windows drive-letter paths (X:/, X:\) as dangerous (#38964)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -14,6 +14,7 @@ from tools.approval import (
     _smart_approve,
     approve_session,
     detect_dangerous_command,
+    detect_hardline_command,
     is_approved,
     load_permanent,
     prompt_dangerous_approval,
@@ -259,6 +260,80 @@ class TestRmRecursiveFlagVariants:
         dangerous, key, desc = detect_dangerous_command("sudo rm -rf /tmp")
         assert dangerous is True
         assert key is not None
+
+
+class TestWindowsDriveLetterApproval:
+    """Regression for #38964: Windows drive-letter paths (X:/foo, X:\\foo)
+    must trigger the same dangerous-pattern checks as Unix '/' paths.
+
+    On Windows (including git-bash), patterns that anchored only on a
+    bare '/' silently let `rm X:/important.txt` through even with
+    approvals.mode=manual.
+    """
+
+    def test_rm_windows_drive_letter_forward_slash_triggers_approval(self):
+        dangerous, key, desc = detect_dangerous_command("rm X:/test.txt")
+        assert dangerous is True, "rm X:/test.txt must trigger approval"
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_rm_windows_drive_letter_backslash_triggers_approval(self):
+        dangerous, key, desc = detect_dangerous_command(r"rm X:\test.txt")
+        assert dangerous is True, r"rm X:\test.txt must trigger approval"
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_rm_windows_drive_letter_lowercase_triggers_approval(self):
+        dangerous, key, desc = detect_dangerous_command("rm c:/foo/bar")
+        assert dangerous is True
+        assert key is not None
+
+    def test_rm_windows_drive_letter_uppercase_triggers_approval(self):
+        dangerous, key, desc = detect_dangerous_command("rm C:/foo/bar")
+        assert dangerous is True
+        assert key is not None
+
+    def test_rm_with_flag_windows_drive_letter_triggers_approval(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf X:/PROJECTs/test")
+        assert dangerous is True
+        assert key is not None
+
+    def test_rm_unix_root_path_still_triggers_approval(self):
+        """Regression: Unix '/foo' paths must still trigger after the fix."""
+        dangerous, key, desc = detect_dangerous_command("rm /x/test.txt")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_rm_relative_path_does_not_trigger(self):
+        """Negative: relative paths like './foo' must NOT trigger."""
+        dangerous, key, desc = detect_dangerous_command("rm ./foo.txt")
+        assert dangerous is False, f"'rm ./foo.txt' should be safe, got: {desc}"
+        assert key is None
+
+    def test_rm_plain_filename_does_not_trigger(self):
+        """Negative regression: bare filename must NOT trigger."""
+        dangerous, key, desc = detect_dangerous_command("rm readme.txt")
+        assert dangerous is False
+        assert key is None
+
+    def test_hardline_windows_drive_root_recursive_delete(self):
+        """`rm -rf X:/` (wipe whole Windows drive) must hit HARDLINE,
+        same as `rm -rf /` does on Unix."""
+        is_hardline, desc = detect_hardline_command("rm -rf X:/")
+        assert is_hardline is True, "rm -rf X:/ must be hardline-blocked"
+        assert "root" in desc.lower() or "filesystem" in desc.lower()
+
+    def test_hardline_windows_drive_root_backslash_recursive_delete(self):
+        is_hardline, desc = detect_hardline_command("rm -rf X:\\")
+        assert is_hardline is True
+        assert "root" in desc.lower() or "filesystem" in desc.lower()
+
+    def test_hardline_unix_root_recursive_delete_still_blocks(self):
+        """Regression: `rm -rf /` Unix hardline still fires."""
+        is_hardline, desc = detect_hardline_command("rm -rf /")
+        assert is_hardline is True
+        assert desc is not None
 
 
 class TestMultilineBypass:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -188,6 +188,15 @@ _CREDENTIAL_FILES = (
 # /etc/sudoers on macOS but bypasses a plain "/etc/" pattern check. Match
 # both forms. Inspired by Claude Code 2.1.113's "dangerous path protection".
 _MACOS_PRIVATE_SYSTEM_PATH = r'/private/(?:etc|var|tmp|home)/'
+# Windows drive-letter paths (X:/foo or X:\foo) must be treated the same
+# as Unix absolute paths (/foo) for "root-style" prefix checks. On Windows
+# (including git-bash), patterns that anchor on a bare '/' miss commands
+# like `rm X:/important.txt`, letting them bypass approval entirely even
+# with approvals.mode=manual. _ROOT_OR_DRIVE_PREFIX collapses both forms
+# (Unix '/' plus optional Windows '[A-Za-z]:[\\/]') into one shared
+# fragment so new and existing patterns stay consistent. Mirrors the
+# dual-form pattern used by _MACOS_PRIVATE_SYSTEM_PATH above. See #38964.
+_ROOT_OR_DRIVE_PREFIX = r'(?:[A-Za-z]:[\\/]|/)'
 # System-config paths that should trigger approval for any write/edit,
 # collapsing /etc, its macOS /private/etc mirror, and /etc/sudoers.d/ into
 # one shared fragment so new DANGEROUS_PATTERNS stay consistent.
@@ -247,8 +256,11 @@ _CMDPOS = (
 )
 
 HARDLINE_PATTERNS = [
-    # rm recursive targeting the root filesystem or protected roots
-    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*)(\s|$)', "recursive delete of root filesystem"),
+    # rm recursive targeting the root filesystem or protected roots.
+    # Unix '/' plus Windows drive roots ('X:/', 'X:\\'): wiping a whole
+    # Windows drive is as catastrophic as wiping Unix root, and bare-'/'
+    # checks miss drive-letter forms entirely on git-bash. See #38964.
+    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*|[A-Za-z]:[\\/]|[A-Za-z]:[\\/]\*)(\s|$)', "recursive delete of root filesystem"),
     (r'\brm\s+(-[^\s]*\s+)*(/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/\*|/var|/var/\*|/bin|/bin/\*|/sbin|/sbin/\*|/boot|/boot/\*|/lib|/lib/\*)(\s|$)', "recursive delete of system directory"),
     (r'\brm\s+(-[^\s]*\s+)*(~|\$HOME)(/?|/\*)?(\s|$)', "recursive delete of home directory"),
     # Filesystem format
@@ -365,7 +377,7 @@ def _sudo_stdin_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
-    (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    (rf'\brm\s+(-[^\s]*\s+)*{_ROOT_OR_DRIVE_PREFIX}', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),


### PR DESCRIPTION
## Summary

Approval patterns in `tools/approval.py` only checked Unix `/` as the prefix for dangerous paths. On Windows (git-bash or native), paths like `X:/foo` or `X:\foo` bypassed approval entirely, even with `approvals.mode=manual`.

## Reproduction (from #38964)

```bash
# Windows 11 + git-bash, approvals.mode: manual
touch /x/test.txt
rm X:/test.txt      # ❌ deleted silently, no approval prompt
rm /x/test.txt      # ✅ correctly triggers "delete in root path"
```

## Root cause

`DANGEROUS_PATTERNS` had `\brm\s+(-[^\s]*\s+)*/` where the literal `/` is the anchor for "absolute / root-style path". Windows drive-letter paths (`X:/` or `X:\`) never match. The same gap existed in the `HARDLINE_PATTERNS` "recursive delete of root filesystem" check.

## Fix

Introduces a shared `_ROOT_OR_DRIVE_PREFIX = r'(?:[A-Za-z]:[\\/]|/)'` fragment and uses it in:

1. **DANGEROUS** `"delete in root path"` — `rm X:/foo` now correctly triggers approval.
2. **HARDLINE** `"recursive delete of root filesystem"` — `rm -rf X:/` now hardline-blocks, mirroring the existing `rm -rf /` behavior. Wiping a whole Windows drive is just as catastrophic as wiping Unix root.

Modeled on the existing `_MACOS_PRIVATE_SYSTEM_PATH` dual-form pattern (which already collapses `/etc` and `/private/etc` into one shared fragment). No new dangerous *file* paths added — this is purely a prefix fix to close the bypass. Unix-only patterns (`/dev/sd`, `/etc/sudoers`, `~/.ssh/`, `/private/etc/`) are unchanged: they reference Unix-specific system files with no Windows analog.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `rm X:/foo` | bypass ❌ | approval ✅ |
| `rm X:\foo` | bypass ❌ | approval ✅ |
| `rm c:/foo` | bypass ❌ | approval ✅ |
| `rm -rf X:/PROJECTs/test` | bypass ❌ | approval ✅ |
| `rm -rf X:/` (drive wipe) | bypass ❌ | **hardline-block** ✅ |
| `rm /x/test.txt` | approval ✅ | approval ✅ |
| `rm -rf /` | hardline-block ✅ | hardline-block ✅ |
| `rm readme.txt` | no trigger ✅ | no trigger ✅ |
| `rm ./foo.txt` | no trigger ✅ | no trigger ✅ |

## Tests

Added 11 tests in `tests/tools/test_approval.py::TestWindowsDriveLetterApproval`:

- `test_rm_windows_drive_letter_forward_slash_triggers_approval`
- `test_rm_windows_drive_letter_backslash_triggers_approval`
- `test_rm_windows_drive_letter_lowercase_triggers_approval`
- `test_rm_windows_drive_letter_uppercase_triggers_approval`
- `test_rm_with_flag_windows_drive_letter_triggers_approval`
- `test_rm_unix_root_path_still_triggers_approval` *(regression)*
- `test_rm_relative_path_does_not_trigger` *(negative)*
- `test_rm_plain_filename_does_not_trigger` *(negative regression)*
- `test_hardline_windows_drive_root_recursive_delete`
- `test_hardline_windows_drive_root_backslash_recursive_delete`
- `test_hardline_unix_root_recursive_delete_still_blocks` *(regression)*

All 11 pass against the new pattern; the Windows-path tests fail against `main` (confirms the bypass). Full `tests/tools/test_approval.py` suite: **205 passed, 0 regressions** locally (3 unrelated tests deselected due to missing optional dev deps in the test env: `agent.auxiliary_client`, `prompt_toolkit`).

## Affected architecture

`tools/approval.py` is the single source of truth for the dangerous-command system. The change is localized to pattern definitions — no logic changes in `detect_dangerous_command`, `detect_hardline_command`, hooks, or the approval transport.

Fixes #38964