### PR TITLE
fix(slack): bot messages in active threads silently dropped with allow_bots=all

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2615,6 +2615,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            is_bot=is_bot_message,
         )
 
         # Per-channel ephemeral prompt

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2304,6 +2304,11 @@ class SlackAdapter(BasePlatformAdapter):
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        # Track whether this is a bot-authored message (e.g. another Hermes instance,
+        # Clo, or any other Slack bot).  Bot messages don't create user-scoped sessions,
+        # so _has_active_session_for_thread() will always return False for them — we
+        # need to fall back to thread-membership signals instead.
+        is_bot_message = bool(event.get("bot_id") or event.get("subtype") == "bot_message")
 
         if not is_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -2328,10 +2333,18 @@ class SlackAdapter(BasePlatformAdapter):
                     event_thread_ts is not None
                     and event_thread_ts in self._mentioned_threads
                 )
-                has_session = is_thread_reply and self._has_active_session_for_thread(
-                    channel_id=channel_id,
-                    thread_ts=event_thread_ts,
-                    user_id=user_id,
+                # For bot-authored messages (e.g. Clo, another Hermes instance),
+                # _has_active_session_for_thread() will always return False because
+                # bots don't own user-scoped sessions.  Skip the session check for
+                # them and rely on thread-membership signals only.
+                has_session = (
+                    not is_bot_message
+                    and is_thread_reply
+                    and self._has_active_session_for_thread(
+                        channel_id=channel_id,
+                        thread_ts=event_thread_ts,
+                        user_id=user_id,
+                    )
                 )
                 if (
                     not reply_to_bot_thread
@@ -2358,6 +2371,9 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
+        # Also re-fetch when a bot posts in an *active* session thread and the
+        # cache has expired — bot messages don't go through the normal session
+        # history pipeline, so without a re-fetch we'd miss them entirely.
         if is_thread_reply and not self._has_active_session_for_thread(
             channel_id=channel_id,
             thread_ts=event_thread_ts,
@@ -2371,6 +2387,25 @@ class SlackAdapter(BasePlatformAdapter):
             )
             if thread_context:
                 text = thread_context + text
+        elif is_thread_reply and is_bot_message:
+            # Active session, but the triggering message is from another bot.
+            # The cache TTL acts as a natural debounce: only re-fetch (and
+            # prepend incremental context) when the cache has gone stale,
+            # avoiding redundant conversations.replies calls on every bot turn.
+            cache_key = f"{channel_id}:{event_thread_ts}:{team_id}"
+            cached = self._thread_context_cache.get(cache_key)
+            cache_stale = cached is None or (
+                time.monotonic() - cached.fetched_at >= self._THREAD_CACHE_TTL
+            )
+            if cache_stale:
+                thread_context = await self._fetch_thread_context(
+                    channel_id=channel_id,
+                    thread_ts=event_thread_ts,
+                    current_ts=ts,
+                    team_id=team_id,
+                )
+                if thread_context:
+                    text = thread_context + text
 
         # Determine message type
         msg_type = MessageType.TEXT

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6939,6 +6939,7 @@ class GatewayRunner:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2636,10 +2636,96 @@ class TestThreadReplyHandling:
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_bot_message_in_mentioned_thread_processed_allow_bots_all(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Bot message in a thread where bot was @mentioned should be processed
+        when allow_bots=all, even without a user-owned session (issue #30091).
 
-# ---------------------------------------------------------------------------
-# TestAssistantThreadLifecycle
-# ---------------------------------------------------------------------------
+        Bot messages don't create user-scoped sessions, so
+        _has_active_session_for_thread() always returns False for them.
+        The fix: skip the session check for bot messages and rely on
+        _mentioned_threads / _bot_message_ts membership instead.
+        """
+        adapter_with_session_store.config = PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"allow_bots": "all"},
+        )
+        # Simulate that the bot was previously mentioned in this thread
+        adapter_with_session_store._mentioned_threads.add("123.000")
+
+        event = {
+            "text": "Hello from Clo!",
+            "bot_id": "B_CLO",
+            "user": "U_CLO_BOT",
+            "channel": "C123",
+            "ts": "123.789",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bot_message_in_bot_started_thread_processed_allow_bots_all(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Bot message in a thread the bot started should be processed
+        when allow_bots=all (issue #30091).
+        """
+        adapter_with_session_store.config = PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"allow_bots": "all"},
+        )
+        # Bot started this thread
+        adapter_with_session_store._bot_message_ts.add("123.000")
+
+        event = {
+            "text": "Replying in the bot-started thread",
+            "bot_id": "B_CLO",
+            "user": "U_CLO_BOT",
+            "channel": "C123",
+            "ts": "123.789",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bot_message_without_thread_membership_ignored(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Bot message in a thread with no membership signals should be
+        ignored even with allow_bots=all (prevents unwanted bot-bot loops).
+        """
+        adapter_with_session_store.config = PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"allow_bots": "all"},
+        )
+        # No _mentioned_threads, no _bot_message_ts, no session
+
+        event = {
+            "text": "Random bot noise",
+            "bot_id": "B_RANDOM",
+            "user": "U_RANDOM_BOT",
+            "channel": "C123",
+            "ts": "123.789",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        await adapter_with_session_store._handle_slack_message(event)
+        adapter_with_session_store.handle_message.assert_not_called()
+
+
+
 
 
 class TestAssistantThreadLifecycle:


### PR DESCRIPTION
## Summary

Bot-authored messages (e.g. another Hermes instance, Clo) were silently dropped in active threads even with `allow_bots: all` configured, making multi-bot collaboration on shared threads impossible.

Two root causes fixed:

---

### Fix 1: `is_bot` not passed to `build_source` (commit 31b6257)

`SessionSource.is_bot` was never set for Slack bot messages because `build_source()` was called without `is_bot=`. This caused `_is_user_authorized()` to skip the `platform_allow_bots_map` check (`source.is_bot` was always `False`) and fall through to deny.

Now passes `is_bot=is_bot_message` so that bot-authored messages correctly trigger the `SLACK_ALLOW_BOTS` bypass when configured.

---

### Fix 2: Bot messages bypass session check with `allow_bots=all` (commit 575cedf)

Bot-authored messages don't create user-scoped sessions, so `_has_active_session_for_thread()` always returned `False` for them — even in an active thread with `allow_bots=all`. Bot replies were silently dropped when they weren't @-mentioning the bot.

**Changes:**

1. Introduce `is_bot_message` flag in `_handle_slack_message`
2. Skip `_has_active_session_for_thread()` for bot messages — rely on `_mentioned_threads` / `_bot_message_ts` membership signals instead (same as human messages without @mention)
3. When a bot message arrives in an active-session thread and the thread-context cache has expired, re-fetch `conversations.replies` so any intervening bot messages are included in the prepended context. Cache TTL (60 s) debounces against the Tier-3 rate-limited API.

---

## Related Issues

- Fixes #30091 — bot-to-bot messages in shared threads silently dropped even with `allow_bots=all`
- Fixes #38861 — bot messages in active threads miss thread context

---

## Modified Files

- `gateway/platforms/slack.py`
  - Line 2112–2123: `allow_bots` filtering logic
  - Line 2311: `is_bot_message` flag introduced
  - Line 2341, 2390: session check bypass for bot messages
  - Line 2618: `build_source(is_bot=is_bot_message)` fix

---

## Test Plan

3 new test cases in `TestThreadReplyHandling`:

- Bot message in @mentioned thread → processed
- Bot message in bot-started thread → processed
- Bot message with no thread membership → ignored (prevents bot-bot loop)

---

## Verified

Tested with two Hermes instances (Hermes + Clo) in a shared Slack thread.  
Both bots can now see and respond to each other's messages with `allow_bots: all` configured.
