### PR TITLE
fix(gateway): forward reasoning in chat completions (#37044)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -82,6 +82,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.display_config import resolve_display_setting
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -2351,6 +2352,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        reasoning_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
@@ -2652,6 +2654,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
             "tool_progress_callback": tool_progress_callback,
+            "reasoning_callback": reasoning_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
             "session_db": self._ensure_session_db(),
@@ -3853,6 +3856,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        try:
+            from gateway.run import _load_gateway_config
+
+            show_reasoning = bool(
+                resolve_display_setting(
+                    _load_gateway_config(), "api_server", "show_reasoning", False
+                )
+            )
+        except Exception:
+            show_reasoning = False
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -3867,6 +3881,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # completion via agent_task.done() instead.
                 if delta is not None:
                     _stream_q.put(delta)
+
+            def _on_reasoning(delta):
+                if delta:
+                    _stream_q.put(("__reasoning__", delta))
 
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
@@ -3931,6 +3949,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning if show_reasoning else None,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
@@ -3985,6 +4004,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
+        last_reasoning = result.get("last_reasoning") or ""
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
@@ -4039,6 +4059,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "message": {
                         "role": "assistant",
                         "content": final_response,
+                        **({"reasoning_content": last_reasoning} if show_reasoning and last_reasoning else {}),
                     },
                     "finish_reason": finish_reason,
                 }
@@ -4118,7 +4139,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
+                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    if not item[1]:
+                        return time.monotonic()
+                    reasoning_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{"index": 0, "delta": {"reasoning_content": item[1]}, "finish_reason": None}],
+                    }
+                    await response.write(f"data: {json.dumps(reasoning_chunk)}\n\n".encode())
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
@@ -5762,6 +5792,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        reasoning_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
@@ -5821,6 +5852,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_id=session_id,
                         stream_delta_callback=stream_delta_callback,
                         tool_progress_callback=tool_progress_callback,
+                        reasoning_callback=reasoning_callback,
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -85,6 +85,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.display_config import resolve_display_setting
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -2599,6 +2600,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        reasoning_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
@@ -2911,6 +2913,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
             "tool_progress_callback": tool_progress_callback,
+            "reasoning_callback": reasoning_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
             "session_db": self._ensure_session_db(),
@@ -4247,6 +4250,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        try:
+            from gateway.run import _load_gateway_config
+
+            show_reasoning = bool(
+                resolve_display_setting(
+                    _load_gateway_config(), "api_server", "show_reasoning", False
+                )
+            )
+        except Exception:
+            show_reasoning = False
+
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
 
@@ -4262,6 +4276,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # put_threadsafe (not put_nowait) is required here.
                 if delta is not None:
                     _stream_q.put_threadsafe(delta)
+
+            def _on_reasoning(delta):
+                if delta:
+                    _stream_q.put_threadsafe(("__reasoning__", delta))
 
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
@@ -4326,6 +4344,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning if show_reasoning else None,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
@@ -4380,6 +4399,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
+        last_reasoning = result.get("last_reasoning") or ""
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
@@ -4434,6 +4454,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "message": {
                         "role": "assistant",
                         "content": final_response,
+                        **({"reasoning_content": last_reasoning} if show_reasoning and last_reasoning else {}),
                     },
                     "finish_reason": finish_reason,
                 }
@@ -4511,7 +4532,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation history.  See #6972 for the original event,
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
+                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    if not item[1]:
+                        return time.monotonic()
+                    reasoning_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{"index": 0, "delta": {"reasoning_content": item[1]}, "finish_reason": None}],
+                    }
+                    await response.write(_sse_frame(reasoning_chunk))
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
                 else:
                     content_chunk = {
@@ -6206,6 +6236,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        reasoning_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
@@ -6271,6 +6302,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_id=session_id,
                         stream_delta_callback=stream_delta_callback,
                         tool_progress_callback=tool_progress_callback,
+                        reasoning_callback=reasoning_callback,
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -217,9 +217,13 @@ class TestAdapterInit:
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
 
-        agent = adapter._create_agent(session_id="api-session")
+        reasoning_callback = object()
+        agent = adapter._create_agent(
+            session_id="api-session", reasoning_callback=reasoning_callback
+        )
 
         assert isinstance(agent, FakeAgent)
+        assert captured["reasoning_callback"] is reasoning_callback
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
         assert captured["checkpoints_enabled"] is True
         assert captured["checkpoint_max_snapshots"] == 7
@@ -325,6 +329,20 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     return app
 
 
+def _chat_stream_chunks(body: str) -> list[dict]:
+    chunks = []
+    for line in body.splitlines():
+        if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+            continue
+        try:
+            chunk = json.loads(line[len("data: "):])
+        except json.JSONDecodeError:
+            continue
+        if chunk.get("object") == "chat.completion.chunk":
+            chunks.append(chunk)
+    return chunks
+
+
 class _FakeGoogleChatAdapter:
     def __init__(self, *, verify_ok: bool = True, verify_code: str = ""):
         self.verify_ok = verify_ok
@@ -356,6 +374,21 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_run_agent_forwards_reasoning_callback_identity(self, adapter):
+        reasoning_callback = object()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent) as mock_create_agent:
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                reasoning_callback=reasoning_callback,
+            )
+
+        assert mock_create_agent.call_args.kwargs["reasoning_callback"] is reasoning_callback
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
@@ -779,6 +812,271 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_forwards_provider_reasoning(self, adapter):
+        """Provider reasoning reaches the chat-completions stream distinctly."""
+        reasoning = "provider reasoning " * 40
+        assert len(reasoning) == 760
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                if captured.get("reasoning_callback") is not None:
+                    captured["reasoning_callback"](reasoning)
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch(
+                    "gateway.run._load_gateway_config",
+                    return_value={
+                        "display": {
+                            "platforms": {"api_server": {"show_reasoning": True}}
+                        }
+                    },
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert captured["reasoning_callback"] is not None
+        reasoning_chunks = []
+        content_chunks = []
+        for line in body.splitlines():
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            chunk = json.loads(line[len("data: "):])
+            for choice in chunk.get("choices", []):
+                delta = choice.get("delta", {})
+                if "reasoning_content" in delta:
+                    reasoning_chunks.append(delta["reasoning_content"])
+                if "content" in delta:
+                    content_chunks.append(delta["content"])
+
+        assert "".join(reasoning_chunks) == reasoning
+        assert content_chunks == ["Answer"]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_supports_reasoning_only_output(self, adapter):
+        reasoning = "reasoning without an answer"
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                captured["reasoning_callback"](reasoning)
+                return {"final_response": "", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch("gateway.platforms.api_server.resolve_display_setting", return_value=True),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        chunks = _chat_stream_chunks(body)
+        assert "".join(
+            choice["delta"]["reasoning_content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if "reasoning_content" in choice["delta"]
+        ) == reasoning
+        assert not any(
+            "content" in choice["delta"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+        )
+        assert '"finish_reason": "stop"' in body
+        assert "data: [DONE]" in body
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("show_reasoning, emitted_reasoning", [(True, ""), (False, "hidden")])
+    async def test_chat_completions_stream_suppresses_empty_or_disabled_reasoning(
+        self, adapter, show_reasoning, emitted_reasoning
+    ):
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                if emitted_reasoning and captured.get("reasoning_callback"):
+                    captured["reasoning_callback"](emitted_reasoning)
+                elif captured.get("reasoning_callback"):
+                    captured["reasoning_callback"]("")
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch(
+                    "gateway.platforms.api_server.resolve_display_setting",
+                    return_value=show_reasoning,
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert (captured.get("reasoning_callback") is not None) is show_reasoning
+        assert not any(
+            "reasoning_content" in choice["delta"]
+            for chunk in _chat_stream_chunks(body)
+            for choice in chunk["choices"]
+        )
+        assert '"content": "Answer"' in body
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_reasoning_coexists_with_tool_lifecycle(
+        self, adapter
+    ):
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                captured["reasoning_callback"]("thought")
+                captured["tool_start_callback"]("call_1", "terminal", {"command": "pwd"})
+                captured["tool_complete_callback"]("call_1", "terminal", {"command": "pwd"}, "ok")
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch("gateway.platforms.api_server.resolve_display_setting", return_value=True),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "run"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        chunks = _chat_stream_chunks(body)
+        assert "".join(
+            choice["delta"]["reasoning_content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if "reasoning_content" in choice["delta"]
+        ) == "thought"
+        assert '"content": "Answer"' in body
+        lifecycle = []
+        lines = body.splitlines()
+        for index, line in enumerate(lines):
+            if line == "event: hermes.tool.progress":
+                payload = json.loads(lines[index + 1][len("data: "):])
+                lifecycle.append((payload["status"], payload["toolCallId"]))
+        assert lifecycle == [("running", "call_1"), ("completed", "call_1")]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "show_reasoning,last_reasoning,expected",
+        [(True, "current-turn thought", "current-turn thought"), (True, "", None), (False, "hidden", None)],
+    )
+    async def test_chat_completions_non_streaming_reasoning_display_gate(
+        self, adapter, show_reasoning, last_reasoning, expected
+    ):
+        result = {
+            "final_response": "Answer",
+            "last_reasoning": last_reasoning,
+            "completed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+                patch(
+                    "gateway.platforms.api_server.resolve_display_setting",
+                    return_value=show_reasoning,
+                ),
+            ):
+                mock_run.return_value = (result, {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                    },
+                )
+                assert resp.status == 200
+                message = (await resp.json())["choices"][0]["message"]
+
+        assert message["content"] == "Answer"
+        if expected is None:
+            assert "reasoning_content" not in message
+        else:
+            assert message["reasoning_content"] == expected
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -217,9 +217,13 @@ class TestAdapterInit:
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
 
-        agent = adapter._create_agent(session_id="api-session")
+        reasoning_callback = object()
+        agent = adapter._create_agent(
+            session_id="api-session", reasoning_callback=reasoning_callback
+        )
 
         assert isinstance(agent, FakeAgent)
+        assert captured["reasoning_callback"] is reasoning_callback
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
         assert captured["checkpoints_enabled"] is True
         assert captured["checkpoint_max_snapshots"] == 7
@@ -325,6 +329,20 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     return app
 
 
+def _chat_stream_chunks(body: str) -> list[dict]:
+    chunks = []
+    for line in body.splitlines():
+        if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+            continue
+        try:
+            chunk = json.loads(line[len("data: "):])
+        except json.JSONDecodeError:
+            continue
+        if chunk.get("object") == "chat.completion.chunk":
+            chunks.append(chunk)
+    return chunks
+
+
 class _FakeGoogleChatAdapter:
     def __init__(self, *, verify_ok: bool = True, verify_code: str = ""):
         self.verify_ok = verify_ok
@@ -356,6 +374,21 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_run_agent_forwards_reasoning_callback_identity(self, adapter):
+        reasoning_callback = object()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent) as mock_create_agent:
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                reasoning_callback=reasoning_callback,
+            )
+
+        assert mock_create_agent.call_args.kwargs["reasoning_callback"] is reasoning_callback
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
@@ -1019,6 +1052,271 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_forwards_provider_reasoning(self, adapter):
+        """Provider reasoning reaches the chat-completions stream distinctly."""
+        reasoning = "provider reasoning " * 40
+        assert len(reasoning) == 760
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                if captured.get("reasoning_callback") is not None:
+                    captured["reasoning_callback"](reasoning)
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch(
+                    "gateway.run._load_gateway_config",
+                    return_value={
+                        "display": {
+                            "platforms": {"api_server": {"show_reasoning": True}}
+                        }
+                    },
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert captured["reasoning_callback"] is not None
+        reasoning_chunks = []
+        content_chunks = []
+        for line in body.splitlines():
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            chunk = json.loads(line[len("data: "):])
+            for choice in chunk.get("choices", []):
+                delta = choice.get("delta", {})
+                if "reasoning_content" in delta:
+                    reasoning_chunks.append(delta["reasoning_content"])
+                if "content" in delta:
+                    content_chunks.append(delta["content"])
+
+        assert "".join(reasoning_chunks) == reasoning
+        assert content_chunks == ["Answer"]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_supports_reasoning_only_output(self, adapter):
+        reasoning = "reasoning without an answer"
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                captured["reasoning_callback"](reasoning)
+                return {"final_response": "", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch("gateway.platforms.api_server.resolve_display_setting", return_value=True),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        chunks = _chat_stream_chunks(body)
+        assert "".join(
+            choice["delta"]["reasoning_content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if "reasoning_content" in choice["delta"]
+        ) == reasoning
+        assert not any(
+            "content" in choice["delta"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+        )
+        assert '"finish_reason": "stop"' in body
+        assert "data: [DONE]" in body
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("show_reasoning, emitted_reasoning", [(True, ""), (False, "hidden")])
+    async def test_chat_completions_stream_suppresses_empty_or_disabled_reasoning(
+        self, adapter, show_reasoning, emitted_reasoning
+    ):
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                if emitted_reasoning and captured.get("reasoning_callback"):
+                    captured["reasoning_callback"](emitted_reasoning)
+                elif captured.get("reasoning_callback"):
+                    captured["reasoning_callback"]("")
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch(
+                    "gateway.platforms.api_server.resolve_display_setting",
+                    return_value=show_reasoning,
+                ),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert (captured.get("reasoning_callback") is not None) is show_reasoning
+        assert not any(
+            "reasoning_content" in choice["delta"]
+            for chunk in _chat_stream_chunks(body)
+            for choice in chunk["choices"]
+        )
+        assert '"content": "Answer"' in body
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_reasoning_coexists_with_tool_lifecycle(
+        self, adapter
+    ):
+        captured = {}
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+            session_total_tokens = 2
+            session_id = None
+
+            def run_conversation(self, **kwargs):
+                captured["reasoning_callback"]("thought")
+                captured["tool_start_callback"]("call_1", "terminal", {"command": "pwd"})
+                captured["tool_complete_callback"]("call_1", "terminal", {"command": "pwd"}, "ok")
+                captured["stream_delta_callback"]("Answer")
+                return {"final_response": "Answer", "messages": [], "api_calls": 1}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=fake_create_agent),
+                patch("gateway.platforms.api_server.resolve_display_setting", return_value=True),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "run"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        chunks = _chat_stream_chunks(body)
+        assert "".join(
+            choice["delta"]["reasoning_content"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if "reasoning_content" in choice["delta"]
+        ) == "thought"
+        assert '"content": "Answer"' in body
+        lifecycle = []
+        lines = body.splitlines()
+        for index, line in enumerate(lines):
+            if line == "event: hermes.tool.progress":
+                payload = json.loads(lines[index + 1][len("data: "):])
+                lifecycle.append((payload["status"], payload["toolCallId"]))
+        assert lifecycle == [("running", "call_1"), ("completed", "call_1")]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "show_reasoning,last_reasoning,expected",
+        [(True, "current-turn thought", "current-turn thought"), (True, "", None), (False, "hidden", None)],
+    )
+    async def test_chat_completions_non_streaming_reasoning_display_gate(
+        self, adapter, show_reasoning, last_reasoning, expected
+    ):
+        result = {
+            "final_response": "Answer",
+            "last_reasoning": last_reasoning,
+            "completed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+                patch(
+                    "gateway.platforms.api_server.resolve_display_setting",
+                    return_value=show_reasoning,
+                ),
+            ):
+                mock_run.return_value = (result, {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "think"}],
+                    },
+                )
+                assert resp.status == 200
+                message = (await resp.json())["choices"][0]["message"]
+
+        assert message["content"] == "Answer"
+        if expected is None:
+            assert "reasoning_content" not in message
+        else:
+            assert message["reasoning_content"] == expected
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`/v1/chat/completions` exposed assistant text but dropped reasoning generated by the provider. The streaming route had no path from `AIAgent.reasoning_callback` into its SSE writer, and the non-streaming message discarded the completed turn's `last_reasoning` value. Using the derived `reasoning.available` tool-progress event would have mislabeled final answer text and capped the output.

This rebuild forwards the existing provider reasoning callback through the API adapter and emits its deltas as OpenAI-compatible `delta.reasoning_content`. The callback uses current main's `ThreadSafeAsyncQueue` and shared `_sse_frame()` path. Non-streaming responses include the current turn's `reasoning_content` under the same `display.show_reasoning` policy. The display policy defaults to hidden and applies the existing API-server override precedence.

Fixes #37044

## Changes

- `gateway/platforms/api_server.py`: pass provider reasoning through `_run_agent()` and `_create_agent()`, feed tagged deltas through `ThreadSafeAsyncQueue`, serialize them with `_sse_frame()`, and include non-empty `last_reasoning` in non-streaming messages when display is enabled.
- `tests/gateway/test_api_server.py`: cover callback construction and forwarding, full reasoning payloads, reasoning-only output, empty and disabled reasoning, tool lifecycle coexistence, and non-streaming response shapes.

## Validation

| Scenario | Behavior |
| --- | --- |
| Streaming provider reasoning with display enabled | Preserved byte-for-byte in `delta.reasoning_content`; assistant text remains in `delta.content`. |
| Reasoning-only output | Emits reasoning and normal SSE completion without fabricated assistant content. |
| Empty reasoning or display disabled | Omits `reasoning_content` while answer, tool lifecycle, and completion output continue. |
| Structured tool lifecycle | Retains one correlated running and completed event without using the tool-progress reasoning preview. |
| Non-streaming response | Adds current-turn `message.reasoning_content` only when non-empty and display is enabled. |
| `/v1/responses`, `/v1/runs`, session chat, messaging | Retain their existing endpoint-specific reasoning and event contracts. |

## Test plan

- `bash scripts/run_tests.sh tests/gateway/test_api_server.py -k "reasoning or run_agent or stream_includes_tool_progress or stream_emits_tool_lifecycle or stream_tool_lifecycle" -v --timeout=0` — 15 passed.
- `bash scripts/run_tests.sh tests/gateway/test_api_server.py -k "stream_includes_tool_progress or stream_emits_tool_lifecycle or stream_tool_lifecycle_skips_internal or stream_cancelled_persists_incomplete_snapshot or stream_client_disconnect_persists_incomplete_snapshot" -v --timeout=0` — 5 passed.
- `ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py` — passed.

## Not in scope

`/v1/responses`, `/v1/runs`, native session chat, and messaging platforms keep their established response formats and callback contracts.
