### PR TITLE
fix(tui): rebuild agent tool schema when background MCP discovery completes (fixes #38945)

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 # agent build briefly joins this so already-spawning fast servers land before
 # the agent snapshots its tool list (see wait_for_mcp_discovery).
 _mcp_discovery_thread = None
+# Signalled once background MCP discovery completes (success or failure).
+# Allows downstream code to wait for discovery without polling the thread.
+_mcp_discovery_done = None  # threading.Event -- set when background MCP discovery completes
 
 
 def _install_sidecar_publisher() -> None:
@@ -242,6 +245,10 @@ def main():
         # discovery (still backgrounded, so it can't block startup).
         _has_mcp_servers = True
     if _has_mcp_servers:
+        import threading as _mcp_threading
+
+        _mcp_discovery_done = _mcp_threading.Event()
+
         def _discover_mcp_background() -> None:
             try:
                 from tools.mcp_tool import discover_mcp_tools
@@ -250,6 +257,8 @@ def main():
                 logger.warning(
                     "Background MCP tool discovery failed", exc_info=True
                 )
+            finally:
+                _mcp_discovery_done.set()
 
         import threading as _mcp_threading
         _mcp_thread = _mcp_threading.Thread(
@@ -258,8 +267,6 @@ def main():
             daemon=True,
         )
         _mcp_thread.start()
-        # Publish the handle so the first agent build can briefly wait for
-        # already-spawning fast servers to land (see wait_for_mcp_discovery).
         global _mcp_discovery_thread
         _mcp_discovery_thread = _mcp_thread
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -563,6 +563,46 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
 
+            # MCP discovery runs in a background daemon thread at startup.
+            # If it hasn't finished yet, the agent's tool snapshot is missing
+            # slow-connecting HTTP MCP servers. Start a watcher that rebuilds
+            # tools once discovery completes (bounded by the event).
+            try:
+                from tui_gateway.entry import _mcp_discovery_done
+
+                if _mcp_discovery_done is not None and not _mcp_discovery_done.is_set():
+                    import threading as _mcp_watch_threading
+
+                    def _rebuild_mcp_tools() -> None:
+                        _mcp_discovery_done.wait()
+                        session = _sessions.get(sid)
+                        if session is None:
+                            return
+                        agent = session.get("agent")
+                        if agent is None:
+                            return
+                        try:
+                            from model_tools import get_tool_definitions
+                            new_defs = get_tool_definitions(
+                                enabled_toolsets=_load_enabled_toolsets(),
+                                quiet_mode=True,
+                            )
+                            agent.tools = new_defs
+                            agent.valid_tool_names = (
+                                {t["function"]["name"] for t in new_defs}
+                                if new_defs else set()
+                            )
+                        except Exception:
+                            pass
+
+                    _mcp_watch_threading.Thread(
+                        target=_rebuild_mcp_tools,
+                        name="tui-mcp-tool-rebuild",
+                        daemon=True,
+                    ).start()
+            except Exception:
+                pass
+
             try:
                 worker = _SlashWorker(key, getattr(agent, "model", _resolve_model()))
                 current["slash_worker"] = worker


### PR DESCRIPTION
MCP tool discovery runs in a background thread at TUI/Desktop startup so a slow server cant freeze the shell. The agent snapshots its tool list once at build time, so servers that take longer than the 750ms wait_for_mcp_discovery() timeout are invisible for the whole session.

This adds a threading.Event that signals when background discovery finishes. The server watches for it after the first agent build and rebuilds the tool schema once any remaining servers connect, without requiring /reload-mcp or /new.

Closes #38945