### PR TITLE
fix(auth): use _save_xai_oauth_tokens in auth_commands to set active_provider

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -329,24 +329,18 @@ def auth_add_command(args) -> None:
             open_browser=not getattr(args, "no_browser", False),
             manual_paste=bool(getattr(args, "manual_paste", False)),
         )
-        label = (getattr(args, "label", None) or "").strip() or label_from_token(
-            creds["tokens"]["access_token"],
-            _oauth_default_label(provider, len(pool.entries()) + 1),
-        )
-        entry = PooledCredential(
-            provider=provider,
-            id=uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:xai_pkce",
-            access_token=creds["tokens"]["access_token"],
-            refresh_token=creds["tokens"].get("refresh_token"),
-            base_url=creds.get("base_url"),
+        auth_mod._save_xai_oauth_tokens(
+            creds["tokens"],
+            discovery=creds.get("discovery"),
+            redirect_uri=creds.get("redirect_uri", ""),
             last_refresh=creds.get("last_refresh"),
         )
-        pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        pool = load_pool(provider)
+        entry = next((e for e in pool.entries() if getattr(e, "source", "") == "loopback_pkce"), None)
+        shown_label = entry.label if entry is not None else label_from_token(
+            creds["tokens"]["access_token"], _oauth_default_label(provider, 1)
+        )
+        print(f'Saved {provider} OAuth credentials: "{shown_label}"')
         return
 
     if provider == "google-gemini-cli":

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -312,6 +312,58 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_xai_oauth_sets_active_provider(tmp_path, monkeypatch):
+    """hermes auth add xai-oauth must write providers singleton and set active_provider.
+
+    Previously pool.add_entry() was called directly, which wrote only the
+    credential-pool entry without setting active_provider. _model_section_has_credentials()
+    checks get_active_provider() first; with it unset, the setup wizard would
+    report "No inference provider configured" after a successful OAuth login.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    access_token = "xai-test-access-token"
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_loopback_login",
+        lambda **kwargs: {
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": "xai-refresh-token",
+                "id_token": "",
+                "token_type": "Bearer",
+            },
+            "discovery": {"token_endpoint": "https://auth.x.ai/token"},
+            "redirect_uri": "http://127.0.0.1:7777/callback",
+            "base_url": "https://api.x.ai/v1",
+            "last_refresh": "2026-06-02T10:00:00Z",
+            "source": "oauth-loopback",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "xai-oauth"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        timeout = None
+        no_browser = False
+        manual_paste = False
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    # active_provider must be set — the core of this regression
+    assert payload["active_provider"] == "xai-oauth"
+    # providers singleton written by _save_xai_oauth_tokens
+    assert payload["providers"]["xai-oauth"]["tokens"]["access_token"] == access_token
+    # pool seeded from singleton by _seed_from_singletons("xai-oauth")
+    entries = payload["credential_pool"]["xai-oauth"]
+    entry = next(item for item in entries if item["source"] == "loopback_pkce")
+    assert entry["refresh_token"] == "xai-refresh-token"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources


### PR DESCRIPTION
`hermes auth add xai-oauth` now sets `active_provider` in auth.json after a successful OAuth login, so the setup wizard recognizes the provider instead of reporting "No inference provider configured".

Salvage of #37600 by @AhmetArif0 (cherry-picked onto current main, authorship preserved).

## Root cause
The xai-oauth branch in `auth_add_command()` called `pool.add_entry()` directly with `source="manual:xai_pkce"`, writing only a credential-pool entry — it never touched `providers["xai-oauth"]` or `active_provider`. `_model_section_has_credentials()` checks `get_active_provider()` first, so with it unset the wizard saw no configured provider despite a valid login.

## Changes
- `hermes_cli/auth_commands.py`: replace the hand-rolled `pool.add_entry()` with the canonical `_save_xai_oauth_tokens()` (which writes the provider singleton and sets `active_provider` via `_save_provider_state`), then `load_pool()` to seed the canonical `loopback_pkce` pool entry. Mirrors the openai-codex fix in #37517 already on main.
- New test `test_auth_add_xai_oauth_sets_active_provider`.

## Validation
| | Before | After |
|---|---|---|
| `active_provider` after login | unset | `xai-oauth` |
| `providers["xai-oauth"]` singleton | not written | written |
| pool entry source | `manual:xai_pkce` | `loopback_pkce` (canonical) |
| `_model_section_has_credentials("xai-oauth")` | `False` | `True` |

E2E verified with isolated HERMES_HOME calling the real `auth_add_command` + `_model_section_has_credentials`. 47/47 `test_auth_commands` pass.

## Infographic

![xai-oauth-active-provider](https://v3b.fal.media/files/b/0a9cf1b7/9GyQJfrJlvFHMp2_jHjiw_k0C8oSXJ.png)
