### PR TITLE
fix(approval): gate perl/ruby -i in-place edits of Hermes config/env

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -449,6 +449,30 @@ class TestHermesConfigWriteProtection:
         )
         assert dangerous is True
 
+    def test_perl_in_place_separate_flag_token(self):
+        # The -i flag does not have to be the first token. `perl -p -i -e`
+        # splits the in-place flag out as its own token after -p; the pattern
+        # must catch it the same as `perl -i -pe`.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -p -i -e 's/approvals.mode: on/approvals.mode: off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_perl_in_place_backup_suffix(self):
+        # `perl -i.bak` keeps a backup but still mutates the file in place.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i.bak -pe 's/x/y/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_perl_eval_no_inplace_safe(self):
+        # `perl -e` with no -i flag is code evaluation, not file mutation —
+        # the perl/ruby -i pattern must not fire on it.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -wne 'print' ~/.hermes/config.yaml"
+        )
+        assert dangerous is False
+
     def test_read_is_safe(self):
         # Reading config is not a write — must not trip.
         dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -428,6 +428,27 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/config.yaml")
         assert dangerous is True
 
+    def test_perl_in_place_config(self):
+        # perl -i performs the same in-place mutation as sed -i but was not
+        # caught by the -e/-c pattern (which targets code evaluation).
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/approvals.mode: on/approvals.mode: off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+        assert "in-place" in desc.lower() or "perl" in desc.lower()
+
+    def test_ruby_in_place_config(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "ruby -i -pe 'gsub(/manual/, \"off\")' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_perl_in_place_env(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/SECRET=old/SECRET=new/' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
     def test_read_is_safe(self):
         # Reading config is not a write — must not trip.
         dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -443,6 +443,10 @@ DANGEROUS_PATTERNS = [
     # the terminal side is not an open door. See #14639.
     (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
+    # perl -i and ruby -i perform the same in-place mutation as sed -i but are
+    # not caught by the -e/-c script-execution pattern above (which targets code
+    # evaluation, not file mutation). Pairs the sed -i coverage from #14639.
+    (rf'\b(?:perl|ruby)\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -446,7 +446,12 @@ DANGEROUS_PATTERNS = [
     # perl -i and ruby -i perform the same in-place mutation as sed -i but are
     # not caught by the -e/-c script-execution pattern above (which targets code
     # evaluation, not file mutation). Pairs the sed -i coverage from #14639.
-    (rf'\b(?:perl|ruby)\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
+    # The -i flag can appear as its own token after other flags
+    # (`perl -p -i -e ... config.yaml`), combined (`perl -pi -e`), or with a
+    # backup suffix (`perl -i.bak`). Match any flag token containing `i`
+    # anywhere in the args, not just the first token — `perl -e '...'` (code
+    # eval, no -i) does not trip because it has no `-...i` flag token.
+    (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),


### PR DESCRIPTION
## Summary
`perl -i` / `ruby -i` in-place edits of `~/.hermes/config.yaml` and `.env` now trip the approval gate, closing the same bypass class that #14639 closed for `sed -i`.

`config.yaml` *is* the security policy (`approvals.mode`, `yolo`, the permanent-approval allowlist), and the mtime-keyed config cache reloads it mid-session — so a successful in-place write flips the gate off immediately. The existing `perl|ruby` pattern only matched `-e`/`-c` (code eval) as the first flag, leaving `-i` (file mutation) uncovered.

Salvaged from #36894 by @AhmetArif0. Follow-up commit widens the regex: the contributor's `-[^\s]*i` matched `-i` only inside the *first* flag token, so `perl -p -i -e '...' config.yaml` (the `-i` split out after `-p`) still slipped through. The pattern now matches a `-...i` flag token anywhere in the args.

## Changes
- `tools/approval.py`: one pattern — `\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:CONFIG|ENV)` against the Hermes config/env paths, mirroring the `sed -i` lines.
- `tests/tools/test_approval.py`: 6 tests — `perl -i` / `ruby -i` / `perl -i` on `.env` (contributor), plus separate-token (`perl -p -i -e`), backup-suffix (`perl -i.bak`), and read-safe (`perl -wne 'print' config.yaml`) cases.

## Validation
| Form | Before | After |
|---|---|---|
| `perl -i -pe ... config.yaml` | not gated | gated |
| `perl -pi -e ... config.yaml` | not gated | gated |
| `perl -p -i -e ... config.yaml` | not gated | gated |
| `perl -i.bak -pe ... config.yaml` | not gated | gated |
| `ruby -i / ruby -p -i -e ... .env` | not gated | gated |
| `perl -wne 'print' config.yaml` (read) | safe | safe |

`scripts/run_tests.sh tests/tools/test_approval.py` → 203 passed. E2E verified all 7 in-place forms gate and reads stay safe via real `detect_dangerous_command` with isolated HERMES_HOME.

Closes #36894.

## Infographic

![gate-perl-ruby-inplace-approval](https://v3b.fal.media/files/b/0a9cf175/Idg4v411mYCnsKp721Ne9_eJ4qtoqt.png)
