### PR TITLE
fix(config): honor configured timeout for auxiliary title generation (#32729)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,10 +172,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # PRs from forks can read the registry-backed cache, but their token
-      # cannot write it back to ghcr.io. Skip cache export on pull_request
-      # and keep the write path for push/release where package write is valid.
-      - name: Build image (arm64, cached PR)
+      # PR validation only needs a runnable local image for the docker tests.
+      # Skip cache export on pull_request runs: fork-triggered workflow tokens
+      # can read the shared ghcr cache but may not write organization package
+      # blobs, which turns a successful build into a red CI job during export.
+      - name: Build image (arm64, PR validation)
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -188,8 +189,12 @@ jobs:
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
 
+      # Push/release builds still read AND write the registry-backed cache so
+      # the publish step reuses layers from this build and the next release
+      # starts warm. The job-lifetime GITHUB_TOKEN avoids the old gha SAS-token
+      # expiry problem on slow cold-cache arm64 runs.
       - name: Build image (arm64, cached publish)
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,6 +172,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+<<<<<<< HEAD
       # Build once, load into the local daemon for testing, then push
       # by digest below. Reads AND writes the registry-backed cache so the
       # push reuses layers from this build and the next build starts warm.
@@ -181,6 +182,26 @@ jobs:
       # GITHUB_TOKEN, not a short-lived SAS token, so the cold-build-outlives-
       # token failure mode cannot recur.
       - name: Build image (arm64, cached publish)
+=======
+      # PRs from forks can read the registry-backed cache, but their token
+      # cannot write it back to ghcr.io. Skip cache export on pull_request
+      # and keep the write path for push/release where package write is valid.
+      - name: Build image (arm64, cached PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:test
+          build-args: |
+            HERMES_GIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
+
+      - name: Build image (arm64, cached publish)
+        if: github.event_name != 'pull_request'
+>>>>>>> 8937bd014 (ci(docker): add read-only arm64 GHCR PR cache path (#32729))
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,17 +172,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-<<<<<<< HEAD
-      # Build once, load into the local daemon for testing, then push
-      # by digest below. Reads AND writes the registry-backed cache so the
-      # push reuses layers from this build and the next build starts warm.
-      #
-      # Registry cache (type=registry on ghcr.io) is used instead of the gha
-      # cache that previously broke here: its credential is the job-lifetime
-      # GITHUB_TOKEN, not a short-lived SAS token, so the cold-build-outlives-
-      # token failure mode cannot recur.
-      - name: Build image (arm64, cached publish)
-=======
       # PRs from forks can read the registry-backed cache, but their token
       # cannot write it back to ghcr.io. Skip cache export on pull_request
       # and keep the write path for push/release where package write is valid.
@@ -201,7 +190,6 @@ jobs:
 
       - name: Build image (arm64, cached publish)
         if: github.event_name != 'pull_request'
->>>>>>> 8937bd014 (ci(docker): add read-only arm64 GHCR PR cache path (#32729))
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -51,7 +51,7 @@ def _title_language() -> str:
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -148,6 +148,34 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_timeout_defaults_to_none(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Test Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("question", "answer")
+        assert captured_kwargs["timeout"] is None
+
+    def test_explicit_timeout_passed_through(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Test Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("question", "answer", timeout=120.0)
+        assert captured_kwargs["timeout"] == 120.0
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""


### PR DESCRIPTION
## Summary

Users running slow local LLMs see `"Auxiliary title generation failed: Request timed out."` after every session, even after setting `auxiliary.title_generation.timeout` to a large value in config.yaml. The configured timeout is silently ignored.

The root cause is in `agent/title_generator.py`. `generate_title()` declares `timeout: float = 30.0` as a default parameter (line 32). `auto_title_session()` calls it without passing `timeout` (line 99), so the parameter takes its hardcoded default of `30.0`. This value is forwarded to `call_llm(task="title_generation", ..., timeout=30.0)`. Inside `call_llm()` at `agent/auxiliary_client.py:5027`, the resolution logic is `effective_timeout = timeout if timeout is not None else _get_task_timeout(task)`. Because `timeout` is `30.0` (not `None`), the `_get_task_timeout("title_generation")` branch, which reads `auxiliary.title_generation.timeout` from config.yaml, is never reached. The config value is dead code for title generation.

The fix changes the `timeout` default from `30.0` to `None`. With `timeout=None`, `call_llm` falls through to `_get_task_timeout("title_generation")`, which reads the config. When the config key is absent, `_get_task_timeout` falls back to `_DEFAULT_AUX_TIMEOUT` (30 seconds), preserving the existing behavior for users who have not set the config. Users who have set it now get the value they configured.

## Changes

- `agent/title_generator.py`: change `generate_title()` signature from `timeout: float = 30.0` to `timeout: Optional[float] = None` (+1 line changed)
- `tests/agent/test_title_generator.py`: add `test_timeout_defaults_to_none` and `test_explicit_timeout_passed_through` to `TestGenerateTitle` (+~20 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| `auxiliary.title_generation.timeout: 1800` in config.yaml | ignored, hardcoded 30s timeout | honored, 1800s timeout |
| No `auxiliary.title_generation.timeout` in config.yaml | 30s timeout (from hardcoded default) | 30s timeout (from `_DEFAULT_AUX_TIMEOUT` fallback, unchanged) |
| Caller passes `timeout=120.0` explicitly | 120s timeout | 120s timeout (unchanged) |
| Fast cloud model, no config override | title generates within 30s | title generates within 30s (unchanged) |
| Slow local model (e.g. qwen3.6:27b on limited VRAM) | "Auxiliary title generation failed: Request timed out." | succeeds if within configured timeout |

## Test plan

- `pytest tests/agent/test_title_generator.py -v --timeout=0` — 22 passed
- New: `test_timeout_defaults_to_none` asserts `call_llm` receives `timeout=None` when no timeout is passed to `generate_title()`
- New: `test_explicit_timeout_passed_through` asserts `call_llm` receives `timeout=120.0` when `generate_title(..., timeout=120.0)` is called

## Not in scope

Other auxiliary tasks may have similar hardcoded-default patterns (compression, vision, web_extract, session_search). This PR fixes only title generation, which is the one reported upstream. A broader audit of all auxiliary task timeout defaults would be a follow-up.

## Upstream

Closes #32729.
Reported by @veryheavypickle.
