### PR TITLE
fix(gateway): reload fallback chain when config changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3266,22 +3266,30 @@ class GatewayRunner:
         return {}
 
     @staticmethod
-    def _load_fallback_model() -> list | None:
-        """Load fallback provider chain from config.yaml.
+    def _load_fallback_model(cfg: dict | None = None) -> list | None:
+        """Load the effective fallback provider chain.
 
         Returns the merged effective chain from ``fallback_providers`` plus any
         legacy ``fallback_model`` entries. ``fallback_providers`` stays first
         when both keys are present.
+
+        Pass ``cfg`` to resolve from an already-loaded config dict — the
+        gateway re-resolves the chain from each turn's fresh config so an
+        operator edit takes effect without a restart (see ``_run_agent``).
+        When ``cfg`` is omitted (the ``__init__`` call), config.yaml is read
+        from disk.
         """
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
+            if cfg is None:
+                import yaml as _y
+                cfg_path = _hermes_home / "config.yaml"
+                if not cfg_path.exists():
+                    return None
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                fb = get_fallback_chain(cfg)
-                if fb:
-                    return fb
+            fb = get_fallback_chain(cfg)
+            if fb:
+                return fb
         except Exception:
             pass
         return None
@@ -12484,6 +12492,9 @@ class GatewayRunner:
 
         try:
             user_config = _load_gateway_config()
+            # Re-resolve the fallback chain from fresh config (see _run_agent)
+            # so background tasks honor operator edits without a restart.
+            self._fallback_model = self._load_fallback_model(user_config)
             model, runtime_kwargs = self._resolve_session_agent_runtime(
                 source=source,
                 user_config=user_config,
@@ -16044,6 +16055,17 @@ class GatewayRunner:
         except Exception:
             out["tools.registry_generation"] = None
 
+        # The fallback provider chain (fallback_providers + legacy
+        # fallback_model) is frozen into each AIAgent at construction. Fold the
+        # *effective* merged chain into the signature so an operator edit to
+        # either key busts the cached agent and the next turn rebuilds with the
+        # new chain — otherwise the gateway keeps routing on the chain captured
+        # at startup until a full restart, even on a brand-new session.
+        try:
+            out["fallback.chain"] = get_fallback_chain(cfg) or None
+        except Exception:
+            out["fallback.chain"] = None
+
         # Honcho identity-mapping keys live in honcho.json, not user_config.
         # Only read that file when Honcho is the active memory provider.
         provider = cfg_get(cfg, "memory", "provider")
@@ -16839,6 +16861,13 @@ class GatewayRunner:
             return self._is_session_run_current(session_key, run_generation)
         
         user_config = _load_gateway_config()
+        # Re-resolve the fallback chain from the freshly-loaded config so an
+        # operator edit to fallback_providers / fallback_model takes effect on
+        # the next turn without a gateway restart. The value loaded once at
+        # __init__ would otherwise pin the chain for the gateway's lifetime.
+        # The agent-cache signature folds this same chain in (via
+        # _extract_cache_busting_config), so a change rebuilds the cached agent.
+        self._fallback_model = self._load_fallback_model(user_config)
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -410,6 +410,127 @@ class TestExtractCacheBustingConfig:
         )
 
 
+class TestFallbackChainCacheBusting:
+    """Editing the fallback chain mid-gateway must rebuild the cached agent.
+
+    ``self._fallback_model`` is loaded once at ``__init__`` and frozen into
+    every AIAgent at construction.  Before this fix, neither the agent-cache
+    signature nor the cache-busting key set included the fallback chain, so an
+    operator who fixed a broken fallback (provider auth/rate-limit) saw the
+    gateway keep routing on the stale chain until a full restart — even on a
+    brand-new session — contradicting the documented "next agent session"
+    config-reload contract.  The fix folds the effective chain into the
+    signature and re-resolves it from each turn's fresh config.
+    """
+
+    def test_extract_includes_effective_fallback_chain(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+                ]
+            }
+        )
+        assert out["fallback.chain"] == [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ]
+
+    def test_extract_fallback_chain_none_when_absent(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config({})
+        assert out["fallback.chain"] is None
+
+    def test_fallback_chain_change_busts_signature(self):
+        """Changing the fallback chain must produce a new agent signature."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg_before = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            ]
+        }
+        cfg_after = {
+            "fallback_providers": [
+                {"provider": "anthropic", "model": "claude-opus-4.6"},
+            ]
+        }
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+        assert sig_before != sig_after, (
+            "Editing the fallback chain in config.yaml must bust the gateway's "
+            "cached agent so the new chain takes effect on the next turn."
+        )
+
+    def test_fallback_chain_unchanged_keeps_signature(self):
+        """An identical chain must NOT bust the cache (no needless churn)."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            ]
+        }
+        sig1 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg),
+        )
+        sig2 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(dict(cfg)),
+        )
+        assert sig1 == sig2
+
+    def test_legacy_fallback_model_merge_preserved_and_busts_signature(self):
+        """Both fallback_providers and legacy fallback_model feed the chain;
+        a change to the legacy key alone must still bust the signature."""
+        from gateway.run import GatewayRunner
+
+        cfg_before = {
+            "fallback_providers": [{"provider": "openrouter", "model": "x/y"}],
+            "fallback_model": [{"provider": "ollama", "model": "llama3"}],
+        }
+        cfg_after = {
+            "fallback_providers": [{"provider": "openrouter", "model": "x/y"}],
+            "fallback_model": [{"provider": "ollama", "model": "qwen2.5"}],
+        }
+        out_before = GatewayRunner._extract_cache_busting_config(cfg_before)
+        out_after = GatewayRunner._extract_cache_busting_config(cfg_after)
+
+        # fallback_providers stays first; legacy fallback_model is appended.
+        assert out_before["fallback.chain"][0]["provider"] == "openrouter"
+        assert any(e["provider"] == "ollama" for e in out_before["fallback.chain"])
+        assert out_before["fallback.chain"] != out_after["fallback.chain"]
+
+    def test_load_fallback_model_resolves_from_passed_config(self):
+        """_load_fallback_model(cfg) merges the effective chain without a disk read."""
+        from gateway.run import GatewayRunner
+
+        chain = GatewayRunner._load_fallback_model(
+            {
+                "fallback_providers": [{"provider": "openrouter", "model": "x/y"}],
+                "fallback_model": {"provider": "ollama", "model": "llama3"},
+            }
+        )
+        assert chain[0] == {"provider": "openrouter", "model": "x/y"}
+        assert {"provider": "ollama", "model": "llama3"} in chain
+
+    def test_load_fallback_model_none_when_no_chain(self):
+        from gateway.run import GatewayRunner
+
+        assert GatewayRunner._load_fallback_model({}) is None
+
+
 class TestAgentCacheLifecycle:
     """End-to-end cache behavior with real AIAgent construction."""
 


### PR DESCRIPTION


## What & why
The gateway loaded the fallback provider chain **once** at `__init__`
(`self._fallback_model`) and never refreshed it. The agent-cache signature
also omitted the chain, so an operator who edited `fallback_providers` /
`fallback_model` in `config.yaml` kept getting routed on the **stale** chain —
even on a brand-new session — until a full gateway restart. This contradicts
the documented "changes take effect on the next agent session or gateway
restart" contract (`web-dashboard.md`), and means a provider auth/rate-limit
fix doesn't actually take hold.

## How
All changes in `gateway/run.py`:
- **`_load_fallback_model(cfg=None)`** — accepts a pre-loaded config so the
  chain can be re-resolved from the current turn's config (no extra disk read).
  Backward compatible; the `__init__` call is unchanged.
- **`_extract_cache_busting_config`** — folds the *effective* merged chain
  (`fallback.chain`) into the agent-cache signature, so a change rebuilds the
  cached agent and an unchanged chain causes no cache churn.
- **`_run_agent`** / **`_run_background_task`** — re-resolve
  `self._fallback_model` from the freshly-loaded `user_config` before building
  the agent.

Legacy `fallback_model` + `fallback_providers` merge semantics are preserved
(`get_fallback_chain`). No behavior change for users without a fallback config
(empty chain → `None`).

## How to test
```
pytest tests/gateway/test_agent_cache.py \
       tests/gateway/test_auth_fallback.py \
       tests/gateway/test_session_model_override_routing.py -q
```

## Tests & results
| Suite | Result |
|---|---|
| `test_agent_cache.py` + `test_auth_fallback.py` + `test_session_model_override_routing.py` | **76 passed** |
| └ new `TestFallbackChainCacheBusting` (regression) | **7 passed** |
| `test_background_command.py` (covers edited `_run_background_task`) | **22 passed** |

New regression tests assert: signature **busts** when the chain changes,
stays **stable** when unchanged (no churn), legacy `fallback_model` merge is
preserved, and `_load_fallback_model(cfg)` resolves from a passed config.

