### PR TITLE
fix(auth): evict placeholder credentials from the pool on write (#38799)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1366,6 +1366,25 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     return list(global_entries) if isinstance(global_entries, list) else []
 
 
+def _is_placeholder_only_entry(entry: Any) -> bool:
+    """Return True when a pool entry's only secret is a placeholder value."""
+    if not isinstance(entry, dict):
+        return False
+    secrets = [
+        str(entry.get(field) or "").strip()
+        for field in ("access_token", "api_key")
+    ]
+    populated = [token for token in secrets if token]
+    if not populated:
+        return False
+    if any(token.lower() not in _PLACEHOLDER_SECRET_VALUES for token in populated):
+        return False
+    return not any(
+        str(entry.get(field) or "").strip()
+        for field in ("refresh_token", "agent_key")
+    )
+
+
 def write_credential_pool(
     provider_id: str,
     entries: List[Dict[str, Any]],
@@ -1385,6 +1404,9 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+    Entries whose only secret field is a placeholder value (e.g. "none",
+    "changeme") are evicted before writing so stale UI-injected credentials
+    do not block real credentials from being seeded. See issue #38799.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -1397,6 +1419,9 @@ def write_credential_pool(
             sanitize_borrowed_credential_payload(entry, provider_id)
             if isinstance(entry, dict) else entry
             for entry in entries
+        ]
+        sanitized_entries = [
+            entry for entry in sanitized_entries if not _is_placeholder_only_entry(entry)
         ]
         existing = pool.get(provider_id)
         existing_list = existing if isinstance(existing, list) else []
@@ -1413,7 +1438,9 @@ def write_credential_pool(
             if not disk_id or disk_id in new_ids or disk_id in removed:
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
-        pool[provider_id] = merged
+        pool[provider_id] = [
+            entry for entry in merged if not _is_placeholder_only_entry(entry)
+        ]
         return _save_auth_store(auth_store)
 
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -116,7 +116,7 @@ def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):
                         "auth_type": "api_key",
                         "priority": 0,
                         "source": "manual",
-                        "access_token": "***",
+                        "access_token": "sk-or-v3-primary-key",
                     },
                     {
                         "id": "cred-2",
@@ -124,7 +124,7 @@ def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):
                         "auth_type": "api_key",
                         "priority": 1,
                         "source": "manual",
-                        "access_token": "***",
+                        "access_token": "sk-or-v3-secondary-key",
                     },
                 ]
             },
@@ -1184,6 +1184,229 @@ def test_write_credential_pool_preserves_known_provider_owned_oauth_state(tmp_pa
     assert persisted["refresh_token"] == f"refresh-{sentinel}"
     assert persisted["agent_key"] == f"agent-{sentinel}"
 
+
+
+def test_write_credential_pool_evicts_placeholder_only_entry(tmp_path, monkeypatch):
+    """Placeholder-only entries are evicted; real entries survive. (#38799)"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [
+        {
+            "id": "placeholder-entry",
+            "label": "placeholder",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "none",
+        },
+        {
+            "id": "real-entry",
+            "label": "real",
+            "auth_type": "api_key",
+            "priority": 1,
+            "source": "manual",
+            "access_token": "sk-or-v3-real-secret-value",
+        },
+    ])
+
+    entries = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["openrouter"]
+    assert len(entries) == 1
+    assert entries[0]["id"] == "real-entry"
+
+
+def test_write_credential_pool_prevents_placeholder_from_masking_real_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [
+        {
+            "id": "placeholder-entry",
+            "label": "placeholder",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "none",
+        },
+        {
+            "id": "real-entry",
+            "label": "real",
+            "auth_type": "api_key",
+            "priority": 1,
+            "source": "manual",
+            "access_token": "sk-or-v3-real-secret-value",
+        },
+    ])
+
+    entry = load_pool("openrouter").peek()
+
+    assert entry is not None
+    assert entry.id == "real-entry"
+
+
+def test_write_credential_pool_preserves_oauth_entry_with_refresh_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [{
+        "id": "oauth-entry",
+        "label": "oauth",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual",
+        "access_token": "none",
+        "refresh_token": "refresh-token",
+    }])
+
+    entry = load_pool("openrouter").peek()
+
+    assert entry is not None
+    assert entry.id == "oauth-entry"
+    assert entry.refresh_token == "refresh-token"
+
+
+def test_write_credential_pool_preserves_nous_entry_with_agent_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = _jwt_with_claims({
+        "sub": "test-user",
+        "scope": ["inference:invoke"],
+        "exp": int(time.time() + 3600),
+    })
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("nous", [{
+        "id": "nous-entry",
+        "label": "nous",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "device_code",
+        "access_token": "none",
+        "agent_key": token,
+        "scope": "inference:invoke",
+    }])
+
+    entry = load_pool("nous").peek()
+
+    assert entry is not None
+    assert entry.id == "nous-entry"
+    assert entry.runtime_api_key == token
+
+
+def test_write_credential_pool_evicts_all_placeholder_variants(tmp_path, monkeypatch):
+    """Every member of _PLACEHOLDER_SECRET_VALUES triggers eviction. (#38799)"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import _PLACEHOLDER_SECRET_VALUES, write_credential_pool
+
+    entries = [
+        {
+            "id": f"entry-{i}",
+            "label": placeholder,
+            "auth_type": "api_key",
+            "priority": i,
+            "source": "manual",
+            "access_token": placeholder,
+        }
+        for i, placeholder in enumerate(sorted(_PLACEHOLDER_SECRET_VALUES))
+    ]
+    write_credential_pool("openrouter", entries)
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["openrouter"]
+    assert persisted == []
+
+
+def test_write_credential_pool_keeps_entry_with_real_secret(tmp_path, monkeypatch):
+    """An entry with a genuine access_token is not evicted. (#38799)"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [
+        {
+            "id": "real-entry",
+            "label": "real",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "sk-or-v3-real-secret-value",
+        }
+    ])
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["openrouter"]
+    assert len(persisted) == 1
+    assert persisted[0]["access_token"] == "sk-or-v3-real-secret-value"
+
+
+def test_write_credential_pool_keeps_entry_with_real_api_key_even_if_access_token_is_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [
+        {
+            "id": "mixed-secret-entry",
+            "label": "mixed-secret-entry",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "none",
+            "api_key": "sk-or-v3-real-api-key",
+        }
+    ])
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["openrouter"]
+    assert len(persisted) == 1
+    assert persisted[0]["api_key"] == "sk-or-v3-real-api-key"
+
+
+def test_write_credential_pool_evicts_placeholder_api_key_field(tmp_path, monkeypatch):
+    """Entries with api_key set to a placeholder (no access_token) are evicted. (#38799)"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openrouter", [
+        {
+            "id": "api-key-placeholder",
+            "label": "api-key-placeholder",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "api_key": "none",
+        }
+    ])
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["openrouter"]
+    assert persisted == []
+
+
+def test_write_credential_pool_keeps_entry_with_no_token(tmp_path, monkeypatch):
+    """Entries with neither access_token nor api_key are NOT evicted. (#38799)"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("nous", [
+        {
+            "id": "tokenless-device",
+            "label": "device-code",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "device_code",
+            # No access_token or api_key — placeholder check must not evict
+        }
+    ])
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())["credential_pool"]["nous"]
+    assert len(persisted) == 1
+    assert persisted[0]["id"] == "tokenless-device"
 
 
 def test_load_pool_prefers_dotenv_over_stale_os_environ(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The Desktop setup wizard enters an infinite loop when a stale credential pool entry with `api_key: "none"` blocks a valid entry from being reached. The stale entry is written at priority 0 during initial local-endpoint setup, and `hermes model` adds a correct entry at priority 1 without evicting the stale one. The setup wizard resolves credentials by calling `load_pool().peek()`, which returns the first available entry sorted by priority. `_available_entries()` does not filter placeholder secrets; it only skips DEAD/EXHAUSTED entries. The P0 stale entry passes availability checks, `has_usable_secret("none")` returns `False`, and the loop continues.

The fix adds placeholder eviction to `write_credential_pool()` in `hermes_cli/auth.py`, which is already the disk-boundary guard that sanitizes borrowed payloads. A new `_is_placeholder_only_entry()` helper checks whether an entry's `access_token` (or legacy `api_key` field) is in `_PLACEHOLDER_SECRET_VALUES` and silently drops it before persistence. This ensures that every write path (manual `hermes model`, `hermes auth add`, and `load_pool()`'s internal persistence at `agent/credential_pool.py:2179`) evicts stale entries, and the persisted pool never contains placeholders that block iteration.

Fixes #38799

## Changes

- `hermes_cli/auth.py`: add `_is_placeholder_only_entry()` helper that returns `True` when a dict entry's secret is a known placeholder; add a list-comprehension filter in `write_credential_pool()` that evicts such entries before persisting (+~20 lines)
- `tests/agent/test_credential_pool.py`: tests that placeholder entries are evicted on write, all `_PLACEHOLDER_SECRET_VALUES` variants are evicted, real entries survive, `api_key`-field placeholders are evicted, and reference-only entries (no token) are preserved (+~60 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| `write_credential_pool` with P0 `"none"` + P1 real key | both persisted; `peek()` returns stale P0 | P0 evicted; `peek()` returns real P1 |
| `write_credential_pool` with all `_PLACEHOLDER_SECRET_VALUES` | all persisted | all evicted |
| `write_credential_pool` with real secret | persisted | persisted (unchanged) |
| `write_credential_pool` with `api_key: "none"` (legacy field) | persisted | evicted |
| `write_credential_pool` with no token (reference-only) | persisted | persisted (unchanged) |
| Existing `test_write_credential_pool_*` | pass | pass (unchanged) |
| Setup wizard with local endpoint after `hermes model` | infinite loop | wizard resolves valid credential |

## Test plan

- `pytest tests/agent/test_credential_pool.py -v --timeout=0` — 83 passed
- New: placeholder entry evicted on write; all placeholder variants evicted; real entries survive; `api_key`-field placeholders evicted; reference-only entries preserved

## Not in scope

Changing `_available_entries()` to also skip placeholder tokens at selection time. While that would be a valid defense-in-depth layer, the root cause is that the placeholder entry should never be persisted in the first place. Filtering at write time is the correct single fix, and matches the existing pattern of `write_credential_pool` as the sanitization boundary. A selection-time guard could be added as a follow-up if other stale-entry patterns emerge.