### PR TITLE
fix(approval): detect Windows drive-letter paths in dangerous command patterns

### DIFF
--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for Windows drive-letter path detection in dangerous commands.
+Issue #38964: paths like X:/foo or X:\\foo bypassed approval on Windows/git-bash.
+"""
+import pytest
+from tools.approval import detect_dangerous_command, detect_hardline_command
+
+
+class TestWindowsDriveLetterApproval:
+    """Windows drive-letter paths must trigger the same checks as Unix '/' paths."""
+
+    # --- rm dangerous patterns ---
+    def test_rm_windows_forward_slash(self):
+        dangerous, key, desc = detect_dangerous_command("rm X:/test.txt")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_rm_windows_backslash(self):
+        dangerous, key, desc = detect_dangerous_command(r"rm X:\test.txt")
+        assert dangerous is True
+        assert key is not None
+
+    def test_rm_windows_lowercase_drive(self):
+        dangerous, key, desc = detect_dangerous_command("rm c:/foo/bar")
+        assert dangerous is True
+
+    def test_rm_windows_uppercase_drive(self):
+        dangerous, key, desc = detect_dangerous_command("rm C:/foo/bar")
+        assert dangerous is True
+
+    def test_rm_with_flags_windows_path(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf X:/PROJECTs/test")
+        assert dangerous is True
+
+    def test_rm_unix_root_still_triggers(self):
+        dangerous, key, desc = detect_dangerous_command("rm /x/test.txt")
+        assert dangerous is True
+        assert "delete" in desc.lower()
+
+    def test_rm_relative_path_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm ./foo.txt")
+        assert dangerous is False
+
+    def test_rm_plain_filename_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm readme.txt")
+        assert dangerous is False
+
+    # --- redirection dangerous patterns ---
+    def test_redirect_to_windows_path(self):
+        dangerous, key, desc = detect_dangerous_command("> C:/config.txt")
+        assert dangerous is True
+
+    def test_append_to_windows_path(self):
+        dangerous, key, desc = detect_dangerous_command("echo foo >> C:/config.txt")
+        assert dangerous is True
+
+    def test_redirect_to_windows_backslash(self):
+        dangerous, key, desc = detect_dangerous_command(r"> C:\config.txt")
+        assert dangerous is True
+
+    # --- tee dangerous patterns ---
+    def test_tee_to_windows_path(self):
+        dangerous, key, desc = detect_dangerous_command(r"tee C:\windows\system32\file")
+        assert dangerous is True
+
+    def test_tee_to_windows_forward_slash(self):
+        dangerous, key, desc = detect_dangerous_command("echo foo | tee C:/important.txt")
+        assert dangerous is True
+
+    # --- hardline patterns ---
+    def test_hardline_wipe_windows_drive_forward_slash(self):
+        is_hardline, desc = detect_hardline_command("rm -rf X:/")
+        assert is_hardline is True
+        assert desc is not None
+
+    def test_hardline_wipe_windows_drive_backslash(self):
+        is_hardline, desc = detect_hardline_command(r"rm -rf X:\\")
+        assert is_hardline is True
+
+    def test_hardline_unix_root_still_blocks(self):
+        is_hardline, desc = detect_hardline_command("rm -rf /")
+        assert is_hardline is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -143,6 +143,7 @@ _CREDENTIAL_FILES = (
 # /etc/sudoers on macOS but bypasses a plain "/etc/" pattern check. Match
 # both forms. Inspired by Claude Code 2.1.113's "dangerous path protection".
 _MACOS_PRIVATE_SYSTEM_PATH = r'/private/(?:etc|var|tmp|home)/'
+_ROOT_OR_DRIVE_PREFIX = r'(?:[A-Za-z]:[\\\\//]|/)'
 # System-config paths that should trigger approval for any write/edit,
 # collapsing /etc, its macOS /private/etc mirror, and /etc/sudoers.d/ into
 # one shared fragment so new DANGEROUS_PATTERNS stay consistent.
@@ -202,7 +203,7 @@ _CMDPOS = (
 
 HARDLINE_PATTERNS = [
     # rm recursive targeting the root filesystem or protected roots
-    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*)(\s|$)', "recursive delete of root filesystem"),
+    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*|[A-Za-z]:[\\\\//][\\\\//]?)(\s|$)', "recursive delete of root filesystem"),
     (r'\brm\s+(-[^\s]*\s+)*(/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/\*|/var|/var/\*|/bin|/bin/\*|/sbin|/sbin/\*|/boot|/boot/\*|/lib|/lib/\*)(\s|$)', "recursive delete of system directory"),
     (r'\brm\s+(-[^\s]*\s+)*(~|\$HOME)(/?|/\*)?(\s|$)', "recursive delete of home directory"),
     # Filesystem format
@@ -319,7 +320,7 @@ def _sudo_stdin_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
-    (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    (rf'\brm\s+(-[^\s]*\s+)*{_ROOT_OR_DRIVE_PREFIX}', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
@@ -355,7 +356,11 @@ DANGEROUS_PATTERNS = [
     (rf'>>?\s*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via redirection"),
     (rf'\btee\b.*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config via tee"),
     (rf'>>?\s*["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config via redirection"),
-    (r'\bxargs\s+.*\brm\b', "xargs with rm"),
+    # Windows drive-letter paths for redirection/overwrite (issue #38964).
+   # Mirrors the Unix redirection patterns above but for X:/... and X:\\...
+   (rf'>>?\s*["\'\']?{_ROOT_OR_DRIVE_PREFIX}', "overwrite path via redirection"),
+   (rf'\btee\b.*["\'\']?{_ROOT_OR_DRIVE_PREFIX}', "overwrite path via tee"),
+   (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     # find -exec rm / -execdir rm — the -execdir variant (same semantics,
     # runs in the directory of each match) was previously missed. Claude
     # Code 2.1.113 tightened their equivalent find rule to stop auto-


### PR DESCRIPTION
## Problem

Windows drive-letter paths (C:/, C:\\) bypassed ALL dangerous command approval patterns on Windows/git-bash (issue #38964).

## Fix (broader than #38977)

1. `_ROOT_OR_DRIVE_PREFIX` helper for reusable pattern
2. HARDLINE rm pattern updated (X:/, X:\\)
3. DANGEROUS rm pattern via helper
4. `>` / `>>` redirection to Windows paths
5. `tee` to Windows paths
6. 13 regression tests

Fixes #38964