### PR TITLE
fix(agent): defer background skill review when a user message is queued (#34102)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -348,6 +348,14 @@ def run_codex_app_server_turn(
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).
+    from agent.conversation_loop import (
+        _defer_skill_review_when_input_pending,
+        _has_pending_user_input,
+    )
+
+    _defer_skill_review_when_input_pending(
+        agent, _has_pending_user_input(agent)
+    )
     should_review_skills = False
     if (
         agent._skill_nudge_interval > 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -89,7 +89,9 @@ def _has_pending_user_input(agent) -> bool:
     return False
 
 
-def _defer_skill_review_when_input_pending(agent) -> None:
+def _defer_skill_review_when_input_pending(
+    agent, pending_user_input: bool
+) -> None:
     """Keep queued user turns ahead of background skill review."""
     if getattr(agent, "_skill_nudge_interval", 0) <= 0:
         return
@@ -97,7 +99,7 @@ def _defer_skill_review_when_input_pending(agent) -> None:
         return
     if getattr(agent, "_iters_since_skill", 0) < agent._skill_nudge_interval:
         return
-    if not _has_pending_user_input(agent):
+    if not pending_user_input:
         return
 
     # Leave the counter one step below the threshold so the next eligible turn

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -73,6 +73,38 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _has_pending_user_input(agent) -> bool:
+    """Return True when another user turn is already queued."""
+    steer_lock = getattr(agent, "_pending_steer_lock", None)
+    if steer_lock is not None:
+        with steer_lock:
+            if getattr(agent, "_pending_steer", None):
+                return True
+    elif getattr(agent, "_pending_steer", None):
+        return True
+    if getattr(agent, "_pending_user_message", None):
+        return True
+    if getattr(agent, "_interrupt_message", None):
+        return True
+    return False
+
+
+def _defer_skill_review_when_input_pending(agent) -> None:
+    """Keep queued user turns ahead of background skill review."""
+    if getattr(agent, "_skill_nudge_interval", 0) <= 0:
+        return
+    if "skill_manage" not in getattr(agent, "valid_tool_names", []):
+        return
+    if getattr(agent, "_iters_since_skill", 0) < agent._skill_nudge_interval:
+        return
+    if not _has_pending_user_input(agent):
+        return
+
+    # Leave the counter one step below the threshold so the next eligible turn
+    # retriggers review without delaying the queued user input.
+    agent._iters_since_skill = max(agent._skill_nudge_interval - 1, 0)
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -48,7 +48,10 @@ def finalize_turn(
     Lifted verbatim from ``run_conversation`` (the region after the main agent
     loop). See module docstring.
     """
-    from agent.conversation_loop import logger
+    from agent.conversation_loop import (
+        _defer_skill_review_when_input_pending,
+        logger,
+    )
 
     if final_response is None and (
         api_call_count >= agent.max_iterations
@@ -431,6 +434,8 @@ def finalize_turn(
 
     # Clear stream callback so it doesn't leak into future calls
     agent._stream_callback = None
+
+    _defer_skill_review_when_input_pending(agent)
 
     # Check skill trigger NOW — based on how many tool iterations THIS turn used.
     _should_review_skills = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -50,6 +50,7 @@ def finalize_turn(
     """
     from agent.conversation_loop import (
         _defer_skill_review_when_input_pending,
+        _has_pending_user_input,
         logger,
     )
 
@@ -420,6 +421,7 @@ def finalize_turn(
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.
+    _pending_user_input = _has_pending_user_input(agent)
     _leftover_steer = agent._drain_pending_steer()
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
@@ -435,7 +437,7 @@ def finalize_turn(
     # Clear stream callback so it doesn't leak into future calls
     agent._stream_callback = None
 
-    _defer_skill_review_when_input_pending(agent)
+    _defer_skill_review_when_input_pending(agent, _pending_user_input)
 
     # Check skill trigger NOW — based on how many tool iterations THIS turn used.
     _should_review_skills = False

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -39,6 +39,8 @@ class _StubAgent:
         self.platform = "cli"
         self._interrupt_requested = False
         self._interrupt_message = None
+        self._pending_steer = None
+        self.background_review_calls = []
         self._tool_guardrail_halt_decision = None
         self._response_was_previewed = False
         self._skill_nudge_interval = 0
@@ -91,13 +93,18 @@ class _StubAgent:
         return False
 
     def _drain_pending_steer(self):
-        return None
+        pending_steer = self._pending_steer
+        self._pending_steer = None
+        return pending_steer
 
     def clear_interrupt(self):
         pass
 
     def _sync_external_memory_for_turn(self, **k):
         pass
+
+    def _spawn_background_review(self, **kwargs):
+        self.background_review_calls.append(kwargs)
 
 
 def _run(
@@ -182,3 +189,17 @@ def test_text_response_on_last_allowed_call_is_completed():
     )
     assert result["final_response"] == "final report"
     assert result["completed"] is True
+
+
+def test_pending_steer_is_snapshotted_before_cleanup():
+    agent = _StubAgent(raise_in=())
+    agent._pending_steer = "queued next turn"
+    agent._skill_nudge_interval = 10
+    agent._iters_since_skill = 10
+    agent.valid_tool_names = ["skill_manage"]
+
+    result = _run(agent, final_response="final report")
+
+    assert result["pending_steer"] == "queued next turn"
+    assert agent.background_review_calls == []
+    assert agent._iters_since_skill == 9

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -378,7 +378,7 @@ def test_background_review_skill_deferred_when_steer_pending():
 
     assert _has_pending_user_input(agent) is True
 
-    _defer_skill_review_when_input_pending(agent)
+    _defer_skill_review_when_input_pending(agent, True)
 
     assert agent._iters_since_skill == 9
 
@@ -394,7 +394,7 @@ def test_background_review_skill_not_deferred_without_pending_input():
     agent._skill_nudge_interval = 10
     agent.valid_tool_names = ["skill_manage"]
 
-    _defer_skill_review_when_input_pending(agent)
+    _defer_skill_review_when_input_pending(agent, False)
 
     assert agent._iters_since_skill == 10
 
@@ -429,7 +429,7 @@ def test_background_review_skill_not_deferred_below_threshold():
     agent._skill_nudge_interval = 10
     agent.valid_tool_names = ["skill_manage"]
 
-    _defer_skill_review_when_input_pending(agent)
+    _defer_skill_review_when_input_pending(agent, True)
 
     assert agent._iters_since_skill == 9
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import threading
+
+from agent.conversation_loop import (
+    _defer_skill_review_when_input_pending,
+    _has_pending_user_input,
+)
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -359,6 +365,73 @@ def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
         "the fork leaks harness prompts into the user's real memory "
         "namespace via on_turn_start / prefetch_all / sync_all."
     )
+
+
+def test_background_review_skill_deferred_when_steer_pending():
+    """Queued user input should outrank a skill review nudge."""
+    agent = _bare_agent()
+    agent._pending_steer = "queued"
+    agent._pending_steer_lock = threading.Lock()
+    agent._iters_since_skill = 10
+    agent._skill_nudge_interval = 10
+    agent.valid_tool_names = ["skill_manage"]
+
+    assert _has_pending_user_input(agent) is True
+
+    _defer_skill_review_when_input_pending(agent)
+
+    assert agent._iters_since_skill == 9
+
+
+def test_background_review_skill_not_deferred_without_pending_input():
+    """The helper leaves the counter alone when no next-turn input exists."""
+    agent = _bare_agent()
+    agent._pending_steer = None
+    agent._pending_steer_lock = threading.Lock()
+    agent._pending_user_message = None
+    agent._interrupt_message = None
+    agent._iters_since_skill = 10
+    agent._skill_nudge_interval = 10
+    agent.valid_tool_names = ["skill_manage"]
+
+    _defer_skill_review_when_input_pending(agent)
+
+    assert agent._iters_since_skill == 10
+
+
+def test_has_pending_user_input_checks_all_sources():
+    agent = _bare_agent()
+    agent._pending_steer_lock = threading.Lock()
+
+    agent._pending_steer = "queued"
+    agent._pending_user_message = None
+    agent._interrupt_message = None
+    assert _has_pending_user_input(agent) is True
+
+    agent._pending_steer = None
+    agent._pending_user_message = "next message"
+    assert _has_pending_user_input(agent) is True
+
+    agent._pending_user_message = None
+    agent._interrupt_message = "interrupt"
+    assert _has_pending_user_input(agent) is True
+
+    agent._interrupt_message = None
+    assert _has_pending_user_input(agent) is False
+
+
+def test_background_review_skill_not_deferred_below_threshold():
+    """The helper leaves the counter alone until the nudge threshold is reached."""
+    agent = _bare_agent()
+    agent._pending_steer = "queued"
+    agent._pending_steer_lock = threading.Lock()
+    agent._iters_since_skill = 9
+    agent._skill_nudge_interval = 10
+    agent.valid_tool_names = ["skill_manage"]
+
+    _defer_skill_review_when_input_pending(agent)
+
+    assert agent._iters_since_skill == 9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -253,6 +253,40 @@ class TestRunConversationCodexPath:
         # Counter should be reset after the review fires
         assert agent._iters_since_skill == 0
 
+    def test_background_review_skill_deferred_when_user_input_is_pending(
+        self, monkeypatch
+    ):
+        """Queued input must suppress the Codex skill-review trigger."""
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text=f"echo: {user_input}",
+                projected_messages=[
+                    {"role": "assistant", "content": f"echo: {user_input}"},
+                ],
+                tool_iterations=10,
+                turn_id="t-pending",
+                thread_id="th-pending",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th-pending"
+        )
+
+        agent = _make_codex_agent()
+        agent._skill_nudge_interval = 10
+        agent._iters_since_skill = 0
+        agent.valid_tool_names = set(getattr(agent, "valid_tool_names", set()))
+        agent.valid_tool_names.add("skill_manage")
+        agent._pending_user_message = "queued next turn"
+
+        with patch.object(agent, "_spawn_background_review",
+                          return_value=None) as spawn:
+            agent.run_conversation("do tool work")
+
+        assert not spawn.called
+        assert agent._iters_since_skill == 9
+
     def test_background_review_signature_never_breaks(self, fake_session):
         """Even when no trigger fires, the helper must never call
         _spawn_background_review with the wrong signature. Run a turn,


### PR DESCRIPTION
## Summary

Background skill review fires after qualifying turns by spawning a forked agent that calls `skill_manage` to evaluate and patch the skill library. Successful patches invalidate the cached skills system prompt, so the next foreground turn has to rebuild the full skills prompt from disk. On local models that rebuild can take minutes, and it lands at exactly the wrong time when another user turn is already queued.

The issue had two trigger paths. `agent.turn_finalizer` used live pending-input state after `_drain_pending_steer()` and `clear_interrupt()`, so queued steer or interrupt input was already gone by the time the deferral helper ran. The Codex app-server path in `agent.codex_runtime` could also hit the same skill-review threshold without consulting queued input at all.

This branch snapshots pending input before finalizer cleanup, passes that snapshot into the shared deferral helper, and applies the same helper on the Codex runtime trigger path. When skill review qualifies and queued input already exists, `_iters_since_skill` is moved to `interval - 1` so the queued foreground turn runs first and the review re-qualifies on the next eligible idle tool turn. Memory review stays unchanged.

Fixes #34102

## Changes

- `agent/conversation_loop.py`: keep `_has_pending_user_input()` as the shared predicate and update `_defer_skill_review_when_input_pending()` to consume an explicit pending-input snapshot
- `agent/turn_finalizer.py`: snapshot pending input before draining steer and clearing interrupt state, then pass that snapshot into the skill-review deferral check
- `agent/codex_runtime.py`: run the same pending-input deferral before deciding whether the Codex app-server path should spawn skill review
- `tests/run_agent/test_background_review.py`: cover pending, clear, and below-threshold helper behavior with the new signature
- `tests/agent/test_turn_finalizer_cleanup_guard.py`: add a finalizer regression proving queued steer survives cleanup and suppresses background review
- `tests/run_agent/test_codex_app_server_integration.py`: add a Codex runtime regression proving queued `_pending_user_message` suppresses skill review there too

## Validation

| Scenario | Before | After |
|---|---|---|
| Skill review qualifies after `finalize_turn()` and a next user turn is already queued | Background review starts immediately because cleanup has already cleared the pending-input state | Pending input is snapshotted before cleanup, the queued turn runs first, and review re-qualifies on the next eligible idle tool turn |
| Skill review qualifies on the Codex app-server path while queued user input already exists | Background review starts immediately because the path never checked pending input | The same deferral helper drops `_iters_since_skill` to `interval - 1` and leaves the queued turn first |
| Skill review qualifies with no queued user input | Background review starts | Unchanged |
| Memory review qualifies with queued user input | Memory review starts | Unchanged |
| Pending input detection on steer / gateway / interrupt state | No shared deferred behavior across both trigger paths | Both trigger paths use `_has_pending_user_input()` before review can fire |

## Test plan

- `python -m pytest tests/run_agent/test_background_review.py tests/agent/test_turn_finalizer_cleanup_guard.py tests/run_agent/test_codex_app_server_integration.py -v --timeout=0` — 46 passed

## Not in scope

Making background review cancellable once it has already started is still a separate problem. This change only prevents skill review from preempting a foreground turn that is already queued.
