### PR TITLE
fix(gateway): report effective per-platform reasoning display state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3180,6 +3180,30 @@ class GatewayRunner:
             default=False,
         )
 
+    def _resolve_effective_show_reasoning(self, source: SessionSource) -> bool:
+        """Resolve the reasoning-display state the user actually sees.
+
+        A per-platform ``display.platforms.<platform>.show_reasoning`` override
+        wins over the global ``display.show_reasoning`` toggle — the same
+        resolution the delivery path uses when deciding whether to prepend
+        reasoning to a reply. Reading it here keeps ``/reasoning`` status in
+        agreement with what gets delivered, instead of reporting only the
+        global toggle via ``_load_show_reasoning()``. Falls back to the
+        session's cached ``_show_reasoning`` when config is unreadable.
+        """
+        try:
+            from gateway.display_config import resolve_display_setting
+            return bool(
+                resolve_display_setting(
+                    _load_gateway_config(),
+                    _platform_config_key(source.platform),
+                    "show_reasoning",
+                    getattr(self, "_show_reasoning", False),
+                )
+            )
+        except Exception:
+            return getattr(self, "_show_reasoning", False)
+
     @staticmethod
     def _load_busy_input_mode() -> str:
         """Load gateway drain-time busy-input behavior from config/env."""
@@ -9464,16 +9488,7 @@ class GatewayRunner:
                 )
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
-            try:
-                from gateway.display_config import resolve_display_setting as _rds
-                _show_reasoning_effective = _rds(
-                    _load_gateway_config(),
-                    _platform_config_key(source.platform),
-                    "show_reasoning",
-                    getattr(self, "_show_reasoning", False),
-                )
-            except Exception:
-                _show_reasoning_effective = getattr(self, "_show_reasoning", False)
+            _show_reasoning_effective = self._resolve_effective_show_reasoning(source)
             if _show_reasoning_effective and response:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
@@ -12716,7 +12731,7 @@ class GatewayRunner:
                 level = rc.get("effort", "medium")
             display_state = (
                 t("gateway.reasoning.display_on")
-                if self._show_reasoning
+                if self._resolve_effective_show_reasoning(event.source)
                 else t("gateway.reasoning.display_off")
             )
             has_session_override = session_key in (getattr(self, "_session_reasoning_overrides", {}) or {})

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -105,6 +105,63 @@ class TestReasoningCommand:
         assert runner._show_reasoning is True
 
     @pytest.mark.asyncio
+    async def test_reasoning_status_reflects_per_platform_show_override(self, tmp_path, monkeypatch):
+        """Status must report the effective per-platform display state.
+
+        Global show_reasoning is off, but the platform has an explicit
+        ``display.platforms.telegram.show_reasoning: true`` override — the
+        same override the delivery path honors. Status must say "on", not
+        read the global toggle and claim "off".
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n"
+            "  show_reasoning: false\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      show_reasoning: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+
+        assert "**Display:** on ✓" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_status_reflects_per_platform_hide_override(self, tmp_path, monkeypatch):
+        """A per-platform hide override wins over a global show toggle.
+
+        Global show_reasoning is on, but ``display.platforms.telegram`` opts
+        out. Reasoning is NOT delivered on Telegram, so status must say "off".
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n"
+            "  show_reasoning: true\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      show_reasoning: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+
+        assert "**Display:** off" in result
+        assert "**Display:** on ✓" not in result
+
+    @pytest.mark.asyncio
     async def test_handle_reasoning_command_updates_config_and_cache(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()


### PR DESCRIPTION


## What & Why
`/reasoning` status read the **global** `display.show_reasoning` via
`_load_show_reasoning()`, while the actual delivery path resolves reasoning
visibility **per-platform** through `resolve_display_setting()`.

So with a per-platform override (e.g. `display.platforms.telegram.show_reasoning: true`
while global is `false`), the bot **shows** reasoning in replies but `/reasoning`
**reports it as off** — the same surface contradicts itself, and users re-toggle
or mis-debug.

## Fix
Both paths now share a single resolver, so they can never diverge again:

- New `_resolve_effective_show_reasoning(source)` helper applies the same
  per-platform-over-global precedence the delivery path already used.
- `/reasoning` status now reports the effective state via this helper.
- The delivery path is refactored onto the same helper (no behavior change,
  removes the duplicated inline resolution).

No config/schema changes. Risk: low — status/refresh now matches real delivery.

## Tests
Added regression tests in `tests/gateway/test_reasoning_command.py`:

- global `false` + `platforms.telegram.show_reasoning: true` → status says **on**
- global `true` + per-platform override `false` → status says **off**

Both fail on the pre-fix code and pass after the fix.

    pytest tests/gateway/test_reasoning_command.py tests/gateway/test_display_config.py -q

| Test file | Result |
|---|---|
| `tests/gateway/test_reasoning_command.py` | **20 passed** |
| `tests/gateway/test_display_config.py` | **34 passed** |
| **Total** | **54 passed** |

