### PR TITLE
Add desktop custom provider setup

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createCustomProvider = vi.fn()
+const deleteEnvVar = vi.fn()
+const getEnvVars = vi.fn()
+const listOAuthProviders = vi.fn()
+const revealEnvVar = vi.fn()
+const setEnvVar = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  createCustomProvider: (body: unknown) => createCustomProvider(body),
+  deleteEnvVar: (key: string) => deleteEnvVar(key),
+  getEnvVars: () => getEnvVars(),
+  listOAuthProviders: () => listOAuthProviders(),
+  revealEnvVar: (key: string) => revealEnvVar(key),
+  setEnvVar: (key: string, value: string) => setEnvVar(key, value)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+beforeEach(() => {
+  createCustomProvider.mockResolvedValue({
+    ok: true,
+    provider: 'ai-router',
+    slug: 'ai-router',
+    key_env: 'CUSTOM_PROVIDER_AI_ROUTER_API_KEY',
+    model: 'openai/gpt-4.1-mini',
+    models: ['openai/gpt-4.1-mini']
+  })
+  getEnvVars.mockResolvedValue({})
+  listOAuthProviders.mockResolvedValue({ providers: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderProvidersSettings() {
+  const { ProvidersSettings } = await import('./providers-settings')
+
+  return render(<ProvidersSettings onViewChange={vi.fn()} view="keys" />)
+}
+
+describe('ProvidersSettings', () => {
+  it('saves a custom provider from the API keys settings view', async () => {
+    await renderProvidersSettings()
+
+    const keyInput = await screen.findByPlaceholderText('Paste custom provider key')
+    expect(keyInput).toBeTruthy()
+    expect(screen.queryByLabelText('Base URL')).toBeNull()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Custom provider/i }))
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://ai-router.app/v1' } })
+    fireEvent.change(keyInput, { target: { value: 'router-secret' } })
+
+    expect(screen.queryByLabelText('Provider name')).toBeNull()
+    expect(screen.queryByLabelText('Model')).toBeNull()
+    expect(screen.queryByLabelText('Key environment variable')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Save custom provider/i }))
+
+    await waitFor(() =>
+      expect(createCustomProvider).toHaveBeenCalledWith({
+        api_key: 'router-secret',
+        base_url: 'https://ai-router.app/v1'
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -10,9 +10,10 @@ import {
 } from '@/components/desktop-onboarding-overlay'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { listOAuthProviders } from '@/hermes'
+import { createCustomProvider, listOAuthProviders } from '@/hermes'
 import { ChevronDown, ExternalLink, KeyRound, Loader2, Save } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualProviderOAuth } from '@/store/onboarding'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
@@ -392,7 +393,115 @@ function OAuthPicker({ onWantApiKey, providers }: { onWantApiKey: () => void; pr
 function NoProviderKeys() {
   return (
     <div className="grid min-h-32 place-items-center px-4 py-8 text-center text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
-      No provider API keys available.
+      No catalog provider API keys available.
+    </div>
+  )
+}
+
+function CustomProviderCard() {
+  const [apiKey, setApiKey] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
+  const [error, setError] = useState<null | string>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const canSave = baseUrl.trim().length > 0
+
+  async function submit() {
+    if (!canSave || saving) {
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+
+    try {
+      const result = await createCustomProvider({
+        api_key: apiKey,
+        base_url: baseUrl
+      })
+
+      notify({
+        kind: 'success',
+        message: `${result.name || result.provider || 'Custom provider'} is available in the model picker.`,
+        title: 'Custom provider saved'
+      })
+      setApiKey('')
+      setBaseUrl('')
+      setExpanded(false)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Could not save custom provider.'
+
+      setError(message)
+      notifyError(err, 'Failed to save custom provider')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'group/card rounded-[6px] px-2 py-2 transition-colors',
+        !expanded && 'hover:bg-(--ui-row-hover-background)',
+        expanded && 'bg-(--ui-bg-quaternary) ring-1 ring-(--ui-stroke-secondary)'
+      )}
+    >
+      <div className="flex flex-wrap items-start gap-x-4 gap-y-2">
+        <button
+          className="flex min-w-44 flex-1 items-center gap-2 py-1 text-left"
+          onClick={() => setExpanded(v => !v)}
+          type="button"
+        >
+          <span className="size-2 shrink-0 rounded-full bg-(--ui-stroke-secondary)" />
+          <span className="truncate text-[length:var(--conversation-text-font-size)] font-medium">
+            Custom provider
+          </span>
+          <ChevronDown className={cn('size-3.5 shrink-0 text-muted-foreground transition', expanded && 'rotate-180')} />
+        </button>
+        <div
+          className="w-full sm:w-80 sm:shrink-0"
+          onFocus={() => {
+            if (!expanded) {
+              setExpanded(true)
+            }
+          }}
+        >
+          <Input
+            aria-label="Custom provider API key"
+            autoComplete="off"
+            className="font-mono"
+            onChange={e => setApiKey(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void submit()}
+            placeholder="Paste custom provider key"
+            size="sm"
+            type="password"
+            value={apiKey}
+          />
+        </div>
+      </div>
+      {expanded && (
+        <div className="mt-3 grid gap-2.5 pl-4">
+          <label className="grid gap-1.5 text-xs font-medium">
+            Base URL
+            <Input
+              autoComplete="off"
+              className="font-mono"
+              onChange={e => setBaseUrl(e.target.value)}
+              placeholder="https://ai-router.app/v1"
+              size="sm"
+              type="url"
+              value={baseUrl}
+            />
+          </label>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex justify-end">
+            <Button disabled={!canSave || saving} onClick={() => void submit()} size="sm">
+              {saving ? <Loader2 className="size-4 animate-spin" /> : <Save />}
+              {saving ? 'Saving' : 'Save custom provider'}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -444,22 +553,20 @@ export function ProvidersSettings({ onViewChange, view }: ProvidersSettingsProps
   if (showApiKeys) {
     return (
       <SettingsContent>
-        {keyGroups.length > 0 ? (
-          <div className="grid gap-2">
-            {keyGroups.map(group => (
-              <ProviderKeyCard
-                expanded={openProvider === group.name}
-                group={group}
-                key={group.name}
-                onExpand={() => setOpenProvider(group.name)}
-                onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
-                rowProps={rowProps}
-              />
-            ))}
-          </div>
-        ) : (
-          <NoProviderKeys />
-        )}
+        <div className="grid gap-2">
+          <CustomProviderCard />
+          {keyGroups.map(group => (
+            <ProviderKeyCard
+              expanded={openProvider === group.name}
+              group={group}
+              key={group.name}
+              onExpand={() => setOpenProvider(group.name)}
+              onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
+              rowProps={rowProps}
+            />
+          ))}
+          {keyGroups.length === 0 && <NoProviderKeys />}
+        </div>
       </SettingsContent>
     )
   }

--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -1,9 +1,8 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import type { OAuthProvider } from '@/types/hermes'
-
 import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
+import type { OAuthProvider } from '@/types/hermes'
 
 import { Picker } from './desktop-onboarding-overlay'
 
@@ -31,6 +30,13 @@ function setProviders(providers: OAuthProvider[]) {
 }
 
 const ctx: OnboardingContext = { requestGateway: async () => undefined as never }
+
+function installApiMock(api: (request: { body?: unknown; path: string }) => Promise<unknown>) {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { api }
+  })
+}
 
 afterEach(() => {
   cleanup()
@@ -68,5 +74,70 @@ describe('onboarding Picker', () => {
     expect(screen.getByText('OpenAI OAuth (ChatGPT)')).toBeTruthy()
     expect(screen.queryByText('Other sign-in options')).toBeNull()
     expect(screen.queryByText('Recommended')).toBeNull()
+  })
+
+  it('collects base URL and API key for a custom provider', async () => {
+    setProviders([])
+
+    const calls: { body?: unknown; path: string }[] = []
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/custom') {
+        return {
+          ok: true,
+          provider: 'ai-router',
+          slug: 'ai-router',
+          key_env: 'CUSTOM_PROVIDER_AI_ROUTER_API_KEY',
+          model: 'openai/gpt-4.1-mini',
+          models: ['openai/gpt-4.1-mini']
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const readyCtx: OnboardingContext = {
+      requestGateway: async method => {
+        if (method === 'reload.env') {
+          return {} as never
+        }
+
+        if (method === 'setup.status') {
+          return { provider_configured: true } as never
+        }
+
+        if (method === 'setup.runtime_check') {
+          return { ok: true } as never
+        }
+
+        throw new Error(`unexpected gateway method: ${method}`)
+      }
+    }
+
+    render(<Picker ctx={readyCtx} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Local \/ custom endpoint/i }))
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://ai-router.app/v1' } })
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'router-secret' } })
+
+    expect(screen.queryByLabelText('Provider name')).toBeNull()
+    expect(screen.queryByLabelText('Model')).toBeNull()
+    expect(screen.queryByLabelText('Key environment variable')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Connect/i }))
+
+    await waitFor(() => {
+      expect(calls).toEqual([
+        {
+          path: '/api/providers/custom',
+          body: {
+            api_key: 'router-secret',
+            base_url: 'https://ai-router.app/v1',
+            make_active: true
+          }
+        }
+      ])
+    })
   })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -29,12 +29,14 @@ import {
   confirmOnboardingModel,
   copyDeviceCode,
   copyExternalCommand,
+  type CustomProviderSetup,
   type OnboardingContext,
   type OnboardingFlow,
   peekPendingProviderOAuth,
   recheckExternalSignin,
   refreshOnboarding,
   saveOnboardingApiKey,
+  saveOnboardingCustomProvider,
   setOnboardingCode,
   setOnboardingMode,
   setOnboardingModel,
@@ -315,6 +317,7 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
         canGoBack={hasOauth}
         onBack={() => setOnboardingMode('oauth')}
         onSave={(envKey, value, name) => saveOnboardingApiKey(envKey, value, name, ctx)}
+        onSaveCustomProvider={input => saveOnboardingCustomProvider(input, ctx)}
       />
     )
   }
@@ -469,6 +472,7 @@ export function ApiKeyForm({
   onBack,
   onClear,
   onSave,
+  onSaveCustomProvider,
   options = API_KEY_OPTIONS,
   redactedValue
 }: {
@@ -477,11 +481,14 @@ export function ApiKeyForm({
   onBack: () => void
   onClear?: (envKey: string) => void
   onSave: (envKey: string, value: string, name: string) => Promise<{ message?: string; ok: boolean }>
+  onSaveCustomProvider?: (input: CustomProviderSetup) => Promise<{ message?: string; ok: boolean }>
   options?: ApiKeyOption[]
   redactedValue?: (envKey: string) => null | string | undefined
 }) {
   const [option, setOption] = useState<ApiKeyOption>(options[0])
   const [value, setValue] = useState('')
+  const [customApiKey, setCustomApiKey] = useState('')
+  const [customBaseUrl, setCustomBaseUrl] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
   // `options` can change at runtime when callers filter the catalog (e.g. the
@@ -510,13 +517,15 @@ export function ApiKeyForm({
   }
 
   const isLocal = option.envKey === 'OPENAI_BASE_URL'
+  const customProviderMode = Boolean(isLocal && onSaveCustomProvider)
   const alreadySet = isSet?.(option.envKey) ?? false
   // When set, surface the backend's redacted value (e.g. "sk-12…wxyz") as the
   // placeholder so users can eyeball that the right key is in place.
   const currentRedacted = alreadySet ? (redactedValue?.(option.envKey) ?? null) : null
+
   // Only require a non-empty value — no length/format validation, so a short
   // or unusual key can't block the user from continuing.
-  const canSave = value.trim().length >= 1
+  const canSave = customProviderMode ? customBaseUrl.trim().length >= 1 : value.trim().length >= 1
 
   const submit = async () => {
     if (!canSave || saving) {
@@ -525,10 +534,19 @@ export function ApiKeyForm({
 
     setSaving(true)
     setError(null)
-    const result = await onSave(option.envKey, value, option.name)
+
+    const result =
+      customProviderMode && onSaveCustomProvider
+        ? await onSaveCustomProvider({
+            apiKey: customApiKey,
+            baseUrl: customBaseUrl
+          })
+        : await onSave(option.envKey, value, option.name)
 
     if (result.ok) {
       setValue('')
+      setCustomApiKey('')
+      setCustomBaseUrl('')
     } else {
       setError(result.message ?? 'Could not save credential.')
     }
@@ -576,18 +594,48 @@ export function ApiKeyForm({
       <div className="grid scroll-mt-4 gap-2" ref={entryRef}>
         <div className="flex items-center justify-between gap-3">
           <p className="text-sm leading-6 text-muted-foreground">{option.description}</p>
-          {option.docsUrl ? <DocsLink href={option.docsUrl}>Get a key</DocsLink> : null}
+          {option.docsUrl ? <DocsLink href={option.docsUrl}>{isLocal ? 'Docs' : 'Get a key'}</DocsLink> : null}
         </div>
-        <Input
-          autoComplete="off"
-          autoFocus
-          className="font-mono"
-          onChange={e => setValue(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submit()}
-          placeholder={currentRedacted ?? (alreadySet ? 'Replace current value' : option.placeholder || 'Paste API key')}
-          type={isLocal ? 'text' : 'password'}
-          value={value}
-        />
+        {customProviderMode ? (
+          <div className="grid gap-3">
+            <label className="grid gap-1.5 text-xs font-medium">
+              Base URL
+              <Input
+                autoComplete="off"
+                autoFocus
+                className="font-mono"
+                onChange={e => setCustomBaseUrl(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && void submit()}
+                placeholder={option.placeholder || 'https://example.com/v1'}
+                type="url"
+                value={customBaseUrl}
+              />
+            </label>
+            <label className="grid gap-1.5 text-xs font-medium">
+              API key
+              <Input
+                autoComplete="off"
+                className="font-mono"
+                onChange={e => setCustomApiKey(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && void submit()}
+                placeholder="Optional for local endpoints"
+                type="password"
+                value={customApiKey}
+              />
+            </label>
+          </div>
+        ) : (
+          <Input
+            autoComplete="off"
+            autoFocus
+            className="font-mono"
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void submit()}
+            placeholder={currentRedacted ?? (alreadySet ? 'Replace current value' : option.placeholder || 'Paste API key')}
+            type={isLocal ? 'text' : 'password'}
+            value={value}
+          />
+        )}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
       </div>
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -11,6 +11,8 @@ import type {
   CronJob,
   CronJobCreatePayload,
   CronJobUpdates,
+  CustomProviderRequest,
+  CustomProviderResponse,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
   HermesConfig,
@@ -60,6 +62,8 @@ export type {
   CronJobCreatePayload,
   CronJobSchedule,
   CronJobUpdates,
+  CustomProviderRequest,
+  CustomProviderResponse,
   ElevenLabsVoice,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
@@ -260,6 +264,14 @@ export function validateProviderCredential(
     path: '/api/providers/validate',
     method: 'POST',
     body: { key, value }
+  })
+}
+
+export function createCustomProvider(body: CustomProviderRequest): Promise<CustomProviderResponse> {
+  return window.hermesDesktop.api<CustomProviderResponse>({
+    path: '/api/providers/custom',
+    method: 'POST',
+    body
   })
 }
 

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -8,6 +8,7 @@ import {
   type OnboardingContext,
   refreshOnboarding,
   requestDesktopOnboarding,
+  saveOnboardingCustomProvider,
   saveOnboardingLocalEndpoint
 } from './onboarding'
 
@@ -271,5 +272,97 @@ describe('saveOnboardingLocalEndpoint', () => {
     expect(result.ok).toBe(false)
     expect(result.message).toContain('No provider can serve the selected model.')
     expect($desktopOnboarding.get().configured).not.toBe(true)
+  })
+})
+
+describe('saveOnboardingCustomProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+    vi.restoreAllMocks()
+  })
+
+  function readyGateway(): OnboardingContext['requestGateway'] {
+    return async method => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        return { ok: true } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+  }
+
+  it('persists a custom provider with base URL and API key', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/custom') {
+        return {
+          ok: true,
+          provider: 'ai-router',
+          slug: 'ai-router',
+          key_env: 'CUSTOM_PROVIDER_AI_ROUTER_API_KEY',
+          model: 'openai/gpt-4.1-mini',
+          models: ['openai/gpt-4.1-mini']
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const onCompleted = vi.fn()
+
+    const result = await saveOnboardingCustomProvider(
+      {
+        apiKey: 'router-secret',
+        baseUrl: 'https://ai-router.app/v1'
+      },
+      { onCompleted, requestGateway: readyGateway() }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(calls).toEqual([
+      {
+        path: '/api/providers/custom',
+        body: {
+          api_key: 'router-secret',
+          base_url: 'https://ai-router.app/v1',
+          make_active: true
+        }
+      }
+    ])
+    expect(onCompleted).toHaveBeenCalledTimes(1)
+    expect($desktopOnboarding.get().configured).toBe(true)
+  })
+
+  it('requires a base URL before saving a custom provider', async () => {
+    const api = vi.fn()
+    installApiMock(api)
+
+    const result = await saveOnboardingCustomProvider(
+      {
+        apiKey: 'router-secret',
+        baseUrl: ''
+      },
+      { requestGateway: readyGateway() }
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('endpoint URL')
+    expect(api).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import {
   cancelOAuthSession,
+  createCustomProvider,
   getGlobalModelOptions,
   getRecommendedDefaultModel,
   listOAuthProviders,
@@ -70,6 +71,11 @@ export interface DesktopOnboardingState {
 export interface OnboardingContext {
   onCompleted?: () => void
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+export interface CustomProviderSetup {
+  apiKey?: string
+  baseUrl: string
 }
 
 const CONFIGURED_CACHE_KEY = 'hermes-desktop-onboarded-v1'
@@ -743,6 +749,44 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
     return { ok: true }
   } catch (error) {
     notifyError(error, 'Could not save local endpoint')
+
+    return { ok: false, message: errMessage(error) }
+  }
+}
+
+export async function saveOnboardingCustomProvider(input: CustomProviderSetup, ctx: OnboardingContext) {
+  const baseUrl = input.baseUrl.trim()
+  const apiKey = input.apiKey?.trim() ?? ''
+
+  if (!baseUrl) {
+    return { ok: false, message: 'Enter the endpoint URL first.' }
+  }
+
+  try {
+    const result = await createCustomProvider({
+      base_url: baseUrl,
+      api_key: apiKey,
+      make_active: true
+    })
+
+    await ctx.requestGateway('reload.env').catch(() => undefined)
+
+    const runtime = await checkRuntime(ctx)
+
+    if (!runtime.ready) {
+      const detail = (runtime.reason ?? '').trim()
+      const providerLabel = result.name || result.provider || 'custom provider'
+
+      return { ok: false, message: detail || `Saved, but Hermes still cannot reach ${providerLabel}.` }
+    }
+
+    notifyReady(result.name || result.provider || 'Custom provider')
+    completeDesktopOnboarding()
+    ctx.onCompleted?.()
+
+    return { ok: true }
+  } catch (error) {
+    notifyError(error, 'Could not save custom provider')
 
     return { ok: false, message: errMessage(error) }
   }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -604,3 +604,24 @@ export interface ModelAssignmentResponse {
   scope?: string
   tasks?: string[]
 }
+
+export interface CustomProviderRequest {
+  api_key?: string
+  base_url: string
+  key_env?: string
+  make_active?: boolean
+  model?: string
+  name?: string
+}
+
+export interface CustomProviderResponse {
+  active?: boolean
+  base_url?: string
+  key_env?: string
+  model?: string
+  models?: string[]
+  name?: string
+  ok: boolean
+  provider: string
+  slug: string
+}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19,6 +19,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import stat
 import subprocess
@@ -620,6 +621,17 @@ class ModelAssignment(BaseModel):
     base_url: str = ""
 
 
+class CustomProviderCreate(BaseModel):
+    """Payload for POST /api/providers/custom — create a named user provider."""
+
+    name: str = ""
+    base_url: str
+    api_key: str = ""
+    model: str = ""
+    key_env: str = ""
+    make_active: bool = False
+
+
 def _apply_main_model_assignment(
     model_cfg: "Any", provider: str, model: str, base_url: str = ""
 ) -> dict:
@@ -645,6 +657,24 @@ def _apply_main_model_assignment(
         model_cfg["base_url"] = ""
     model_cfg.pop("context_length", None)
     return model_cfg
+
+
+def _slugify_custom_provider_name(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    if not slug:
+        raise HTTPException(status_code=400, detail="provider name is required")
+    return slug
+
+
+def _custom_provider_key_env(slug: str) -> str:
+    env_slug = slug.replace("-", "_").upper()
+    return f"CUSTOM_PROVIDER_{env_slug}_API_KEY"
+
+
+def _custom_provider_name_from_base_url(base_url: str) -> str:
+    parsed = urllib.parse.urlparse(base_url)
+    host = (parsed.hostname or "").strip()
+    return host or "Custom provider"
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -2139,6 +2169,87 @@ async def set_model_assignment(body: ModelAssignment):
         raise HTTPException(status_code=500, detail="Failed to save model assignment")
 
 
+@app.post("/api/providers/custom")
+async def create_custom_provider(body: CustomProviderCreate):
+    """Create/update a named OpenAI-compatible custom provider.
+
+    The provider entry lives in config.yaml under ``providers`` while the
+    credential is stored in ``.env`` and referenced by ``key_env``. This keeps
+    arbitrary custom hosts away from the global OPENAI_API_KEY path.
+    """
+    base_url = (body.base_url or "").strip().rstrip("/")
+    if not base_url:
+        raise HTTPException(status_code=400, detail="base_url is required")
+
+    name = (body.name or "").strip() or _custom_provider_name_from_base_url(base_url)
+    model = (body.model or "").strip()
+    api_key = (body.api_key or "").strip()
+    slug = _slugify_custom_provider_name(name)
+    key_env = (body.key_env or "").strip() or _custom_provider_key_env(slug)
+
+    try:
+        if api_key:
+            save_env_value(key_env, api_key)
+
+        discovered_models: List[str] = []
+        try:
+            from hermes_cli.models import fetch_api_models
+
+            discovered_models = fetch_api_models(api_key or None, base_url, timeout=8.0) or []
+        except Exception:
+            discovered_models = []
+
+        if not model and discovered_models:
+            model = discovered_models[0]
+        if bool(body.make_active) and not model:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Could not discover models from {base_url.rstrip('/')}/models",
+            )
+
+        cfg = load_config()
+        providers = cfg.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+
+        entry = {
+            "name": name,
+            "api": base_url,
+            "key_env": key_env,
+        }
+        if model:
+            entry["default_model"] = model
+        if discovered_models:
+            models = [model, *discovered_models] if model else discovered_models
+            entry["models"] = list(dict.fromkeys(m for m in models if m))
+        providers[slug] = entry
+        cfg["providers"] = providers
+
+        provider_id = slug
+        if body.make_active and model:
+            cfg["model"] = _apply_main_model_assignment(
+                cfg.get("model", {}), provider_id, model
+            )
+
+        save_config(cfg)
+        return {
+            "ok": True,
+            "slug": slug,
+            "provider": provider_id,
+            "name": name,
+            "base_url": base_url,
+            "key_env": key_env,
+            "model": model,
+            "models": discovered_models,
+            "active": bool(body.make_active and model),
+        }
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        _log.exception("POST /api/providers/custom failed")
+        raise HTTPException(status_code=500, detail="Failed to save custom provider")
 
 
 def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1160,6 +1160,104 @@ class TestWebServerEndpoints:
         assert model_cfg["provider"] == "openrouter"
         assert model_cfg.get("base_url", "") == ""
 
+    def test_create_custom_provider_persists_named_provider_key_and_active_model(self, monkeypatch):
+        """Desktop custom-provider setup should persist a reusable provider,
+        keep the API key in .env via key_env, and optionally make it active."""
+        from hermes_cli.config import load_config, load_env
+        import hermes_cli.models as models
+
+        monkeypatch.setattr(models, "fetch_api_models", lambda api_key, base_url, timeout=5.0: ["router-model"])
+
+        resp = self.client.post(
+            "/api/providers/custom",
+            json={
+                "name": "My Router",
+                "base_url": "https://my-router.example/v1",
+                "api_key": "router-secret",
+                "model": "router-model",
+                "make_active": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["slug"] == "my-router"
+        assert data["provider"] == "my-router"
+        assert data["key_env"] == "CUSTOM_PROVIDER_MY_ROUTER_API_KEY"
+
+        env = load_env()
+        assert env["CUSTOM_PROVIDER_MY_ROUTER_API_KEY"] == "router-secret"
+
+        cfg = load_config()
+        assert cfg["providers"]["my-router"] == {
+            "name": "My Router",
+            "api": "https://my-router.example/v1",
+            "key_env": "CUSTOM_PROVIDER_MY_ROUTER_API_KEY",
+            "default_model": "router-model",
+            "models": ["router-model"],
+        }
+        assert cfg["model"] == {
+            "provider": "my-router",
+            "default": "router-model",
+        }
+
+        options = self.client.get("/api/model/options").json()
+        row = next(provider for provider in options["providers"] if provider["slug"] == "my-router")
+        assert options["provider"] == "my-router"
+        assert row["is_current"] is True
+        assert "router-model" in row["models"]
+
+    def test_create_custom_provider_can_discover_models_without_user_model(self, monkeypatch):
+        """Settings only needs base_url + api_key; model list comes from /models."""
+        from hermes_cli.config import load_config, load_env
+        import hermes_cli.models as models
+
+        captured = {}
+
+        def fake_fetch_api_models(api_key, base_url, timeout=5.0):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+            captured["timeout"] = timeout
+            return ["openai/gpt-4.1-mini", "anthropic/claude-haiku-4.5"]
+
+        monkeypatch.setattr(models, "fetch_api_models", fake_fetch_api_models)
+
+        resp = self.client.post(
+            "/api/providers/custom",
+            json={
+                "base_url": "https://ai-router.app/api/v1",
+                "api_key": "router-secret",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["slug"] == "ai-router-app"
+        assert data["provider"] == "ai-router-app"
+        assert data["model"] == "openai/gpt-4.1-mini"
+        assert data["models"] == ["openai/gpt-4.1-mini", "anthropic/claude-haiku-4.5"]
+        assert captured == {
+            "api_key": "router-secret",
+            "base_url": "https://ai-router.app/api/v1",
+            "timeout": 8.0,
+        }
+
+        env = load_env()
+        assert env["CUSTOM_PROVIDER_AI_ROUTER_APP_API_KEY"] == "router-secret"
+
+        cfg = load_config()
+        assert cfg["providers"]["ai-router-app"] == {
+            "name": "ai-router.app",
+            "api": "https://ai-router.app/api/v1",
+            "key_env": "CUSTOM_PROVIDER_AI_ROUTER_APP_API_KEY",
+            "default_model": "openai/gpt-4.1-mini",
+            "models": ["openai/gpt-4.1-mini", "anthropic/claude-haiku-4.5"],
+        }
+        model_cfg = cfg.get("model")
+        assert not isinstance(model_cfg, dict) or model_cfg.get("provider") != "ai-router-app"
+
     def test_set_model_main_gateway_failure_does_not_block_save(self, monkeypatch):
         """A Portal/gateway hiccup must never prevent saving the model."""
         import hermes_cli.nous_subscription as ns
@@ -3967,4 +4065,3 @@ class TestValidateProviderCredential:
     def test_empty_value_rejected(self):
         data = self._post("OPENAI_API_KEY", "   ").json()
         assert data["ok"] is False
-


### PR DESCRIPTION
## Summary

Fixes #38975.

Adds first-class Desktop support for reusable OpenAI-compatible custom providers. The flow is intentionally generic: it is not tied to AI Router, LiteLLM, LM Studio, or any single service.

## What changed

- Add `POST /api/providers/custom` for creating/updating custom providers in Desktop.
- Store custom provider metadata under `providers:` in config and keep secrets in `.env` via a generated `key_env`.
- Derive provider identity from the configured Base URL when the UI does not supply a name:
  - display name: hostname, e.g. `https://ai-router.app/api/v1` -> `ai-router.app`
  - provider slug: `ai-router-app`
  - env var: `CUSTOM_PROVIDER_AI_ROUTER_APP_API_KEY`
- Fetch model IDs from the OpenAI-compatible models endpoint: `GET {base_url}/models`.
  - Example: `https://ai-router.app/api/v1` -> `https://ai-router.app/api/v1/models`
- Persist discovered models on the custom provider so the model picker/settings can show the provider normally.
- When onboarding makes the provider active, use the first discovered model as the initial default. If model discovery fails in that path, return a clear setup error instead of requiring the user to type an internal model field.
- Update Desktop Settings -> Providers -> API keys:
  - `Custom provider` appears like the other provider rows.
  - API key is on the same row as the provider name.
  - Base URL is the expanded advanced field.
  - Users do not manually enter provider name, model, or `key_env`.
- Update Desktop onboarding `Local / custom endpoint` custom-provider flow to require only Base URL plus optional API key.

## Notes

This keeps custom-provider credentials isolated from generic `OPENAI_API_KEY`, so arbitrary custom hosts only receive the key explicitly configured for that custom provider.

For local Desktop testing, the packaged renderer and Python backend must come from the same checkout. If a locally packaged app starts the already-installed `~/.hermes/hermes-agent` backend from an older commit, `POST /api/providers/custom` can return `405 Method Not Allowed` because the backend route is not present there. Use `HERMES_DESKTOP_HERMES_ROOT=/path/to/checkout` when testing this PR locally.

## Validation

- `npm run --prefix apps/desktop type-check`
- `npm run --prefix apps/desktop test:ui -- src/app/settings/providers-settings.test.tsx src/store/onboarding.test.ts src/components/desktop-onboarding-overlay.test.tsx`
- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_set_model_main_custom_persists_base_url tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_set_model_main_non_custom_clears_stale_base_url tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_create_custom_provider_persists_named_provider_key_and_active_model tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_create_custom_provider_can_discover_models_without_user_model -q`
- `uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- Targeted ESLint on changed Desktop files: 0 errors, existing padding warnings remain in `store/onboarding*`.
