### PR TITLE
fix(auxiliary): rebuild closed cached sync clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4367,6 +4367,28 @@ def neuter_async_httpx_del() -> None:
         pass  # Graceful degradation if the SDK changes its internals
 
 
+def _client_is_closed(client: Any) -> bool:
+    """Best-effort check for cached sync clients with closed transports."""
+    candidates = [
+        client,
+        getattr(client, "_client", None),
+        getattr(client, "client", None),
+        getattr(client, "_real_client", None),
+    ]
+    real_client = getattr(client, "_real_client", None)
+    if real_client is not None:
+        candidates.extend([
+            getattr(real_client, "_client", None),
+            getattr(real_client, "client", None),
+        ])
+    for obj in candidates:
+        if obj is None:
+            continue
+        if getattr(obj, "is_closed", False) is True:
+            return True
+    return False
+
+
 def _force_close_async_httpx(client: Any) -> None:
     """Mark the httpx AsyncClient inside an AsyncOpenAI client as closed.
 
@@ -4523,8 +4545,11 @@ def _get_cached_client(
                 _force_close_async_httpx(cached_client)
                 del _client_cache[cache_key]
             else:
-                effective = _compat_model(cached_client, model, cached_default)
-                return cached_client, effective
+                if _client_is_closed(cached_client):
+                    del _client_cache[cache_key]
+                else:
+                    effective = _compat_model(cached_client, model, cached_default)
+                    return cached_client, effective
     # Build outside the lock.
     # For pool-backed api_key providers, derive the active API key from the
     # pool entry rather than from env vars.  resolve_api_key_provider_credentials

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3032,6 +3032,41 @@ class TestAuxiliaryClientPoisonedCacheEviction:
         assert _evict_cached_client_instance(None) is False
         assert _evict_cached_client_instance(MagicMock()) is False
 
+    def test_get_cached_client_rebuilds_closed_sync_client(self):
+        """A cached sync client with a closed transport must not be reused."""
+        from agent.auxiliary_client import (
+            _client_cache, _client_cache_key, _client_cache_lock, _get_cached_client,
+        )
+
+        closed_client = SimpleNamespace(
+            _client=SimpleNamespace(is_closed=True),
+            base_url="https://openrouter.ai/api/v1",
+        )
+        fresh_client = SimpleNamespace(
+            _client=SimpleNamespace(is_closed=False),
+            base_url="https://openrouter.ai/api/v1",
+        )
+        cache_key = _client_cache_key("openrouter", async_mode=False)
+
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (closed_client, "openrouter/model", None)
+
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fresh_client, "openrouter/model"),
+            ) as resolve_mock:
+                client, model = _get_cached_client("openrouter")
+
+            assert client is fresh_client
+            assert model == "openrouter/model"
+            resolve_mock.assert_called_once()
+            assert _client_cache[cache_key][0] is fresh_client
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
     def test_evict_cached_client_instance_walks_async_wrapper(self):
         """async_mode is part of the cache key so sync and async share the same
         underlying OpenAI client across two distinct cache entries. A single


### PR DESCRIPTION
## What does this PR do?

Evicts cached auxiliary clients whose underlying sync HTTP transport is already closed before reusing them. Without this guard, a closed cached sync client can be returned from `_get_cached_client`, causing follow-up auxiliary calls to keep failing until process restart instead of rebuilding the provider client.

## Related Issue

Related to auxiliary client cache/transport lifecycle fixes; no dedicated issue found for this exact closed-sync-cache-hit path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_client_is_closed()` in `agent/auxiliary_client.py` to detect cached clients or wrapped clients whose transport exposes `is_closed is True`.
- Updated `_get_cached_client()` to evict closed cached clients and rebuild them instead of returning them.
- Added regression coverage in `tests/agent/test_auxiliary_client.py` proving a closed cached sync client is replaced with a fresh client.

## How to Test

1. `PYTHONPATH=$PWD /workspace/repos/hermes-agent/.venv/bin/python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction -q -o 'addopts='`
2. `PYTHONPATH=$PWD /workspace/repos/hermes-agent/.venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`
3. `ln -sfn /workspace/repos/hermes-agent/.venv .venv && scripts/run_tests.sh tests/agent/test_auxiliary_client.py && rm -f .venv`
4. `PYTHONPATH=$PWD /workspace/repos/hermes-agent/.venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
5. Full `scripts/run_tests.sh` was attempted in this environment but timed out after 10 minutes, with failures observed in unrelated CLI/gateway systemd tests before timeout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(auxiliary): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (related poisoned-cache/transport lifecycle fixes reviewed; no duplicate closed-sync-cache-hit fix found)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite attempted; blocked/timed out as noted above)
- [x] I've added tests for my changes (closed cached sync client rebuild regression coverage)
- [x] I've tested on my platform: Linux 5.15 container

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal cache lifecycle fix with no user-facing behavior/config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-agnostic Python cache handling; no OS-specific paths/subprocesses
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schemas changed

## Screenshots / Logs

Targeted regression failed before the fix on upstream main:

```text
FAILED tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_get_cached_client_rebuilds_closed_sync_client
AssertionError: assert closed_client is fresh_client
```

After the fix:

```text
8 passed, 1 warning in 6.90s
208 passed, 1 warning in 20.96s
scripts/run_tests.sh tests/agent/test_auxiliary_client.py: 208 tests passed
```
