### PR TITLE
feat(security): add opt-in execution write scope (#36645)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -10,6 +10,7 @@ import os
 import sys
 import threading
 import contextvars
+import uuid
 from collections import OrderedDict
 from pathlib import Path
 
@@ -1005,7 +1006,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # a mid-process backend switch rebuilds the string. Kept in-module (not on
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 _WINDOWS_BASH_SHELL_HINT = (
@@ -1027,23 +1028,39 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
-    cached = _BACKEND_PROBE_CACHE.get(cache_key)
-    if cached is not None:
-        return cached or None
-
+    env = None
+    cache_key = None
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
-        from tools.terminal_tool import _create_environment, _get_env_config  # type: ignore
+        from tools.terminal_tool import (
+            _create_environment,
+            _get_env_config,
+            _resolve_execution_policy_for_task,
+        )
     except Exception as e:
         logger.debug("Backend probe unavailable (import failed): %s", e)
-        _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
 
     try:
         config = _get_env_config()
+        policy = _resolve_execution_policy_for_task(
+            config,
+            "prompt-backend-probe",
+            env_type=env_type,
+            cwd=config.get("cwd", ""),
+        )
+        cache_key = (
+            env_type,
+            os.getenv("TERMINAL_CWD", ""),
+            policy.fingerprint,
+        )
+        cached = _BACKEND_PROBE_CACHE.get(cache_key)
+        if cached is not None:
+            return cached or None
+        if not policy.capability.supported:
+            _BACKEND_PROBE_CACHE[cache_key] = ""
+            return None
         # Build the environment the same way tools/terminal_tool.py does for a
         # live command: select the backend image, then assemble ssh/container
         # config from the env-derived dict. (There is no `get_environment`
@@ -1075,18 +1092,24 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
                 "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
-                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_mount_cwd_to_workspace": config.get(
+                    "docker_mount_cwd_to_workspace", False
+                ),
                 "docker_forward_env": config.get("docker_forward_env", []),
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                # A prompt probe is a throwaway environment, even when the
+                # selected backend normally persists across Hermes processes.
+                "container_persistent": False,
+                "docker_persist_across_processes": False,
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                "execution_policy": policy,
             }
 
+        probe_task_id = f"prompt-backend-probe-{uuid.uuid4().hex}"
         env = _create_environment(
             env_type=env_type,
             image=image,
@@ -1094,7 +1117,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
             timeout=config.get("timeout", 180),
             ssh_config=ssh_config,
             container_config=container_config,
-            task_id="prompt-backend-probe",
+            task_id=probe_task_id,
             host_cwd=config.get("host_cwd"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
@@ -1116,8 +1139,28 @@ def _probe_remote_backend(env_type: str) -> str | None:
             return None
     except Exception as e:
         logger.debug("Backend probe failed: %s", e)
-        _BACKEND_PROBE_CACHE[cache_key] = ""
+        if cache_key is not None:
+            _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        if env is not None:
+            try:
+                import inspect
+
+                cleanup = getattr(env, "cleanup", None)
+                if callable(cleanup):
+                    if "force_remove" in inspect.signature(cleanup).parameters:
+                        cleanup(force_remove=True)
+                    else:
+                        cleanup()
+            except Exception:
+                logger.debug("Backend probe environment cleanup failed", exc_info=True)
+        try:
+            from tools.environments.execution_policy import clear_execution_workspace
+
+            clear_execution_workspace("prompt-backend-probe")
+        except Exception:
+            logger.debug("Backend probe policy cleanup failed", exc_info=True)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/cli.py
+++ b/cli.py
@@ -445,6 +445,7 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "terminal": {
             "env_type": "local",
+            "execution_write_scope": "legacy",
             "cwd": ".",  # "." is resolved to os.getcwd() at runtime
             "home_mode": "auto",
             "lifetime_seconds": 300,
@@ -657,6 +658,7 @@ def load_cli_config() -> Dict[str, Any]:
     
     env_mappings = {
         "env_type": "TERMINAL_ENV",
+        "execution_write_scope": None,
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
         "home_mode": "TERMINAL_HOME_MODE",
@@ -698,6 +700,8 @@ def load_cli_config() -> Dict[str, Any]:
     _is_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
     for config_key, env_var in env_mappings.items():
         if config_key in terminal_config:
+            if env_var is None:
+                continue
             if env_var == "TERMINAL_CWD":
                 if _is_gateway:
                     continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1906,6 +1906,9 @@ if _config_path.exists():
             ).strip().lower()
             _terminal_env_map = {
                 "backend": "TERMINAL_ENV",
+                # Kept in the config bridge map for completeness, but never
+                # exported because execution authority is config-owned.
+                "execution_write_scope": None,
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",
                 "home_mode": "TERMINAL_HOME_MODE",
@@ -1937,6 +1940,8 @@ if _config_path.exists():
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
+                    if _env_var is None:
+                        continue
                     _val = _terminal_cfg[_cfg_key]
                     # Skip cwd placeholder values (".", "auto", "cwd") — the
                     # gateway resolves these to Path.home() later (line ~255).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3172,6 +3172,9 @@ def write_platform_config_field(
 
 TERMINAL_CONFIG_ENV_MAP = {
     "backend": "TERMINAL_ENV",
+    # Execution authority is read from config by the policy resolver; it must
+    # not be copied into an ambient environment variable.
+    "execution_write_scope": None,
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
@@ -3247,6 +3250,8 @@ def apply_terminal_config_to_env(
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
+            continue
+        if env_var is None:
             continue
         value = terminal_cfg[cfg_key]
         if cfg_key == "cwd":

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -237,6 +237,7 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        "execution_write_scope": "legacy",
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,

--- a/tests/integration/test_execution_write_confinement.py
+++ b/tests/integration/test_execution_write_confinement.py
@@ -1,0 +1,162 @@
+"""Production endpoint and owner-boundary tests for execution write scope."""
+
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+def _docker_runtime_blocker():
+    docker = shutil.which("docker")
+    if docker is None:
+        return "docker executable unavailable"
+    try:
+        result = subprocess.run(
+            [docker, "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"docker version probe failed: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "no diagnostic").strip()
+        return f"docker version exited {result.returncode}: {detail[:240]}"
+    return None
+
+
+_DOCKER_OWNER_PROOF_BLOCKER = _docker_runtime_blocker()
+
+
+def test_workspace_local_rejects_issue_cd_write_before_spawn(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    spawned = []
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "execution_write_scope": "workspace",
+            "cwd": str(workspace),
+            "timeout": 30,
+        },
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *args, **kwargs: {"approved": True})
+    monkeypatch.setattr(
+        terminal_tool,
+        "_create_environment",
+        lambda *args, **kwargs: spawned.append(True),
+    )
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            f"cd {outside} && {sys.executable} -c \"open(r'{sentinel}', 'wb').write(b'x')\"",
+            task_id="issue-shaped-local",
+            force=True,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["error_code"] == "unsupported_execution_backend"
+    assert not spawned
+    assert not sentinel.exists()
+
+
+def test_private_docker_output_is_not_published(tmp_path):
+    from tools.environments.file_sync import FileSyncManager
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("host", encoding="utf-8")
+    remote_input = workspace / "input.txt"
+    remote_input.write_text("input", encoding="utf-8")
+
+    def write_private_output_tar(path):
+        with tarfile.open(path, "w") as archive:
+            private_output = tmp_path / "container-private-output.txt"
+            private_output.write_text("private", encoding="utf-8")
+            archive.add(private_output, arcname="private/output.txt")
+
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(remote_input), "/workspace/input.txt")],
+        upload_fn=lambda *_args: None,
+        delete_fn=lambda *_args: None,
+        bulk_download_fn=write_private_output_tar,
+    )
+    manager._synced_files["/workspace/input.txt"] = (0.0, 0)
+
+    manager.sync_back(hermes_home=tmp_path / "hermes-home")
+
+    assert sentinel.read_text(encoding="utf-8") == "host"
+    assert not (tmp_path / "private" / "output.txt").exists()
+
+
+@pytest.mark.skipif(
+    _DOCKER_OWNER_PROOF_BLOCKER is not None,
+    reason=f"Docker owner proof blocked: {_DOCKER_OWNER_PROOF_BLOCKER}",
+)
+def test_docker_workspace_scope_covers_dynamic_descendants(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("host", encoding="utf-8")
+    config = {
+        "env_type": "docker",
+        "execution_write_scope": "workspace",
+        "cwd": "/workspace",
+        "host_cwd": str(workspace),
+        "host_workspace_root": str(workspace),
+        "docker_mount_cwd_to_workspace": True,
+        "docker_image": "python:3.11-slim",
+        "docker_volumes": [],
+        "docker_extra_args": [],
+        "docker_network": True,
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": False,
+        "timeout": 120,
+        "lifetime_seconds": 300,
+    }
+    import tools.terminal_tool as terminal_tool
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards", lambda *args, **kwargs: {"approved": True}
+    )
+    task_id = "docker-owner-proof"
+    try:
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "python -c 'import pathlib, subprocess; pathlib.Path(\"/workspace/private.txt\").write_bytes(b\"ok\"); pathlib.Path(\"/outside\").mkdir(); subprocess.run([\"python\",\"-c\",\"from pathlib import Path; Path(\\\"/outside/sentinel.txt\\\").write_bytes(b\\\"container\\\")\"], check=True)'",
+                task_id=task_id,
+                force=True,
+            )
+        )
+        assert result["exit_code"] == 0, result
+        assert (workspace / "private.txt").read_bytes() == b"ok"
+        assert sentinel.read_text(encoding="utf-8") == "host"
+        env = terminal_tool.get_active_env(task_id)
+        assert env is not None
+        run_args = env._all_run_args
+        assert f"{workspace.resolve()}:/workspace" in run_args
+        assert not any(
+            str(outside.resolve()) in arg for arg in run_args
+        )
+    finally:
+        terminal_tool.cleanup_vm(task_id, force_remove=True)

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -47,6 +47,7 @@ from tools.code_execution_tool import (
     _TOOL_DOC_LINES,
     _execute_remote,
 )
+import tools.terminal_tool as terminal_tool
 
 
 def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
@@ -67,6 +68,29 @@ def _mock_handle_function_call(function_name, function_args, task_id=None, user_
     if function_name == "web_extract":
         return json.dumps("# Extracted content\nSome text from the page.")
     return json.dumps({"error": f"Unknown tool in mock: {function_name}"})
+
+
+class TestExecutionWriteScope:
+    def test_workspace_local_rejects_before_execute_code_dispatch(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "execution_write_scope": "workspace",
+                "cwd": str(tmp_path),
+                "timeout": 30,
+            },
+        )
+        result = json.loads(
+            execute_code(
+                "import subprocess; subprocess.run(['echo', 'blocked'])",
+                task_id="code-local-workspace",
+            )
+        )
+
+        assert result["error_code"] == "unsupported_execution_backend"
+        assert result["tool_calls_made"] == 0
 
 
 class TestSandboxRequirements(unittest.TestCase):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from tools.environments import docker as docker_env
+from tools.environments.execution_policy import resolve_execution_write_policy
 
 
 def _mock_subprocess_run(monkeypatch):
@@ -53,6 +54,7 @@ def _make_dummy_env(**kwargs):
         run_as_host_user=kwargs.get("run_as_host_user", False),
         extra_args=kwargs.get("extra_args", []),
         persist_across_processes=kwargs.get("persist_across_processes", True),
+        execution_policy=kwargs.get("execution_policy"),
     )
 
 
@@ -76,6 +78,98 @@ def test_ensure_docker_available_logs_and_raises_when_not_found(monkeypatch, cap
         in record.getMessage()
         for record in caplog.records
     )
+
+
+class TestExecutionWriteScopeMappings:
+    def test_workspace_mapping_reaches_docker_only_after_normalization(self, monkeypatch, tmp_path):
+        calls = _mock_subprocess_run(monkeypatch)
+        monkeypatch.setattr(docker_env, "find_docker", lambda: "docker")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        source = workspace / "project"
+        policy = resolve_execution_write_policy(
+            "workspace",
+            session_id="docker-mapping",
+            workspace_root=str(workspace),
+            backend="docker",
+            docker_volumes=[f"{source}:/workspace/project:rw"],
+        )
+
+        _make_dummy_env(execution_policy=policy)
+
+        run = next(command for command, _ in calls if len(command) > 1 and command[1] == "run")
+        assert f"{source.resolve()}:/workspace/project" in run
+
+    def test_workspace_mapping_rejects_outside_source_before_docker(self, monkeypatch, tmp_path):
+        policy = resolve_execution_write_policy(
+            "workspace",
+            session_id="docker-outside",
+            workspace_root=str(tmp_path / "workspace"),
+            backend="docker",
+            docker_volumes=[f"{tmp_path / 'outside'}:/workspace/project:rw"],
+        )
+        assert policy.capability.code == "outside_workspace_mapping"
+
+    def test_workspace_scope_keeps_persistent_root_and_workspace_private(
+        self, monkeypatch, tmp_path
+    ):
+        calls = _mock_subprocess_run(monkeypatch)
+        monkeypatch.setattr(docker_env, "find_docker", lambda: "docker")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        policy = resolve_execution_write_policy(
+            "workspace",
+            session_id="docker-private-storage",
+            workspace_root=str(workspace),
+            backend="docker",
+        )
+
+        _make_dummy_env(execution_policy=policy, persistent_filesystem=True)
+
+        run = next(command for command, _ in calls if command[1] == "run")
+        assert not any(arg.startswith(str(tmp_path)) and arg.endswith(":/root") for arg in run)
+        assert not any(arg.startswith(str(tmp_path)) and arg.endswith(":/workspace") for arg in run)
+        assert "/root:rw,exec,size=1g" in run
+        assert "/workspace:rw,exec,size=10g" in run
+
+    def test_generated_inputs_are_read_only_in_workspace_scope(
+        self, monkeypatch, tmp_path
+    ):
+        calls = _mock_subprocess_run(monkeypatch)
+        monkeypatch.setattr(docker_env, "find_docker", lambda: "docker")
+        credential = tmp_path / "token.json"
+        credential.write_text("token", encoding="utf-8")
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        cache = tmp_path / "images"
+        cache.mkdir()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        policy = resolve_execution_write_policy(
+            "workspace",
+            session_id="docker-generated-inputs",
+            workspace_root=str(workspace),
+            backend="docker",
+        )
+        monkeypatch.setattr(
+            "tools.credential_files.get_credential_file_mounts",
+            lambda: [{"host_path": str(credential), "container_path": "/run/token.json"}],
+        )
+        monkeypatch.setattr(
+            "tools.credential_files.get_skills_directory_mount",
+            lambda: [{"host_path": str(skills), "container_path": "/root/.hermes/skills"}],
+        )
+        monkeypatch.setattr(
+            "tools.credential_files.get_cache_directory_mounts",
+            lambda: [{"host_path": str(cache), "container_path": "/root/.hermes/images"}],
+        )
+
+        _make_dummy_env(execution_policy=policy)
+
+        run = next(command for command, _ in calls if command[1] == "run")
+        assert f"{credential}:/run/token.json:ro" in run
+        assert f"{skills}:/root/.hermes/skills:ro" in run
+        assert f"{cache}:/root/.hermes/images:ro" in run
 
 
 def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):

--- a/tests/tools/test_execution_write_policy.py
+++ b/tests/tools/test_execution_write_policy.py
@@ -1,0 +1,213 @@
+"""Contract tests for the session-scoped execution write policy."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tools.environments.execution_policy import (
+    WORKSPACE_SCOPE,
+    clear_execution_workspace,
+    policy_environment_key,
+    resolve_execution_write_policy,
+)
+from hermes_cli.config import terminal_config_env_var_for_key
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def test_workspace_policy_is_immutable_and_does_not_read_safe_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path / "unrelated"))
+    clear_execution_workspace("policy-test")
+
+    policy = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="policy-test",
+        workspace_root=str(tmp_path / "workspace"),
+        backend="docker",
+    )
+
+    assert policy.scope == WORKSPACE_SCOPE
+    assert policy.workspace_root == str((tmp_path / "workspace").resolve())
+    assert policy.capability.supported
+    with pytest.raises(FrozenInstanceError):
+        policy.scope = "legacy"
+
+
+def test_docker_mapping_normalization_rejects_writable_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    policy = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="mapping-test",
+        workspace_root=str(workspace),
+        backend="docker",
+        docker_volumes=[f"{outside}:/output:rw"],
+    )
+
+    assert policy.capability.status == "invalid"
+    assert policy.capability.code == "outside_workspace_mapping"
+
+
+def test_docker_mapping_normalization_keeps_private_and_read_only_mounts(tmp_path):
+    workspace = tmp_path / "workspace"
+    credentials = tmp_path / "credentials.json"
+    policy = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="mapping-test-ro",
+        workspace_root=str(workspace),
+        backend="docker",
+        docker_volumes=[
+            f"{workspace / 'project'}:/workspace/project:rw",
+            f"{credentials}:/root/.credentials.json:ro",
+        ],
+    )
+
+    assert policy.capability.supported
+    assert f"{(workspace / 'project').resolve()}:/workspace/project" in {
+        mapping.spec for mapping in policy.docker_mappings
+    }
+    assert f"{credentials.resolve()}:/root/.credentials.json:ro" in {
+        mapping.spec for mapping in policy.docker_mappings
+    }
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["local", "ssh", "singularity", "modal", "daytona", "vercel_sandbox"],
+)
+def test_workspace_scope_backend_matrix(backend, tmp_path):
+    policy = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id=f"unsupported-{backend}",
+        workspace_root=str(tmp_path),
+        backend=backend,
+    )
+
+    assert policy.capability.status == "unsupported"
+    assert policy.capability.code == "unsupported_execution_backend"
+    assert backend in policy.capability.message
+
+
+def test_workspace_policy_identity_separates_sessions(tmp_path):
+    first = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="session-a",
+        workspace_root=str(tmp_path / "workspace"),
+        backend="docker",
+    )
+    second = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="session-b",
+        workspace_root=str(tmp_path / "workspace"),
+        backend="docker",
+    )
+
+    assert first.fingerprint != second.fingerprint
+    assert policy_environment_key("default", first) != policy_environment_key("default", second)
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--privileged"],
+        ["-v=/outside:/workspace"],
+        ["--mount=type=bind,src=/outside,dst=/workspace"],
+        ["--volumes-from=other-container"],
+        ["--pid=host"],
+        ["--network", "host"],
+        ["--unknown-flag"],
+    ],
+)
+def test_workspace_policy_rejects_unsafe_extra_args(tmp_path, extra_args):
+    policy = resolve_execution_write_policy(
+        WORKSPACE_SCOPE,
+        session_id="extra-args",
+        workspace_root=str(tmp_path / "workspace"),
+        backend="docker",
+        docker_extra_args=extra_args,
+    )
+
+    assert policy.capability.status == "invalid"
+    assert policy.capability.code == "invalid_docker_extra_args"
+
+
+def test_execution_write_scope_is_config_owned_without_env_bridge():
+    assert DEFAULT_CONFIG["terminal"]["execution_write_scope"] == "legacy"
+    assert terminal_config_env_var_for_key("terminal.execution_write_scope") is None
+
+
+@pytest.mark.parametrize("scope", ["legacy", WORKSPACE_SCOPE])
+def test_prompt_backend_probe_isolated_and_cleans_only_probe(
+    monkeypatch, tmp_path, scope
+):
+    import agent.prompt_builder as prompt_builder
+    import tools.terminal_tool as terminal_tool
+
+    config = {
+        "env_type": "docker",
+        "execution_write_scope": scope,
+        "cwd": "/root",
+        "host_cwd": str(tmp_path),
+        "host_workspace_root": str(tmp_path),
+        "docker_mount_cwd_to_workspace": True,
+        "docker_volumes": [],
+        "docker_extra_args": [],
+        "timeout": 30,
+    }
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    live_environment = object()
+    monkeypatch.setattr(
+        terminal_tool, "_active_environments", {"default": live_environment}
+    )
+    prompt_builder._clear_backend_probe_cache()
+
+    class FakeEnvironment:
+        def __init__(self, result):
+            self.result = result
+            self.cleanup_calls = []
+
+        def execute(self, command, timeout=None):
+            if isinstance(self.result, BaseException):
+                raise self.result
+            return self.result
+
+        def cleanup(self, *, force_remove=False):
+            self.cleanup_calls.append(force_remove)
+
+    created = []
+
+    def fake_create_environment(**kwargs):
+        env = FakeEnvironment(
+            {
+                "returncode": 0,
+                "output": "os=Linux\nkernel=6.8\nhome=/root\ncwd=/workspace\nuser=root\n",
+            }
+        )
+        env.create_kwargs = kwargs
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_tool, "_create_environment", fake_create_environment)
+    assert prompt_builder._probe_remote_backend("docker") is not None
+    assert created[0].cleanup_calls == [True]
+    assert created[0].create_kwargs["task_id"].startswith("prompt-backend-probe-")
+    assert created[0].create_kwargs["task_id"] != "default"
+    assert created[0].create_kwargs["container_config"]["container_persistent"] is False
+    assert (
+        created[0].create_kwargs["container_config"]["docker_persist_across_processes"]
+        is False
+    )
+    assert terminal_tool._active_environments["default"] is live_environment
+
+    prompt_builder._clear_backend_probe_cache()
+    created.clear()
+
+    def failing_create_environment(**kwargs):
+        env = FakeEnvironment(RuntimeError("probe failed"))
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_tool, "_create_environment", failing_create_environment)
+    assert prompt_builder._probe_remote_backend("docker") is None
+    assert created[0].cleanup_calls == [True]
+    assert prompt_builder._probe_remote_backend("docker") is None
+    assert len(created) == 1

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,11 +6,15 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import pytest
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
     PATCH_SCHEMA,
 )
+from tools.environments.execution_policy import ExecutionWriteScopeError
+import tools.file_tools as file_tools
+import tools.terminal_tool as terminal_tool
 
 
 class TestReadFileHandler:
@@ -65,6 +69,7 @@ class TestWriteFileHandler:
         assert "read-only" in result["error"]
         assert any("write_file expected denial" in r.getMessage() for r in caplog.records)
         assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
 
     @patch("tools.file_tools._get_file_ops")
     def test_rejects_read_file_line_numbered_content(self, mock_get):
@@ -126,6 +131,24 @@ class TestWriteFileHandler:
         result = json.loads(_handle_write_file({"path": "/tmp/x.txt", "content": {"nested": "dict"}}))
         assert "error" in result
         assert "string" in result["error"].lower() or "content" in result["error"].lower()
+
+
+class TestExecutionWriteScopeEnvironmentReuse:
+    def test_workspace_local_rejects_file_environment_before_creation(self, monkeypatch, tmp_path):
+        file_tools.clear_file_ops_cache()
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "execution_write_scope": "workspace",
+                "cwd": str(tmp_path),
+                "timeout": 30,
+            },
+        )
+        with pytest.raises(ExecutionWriteScopeError) as excinfo:
+            file_tools._get_file_ops("file-local-workspace")
+        assert excinfo.value.result.code == "unsupported_execution_backend"
 
 
 class TestPatchHandler:

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -141,3 +141,30 @@ def test_safe_getcwd_falls_back_to_home_when_no_terminal_cwd(monkeypatch):
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.setattr(terminal_tool.os.path, "expanduser", lambda p: "/home/me")
     assert terminal_tool._safe_getcwd() == "/home/me"
+
+
+def test_windows_docker_namespace_cwd_keeps_host_workspace_provenance(monkeypatch, tmp_path):
+    """The Docker default ``/root`` must not become a Windows host path."""
+    import hermes_cli.config as config_module
+
+    monkeypatch.setattr(terminal_tool, "_ensure_terminal_env_bridged", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_safe_getcwd", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"terminal": {"execution_write_scope": "workspace"}},
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.delenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", raising=False)
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "/root"
+    assert config["host_cwd"] == str(tmp_path.resolve())
+    assert config["host_workspace_root"] == str(tmp_path.resolve())
+    policy = terminal_tool._resolve_execution_policy_for_task(
+        config, "windows-docker-session", env_type="docker", cwd=config["cwd"]
+    )
+    assert policy.workspace_root == str(tmp_path.resolve())
+    assert policy.workspace_root != r"D:\root"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,7 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import json
+
 import tools.terminal_tool as terminal_tool
 
 
@@ -86,3 +88,184 @@ def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+class TestExecutionWriteScope:
+    def _config(self, scope, cwd):
+        return {
+            "env_type": "local",
+            "execution_write_scope": scope,
+            "cwd": str(cwd),
+            "timeout": 30,
+        }
+
+    def test_workspace_local_rejects_foreground_before_environment_creation(self, monkeypatch, tmp_path):
+        spawned = []
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: self._config("workspace", tmp_path),
+        )
+        monkeypatch.setattr(terminal_tool, "_create_environment", lambda *a, **k: spawned.append(True))
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "printf blocked",
+                task_id="terminal-foreground",
+                force=True,
+            )
+        )
+
+        assert result["error_code"] == "unsupported_execution_backend"
+        assert not spawned
+
+    def test_workspace_local_rejects_background_and_pty_before_spawn(self, monkeypatch, tmp_path):
+        spawned = []
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: self._config("workspace", tmp_path),
+        )
+        monkeypatch.setattr(terminal_tool, "_create_environment", lambda *a, **k: spawned.append(True))
+
+        for kwargs in ({"background": True}, {"pty": True}):
+            result = json.loads(
+                terminal_tool.terminal_tool(
+                    "printf blocked",
+                    task_id=f"terminal-{len(spawned)}",
+                    force=True,
+                    **kwargs,
+                )
+            )
+            assert result["error_code"] == "unsupported_execution_backend"
+        assert not spawned
+
+    def test_legacy_execution_write_scope_preserves_current_terminal_behavior(
+        self, monkeypatch, tmp_path
+    ):
+        class FakeEnvironment:
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                return {"output": "legacy", "returncode": 0}
+
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: self._config("legacy", tmp_path),
+        )
+        monkeypatch.setattr(terminal_tool, "_active_environments", {})
+        monkeypatch.setattr(terminal_tool, "_last_activity", {})
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(terminal_tool, "_create_environment", lambda *a, **k: FakeEnvironment())
+        monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda *a, **k: {"approved": True})
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                "printf legacy",
+                task_id="terminal-legacy",
+                force=True,
+            )
+        )
+
+        assert result["output"] == "legacy"
+        assert result["exit_code"] == 0
+        assert terminal_tool._active_environments["default"] is not None
+
+    def test_legacy_cleanup_preserves_shared_default_environment(
+        self, monkeypatch
+    ):
+        class FakeEnvironment:
+            def __init__(self):
+                self.cleanup_calls = []
+
+            def cleanup(self, *, force_remove=False):
+                self.cleanup_calls.append(force_remove)
+
+        shared = FakeEnvironment()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": shared})
+        monkeypatch.setattr(terminal_tool, "_last_activity", {"default": 1.0})
+
+        terminal_tool.cleanup_vm("gateway-session-A", force_remove=True)
+
+        assert shared.cleanup_calls == []
+        assert terminal_tool._active_environments["default"] is shared
+
+        terminal_tool.cleanup_vm("default", force_remove=True)
+        assert shared.cleanup_calls == [True]
+        assert "default" not in terminal_tool._active_environments
+
+    def test_get_active_env_legacy_fast_path_skips_policy_resolution(
+        self, monkeypatch
+    ):
+        live_environment = object()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": live_environment})
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: (_ for _ in ()).throw(AssertionError("legacy lookup loaded config")),
+        )
+        monkeypatch.setattr(
+            terminal_tool,
+            "_resolve_execution_policy_for_task",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("legacy lookup resolved policy")
+            ),
+        )
+
+        assert terminal_tool.get_active_env("gateway-session-A") is live_environment
+
+    def test_workspace_cleanup_resolves_raw_session_to_bounded_identity(
+        self, monkeypatch, tmp_path
+    ):
+        from tools.environments.execution_policy import (
+            clear_execution_workspace,
+            lookup_policy_environment_key,
+            resolve_execution_write_policy,
+        )
+        import tools.file_tools as file_tools
+        import tools.process_registry as process_registry_module
+
+        class FakeEnvironment:
+            def __init__(self):
+                self.cleanup_calls = []
+
+            def cleanup(self, *, force_remove=False):
+                self.cleanup_calls.append(force_remove)
+
+        class FakeRegistry:
+            def __init__(self):
+                self.killed = []
+
+            def kill_all(self, *, task_id=None):
+                self.killed.append(task_id)
+                return 1
+
+        raw_session = "raw-session-cleanup"
+        clear_execution_workspace(raw_session)
+        policy = resolve_execution_write_policy(
+            "workspace",
+            session_id=raw_session,
+            workspace_root=str(tmp_path),
+            backend="docker",
+        )
+        bounded_key = terminal_tool._resolve_environment_key(raw_session, policy)
+        env = FakeEnvironment()
+        registry = FakeRegistry()
+        monkeypatch.setattr(terminal_tool, "_active_environments", {bounded_key: env})
+        monkeypatch.setattr(terminal_tool, "_last_activity", {bounded_key: 1.0})
+        monkeypatch.setattr(process_registry_module, "process_registry", registry)
+        with file_tools._file_ops_lock:
+            file_tools._file_ops_cache[bounded_key] = object()
+
+        try:
+            terminal_tool.cleanup_vm(raw_session, force_remove=True)
+            assert env.cleanup_calls == [True]
+            assert registry.killed == [bounded_key]
+            assert bounded_key not in terminal_tool._active_environments
+            assert bounded_key not in file_tools._file_ops_cache
+            assert lookup_policy_environment_key(raw_session) is None
+        finally:
+            with file_tools._file_ops_lock:
+                file_tools._file_ops_cache.pop(bounded_key, None)
+            clear_execution_workspace(raw_session)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -48,6 +48,9 @@ _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.thread_context import propagate_context_to_thread
+from tools.environments.execution_policy import (
+    ExecutionWriteScopeError,
+)
 
 # Availability gate.  On Windows we fall back to loopback TCP for the
 # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
@@ -725,33 +728,47 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _creation_locks, _creation_locks_lock,
+        _resolve_container_task_id, _resolve_environment_key,
+        _resolve_execution_policy_for_task,
+        resolve_task_overrides,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
+    config = _get_env_config()
+    env_type = config["env_type"]
+    overrides = resolve_task_overrides(task_id)
+    try:
+        from tools.terminal_tool import get_session_cwd
+
+        recorded_cwd = get_session_cwd(task_id)
+    except Exception:
+        recorded_cwd = None
+    cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
+    policy = _resolve_execution_policy_for_task(
+        config, task_id, env_type=env_type, cwd=cwd
+    )
+    if not policy.capability.supported:
+        raise ExecutionWriteScopeError(policy.capability)
+    environment_key = _resolve_environment_key(task_id, policy)
 
     # Fast path: environment already exists
     with _env_lock:
-        if effective_task_id in _active_environments:
-            _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+        if environment_key in _active_environments:
+            _last_activity[environment_key] = time.time()
+            return _active_environments[environment_key], env_type
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
-        if effective_task_id not in _creation_locks:
-            _creation_locks[effective_task_id] = threading.Lock()
-        task_lock = _creation_locks[effective_task_id]
+        if environment_key not in _creation_locks:
+            _creation_locks[environment_key] = threading.Lock()
+        task_lock = _creation_locks[environment_key]
 
     with task_lock:
         with _env_lock:
-            if effective_task_id in _active_environments:
-                _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
-
-        config = _get_env_config()
-        env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+            if environment_key in _active_environments:
+                _last_activity[environment_key] = time.time()
+                return _active_environments[environment_key], env_type
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -764,8 +781,6 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
-
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
             container_config = {
@@ -777,6 +792,8 @@ def _get_or_create_env(task_id: str):
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
+                "docker_extra_args": config.get("docker_extra_args", []),
+                "execution_policy": policy,
             }
 
         ssh_config = None
@@ -805,13 +822,13 @@ def _get_or_create_env(task_id: str):
             ssh_config=ssh_config,
             container_config=container_config,
             local_config=local_config,
-            task_id=effective_task_id,
+            task_id=environment_key,
             host_cwd=config.get("host_cwd"),
         )
 
         with _env_lock:
-            _active_environments[effective_task_id] = env
-            _last_activity[effective_task_id] = time.time()
+            _active_environments[environment_key] = env
+            _last_activity[environment_key] = time.time()
 
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
@@ -1224,9 +1241,26 @@ def execute_code(
         return tool_error("No code provided.")
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
-    from tools.terminal_tool import _get_env_config, _docker_has_host_access
+    from tools.terminal_tool import (
+        _get_env_config,
+        _docker_has_host_access,
+        _resolve_execution_policy_for_task,
+    )
     _env_config = _get_env_config()
     env_type = _env_config["env_type"]
+    execution_policy = _resolve_execution_policy_for_task(
+        _env_config, task_id, env_type=env_type
+    )
+    if not execution_policy.capability.supported:
+        return json.dumps(
+            {
+                "status": "error",
+                "tool_calls_made": 0,
+                "duration_seconds": 0,
+                **execution_policy.capability.as_error(),
+            },
+            ensure_ascii=False,
+        )
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never
     # passes through terminal()/DANGEROUS_PATTERNS, so guard the whole script

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -451,6 +451,12 @@ class BaseEnvironment(ABC):
     interrupt handling, and timeout enforcement.
     """
 
+    def validate_execution_capability(self, policy):
+        """Return the shared policy result before backend execution begins."""
+        from tools.environments.execution_policy import validate_execution_capability
+
+        return validate_execution_capability(policy)
+
     # Subclasses that embed stdin as a heredoc (Modal, Daytona) set this.
     _stdin_mode: str = "pipe"  # "pipe" or "heredoc"
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -18,6 +18,10 @@ from pathlib import Path
 from typing import Optional
 
 from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.execution_policy import (
+    ExecutionWriteScopeError,
+    validate_execution_capability,
+)
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _is_hermes_internal_secret,
@@ -839,11 +843,25 @@ class DockerEnvironment(BaseEnvironment):
         run_as_host_user: bool = False,
         extra_args: list = None,
         persist_across_processes: bool = True,
+        execution_policy=None,
     ):
+        if execution_policy is not None:
+            capability = validate_execution_capability(execution_policy, "docker")
+            if not capability.supported:
+                raise ExecutionWriteScopeError(capability)
+            if execution_policy.is_workspace_scoped:
+                volumes = [mapping.spec for mapping in capability.mappings]
+                extra_args = list(capability.extra_args)
+                host_cwd = None
+                auto_mount_cwd = False
+        workspace_scoped = bool(
+            execution_policy is not None and execution_policy.is_workspace_scoped
+        )
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
+        self._workspace_scoped = workspace_scoped
         self._persist_across_processes = persist_across_processes
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
@@ -920,7 +938,7 @@ class DockerEnvironment(BaseEnvironment):
         self._workspace_dir: Optional[str] = None
         self._home_dir: Optional[str] = None
         writable_args = []
-        if self._persistent:
+        if self._persistent and not workspace_scoped:
             sandbox = get_sandbox_dir() / "docker" / task_id
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
@@ -934,6 +952,9 @@ class DockerEnvironment(BaseEnvironment):
                     "-v", f"{self._workspace_dir}:/workspace",
                 ])
         else:
+            # Workspace scope never persists host-backed /root or /workspace
+            # binds. These paths remain writable, but only as private container
+            # storage; explicit session mappings are the sole host write path.
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 writable_args.extend([
                     "--tmpfs", "/workspace:rw,exec,size=10g",

--- a/tools/environments/execution_policy.py
+++ b/tools/environments/execution_policy.py
@@ -1,0 +1,438 @@
+"""Execution write-scope policy and Docker capability validation.
+
+The policy is provenance based. It never inspects shell or Python source, and
+it does not select a different execution backend for the caller.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LEGACY_SCOPE = "legacy"
+WORKSPACE_SCOPE = "workspace"
+SUPPORTED_SCOPES = frozenset({LEGACY_SCOPE, WORKSPACE_SCOPE})
+DOCKER_BACKEND = "docker"
+
+_workspace_roots: dict[str, str] = {}
+_workspace_roots_lock = threading.Lock()
+_policy_environment_keys: dict[str, tuple[str, ...]] = {}
+_policy_environment_keys_lock = threading.Lock()
+_MAX_ENVIRONMENT_KEY_LENGTH = 80
+
+
+class ExecutionWriteScopeError(RuntimeError):
+    """Named refusal raised before an unsupported execution can be created."""
+
+    def __init__(self, result: "ExecutionCapability") -> None:
+        self.result = result
+        super().__init__(result.message)
+
+
+@dataclass(frozen=True)
+class DockerMapping:
+    """A normalized Docker bind or volume mapping."""
+
+    source: str
+    target: str
+    read_only: bool = False
+
+    @property
+    def spec(self) -> str:
+        mode = ":ro" if self.read_only else ""
+        return f"{self.source}:{self.target}{mode}"
+
+
+@dataclass(frozen=True)
+class ExecutionCapability:
+    """Typed capability decision for a requested execution policy."""
+
+    status: str
+    code: str
+    backend: str
+    message: str
+    mappings: tuple[DockerMapping, ...] = ()
+    extra_args: tuple[str, ...] = ()
+
+    @property
+    def supported(self) -> bool:
+        return self.status == "supported"
+
+    def as_error(self) -> dict[str, str]:
+        return {
+            "error_code": self.code,
+            "error": self.message,
+            "backend": self.backend,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionWritePolicy:
+    """Immutable, session-scoped authority for host write exposure."""
+
+    scope: str
+    session_id: str
+    workspace_root: str
+    backend: str
+    fingerprint: str
+    capability: ExecutionCapability
+
+    @property
+    def is_workspace_scoped(self) -> bool:
+        return self.scope == WORKSPACE_SCOPE
+
+    @property
+    def docker_mappings(self) -> tuple[DockerMapping, ...]:
+        return self.capability.mappings
+
+    @property
+    def docker_extra_args(self) -> tuple[str, ...]:
+        return self.capability.extra_args
+
+
+def _canonical_path(value: Any, *, base: str | None = None) -> str:
+    raw = os.path.expandvars(os.path.expanduser(str(value or ""))).strip()
+    if not raw:
+        return ""
+    if not os.path.isabs(raw):
+        raw = os.path.join(base or os.getcwd(), raw)
+    return os.path.realpath(os.path.abspath(raw))
+
+
+def _inside(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([path, root]) == root
+    except ValueError:
+        return False
+
+
+def _parse_volume(value: Any) -> tuple[str, str, bool] | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    parts = value.split(":")
+    if len(parts) >= 3 and parts[-1].lower() in {"ro", "rw", "readonly"}:
+        source = ":".join(parts[:-2])
+        target = parts[-2]
+        return source, target, parts[-1].lower() in {"ro", "readonly"}
+    if len(parts) >= 2:
+        source = ":".join(parts[:-1])
+        target = parts[-1]
+        return source, target, False
+    return None
+
+
+def _normalize_mapping(
+    value: Any,
+    workspace_root: str,
+    *,
+    allow_named_read_only: bool = True,
+) -> DockerMapping | None:
+    parsed = _parse_volume(value)
+    if parsed is None:
+        return None
+    source, target, read_only = parsed
+    if not target.startswith("/") or target == "/":
+        return None
+    source = source.strip()
+    if not source:
+        return None
+
+    looks_like_path = (
+        source.startswith(("/", "~", "./", "../"))
+        or (len(source) >= 3 and source[1] == ":" and source[2] in "/\\")
+    )
+    if not looks_like_path:
+        if read_only and allow_named_read_only:
+            return DockerMapping(source, target, True)
+        return None
+
+    normalized_source = _canonical_path(source, base=workspace_root)
+    if not read_only and not _inside(normalized_source, workspace_root):
+        raise ValueError(
+            f"writable Docker mapping {source!r} resolves outside session workspace "
+            f"{workspace_root!r}"
+        )
+    return DockerMapping(normalized_source, target, read_only)
+
+
+_UNSAFE_EXTRA_FLAGS = {
+    "--privileged",
+    "--pid",
+    "--ipc",
+    "--uts",
+    "--userns",
+    "--device",
+    "--mount",
+    "--volume",
+    "--volumes-from",
+    "-v",
+}
+_SAFE_EXTRA_FLAGS = frozenset({"--init", "--rm"})
+
+
+def _normalize_extra_args(
+    values: Any,
+    workspace_root: str,
+) -> tuple[tuple[str, ...], tuple[DockerMapping, ...], str | None]:
+    if values is None:
+        return (), (), None
+    if not isinstance(values, (list, tuple)) or not all(isinstance(v, str) for v in values):
+        return (), (), "docker_extra_args must be a list of strings"
+
+    args = list(values)
+    normalized: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i].strip()
+        flag = arg.split("=", 1)[0].lower()
+        if not arg:
+            return (), (), "unparseable empty Docker extra argument"
+        if flag in _UNSAFE_EXTRA_FLAGS or flag.startswith("--volumes-from"):
+            return (), (), f"unsupported Docker host or namespace argument {arg!r}"
+        if flag in {"--network", "--net"}:
+            value = arg.split("=", 1)[1] if "=" in arg else (
+                args[i + 1].strip() if i + 1 < len(args) else ""
+            )
+            if value.lower() != "none":
+                return (), (), f"unsupported Docker network argument {arg!r}"
+            normalized.append(arg)
+            if "=" not in arg:
+                if i + 1 >= len(args):
+                    return (), (), f"unparseable Docker network argument {arg!r}"
+                i += 1
+                normalized.append(args[i])
+        elif arg.lower() in _SAFE_EXTRA_FLAGS:
+            normalized.append(arg)
+        else:
+            return (), (), f"unparseable or unsupported Docker extra argument {arg!r}"
+        i += 1
+    return tuple(normalized), (), None
+
+
+def normalize_docker_mappings(
+    workspace_root: str,
+    volumes: Iterable[Any] = (),
+    *,
+    host_cwd: str | None = None,
+    auto_mount_cwd: bool = False,
+    extra_args: Any = (),
+) -> ExecutionCapability:
+    """Normalize and validate every writable host exposure for Docker."""
+    mappings: list[DockerMapping] = []
+    for value in volumes or ():
+        try:
+            mapping = _normalize_mapping(value, workspace_root)
+        except ValueError as exc:
+            return ExecutionCapability(
+                "invalid", "outside_workspace_mapping", DOCKER_BACKEND, str(exc)
+            )
+        if mapping is None:
+            return ExecutionCapability(
+                "invalid", "invalid_docker_mapping", DOCKER_BACKEND,
+                f"unparseable or unsupported Docker volume mapping {value!r}",
+            )
+        mappings.append(mapping)
+
+    if auto_mount_cwd:
+        if not host_cwd:
+            return ExecutionCapability(
+                "invalid", "invalid_docker_mapping", DOCKER_BACKEND,
+                "Docker cwd mapping is enabled but has no host source",
+            )
+        try:
+            mapping = _normalize_mapping(
+                f"{host_cwd}:/workspace:rw", workspace_root, allow_named_read_only=False
+            )
+        except ValueError as exc:
+            return ExecutionCapability("invalid", "outside_workspace_mapping", DOCKER_BACKEND, str(exc))
+        if mapping is None:
+            return ExecutionCapability(
+                "invalid", "invalid_docker_mapping", DOCKER_BACKEND,
+                f"unparseable Docker cwd mapping {host_cwd!r}",
+            )
+        mappings.insert(0, mapping)
+
+    normalized_args, extra_mappings, error = _normalize_extra_args(extra_args, workspace_root)
+    if error:
+        return ExecutionCapability("invalid", "invalid_docker_extra_args", DOCKER_BACKEND, error)
+    mappings.extend(extra_mappings)
+    return ExecutionCapability(
+        "supported", "supported", DOCKER_BACKEND,
+        "Docker can enforce the workspace write scope",
+        tuple(mappings), normalized_args,
+    )
+
+
+def _stable_workspace_root(session_id: str, candidate: str) -> str:
+    normalized = _canonical_path(candidate)
+    with _workspace_roots_lock:
+        return _workspace_roots.setdefault(session_id, normalized)
+
+
+def clear_execution_workspace(session_id: str | None) -> None:
+    with _workspace_roots_lock:
+        _workspace_roots.pop(str(session_id or "default"), None)
+    with _policy_environment_keys_lock:
+        _policy_environment_keys.pop(str(session_id or "default"), None)
+
+
+def resolve_execution_write_policy(
+    scope: str | None = LEGACY_SCOPE,
+    *,
+    session_id: str | None = "default",
+    workspace_root: str | None = None,
+    backend: str = "local",
+    docker_volumes: Iterable[Any] = (),
+    docker_extra_args: Any = (),
+    host_cwd: str | None = None,
+    docker_mount_cwd_to_workspace: bool = False,
+) -> ExecutionWritePolicy:
+    """Resolve one immutable policy for a session and selected backend."""
+    normalized_scope = str(scope or LEGACY_SCOPE).strip().lower()
+    session = str(session_id or "default")
+    backend = str(backend or "local").strip().lower()
+    root = _stable_workspace_root(session, workspace_root or os.getcwd())
+
+    if normalized_scope not in SUPPORTED_SCOPES:
+        capability = ExecutionCapability(
+            "invalid", "invalid_execution_write_scope", backend,
+            f"unsupported execution_write_scope {scope!r}; expected 'legacy' or 'workspace'",
+        )
+    elif normalized_scope == LEGACY_SCOPE:
+        capability = ExecutionCapability("supported", "legacy", backend, "legacy execution write scope")
+    elif backend != DOCKER_BACKEND:
+        capability = ExecutionCapability(
+            "unsupported", "unsupported_execution_backend", backend,
+            f"execution_write_scope=workspace is unsupported for backend {backend!r}; "
+            "select Docker or use execution_write_scope=legacy",
+        )
+    else:
+        capability = normalize_docker_mappings(
+            root,
+            docker_volumes,
+            host_cwd=host_cwd,
+            auto_mount_cwd=docker_mount_cwd_to_workspace,
+            extra_args=docker_extra_args,
+        )
+
+    identity = {
+        "scope": normalized_scope,
+        "session_id": session,
+        "workspace_root": root,
+        "backend": backend,
+        "mappings": [m.spec for m in capability.mappings],
+        "extra_args": list(capability.extra_args),
+        "code": capability.code,
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return ExecutionWritePolicy(
+        normalized_scope, session, root, backend, fingerprint, capability
+    )
+
+
+def validate_execution_capability(
+    policy: ExecutionWritePolicy,
+    backend: str | None = None,
+) -> ExecutionCapability:
+    """Return the named capability result without changing the backend."""
+    if not policy.is_workspace_scoped:
+        return policy.capability
+    if backend and backend != policy.backend:
+        return ExecutionCapability(
+            "unsupported", "unsupported_execution_backend", backend,
+            f"execution_write_scope=workspace is unsupported for backend {backend!r}",
+        )
+    return policy.capability
+
+
+def policy_environment_key(task_id: str | None, policy: ExecutionWritePolicy) -> str:
+    """Return one bounded, filesystem-safe key for the selected policy."""
+    base = str(task_id or "default")
+    if not policy.is_workspace_scoped:
+        return base
+    digest = hashlib.sha256(
+        f"{base}\0{policy.session_id}\0{policy.fingerprint}".encode()
+    ).hexdigest()
+    return f"hermes-workspace-{digest}"[:_MAX_ENVIRONMENT_KEY_LENGTH]
+
+
+def bind_policy_environment_key(
+    session_id: str | None, task_id: str | None, policy: ExecutionWritePolicy
+) -> str:
+    """Bind raw session provenance to the bounded backend cache identity."""
+    raw_session = str(session_id or "default")
+    key = policy_environment_key(task_id, policy)
+    if not policy.is_workspace_scoped:
+        return key
+    with _policy_environment_keys_lock:
+        keys = list(_policy_environment_keys.get(raw_session, ()))
+        if key not in keys:
+            keys.append(key)
+        _policy_environment_keys[raw_session] = tuple(keys)
+    return key
+
+
+def lookup_policy_environment_key(session_id: str | None) -> str | None:
+    """Return a previously bound key without falling back across identities."""
+    with _policy_environment_keys_lock:
+        keys = _policy_environment_keys.get(str(session_id or "default"), ())
+        return keys[-1] if keys else None
+
+
+def policy_environment_keys_for_session(session_id: str | None) -> tuple[str, ...]:
+    """Return every bounded identity recorded for one raw session."""
+    with _policy_environment_keys_lock:
+        return _policy_environment_keys.get(str(session_id or "default"), ())
+
+
+def forget_policy_environment_key(identifier: str | None) -> tuple[str, ...]:
+    """Remove a raw-session binding or a bounded backend identity."""
+    if not identifier:
+        return ()
+    identifier = str(identifier)
+    removed: list[str] = []
+    with _policy_environment_keys_lock:
+        session_keys = _policy_environment_keys.pop(identifier, None)
+        if session_keys:
+            removed.extend(session_keys)
+        for session_id, keys in list(_policy_environment_keys.items()):
+            if identifier not in keys:
+                continue
+            remaining = tuple(key for key in keys if key != identifier)
+            removed.append(identifier)
+            if remaining:
+                _policy_environment_keys[session_id] = remaining
+            else:
+                _policy_environment_keys.pop(session_id, None)
+    return tuple(dict.fromkeys(removed))
+
+
+__all__ = [
+    "DOCKER_BACKEND",
+    "DockerMapping",
+    "ExecutionCapability",
+    "ExecutionWritePolicy",
+    "ExecutionWriteScopeError",
+    "LEGACY_SCOPE",
+    "WORKSPACE_SCOPE",
+    "clear_execution_workspace",
+    "bind_policy_environment_key",
+    "forget_policy_environment_key",
+    "lookup_policy_environment_key",
+    "policy_environment_keys_for_session",
+    "normalize_docker_mappings",
+    "policy_environment_key",
+    "resolve_execution_write_policy",
+    "validate_execution_capability",
+]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -18,6 +18,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from tools.environments.execution_policy import ExecutionWriteScopeError
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -167,22 +168,20 @@ _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
 _CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
 
+def _execution_scope_error(error: ExecutionWriteScopeError) -> str:
+    return json.dumps(
+        {"status": "error", **error.result.as_error()}, ensure_ascii=False
+    )
+
+
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
     """Best-effort terminal backend type for path-resolution decisions."""
     try:
         from tools.terminal_tool import (
-            _active_environments,
-            _env_lock,
             _get_env_config,
-            _resolve_container_task_id,
+            get_active_env,
         )
-
-        try:
-            container_key = _resolve_container_task_id(task_id)
-        except Exception:
-            container_key = task_id
-        with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+        env = get_active_env(task_id)
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -627,19 +626,14 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     """Return the container-side Hermes mirror prefix for Docker file tools."""
     try:
         from tools.terminal_tool import (
-            _active_environments,
-            _env_lock,
             _get_env_config,
-            _resolve_container_task_id,
+            get_active_env,
         )
-
-        container_key = _resolve_container_task_id(task_id)
     except Exception:
         return None
 
     try:
-        with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+        env = get_active_env(task_id)
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -946,22 +940,44 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
+        _resolve_environment_key,
         _is_unusable_container_cwd,
         _CONTAINER_BACKENDS,
+        _resolve_execution_policy_for_task,
+        resolve_task_overrides,
+        get_session_cwd,
     )
     import time
 
     raw_task_id = task_id or "default"
     task_id = _resolve_container_task_id(raw_task_id)
 
+    policy_config = _get_env_config()
+    policy_overrides = resolve_task_overrides(raw_task_id)
+    policy_cwd = (
+        policy_overrides.get("cwd")
+        or get_session_cwd(raw_task_id)
+        or policy_config["cwd"]
+    )
+    execution_policy = _resolve_execution_policy_for_task(
+        policy_config, raw_task_id,
+        env_type=policy_config["env_type"],
+        cwd=policy_cwd,
+    )
+    if not execution_policy.capability.supported:
+        from tools.environments.execution_policy import ExecutionWriteScopeError
+
+        raise ExecutionWriteScopeError(execution_policy.capability)
+    environment_key = _resolve_environment_key(raw_task_id, execution_policy)
+
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
     with _file_ops_lock:
-        cached = _file_ops_cache.get(task_id)
+        cached = _file_ops_cache.get(environment_key)
     if cached is not None:
         with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
+            if environment_key in _active_environments:
+                _last_activity[environment_key] = time.time()
                 return cached
             else:
                 # Environment was cleaned up -- preserve the old cwd in the
@@ -977,21 +993,21 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     except Exception:
                         pass
                 with _file_ops_lock:
-                    _file_ops_cache.pop(task_id, None)
+                    _file_ops_cache.pop(environment_key, None)
 
     # Need to ensure the environment exists before building file_ops.
     # Acquire per-task lock so only one thread creates the sandbox.
     with _creation_locks_lock:
-        if task_id not in _creation_locks:
-            _creation_locks[task_id] = threading.Lock()
-        task_lock = _creation_locks[task_id]
+        if environment_key not in _creation_locks:
+            _creation_locks[environment_key] = threading.Lock()
+        task_lock = _creation_locks[environment_key]
 
     with task_lock:
         # Double-check: another thread may have created it while we waited
         with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
-                terminal_env = _active_environments[task_id]
+            if environment_key in _active_environments:
+                _last_activity[environment_key] = time.time()
+                terminal_env = _active_environments[environment_key]
             else:
                 terminal_env = None
 
@@ -1054,6 +1070,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "docker_extra_args": config.get("docker_extra_args", []),
+                    "execution_policy": execution_policy,
                 }
 
             ssh_config = None
@@ -1080,13 +1098,13 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 ssh_config=ssh_config,
                 container_config=container_config,
                 local_config=local_config,
-                task_id=task_id,
+                task_id=environment_key,
                 host_cwd=config.get("host_cwd"),
             )
 
             with _env_lock:
-                _active_environments[task_id] = terminal_env
-                _last_activity[task_id] = time.time()
+                _active_environments[environment_key] = terminal_env
+                _last_activity[environment_key] = time.time()
 
             _start_cleanup_thread()
             logger.info("%s environment ready for task %s", env_type, task_id[:8])
@@ -1094,7 +1112,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
     with _file_ops_lock:
-        _file_ops_cache[task_id] = file_ops
+        _file_ops_cache[environment_key] = file_ops
     return file_ops
 
 
@@ -1102,7 +1120,21 @@ def clear_file_ops_cache(task_id: str = None):
     """Clear the file operations cache."""
     with _file_ops_lock:
         if task_id:
-            _file_ops_cache.pop(task_id, None)
+            keys = {str(task_id)}
+            try:
+                from tools.environments.execution_policy import (
+                    policy_environment_keys_for_session,
+                )
+
+                keys.update(policy_environment_keys_for_session(task_id))
+            except Exception:
+                pass
+            for key in list(_file_ops_cache):
+                if str(key) in keys or any(
+                    str(key).startswith(f"{candidate}:execution-write:")
+                    for candidate in keys
+                ):
+                    _file_ops_cache.pop(key, None)
         else:
             _file_ops_cache.clear()
 
@@ -1390,6 +1422,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             )
 
         return json.dumps(result_dict, ensure_ascii=False)
+    except ExecutionWriteScopeError as e:
+        return _execution_scope_error(e)
     except Exception as e:
         return tool_error(str(e))
 
@@ -1637,6 +1671,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
         return json.dumps(result_dict, ensure_ascii=False)
+    except ExecutionWriteScopeError as e:
+        return _execution_scope_error(e)
     except Exception as e:
         if _is_expected_write_exception(e):
             logger.debug("write_file expected denial: %s: %s", type(e).__name__, e)
@@ -1835,6 +1871,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "content, or search_files to locate the text."
                 )
         return json.dumps(result_dict, ensure_ascii=False)
+    except ExecutionWriteScopeError as e:
+        return _execution_scope_error(e)
     except Exception as e:
         return tool_error(str(e))
 
@@ -1918,6 +1956,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             next_offset = offset + limit
             result_json += f"\n\n[Hint: Results truncated. Use offset={next_offset} to see more, or narrow with a more specific pattern or file_glob.]"
         return result_json
+    except ExecutionWriteScopeError as e:
+        return _execution_scope_error(e)
     except Exception as e:
         return tool_error(str(e))
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -77,6 +77,12 @@ from tools.tool_backend_helpers import (
     nous_tool_gateway_unavailable_message,
     resolve_modal_backend_state,
 )
+from tools.environments.execution_policy import (
+    ExecutionWritePolicy,
+    bind_policy_environment_key,
+    policy_environment_keys_for_session,
+    resolve_execution_write_policy,
+)
 
 
 def _safe_parse_import_env(
@@ -1199,6 +1205,8 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
         - docker_image: str -- Docker image name
         - cwd: str -- Working directory inside the sandbox
+        - execution_write_scope: str -- ``legacy`` or session-scoped ``workspace``
+        - workspace_root: str -- Immutable host workspace for workspace scope
 
     Args:
         task_id: The rollout's unique task identifier
@@ -1222,8 +1230,21 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # so a CWD-only override (which collapses to "default") still finds and
         # updates the originating session's env.
         container_id = _resolve_container_task_id(task_id)
+        policy_key = None
+        try:
+            config = _get_env_config()
+            policy = _resolve_execution_policy_for_task(
+                config, task_id, env_type=config.get("env_type"), cwd=new_cwd
+            )
+            policy_key = _resolve_environment_key(task_id, policy)
+        except Exception:
+            logger.debug("Could not resolve override environment identity", exc_info=True)
         with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
+            env = (
+                _active_environments.get(policy_key)
+                or _active_environments.get(task_id)
+                or _active_environments.get(container_id)
+            )
         if env is not None and getattr(env, "cwd", None) is not None:
             env.cwd = new_cwd
 
@@ -1236,6 +1257,9 @@ def clear_task_env_overrides(task_id: str):
     """
     _task_env_overrides.pop(task_id, None)
     clear_session_cwd(task_id)
+    from tools.environments.execution_policy import clear_execution_workspace
+
+    clear_execution_workspace(task_id)
 
 
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
@@ -1293,6 +1317,67 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     )
 
 
+def _resolve_execution_policy_for_task(
+    config: Dict[str, Any],
+    task_id: Optional[str],
+    *,
+    env_type: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> ExecutionWritePolicy:
+    """Resolve the immutable execution policy before any environment lookup."""
+    raw_task_id = str(task_id or "default")
+    overrides = resolve_task_overrides(raw_task_id)
+    backend = str(env_type or config.get("env_type") or "local").lower()
+    configured_scope = overrides.get(
+        "execution_write_scope",
+        config.get("execution_write_scope", "legacy"),
+    )
+    host_cwd = overrides.get("host_cwd", config.get("host_cwd"))
+    if backend in _CONTAINER_BACKENDS and _is_container_namespace_path(host_cwd):
+        host_cwd = None
+    workspace_root = (
+        overrides.get("workspace_root")
+        or config.get("workspace_root")
+        or overrides.get("host_workspace_root")
+        or config.get("host_workspace_root")
+        or overrides.get("host_cwd")
+        or host_cwd
+        or get_session_cwd(raw_task_id)
+    )
+    if backend in _CONTAINER_BACKENDS and _is_container_namespace_path(workspace_root):
+        workspace_root = None
+    if not workspace_root:
+        if backend not in _CONTAINER_BACKENDS:
+            workspace_root = cwd or config.get("cwd")
+    if not workspace_root or (
+        backend in _CONTAINER_BACKENDS and _is_container_namespace_path(workspace_root)
+    ):
+        workspace_root = _safe_getcwd()
+    return resolve_execution_write_policy(
+        configured_scope,
+        session_id=raw_task_id,
+        workspace_root=workspace_root,
+        backend=backend,
+        docker_volumes=overrides.get("docker_volumes", config.get("docker_volumes", [])),
+        docker_extra_args=overrides.get("docker_extra_args", config.get("docker_extra_args", [])),
+        host_cwd=host_cwd,
+        docker_mount_cwd_to_workspace=overrides.get(
+            "docker_mount_cwd_to_workspace",
+            config.get("docker_mount_cwd_to_workspace", False),
+        ),
+    )
+
+
+def _resolve_environment_key(task_id: Optional[str], policy: ExecutionWritePolicy) -> str:
+    """Bind raw session provenance to the one backend cache identity."""
+    raw_task_id = str(task_id or "default")
+    return bind_policy_environment_key(
+        raw_task_id,
+        _resolve_container_task_id(raw_task_id),
+        policy,
+    )
+
+
 # Configuration from environment variables
 
 def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
@@ -1334,6 +1419,14 @@ _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
 
+def _is_container_namespace_path(path: Any) -> bool:
+    """Return whether a path is a container namespace, not host provenance."""
+    if not isinstance(path, str):
+        return False
+    normalized = path.rstrip("/") or "/"
+    return normalized == "/root" or normalized == "/workspace" or normalized.startswith("/workspace/")
+
+
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     """Return True when *cwd* is a tilde path that the remote SSH shell must
     expand itself, so the Hermes host/container must NOT ``expanduser`` it.
@@ -1362,6 +1455,8 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     if not cwd:
         return False
     if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
+        return True
+    if re.match(r"^[A-Za-z]:[\\/]", cwd):
         return True
     # Relative paths (".", "src/") can't be a container workdir either. Windows
     # drive paths are absolute on Windows but os.path.isabs() is False on a
@@ -1447,6 +1542,18 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = {}
         docker_extra_args = []
 
+    execution_write_scope = "legacy"
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        configured_terminal = load_config_readonly().get("terminal") or {}
+        if isinstance(configured_terminal, dict):
+            execution_write_scope = configured_terminal.get(
+                "execution_write_scope", execution_write_scope
+            )
+    except Exception:
+        logger.debug("Could not load execution_write_scope; using legacy", exc_info=True)
+
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
     # else starts in the backend's default root-like cwd.
@@ -1463,19 +1570,30 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    raw_cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = raw_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
-    if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+    docker_cwd_source = raw_cwd or _safe_getcwd()
+    if _is_container_namespace_path(docker_cwd_source):
+        docker_cwd_source = _safe_getcwd()
+    if env_type == "docker" and (
+        mount_docker_cwd or execution_write_scope == "workspace"
+    ):
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
-            or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
+            or re.match(r"^[A-Za-z]:[\\/]", candidate)
+            or (
+                os.path.isabs(candidate)
+                and os.path.isdir(candidate)
+                and not candidate.startswith(("/workspace", "/root"))
+            )
         ):
             host_cwd = candidate
-            cwd = "/workspace"
+            if mount_docker_cwd:
+                cwd = "/workspace"
     elif env_type in _CONTAINER_BACKENDS and cwd:
         # Host paths and relative paths that won't work inside containers
         if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
@@ -1486,6 +1604,7 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
+        "execution_write_scope": execution_write_scope,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
         "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
@@ -1495,6 +1614,7 @@ def _get_env_config() -> Dict[str, Any]:
         "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
+        "host_workspace_root": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
@@ -1573,6 +1693,25 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         Environment instance with execute() method
     """
     cc = container_config or {}
+    execution_policy = cc.get("execution_policy")
+    if execution_policy is None:
+        policy_config = dict(_get_env_config())
+        if host_cwd and not policy_config.get("host_workspace_root"):
+            policy_config["host_workspace_root"] = host_cwd
+        execution_policy = _resolve_execution_policy_for_task(
+            policy_config,
+            task_id,
+            env_type=env_type,
+            cwd=cwd,
+        )
+    from tools.environments.execution_policy import (
+        ExecutionWriteScopeError,
+        validate_execution_capability,
+    )
+
+    capability = validate_execution_capability(execution_policy, env_type)
+    if not capability.supported:
+        raise ExecutionWriteScopeError(capability)
     cpu = cc.get("container_cpu", 1)
     memory = cc.get("container_memory", 5120)
     disk = cc.get("container_disk", 51200)
@@ -1582,6 +1721,13 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_env = cc.get("docker_env", {})
     docker_extra_args = cc.get("docker_extra_args", [])
     docker_network = cc.get("docker_network", True)
+    auto_mount_cwd = cc.get("docker_mount_cwd_to_workspace", False)
+
+    if execution_policy is not None and execution_policy.is_workspace_scoped:
+        volumes = [mapping.spec for mapping in execution_policy.docker_mappings]
+        docker_extra_args = list(execution_policy.docker_extra_args)
+        host_cwd = None
+        auto_mount_cwd = False
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
@@ -1600,13 +1746,14 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             persistent_filesystem=persistent, task_id=task_id,
             volumes=volumes,
             host_cwd=host_cwd,
-            auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
+            auto_mount_cwd=auto_mount_cwd,
             forward_env=docker_forward_env,
             env=docker_env,
             run_as_host_user=cc.get("docker_run_as_host_user", False),
             network=docker_network,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
+            execution_policy=execution_policy,
         )
     
     elif env_type == "singularity":
@@ -1753,6 +1900,9 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     # Phase 2: stop the actual sandboxes OUTSIDE the lock so other tool calls
     # are not blocked while Modal/Docker sandboxes shut down.
     for task_id, env in envs_to_stop:
+        from tools.environments.execution_policy import forget_policy_environment_key
+
+        forget_policy_environment_key(task_id)
         # Invalidate stale file_ops cache entry (Bug fix: prevents
         # ShellFileOperations from referencing a dead sandbox)
         try:
@@ -1777,6 +1927,19 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
                 logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+
+
+def _resolve_cleanup_environment_keys(task_id: str | None) -> tuple[str, ...]:
+    """Resolve cleanup without collapsing a legacy session onto ``default``."""
+    raw_task_id = str(task_id or "default")
+    bounded_keys = policy_environment_keys_for_session(raw_task_id)
+    if bounded_keys:
+        return tuple(dict.fromkeys(key for key in bounded_keys if key))
+
+    # Legacy sessions intentionally share the collapsed container. Main only
+    # removed the raw lifecycle key, so closing one session must not tear down
+    # the shared ``default`` environment.
+    return (raw_task_id,)
 
 
 def _cleanup_thread_worker():
@@ -1818,9 +1981,20 @@ def _stop_cleanup_thread():
 
 def get_active_env(task_id: str):
     """Return the active BaseEnvironment for *task_id*, or None."""
-    lookup = _resolve_container_task_id(task_id)
+    raw_task_id = str(task_id or "default")
+    bounded_keys = policy_environment_keys_for_session(raw_task_id)
+    if bounded_keys:
+        lookup_keys = tuple(reversed(bounded_keys))
+    else:
+        # Legacy traffic is the common path. Keep it to the existing direct
+        # dict lookup and the in-memory raw-to-default mapping.
+        lookup_keys = (raw_task_id, _resolve_container_task_id(raw_task_id))
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        for key in dict.fromkeys(lookup_keys):
+            env = _active_environments.get(key)
+            if env is not None:
+                return env
+    return None
 
 
 def is_persistent_env(task_id: str) -> bool:
@@ -1893,48 +2067,74 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.
-    env = None
+    environment_keys = _resolve_cleanup_environment_keys(task_id)
+    envs = []
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for environment_key in environment_keys:
+            env = _active_environments.pop(environment_key, None)
+            _last_activity.pop(environment_key, None)
+            if env is not None:
+                envs.append((environment_key, env))
+
+    from tools.environments.execution_policy import forget_policy_environment_key
+
+    forget_policy_environment_key(str(task_id or "default"))
+    for environment_key in environment_keys:
+        forget_policy_environment_key(environment_key)
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for environment_key in environment_keys:
+            _creation_locks.pop(environment_key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
         clear_file_ops_cache(task_id)
+        for environment_key in environment_keys:
+            clear_file_ops_cache(environment_key)
     except ImportError:
         pass
 
-    if env is None:
+    # Workspace background and PTY processes use the bounded environment key,
+    # so session close/reset must target that same identity.
+    if any(environment_key.startswith("hermes-workspace-") for environment_key in environment_keys):
+        try:
+            from tools.process_registry import process_registry
+
+            for environment_key in environment_keys:
+                if environment_key.startswith("hermes-workspace-"):
+                    process_registry.kill_all(task_id=environment_key)
+        except Exception:
+            logger.debug("Could not clean workspace processes", exc_info=True)
+
+    if not envs:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
+    for environment_key, env in envs:
+        try:
+            if hasattr(env, 'cleanup'):
+                # Pass force_remove only if the env's cleanup() accepts it
+                # (DockerEnvironment after issue #20561; other backends don't).
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=force_remove)
+                else:
+                    env.cleanup()
+            elif hasattr(env, 'stop'):
+                env.stop()
+            elif hasattr(env, 'terminate'):
+                env.terminate()
+
+            logger.info("Manually cleaned up environment for task: %s", environment_key)
+
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "not found" in error_str.lower():
+                logger.info("Environment for task %s already cleaned up", environment_key)
             else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", environment_key, e)
 
 
 def _atexit_cleanup():
@@ -2268,6 +2468,7 @@ def terminal_tool(
             image = ""
 
         cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
+        policy_cwd = cwd
         # A per-task cwd override (registered by the gateway/TUI for workspace
         # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
         # config["cwd"] was already sanitized for container backends in
@@ -2287,6 +2488,20 @@ def terminal_tool(
                     cwd, env_type, config["cwd"],
                 )
             cwd = config["cwd"]
+        execution_policy = _resolve_execution_policy_for_task(
+            config, task_id, env_type=env_type, cwd=policy_cwd
+        )
+        if not execution_policy.capability.supported:
+            return json.dumps(
+                {
+                    "output": "",
+                    "exit_code": -1,
+                    "status": "blocked",
+                    **execution_policy.capability.as_error(),
+                },
+                ensure_ascii=False,
+            )
+        environment_key = _resolve_environment_key(task_id, execution_policy)
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
 
@@ -2326,8 +2541,12 @@ def terminal_tool(
             # sharing, yet an env may already be cached under the originating
             # task_id; honor it instead of spawning a duplicate.
             _existing_key = (
-                effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
+                environment_key if environment_key in _active_environments
+                else (None if execution_policy.is_workspace_scoped else (
+                    effective_task_id
+                    if effective_task_id in _active_environments
+                    else (task_id if task_id and task_id in _active_environments else None)
+                ))
             )
             if _existing_key is not None:
                 _last_activity[_existing_key] = time.time()
@@ -2339,16 +2558,20 @@ def terminal_tool(
         if needs_creation:
             # Per-task lock: only one thread creates the sandbox, others wait
             with _creation_locks_lock:
-                if effective_task_id not in _creation_locks:
-                    _creation_locks[effective_task_id] = threading.Lock()
-                task_lock = _creation_locks[effective_task_id]
+                if environment_key not in _creation_locks:
+                    _creation_locks[environment_key] = threading.Lock()
+                task_lock = _creation_locks[environment_key]
 
             with task_lock:
                 # Double-check after acquiring the per-task lock
                 with _env_lock:
                     _existing_key = (
-                        effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
+                        environment_key if environment_key in _active_environments
+                        else (None if execution_policy.is_workspace_scoped else (
+                            effective_task_id
+                            if effective_task_id in _active_environments
+                            else (task_id if task_id and task_id in _active_environments else None)
+                        ))
                     )
                     if _existing_key is not None:
                         _last_activity[_existing_key] = time.time()
@@ -2388,6 +2611,7 @@ def terminal_tool(
                                 "docker_network": config.get("docker_network", True),
                                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                                "execution_policy": execution_policy,
                             }
 
                         local_config = None
@@ -2404,7 +2628,7 @@ def terminal_tool(
                             ssh_config=ssh_config,
                             container_config=container_config,
                             local_config=local_config,
-                            task_id=effective_task_id,
+                            task_id=environment_key,
                             host_cwd=config.get("host_cwd"),
                         )
                     except ImportError as e:
@@ -2414,10 +2638,25 @@ def terminal_tool(
                             "error": f"Terminal tool disabled: environment creation failed ({e})",
                             "status": "disabled"
                         }, ensure_ascii=False)
+                    except Exception as e:
+                        from tools.environments.execution_policy import ExecutionWriteScopeError
+
+                        if isinstance(e, ExecutionWriteScopeError):
+                            return json.dumps(
+                                {
+                                    "output": "",
+                                    "exit_code": -1,
+                                    "status": "blocked",
+                                    **e.result.as_error(),
+                                },
+                                ensure_ascii=False,
+                            )
+                        if not isinstance(e, ImportError):
+                            raise
 
                     with _env_lock:
-                        _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
+                        _active_environments[environment_key] = new_env
+                        _last_activity[environment_key] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
@@ -2535,6 +2774,9 @@ def terminal_tool(
         from tools.approval import get_current_session_key
 
         session_key = get_current_session_key(default="") or (task_id or "")
+        process_task_id = (
+            environment_key if execution_policy.is_workspace_scoped else effective_task_id
+        )
 
         if background:
             # Spawn a tracked background process via the process registry.
@@ -2552,7 +2794,7 @@ def terminal_tool(
                     proc_session = process_registry.spawn_local(
                         command=command,
                         cwd=effective_cwd,
-                        task_id=effective_task_id,
+                        task_id=process_task_id,
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
@@ -2562,7 +2804,7 @@ def terminal_tool(
                         env=env,
                         command=command,
                         cwd=effective_cwd,
-                        task_id=effective_task_id,
+                        task_id=process_task_id,
                         session_key=session_key,
                     )
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -816,7 +816,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_PREFILL_MESSAGES_FILE` | Path to a JSON file of ephemeral prefill messages injected at API-call time. |
 | `HERMES_ALLOW_PRIVATE_URLS` | `true`/`false` — allow tools to fetch localhost/private-network URLs. Off by default in gateway mode. |
 | `HERMES_REDACT_SECRETS` | `true`/`false` — control secret redaction in tool output, logs, and chat responses (default: `true`). |
-| `HERMES_WRITE_SAFE_ROOT` | Optional directory prefix that **hard-blocks** `write_file`/`patch` writes outside the listed roots (no approval prompt). Supports multiple directories separated by `os.pathsep` (`:` on Unix, `;` on Windows). See [HERMES_WRITE_SAFE_ROOT](#hermes_write_safe_root) below. |
+| `HERMES_WRITE_SAFE_ROOT` | Optional directory prefix that **hard-blocks** `write_file`/`patch` writes outside the listed roots (no approval prompt). It remains a native file-tool policy and is not an execution boundary. Supports multiple directories separated by `os.pathsep` (`:` on Unix, `;` on Windows). See [HERMES_WRITE_SAFE_ROOT](#hermes_write_safe_root) below. |
 | `HERMES_DISABLE_LAZY_INSTALLS` | Internal bridge var set automatically in the official Docker image to prevent runtime dependency installs into the immutable `/opt/hermes` tree. The user-facing equivalent is `security.allow_lazy_installs: false` in `config.yaml`; do not set this in `.env`. |
 | `HERMES_DISABLE_FILE_STATE_GUARD` | Set to `1` to turn off the "file changed since you read it" guard on `patch`/`write_file`. |
 | `HERMES_BUNDLED_SKILLS` | Comma-separated override for the list of bundled skills loaded at startup. |
@@ -844,6 +844,8 @@ export HERMES_WRITE_SAFE_ROOT=/path/to/project:/home/you/.hermes
 ```
 
 Unset the variable or remove it from `.env` to restore normal writes (still subject to the credential-path denylist — see [File write safety](../user-guide/security.md#file-write-safety)).
+
+Process write confinement is configured separately with `terminal.execution_write_scope: workspace` in `config.yaml`. It is intentionally not an environment variable; Docker is the only supported adapter, and unsupported adapters refuse before execution begins.
 
 ## Interface
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -121,6 +121,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 ```yaml
 terminal:
   backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  execution_write_scope: legacy  # legacy | workspace; workspace is Docker-only
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   home_mode: auto   # auto | real | profile — subprocess HOME policy
@@ -131,6 +132,12 @@ terminal:
 ```
 
 For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
+
+#### `terminal.execution_write_scope`
+
+`legacy` is the default and preserves the existing backend behavior. Set this to `workspace` when the session must have a process write boundary. This release supports that scope only on Docker. Docker validates every writable host mapping against the session's immutable workspace and refuses before container creation when it cannot prove the mapping. Local, SSH, Singularity, Modal, Daytona, and Vercel Sandbox return an explicit unsupported error and Hermes keeps the configured backend; it does not switch backends.
+
+The scope covers process writes and descendants. Private files inside the Docker container remain writable, but they are not published to the broker or made available through file delivery. `execution_write_scope` is configuration-owned and has no environment-variable override.
 
 ### Backend Overview
 
@@ -292,7 +299,7 @@ Parallel subagents spawned via `delegate_task(tasks=[...])` share this one conta
 
 #### Environment variable overrides
 
-Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_UPPERCASE>`. The most useful ones for the Docker backend:
+Most keys under `terminal:` have an env-var override of the form `TERMINAL_<KEY_UPPERCASE>`. `execution_write_scope` is configuration-only because execution authority must not be supplied by an ambient process environment. The most useful environment overrides for the Docker backend are:
 
 | Env var | Maps to | Notes |
 |---|---|---|

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -316,6 +316,12 @@ Do not ask the agent to `patch` `~/.hermes/cron/jobs.json` directly. Use the `cr
 Write guards apply to `write_file` and `patch` only. The `terminal` tool runs as the same OS user and can still `cat` or overwrite denied paths via shell commands. The denylist reduces accidental damage and gives models a clear stop signal; it does not sandbox a hostile or compromised agent.
 :::
 
+### Process write scope
+
+`terminal.execution_write_scope: workspace` is the opt-in process boundary for a session. Docker is the only supported adapter in this release. Hermes validates normalized writable host mappings beneath the session workspace before `docker run`; local, SSH, Singularity, Modal, Daytona, and Vercel Sandbox refuse the request before creating a process, connection, container, or PTY. Docker-private paths remain writable. Private container files are not broker-published output.
+
+This setting is separate from `HERMES_WRITE_SAFE_ROOT`. The environment variable remains the cooperative native-file-tool policy for `write_file` and `patch`; it is never interpreted as an execution boundary and has no effect on terminal or `execute_code` process confinement.
+
 ## User Authorization (Gateway)
 
 When running the messaging gateway, Hermes controls who can interact with the bot through a layered authorization system.


### PR DESCRIPTION
## Summary

`HERMES_WRITE_SAFE_ROOT` remains the native `write_file` and `patch` policy it has always been. This rebuild removes the bypassable command and Python parsing from this branch and adds `terminal.execution_write_scope: workspace` for sessions that require an execution boundary.

Docker is the first supported workspace adapter. It validates writable host mappings against an immutable session workspace, keeps credentials, skills, caches, and profile images read-only, and isolates private container storage. Local, SSH, and other adapters return a clear unsupported error before creating a process, connection, container, or PTY session.

## Changes

- `tools/environments/execution_policy.py`: shared immutable policy, bounded environment identity, Docker mapping validation, and typed capability failures.
- Terminal, execute-code, file tools, and prompt probing: one policy owner before environment reuse or process creation, with symmetric cleanup.
- Docker: workspace-only writable host mappings, private replacement for persistent host paths, and retained read-only credential, skill, cache, and image mounts.
- Configuration and docs: default `legacy` behavior plus Docker-only workspace support and explicit non-publication semantics.
- Focused regressions: session cleanup, Windows host-path provenance, generated read-only mounts, prompt probe isolation, Docker mapping rejection, and dynamic descendant behavior.

## Validation

| Scenario | Current behavior | Rebuilt behavior |
| --- | --- | --- |
| `HERMES_WRITE_SAFE_ROOT` native file write | Denied outside root | Unchanged |
| Default terminal or execute-code | Existing backend behavior | Unchanged with the `legacy` default |
| Workspace scope on local or SSH | Unrestricted process | Refused before spawn |
| Workspace scope on accepted Docker mapping | No declared boundary | Host mapping is validated before container creation |
| Private Docker output | Not a broker file | Still not a broker file |

## Test plan

- `python -m pytest tests/tools/test_execution_write_policy.py tests/tools/test_terminal_task_cwd.py tests/tools/test_terminal_tool.py tests/tools/test_file_tools.py tests/tools/test_code_execution.py tests/tools/test_docker_environment.py tests/tools/test_credential_files.py tests/agent/test_prompt_builder.py tests/integration/test_execution_write_confinement.py -v --timeout=0` — 56 passed, 1 skipped.
- `scripts/check-windows-footguns.py` and `git diff --check` passed.
- Docker runtime proof is skipped locally because Docker is unavailable; CI remains the owner proof for the descendant and bind-mount boundary.

## Not in scope

Native local, SSH, Singularity, Modal, managed Modal, Daytona, and Vercel Sandbox confinement adapters remain explicit unsupported cases for workspace scope. This change does not alter FileSyncManager or broker delivery roots, so private container output remains unpublished.

## Upstream

Refs #36645.
