### PR TITLE
fix(ssh): WinError 1314 symlink fallback for Windows bulk upload (salvage #8996)

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -90,7 +90,12 @@ class TestSSHBulkUpload:
         assert "/home/testuser/.hermes/credentials" in mkdir_str
 
     def test_staging_symlinks_mirror_remote_layout(self, mock_env, tmp_path):
-        """Symlinks in staging dir should mirror the .hermes-relative layout."""
+        """Staged file in staging dir should mirror the remote path structure.
+
+        On platforms where symlinks are available (Linux/macOS) the staged
+        entry is a symlink; on Windows it may be a regular copy.  Either way
+        the file must exist at the expected path and contain the right data.
+        """
         f1 = tmp_path / "local_a.txt"
         f1.write_text("content a")
 
@@ -105,11 +110,14 @@ class TestSSHBulkUpload:
                 # Capture the staging dir from -C argument
                 c_idx = cmd.index("-C")
                 staging_dir = cmd[c_idx + 1]
-                # Check the symlink exists
+                # Check the staged entry exists at the base-relative path
                 expected = os.path.join(staging_dir, "skills/my_skill.md")
                 staging_paths.append(expected)
-                assert os.path.islink(expected), f"Expected symlink at {expected}"
-                assert os.readlink(expected) == os.path.abspath(str(f1))
+                # File must exist (either as symlink or copy)
+                assert os.path.exists(expected), f"Expected staged file at {expected}"
+                # Content must match the source
+                with open(expected, "r") as fh:
+                    assert fh.read() == "content a"
 
             mock = MagicMock()
             mock.stdout = MagicMock()

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -9,6 +9,7 @@ view) and don't need this.
 import hashlib
 import logging
 import os
+import posixpath
 import shlex
 import shutil
 import signal
@@ -87,7 +88,7 @@ def quoted_mkdir_command(dirs: list[str]) -> str:
 
 def unique_parent_dirs(files: list[tuple[str, str]]) -> list[str]:
     """Extract sorted unique parent directories from (host, remote) pairs."""
-    return sorted({str(Path(remote).parent) for _, remote in files})
+    return sorted({posixpath.dirname(remote) for _, remote in files})
 
 
 def _sha256_file(path: str) -> str:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -179,8 +179,10 @@ class SSHEnvironment(BaseEnvironment):
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
 
         # Symlink staging avoids fragile GNU tar --transform rules.
-        # On Windows, symlink creation requires admin rights or Developer Mode,
-        # so fall back to copying the file when os.symlink raises OSError.
+        # On Windows without Developer Mode, symlink creation raises
+        # OSError with winerror 1314 (privilege not held).  Catch only
+        # that specific error and fall back to a plain copy; all other
+        # OSErrors (e.g. disk full, bad path) are re-raised as normal.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
             for host_path, remote_path in files:
                 try:
@@ -199,8 +201,12 @@ class SSHEnvironment(BaseEnvironment):
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
                 try:
                     os.symlink(os.path.abspath(host_path), staged)
-                except OSError:
-                    shutil.copy2(host_path, staged)
+                except OSError as e:
+                    # WinError 1314: symlink privilege not held (Windows without Dev Mode)
+                    if getattr(e, "winerror", None) == 1314:
+                        shutil.copy2(host_path, staged)
+                    else:
+                        raise
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -179,6 +179,8 @@ class SSHEnvironment(BaseEnvironment):
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
 
         # Symlink staging avoids fragile GNU tar --transform rules.
+        # On Windows, symlink creation requires admin rights or Developer Mode,
+        # so fall back to copying the file when os.symlink raises OSError.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
             for host_path, remote_path in files:
                 try:
@@ -195,7 +197,10 @@ class SSHEnvironment(BaseEnvironment):
 
                 staged = os.path.join(staging, rel_remote)
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
-                os.symlink(os.path.abspath(host_path), staged)
+                try:
+                    os.symlink(os.path.abspath(host_path), staged)
+                except OSError:
+                    shutil.copy2(host_path, staged)
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()


### PR DESCRIPTION
## Summary
SSH bulk-upload now works on Windows without Administrator rights or Developer Mode.

Salvage of #8996 by @Kewe63, cherry-picked onto current main with authorship preserved.

Root cause: the bulk-upload staging step used `os.symlink()` to mirror the remote layout before piping through tar. On Windows, `os.symlink()` raises `OSError` (WinError 1314, "a required privilege is not held") unless the process is elevated or Dev Mode is on — so every `ssh_bulk_upload` failed there. A second, latent bug: `unique_parent_dirs()` built remote directory paths with `pathlib.Path`, which uses the host separator (`\` on Windows) for paths that are sent to a remote Linux host.

## Changes
- `tools/environments/ssh.py`: wrap `os.symlink()` in try/except; fall back to `shutil.copy2()` **only** when `e.winerror == 1314`, re-raise every other `OSError` (disk full, bad path, etc.) so genuine failures aren't swallowed
- `tools/environments/file_sync.py`: `unique_parent_dirs()` uses `posixpath.dirname()` so remote paths always use forward slashes
- `tests/tools/test_ssh_bulk_upload.py`: make the staging-layout test platform-agnostic (assert existence + content, not `islink`/`readlink`)
- `scripts/release.py`: add @Kewe63 to AUTHOR_MAP

Both contributor commits preserved: the fix, plus the follow-up that narrows the catch to WinError 1314.

## Validation
| Case | Result |
|---|---|
| WinError 1314 raised | falls back to `shutil.copy2` (E2E verified) |
| Other `OSError` (e.g. disk full) | re-raised, not swallowed (E2E verified) |
| No error (Linux/macOS) | symlink created as before (E2E verified) |
| Remote dir of `/remote/dir/a.txt` | `/remote/dir` — forward slashes preserved (E2E verified) |
| `tests/tools/test_ssh_bulk_upload.py` | 21/21 pass |

Closes #8996 via salvage.

## Infographic

![symlink-fallback-windows-ssh](https://v3b.fal.media/files/b/0a9cf1ec/YgazrCAnFehvanxvs-6Xc_5mrquGVU.png)
