### PR TITLE
fix(cli): detect venv python workers before update to prevent .pyd lock failures (#38789)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7226,6 +7226,17 @@ def _detect_concurrent_hermes_instances(
             shim_paths.add(str(shim.resolve()).lower())
         except OSError:
             shim_paths.add(str(shim).lower())
+
+    # Also detect venv python.exe workers (Gateway, Dashboard, REPLs).
+    # These hold .pyd file locks that block uv pip install. Issue #38789.
+    for py_name in ("python.exe", "pythonw.exe"):
+        py_path = scripts_dir / py_name
+        if py_path.exists():
+            try:
+                shim_paths.add(str(py_path.resolve()).lower())
+            except OSError:
+                shim_paths.add(str(py_path).lower())
+
     if not shim_paths:
         return []
 
@@ -7309,13 +7320,12 @@ def _format_concurrent_instances_message(
     matches: list[tuple[int, str]], scripts_dir: Path
 ) -> str:
     """Build a human-readable explanation + remediation hint for the user."""
-    shim = scripts_dir / "hermes.exe"
-    lines = ["✗ Another hermes.exe is running:"]
+    lines = ["✗ Hermes processes are using the active venv:"]
     for pid, name in matches:
         lines.append(f"    PID {pid}  {name}")
     lines.append("")
-    lines.append(f"  Updating now would fail to overwrite {shim} because")
-    lines.append("  Windows blocks REPLACE on a running executable.")
+    lines.append("  Updating now would fail because Windows blocks replacement")
+    lines.append("  of running executables (.exe) and loaded native modules (.pyd).")
     lines.append("")
     lines.append("  Close Hermes Desktop, exit any open `hermes` REPLs, and")
     lines.append("  stop the gateway (`hermes gateway stop`) before retrying.")

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -332,8 +332,6 @@ def test_format_message_mentions_pids_and_remediation(tmp_path):
     assert "hermes.exe" in msg
     assert "Hermes Desktop" in msg
     assert "--force" in msg
-    # Mentions the file that would have been overwritten
-    assert str(tmp_path / "hermes.exe") in msg
     # Self-service kill command targets the exact stale PIDs (issue #34795).
     assert "taskkill" in msg
     assert "/PID 1234" in msg
@@ -795,3 +793,93 @@ def test_cmd_update_force_bypasses_concurrent_check(_winp, tmp_path):
 
     # When --force is set, we should not have even consulted psutil.
     detect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# venv python.exe / pythonw.exe worker detection (issue #38789)
+# ---------------------------------------------------------------------------
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_concurrent_finds_venv_python_worker(_winp, tmp_path):
+    """A python.exe process running from the venv scripts dir is detected.
+
+    Gateway, Dashboard, and REPL workers run as venv python.exe. They hold
+    .pyd file locks that block uv pip install during ``hermes update``.
+    """
+    scripts_dir = tmp_path
+    (scripts_dir / "hermes.exe").write_bytes(b"")
+    py_path = scripts_dir / "python.exe"
+    py_path.write_bytes(b"")
+
+    other_pid = os.getpid() + 1
+    procs = [_make_proc(other_pid, str(py_path), "python.exe")]
+    fake_psutil = types.SimpleNamespace(process_iter=lambda attrs: iter(procs))
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_concurrent_hermes_instances(scripts_dir)
+
+    assert result == [(other_pid, "python.exe")]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_concurrent_excludes_self_python_worker(_winp, tmp_path):
+    """The running process's own python.exe is excluded (same PID as os.getpid())."""
+    scripts_dir = tmp_path
+    py_path = scripts_dir / "python.exe"
+    py_path.write_bytes(b"")
+
+    my_pid = os.getpid()
+    procs = [_make_proc(my_pid, str(py_path), "python.exe")]
+    fake_psutil = types.SimpleNamespace(process_iter=lambda attrs: iter(procs))
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_concurrent_hermes_instances(scripts_dir)
+
+    assert result == []
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_concurrent_finds_pythonw_worker(_winp, tmp_path):
+    """pythonw.exe (GUI/headless workers) is also detected when running from venv."""
+    scripts_dir = tmp_path
+    (scripts_dir / "hermes.exe").write_bytes(b"")
+    pyw_path = scripts_dir / "pythonw.exe"
+    pyw_path.write_bytes(b"")
+
+    other_pid = os.getpid() + 1
+    procs = [_make_proc(other_pid, str(pyw_path), "pythonw.exe")]
+    fake_psutil = types.SimpleNamespace(process_iter=lambda attrs: iter(procs))
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_concurrent_hermes_instances(scripts_dir)
+
+    assert result == [(other_pid, "pythonw.exe")]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_concurrent_finds_both_shim_and_python(_winp, tmp_path):
+    """Both a hermes.exe shim and a python.exe worker are reported together."""
+    scripts_dir = tmp_path
+    shim = scripts_dir / "hermes.exe"
+    shim.write_bytes(b"")
+    py_path = scripts_dir / "python.exe"
+    py_path.write_bytes(b"")
+
+    shim_pid = os.getpid() + 1
+    py_pid = os.getpid() + 2
+    procs = [
+        _make_proc(shim_pid, str(shim), "hermes.exe"),
+        _make_proc(py_pid, str(py_path), "python.exe"),
+    ]
+    fake_psutil = types.SimpleNamespace(process_iter=lambda attrs: iter(procs))
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_concurrent_hermes_instances(scripts_dir)
+
+    assert (shim_pid, "hermes.exe") in result
+    assert (py_pid, "python.exe") in result
+    assert len(result) == 2
+
+
+def test_format_message_mentions_pyd(tmp_path):
+    """The updated message flags .pyd locks so users understand the full scope."""
+    matches = [(9999, "python.exe")]
+    msg = cli_main._format_concurrent_instances_message(matches, tmp_path)
+    assert ".pyd" in msg


### PR DESCRIPTION
## Summary

On Windows, `hermes update` can fail with `Access is denied (os error 5)` even after the existing `hermes.exe` quarantine and concurrent-instance detection (#23327, #26670), because long-running Gateway and Dashboard processes load native extension modules (`.pyd` files) from the project venv. `uv pip install` cannot remove or rename loaded `.pyd` files, and repeated retries leave the venv partially inconsistent with missing `RECORD` files.

The existing `_detect_concurrent_hermes_instances()` in `hermes_cli/main.py` only scans for processes whose `.exe` matches the venv's entry-point shims (`hermes.exe`, `hermes-gateway.exe`). Gateway and Dashboard workers launched via `python.exe -m hermes_cli.main gateway run` or scheduled tasks use `python.exe` directly, not the shim, so they are invisible to the current check. When they have imported packages with `.pyd` extensions (e.g. `aiohttp/_http_parser.cp311-win_amd64.pyd`), Windows refuses to replace those files during the install step.

The fix extends `_detect_concurrent_hermes_instances()` to include the venv's `python.exe` and `pythonw.exe` in the set of monitored executables, so any process running from the project venv is detected before the update starts. The existing ancestor-chain exclusion logic already handles the running `hermes update` process itself (it excludes `os.getpid()` and all shim-matching ancestors), so the update invocation does not falsely flag itself. The user message is updated to explain both `.exe` and `.pyd` lock failures.

Fixes #38789

## Changes

- `hermes_cli/main.py`: in `_detect_concurrent_hermes_instances()`, add the venv's `python.exe` and `pythonw.exe` to the `shim_paths` scan set; update `_format_concurrent_instances_message()` to mention `.pyd` lock failures alongside `.exe` (+~10 lines net)
- `tests/hermes_cli/test_update_concurrent_quarantine.py`: tests that venv `python.exe` workers are detected, self-exclusion still works for `python.exe`, `pythonw.exe` is also detected, both shim and python matches are reported together, and the updated message mentions `.pyd` (+~50 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| Gateway `python.exe` running from venv during `hermes update` | not detected; `uv pip install` fails with os error 5 on `.pyd` | detected; update refuses early with named-process message |
| Dashboard `python.exe` running from venv during `hermes update` | not detected; same failure | detected; same refusal |
| `pythonw.exe` workers from venv | not detected | detected |
| `hermes update` running as `python.exe` inside venv (self) | N/A (not scanned) | excluded by ancestor-chain logic; no false positive |
| `hermes.exe` concurrent instance (existing behavior) | detected | detected (unchanged) |
| Non-venv `python.exe` (e.g. system Python, other venvs) | not detected | not detected (unchanged; only venv-path matches count) |
| `--force` flag | skips concurrent check | skips concurrent check (unchanged) |
| Non-Windows platforms | returns empty | returns empty (unchanged) |

## Test plan

- `pytest tests/hermes_cli/test_update_concurrent_quarantine.py -v --timeout=0` — 23 passed
- New: venv `python.exe` worker detected; self-exclusion for `python.exe`; `pythonw.exe` detected; mixed shim+python matches; message mentions `.pyd`
- Existing: all `test_detect_concurrent_*` tests pass unchanged

## Not in scope

Implementing the full "safe update" lifecycle from Option B in the issue (stop services, wait for locks, restart). That requires a broker process independent of the venv being updated, which is a significantly larger change. This PR implements Option A (refuse early with a clear message), which prevents the partially-inconsistent venv state that is the worst outcome. The `--force` flag remains available for users who have manually stopped the workers.