### PR TITLE
fix(delegate): scope HERMES_SESSION_ID to subagent env instead of mutating parent (#37356)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1259,12 +1259,17 @@ def init_agent(
     # reference their own session for --resume commands, cross-session
     # coordination, and logging. Keep the ContextVar and os.environ
     # fallback synchronized because different tool paths still read both.
+    # Subagents skip the os.environ write so they don't clobber the parent's
+    # process-global HERMES_SESSION_ID; the ContextVar update is sufficient
+    # because subagent tool calls run in the same async task context.
+    _is_subagent = bool(parent_session_id)
     try:
         from gateway.session_context import set_current_session_id
 
-        set_current_session_id(agent.session_id)
+        set_current_session_id(agent.session_id, update_environ=not _is_subagent)
     except Exception:
-        os.environ["HERMES_SESSION_ID"] = agent.session_id
+        if not _is_subagent:
+            os.environ["HERMES_SESSION_ID"] = agent.session_id
 
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
     hermes_home = get_hermes_home()

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1259,16 +1259,12 @@ def init_agent(
     # reference their own session for --resume commands, cross-session
     # coordination, and logging. Keep the ContextVar and os.environ
     # fallback synchronized because different tool paths still read both.
-    # Subagents skip the os.environ write so they don't clobber the parent's
-    # process-global HERMES_SESSION_ID; the ContextVar update is sufficient
-    # because subagent tool calls run in the same async task context.
-    _is_subagent = bool(parent_session_id)
-    try:
-        from gateway.session_context import set_current_session_id
+    if parent_session_id is None:
+        try:
+            from gateway.session_context import set_current_session_id
 
-        set_current_session_id(agent.session_id, update_environ=not _is_subagent)
-    except Exception:
-        if not _is_subagent:
+            set_current_session_id(agent.session_id)
+        except Exception:
             os.environ["HERMES_SESSION_ID"] = agent.session_id
 
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -873,9 +873,13 @@ def compress_context(
                     try:
                         from gateway.session_context import set_current_session_id
 
-                        set_current_session_id(agent.session_id)
+                        set_current_session_id(
+                            agent.session_id,
+                            update_environ=not bool(getattr(agent, "_parent_session_id", None)),
+                        )
                     except Exception:
-                        os.environ["HERMES_SESSION_ID"] = agent.session_id
+                        if not getattr(agent, "_parent_session_id", None):
+                            os.environ["HERMES_SESSION_ID"] = agent.session_id
                     # The gateway/tools session context (ContextVar + env) and the
                     # logging session context are SEPARATE mechanisms. The call above
                     # moves the former; the ``[session_id]`` tag on log lines comes
@@ -918,9 +922,13 @@ def compress_context(
                         agent.session_id = old_session_id
                         try:
                             from gateway.session_context import set_current_session_id
-                            set_current_session_id(agent.session_id)
+                            set_current_session_id(
+                                agent.session_id,
+                                update_environ=not bool(getattr(agent, "_parent_session_id", None)),
+                            )
                         except Exception:
-                            os.environ["HERMES_SESSION_ID"] = agent.session_id
+                            if not getattr(agent, "_parent_session_id", None):
+                                os.environ["HERMES_SESSION_ID"] = agent.session_id
                         try:
                             from hermes_logging import set_session_context
                             set_session_context(agent.session_id)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -139,7 +139,7 @@ _VAR_MAP = {
 }
 
 
-def set_current_session_id(session_id: str, *, update_environ: bool = True) -> None:
+def set_current_session_id(session_id: str, *, update_environ: bool = True):
     """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ``.
 
     Long-lived single-process entrypoints like the CLI can rotate sessions via
@@ -151,10 +151,16 @@ def set_current_session_id(session_id: str, *, update_environ: bool = True) -> N
     When *update_environ* is False, only the task-local ContextVar is updated.
     Subagents use this to avoid clobbering the parent's process-global env.
     """
-    _SESSION_ID.set(session_id)
+    token = _SESSION_ID.set(session_id)
     if update_environ:
         import os
         os.environ["HERMES_SESSION_ID"] = session_id
+    return token
+
+
+def reset_current_session_id(token) -> None:
+    """Restore the previous task-local session ID."""
+    _SESSION_ID.reset(token)
 
 
 def set_session_vars(

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -139,7 +139,7 @@ _VAR_MAP = {
 }
 
 
-def set_current_session_id(session_id: str) -> None:
+def set_current_session_id(session_id: str, *, update_environ: bool = True) -> None:
     """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ``.
 
     Long-lived single-process entrypoints like the CLI can rotate sessions via
@@ -147,11 +147,14 @@ def set_current_session_id(session_id: str) -> None:
     reconstructing the entire agent. Tools still consult
     ``get_session_env("HERMES_SESSION_ID")`` with an ``os.environ`` fallback,
     so both storage paths must move together when the active session changes.
-    """
-    import os
 
-    os.environ["HERMES_SESSION_ID"] = session_id
+    When *update_environ* is False, only the task-local ContextVar is updated.
+    Subagents use this to avoid clobbering the parent's process-global env.
+    """
     _SESSION_ID.set(session_id)
+    if update_environ:
+        import os
+        os.environ["HERMES_SESSION_ID"] = session_id
 
 
 def set_session_vars(

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -835,10 +835,15 @@ class TestSubagentSessionEnvPreservation:
     session ID that tools and the CLI rely on for cross-session coordination.
     """
 
-    def test_init_agent_subagent_preserves_parent_environ(self):
+    def test_init_agent_subagent_preserves_parent_session(self):
         from run_agent import AIAgent
+        from gateway.session_context import (
+            get_session_env,
+            reset_current_session_id,
+            set_current_session_id,
+        )
 
-        os.environ["HERMES_SESSION_ID"] = "parent-session"
+        session_token = set_current_session_id("parent-session")
         try:
             AIAgent(
                 api_key="test-key",
@@ -851,5 +856,7 @@ class TestSubagentSessionEnvPreservation:
             assert os.environ.get("HERMES_SESSION_ID") == "parent-session", (
                 "init_agent must not overwrite HERMES_SESSION_ID when parent_session_id is set"
             )
+            assert get_session_env("HERMES_SESSION_ID") == "parent-session"
         finally:
             os.environ.pop("HERMES_SESSION_ID", None)
+            reset_current_session_id(session_token)

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -824,3 +824,32 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestSubagentSessionEnvPreservation:
+    """init_agent must not clobber the parent's HERMES_SESSION_ID when called
+    as a subagent (parent_session_id set).
+
+    Regression: before the fix, every child AIAgent.__init__ wrote its own
+    session_id into os.environ["HERMES_SESSION_ID"], overwriting the parent
+    session ID that tools and the CLI rely on for cross-session coordination.
+    """
+
+    def test_init_agent_subagent_preserves_parent_environ(self):
+        from run_agent import AIAgent
+
+        os.environ["HERMES_SESSION_ID"] = "parent-session"
+        try:
+            AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                parent_session_id="parent-session",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert os.environ.get("HERMES_SESSION_ID") == "parent-session", (
+                "init_agent must not overwrite HERMES_SESSION_ID when parent_session_id is set"
+            )
+        finally:
+            os.environ.pop("HERMES_SESSION_ID", None)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3155,5 +3155,44 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestSubagentSessionEnvIsolation(unittest.TestCase):
+    """Subagent init must not clobber the parent's HERMES_SESSION_ID env var.
+
+    Regression: before the fix, every child AIAgent.__init__ called
+    set_current_session_id(child_session_id) which overwrote the process-global
+    os.environ["HERMES_SESSION_ID"] with the child's ID. The parent's tools
+    (and any code reading the env var after delegation) then saw the child's
+    session ID instead of the original parent session.
+    """
+
+    def test_subagent_does_not_clobber_parent_environ(self):
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "parent-session-abc"
+
+        os.environ["HERMES_SESSION_ID"] = "parent-original"
+        try:
+            with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+                 patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_child = MagicMock()
+                mock_child.session_id = "child-session-xyz"
+                mock_build.return_value = mock_child
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "done",
+                    "api_calls": 1,
+                    "duration_seconds": 0.5,
+                }
+                delegate_task(goal="isolation test", parent_agent=parent)
+
+            self.assertEqual(
+                os.environ.get("HERMES_SESSION_ID"),
+                "parent-original",
+                "delegate_task must not overwrite the parent's HERMES_SESSION_ID",
+            )
+        finally:
+            os.environ.pop("HERMES_SESSION_ID", None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,10 +11,12 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -35,6 +37,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
+    _run_single_child,
 )
 
 
@@ -59,6 +62,44 @@ def _make_mock_parent(depth=0):
     parent.tool_progress_callback = None
     parent.thinking_callback = None
     return parent
+
+
+def _make_real_child(session_root: Path, session_id: str):
+    from hermes_state import SessionDB
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        db = SessionDB(db_path=session_root / "state.db")
+        db.create_session(session_id, source="cli", model="test/model")
+        child = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "assistant", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_summary_auth_failure = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    child.context_compressor = compressor
+    child._compression_feasibility_checked = True
+    child.compression_in_place = False
+    return child, db
 
 
 class TestDelegateRequirements(unittest.TestCase):
@@ -3156,42 +3197,168 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
 
 class TestSubagentSessionEnvIsolation(unittest.TestCase):
-    """Subagent init must not clobber the parent's HERMES_SESSION_ID env var.
+    """Child session context is scoped to the execution worker."""
 
-    Regression: before the fix, every child AIAgent.__init__ called
-    set_current_session_id(child_session_id) which overwrote the process-global
-    os.environ["HERMES_SESSION_ID"] with the child's ID. The parent's tools
-    (and any code reading the env var after delegation) then saw the child's
-    session ID instead of the original parent session.
-    """
-
-    def test_subagent_does_not_clobber_parent_environ(self):
+    def test_child_worker_binds_session_and_restores_parent(self):
         parent = _make_mock_parent(depth=0)
         parent.session_id = "parent-session-abc"
+        from gateway.session_context import get_session_env, set_current_session_id
+        from tools.environments.local import _make_run_env
 
-        os.environ["HERMES_SESSION_ID"] = "parent-original"
+        parent_token = set_current_session_id("parent-session-abc")
         try:
-            with patch("tools.delegate_tool._build_child_agent") as mock_build, \
-                 patch("tools.delegate_tool._run_single_child") as mock_run:
-                mock_child = MagicMock()
-                mock_child.session_id = "child-session-xyz"
-                mock_build.return_value = mock_child
-                mock_run.return_value = {
-                    "task_index": 0,
-                    "status": "completed",
-                    "summary": "done",
-                    "api_calls": 1,
-                    "duration_seconds": 0.5,
-                }
-                delegate_task(goal="isolation test", parent_agent=parent)
+            child = MagicMock()
+            child.session_id = "child-session-xyz"
+            child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+            observed = {}
 
-            self.assertEqual(
-                os.environ.get("HERMES_SESSION_ID"),
-                "parent-original",
-                "delegate_task must not overwrite the parent's HERMES_SESSION_ID",
-            )
+            def run_child(**_kwargs):
+                observed["session"] = get_session_env("HERMES_SESSION_ID")
+                observed["subprocess"] = _make_run_env({})["HERMES_SESSION_ID"]
+                return child.run_conversation.return_value
+
+            child.run_conversation.side_effect = run_child
+            result = _run_single_child(0, "isolation test", child, parent)
+
+            self.assertEqual(result["status"], "completed")
+            self.assertEqual(observed, {
+                "session": child.session_id,
+                "subprocess": child.session_id,
+            })
+            self.assertEqual(get_session_env("HERMES_SESSION_ID"), parent.session_id)
+            self.assertEqual(os.environ["HERMES_SESSION_ID"], parent.session_id)
         finally:
             os.environ.pop("HERMES_SESSION_ID", None)
+            from gateway.session_context import reset_current_session_id
+            reset_current_session_id(parent_token)
+
+    def test_child_worker_resets_session_after_failure(self):
+        from gateway import session_context
+
+        parent_token = session_context.set_current_session_id("parent-session-abc")
+        child = MagicMock()
+        child.session_id = "child-session-xyz"
+        child.run_conversation.side_effect = RuntimeError("boom")
+        reset = session_context.reset_current_session_id
+
+        with patch.object(session_context, "reset_current_session_id", wraps=reset) as spy:
+            result = _run_single_child(0, "failure", child, _make_mock_parent())
+
+        self.assertEqual(result["status"], "error")
+        spy.assert_called_once()
+        os.environ.pop("HERMES_SESSION_ID", None)
+        session_context.reset_current_session_id(parent_token)
+
+    def test_child_session_rotation_keeps_parent_environ(self):
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "parent-session-abc"
+        from gateway.session_context import get_session_env, set_current_session_id
+        from tools.environments.local import _make_run_env
+
+        with tempfile.TemporaryDirectory() as tmp:
+            child, db = _make_real_child(Path(tmp), "child-session-xyz")
+            parent_token = set_current_session_id("parent-session-abc")
+            try:
+                child._parent_session_id = parent.session_id
+                observed = {}
+
+                def run_child(**_kwargs):
+                    child._compress_context(
+                        [{"role": "user", "content": f"m{i}"} for i in range(20)],
+                        "sys",
+                        approx_tokens=120_000,
+                    )
+                    observed["session"] = get_session_env("HERMES_SESSION_ID")
+                    observed["subprocess"] = _make_run_env({})["HERMES_SESSION_ID"]
+                    observed["environ"] = os.environ["HERMES_SESSION_ID"]
+                    observed["child"] = child.session_id
+                    return {
+                        "final_response": "done",
+                        "completed": True,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                child.run_conversation = run_child
+                result = _run_single_child(0, "compression rotation", child, parent)
+
+                self.assertEqual(result["status"], "completed")
+                self.assertNotEqual(child.session_id, "child-session-xyz")
+                self.assertEqual(observed, {
+                    "session": child.session_id,
+                    "subprocess": child.session_id,
+                    "environ": parent.session_id,
+                    "child": child.session_id,
+                })
+                self.assertEqual(get_session_env("HERMES_SESSION_ID"), parent.session_id)
+                self.assertEqual(os.environ["HERMES_SESSION_ID"], parent.session_id)
+            finally:
+                child.close()
+                db.close()
+                os.environ.pop("HERMES_SESSION_ID", None)
+                from gateway.session_context import reset_current_session_id
+                reset_current_session_id(parent_token)
+
+    def test_child_compression_rollback_keeps_parent_environ(self):
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "parent-session-abc"
+        from gateway.session_context import get_session_env, set_current_session_id
+        from tools.environments.local import _make_run_env
+
+        with tempfile.TemporaryDirectory() as tmp:
+            child, db = _make_real_child(Path(tmp), "child-session-xyz")
+            parent_token = set_current_session_id("parent-session-abc")
+            try:
+                child._parent_session_id = parent.session_id
+                observed = {}
+
+                def run_child(**_kwargs):
+                    with patch.object(
+                        db,
+                        "create_session",
+                        side_effect=RuntimeError("FOREIGN KEY constraint failed"),
+                    ):
+                        child._compress_context(
+                            [{"role": "user", "content": f"m{i}"} for i in range(20)],
+                            "sys",
+                            approx_tokens=120_000,
+                        )
+                    observed["session"] = get_session_env("HERMES_SESSION_ID")
+                    observed["subprocess"] = _make_run_env({})["HERMES_SESSION_ID"]
+                    observed["environ"] = os.environ["HERMES_SESSION_ID"]
+                    observed["child"] = child.session_id
+                    return {
+                        "final_response": "done",
+                        "completed": True,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                child.run_conversation = run_child
+                result = _run_single_child(0, "compression rollback", child, parent)
+
+                self.assertEqual(result["status"], "completed")
+                self.assertEqual(child.session_id, "child-session-xyz")
+                self.assertEqual(observed, {
+                    "session": child.session_id,
+                    "subprocess": child.session_id,
+                    "environ": parent.session_id,
+                    "child": child.session_id,
+                })
+                self.assertIsNotNone(db.get_session("child-session-xyz"))
+                self.assertEqual(get_session_env("HERMES_SESSION_ID"), parent.session_id)
+                self.assertEqual(os.environ["HERMES_SESSION_ID"], parent.session_id)
+            finally:
+                child.close()
+                db.close()
+                os.environ.pop("HERMES_SESSION_ID", None)
+                from gateway.session_context import reset_current_session_id
+                reset_current_session_id(parent_token)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -43,6 +43,7 @@ class _StubChild:
         tool_schema=None,
     ):
         self._subagent_id = subagent_id
+        self.session_id = subagent_id
         self._delegate_depth = 1
         self._delegate_role = "leaf"
         self.model = "test/model"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1945,11 +1945,22 @@ def _run_single_child(
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
-            return child.run_conversation(
-                user_message=goal,
-                task_id=child_task_id,
-                stream_callback=_relay_child_text,
+            from gateway.session_context import (
+                reset_current_session_id,
+                set_current_session_id,
             )
+
+            session_token = set_current_session_id(
+                child.session_id, update_environ=False
+            )
+            try:
+                return child.run_conversation(
+                    user_message=goal,
+                    task_id=child_task_id,
+                    stream_callback=_relay_child_text,
+                )
+            finally:
+                reset_current_session_id(session_token)
 
         _child_future = _timeout_executor.submit(_run_with_thread_capture)
         try:


### PR DESCRIPTION
## Summary

`delegate_task` subagents cross three different session-context scopes:

- child construction on the parent thread,
- child execution on the timeout worker,
- child compression rotation or rollback inside that worker.

The original patch only stopped the constructor from overwriting `os.environ["HERMES_SESSION_ID"]`. It still rebound the parent's task-local ContextVar during child construction, and the real compression rotation or rollback path could still repopulate the child session into the worker's process-environment write path. That left the parent thread and the child worker disagreeing about who owned the live session binding.

This version makes session ownership explicit by scope. Top-level agent construction still synchronizes both the ContextVar and `os.environ`. Child construction leaves the caller thread untouched. The delegate worker binds `child.session_id` immediately around `child.run_conversation` and restores the previous token in `finally`. Compression rotation and rollback keep updating the child worker's ContextVar, but skip process-environment writes for delegated children so the parent process environment remains stable while child subprocesses still inherit the active child session id through `_make_run_env()`.

Fixes #37356

## Changes

- `gateway/session_context.py`: return the ContextVar token from `set_current_session_id()`, add `reset_current_session_id(token)`, and keep `update_environ` as the switch for process-environment writes
- `agent/agent_init.py`: treat `parent_session_id` as a child-construction signal and avoid mutating the caller's ContextVar or `os.environ` in that path
- `tools/delegate_tool.py`: bind `child.session_id` inside `_run_with_thread_capture()` and restore the prior token in `finally`
- `agent/conversation_compression.py`: on delegated-child rotation and rollback, update the worker ContextVar but skip process-environment writes so the parent process environment stays on the parent session
- `tests/cli/test_cli_init.py`: assert subagent initialization preserves the parent session in both the caller ContextVar and `os.environ`
- `tests/tools/test_delegate.py`: cover worker binding, worker reset on failure, and real delegated compression rotation and rollback through `_run_single_child()` with a real `SessionDB`

## Validation

| Scenario | Before | After |
|---|---|---|
| Child construction on parent thread | rebinding could replace the parent's task-local session | caller ContextVar and `os.environ` stay on the parent |
| Child execution on worker thread | worker started from a fresh context, so constructor-time binding did not carry over | worker binds `child.session_id` only for the execution window |
| Child subprocesses during execution | inherited whichever process-global value happened to be live | `_make_run_env()` derives the active child session id from the worker ContextVar |
| Child compression rotation | delegated child could write its rotated session id back toward the process environment | worker ContextVar rotates, process environment stays on the parent |
| Child compression rollback after failed child-session create | rollback path could still touch delegated-child environment state | rollback restores the child worker session while keeping the parent process environment unchanged |
| Parent state after child success or failure | parent thread could be left with child session state | worker reset restores the prior parent binding |

## Test plan

- `pytest tests/tools/test_delegate.py -v --timeout=0` — 148 passed
- `pytest tests/cli/test_cli_init.py -v --timeout=0` — 54 passed

## Not in scope

Replacing every direct `os.environ["HERMES_SESSION_ID"]` read with `get_session_env("HERMES_SESSION_ID")`. This PR keeps delegated-child session ownership correct with the current environment bridge. Wider cleanup of legacy readers is separate work.
