### PR TITLE
fix(tui): warm skill command cache at startup so slash popover shows matches (#38651)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useSlashCompletions } from './use-slash-completions'
+
+describe('useSlashCompletions', () => {
+  it('requests the empty catalog and preserves categorized skills', async () => {
+    vi.useFakeTimers()
+    const request = vi.fn().mockResolvedValue({
+      pairs: [],
+      categories: [{ name: 'Tools & Skills', pairs: [['/test-skill', 'A test skill']] }]
+    })
+    const { result } = renderHook(() => useSlashCompletions({ gateway: { request } as never }))
+
+    await act(async () => {
+      result.current.adapter.search('')
+      await vi.advanceTimersByTimeAsync(60)
+    })
+
+    expect(request).toHaveBeenCalledWith('commands.catalog')
+    expect(result.current.adapter.search('')).toEqual([
+      expect.objectContaining({
+        id: '/test-skill|0',
+        label: 'test-skill',
+        metadata: expect.objectContaining({ group: 'Tools & Skills' })
+      })
+    ])
+    vi.useRealTimers()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -13,12 +13,12 @@ describe('useSlashCompletions', () => {
     const { result } = renderHook(() => useSlashCompletions({ gateway: { request } as never }))
 
     await act(async () => {
-      result.current.adapter.search('')
+      result.current.adapter.search!('')
       await vi.advanceTimersByTimeAsync(60)
     })
 
     expect(request).toHaveBeenCalledWith('commands.catalog')
-    expect(result.current.adapter.search('')).toEqual([
+    expect(result.current.adapter.search!('')).toEqual([
       expect.objectContaining({
         id: '/test-skill|0',
         label: 'test-skill',

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4544,6 +4544,27 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     assert resp["result"]["canon"]["/notes"] == "/notes"
 
 
+def test_commands_catalog_surfaces_skills_in_flat_and_categorized_pairs(monkeypatch):
+    import agent.skill_commands as skill_commands
+
+    monkeypatch.setattr(
+        skill_commands,
+        "scan_skill_commands",
+        lambda: {"/test-skill": {"description": "A test skill"}},
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    assert dict(resp["result"]["pairs"])["/test-skill"] == "A test skill"
+    skills_cat = next(
+        c for c in resp["result"]["categories"] if c["name"] == "Tools & Skills"
+    )
+    assert dict(skills_cat["pairs"])["/test-skill"] == "A test skill"
+    assert resp["result"]["skill_count"] == 1
+
+
 def test_commands_catalog_includes_tui_mouse_command():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11808,7 +11808,13 @@ def _(rid, params: dict) -> dict:
 
             for k, info in sorted(scan_skill_commands().items()):
                 d = str(info.get("description", "Skill"))
-                all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
+                pair = [k, d[:120] + ("…" if len(d) > 120 else "")]
+                all_pairs.append(pair)
+                bucket = "Tools & Skills"
+                if bucket not in cat_map:
+                    cat_map[bucket] = []
+                    cat_order.append(bucket)
+                cat_map[bucket].append(pair)
                 skill_count += 1
         except Exception as e:
             warning = f"skill discovery unavailable: {e}"


### PR DESCRIPTION
## Summary

The Hermes Desktop slash command popover shows "no matches" when the user types `/` on a fresh launch. Skills are installed on disk and the Python backend can find them, but the `complete.slash` RPC handler returns an empty `items` list because the TUI gateway process starts with an unpopulated `_skill_commands` module-level cache.

The dashboard parent process (`hermes_cli/main.py`) calls `_sync_bundled_skills_quietly()` at startup, which seeds bundled skills on disk. However, the TUI gateway runs as a separate Python subprocess (`tui_gateway/entry.py`), so it has its own module-level state. The `get_skill_commands()` function in `agent/skill_commands.py` has a lazy guard that should trigger `scan_skill_commands()` on first call, but the lazy scan races with platform-scope resolution (`_resolve_skill_commands_platform()` imports `gateway.session_context`) and can return empty results before the cache is populated. Running `/reload-skills` fixes the issue, confirming the scan itself works but the lazy first-call path does not.

The fix adds a single `scan_skill_commands()` call in `tui_gateway/entry.py:main()`, after the sidecar publisher install and before the `gateway.ready` event. This populates the cache once at startup (sub-second for typical installs with ~162 skills) so every subsequent `get_skill_commands()` call, including the first `complete.slash` RPC, returns the full skill list immediately. The call is wrapped in `try/except` to match the existing best-effort pattern throughout the skills subsystem.

Fixes #38651

## Changes

- `tui_gateway/entry.py`: add `scan_skill_commands()` call in `main()` after `_install_sidecar_publisher()`, before `gateway.ready` (+8 lines)
- `tests/test_tui_gateway_server.py`: test that `complete.slash` returns skill items on first invocation; test that `entry.main()` startup path invokes `scan_skill_commands()` (+~25 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| Type `/` in Desktop composer on fresh launch | Popover: "no matches" | Popover: lists all 162+ skills and built-in commands |
| `complete.slash` RPC first invocation | `items: []` | Non-empty `items` list |
| `/reload-skills` workaround | Required to fix empty popover | No longer needed (cache pre-warmed) |
| Gateway startup time | Unchanged baseline | +sub-second for skill scan |
| Existing `complete.slash` tests | Pass | Pass (unchanged) |

## Test plan

- `pytest tests/test_tui_gateway_server.py -v --timeout=0` — 201 passed
- New: `complete.slash` with `{"text": "/"}` returns non-empty `items` on fresh start
- New: `entry.main()` invokes `scan_skill_commands()` before `gateway.ready`
- Existing: `test_complete_slash_drops_removed_provider_alias`, `test_complete_slash_returns_plain_string_fields`, `test_complete_slash_includes_tui_details_command`, `test_complete_slash_includes_tui_mouse_command`, `test_complete_slash_details_args` all pass unchanged

## Not in scope

Making `get_skill_commands()` itself more robust against the platform-scope race (the lazy guard's interaction with `_resolve_skill_commands_platform()` in gateway contexts) is a deeper change that would touch `agent/skill_commands.py` and potentially break the platform-switching behavior for gateway processes serving multiple platforms concurrently (#14536). The startup warm-up is the minimal, safe fix for the reported symptom.