### PR TITLE
docs(wecom): stop implying live streaming and typing support

### DIFF
--- a/website/docs/user-guide/messaging/wecom.md
+++ b/website/docs/user-guide/messaging/wecom.md
@@ -92,8 +92,15 @@ hermes gateway
 - **AES-encrypted media** — automatic decryption for inbound attachments
 - **Quote context** — preserves reply threading
 - **Markdown rendering** — rich text responses
-- **Reply-mode streaming** — correlates responses to inbound message context
+- **Reply correlation** — responses are correlated to the inbound message context
 - **Auto-reconnect** — exponential backoff on connection drops
+
+:::note Streaming and typing indicators
+The WeCom adapter delivers each response as a single complete message — it does
+**not** stream responses token-by-token, and it does **not** show a typing
+indicator. "Reply correlation" (below) only threads a response to its inbound
+request; it is not live streaming.
+:::
 
 ## Configuration Options
 
@@ -226,11 +233,11 @@ No configuration is needed — decryption happens transparently when encrypted m
 
 Files exceeding the absolute 20 MB limit are rejected with an informational message sent to the chat.
 
-## Reply-Mode Stream Responses
+## Reply-Mode Responses
 
-When the bot receives a message via the WeCom callback, the adapter remembers the inbound request ID. If a response is sent while the request context is still active, the adapter uses WeCom's reply-mode (`aibot_respond_msg`) with streaming to correlate the response directly to the inbound message. This provides a more natural conversation experience in the WeCom client.
+When the bot receives a message via the WeCom callback, the adapter remembers the inbound request ID. If a response is sent while the request context is still active, the adapter uses WeCom's reply-mode (`aibot_respond_msg`) to correlate the response directly to the inbound message. This provides a more natural conversation experience in the WeCom client.
 
-If the inbound request context has expired or is unavailable, the adapter falls back to proactive message sending via `aibot_send_msg`.
+The full response is delivered as a single message — the adapter does not stream tokens incrementally. If the inbound request context has expired or is unavailable, the adapter falls back to proactive message sending via `aibot_send_msg`.
 
 Reply-mode also works for media: uploaded media can be sent as a reply to the originating message.
 


### PR DESCRIPTION
## Summary
The WeCom docs page no longer promises live token streaming or typing indicators — neither is implemented in the adapter.

## Changes
- `website/docs/user-guide/messaging/wecom.md`: rename the "Reply-mode streaming" feature bullet to "Reply correlation"; retitle the "Reply-Mode Stream Responses" section to "Reply-Mode Responses" and state the response is delivered as a single message; add a note clarifying neither streaming nor typing is supported.

## Why
A user (0x0001) flagged that the [WeCom docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/wecom) imply streaming responses, but `main` does not support it. Verified against the code:
- `WeComAdapter` does **not** override `edit_message`, so it inherits the base no-op (`SendResult(success=False, error="Not supported")`). The gateway's edit-based streaming therefore can't apply — `can_edit` flips false and the full reply is delivered once.
- `_send_reply_markdown` / `send` deliver the entire `content` in a single `aibot_respond_msg` / `aibot_send_msg` call — no chunking, no stream flag.
- `send_typing()` is an explicit no-op.

PR #31223 (eager typing) was a separate feature the contributor closed himself as untested/unreliable; it wouldn't have helped WeCom regardless since `send_typing` is a no-op.

Implementing real WeCom streaming (mapping the gateway's edit-streaming onto WeCom's WS stream-chunk protocol) is a separate, larger change that needs live WeCom testing. This PR just makes the docs accurate to `main`.

## Validation
Titled `:::note` admonition syntax matches existing usage across the docs (faq.md, cli-commands.md, etc.). Docs-only change.

## Infographic

![wecom-docs-streaming-reality-check](https://v3b.fal.media/files/b/0a9cf15d/BZlHVnPlvvED1cU9wATtB_MDoAO0l4.png)
