### PR TITLE
fix(kanban): allow assignees in read-only sandboxes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -15,6 +15,7 @@ Exposes the full Kanban command surface documented in the design spec
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import shlex
@@ -41,6 +42,22 @@ _STATUS_ICONS = {
     "done":     "✓",
     "archived": "—",
 }
+
+_READONLY_EXISTING_DB_ACTIONS = {"assignees"}
+
+
+def _is_filesystem_permission_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` or its chain is an OS permission failure."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, PermissionError):
+            return True
+        if isinstance(current, OSError) and current.errno in {errno.EACCES, errno.EPERM}:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def _fmt_ts(ts: Optional[int]) -> str:
@@ -915,6 +932,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         os.environ["HERMES_KANBAN_BOARD"] = normed
         restore_board_env = True
 
+    readonly_existing_db = False
+
     # Auto-initialize the DB before dispatching any subcommand. init_db
     # is idempotent, so running it every invocation is cheap (one
     # SELECT against sqlite_master when tables already exist) and
@@ -925,9 +944,21 @@ def kanban_command(args: argparse.Namespace) -> int:
     try:
         kb.init_db()
     except Exception as exc:
-        print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
-        _restore_board_env()
-        return 1
+        db_exists = False
+        try:
+            db_exists = kb.kanban_db_path().exists()
+        except Exception:
+            db_exists = False
+        if (
+            action in _READONLY_EXISTING_DB_ACTIONS
+            and db_exists
+            and _is_filesystem_permission_error(exc)
+        ):
+            readonly_existing_db = True
+        else:
+            print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
+            _restore_board_env()
+            return 1
 
     handlers = {
         "init":     _cmd_init,
@@ -974,6 +1005,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         print(f"kanban: unknown action {action!r}", file=sys.stderr)
         _restore_board_env()
         return 2
+    if readonly_existing_db:
+        setattr(args, "_kanban_readonly_existing_db", True)
     try:
         return int(handler(args) or 0)
     except (ValueError, RuntimeError) as exc:
@@ -1297,8 +1330,12 @@ def _cmd_heartbeat(args: argparse.Namespace) -> int:
 
 
 def _cmd_assignees(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        data = kb.known_assignees(conn)
+    if getattr(args, "_kanban_readonly_existing_db", False):
+        with kb.connect_readonly_existing_closing() as conn:
+            data = kb.known_assignees(conn)
+    else:
+        with kb.connect_closing() as conn:
+            data = kb.known_assignees(conn)
     if getattr(args, "json", False):
         print(json.dumps(data, indent=2, ensure_ascii=False))
         return 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1157,6 +1157,21 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _sqlite_connect_readonly(path: Path) -> sqlite3.Connection:
+    """Open an existing Kanban SQLite DB without creating lock sidecars."""
+    busy_timeout_ms = _resolve_busy_timeout_ms()
+    uri = path.resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(
+        uri,
+        uri=True,
+        isolation_level=None,
+        timeout=busy_timeout_ms / 1000.0,
+    )
+    conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
 @contextlib.contextmanager
 def _cross_process_init_lock(path: Path):
     """Serialize first-connect WAL/schema/integrity setup across processes.
@@ -1465,6 +1480,37 @@ def connect(
     return conn
 
 
+def connect_readonly_existing(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> sqlite3.Connection:
+    """Open an existing kanban DB for read-only commands without init locks.
+
+    This is a degraded path for sandboxed/read-only environments. Normal
+    ``connect()`` remains the canonical entry point because it validates,
+    initializes, migrates, enables WAL, and runs integrity checks. Some
+    read-only command surfaces, however, are useful even when the caller can
+    read ``kanban.db`` but cannot create ``kanban.db.init.lock``. This helper
+    deliberately refuses to create or migrate anything.
+    """
+    if db_path is not None:
+        path = db_path
+    else:
+        path = kanban_db_path(board=board)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    _validate_sqlite_header(path)
+    conn = _sqlite_connect_readonly(path)
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
 @contextlib.contextmanager
 def connect_closing(
     db_path: Optional[Path] = None,
@@ -1491,6 +1537,23 @@ def connect_closing(
     callers) continue to work.
     """
     conn = connect(db_path=db_path, board=board)
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+@contextlib.contextmanager
+def connect_readonly_existing_closing(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+):
+    """Open an existing read-only kanban DB and close it on exit."""
+    conn = connect_readonly_existing(db_path=db_path, board=board)
     try:
         yield conn
     finally:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -166,6 +166,25 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_assignees_falls_back_when_init_lock_is_not_writable(kanban_home):
+    kc.run_slash("create 'sandboxed task' --assignee alice")
+    lock_path = kb.kanban_db_path().with_name(kb.kanban_db_path().name + ".init.lock")
+    lock_path.touch()
+    lock_path.chmod(0o400)
+    try:
+        out = kc.run_slash("assignees")
+    finally:
+        lock_path.chmod(0o600)
+
+    assert "alice" in out
+    assert "ready=1" in out
+
+
+def test_kanban_init_fallback_guard_is_permission_scoped():
+    assert kc._is_filesystem_permission_error(PermissionError("no write"))
+    assert not kc._is_filesystem_permission_error(RuntimeError("schema failed"))
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")


### PR DESCRIPTION
## Summary
- add an existing-DB read-only Kanban connection path that skips init-lock sidecars
- let `hermes kanban assignees` fall back to that path when normal DB init fails from a filesystem permission error and the board DB already exists
- keep normal init/migration/integrity behavior for every mutating command and for non-permission DB failures
- cover the sandbox regression where `kanban.db.init.lock` is not writable

## Why this matters
Hermes Kanban is often inspected from restricted agents, read-only automation, CI diagnostics, or sandboxed coding assistants. In those environments the caller may be allowed to read `kanban.db` but not create or open `kanban.db.init.lock` beside it. Today, even a read-only command such as `hermes kanban assignees` runs the full init path before dispatch and fails before it can print useful board state.

That failure is especially painful during incident/debug workflows: the board exists, the tasks are readable, and the operator only needs assignee/task counts, but the command exits early because the sandbox cannot write the init-lock sidecar. The fallback in this PR makes that read-only inspection path work without weakening the normal writer path.

## Scenarios covered
- A sandboxed coding agent needs to inspect Kanban assignee load but has read-only access to `~/.hermes/kanban/.../kanban.db`.
- CI or support diagnostics collect board state from an existing DB without permission to create lock files next to it.
- A user runs a read-only command against a board directory mounted as read-mostly, where SQLite contents are readable but new sidecar files are denied.
- Normal local Hermes usage continues to initialize, migrate, check, and use WAL through the existing `connect()` path.
- Corrupt DB, schema, SQLite, and other non-permission init failures still fail closed instead of being masked as read-only fallback.

## Verification
- `/Users/gavinnlp/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_cli.py -q` -> 48 passed
- `/Users/gavinnlp/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_db_init.py -q` -> 216 passed
- `/Users/gavinnlp/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_cli.py` -> All checks passed