### PR TITLE
fix(gateway): pass encoding="utf-8" to read_text/write_text in update path (#37423)

### DIFF
--- a/gateway/dead_targets.py
+++ b/gateway/dead_targets.py
@@ -67,7 +67,7 @@ class DeadTargetRegistry:
     def _load(self) -> None:
         try:
             if self._path.exists():
-                raw = json.loads(self._path.read_text())
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
                 if isinstance(raw, dict):
                     # Only keep well-shaped entries.
                     self._dead = {
@@ -82,7 +82,7 @@ class DeadTargetRegistry:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-            tmp.write_text(json.dumps(self._dead, indent=2))
+            tmp.write_text(json.dumps(self._dead, indent=2), encoding="utf-8")
             tmp.replace(self._path)
         except OSError as exc:
             # Best-effort: keep the in-memory state, don't break delivery.

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -357,7 +357,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        output_path.write_text("\n".join(lines), encoding="utf-8")
         
         return {
             "path": str(output_path),
@@ -370,7 +370,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         return path
 
     def _filter_silence_narration_enabled(self) -> bool:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1193,7 +1193,7 @@ class QQAdapter(BasePlatformAdapter):
             home = get_hermes_home()
             response_path = home / ".update_response"
             tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer)
+            tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
             logger.info(
                 "QQ update prompt answered %r by %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3177,7 +3177,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
-            data = json.loads(self._VOICE_MODE_PATH.read_text())
+            data = json.loads(self._VOICE_MODE_PATH.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return {}
 
@@ -3205,7 +3205,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             self._VOICE_MODE_PATH.parent.mkdir(parents=True, exist_ok=True)
             self._VOICE_MODE_PATH.write_text(
-                json.dumps(self._voice_mode, indent=2)
+                json.dumps(self._voice_mode, indent=2), encoding="utf-8"
             )
         except OSError as e:
             logger.warning("Failed to save voice modes: %s", e)
@@ -5923,7 +5923,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         path = _hermes_home / self._STUCK_LOOP_FILE
         try:
-            counts = json.loads(path.read_text()) if path.exists() else {}
+            counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
         except Exception:
             counts = {}
 
@@ -5953,7 +5953,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return 0
 
         try:
-            counts = json.loads(path.read_text())
+            counts = json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             return 0
 
@@ -5999,7 +5999,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not path.exists():
             return
         try:
-            counts = json.loads(path.read_text())
+            counts = json.loads(path.read_text(encoding="utf-8"))
             if session_key in counts:
                 del counts[session_key]
                 if counts:
@@ -8832,7 +8832,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
+                    tmp.write_text(response_text, encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                 except OSError as e:
@@ -8852,7 +8852,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text("")
+                    tmp.write_text("", encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                     logger.info(
@@ -12184,7 +12184,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._booted_from_restart = False
                     return True
                 return False
-            data = json.loads(marker_path.read_text())
+            data = json.loads(marker_path.read_text(encoding="utf-8"))
         except Exception:
             return False
 
@@ -14019,7 +14019,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for path in (claimed_path, pending_path):
             if path.exists():
                 try:
-                    pending = json.loads(path.read_text())
+                    pending = json.loads(path.read_text(encoding="utf-8"))
                     platform_str = pending.get("platform")
                     chat_id = pending.get("chat_id")
                     chat_type = pending.get("chat_type")
@@ -14058,7 +14058,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 await asyncio.sleep(poll_interval)
             if (pending_path.exists() or claimed_path.exists()) and not exit_code_path.exists():
-                exit_code_path.write_text("124")
+                exit_code_path.write_text("124", encoding="utf-8")
                 await self._send_update_notification()
             return
 
@@ -14100,7 +14100,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Read any remaining output
                 if output_path.exists():
                     try:
-                        content = output_path.read_text()
+                        content = output_path.read_text(encoding="utf-8")
                         if len(content) > bytes_sent:
                             buffer += content[bytes_sent:]
                             bytes_sent = len(content)
@@ -14110,7 +14110,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 # Send final status
                 try:
-                    exit_code_raw = exit_code_path.read_text().strip() or "1"
+                    exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
                     exit_code = int(exit_code_raw)
                     if exit_code == 0:
                         await adapter.send(
@@ -14139,7 +14139,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check for new output
             if output_path.exists():
                 try:
-                    content = output_path.read_text()
+                    content = output_path.read_text(encoding="utf-8")
                     if len(content) > bytes_sent:
                         buffer += content[bytes_sent:]
                         bytes_sent = len(content)
@@ -14157,7 +14157,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (prompt_path.exists() and session_key
                     and not self._update_prompt_pending.get(session_key)):
                 try:
-                    prompt_data = json.loads(prompt_path.read_text())
+                    prompt_data = json.loads(prompt_path.read_text(encoding="utf-8"))
                     prompt_text = prompt_data.get("prompt", "")
                     default = prompt_data.get("default", "")
                     if prompt_text:
@@ -14205,7 +14205,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Timeout
         if not exit_code_path.exists():
             logger.warning("Update watcher timed out after %.0fs", timeout)
-            exit_code_path.write_text("124")
+            exit_code_path.write_text("124", encoding="utf-8")
             await _flush_buffer()
             try:
                 await adapter.send(
@@ -14251,7 +14251,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif not claimed_path.exists():
                 return True
 
-            pending = json.loads(claimed_path.read_text())
+            pending = json.loads(claimed_path.read_text(encoding="utf-8"))
             platform_str = pending.get("platform")
             chat_id = pending.get("chat_id")
             chat_type = pending.get("chat_type")
@@ -14265,13 +14265,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 claimed_path.replace(pending_path)
                 return False
 
-            exit_code_raw = exit_code_path.read_text().strip() or "1"
+            exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
             exit_code = int(exit_code_raw)
 
             # Read the captured update output
             output = ""
             if output_path.exists():
-                output = output_path.read_text()
+                output = output_path.read_text(encoding="utf-8")
 
             # Resolve adapter
             platform = Platform(platform_str)
@@ -14346,7 +14346,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
 
         try:
-            data = json.loads(notify_path.read_text())
+            data = json.loads(notify_path.read_text(encoding="utf-8"))
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
             chat_type = data.get("chat_type")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4523,7 +4523,7 @@ class GatewaySlashCommandsMixin:
         if event.message_id:
             pending["message_id"] = event.message_id
         _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending))
+        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
         _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -444,7 +444,7 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
         return None
 
     try:
-        raw = pid_path.read_text().strip()
+        raw = pid_path.read_text(encoding="utf-8").strip()
     except (OSError, UnicodeDecodeError):
         # File was deleted between exists() and read_text(), permission
         # flipped, or it holds non-UTF-8 / binary garbage.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6804,7 +6804,7 @@ def _define_discord_view_classes() -> None:
                 home = get_hermes_home()
                 response_path = home / ".update_response"
                 tmp = response_path.with_suffix(".tmp")
-                tmp.write_text(answer)
+                tmp.write_text(answer, encoding="utf-8")
                 tmp.replace(response_path)
                 logger.info(
                     "Discord update prompt answered '%s' by %s",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2152,7 +2152,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _write_update_prompt_response(answer: str) -> None:
         response_path = get_hermes_home() / ".update_response"
         tmp_path = response_path.with_suffix(".tmp")
-        tmp_path.write_text(answer)
+        tmp_path.write_text(answer, encoding="utf-8")
         tmp_path.replace(response_path)
 
     async def send_voice(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5565,7 +5565,7 @@ class TelegramAdapter(BasePlatformAdapter):
             home = get_hermes_home()
             response_path = home / ".update_response"
             tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer)
+            tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
             logger.info("Telegram update prompt answered '%s' by user %s",
                         answer, getattr(query.from_user, "id", "unknown"))

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -166,7 +166,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
     try:
         # Format: line 1 = pid, optional line 2 = kernel start time. Legacy
         # files written before the guard existed have only the pid.
-        lines = pid_file.read_text().split("\n")
+        lines = pid_file.read_text(encoding="utf-8").split("\n")
         pid = int(lines[0].strip())
         if len(lines) > 1 and lines[1].strip():
             recorded_start = int(lines[1].strip())
@@ -207,7 +207,7 @@ def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
         from gateway.status import get_process_start_time
         start = get_process_start_time(pid)
         text = str(pid) if start is None else "{}\n{}".format(pid, start)
-        (session_path / "bridge.pid").write_text(text)
+        (session_path / "bridge.pid").write_text(text, encoding="utf-8")
     except OSError:
         pass
 
@@ -530,7 +530,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             _deps_fresh = False
             if (bridge_dir / "node_modules").exists():
                 try:
-                    _deps_fresh = (_dep_stamp.read_text().strip() == _pkg_hash) and bool(_pkg_hash)
+                    _deps_fresh = (
+                        _dep_stamp.read_text(encoding="utf-8").strip() == _pkg_hash
+                    ) and bool(_pkg_hash)
                 except OSError:
                     _deps_fresh = False
             if not _deps_fresh:
@@ -556,7 +558,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}] Dependencies installed")
                     if _pkg_hash:
                         try:
-                            _dep_stamp.write_text(_pkg_hash)
+                            _dep_stamp.write_text(_pkg_hash, encoding="utf-8")
                         except OSError:
                             pass  # Stamp is an optimization; install still succeeded
                 except Exception as e:

--- a/tests/gateway/test_gateway_utf8_encoding.py
+++ b/tests/gateway/test_gateway_utf8_encoding.py
@@ -1,6 +1,7 @@
-"""Static guard: every ``read_text`` / ``write_text`` call under ``gateway/``
-must pass an explicit ``encoding=`` keyword argument so non-UTF-8 Windows
-locales don't corrupt file IPC.  Mirrors the AST-based guard pattern in
+"""Static guard: every ``read_text`` / ``write_text`` call in the gateway and
+bundled update-response adapters must pass an explicit ``encoding=`` keyword
+argument so non-UTF-8 Windows locales don't corrupt file IPC.  Mirrors the
+AST-based guard pattern in
 ``tests/tools/test_windows_compat.py``.
 """
 
@@ -8,14 +9,21 @@ import ast
 import pathlib
 import pytest
 
-GATEWAY_DIR = pathlib.Path(__file__).resolve().parents[2] / "gateway"
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+GATEWAY_DIR = REPO_ROOT / "gateway"
+UPDATE_RESPONSE_FILES = (
+    REPO_ROOT / "plugins/platforms/discord/adapter.py",
+    REPO_ROOT / "plugins/platforms/telegram/adapter.py",
+    REPO_ROOT / "plugins/platforms/feishu/adapter.py",
+)
 METHODS = {"read_text", "write_text"}
 SUPPRESSION = "# gateway-utf8: ok"
 
 
 def _find_violations():
     violations = []
-    for py_file in sorted(GATEWAY_DIR.rglob("*.py")):
+    py_files = list(GATEWAY_DIR.rglob("*.py")) + list(UPDATE_RESPONSE_FILES)
+    for py_file in sorted(py_files):
         source = py_file.read_text(encoding="utf-8")
         source_lines = source.splitlines()
         try:
@@ -35,7 +43,7 @@ def _find_violations():
             lineno = node.lineno
             if lineno <= len(source_lines) and SUPPRESSION in source_lines[lineno - 1]:
                 continue
-            rel = py_file.relative_to(GATEWAY_DIR.parent)
+            rel = py_file.relative_to(REPO_ROOT)
             violations.append(f"{rel}:{lineno}")
     return violations
 

--- a/tests/gateway/test_gateway_utf8_encoding.py
+++ b/tests/gateway/test_gateway_utf8_encoding.py
@@ -1,0 +1,49 @@
+"""Static guard: every ``read_text`` / ``write_text`` call under ``gateway/``
+must pass an explicit ``encoding=`` keyword argument so non-UTF-8 Windows
+locales don't corrupt file IPC.  Mirrors the AST-based guard pattern in
+``tests/tools/test_windows_compat.py``.
+"""
+
+import ast
+import pathlib
+import pytest
+
+GATEWAY_DIR = pathlib.Path(__file__).resolve().parents[2] / "gateway"
+METHODS = {"read_text", "write_text"}
+SUPPRESSION = "# gateway-utf8: ok"
+
+
+def _find_violations():
+    violations = []
+    for py_file in sorted(GATEWAY_DIR.rglob("*.py")):
+        source = py_file.read_text(encoding="utf-8")
+        source_lines = source.splitlines()
+        try:
+            tree = ast.parse(source, filename=str(py_file))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr not in METHODS:
+                continue
+            if any(kw.arg == "encoding" for kw in node.keywords):
+                continue
+            lineno = node.lineno
+            if lineno <= len(source_lines) and SUPPRESSION in source_lines[lineno - 1]:
+                continue
+            rel = py_file.relative_to(GATEWAY_DIR.parent)
+            violations.append(f"{rel}:{lineno}")
+    return violations
+
+
+def test_all_read_write_text_pass_encoding():
+    violations = _find_violations()
+    assert not violations, (
+        "Bare read_text()/write_text() calls found (missing encoding= kwarg).\n"
+        "Add encoding=\"utf-8\" or suppress with '# gateway-utf8: ok':\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )


### PR DESCRIPTION
## Summary

On native Windows with a non-UTF-8 locale such as cp1252 or GBK, the gateway update flow could crash or corrupt file-based IPC. Several gateway code paths still used bare `Path.read_text()` or `Path.write_text()` calls for update response files, pending-session JSON, exit codes, captured subprocess output, prompt JSON, PID files, and small restart or state markers. Python defaults those calls to the active locale codec instead of UTF-8, which can raise `UnicodeEncodeError` when writing emoji or CJK input, `UnicodeDecodeError` when reading UTF-8 subprocess output, or silently mojibake the payload.

This branch keeps the original fix intent on current `main`: every remaining gateway `read_text()` and `write_text()` call in the update path now passes `encoding="utf-8"` explicitly, and the regression guard enforces that invariant across `gateway/`. The maintainer follow-up on this PR found one bundled sibling outside `gateway/`: the Discord update-response writer still used a bare `write_text()`, and the AST guard only scanned `gateway/`, so it could not detect that omission. This rework adds the missing Discord encoding and extends the guard to the bundled Discord, Telegram, and Feishu `.update_response` adapters alongside the recursive gateway tree.

Fixes #37423

## Changes

- `gateway/run.py`: add `encoding="utf-8"` to update-path and gateway-state `read_text()` / `write_text()` calls
- `gateway/slash_commands.py`: add `encoding="utf-8"` to the `/update` pending-session marker write
- `gateway/delivery.py`: add `encoding="utf-8"` to delivery output writes
- `gateway/dead_targets.py`: add `encoding="utf-8"` to dead-target registry text I/O
- `gateway/status.py`: add `encoding="utf-8"` to the PID record read
- `gateway/platforms/qqbot/adapter.py`: add `encoding="utf-8"` to the update-prompt answer write
- `plugins/platforms/telegram/adapter.py`: add `encoding="utf-8"` to the update-prompt answer write
- `plugins/platforms/feishu/adapter.py`: add `encoding="utf-8"` to the update-prompt answer write
- `plugins/platforms/discord/adapter.py`: add `encoding="utf-8"` to the update-prompt answer write that the review thread flagged
- `plugins/platforms/whatsapp/adapter.py`: add `encoding="utf-8"` to the PID and dependency-stamp reads and writes
- `tests/gateway/test_gateway_utf8_encoding.py`: keep the AST regression guard for bare `read_text()` / `write_text()` calls under `gateway/` and extend it to the bundled Discord, Telegram, and Feishu update-response adapters

## Validation

| Scenario | Before | After |
|---|---|---|
| User replies to an update prompt with emoji on cp1252 Windows | `UnicodeEncodeError` could crash the gateway command handler | UTF-8 write succeeds |
| `hermes update` emits UTF-8 box-drawing, emoji, or CJK output | `UnicodeDecodeError` could crash the update watcher, or output could mojibake under a non-UTF-8 locale | UTF-8 read succeeds and streams correctly |
| Pending `/update` metadata is written on a non-UTF-8 locale | pending-session JSON could be locale-encoded | pending-session JSON is always UTF-8 |
| Telegram, Discord, QQ, or Feishu update-prompt answers contain non-ASCII text | adapter write could fail with `UnicodeEncodeError` | adapter write succeeds |
| WhatsApp bridge PID or dependency stamp is read on a non-UTF-8 locale | locale decoding could be inconsistent | read and write are explicit UTF-8 |
| Future bare `read_text()` / `write_text()` call appears in `gateway/` or the bundled update-response adapters | the Discord sibling sat outside the old guard | the AST test fails immediately |

## Test plan

- `python -m pytest tests/gateway/test_gateway_utf8_encoding.py -v --timeout=0` — 1 passed

## Not in scope

The surrounding `except OSError` guards still do not catch `UnicodeError` subclasses. This change keeps those errors from arising by forcing UTF-8 at the file boundary, but it does not broaden the exception handling itself.
