### PR TITLE
fix(cli): launchd KeepAlive unconditional restart (#37388)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -227,9 +227,8 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
 
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``
     which drains in-flight agent runs (up to ``agent.restart_drain_timeout``
-    seconds), then exits.  systemd relaunches clean exits via
-    ``Restart=always``; launchd still uses a non-zero planned-restart exit
-    because its plist has ``KeepAlive.SuccessfulExit = false``.
+    seconds), then exits.  Both systemd (``Restart=always``) and launchd
+    (unconditional ``<key>KeepAlive</key><true/>``) restart on any exit.
 
     This is the drain-aware alternative to ``systemctl restart`` / ``SIGTERM``,
     which SIGKILL in-flight agents after a short timeout.
@@ -3083,10 +3082,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -3249,7 +3245,7 @@ def launchd_stop():
         pass
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # immediately restarts it because KeepAlive is unconditionally true.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -72,6 +72,7 @@ AUTHOR_MAP = {
     "kchuang1015@users.noreply.github.com": "kchuang1015",
     "maheshthedev@gmail.com": "MaheshtheDev",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",
+    "shriganesh.patel@gmail.com": "ashishpatel26",
     "45688690+fujinice@users.noreply.github.com": "fujinice",
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2579,3 +2579,24 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+    def test_launchd_plist_keepalive_unconditional(self, tmp_path, monkeypatch):
+        """KeepAlive must be unconditional <true/> so the gateway restarts on clean exits.
+
+        Bug #37388: the old ``KeepAlive.SuccessfulExit = false`` dict form meant
+        launchd would NOT restart after a zero-exit (e.g. ``gateway run --replace``
+        causes the old instance to exit cleanly).  Switching to the scalar
+        ``<key>KeepAlive</key><true/>`` makes launchd restart regardless of exit code.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        plist = gateway_cli.generate_launchd_plist()
+
+        # Scalar <true/> must be present immediately after the KeepAlive key
+        assert "<key>KeepAlive</key>" in plist
+        # The unconditional form
+        assert "<key>KeepAlive</key>\n    <true/>" in plist
+        # The old conditional dict form must NOT appear
+        assert "SuccessfulExit" not in plist
+        assert "<key>KeepAlive</key>\n    <dict>" not in plist


### PR DESCRIPTION
## Summary
The macOS launchd gateway now restarts after a clean (exit-0) `gateway run --replace` handoff, instead of staying down until manually restarted.

Root cause: the plist shipped `KeepAlive.SuccessfulExit=false`, so launchd only respawned on a non-zero exit. A `--replace` restart exits cleanly (code 0), which launchd treats as success and does not relaunch — Telegram/crons silently die.

## Changes
- `hermes_cli/gateway.py`: `generate_launchd_plist()` now emits scalar `<key>KeepAlive</key><true/>` (restart regardless of exit code); updated the `_graceful_restart_via_sigusr1` and `launchd_stop` doc comments to match.
- `tests/hermes_cli/test_gateway_service.py`: new `test_launchd_plist_keepalive_unconditional` asserts the scalar form is present and the old `SuccessfulExit` dict is gone.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor's commit email.

## Validation
| | Before | After |
|---|---|---|
| launchd restart on clean `--replace` exit | no — gateway stays down | yes |
| `tests/hermes_cli/test_gateway_service.py -k launchd` | — | 15 passed |

Salvage of #38796 (@ashishpatel26) onto current main; commit authorship preserved via cherry-pick. Closes #37388.

Duplicate PRs for the same issue — #37411 (@Tranquil-Flow, first submitted) and #37534 (@kyssta-exe) — credited and closed.

## Infographic

![launchd-keepalive-fix](https://v3b.fal.media/files/b/0a9cf17e/j1vRMZAmc0lY7QVku2kRf_99LFwyIk.png)
