### PR TITLE
fix(desktop): declare ES2023 lib so findLast/findLastIndex type-check (TS2550)

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## What does this PR do?

Makes the desktop TypeScript build correct for the ES2023 array APIs it already uses, fixing the `TS2550` desktop build failure reported on Windows.

Refs #38970

## Root cause (TS2550)

The desktop code uses ES2023 array methods:

- `messages.findLast(...)` — `src/app/chat/composer/index.tsx`
- `currentMessages.findLastIndex(...)` — `src/app/session/hooks/use-session-actions.ts`

…but `apps/desktop/tsconfig.json` declared only the **ES2022** lib:

```json
"target": "ES2022",
"lib": ["DOM", "DOM.Iterable", "ES2022"],
```

`findLast` / `findLastIndex` live in `lib.es2023.array.d.ts`. Some TypeScript versions tolerate the mismatch (so it builds in some environments), but a correct/stricter `tsc` fails:

```
TS2550: Property 'findLast' does not exist on type 'ChatMessage[]'.
Do you need to change your target library? Try changing 'lib' to 'es2023' or later.
```

This is exactly Error 2 in #38970 (Windows / Node 24).

## Change

Bump `target` and `lib` to `ES2023`. `tsconfig.json` here is type-check only (`noEmit: true`; Vite owns the actual build target), so this just makes type resolution match the code.

## How to test

```bash
cd apps/desktop && npx tsc -b   # passes
```

## Note on Error 1 (TS7016, @tanstack/react-query)

I could not reproduce TS7016 on current `main`: the pinned `@tanstack/react-query` (5.100.8) ships a proper `exports` map with `types` under both `import` and `require`, and `moduleResolution: "Bundler"` resolves `build/modern/index.d.ts` cleanly (`tsc -b` passes). That error appears tied to an older/drifted dependency version on the reporter's older commits rather than the current config, so this PR is scoped to the actionable, reproducible `TS2550` fix. Happy to follow up if TS7016 still reproduces against current `main` deps.