### PR TITLE
fix(desktop): remove session search aux model option

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -29,7 +29,6 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'vision', label: 'Vision', hint: 'Image analysis' },
   { key: 'web_extract', label: 'Web extract', hint: 'Page summarization' },
   { key: 'compression', label: 'Compression', hint: 'Context compaction' },
-  { key: 'session_search', label: 'Session search', hint: 'Recall queries' },
   { key: 'skills_hub', label: 'Skills hub', hint: 'Skill search' },
   { key: 'approval', label: 'Approval', hint: 'Smart auto-approve' },
   { key: 'mcp', label: 'MCP', hint: 'MCP tool routing' },

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "tonybear55665566@gmail.com": "TonyPepeBear",
     "kaspersniels@gmail.com": "nielskaspers",
     "kurobaryo@gmail.com": "kurobaryo",
+    "scubamount@users.noreply.github.com": "scubamount",
     "155192176+alelpoan@users.noreply.github.com": "alelpoan",
     "aman@abacus.ai": "Aman113114-IITD",
     "octavio.turra@gmail.com": "octavioturra",


### PR DESCRIPTION
## Summary
The desktop settings UI no longer offers `session_search` as an auxiliary-model task, so it can't trip the backend's `400: unknown auxiliary task: session_search` validation.

Session search is FTS5-only now — it doesn't use an auxiliary LLM, so it was removed from `_AUX_TASK_SLOTS`. The desktop list was the last stale reference still sending `task: session_search` to `/api/model/set`.

## Changes
- `apps/desktop/src/app/settings/model-settings.tsx`: drop the stale `session_search` entry from `AUX_TASKS` so the list matches the backend slots.
- `scripts/release.py`: add @scubamount to `AUTHOR_MAP` (CI author gate).

## Validation
| | Before | After |
|---|---|---|
| Desktop sets aux model for session_search | `400 unknown auxiliary task` | n/a — option removed |
| Desktop `AUX_TASKS` keys vs `_AUX_TASK_SLOTS` | superset (session_search extra) | strict subset |

Salvage of #37616 by @scubamount — original commit cherry-picked onto current main, authorship preserved.

## Infographic

![remove-session-search-aux-model](https://v3b.fal.media/files/b/0a9cf1b7/b81YQGkvs7ARGnBXjlSOL_F0grLtNm.png)
