### PR TITLE
feat(gateway): stream session tool lifecycle events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1689,6 +1689,7 @@ class APIServerAdapter(BasePlatformAdapter):
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
+        tool_started_at: dict[str, float] = {}
         seq = 0
 
         def _event_payload(name: str, payload: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
@@ -1721,9 +1722,41 @@ class APIServerAdapter(BasePlatformAdapter):
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
-            elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
-                event_name = event_type.replace("tool.", "tool.")
-                _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
+
+        def _on_tool_start(tool_call_id, function_name, function_args):
+            if not tool_call_id or not function_name or function_name.startswith("_"):
+                return
+            tool_started_at[tool_call_id] = time.monotonic()
+            preview = None
+            try:
+                from agent.display import build_tool_preview
+                preview = build_tool_preview(function_name, function_args)
+            except Exception:
+                preview = None
+            _enqueue("tool.started", {
+                "message_id": message_id,
+                "tool_call_id": tool_call_id,
+                "tool_name": function_name,
+                "preview": preview or function_name,
+                "args": function_args or {},
+            })
+
+        def _on_tool_complete(tool_call_id, function_name, _function_args, _function_result):
+            if not tool_call_id or not function_name or function_name.startswith("_"):
+                return
+
+            started = tool_started_at.pop(tool_call_id, None)
+            if started is None:
+                return
+
+            payload = {
+                "message_id": message_id,
+                "tool_call_id": tool_call_id,
+                "tool_name": function_name,
+                "duration_s": round(time.monotonic() - started, 3),
+            }
+
+            _enqueue("tool.completed", payload)
 
         async def _run_and_signal() -> None:
             try:
@@ -1737,6 +1770,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
+                    tool_start_callback=_on_tool_start,
+                    tool_complete_callback=_on_tool_complete,
                     gateway_session_key=gateway_session_key,
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -49,6 +50,25 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     return app
+
+
+def _parse_sse_events(body: str):
+    events = []
+    for block in body.split("\n\n"):
+        if not block.strip():
+            continue
+        event_name = None
+        data_lines = []
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event_name = line[len("event: "):]
+            elif line.startswith("data: "):
+                data_lines.append(line[len("data: "):])
+        if event_name is None:
+            continue
+        data = json.loads("\n".join(data_lines)) if data_lines else {}
+        events.append((event_name, data))
+    return events
 
 
 @pytest.mark.asyncio
@@ -338,6 +358,132 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
     assert "event: assistant.completed" in body
     assert "event: run.completed" in body
     assert "event: done" in body
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_emits_correlated_tool_lifecycle_events(adapter, session_db):
+    session_id = session_db.create_session("tool-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["tool_start_callback"]("call_search", "web_search", {"query": "hermes"})
+        kwargs["tool_complete_callback"](
+            "call_search",
+            "web_search",
+            {"query": "hermes"},
+            '{"items":[1]}',
+        )
+        return {
+            "final_response": "Found it.",
+            "session_id": session_id,
+            "messages": [
+                {"role": "user", "content": "search hermes"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_search",
+                            "type": "function",
+                            "function": {"name": "web_search", "arguments": '{"query":"hermes"}'},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": '{"items":[1]}',
+                    "tool_call_id": "call_search",
+                    "tool_name": "web_search",
+                },
+                {"role": "assistant", "content": "Found it."},
+            ],
+        }, {"total_tokens": 7}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "search hermes"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    events = _parse_sse_events(body)
+    started = next(data for name, data in events if name == "tool.started")
+    assert started["tool_call_id"] == "call_search"
+    assert started["tool_name"] == "web_search"
+    assert started["args"] == {"query": "hermes"}
+    assert started.get("message_id")
+
+    completed = next(data for name, data in events if name == "tool.completed")
+    assert completed["tool_call_id"] == "call_search"
+    assert completed["tool_name"] == "web_search"
+    assert isinstance(completed.get("duration_s"), (int, float))
+    assert "result_preview" not in completed
+
+    run_completed = next(data for name, data in events if name == "run.completed")
+    messages = run_completed["messages"]
+    assert any(
+        msg.get("role") == "assistant"
+        and any(tc.get("id") == "call_search" for tc in (msg.get("tool_calls") or []))
+        for msg in messages
+    )
+    assert any(
+        msg.get("role") == "tool"
+        and msg.get("tool_call_id") == "call_search"
+        and msg.get("content") == '{"items":[1]}'
+        for msg in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_drops_unmatched_tool_completion(adapter, session_db):
+    session_id = session_db.create_session("orphan-tool-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["tool_complete_callback"]("call_orphan", "web_search", {"query": "missing"}, "result")
+        return {"final_response": "Done.", "session_id": session_id}, {"total_tokens": 3}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "orphan completion"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    events = _parse_sse_events(body)
+    assert [name for name, _ in events if name == "tool.completed"] == []
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_keeps_parallel_tool_ids_distinct(adapter, session_db):
+    session_id = session_db.create_session("parallel-tool-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["tool_start_callback"]("call_a", "web_search", {"query": "a"})
+        kwargs["tool_start_callback"]("call_b", "web_search", {"query": "b"})
+        kwargs["tool_complete_callback"]("call_b", "web_search", {"query": "b"}, '{"items":["b"]}')
+        kwargs["tool_complete_callback"]("call_a", "web_search", {"query": "a"}, '{"items":["a"]}')
+        return {"final_response": "Done.", "session_id": session_id}, {"total_tokens": 3}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "parallel search"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    events = _parse_sse_events(body)
+    starts = [data["tool_call_id"] for name, data in events if name == "tool.started"]
+    completions = [data["tool_call_id"] for name, data in events if name == "tool.completed"]
+    assert starts == ["call_a", "call_b"]
+    assert completions == ["call_b", "call_a"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Streams correlated tool lifecycle events from `POST /api/sessions/{session_id}/chat/stream`.

The session streaming endpoint now wires `tool_start_callback` and `tool_complete_callback` into `_run_agent`, emitting `tool.started` and `tool.completed` events with stable `tool_call_id` values. This lets clients render tool activity while a turn is still running and reliably match each completion back to its start event.

The existing `tool_progress_callback` path is kept only for reasoning progress, since tool lifecycle events from that callback do not carry stable call IDs.

## Related Issue

Closes https://github.com/NousResearch/hermes-agent/issues/38994

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/api_server.py` to emit `tool.started` and `tool.completed` SSE events from stable tool lifecycle callbacks.
- Included stable `tool_call_id` values, tool names, start previews, arguments, and completion duration metadata.
- Kept tool result content out of lifecycle events; clients can reconcile results from `run.completed.messages` or the session messages API.
- Kept reasoning progress emission on `tool.progress`.
- Added session stream tests in `tests/gateway/test_session_api.py` covering correlated tool lifecycle events, unmatched completions, and interleaved parallel tool IDs.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/gateway/test_session_api.py -q -k "session_chat_stream"
2. Start the API server and call `POST /api/sessions/{session_id}/chat/stream` with a prompt that invokes a tool.
3. Confirm the SSE stream emits `tool.started` and `tool.completed` with matching `tool_call_id` values before `run.completed`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (local full-suite run was attempted, but unrelated environment/provider/Docker integration failures prevented a clean local pass).
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] Config update N/A
- [x] CONTRIBUTING/AGENTS update N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update N/A