### PR TITLE
[codex] Add Elixir analytics profile distribution

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -63,6 +63,52 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_DIRECT_TOOL_FINAL_RESPONSE_KEY = "hermes_direct_final_response"
+_DIRECT_TOOL_FINAL_RESPONSE_MAX_CHARS = 20_000
+
+
+def _extract_direct_tool_final_response(messages: list, tool_calls: list) -> str | None:
+    """Return an opt-in final response emitted by a single tool result.
+
+    This is deliberately narrow: the model must have made exactly one tool call,
+    and the most recent tool message must be that call's JSON result containing
+    `hermes_direct_final_response`. It lets deterministic tools return a
+    user-ready answer without paying for an extra model turn.
+    """
+    if len(tool_calls or []) != 1 or not messages:
+        return None
+
+    last_message = messages[-1]
+    if not isinstance(last_message, dict) or last_message.get("role") != "tool":
+        return None
+
+    tool_call = tool_calls[0]
+    if last_message.get("tool_call_id") != getattr(tool_call, "id", None):
+        return None
+
+    content = last_message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+
+    try:
+        payload = json.loads(content)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    direct_response = payload.get(_DIRECT_TOOL_FINAL_RESPONSE_KEY)
+    if not isinstance(direct_response, str) or not direct_response.strip():
+        return None
+
+    direct_response = direct_response.strip()
+    if len(direct_response) <= _DIRECT_TOOL_FINAL_RESPONSE_MAX_CHARS:
+        return direct_response
+    return (
+        direct_response[:_DIRECT_TOOL_FINAL_RESPONSE_MAX_CHARS].rstrip()
+        + "\n\n[Direct tool response truncated.]"
+    )
+
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
@@ -3904,6 +3950,16 @@ def run_conversation(
                                 agent.stream_delta_callback(None)
                             except Exception:
                                 pass
+                    break
+
+                direct_final_response = _extract_direct_tool_final_response(
+                    messages,
+                    assistant_message.tool_calls,
+                )
+                if direct_final_response is not None:
+                    _turn_exit_reason = "direct_tool_final_response"
+                    final_response = direct_final_response
+                    messages.append({"role": "assistant", "content": final_response})
                     break
 
                 # Reset per-turn retry counters after successful tool

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -369,6 +369,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        self._socket_transport_was_unhealthy = False
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -443,6 +444,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
+            self._socket_transport_was_unhealthy = True
             await self._stop_socket_mode_handler()
 
             try:
@@ -475,6 +477,9 @@ class SlackAdapter(BasePlatformAdapter):
                     continue
 
                 connected = await self._socket_transport_connected()
+                if connected is True and self._socket_transport_was_unhealthy:
+                    self._socket_transport_was_unhealthy = False
+                    logger.info("[Slack] Socket Mode connected (recovered)")
                 if connected is False:
                     await self._restart_socket_mode("transport disconnected")
             except asyncio.CancelledError:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2,19 +2,21 @@
 Hermes Plugin System
 ====================
 
-Discovers, loads, and manages plugins from four sources:
+Discovers, loads, and manages plugins from five sources:
 
 1. **Bundled plugins** – ``<repo>/plugins/<name>/`` (shipped with hermes-agent;
    ``memory/`` and ``context_engine/`` subdirs are excluded — they have their
    own discovery paths)
-2. **User plugins**   – ``~/.hermes/plugins/<name>/``
-3. **Project plugins** – ``./.hermes/plugins/<name>/`` (opt-in via
+2. **Profile plugins** – ``$HERMES_HOME/profile_plugins/<name>/``
+   (distribution-owned, opt-in via ``plugins.enabled``)
+3. **User plugins**   – ``~/.hermes/plugins/<name>/``
+4. **Project plugins** – ``./.hermes/plugins/<name>/`` (opt-in via
    ``HERMES_ENABLE_PROJECT_PLUGINS``)
-4. **Pip plugins**     – packages that expose the ``hermes_agent.plugins``
+5. **Pip plugins**     – packages that expose the ``hermes_agent.plugins``
    entry-point group.
 
 Later sources override earlier ones on name collision, so a user or project
-plugin with the same name as a bundled plugin replaces it.
+plugin with the same name as a bundled or profile plugin replaces it.
 
 Each directory plugin must contain a ``plugin.yaml`` manifest **and** an
 ``__init__.py`` with a ``register(ctx)`` function.
@@ -240,7 +242,7 @@ class PluginManifest:
     requires_env: List[Union[str, Dict[str, Any]]] = field(default_factory=list)
     provides_tools: List[str] = field(default_factory=list)
     provides_hooks: List[str] = field(default_factory=list)
-    source: str = ""        # "user", "project", or "entrypoint"
+    source: str = ""        # "bundled", "profile", "user", "project", or "entrypoint"
     path: Optional[str] = None
     # Plugin kind — see plugins.py module docstring for semantics.
     # ``standalone`` (default): hooks/tools of its own; opt-in via
@@ -1074,14 +1076,21 @@ class PluginManager:
         logger.debug("  bundled/platforms: %d manifest(s)", len(bundled_platforms))
         manifests.extend(bundled_platforms)
 
-        # 2. User plugins (~/.hermes/plugins/)
+        # 2. Profile-distributed plugins ($HERMES_HOME/profile_plugins/)
+        profile_dir = get_hermes_home() / "profile_plugins"
+        logger.debug("Scanning profile plugins: %s", profile_dir)
+        profile_manifests = self._scan_directory(profile_dir, source="profile")
+        logger.debug("  profile: %d manifest(s)", len(profile_manifests))
+        manifests.extend(profile_manifests)
+
+        # 3. User plugins (~/.hermes/plugins/)
         user_dir = get_hermes_home() / "plugins"
         logger.debug("Scanning user plugins: %s", user_dir)
         user_manifests = self._scan_directory(user_dir, source="user")
         logger.debug("  user: %d manifest(s)", len(user_manifests))
         manifests.extend(user_manifests)
 
-        # 3. Project plugins (./.hermes/plugins/)
+        # 4. Project plugins (./.hermes/plugins/)
         if _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
             project_dir = Path.cwd() / ".hermes" / "plugins"
             logger.debug("Scanning project plugins: %s", project_dir)
@@ -1093,7 +1102,7 @@ class PluginManager:
                 "Project plugins disabled (set HERMES_ENABLE_PROJECT_PLUGINS=1 to enable)"
             )
 
-        # 4. Pip / entry-point plugins
+        # 5. Pip / entry-point plugins
         ep_manifests = self._scan_entry_points()
         logger.debug("  entrypoints: %d manifest(s)", len(ep_manifests))
         manifests.extend(ep_manifests)
@@ -1411,7 +1420,7 @@ class PluginManager:
         )
 
         try:
-            if manifest.source in {"user", "project", "bundled"}:
+            if manifest.source in {"user", "project", "bundled", "profile"}:
                 module = self._load_directory_module(manifest)
             else:
                 module = self._load_entrypoint_module(manifest)

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -45,12 +45,13 @@ Manifest format (``distribution.yaml`` at the profile root)::
     distribution_owned:      # optional; sensible defaults apply
       - SOUL.md
       - skills/
+      - profile_plugins/
       - cron/
       - mcp.json
 
 Update semantics:
 
-* Distribution-owned paths (SOUL.md, mcp.json, skills/, cron/,
+* Distribution-owned paths (SOUL.md, mcp.json, skills/, profile_plugins/, cron/,
   distribution.yaml) are replaced from the new source.
 * ``config.yaml`` is distribution-owned but preserved on update unless
   ``--force-config`` is passed (user overrides typically live here).
@@ -89,6 +90,7 @@ DEFAULT_DIST_OWNED: Tuple[str, ...] = (
     "config.yaml",
     "mcp.json",
     "skills",
+    "profile_plugins",
     "cron",
     MANIFEST_FILENAME,
 )

--- a/profile-distributions/elixir-analytics/HOSTED_GATEWAY.md
+++ b/profile-distributions/elixir-analytics/HOSTED_GATEWAY.md
@@ -1,0 +1,155 @@
+# Elixir Analytics Hosted Gateway Runbook
+
+This runbook is for Milestone 12A: make Slack `macros` independent of the
+local laptop.
+
+## Target Shape
+
+Run one long-lived Hermes gateway process for the `elixir-analytics` profile:
+
+```bash
+hermes -p elixir-analytics gateway run
+```
+
+Equivalent module form:
+
+```bash
+venv/bin/python -m hermes_cli.main --profile elixir-analytics gateway run
+```
+
+The host must support:
+
+- a persistent process, not request/response serverless execution
+- restart-on-crash supervision
+- persistent profile storage for sessions, auth, skills, logs, and plugin state
+- outbound HTTPS/WebSocket access for Slack Socket Mode, model providers,
+  Supabase/Postgres, PostHog, GitHub, and the analytics dashboard
+- private environment variables or mounted secret files
+
+## Required Secrets
+
+Keep secrets scoped to this profile and Slack app.
+
+Required:
+
+- `SLACK_APP_TOKEN`: Socket Mode app token for the Slack app `macros`
+- `SLACK_BOT_TOKEN`: bot token for the Slack app `macros`
+
+Required by current analytics milestones:
+
+- `ANALYTICS_DATABASE_URL`: read-only Supabase/Postgres DSN
+- `POSTHOG_API_KEY`: read-only PostHog API key
+- `POSTHOG_PROJECT_ID`: PostHog project id
+
+Optional, depending on visualization handoff:
+
+- `ELIXIR_ANALYTICS_ARTIFACT_API_URL`
+- `ELIXIR_ANALYTICS_ARTIFACT_API_SECRET`
+
+Model auth must be available through the profile's configured provider. Current
+live profile evidence uses `openai-codex` provider auth; if the hosted process
+cannot use that auth, configure a managed provider or provider API key before
+cutover.
+
+## Filesystem Layout
+
+Use one profile home for the hosted process:
+
+```text
+$HERMES_HOME/
+  config.yaml
+  .env
+  auth.json
+  skills/
+  profile_plugins/
+  logs/
+  sessions/
+  state.db*
+```
+
+Install the distribution:
+
+```bash
+hermes profile install ./profile-distributions/elixir-analytics --name elixir-analytics
+```
+
+Then copy only the required profile secrets into the installed profile `.env`.
+Do not copy default-profile Slack tokens into this profile.
+
+## Process Supervision
+
+The supervisor should:
+
+- start the command from the Hermes checkout or installed package directory
+- set the profile explicitly with `-p elixir-analytics`
+- restart on non-zero exit with a small backoff
+- preserve stdout/stderr logs, or ship them to the host log system
+- expose a way to run `hermes -p elixir-analytics gateway status`
+- avoid running a second gateway for the same Slack app token
+
+Example unit shape:
+
+```text
+Command: hermes -p elixir-analytics gateway run
+Working directory: /srv/hermes-agent
+Restart policy: always / on-failure
+Health signal: gateway log contains "Gateway running" and "Socket Mode connected"
+Rollback: stop hosted process, restart local launchd gateway
+```
+
+## Cutover Checklist
+
+1. Stop the local profile gateway or disable its launchd service.
+2. Start the hosted `elixir-analytics` gateway.
+3. Confirm only one process is connected to Slack Socket Mode for `macros`.
+4. Run:
+
+   ```bash
+   hermes -p elixir-analytics gateway status
+   ```
+
+5. Confirm hosted logs show both:
+
+   ```text
+   Gateway running
+   Socket Mode connected
+   ```
+
+6. Send the Slack smoke prompts:
+
+   - `show GTV last 30 days by week`
+   - `which users spent on Swiggy this week?`
+   - `how many app active users this week?`
+   - `active users this week`
+   - `delete from profiles`
+
+7. From the analytics repo, verify the acceptance log:
+
+   ```bash
+   node --import tsx scripts/check-slack-e2e-logs.ts \
+     --gateway-log <hosted-gateway-log-path> \
+     --agent-log <hosted-agent-log-path>
+   ```
+
+## Rollback
+
+Rollback is simple because Slack Socket Mode is token-scoped:
+
+1. Stop the hosted gateway process.
+2. Start the local `ai.hermes.gateway-elixir-analytics` launchd service.
+3. Confirm local `logs/gateway.log` shows `Socket Mode connected`.
+4. Re-run one saved-topic prompt in Slack.
+
+Do not leave hosted and local gateways connected to the same Slack app token at
+the same time.
+
+## Done Criteria
+
+Milestone 12A is done when:
+
+- Slack `macros` answers from the hosted process with the local gateway stopped
+- restart-on-crash is configured and tested once
+- hosted logs are accessible for Slack E2E verification
+- rollback to the local launchd gateway is documented and tested
+- ops readiness can be run with explicit hosted gateway evidence
+

--- a/profile-distributions/elixir-analytics/HOSTED_GATEWAY.md
+++ b/profile-distributions/elixir-analytics/HOSTED_GATEWAY.md
@@ -76,6 +76,68 @@ hermes profile install ./profile-distributions/elixir-analytics --name elixir-an
 Then copy only the required profile secrets into the installed profile `.env`.
 Do not copy default-profile Slack tokens into this profile.
 
+## Deployment Templates
+
+This distribution ships two deployable templates:
+
+- `deploy/docker-compose.gateway.yml` for a container host
+- `deploy/systemd/hermes-elixir-analytics-gateway.service` for a plain Linux VM
+
+Both templates run the same profile command and keep the `macros` Slack tokens
+scoped to the `elixir-analytics` profile.
+
+### Docker Compose Host
+
+From the Hermes repo root:
+
+```bash
+cp profile-distributions/elixir-analytics/deploy/.env.hosted-gateway.example .env.hosted-gateway
+$EDITOR .env.hosted-gateway
+docker compose -f profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml \
+  --env-file .env.hosted-gateway \
+  run --rm gateway profile install /opt/hermes/profile-distributions/elixir-analytics --name elixir-analytics
+docker compose -f profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml \
+  --env-file .env.hosted-gateway \
+  up -d --build
+```
+
+Useful checks:
+
+```bash
+docker compose -f profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml ps
+docker logs hermes-elixir-analytics-gateway --tail 200
+```
+
+### Systemd Host
+
+Expected host layout:
+
+```text
+/srv/hermes-agent
+/var/lib/hermes
+/etc/hermes/elixir-analytics-gateway.env
+```
+
+Install the profile and service:
+
+```bash
+sudo install -d -o hermes -g hermes /var/lib/hermes
+sudo install -d -o root -g root /etc/hermes
+sudo cp profile-distributions/elixir-analytics/deploy/systemd/elixir-analytics-gateway.env.example /etc/hermes/elixir-analytics-gateway.env
+sudo chmod 600 /etc/hermes/elixir-analytics-gateway.env
+sudo -u hermes HERMES_HOME=/var/lib/hermes /srv/hermes-agent/venv/bin/python -m hermes_cli.main profile install /srv/hermes-agent/profile-distributions/elixir-analytics --name elixir-analytics
+sudo cp profile-distributions/elixir-analytics/deploy/systemd/hermes-elixir-analytics-gateway.service /etc/systemd/system/hermes-elixir-analytics-gateway.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now hermes-elixir-analytics-gateway
+```
+
+Useful checks:
+
+```bash
+systemctl status hermes-elixir-analytics-gateway
+journalctl -u hermes-elixir-analytics-gateway -n 200 --no-pager
+```
+
 ## Process Supervision
 
 The supervisor should:
@@ -152,4 +214,3 @@ Milestone 12A is done when:
 - hosted logs are accessible for Slack E2E verification
 - rollback to the local launchd gateway is documented and tested
 - ops readiness can be run with explicit hosted gateway evidence
-

--- a/profile-distributions/elixir-analytics/README.md
+++ b/profile-distributions/elixir-analytics/README.md
@@ -35,4 +35,5 @@ remaining external blockers, and the Slack E2E prompts that must pass before
 calling the analytics agent production-ready.
 
 Use `HOSTED_GATEWAY.md` for the always-on Slack gateway cutover runbook once a
-host is chosen.
+host is chosen. The `deploy/` directory includes Docker Compose and systemd
+templates for the hosted `macros` gateway.

--- a/profile-distributions/elixir-analytics/README.md
+++ b/profile-distributions/elixir-analytics/README.md
@@ -33,3 +33,6 @@ Use `ROADMAP.md` as the canonical product roadmap and production rollout
 checklist for this profile. It tracks local implementation milestones,
 remaining external blockers, and the Slack E2E prompts that must pass before
 calling the analytics agent production-ready.
+
+Use `HOSTED_GATEWAY.md` for the always-on Slack gateway cutover runbook once a
+host is chosen.

--- a/profile-distributions/elixir-analytics/README.md
+++ b/profile-distributions/elixir-analytics/README.md
@@ -1,0 +1,28 @@
+# Elixir Analytics Hermes Profile
+
+This profile turns Hermes into a Slack-first analytics agent for Elixir.
+
+It keeps the self-improvement loop enabled while narrowing the active runtime
+to analytics work: Slack, read-only query execution, skills, memory, session
+search, source maintenance, and scheduled review.
+
+The intended Slack app for this profile is `macros`. Its Slack tokens should
+live only in the installed `elixir-analytics` profile's `.env`.
+
+## Install Locally
+
+From the Hermes repo:
+
+```bash
+hermes profile install ./profile-distributions/elixir-analytics --name elixir-analytics
+```
+
+Then copy the generated `.env.EXAMPLE` inside the installed profile to `.env`
+and fill in the required Slack tokens plus any analytics credentials needed for
+the current milestone.
+
+## Runtime Boundary
+
+Hermes owns AI reasoning and analytics execution. The Next.js analytics app
+renders temporary visualization artifacts. Source-of-truth analytics changes
+should happen through GitHub PRs against the analytics repo.

--- a/profile-distributions/elixir-analytics/README.md
+++ b/profile-distributions/elixir-analytics/README.md
@@ -26,3 +26,10 @@ the current milestone.
 Hermes owns AI reasoning and analytics execution. The Next.js analytics app
 renders temporary visualization artifacts. Source-of-truth analytics changes
 should happen through GitHub PRs against the analytics repo.
+
+## Roadmap And Rollout
+
+Use `ROADMAP.md` as the canonical product roadmap and production rollout
+checklist for this profile. It tracks local implementation milestones,
+remaining external blockers, and the Slack E2E prompts that must pass before
+calling the analytics agent production-ready.

--- a/profile-distributions/elixir-analytics/RELEASE_PACKAGING.md
+++ b/profile-distributions/elixir-analytics/RELEASE_PACKAGING.md
@@ -1,0 +1,80 @@
+# Elixir Analytics Hermes Release Packaging
+
+Use this guide before staging, committing, or opening a PR from the Hermes
+worktree for the analytics agent.
+
+## Package Lanes
+
+### profile-distribution
+
+Includes the user-facing Elixir analytics profile:
+
+- `profile-distributions/elixir-analytics/config.yaml`
+- `profile-distributions/elixir-analytics/SOUL.md`
+- `profile-distributions/elixir-analytics/ROADMAP.md`
+- `profile-distributions/elixir-analytics/skills/**`
+- `profile-distributions/elixir-analytics/profile_plugins/**`
+
+This package changes what the installed `elixir-analytics` profile knows and
+which deterministic analytics tools it can call.
+
+### hermes-runtime
+
+Includes Hermes core changes required by the profile:
+
+- profile-owned plugin discovery
+- profile distribution installation support
+- toolset exposure for `elixir-analytics-runner`
+- tests that prove the profile distribution can be installed and the runner
+  plugin is exposed
+
+This package is the minimum Hermes-core surface needed for the analytics profile
+to work without hardcoding analytics logic into generic gateway code.
+
+### slack-gateway
+
+Includes Slack transport health changes:
+
+- Slack Socket Mode reconnect/recovery logging
+- tests that prove the gateway logs a recovered connection after transport
+  self-healing
+
+This package can ship with runtime changes, but it should remain reviewable as
+gateway reliability work rather than analytics prompt behavior.
+
+## Checker
+
+Run from the Hermes repo:
+
+```bash
+venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict
+```
+
+Use JSON output when preparing package-specific staging:
+
+```bash
+venv/bin/python scripts/check_elixir_analytics_release_packaging.py --json
+```
+
+`--strict` fails when changed files are unclassified. Local artifacts such as
+`.hermes-bootstrap-complete` are reported separately and should not be staged.
+
+## Release Rule
+
+Do not stage the full Hermes dirty worktree as one commit.
+
+Package in this order unless the user chooses otherwise:
+
+1. `hermes-runtime`
+2. `profile-distribution`
+3. `slack-gateway`
+
+After profile distribution changes, sync the installed profile before Slack E2E:
+
+```bash
+cp profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md /Users/ritik/.hermes/profiles/elixir-analytics/skills/elixir-analytics/SKILL.md
+cp profile-distributions/elixir-analytics/ROADMAP.md /Users/ritik/.hermes/profiles/elixir-analytics/ROADMAP.md
+cp profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py /Users/ritik/.hermes/profiles/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
+```
+
+Then restart the profile gateway and verify Slack Socket Mode reconnects.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -297,6 +297,10 @@ Done means Slack `macros` does not depend on the laptop: the gateway has an
 always-on host, restart policy, health check, log access, and documented rollback
 path.
 
+Use `HOSTED_GATEWAY.md` as the cutover runbook. The remaining product decision
+is the host itself; the required process shape, secrets, health checks, smoke
+prompts, and rollback steps are documented there.
+
 Milestone 13A: choose Hermes upstream/private sync path.
 
 Done means the `elixir-analytics` profile distribution, runner plugin, and Slack

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -309,7 +309,7 @@ private profile distribution.
 
 Current evidence: branch `codex/elixir-analytics-profile` is pushed to the
 `ritikmdn/hermes-agent` fork, dry-merges cleanly into current upstream `main`,
-and focused verification passed 252 Hermes tests plus strict release packaging.
+and focused verification passed 253 Hermes tests plus strict release packaging.
 
 Milestone 14A: compact Slack answer links.
 
@@ -323,5 +323,4 @@ These are not solved by local code alone:
 
 - Choose where the always-on Slack gateway should run after local supervision.
 - Confirm the Hermes upstream sync path: push branch, open PR, or keep private.
-- Decide when to commit/push the local Hermes profile and analytics docs patches.
 - Decide the acceptable latency target for Supabase ad hoc Slack answers.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -47,7 +47,8 @@ Do not call the agent or dashboard production-ready until all gates pass:
 1. Analytics branch is merged or deployed to the production Vercel project.
 2. Deployed Next.js env includes read-only `ANALYTICS_DATABASE_URL`.
 3. Deployed app has the artifact API env vars if temporary visuals are enabled.
-4. Hermes `elixir-analytics` profile has a configured inference provider.
+4. Hermes `elixir-analytics` profile has an inference provider key, managed
+   provider, or verified OAuth provider auth.
 5. Slack `macros` gateway is connected and supervised.
 6. Smart approvals are enabled.
 7. Generic Hermes tools remain enabled for debugging and source changes.
@@ -62,8 +63,8 @@ Run these from `/Users/ritik/Coding/claude-analytics` after analytics changes:
 npm run lint
 npm test
 npm run build
-node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
 ```
 
 Run this from the Hermes repo after profile changes:
@@ -90,7 +91,6 @@ These are not solved by local code changes:
 
 - Decide whether to merge/deploy `codex/mock-single-dashboard` or open a PR.
 - Configure production Vercel env vars for database reads and temporary visuals.
-- Choose the gateway host for Slack `macros`.
-- Configure the inference provider for the live Hermes profile.
+- Keep Slack `macros` gateway supervision verified during rollout.
+- Verify Hermes OAuth provider auth before passing `--provider-authenticated`.
 - Push or PR the Hermes profile branch once GitHub permissions are available.
-

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -33,9 +33,10 @@ Verified:
   `codex/mock-single-dashboard`, not `main`, and deployed reads are missing
   `ANALYTICS_DATABASE_URL`.
 - Latest local verification is green: `npm run lint` has no warnings,
-  `npm test` passed 210 analytics tests, `npm run build` passed, and focused
-  Hermes profile/plugin/toolset tests passed 55 tests with one external
-  dependency warning.
+  `npm test` passed 213 analytics tests, `npm run build` passed, strict
+  analytics release packaging passed, the analytics smoke suite passed, and
+  focused Hermes profile/plugin/toolset tests passed 55 tests with one
+  external dependency warning.
 - `/query` now distinguishes an unknown saved topic from a known saved topic
   whose database execution fails, so a missing Vercel database env shows as
   saved-query data unavailable rather than an ambiguous empty visualization.
@@ -129,11 +130,15 @@ Verified:
 - Temporary visualization payloads now strip both Supabase SQL and PostHog
   HogQL before encoding `/query?payload=...`, reducing Slack link bulk and
   keeping executable query text out of no-persistence dashboard URLs.
+- Oversized temporary visualization payloads now compact before falling back to
+  no-link answers: rows are bounded, long text is trimmed, sensitive fields are
+  dropped, metadata is shortened, and pathological payloads still refuse to
+  emit a dashboard link.
 - The analytics repo now has `scripts/check-release-packaging.ts` and
   `docs/release-packaging.md`. The current dirty analytics worktree classifies
-  cleanly into `analytics-runtime`, `executive-dashboard`, and `release-docs`
-  with no unclassified files, so runtime and dashboard changes can be packaged
-  separately instead of merged as one broad release.
+  cleanly into `analytics-runtime` and `release-docs` with no unclassified
+  files, so runtime and docs changes can be packaged without dragging in
+  unrelated dashboard work.
 - The Hermes repo now has `scripts/check_elixir_analytics_release_packaging.py`
   and `profile-distributions/elixir-analytics/RELEASE_PACKAGING.md`. The
   latest Hermes delta classifies cleanly into `profile-distribution` and
@@ -162,9 +167,8 @@ Known gaps:
   the `answer_question` fast-path sync to prove the model chooses the shortcut
   tool and meets the latency target.
 - A local Hermes one-shot answered Swiggy correctly after the sync, but still
-  took about 64 seconds end-to-end and produced a verbose direct payload URL.
-  If Slack shows the same behavior, the next polish step is a stronger
-  Slack-specific answer formatter or payload compaction.
+  took about 64 seconds end-to-end. If Slack shows the same behavior, the next
+  polish step is a stronger Slack-specific fast-path or answer formatter.
 
 ## Milestones
 
@@ -173,7 +177,7 @@ Known gaps:
 | 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done |
 | 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Done |
 | 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Done; fast-path polish pending |
-| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Direct-link passed locally/live once; production env recheck pending |
+| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Built with SQL/HogQL stripping and compact payload fallback; production env recheck pending |
 | 5 | PostHog runner | App/product analytics route to read-only HogQL. | Passed live; fast-path polish pending |
 | 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built, scope-checkable, runner-accessible; first live change request pending |
 | 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
@@ -183,7 +187,7 @@ Known gaps:
 | 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Functional history exists; fresh post-fix pass pending |
 | 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
 | 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Pending GitHub permission |
-| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | `payload.slackText` built/tested; live Slack latency recheck pending |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | `payload.slackText` and compact visualization links built/tested; live Slack latency recheck pending |
 | 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
 ## Production Gates

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -1,165 +1,323 @@
 # Elixir Analytics Agent Roadmap
 
-This roadmap is the operating runbook for the `elixir-analytics` Hermes
-profile. Keep it aligned after each execution pass so Slack behavior, the
-analytics repo, and the executive Next.js dashboard move through the same
-product milestones.
-
-Last updated: 2026-06-04 19:25 IST.
+This roadmap is the product runbook for the `elixir-analytics` Hermes profile.
+Use it to keep Slack, the analytics repo, and the executive Next.js dashboard
+moving through the same milestones.
 
 ## Product Shape
 
 ```text
 Slack app: macros
   -> Hermes profile: elixir-analytics
-  -> claude-analytics deterministic runner or planner
-  -> saved topic, Supabase ad hoc, PostHog ad hoc, clarification, or source-change workflow
-  -> Slack answer with assumptions, metadata, and optional dashboard link
-  -> executive Next.js dashboard or no-persistence query visualization
-  -> query log and self-improvement review
+  -> deterministic shortcut runner or planner in claude-analytics
+  -> saved topic, Supabase ad hoc, PostHog ad hoc, or clarification
+  -> Slack answer with metadata and dashboard link
+  -> executive dashboard or temporary visualization link
+  -> logged answer feeds source-of-truth and self-improvement workflows
 ```
 
-Hermes owns AI reasoning, Slack conversation, approvals, profile routing,
-source-change orchestration, and self-improvement. `claude-analytics` owns
-metric contracts, deterministic query runners, read-only validation, dashboard
-rendering, release checks, and production deployment.
+Hermes owns AI reasoning, source-change orchestration, approvals, and Slack
+conversation. The analytics repo owns deterministic query contracts, runners,
+tests, dashboard rendering, and production deployment.
 
 ## Current Status Snapshot
 
-| Area | Status | Evidence |
-|---|---|---|
-| Slack profile routing | Working | Slack app `macros` reaches the launchd-managed `elixir-analytics` gateway. Socket Mode connected in `logs/gateway.log`. |
-| Hermes provider | Working | Live profile uses `openai-codex` / `gpt-5.5`; Slack turns complete. |
-| Generic tools | Enabled | Smart approvals and generic tools remain available for debugging and source changes. |
-| Supabase saved topic | Working | `show GTV last 30 days by week` routed to `card-gtv-weekly` through `answer_question`, returned a dashboard link, 2 model calls, 30.0s gateway time. |
-| Supabase ad hoc | Working and fast for the key shortcut | `which users spent on Swiggy this week?` routed to `supabase_ad_hoc` shortcut `swiggy_users_this_week`, returned 15 rows, dashboard link, 2 model calls, 9.8s gateway time. |
-| Production dashboard | Working for GTV link | `https://analytics.joinelixir.club/query?topic=card-gtv-weekly&range=30d` was rechecked after the Vercel env fix and now loads data. |
-| Active-user ambiguity | Working for first step | `active users this week` asks whether to use card, app, or combined active users before querying. |
-| Write-SQL rejection | Working | `delete from profiles` was refused in Slack with read-only alternatives, 3 model calls, 17.4s gateway time. |
-| Row cap/truncation | Covered by runner smoke suite | `row_cap_truncation` in `scripts/run-analytics-smoke-suite.ts` proves large ad hoc output is bounded and returns `truncated: true`. |
-| PostHog | Built, but fresh fast Slack evidence pending | Earlier live app-active run was functionally correct but too slow and used generic tooling; needs a fresh post-direct-answer Slack pass. |
-| Source-change workflow | Built | Runner modes `source_change_plan` and `source_change_scope_check` exist and have live direct checks. |
-| Self-improvement loop | Built | Runner mode `self_improvement_plan` exists; query-log cadence tooling exists. |
-| Hermes PR | Open draft | `NousResearch/hermes-agent#39041`, branch `ritikmdn:codex/elixir-analytics-profile`. Current local direct-answer updates still need commit/push. |
-| Analytics PR | Merged/deployed | Runtime/dashboard fixes are deployed to `analytics.joinelixir.club`; current work here is Hermes-side. |
+Last updated: 2026-06-04.
 
-## Fresh Slack Evidence
+Verified:
 
-| Prompt | Expected product behavior | Current evidence | Status |
-|---|---|---|---|
-| `show GTV last 30 days by week` | Saved topic `card-gtv-weekly`, dashboard link with data | 2026-06-04 19:11 IST: runner route `saved_topic`, shortcut `card_gtv_weekly_30d`, 2 calls, 30.0s, 497 chars | Pass |
-| `which users spent on Swiggy this week?` | Supabase ad hoc shortcut, India week-to-date, user rows, dashboard link | 2026-06-04 19:10 IST: runner route `supabase_ad_hoc`, shortcut `swiggy_users_this_week`, 15 rows, 2 calls, 9.8s, 4845 chars | Pass |
-| `active users this week` | Clarify before querying | 2026-06-04 19:12 IST: Slack reply asked card/app/combined active users before executing a metric query | Pass for clarification |
-| `delete from profiles` | Refuse destructive SQL and offer safe alternatives | 2026-06-04 19:16 IST: Slack reply refused `DELETE FROM profiles`, 3 calls, 17.4s | Pass |
-| `how many app active users this week?` | PostHog ad hoc shortcut, no generic shell path | Fresh post-direct-answer Slack pass pending | Pending |
-| Large ad hoc result | Bound rows and mark `truncated: true` | Covered in smoke suite via `row_cap_truncation` | Pass by automated runner evidence |
+- The live ops-readiness check can load the installed Hermes profile with
+  `--profile-home`, infer Slack Socket Mode from `logs/gateway.log`, and avoid
+  printing secrets.
+- Current live ops-readiness status from analytics `main` is `ready` when using
+  the ignored production env pull file `.env.production.local`. Vercel confirms
+  `ANALYTICS_DATABASE_URL` exists for Development, Preview, and Production.
+- Analytics PR #6, `Reconcile Slack E2E runtime polish`, is merged to `main` at
+  `4f4ddd6`. It restored the session-aware Slack E2E checker and added the
+  deterministic `top_card_spenders_30d` shortcut on top of current production
+  code.
+- Latest local verification is green: `npm run lint` has no warnings,
+  `npm test` passed 221 analytics tests, `npm run build` passed, strict release
+  packaging passed, the smoke suite passed from `main`, and the live Slack log
+  checker passed from `main`.
+- `/query` now distinguishes an unknown saved topic from a known saved topic
+  whose database execution fails, so a missing Vercel database env shows as
+  saved-query data unavailable rather than an ambiguous empty visualization.
+- The `elixir-analytics` Hermes gateway is running under local supervision and
+  Slack Socket Mode is connected after a targeted restart of
+  `ai.hermes.gateway-elixir-analytics`.
+- Hermes Slack Socket Mode watchdog now emits
+  `Socket Mode connected (recovered)` after a transport-drop self-heal, so
+  log-based readiness can distinguish a recovered gateway from a stuck
+  reconnecting one.
+- Real Slack E2E passed for saved GTV and Supabase Swiggy ad hoc questions.
+- The fresh Swiggy recheck used a direct `analytics.joinelixir.club/query?...`
+  dashboard link, not a third-party shortener.
+- Real Slack E2E also passed for active-user clarification, PostHog app-active
+  users, and write-SQL rejection.
+- Hermes profile tests and the full analytics test/build/lint suite pass
+  locally.
+- Hermes now supports profile-owned plugins from `profile_plugins/`, and the
+  `elixir-analytics` distribution ships `elixir-analytics-runner`.
+- The runner plugin exposes `elixir_analytics_runner` for planner, saved-topic,
+  common-question shortcut, Supabase ad hoc, and PostHog ad hoc calls without
+  first using generic `execute_code` or ad hoc shell composition.
+- The runner plugin also exposes deterministic maintenance modes:
+  `source_change_plan` for definition/glossary/schema/dashboard change
+  planning, and `self_improvement_plan` for query-log review/promotion
+  planning.
+- Live profile checks passed for both maintenance modes: `source_change_plan`
+  returned a GTV `metric_definition` PR plan with `prRequired: true`, and
+  `self_improvement_plan` reviewed 5 query-log entries with 4 suggestions.
+- Local dry-runs passed through the plugin for planner, saved GTV, Swiggy-style
+  Supabase ad hoc, and app-active PostHog ad hoc routes.
+- The installed `elixir-analytics` profile has been synced with the runner
+  plugin, and the launchd-managed Slack gateway was restarted successfully.
+- A live read-only saved-topic call through `elixir_analytics_runner` returned
+  5 rows for `card-gtv-weekly` and the direct production dashboard link in
+  20.65 seconds.
+- The distributed skill and tool schema now instruct Hermes to use
+  `answer_question` first for plain Slack analytics questions, with compact row
+  caps for user lists unless the user asks for exhaustive output.
+- Direct live shortcut checks passed outside Slack: Swiggy users this week
+  returned 15 rows through Supabase in 0.56 seconds, and app-active users this
+  week returned 1 KPI row through PostHog in 1.23 seconds.
+- The analytics shortcut runner now also detects `show GTV last 30 days by
+  week` and routes it directly to saved topic `card-gtv-weekly`; live Hermes
+  wrapper dry-run confirms `answer_question` returns the saved-topic dashboard
+  path `/query?topic=card-gtv-weekly&range=30d`.
+- A live `run-analytics-question.ts` shortcut query for `show GTV last 30 days
+  by week` returned 5 weekly rows and the production dashboard link in 20.5
+  seconds.
+- The live profile plugin was resynced and the gateway restarted after the
+  `answer_question` guidance and compact-row default were added. Live plugin
+  dry-run confirms `answer_question` defaults to `maxRows: 100`.
+- The skill now has a top-level mandatory-first-call rule: plain Slack data
+  questions must call `elixir_analytics_runner` mode `answer_question` before
+  planning, file inspection, SQL writing, `execute_code`, or source edits.
+- The runner plugin defensively treats a question-only call as
+  `answer_question`; live profile dry-run confirms `show GTV last 30 days by
+  week` routes to `card_gtv_weekly_30d` even when mode is omitted.
+- The runner plugin now emits safe telemetry through
+  `hermes.elixir_analytics_runner`: mode, route, shortcut, topic/result type,
+  row count, truncation, dashboard presence, elapsed time, and error type. It
+  does not log raw rows, SQL, or the raw user question.
+- The analytics repo now includes `scripts/check-slack-e2e-logs.ts`, which
+  reads the live Hermes gateway and agent logs after Slack prompts and reports
+  route, timing, API-call, and safe telemetry status for the acceptance suite.
+- The current live log checker passes saved-topic, Supabase ad hoc, PostHog,
+  clarification, and write-SQL rejection scenarios with safe route telemetry.
+- The analytics smoke suite now includes `source_change_workflow`, proving that
+  a request like `GTV definition is wrong...` routes to source-of-truth PR
+  planning with glossary, metric-contract, saved-topic, and test-file evidence.
+- The analytics smoke suite also keeps `row_cap_truncation`, proving large ad
+  hoc result sets are bounded and marked `truncated: true`.
+- Full analytics verification after PR #6: `npm run lint` completed with no
+  warnings, `npm test` passed 221 tests, strict release packaging passed, the
+  smoke suite passed from `main`, and `npm run build` passed. Earlier Hermes
+  profile/plugin tests passed with 91 tests and Slack reconnect tests passed
+  with 223 tests.
+- Temporary no-persistence `/query?payload=...` handoff is now covered by a
+  focused resolver regression test: payload links decode rows and metadata
+  without executing a saved topic.
+- The common-question shortcut runner now returns `payload.slackText` for saved
+  GTV, Swiggy Supabase, and app-active PostHog answers. The Hermes tool schema
+  and skill both tell the model to use that text as the Slack-facing answer
+  before extra summarization or maintenance work.
+- Temporary visualization payloads now strip both Supabase SQL and PostHog
+  HogQL before encoding `/query?payload=...`, reducing Slack link bulk and
+  keeping executable query text out of no-persistence dashboard URLs.
+- The analytics repo now has `scripts/check-release-packaging.ts` and
+  `docs/release-packaging.md`. Strict release packaging passes on clean `main`,
+  so runtime and dashboard changes can be packaged separately instead of merged
+  as one broad release.
+- The Hermes repo now has `scripts/check_elixir_analytics_release_packaging.py`
+  and `profile-distributions/elixir-analytics/RELEASE_PACKAGING.md`. The
+  current dirty Hermes worktree classifies cleanly into
+  `profile-distribution`, `hermes-runtime`, and `slack-gateway`, with
+  `.hermes-bootstrap-complete` reported as a local artifact rather than a file
+  to stage.
+- Post-merge verification on analytics `main` passed the live Slack log checker:
+  saved weekly GTV, last-7-days GTV, Swiggy Supabase ad hoc, top card spenders,
+  PostHog app-active users, active-user clarification, and write-SQL rejection
+  all used the intended routes.
+- Production dashboard link check confirms
+  `https://analytics.joinelixir.club/query?topic=card-gtv-weekly&range=30d`
+  redirects signed-out users to
+  `/sign-in?callbackUrl=%2Fquery%3Ftopic%3Dcard-gtv-weekly%26range%3D30d` with
+  no console errors. The controlled Chrome profile was not signed in, so
+  post-sign-in data rendering still needs either user-authenticated browser
+  verification or a manual user check.
+- Vercel production deployment
+  `https://analytics-agent-c6o7dsrvz-ritikmdns-projects.vercel.app` is Ready
+  and aliased to `https://analytics.joinelixir.club`.
 
-## Current Gaps
+Known gaps:
 
-- PostHog needs a fresh live Slack recheck after the direct-answer and compact
-  skill-view changes. The old evidence is functionally correct but too slow.
-- Clarified follow-up ranking questions can still drift into generic
-  file/search/tool work. Example: a separate "Who spent the most in last 30
-  days?" thread completed but took 189.1s and 19 model calls. This belongs in
-  answer-polish and deterministic shortcut expansion.
-- `scripts/check-slack-e2e-logs.ts` in `claude-analytics` is stale relative to
-  the current runner-first rule. It still expects no runner call for
-  clarification/rejection scenarios, but Hermes now intentionally calls
-  `answer_question` first for plain analytics questions. The checker should be
-  updated in the analytics repo.
-- The Hermes direct-final response update is local and still needs full focused
-  verification, commit, and push to PR #39041.
-- The gateway is locally supervised, not yet hosted in an always-on production
-  environment.
+- Signed-in production dashboard rendering needs one fresh user-authenticated
+  browser check. Signed-out callback preservation is verified.
+- The gateway is supervised and Socket Mode connected locally, but the product
+  still needs a hosted always-on gateway decision before calling Slack analytics
+  fully production-ready.
+- Hermes profile distribution branch `codex/elixir-analytics-profile` is pushed
+  to `ritikmdn/hermes-agent`, dry-merges cleanly into current
+  `NousResearch/hermes-agent` `main`, and focused Hermes verification passes
+  252 tests. Opening a public upstream PR remains a product/privacy decision
+  because the profile is Elixir-specific.
+- Slack answer polish is functionally acceptable, but user-list answers can be
+  verbose because temporary dashboard payload links are long. Payload compaction
+  or a stronger Slack-specific formatter remains a polish lane.
 
 ## Milestones
 
 | Phase | Milestone | Product outcome | Status |
 |---|---|---|---|
 | 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done |
-| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics and dashboard links. | Done |
-| 3 | Supabase ad hoc runner | Arbitrary Supabase analytics questions use a read-only JSON contract. | Done |
-| 4 | Query-specific visualization handoff | Ad hoc results can link to temporary no-persistence dashboard payloads. | Built; core production saved-topic link verified |
-| 5 | PostHog runner | Product analytics route to read-only HogQL with separate definitions. | Built; fresh fast Slack pass pending |
-| 6 | Source-of-truth workflow | Definition/glossary/query changes become scoped repo changes and PRs. | Built; first real source-change PR still pending |
-| 7 | Self-improvement loop | Repeated questions become saved-topic, glossary, and dashboard candidates. | Built; cadence/live usage pending |
-| 8 | Ops readiness | Deployment blockers, gateway health, and env readiness are inspectable. | Local checks built; hosted gateway pending |
-| 9 | Slack smoke suite | Core scenarios are covered by deterministic tests/smoke tooling. | Built; log checker needs rule alignment |
-| 10 | Production deploy | Analytics app is merged, deployed, and env-backed. | Done for current GTV dashboard path |
-| 11 | Slack end-to-end validation | Real Slack proves saved topic, Supabase ad hoc, clarification, rejection, and PostHog. | Mostly done; PostHog fresh pass pending |
-| 12 | Hosted gateway | Slack gateway is reliable beyond the local machine. | Pending product/infra decision |
-| 13 | Hermes upstream sync | Profile distribution and runtime changes are pushed upstream. | PR open; current patch pending push |
-| 14 | Answer polish | Common questions respond fast, compactly, and with useful links. | Supabase improved; PostHog and ranking shortcuts pending |
-| 15 | Operating cadence | Query-log and self-improvement review run regularly. | Tooling built; cadence not operationalized |
+| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Done |
+| 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Done; live Swiggy and top-spenders paths pass |
+| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Done for saved and payload links; signed-in browser proof pending |
+| 5 | PostHog runner | App/product analytics route to read-only HogQL. | Done; live app-active route passes |
+| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built and smoke-covered; first live change request pending |
+| 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
+| 8 | Ops readiness | Production blockers are reported before rollout claims. | Ready when run with production env pull |
+| 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Done |
+| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Main merged, Vercel production Ready, readiness ready with production env pull; signed-in browser proof pending |
+| 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Passed via live logs after PR #6 |
+| 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
+| 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Branch pushed/tested; public upstream PR decision pending |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | Fast routes pass; verbosity/link compaction pending |
+| 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
-## Immediate Goal
+## Production Gates
 
-Finish the current Hermes PR update.
+Do not call the agent or dashboard production-ready until all gates pass:
 
-Done means:
+1. Analytics changes are merged and deployed to the production Vercel project.
+2. Deployed Next.js env includes read-only `ANALYTICS_DATABASE_URL`.
+3. Temporary visuals use direct `/query?payload=...` or saved topic links with
+   no durable storage and no third-party URL shorteners.
+4. Hermes `elixir-analytics` profile has an inference provider key, managed
+   provider, or verified OAuth provider auth.
+5. Slack `macros` gateway is connected and supervised.
+6. Smart approvals are enabled.
+7. Generic Hermes tools remain enabled for debugging and source changes.
+8. The Slack smoke suite passes.
+9. A real Slack E2E pass covers saved topic, Supabase ad hoc direct-link,
+   PostHog, clarification, and write-SQL rejection.
 
-1. The roadmap reflects the current product state.
-2. Hermes focused tests pass for profile distribution, runner plugin, direct
-   final-response behavior, and release packaging.
-3. The current direct-answer/profile/test changes are committed and pushed to
-   `ritikmdn:codex/elixir-analytics-profile`.
-4. The live gateway remains connected after any restart needed for sync.
+## Packaging Plan
 
-## Next Product Milestone
+Keep the current dirty work split by product lane:
 
-Milestone 11B: finish fresh Slack acceptance.
+1. Hermes profile package: profile-owned plugin discovery, distribution sync,
+   `elixir-analytics-runner`, toolset exposure, skill guidance, and Slack
+   recovery logging.
+2. Analytics runtime package: deterministic question runner, Supabase/PostHog
+   runner hardening, ops-readiness checker, Slack E2E log checker, smoke suite,
+   query-page data loader, temporary payload handoff, and related tests/docs.
+3. Executive dashboard package: visual/theme/dashboard layout work in the
+   Next.js app. Package separately unless the user explicitly wants it merged
+   with the runtime lane.
+4. Release docs package: packaging, ops, Slack smoke, source-change, and ad hoc
+   operating docs plus the release classifier.
 
-Done means:
+Do not stage or PR the entire analytics worktree as one unit until the dashboard
+lane is intentionally accepted into the same release.
 
-1. `how many app active users this week?` uses the PostHog shortcut path from
-   Slack with low call count and no generic shell path.
-2. `scripts/check-slack-e2e-logs.ts` is updated so current runner-first
-   behavior counts as valid for clarification and destructive-query rejection.
-3. The log checker passes on fresh Slack evidence or reports only intentionally
-   deferred scenarios.
-
-Milestone 14E: add deterministic ranking shortcuts.
-
-Done means:
-
-1. "Who spent the most in last 30 days?" maps to a bounded Supabase ad hoc
-   request without broad file/search exploration.
-2. The Slack answer includes top users, spend, count, date window, and optional
-   dashboard link within the agreed latency target.
-
-Milestone 12A: choose and implement hosted gateway.
-
-Done means:
-
-1. The gateway is running on a stable host instead of relying on the local Mac.
-2. Secrets are scoped to the `macros` analytics Slack app/profile.
-3. Restart health, logs, and rollback are documented.
-
-## Standard Verification
-
-From `/Users/ritik/.hermes/hermes-agent`:
+From `/Users/ritik/Coding/claude-analytics`, run:
 
 ```bash
-scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py tests/hermes_cli/test_elixir_analytics_runner_plugin.py tests/hermes_cli/test_elixir_analytics_release_packaging.py tests/gateway/test_slack.py tests/plugins/test_disk_cleanup_plugin.py tests/test_toolsets.py -- -q
-HERMES_HOME=/private/tmp/hermes-agent-test venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k direct_final_response
+node --import tsx scripts/check-release-packaging.ts --strict
+```
+
+Strict mode must have zero unclassified files before staging package-specific
+commits.
+
+From `/Users/ritik/.hermes/hermes-agent`, run:
+
+```bash
 venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict
 ```
 
-From `/Users/ritik/Coding/claude-analytics` after analytics changes:
+The Hermes checker separates profile distribution, runtime/plugin loading, and
+Slack gateway reliability changes; local artifacts must remain unstaged.
+
+## Standard Verification
+
+Run these from `/Users/ritik/Coding/claude-analytics` after analytics changes:
 
 ```bash
 npm run lint
 npm test
 npm run build
-node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch main --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
-node --import tsx scripts/check-slack-e2e-logs.ts --gateway-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/gateway.log --agent-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/agent.log
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --profile-home /Users/ritik/.hermes/profiles/elixir-analytics --provider-authenticated openai-codex --smart-approvals --generic-tools
 ```
 
-## Open Decisions
+Run this from the Hermes repo after profile changes:
 
-- Hosted gateway target: Vercel service, small VPS, Render/Fly, or another
-  always-on host.
-- Product default for ambiguous active users: always clarify, or choose a
-  default such as card active users.
-- Slack latency targets. Current suggested target: under 15s for deterministic
-  shortcuts, under 45s for broader ad hoc questions.
+```bash
+scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py -- -q
+```
+
+## Slack E2E Checklist
+
+Verify these exact prompts in Slack:
+
+| Prompt | Expected route | Status |
+|---|---|---|
+| `show GTV last 30 days by week` | saved topic `card-gtv-weekly` with non-empty dashboard data and dashboard link | Passed live via `answer_question`, 2 API calls, dashboard link present |
+| `what was GTV for last 7 days?` | saved topic `card-gtv` with `7d` range | Passed live via `answer_question`, 2 API calls, dashboard link present |
+| `which users spent on Swiggy this week?` | Supabase ad hoc runner with India week-to-date assumption and temporary dashboard link | Passed live via `swiggy_users_this_week`, 2 API calls, 15 rows |
+| `who spent the most in last 30 days?` | Supabase ad hoc top-spenders shortcut with bounded user rows | Passed live via `top_card_spenders_30d`, 2 API calls, 25 rows, truncated |
+| `active users this week` | clarification before querying | Passed live; clarification flow intentionally waits for user input |
+| `how many app active users this week?` | PostHog ad hoc runner with `active_app_user` | Passed live via `app_active_users_this_week`, 2 API calls, 1 KPI row |
+| `delete from profiles` | read-only validation rejection | Passed live without runner execution |
+
+## Next Execution Milestone
+
+Milestone 10A: finish production dashboard signed-in proof.
+
+Done means the production saved-topic link opens with non-empty data after
+sign-in from an authenticated browser session. Env/readiness reconciliation is
+already complete.
+
+Execution order:
+
+1. Use an authenticated browser profile or ask the user to sign in through the
+   controlled Chrome profile.
+2. Recheck `https://analytics.joinelixir.club/query?topic=card-gtv-weekly&range=30d`
+   and confirm rows render.
+3. Record whether the page shows `Weekly GTV`, row count/table data, and zero
+   console errors.
+
+Milestone 12A: choose and implement hosted gateway.
+
+Done means Slack `macros` does not depend on the laptop: the gateway has an
+always-on host, restart policy, health check, log access, and documented rollback
+path.
+
+Milestone 13A: choose Hermes upstream/private sync path.
+
+Done means the `elixir-analytics` profile distribution, runner plugin, and Slack
+gateway patches are either pushed/PR'd upstream or intentionally documented as a
+private profile distribution.
+
+Current evidence: branch `codex/elixir-analytics-profile` is pushed to the
+`ritikmdn/hermes-agent` fork, dry-merges cleanly into current upstream `main`,
+and focused verification passed 252 Hermes tests plus strict release packaging.
+
+Milestone 14A: compact Slack answer links.
+
+Done means user-list answers still include dashboard links, but the Slack message
+stays compact enough for executive reading and does not expose executable query
+text in the URL.
+
+## Current Open Decisions
+
+These are not solved by local code alone:
+
+- Choose where the always-on Slack gateway should run after local supervision.
+- Confirm the Hermes upstream sync path: push branch, open PR, or keep private.
+- Decide when to commit/push the local Hermes profile and analytics docs patches.
+- Decide the acceptable latency target for Supabase ad hoc Slack answers.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -299,7 +299,8 @@ path.
 
 Use `HOSTED_GATEWAY.md` as the cutover runbook. The remaining product decision
 is the host itself; the required process shape, secrets, health checks, smoke
-prompts, and rollback steps are documented there.
+prompts, rollback steps, Docker Compose template, and systemd unit are
+documented there.
 
 Milestone 13A: choose Hermes upstream/private sync path.
 

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -1,359 +1,165 @@
 # Elixir Analytics Agent Roadmap
 
-This roadmap is the product runbook for the `elixir-analytics` Hermes profile.
-Use it to keep Slack, the analytics repo, and the executive Next.js dashboard
-moving through the same milestones.
+This roadmap is the operating runbook for the `elixir-analytics` Hermes
+profile. Keep it aligned after each execution pass so Slack behavior, the
+analytics repo, and the executive Next.js dashboard move through the same
+product milestones.
+
+Last updated: 2026-06-04 19:25 IST.
 
 ## Product Shape
 
 ```text
 Slack app: macros
   -> Hermes profile: elixir-analytics
-  -> deterministic shortcut runner or planner in claude-analytics
-  -> saved topic, Supabase ad hoc, PostHog ad hoc, or clarification
-  -> Slack answer with metadata and dashboard link
-  -> executive dashboard or temporary visualization link
-  -> logged answer feeds source-of-truth and self-improvement workflows
+  -> claude-analytics deterministic runner or planner
+  -> saved topic, Supabase ad hoc, PostHog ad hoc, clarification, or source-change workflow
+  -> Slack answer with assumptions, metadata, and optional dashboard link
+  -> executive Next.js dashboard or no-persistence query visualization
+  -> query log and self-improvement review
 ```
 
-Hermes owns AI reasoning, source-change orchestration, approvals, and Slack
-conversation. The analytics repo owns deterministic query contracts, runners,
-tests, dashboard rendering, and production deployment.
+Hermes owns AI reasoning, Slack conversation, approvals, profile routing,
+source-change orchestration, and self-improvement. `claude-analytics` owns
+metric contracts, deterministic query runners, read-only validation, dashboard
+rendering, release checks, and production deployment.
 
 ## Current Status Snapshot
 
-Last updated: 2026-06-04.
+| Area | Status | Evidence |
+|---|---|---|
+| Slack profile routing | Working | Slack app `macros` reaches the launchd-managed `elixir-analytics` gateway. Socket Mode connected in `logs/gateway.log`. |
+| Hermes provider | Working | Live profile uses `openai-codex` / `gpt-5.5`; Slack turns complete. |
+| Generic tools | Enabled | Smart approvals and generic tools remain available for debugging and source changes. |
+| Supabase saved topic | Working | `show GTV last 30 days by week` routed to `card-gtv-weekly` through `answer_question`, returned a dashboard link, 2 model calls, 30.0s gateway time. |
+| Supabase ad hoc | Working and fast for the key shortcut | `which users spent on Swiggy this week?` routed to `supabase_ad_hoc` shortcut `swiggy_users_this_week`, returned 15 rows, dashboard link, 2 model calls, 9.8s gateway time. |
+| Production dashboard | Working for GTV link | `https://analytics.joinelixir.club/query?topic=card-gtv-weekly&range=30d` was rechecked after the Vercel env fix and now loads data. |
+| Active-user ambiguity | Working for first step | `active users this week` asks whether to use card, app, or combined active users before querying. |
+| Write-SQL rejection | Working | `delete from profiles` was refused in Slack with read-only alternatives, 3 model calls, 17.4s gateway time. |
+| Row cap/truncation | Covered by runner smoke suite | `row_cap_truncation` in `scripts/run-analytics-smoke-suite.ts` proves large ad hoc output is bounded and returns `truncated: true`. |
+| PostHog | Built, but fresh fast Slack evidence pending | Earlier live app-active run was functionally correct but too slow and used generic tooling; needs a fresh post-direct-answer Slack pass. |
+| Source-change workflow | Built | Runner modes `source_change_plan` and `source_change_scope_check` exist and have live direct checks. |
+| Self-improvement loop | Built | Runner mode `self_improvement_plan` exists; query-log cadence tooling exists. |
+| Hermes PR | Open draft | `NousResearch/hermes-agent#39041`, branch `ritikmdn:codex/elixir-analytics-profile`. Current local direct-answer updates still need commit/push. |
+| Analytics PR | Merged/deployed | Runtime/dashboard fixes are deployed to `analytics.joinelixir.club`; current work here is Hermes-side. |
 
-Verified:
+## Fresh Slack Evidence
 
-- The live ops-readiness check can load the installed Hermes profile with
-  `--profile-home`, infer Slack Socket Mode from `logs/gateway.log`, and avoid
-  printing secrets.
-- Current live ops-readiness status is `blocked`: the local analytics branch is
-  `codex/mock-single-dashboard`, not `main`, and deployed reads are missing
-  `ANALYTICS_DATABASE_URL`.
-- Latest local verification is green: `npm run lint` has no warnings,
-  `npm test` passed 214 analytics tests, `npm run build` passed, strict
-  analytics release packaging passed, the analytics smoke suite passed, and
-  focused Hermes profile/plugin/toolset tests passed 55 tests with one
-  external dependency warning.
-- `/query` now distinguishes an unknown saved topic from a known saved topic
-  whose database execution fails, so a missing Vercel database env shows as
-  saved-query data unavailable rather than an ambiguous empty visualization.
-- The `elixir-analytics` Hermes gateway is running under local supervision and
-  Slack Socket Mode is connected after a targeted restart of
-  `ai.hermes.gateway-elixir-analytics`.
-- Hermes Slack Socket Mode watchdog now emits
-  `Socket Mode connected (recovered)` after a transport-drop self-heal, so
-  log-based readiness can distinguish a recovered gateway from a stuck
-  reconnecting one.
-- The analytics ops-readiness detector now treats a later
-  `Socket Mode connected (recovered)` event as healthy even if the same gateway
-  run had an earlier transient transport disconnect; the live readiness check is
-  back to two blockers only: branch not `main` and missing deployed
-  `ANALYTICS_DATABASE_URL`.
-- Real Slack E2E passed for saved GTV and Supabase Swiggy ad hoc questions.
-- The fresh Swiggy recheck used a direct `analytics.joinelixir.club/query?...`
-  dashboard link, not a third-party shortener.
-- Real Slack E2E also passed for active-user clarification, PostHog app-active
-  users, and write-SQL rejection.
-- Hermes profile tests and the full analytics test/build/lint suite pass
-  locally.
-- Hermes now supports profile-owned plugins from `profile_plugins/`, and the
-  `elixir-analytics` distribution ships `elixir-analytics-runner`.
-- The runner plugin exposes `elixir_analytics_runner` for planner, saved-topic,
-  common-question shortcut, Supabase ad hoc, and PostHog ad hoc calls without
-  first using generic `execute_code` or ad hoc shell composition.
-- The runner plugin also exposes deterministic maintenance modes:
-  `source_change_plan` for definition/glossary/schema/dashboard change
-  planning, `source_change_scope_check` for checking changed files before a
-  source-of-truth PR commit, and `self_improvement_plan` for query-log
-  review/promotion planning.
-- Live profile checks passed for both maintenance modes: `source_change_plan`
-  returned a GTV `metric_definition` PR plan with `prRequired: true`, and
-  `self_improvement_plan` reviewed 5 query-log entries with 4 suggestions.
-- Local dry-runs passed through the plugin for planner, saved GTV, Swiggy-style
-  Supabase ad hoc, and app-active PostHog ad hoc routes.
-- The installed `elixir-analytics` profile has been synced with the runner
-  plugin, and the launchd-managed Slack gateway was restarted successfully.
-- A live read-only saved-topic call through `elixir_analytics_runner` returned
-  5 rows for `card-gtv-weekly` and the direct production dashboard link in
-  20.65 seconds.
-- The distributed skill and tool schema now instruct Hermes to use
-  `answer_question` first for plain Slack analytics questions, with compact row
-  caps for user lists unless the user asks for exhaustive output.
-- Direct live shortcut checks passed outside Slack: Swiggy users this week
-  returned 15 rows through Supabase in 0.56 seconds, and app-active users this
-  week returned 1 KPI row through PostHog in 1.23 seconds.
-- The analytics shortcut runner now also detects `show GTV last 30 days by
-  week` and routes it directly to saved topic `card-gtv-weekly`; live Hermes
-  wrapper dry-run confirms `answer_question` returns the saved-topic dashboard
-  path `/query?topic=card-gtv-weekly&range=30d`.
-- A live `run-analytics-question.ts` shortcut query for `show GTV last 30 days
-  by week` returned 5 weekly rows and the production dashboard link in 20.5
-  seconds.
-- The live profile plugin was resynced and the gateway restarted after the
-  `answer_question` guidance and compact-row default were added. Live plugin
-  dry-run confirms `answer_question` defaults to `maxRows: 100`.
-- The skill now has a top-level mandatory-first-call rule: plain Slack data
-  questions must call `elixir_analytics_runner` mode `answer_question` before
-  planning, file inspection, SQL writing, `execute_code`, or source edits.
-- The runner plugin defensively treats a question-only call as
-  `answer_question`; live profile dry-run confirms `show GTV last 30 days by
-  week` routes to `card_gtv_weekly_30d` even when mode is omitted.
-- The runner plugin now emits safe telemetry through
-  `hermes.elixir_analytics_runner`: mode, route, shortcut, topic/result type,
-  row count, truncation, dashboard presence, elapsed time, and error type. It
-  does not log raw rows, SQL, or the raw user question.
-- The analytics repo now includes `scripts/check-slack-e2e-logs.ts`, which
-  reads the live Hermes gateway and agent logs after Slack prompts and reports
-  route, timing, API-call, and safe telemetry status for the acceptance suite.
-- Running the log checker on the current pre-telemetry Slack logs correctly
-  fails saved GTV, Swiggy, and PostHog because runner telemetry is absent and
-  the older Swiggy/PostHog runs exceeded latency/call-count targets; the
-  clarification and write-SQL rejection scenarios pass.
-- The analytics smoke suite now includes `source_change_workflow`, proving that
-  a request like `GTV definition is wrong...` routes to source-of-truth PR
-  planning with glossary, metric-contract, saved-topic, and test-file evidence.
-- The analytics repo now includes `scripts/check-source-change-scope.ts`, which
-  verifies a source-change request against changed source/test files before
-  committing. The Hermes profile exposes it through `elixir_analytics_runner`
-  mode `source_change_scope_check`; the installed profile was synced, the local
-  Slack gateway was restarted, and a live installed-profile direct check
-  returned `status: "ready"` for a scoped GTV definition change.
-- Full verification after the source-change scope checker update: Hermes
-  profile/plugin/toolset tests passed with 55 tests, `npm run lint` completed
-  with no warnings, `npm test` passed 210 tests, `npm run build` passed, and
-  both analytics and Hermes release-packaging checks passed.
-- Temporary no-persistence `/query?payload=...` handoff is now covered by a
-  focused resolver regression test: payload links decode rows and metadata
-  without executing a saved topic.
-- The common-question shortcut runner now returns `payload.slackText` for saved
-  GTV, Swiggy Supabase, and app-active PostHog answers. The Hermes tool schema
-  and skill both tell the model to use that text as the Slack-facing answer
-  before extra summarization or maintenance work.
-- Temporary visualization payloads now strip both Supabase SQL and PostHog
-  HogQL before encoding `/query?payload=...`, reducing Slack link bulk and
-  keeping executable query text out of no-persistence dashboard URLs.
-- Oversized temporary visualization payloads now compact before falling back to
-  no-link answers: rows are bounded, long text is trimmed, sensitive fields are
-  dropped, metadata is shortened, and pathological payloads still refuse to
-  emit a dashboard link.
-- The analytics repo now has `scripts/check-release-packaging.ts` and
-  `docs/release-packaging.md`. The current dirty analytics worktree classifies
-  cleanly into `analytics-runtime` and `release-docs` with no unclassified
-  files, so runtime and docs changes can be packaged without dragging in
-  unrelated dashboard work.
-- The Hermes repo now has `scripts/check_elixir_analytics_release_packaging.py`
-  and `profile-distributions/elixir-analytics/RELEASE_PACKAGING.md`. The
-  latest Hermes delta classifies cleanly into `profile-distribution` and
-  `hermes-runtime`, with `.hermes-bootstrap-complete` reported as a local
-  artifact rather than a file to stage.
-- Analytics commits through `3d60289` are pushed to
-  `origin/codex/mock-single-dashboard`, and draft PR
-  `ritikmdn/analytics-agent#4` is open against `main`.
-- Hermes commits through `8c147eab5` are pushed to the `ritikmdn/hermes-agent`
-  fork, and draft upstream PR `NousResearch/hermes-agent#39041` is open from
-  `ritikmdn:codex/elixir-analytics-profile` to `main`.
+| Prompt | Expected product behavior | Current evidence | Status |
+|---|---|---|---|
+| `show GTV last 30 days by week` | Saved topic `card-gtv-weekly`, dashboard link with data | 2026-06-04 19:11 IST: runner route `saved_topic`, shortcut `card_gtv_weekly_30d`, 2 calls, 30.0s, 497 chars | Pass |
+| `which users spent on Swiggy this week?` | Supabase ad hoc shortcut, India week-to-date, user rows, dashboard link | 2026-06-04 19:10 IST: runner route `supabase_ad_hoc`, shortcut `swiggy_users_this_week`, 15 rows, 2 calls, 9.8s, 4845 chars | Pass |
+| `active users this week` | Clarify before querying | 2026-06-04 19:12 IST: Slack reply asked card/app/combined active users before executing a metric query | Pass for clarification |
+| `delete from profiles` | Refuse destructive SQL and offer safe alternatives | 2026-06-04 19:16 IST: Slack reply refused `DELETE FROM profiles`, 3 calls, 17.4s | Pass |
+| `how many app active users this week?` | PostHog ad hoc shortcut, no generic shell path | Fresh post-direct-answer Slack pass pending | Pending |
+| Large ad hoc result | Bound rows and mark `truncated: true` | Covered in smoke suite via `row_cap_truncation` | Pass by automated runner evidence |
 
-Known gaps:
+## Current Gaps
 
-- Swiggy direct-link recheck was too slow: 418.3 seconds across 33 model calls.
-- The slow Swiggy run also revealed source-edit drift: the agent attempted
-  maintenance/source edits during a plain data answer. The profile skill now
-  says to answer first and defer logging/source changes.
-- PostHog app-active live E2E was functionally correct but too slow: 266.6
-  seconds across 20 model calls, with generic `execute_code` used before the
-  final answer.
-- The gateway is locally supervised, not yet moved to a hosted always-on setup.
-- Hermes profile distribution changes now have an upstream draft PR path; merge
-  still depends on maintainer review and any upstream CI requirements.
-- Production dashboard links need a fresh deploy with
-  `ANALYTICS_DATABASE_URL`; the user-observed no-data GTV link is consistent
-  with the current live ops-readiness blocker.
-- The live Slack gateway still needs Swiggy and PostHog prompts rechecked after
-  the `answer_question` fast-path sync to prove the model chooses the shortcut
-  tool and meets the latency target.
-- A local Hermes one-shot answered Swiggy correctly after the sync, but still
-  took about 64 seconds end-to-end. If Slack shows the same behavior, the next
-  polish step is a stronger Slack-specific fast-path or answer formatter.
+- PostHog needs a fresh live Slack recheck after the direct-answer and compact
+  skill-view changes. The old evidence is functionally correct but too slow.
+- Clarified follow-up ranking questions can still drift into generic
+  file/search/tool work. Example: a separate "Who spent the most in last 30
+  days?" thread completed but took 189.1s and 19 model calls. This belongs in
+  answer-polish and deterministic shortcut expansion.
+- `scripts/check-slack-e2e-logs.ts` in `claude-analytics` is stale relative to
+  the current runner-first rule. It still expects no runner call for
+  clarification/rejection scenarios, but Hermes now intentionally calls
+  `answer_question` first for plain analytics questions. The checker should be
+  updated in the analytics repo.
+- The Hermes direct-final response update is local and still needs full focused
+  verification, commit, and push to PR #39041.
+- The gateway is locally supervised, not yet hosted in an always-on production
+  environment.
 
 ## Milestones
 
 | Phase | Milestone | Product outcome | Status |
 |---|---|---|---|
 | 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done |
-| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Done |
-| 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Done; fast-path polish pending |
-| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Built with SQL/HogQL stripping and compact payload fallback; production env recheck pending |
-| 5 | PostHog runner | App/product analytics route to read-only HogQL. | Passed live; fast-path polish pending |
-| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built, scope-checkable, runner-accessible; first live change request pending |
-| 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
-| 8 | Ops readiness | Production blockers are reported before rollout claims. | Checker done; live status blocked |
-| 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Done |
-| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Draft PR open; blocked on merge/deploy + `ANALYTICS_DATABASE_URL` |
-| 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Functional history exists; fresh post-fix pass pending |
-| 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
-| 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Draft upstream PR open; maintainer review pending |
-| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | `payload.slackText` and compact visualization links built/tested; live Slack latency recheck pending |
-| 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
+| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics and dashboard links. | Done |
+| 3 | Supabase ad hoc runner | Arbitrary Supabase analytics questions use a read-only JSON contract. | Done |
+| 4 | Query-specific visualization handoff | Ad hoc results can link to temporary no-persistence dashboard payloads. | Built; core production saved-topic link verified |
+| 5 | PostHog runner | Product analytics route to read-only HogQL with separate definitions. | Built; fresh fast Slack pass pending |
+| 6 | Source-of-truth workflow | Definition/glossary/query changes become scoped repo changes and PRs. | Built; first real source-change PR still pending |
+| 7 | Self-improvement loop | Repeated questions become saved-topic, glossary, and dashboard candidates. | Built; cadence/live usage pending |
+| 8 | Ops readiness | Deployment blockers, gateway health, and env readiness are inspectable. | Local checks built; hosted gateway pending |
+| 9 | Slack smoke suite | Core scenarios are covered by deterministic tests/smoke tooling. | Built; log checker needs rule alignment |
+| 10 | Production deploy | Analytics app is merged, deployed, and env-backed. | Done for current GTV dashboard path |
+| 11 | Slack end-to-end validation | Real Slack proves saved topic, Supabase ad hoc, clarification, rejection, and PostHog. | Mostly done; PostHog fresh pass pending |
+| 12 | Hosted gateway | Slack gateway is reliable beyond the local machine. | Pending product/infra decision |
+| 13 | Hermes upstream sync | Profile distribution and runtime changes are pushed upstream. | PR open; current patch pending push |
+| 14 | Answer polish | Common questions respond fast, compactly, and with useful links. | Supabase improved; PostHog and ranking shortcuts pending |
+| 15 | Operating cadence | Query-log and self-improvement review run regularly. | Tooling built; cadence not operationalized |
 
-## Production Gates
+## Immediate Goal
 
-Do not call the agent or dashboard production-ready until all gates pass:
+Finish the current Hermes PR update.
 
-1. Analytics changes are merged and deployed to the production Vercel project.
-2. Deployed Next.js env includes read-only `ANALYTICS_DATABASE_URL`.
-3. Temporary visuals use direct `/query?payload=...` or saved topic links with
-   no durable storage and no third-party URL shorteners.
-4. Hermes `elixir-analytics` profile has an inference provider key, managed
-   provider, or verified OAuth provider auth.
-5. Slack `macros` gateway is connected and supervised.
-6. Smart approvals are enabled.
-7. Generic Hermes tools remain enabled for debugging and source changes.
-8. The Slack smoke suite passes.
-9. A real Slack E2E pass covers saved topic, Supabase ad hoc direct-link,
-   PostHog, clarification, and write-SQL rejection.
+Done means:
 
-## Packaging Plan
+1. The roadmap reflects the current product state.
+2. Hermes focused tests pass for profile distribution, runner plugin, direct
+   final-response behavior, and release packaging.
+3. The current direct-answer/profile/test changes are committed and pushed to
+   `ritikmdn:codex/elixir-analytics-profile`.
+4. The live gateway remains connected after any restart needed for sync.
 
-Keep the current dirty work split by product lane:
+## Next Product Milestone
 
-1. Hermes profile package: profile-owned plugin discovery, distribution sync,
-   `elixir-analytics-runner`, toolset exposure, skill guidance, and Slack
-   recovery logging.
-2. Analytics runtime package: deterministic question runner, Supabase/PostHog
-   runner hardening, ops-readiness checker, Slack E2E log checker, smoke suite,
-   query-page data loader, temporary payload handoff, and related tests/docs.
-3. Executive dashboard package: visual/theme/dashboard layout work in the
-   Next.js app. Package separately unless the user explicitly wants it merged
-   with the runtime lane.
-4. Release docs package: packaging, ops, Slack smoke, source-change, and ad hoc
-   operating docs plus the release classifier.
+Milestone 11B: finish fresh Slack acceptance.
 
-Do not stage or PR the entire analytics worktree as one unit until the dashboard
-lane is intentionally accepted into the same release.
+Done means:
 
-From `/Users/ritik/Coding/claude-analytics`, run:
+1. `how many app active users this week?` uses the PostHog shortcut path from
+   Slack with low call count and no generic shell path.
+2. `scripts/check-slack-e2e-logs.ts` is updated so current runner-first
+   behavior counts as valid for clarification and destructive-query rejection.
+3. The log checker passes on fresh Slack evidence or reports only intentionally
+   deferred scenarios.
 
-```bash
-node --import tsx scripts/check-release-packaging.ts --strict
-```
+Milestone 14E: add deterministic ranking shortcuts.
 
-Strict mode must have zero unclassified files before staging package-specific
-commits.
+Done means:
 
-From `/Users/ritik/.hermes/hermes-agent`, run:
+1. "Who spent the most in last 30 days?" maps to a bounded Supabase ad hoc
+   request without broad file/search exploration.
+2. The Slack answer includes top users, spend, count, date window, and optional
+   dashboard link within the agreed latency target.
 
-```bash
-venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict
-```
+Milestone 12A: choose and implement hosted gateway.
 
-The Hermes checker separates profile distribution, runtime/plugin loading, and
-Slack gateway reliability changes; local artifacts must remain unstaged.
+Done means:
+
+1. The gateway is running on a stable host instead of relying on the local Mac.
+2. Secrets are scoped to the `macros` analytics Slack app/profile.
+3. Restart health, logs, and rollback are documented.
 
 ## Standard Verification
 
-Run these from `/Users/ritik/Coding/claude-analytics` after analytics changes:
+From `/Users/ritik/.hermes/hermes-agent`:
+
+```bash
+scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py tests/hermes_cli/test_elixir_analytics_runner_plugin.py tests/hermes_cli/test_elixir_analytics_release_packaging.py tests/gateway/test_slack.py tests/plugins/test_disk_cleanup_plugin.py tests/test_toolsets.py -- -q
+HERMES_HOME=/private/tmp/hermes-agent-test venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k direct_final_response
+venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict
+```
+
+From `/Users/ritik/Coding/claude-analytics` after analytics changes:
 
 ```bash
 npm run lint
 npm test
 npm run build
-node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --profile-home /Users/ritik/.hermes/profiles/elixir-analytics --provider-authenticated openai-codex --smart-approvals --generic-tools
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch main --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
+node --import tsx scripts/check-slack-e2e-logs.ts --gateway-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/gateway.log --agent-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/agent.log
 ```
 
-Run this from the Hermes repo after profile changes:
+## Open Decisions
 
-```bash
-scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py -- -q
-```
-
-## Slack E2E Checklist
-
-Verify these exact prompts in Slack:
-
-| Prompt | Expected route | Status |
-|---|---|---|
-| `show GTV last 30 days by week` | saved topic `card-gtv-weekly` with non-empty dashboard data and dashboard link | Slack answer passed historically; dashboard link needs fresh verification after Vercel env fix |
-| `which users spent on Swiggy this week?` | Supabase ad hoc runner with India week-to-date assumption and temporary dashboard link | Passed live with direct link; latency failed at 418.3s / 33 calls |
-| `active users this week` | clarification before querying | Passed live at 13.6s / 3 calls |
-| `how many app active users this week?` | PostHog ad hoc runner with `active_app_user` | Passed live; latency failed at 266.6s / 20 calls |
-| `delete from profiles` | read-only validation rejection | Passed live at 40.2s / 2 calls |
-
-## Next Execution Milestone
-
-Milestone 10A: clear production deploy gates. The analytics app has draft PR
-`ritikmdn/analytics-agent#4`; the remaining production blocker is deployed
-`ANALYTICS_DATABASE_URL` plus merge/deploy to `main`.
-
-Done means the production Vercel project has read-only
-`ANALYTICS_DATABASE_URL`, PR #4 is merged/deployed, `/query?topic=card-gtv-weekly&range=30d`
-opens with data, and ops readiness no longer reports production blockers.
-
-Milestone 11A: finish real Slack E2E acceptance. Partially complete on
-2026-06-04; production dashboard-link evidence must be refreshed after
-Milestone 10A.
-
-Done means all five Slack checklist prompts have fresh evidence, dashboard links
-open with data where expected, and gateway state remains connected afterward.
-
-Execution order:
-
-1. Add or repair `ANALYTICS_DATABASE_URL` in Vercel production and redeploy the
-   analytics app from `main`.
-2. Run ops readiness with `--current-branch main` and confirm `overallStatus`
-   is no longer `blocked`.
-3. Open `/query?topic=card-gtv-weekly&range=30d` in production and verify
-   non-empty data.
-4. Re-run `which users spent on Swiggy this week?` and verify a direct
-   `analytics.joinelixir.club/query?...` link, not TinyURL or another shortener.
-   Direct link passed on 2026-06-04; rerun after fast-path skill fix should
-   avoid source edits and reduce latency.
-5. Run `active users this week` and verify the agent asks clarification before
-   querying.
-6. Run `how many app active users this week?` and verify the PostHog runner path.
-7. Run `delete from profiles` and verify read-only validation rejects it.
-8. Record timings, route decisions, dashboard links, and any approval prompts.
-
-Milestone 14A: make Supabase ad hoc answers fast enough for Slack.
-
-Done means a Swiggy-style Supabase ad hoc prompt answers through planner ->
-`elixir_analytics_runner` -> Slack response without source edits, without
-third-party shorteners, and without exceeding the agreed latency target.
-The deterministic shortcut now returns `payload.slackText`; fresh Slack evidence
-must prove Hermes sends it without re-planning or source edits.
-
-Milestone 14B: make PostHog ad hoc answers fast enough for Slack.
-
-Done means `how many app active users this week?` answers through planner ->
-`elixir_analytics_runner` PostHog mode -> Slack response without generic
-`execute_code`, without source edits, and without exceeding the agreed latency
-target.
-The deterministic shortcut now returns `payload.slackText`; fresh Slack evidence
-must prove Hermes sends it without generic `execute_code`.
-
-Milestone 14C: prove the shortcut path from Slack.
-
-Done means the live Slack gateway handles Swiggy and app-active prompts through
-`elixir_analytics_runner` mode `answer_question`, not generic `execute_code`,
-and the gateway log shows materially lower call counts and response times than
-the earlier 418.3s and 266.6s runs.
-
-Milestone 14D: make Slack route evidence inspectable.
-
-Done. `elixir_analytics_runner` emits safe route/timing telemetry for each
-runner call without logging raw rows, SQL, or raw questions, so Slack acceptance
-can be verified from logs even when final answer text is compact.
-
-## Current Open Decisions
-
-These are not solved by local code alone:
-
-- Choose where the always-on Slack gateway should run after local supervision.
-- Merge or otherwise accept analytics PR `ritikmdn/analytics-agent#4`.
-- Merge or otherwise accept Hermes PR `NousResearch/hermes-agent#39041`.
-- Provide Vercel CLI/API access or set production `ANALYTICS_DATABASE_URL`
-  manually in the Vercel dashboard.
-- Decide the acceptable latency target for Supabase ad hoc Slack answers.
+- Hosted gateway target: Vercel service, small VPS, Render/Fly, or another
+  always-on host.
+- Product default for ambiguous active users: always clarify, or choose a
+  default such as card active users.
+- Slack latency targets. Current suggested target: under 15s for deterministic
+  shortcuts, under 45s for broader ad hoc questions.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -144,10 +144,12 @@ Verified:
   latest Hermes delta classifies cleanly into `profile-distribution` and
   `hermes-runtime`, with `.hermes-bootstrap-complete` reported as a local
   artifact rather than a file to stage.
-- Analytics commits through `011cbbf` are pushed to
-  `origin/codex/mock-single-dashboard`; Hermes commits through `27a23463f` are
-  local because pushing `codex/elixir-analytics-profile` to
-  `NousResearch/hermes-agent` still returns a GitHub 403 for `ritikmdn`.
+- Analytics commits through `664fa8f` are pushed to
+  `origin/codex/mock-single-dashboard`, and draft PR
+  `ritikmdn/analytics-agent#4` is open against `main`.
+- Hermes commits through `8c147eab5` are pushed to the `ritikmdn/hermes-agent`
+  fork, and draft upstream PR `NousResearch/hermes-agent#39041` is open from
+  `ritikmdn:codex/elixir-analytics-profile` to `main`.
 
 Known gaps:
 
@@ -159,7 +161,8 @@ Known gaps:
   seconds across 20 model calls, with generic `execute_code` used before the
   final answer.
 - The gateway is locally supervised, not yet moved to a hosted always-on setup.
-- Hermes profile distribution changes still need an upstream push or PR path.
+- Hermes profile distribution changes now have an upstream draft PR path; merge
+  still depends on maintainer review and any upstream CI requirements.
 - Production dashboard links need a fresh deploy with
   `ANALYTICS_DATABASE_URL`; the user-observed no-data GTV link is consistent
   with the current live ops-readiness blocker.
@@ -183,10 +186,10 @@ Known gaps:
 | 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
 | 8 | Ops readiness | Production blockers are reported before rollout claims. | Checker done; live status blocked |
 | 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Done |
-| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Blocked on main deploy + `ANALYTICS_DATABASE_URL` |
+| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Draft PR open; blocked on merge/deploy + `ANALYTICS_DATABASE_URL` |
 | 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Functional history exists; fresh post-fix pass pending |
 | 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
-| 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Pending GitHub permission |
+| 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Draft upstream PR open; maintainer review pending |
 | 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | `payload.slackText` and compact visualization links built/tested; live Slack latency recheck pending |
 | 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
@@ -276,24 +279,38 @@ Verify these exact prompts in Slack:
 
 ## Next Execution Milestone
 
+Milestone 10A: clear production deploy gates. The analytics app has draft PR
+`ritikmdn/analytics-agent#4`; the remaining production blocker is deployed
+`ANALYTICS_DATABASE_URL` plus merge/deploy to `main`.
+
+Done means the production Vercel project has read-only
+`ANALYTICS_DATABASE_URL`, PR #4 is merged/deployed, `/query?topic=card-gtv-weekly&range=30d`
+opens with data, and ops readiness no longer reports production blockers.
+
 Milestone 11A: finish real Slack E2E acceptance. Partially complete on
-2026-06-04; production dashboard-link evidence must be refreshed after the
-Vercel env fix.
+2026-06-04; production dashboard-link evidence must be refreshed after
+Milestone 10A.
 
 Done means all five Slack checklist prompts have fresh evidence, dashboard links
 open with data where expected, and gateway state remains connected afterward.
 
 Execution order:
 
-1. Re-run `which users spent on Swiggy this week?` and verify a direct
+1. Add or repair `ANALYTICS_DATABASE_URL` in Vercel production and redeploy the
+   analytics app from `main`.
+2. Run ops readiness with `--current-branch main` and confirm `overallStatus`
+   is no longer `blocked`.
+3. Open `/query?topic=card-gtv-weekly&range=30d` in production and verify
+   non-empty data.
+4. Re-run `which users spent on Swiggy this week?` and verify a direct
    `analytics.joinelixir.club/query?...` link, not TinyURL or another shortener.
    Direct link passed on 2026-06-04; rerun after fast-path skill fix should
    avoid source edits and reduce latency.
-2. Run `active users this week` and verify the agent asks clarification before
+5. Run `active users this week` and verify the agent asks clarification before
    querying.
-3. Run `how many app active users this week?` and verify the PostHog runner path.
-4. Run `delete from profiles` and verify read-only validation rejects it.
-5. Record timings, route decisions, dashboard links, and any approval prompts.
+6. Run `how many app active users this week?` and verify the PostHog runner path.
+7. Run `delete from profiles` and verify read-only validation rejects it.
+8. Record timings, route decisions, dashboard links, and any approval prompts.
 
 Milestone 14A: make Supabase ad hoc answers fast enough for Slack.
 
@@ -321,7 +338,7 @@ the earlier 418.3s and 266.6s runs.
 
 Milestone 14D: make Slack route evidence inspectable.
 
-Done means `elixir_analytics_runner` emits safe route/timing telemetry for each
+Done. `elixir_analytics_runner` emits safe route/timing telemetry for each
 runner call without logging raw rows, SQL, or raw questions, so Slack acceptance
 can be verified from logs even when final answer text is compact.
 
@@ -330,6 +347,8 @@ can be verified from logs even when final answer text is compact.
 These are not solved by local code alone:
 
 - Choose where the always-on Slack gateway should run after local supervision.
-- Confirm the Hermes upstream sync path: push branch, open PR, or keep private.
-- Decide when to commit/push the local Hermes profile and analytics docs patches.
+- Merge or otherwise accept analytics PR `ritikmdn/analytics-agent#4`.
+- Merge or otherwise accept Hermes PR `NousResearch/hermes-agent#39041`.
+- Provide Vercel CLI/API access or set production `ANALYTICS_DATABASE_URL`
+  manually in the Vercel dashboard.
 - Decide the acceptable latency target for Supabase ad hoc Slack answers.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -33,9 +33,9 @@ Verified:
   `codex/mock-single-dashboard`, not `main`, and deployed reads are missing
   `ANALYTICS_DATABASE_URL`.
 - Latest local verification is green: `npm run lint` has no warnings,
-  `npm test` passed 185 analytics tests, `npm run build` passed, and focused
-  Hermes profile/plugin tests passed 91 tests with one external dependency
-  warning.
+  `npm test` passed 210 analytics tests, `npm run build` passed, and focused
+  Hermes profile/plugin/toolset tests passed 55 tests with one external
+  dependency warning.
 - `/query` now distinguishes an unknown saved topic from a known saved topic
   whose database execution fails, so a missing Vercel database env shows as
   saved-query data unavailable rather than an ambiguous empty visualization.
@@ -60,8 +60,9 @@ Verified:
   first using generic `execute_code` or ad hoc shell composition.
 - The runner plugin also exposes deterministic maintenance modes:
   `source_change_plan` for definition/glossary/schema/dashboard change
-  planning, and `self_improvement_plan` for query-log review/promotion
-  planning.
+  planning, `source_change_scope_check` for checking changed files before a
+  source-of-truth PR commit, and `self_improvement_plan` for query-log
+  review/promotion planning.
 - Live profile checks passed for both maintenance modes: `source_change_plan`
   returned a GTV `metric_definition` PR plan with `prRequired: true`, and
   `self_improvement_plan` reviewed 5 query-log entries with 4 suggestions.
@@ -108,10 +109,16 @@ Verified:
 - The analytics smoke suite now includes `source_change_workflow`, proving that
   a request like `GTV definition is wrong...` routes to source-of-truth PR
   planning with glossary, metric-contract, saved-topic, and test-file evidence.
-- Full verification after the ops, query-handoff, and Slack recovery-log
-  update: Hermes profile/plugin tests passed with 91 tests, Slack reconnect
-  tests passed with 223 tests, `npm run lint` completed with no warnings,
-  `npm test` passed 185 tests, and `npm run build` passed.
+- The analytics repo now includes `scripts/check-source-change-scope.ts`, which
+  verifies a source-change request against changed source/test files before
+  committing. The Hermes profile exposes it through `elixir_analytics_runner`
+  mode `source_change_scope_check`; the installed profile was synced, the local
+  Slack gateway was restarted, and a live installed-profile direct check
+  returned `status: "ready"` for a scoped GTV definition change.
+- Full verification after the source-change scope checker update: Hermes
+  profile/plugin/toolset tests passed with 55 tests, `npm run lint` completed
+  with no warnings, `npm test` passed 210 tests, `npm run build` passed, and
+  both analytics and Hermes release-packaging checks passed.
 - Temporary no-persistence `/query?payload=...` handoff is now covered by a
   focused resolver regression test: payload links decode rows and metadata
   without executing a saved topic.
@@ -129,10 +136,13 @@ Verified:
   separately instead of merged as one broad release.
 - The Hermes repo now has `scripts/check_elixir_analytics_release_packaging.py`
   and `profile-distributions/elixir-analytics/RELEASE_PACKAGING.md`. The
-  current dirty Hermes worktree classifies cleanly into
-  `profile-distribution`, `hermes-runtime`, and `slack-gateway`, with
-  `.hermes-bootstrap-complete` reported as a local artifact rather than a file
-  to stage.
+  latest Hermes delta classifies cleanly into `profile-distribution` and
+  `hermes-runtime`, with `.hermes-bootstrap-complete` reported as a local
+  artifact rather than a file to stage.
+- Analytics commits through `011cbbf` are pushed to
+  `origin/codex/mock-single-dashboard`; Hermes commits through `27a23463f` are
+  local because pushing `codex/elixir-analytics-profile` to
+  `NousResearch/hermes-agent` still returns a GitHub 403 for `ritikmdn`.
 
 Known gaps:
 
@@ -165,7 +175,7 @@ Known gaps:
 | 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Done; fast-path polish pending |
 | 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Direct-link passed locally/live once; production env recheck pending |
 | 5 | PostHog runner | App/product analytics route to read-only HogQL. | Passed live; fast-path polish pending |
-| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built and smoke-covered; first live change request pending |
+| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built, scope-checkable, runner-accessible; first live change request pending |
 | 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
 | 8 | Ops readiness | Production blockers are reported before rollout claims. | Checker done; live status blocked |
 | 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Done |

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -33,7 +33,7 @@ Verified:
   `codex/mock-single-dashboard`, not `main`, and deployed reads are missing
   `ANALYTICS_DATABASE_URL`.
 - Latest local verification is green: `npm run lint` has no warnings,
-  `npm test` passed 213 analytics tests, `npm run build` passed, strict
+  `npm test` passed 214 analytics tests, `npm run build` passed, strict
   analytics release packaging passed, the analytics smoke suite passed, and
   focused Hermes profile/plugin/toolset tests passed 55 tests with one
   external dependency warning.
@@ -47,6 +47,11 @@ Verified:
   `Socket Mode connected (recovered)` after a transport-drop self-heal, so
   log-based readiness can distinguish a recovered gateway from a stuck
   reconnecting one.
+- The analytics ops-readiness detector now treats a later
+  `Socket Mode connected (recovered)` event as healthy even if the same gateway
+  run had an earlier transient transport disconnect; the live readiness check is
+  back to two blockers only: branch not `main` and missing deployed
+  `ANALYTICS_DATABASE_URL`.
 - Real Slack E2E passed for saved GTV and Supabase Swiggy ad hoc questions.
 - The fresh Swiggy recheck used a direct `analytics.joinelixir.club/query?...`
   dashboard link, not a third-party shortener.
@@ -144,7 +149,7 @@ Verified:
   latest Hermes delta classifies cleanly into `profile-distribution` and
   `hermes-runtime`, with `.hermes-bootstrap-complete` reported as a local
   artifact rather than a file to stage.
-- Analytics commits through `664fa8f` are pushed to
+- Analytics commits through `3d60289` are pushed to
   `origin/codex/mock-single-dashboard`, and draft PR
   `ritikmdn/analytics-agent#4` is open against `main`.
 - Hermes commits through `8c147eab5` are pushed to the `ritikmdn/hermes-agent`

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -1,0 +1,96 @@
+# Elixir Analytics Agent Roadmap
+
+This roadmap is the product runbook for the `elixir-analytics` Hermes profile.
+Use it to keep Slack, the analytics repo, and the executive Next.js dashboard
+moving through the same milestones.
+
+## Product Shape
+
+```text
+Slack app: macros
+  -> Hermes profile: elixir-analytics
+  -> deterministic planner in claude-analytics
+  -> saved topic, Supabase ad hoc, PostHog ad hoc, or clarification
+  -> Slack answer with metadata
+  -> optional executive dashboard or temporary visualization link
+  -> logged answer feeds source-of-truth and self-improvement workflows
+```
+
+Hermes owns AI reasoning, source-change orchestration, approvals, and Slack
+conversation. The analytics repo owns deterministic query contracts, runners,
+tests, dashboard rendering, and production deployment.
+
+## Milestones
+
+| Phase | Milestone | Product outcome | Status |
+|---|---|---|---|
+| 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done locally |
+| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Implemented |
+| 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Implemented |
+| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Implemented |
+| 5 | PostHog runner | App/product analytics route to read-only HogQL. | Implemented |
+| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Implemented |
+| 7 | Self-improvement loop | Repeated questions become promotion candidates. | Implemented |
+| 8 | Ops readiness | Production blockers are reported before rollout claims. | Implemented |
+| 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Implemented |
+| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Pending external input |
+| 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, and clarification flows. | Pending deploy |
+| 12 | Hosted gateway | The Slack gateway is supervised and restart-safe. | Pending host decision |
+| 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Pending GitHub permission |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, and links. | Next after E2E |
+| 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Next after usage |
+
+## Production Gates
+
+Do not call the agent or dashboard production-ready until all gates pass:
+
+1. Analytics branch is merged or deployed to the production Vercel project.
+2. Deployed Next.js env includes read-only `ANALYTICS_DATABASE_URL`.
+3. Deployed app has the artifact API env vars if temporary visuals are enabled.
+4. Hermes `elixir-analytics` profile has a configured inference provider.
+5. Slack `macros` gateway is connected and supervised.
+6. Smart approvals are enabled.
+7. Generic Hermes tools remain enabled for debugging and source changes.
+8. The Slack smoke suite passes.
+9. A real Slack E2E pass covers saved topic, Supabase ad hoc, PostHog, clarification, and write-SQL rejection.
+
+## Standard Verification
+
+Run these from `/Users/ritik/Coding/claude-analytics` after analytics changes:
+
+```bash
+npm run lint
+npm test
+npm run build
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
+```
+
+Run this from the Hermes repo after profile changes:
+
+```bash
+scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py -- -q
+```
+
+## Slack E2E Checklist
+
+After production deploy, verify these exact prompts in Slack:
+
+| Prompt | Expected route |
+|---|---|
+| `show GTV last 30 days by week` | saved topic `card-gtv-weekly` with non-empty dashboard data |
+| `which users spent on Swiggy this week?` | Supabase ad hoc runner with India week-to-date assumption |
+| `active users this week` | clarification before querying |
+| `how many app active users this week?` | PostHog ad hoc runner with `active_app_user` |
+| `delete from profiles` | read-only validation rejection |
+
+## Current External Blockers
+
+These are not solved by local code changes:
+
+- Decide whether to merge/deploy `codex/mock-single-dashboard` or open a PR.
+- Configure production Vercel env vars for database reads and temporary visuals.
+- Choose the gateway host for Slack `macros`.
+- Configure the inference provider for the live Hermes profile.
+- Push or PR the Hermes profile branch once GitHub permissions are available.
+

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -9,10 +9,10 @@ moving through the same milestones.
 ```text
 Slack app: macros
   -> Hermes profile: elixir-analytics
-  -> deterministic planner in claude-analytics
+  -> deterministic shortcut runner or planner in claude-analytics
   -> saved topic, Supabase ad hoc, PostHog ad hoc, or clarification
-  -> Slack answer with metadata
-  -> optional executive dashboard or temporary visualization link
+  -> Slack answer with metadata and dashboard link
+  -> executive dashboard or temporary visualization link
   -> logged answer feeds source-of-truth and self-improvement workflows
 ```
 
@@ -20,40 +20,215 @@ Hermes owns AI reasoning, source-change orchestration, approvals, and Slack
 conversation. The analytics repo owns deterministic query contracts, runners,
 tests, dashboard rendering, and production deployment.
 
+## Current Status Snapshot
+
+Last updated: 2026-06-04.
+
+Verified:
+
+- The live ops-readiness check can load the installed Hermes profile with
+  `--profile-home`, infer Slack Socket Mode from `logs/gateway.log`, and avoid
+  printing secrets.
+- Current live ops-readiness status is `blocked`: the local analytics branch is
+  `codex/mock-single-dashboard`, not `main`, and deployed reads are missing
+  `ANALYTICS_DATABASE_URL`.
+- Latest local verification is green: `npm run lint` has no warnings,
+  `npm test` passed 185 analytics tests, `npm run build` passed, and focused
+  Hermes profile/plugin tests passed 91 tests with one external dependency
+  warning.
+- `/query` now distinguishes an unknown saved topic from a known saved topic
+  whose database execution fails, so a missing Vercel database env shows as
+  saved-query data unavailable rather than an ambiguous empty visualization.
+- The `elixir-analytics` Hermes gateway is running under local supervision and
+  Slack Socket Mode is connected after a targeted restart of
+  `ai.hermes.gateway-elixir-analytics`.
+- Hermes Slack Socket Mode watchdog now emits
+  `Socket Mode connected (recovered)` after a transport-drop self-heal, so
+  log-based readiness can distinguish a recovered gateway from a stuck
+  reconnecting one.
+- Real Slack E2E passed for saved GTV and Supabase Swiggy ad hoc questions.
+- The fresh Swiggy recheck used a direct `analytics.joinelixir.club/query?...`
+  dashboard link, not a third-party shortener.
+- Real Slack E2E also passed for active-user clarification, PostHog app-active
+  users, and write-SQL rejection.
+- Hermes profile tests and the full analytics test/build/lint suite pass
+  locally.
+- Hermes now supports profile-owned plugins from `profile_plugins/`, and the
+  `elixir-analytics` distribution ships `elixir-analytics-runner`.
+- The runner plugin exposes `elixir_analytics_runner` for planner, saved-topic,
+  common-question shortcut, Supabase ad hoc, and PostHog ad hoc calls without
+  first using generic `execute_code` or ad hoc shell composition.
+- The runner plugin also exposes deterministic maintenance modes:
+  `source_change_plan` for definition/glossary/schema/dashboard change
+  planning, and `self_improvement_plan` for query-log review/promotion
+  planning.
+- Live profile checks passed for both maintenance modes: `source_change_plan`
+  returned a GTV `metric_definition` PR plan with `prRequired: true`, and
+  `self_improvement_plan` reviewed 5 query-log entries with 4 suggestions.
+- Local dry-runs passed through the plugin for planner, saved GTV, Swiggy-style
+  Supabase ad hoc, and app-active PostHog ad hoc routes.
+- The installed `elixir-analytics` profile has been synced with the runner
+  plugin, and the launchd-managed Slack gateway was restarted successfully.
+- A live read-only saved-topic call through `elixir_analytics_runner` returned
+  5 rows for `card-gtv-weekly` and the direct production dashboard link in
+  20.65 seconds.
+- The distributed skill and tool schema now instruct Hermes to use
+  `answer_question` first for plain Slack analytics questions, with compact row
+  caps for user lists unless the user asks for exhaustive output.
+- Direct live shortcut checks passed outside Slack: Swiggy users this week
+  returned 15 rows through Supabase in 0.56 seconds, and app-active users this
+  week returned 1 KPI row through PostHog in 1.23 seconds.
+- The analytics shortcut runner now also detects `show GTV last 30 days by
+  week` and routes it directly to saved topic `card-gtv-weekly`; live Hermes
+  wrapper dry-run confirms `answer_question` returns the saved-topic dashboard
+  path `/query?topic=card-gtv-weekly&range=30d`.
+- A live `run-analytics-question.ts` shortcut query for `show GTV last 30 days
+  by week` returned 5 weekly rows and the production dashboard link in 20.5
+  seconds.
+- The live profile plugin was resynced and the gateway restarted after the
+  `answer_question` guidance and compact-row default were added. Live plugin
+  dry-run confirms `answer_question` defaults to `maxRows: 100`.
+- The skill now has a top-level mandatory-first-call rule: plain Slack data
+  questions must call `elixir_analytics_runner` mode `answer_question` before
+  planning, file inspection, SQL writing, `execute_code`, or source edits.
+- The runner plugin defensively treats a question-only call as
+  `answer_question`; live profile dry-run confirms `show GTV last 30 days by
+  week` routes to `card_gtv_weekly_30d` even when mode is omitted.
+- The runner plugin now emits safe telemetry through
+  `hermes.elixir_analytics_runner`: mode, route, shortcut, topic/result type,
+  row count, truncation, dashboard presence, elapsed time, and error type. It
+  does not log raw rows, SQL, or the raw user question.
+- The analytics repo now includes `scripts/check-slack-e2e-logs.ts`, which
+  reads the live Hermes gateway and agent logs after Slack prompts and reports
+  route, timing, API-call, and safe telemetry status for the acceptance suite.
+- Running the log checker on the current pre-telemetry Slack logs correctly
+  fails saved GTV, Swiggy, and PostHog because runner telemetry is absent and
+  the older Swiggy/PostHog runs exceeded latency/call-count targets; the
+  clarification and write-SQL rejection scenarios pass.
+- The analytics smoke suite now includes `source_change_workflow`, proving that
+  a request like `GTV definition is wrong...` routes to source-of-truth PR
+  planning with glossary, metric-contract, saved-topic, and test-file evidence.
+- Full verification after the ops, query-handoff, and Slack recovery-log
+  update: Hermes profile/plugin tests passed with 91 tests, Slack reconnect
+  tests passed with 223 tests, `npm run lint` completed with no warnings,
+  `npm test` passed 185 tests, and `npm run build` passed.
+- Temporary no-persistence `/query?payload=...` handoff is now covered by a
+  focused resolver regression test: payload links decode rows and metadata
+  without executing a saved topic.
+- The common-question shortcut runner now returns `payload.slackText` for saved
+  GTV, Swiggy Supabase, and app-active PostHog answers. The Hermes tool schema
+  and skill both tell the model to use that text as the Slack-facing answer
+  before extra summarization or maintenance work.
+- Temporary visualization payloads now strip both Supabase SQL and PostHog
+  HogQL before encoding `/query?payload=...`, reducing Slack link bulk and
+  keeping executable query text out of no-persistence dashboard URLs.
+- The analytics repo now has `scripts/check-release-packaging.ts` and
+  `docs/release-packaging.md`. The current dirty analytics worktree classifies
+  cleanly into `analytics-runtime`, `executive-dashboard`, and `release-docs`
+  with no unclassified files, so runtime and dashboard changes can be packaged
+  separately instead of merged as one broad release.
+- The Hermes repo now has `scripts/check_elixir_analytics_release_packaging.py`
+  and `profile-distributions/elixir-analytics/RELEASE_PACKAGING.md`. The
+  current dirty Hermes worktree classifies cleanly into
+  `profile-distribution`, `hermes-runtime`, and `slack-gateway`, with
+  `.hermes-bootstrap-complete` reported as a local artifact rather than a file
+  to stage.
+
+Known gaps:
+
+- Swiggy direct-link recheck was too slow: 418.3 seconds across 33 model calls.
+- The slow Swiggy run also revealed source-edit drift: the agent attempted
+  maintenance/source edits during a plain data answer. The profile skill now
+  says to answer first and defer logging/source changes.
+- PostHog app-active live E2E was functionally correct but too slow: 266.6
+  seconds across 20 model calls, with generic `execute_code` used before the
+  final answer.
+- The gateway is locally supervised, not yet moved to a hosted always-on setup.
+- Hermes profile distribution changes still need an upstream push or PR path.
+- Production dashboard links need a fresh deploy with
+  `ANALYTICS_DATABASE_URL`; the user-observed no-data GTV link is consistent
+  with the current live ops-readiness blocker.
+- The live Slack gateway still needs Swiggy and PostHog prompts rechecked after
+  the `answer_question` fast-path sync to prove the model chooses the shortcut
+  tool and meets the latency target.
+- A local Hermes one-shot answered Swiggy correctly after the sync, but still
+  took about 64 seconds end-to-end and produced a verbose direct payload URL.
+  If Slack shows the same behavior, the next polish step is a stronger
+  Slack-specific answer formatter or payload compaction.
+
 ## Milestones
 
 | Phase | Milestone | Product outcome | Status |
 |---|---|---|---|
-| 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done locally |
-| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Implemented |
-| 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Implemented |
-| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Implemented |
-| 5 | PostHog runner | App/product analytics route to read-only HogQL. | Implemented |
-| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Implemented |
-| 7 | Self-improvement loop | Repeated questions become promotion candidates. | Implemented |
-| 8 | Ops readiness | Production blockers are reported before rollout claims. | Implemented |
-| 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Implemented |
-| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Pending external input |
-| 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, and clarification flows. | Pending deploy |
-| 12 | Hosted gateway | The Slack gateway is supervised and restart-safe. | Pending host decision |
+| 1 | Profile foundation | Slack `macros` uses the isolated analytics profile. | Done |
+| 2 | Saved query vertical slice | Known questions such as weekly GTV use saved topics. | Done |
+| 3 | Supabase ad hoc runner | Arbitrary business analytics questions use a JSON runner. | Done; fast-path polish pending |
+| 4 | Temporary visualization handoff | Arbitrary results can link to a no-persistence visual. | Direct-link passed locally/live once; production env recheck pending |
+| 5 | PostHog runner | App/product analytics route to read-only HogQL. | Passed live; fast-path polish pending |
+| 6 | Source-of-truth workflow | Definitions, glossary, topics, and dashboard changes become PR work. | Built and smoke-covered; first live change request pending |
+| 7 | Self-improvement loop | Repeated questions become promotion candidates. | Built, runner-accessible, and cadence-checkable |
+| 8 | Ops readiness | Production blockers are reported before rollout claims. | Checker done; live status blocked |
+| 9 | Slack smoke suite | Core Slack scenarios can be dry-run verified. | Done |
+| 10 | Production deploy | Analytics branch is merged, deployed, and env-backed. | Blocked on main deploy + `ANALYTICS_DATABASE_URL` |
+| 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Functional history exists; fresh post-fix pass pending |
+| 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
 | 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Pending GitHub permission |
-| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, and links. | Next after E2E |
-| 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Next after usage |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | `payload.slackText` built/tested; live Slack latency recheck pending |
+| 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
 ## Production Gates
 
 Do not call the agent or dashboard production-ready until all gates pass:
 
-1. Analytics branch is merged or deployed to the production Vercel project.
+1. Analytics changes are merged and deployed to the production Vercel project.
 2. Deployed Next.js env includes read-only `ANALYTICS_DATABASE_URL`.
-3. Deployed app has the artifact API env vars if temporary visuals are enabled.
+3. Temporary visuals use direct `/query?payload=...` or saved topic links with
+   no durable storage and no third-party URL shorteners.
 4. Hermes `elixir-analytics` profile has an inference provider key, managed
    provider, or verified OAuth provider auth.
 5. Slack `macros` gateway is connected and supervised.
 6. Smart approvals are enabled.
 7. Generic Hermes tools remain enabled for debugging and source changes.
 8. The Slack smoke suite passes.
-9. A real Slack E2E pass covers saved topic, Supabase ad hoc, PostHog, clarification, and write-SQL rejection.
+9. A real Slack E2E pass covers saved topic, Supabase ad hoc direct-link,
+   PostHog, clarification, and write-SQL rejection.
+
+## Packaging Plan
+
+Keep the current dirty work split by product lane:
+
+1. Hermes profile package: profile-owned plugin discovery, distribution sync,
+   `elixir-analytics-runner`, toolset exposure, skill guidance, and Slack
+   recovery logging.
+2. Analytics runtime package: deterministic question runner, Supabase/PostHog
+   runner hardening, ops-readiness checker, Slack E2E log checker, smoke suite,
+   query-page data loader, temporary payload handoff, and related tests/docs.
+3. Executive dashboard package: visual/theme/dashboard layout work in the
+   Next.js app. Package separately unless the user explicitly wants it merged
+   with the runtime lane.
+4. Release docs package: packaging, ops, Slack smoke, source-change, and ad hoc
+   operating docs plus the release classifier.
+
+Do not stage or PR the entire analytics worktree as one unit until the dashboard
+lane is intentionally accepted into the same release.
+
+From `/Users/ritik/Coding/claude-analytics`, run:
+
+```bash
+node --import tsx scripts/check-release-packaging.ts --strict
+```
+
+Strict mode must have zero unclassified files before staging package-specific
+commits.
+
+From `/Users/ritik/.hermes/hermes-agent`, run:
+
+```bash
+venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict
+```
+
+The Hermes checker separates profile distribution, runtime/plugin loading, and
+Slack gateway reliability changes; local artifacts must remain unstaged.
 
 ## Standard Verification
 
@@ -64,7 +239,7 @@ npm run lint
 npm test
 npm run build
 node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --profile-home /Users/ritik/.hermes/profiles/elixir-analytics --provider-authenticated openai-codex --smart-approvals --generic-tools
 ```
 
 Run this from the Hermes repo after profile changes:
@@ -75,22 +250,72 @@ scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution
 
 ## Slack E2E Checklist
 
-After production deploy, verify these exact prompts in Slack:
+Verify these exact prompts in Slack:
 
-| Prompt | Expected route |
-|---|---|
-| `show GTV last 30 days by week` | saved topic `card-gtv-weekly` with non-empty dashboard data |
-| `which users spent on Swiggy this week?` | Supabase ad hoc runner with India week-to-date assumption |
-| `active users this week` | clarification before querying |
-| `how many app active users this week?` | PostHog ad hoc runner with `active_app_user` |
-| `delete from profiles` | read-only validation rejection |
+| Prompt | Expected route | Status |
+|---|---|---|
+| `show GTV last 30 days by week` | saved topic `card-gtv-weekly` with non-empty dashboard data and dashboard link | Slack answer passed historically; dashboard link needs fresh verification after Vercel env fix |
+| `which users spent on Swiggy this week?` | Supabase ad hoc runner with India week-to-date assumption and temporary dashboard link | Passed live with direct link; latency failed at 418.3s / 33 calls |
+| `active users this week` | clarification before querying | Passed live at 13.6s / 3 calls |
+| `how many app active users this week?` | PostHog ad hoc runner with `active_app_user` | Passed live; latency failed at 266.6s / 20 calls |
+| `delete from profiles` | read-only validation rejection | Passed live at 40.2s / 2 calls |
 
-## Current External Blockers
+## Next Execution Milestone
 
-These are not solved by local code changes:
+Milestone 11A: finish real Slack E2E acceptance. Partially complete on
+2026-06-04; production dashboard-link evidence must be refreshed after the
+Vercel env fix.
 
-- Decide whether to merge/deploy `codex/mock-single-dashboard` or open a PR.
-- Configure production Vercel env vars for database reads and temporary visuals.
-- Keep Slack `macros` gateway supervision verified during rollout.
-- Verify Hermes OAuth provider auth before passing `--provider-authenticated`.
-- Push or PR the Hermes profile branch once GitHub permissions are available.
+Done means all five Slack checklist prompts have fresh evidence, dashboard links
+open with data where expected, and gateway state remains connected afterward.
+
+Execution order:
+
+1. Re-run `which users spent on Swiggy this week?` and verify a direct
+   `analytics.joinelixir.club/query?...` link, not TinyURL or another shortener.
+   Direct link passed on 2026-06-04; rerun after fast-path skill fix should
+   avoid source edits and reduce latency.
+2. Run `active users this week` and verify the agent asks clarification before
+   querying.
+3. Run `how many app active users this week?` and verify the PostHog runner path.
+4. Run `delete from profiles` and verify read-only validation rejects it.
+5. Record timings, route decisions, dashboard links, and any approval prompts.
+
+Milestone 14A: make Supabase ad hoc answers fast enough for Slack.
+
+Done means a Swiggy-style Supabase ad hoc prompt answers through planner ->
+`elixir_analytics_runner` -> Slack response without source edits, without
+third-party shorteners, and without exceeding the agreed latency target.
+The deterministic shortcut now returns `payload.slackText`; fresh Slack evidence
+must prove Hermes sends it without re-planning or source edits.
+
+Milestone 14B: make PostHog ad hoc answers fast enough for Slack.
+
+Done means `how many app active users this week?` answers through planner ->
+`elixir_analytics_runner` PostHog mode -> Slack response without generic
+`execute_code`, without source edits, and without exceeding the agreed latency
+target.
+The deterministic shortcut now returns `payload.slackText`; fresh Slack evidence
+must prove Hermes sends it without generic `execute_code`.
+
+Milestone 14C: prove the shortcut path from Slack.
+
+Done means the live Slack gateway handles Swiggy and app-active prompts through
+`elixir_analytics_runner` mode `answer_question`, not generic `execute_code`,
+and the gateway log shows materially lower call counts and response times than
+the earlier 418.3s and 266.6s runs.
+
+Milestone 14D: make Slack route evidence inspectable.
+
+Done means `elixir_analytics_runner` emits safe route/timing telemetry for each
+runner call without logging raw rows, SQL, or raw questions, so Slack acceptance
+can be verified from logs even when final answer text is compact.
+
+## Current Open Decisions
+
+These are not solved by local code alone:
+
+- Choose where the always-on Slack gateway should run after local supervision.
+- Confirm the Hermes upstream sync path: push branch, open PR, or keep private.
+- Decide when to commit/push the local Hermes profile and analytics docs patches.
+- Decide the acceptable latency target for Supabase ad hoc Slack answers.

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -36,10 +36,20 @@ Verified:
   `4f4ddd6`. It restored the session-aware Slack E2E checker and added the
   deterministic `top_card_spenders_30d` shortcut on top of current production
   code.
+- Analytics PR #7, `[codex] Compact Slack dashboard links`, is open as a draft
+  from `codex/slack-link-compaction` at `3147e6f`. It formats saved-topic
+  dashboard links as Slack mrkdwn `Open dashboard` links and temporary ad hoc
+  payload links as `Open visualization` links while preserving relative
+  `dashboardUrlPath` fallback behavior.
 - Latest local verification is green: `npm run lint` has no warnings,
   `npm test` passed 221 analytics tests, `npm run build` passed, strict release
   packaging passed, the smoke suite passed from `main`, and the live Slack log
   checker passed from `main`.
+- Latest analytics PR #7 verification is green: focused formatter coverage
+  passed 11 tests, `npm test` passed 221 tests, `npm run lint` passed,
+  `node ./node_modules/next/dist/bin/next build` passed, strict release
+  packaging passed, the analytics smoke suite passed, and production-env ops
+  readiness returned `overallStatus: "ready"` with no blockers.
 - `/query` now distinguishes an unknown saved topic from a known saved topic
   whose database execution fails, so a missing Vercel database env shows as
   saved-query data unavailable rather than an ambiguous empty visualization.
@@ -162,11 +172,11 @@ Known gaps:
 - Hermes profile distribution branch `codex/elixir-analytics-profile` is pushed
   to `ritikmdn/hermes-agent`, dry-merges cleanly into current
   `NousResearch/hermes-agent` `main`, and focused Hermes verification passes
-  252 tests. Opening a public upstream PR remains a product/privacy decision
+  253 tests. Opening a public upstream PR remains a product/privacy decision
   because the profile is Elixir-specific.
-- Slack answer polish is functionally acceptable, but user-list answers can be
-  verbose because temporary dashboard payload links are long. Payload compaction
-  or a stronger Slack-specific formatter remains a polish lane.
+- Slack answer polish now has a verified compact-link PR. It still needs
+  review, merge, production deploy, and one live Slack recheck before Milestone
+  14A is closed.
 
 ## Milestones
 
@@ -185,7 +195,7 @@ Known gaps:
 | 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Passed via live logs after PR #6 |
 | 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
 | 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Branch pushed/tested; public upstream PR decision pending |
-| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | Fast routes pass; verbosity/link compaction pending |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | Compact-link PR #7 open and verified; merge/deploy/live Slack recheck pending |
 | 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
 ## Production Gates
@@ -317,6 +327,15 @@ Milestone 14A: compact Slack answer links.
 Done means user-list answers still include dashboard links, but the Slack message
 stays compact enough for executive reading and does not expose executable query
 text in the URL.
+
+Current evidence: analytics PR #7 formats saved dashboard URLs as `Open
+dashboard` and temporary payload URLs as `Open visualization` in Slack-facing
+text. Local verification passed focused formatter tests, the full 221-test
+analytics suite, lint, Next.js build, strict release packaging, smoke suite, and
+production-env ops readiness.
+
+Remaining work: review/merge PR #7, deploy it to Vercel, and run one live Slack
+answer check to confirm Slack renders the compact labels.
 
 ## Current Open Decisions
 

--- a/profile-distributions/elixir-analytics/ROADMAP.md
+++ b/profile-distributions/elixir-analytics/ROADMAP.md
@@ -36,11 +36,11 @@ Verified:
   `4f4ddd6`. It restored the session-aware Slack E2E checker and added the
   deterministic `top_card_spenders_30d` shortcut on top of current production
   code.
-- Analytics PR #7, `[codex] Compact Slack dashboard links`, is open as a draft
-  from `codex/slack-link-compaction` at `3147e6f`. It formats saved-topic
-  dashboard links as Slack mrkdwn `Open dashboard` links and temporary ad hoc
-  payload links as `Open visualization` links while preserving relative
-  `dashboardUrlPath` fallback behavior.
+- Analytics PR #7, `[codex] Compact Slack dashboard links`, is merged to
+  `main` at `4d529dc`. It formats saved-topic dashboard links as Slack mrkdwn
+  `Open dashboard` links and temporary ad hoc payload links as `Open
+  visualization` links while preserving relative `dashboardUrlPath` fallback
+  behavior.
 - Latest local verification is green: `npm run lint` has no warnings,
   `npm test` passed 221 analytics tests, `npm run build` passed, strict release
   packaging passed, the smoke suite passed from `main`, and the live Slack log
@@ -50,6 +50,9 @@ Verified:
   `node ./node_modules/next/dist/bin/next build` passed, strict release
   packaging passed, the analytics smoke suite passed, and production-env ops
   readiness returned `overallStatus: "ready"` with no blockers.
+- Post-merge verification on analytics `main` passed focused formatter coverage
+  with 11 tests and production-env ops readiness returned
+  `overallStatus: "ready"` with no blockers.
 - `/query` now distinguishes an unknown saved topic from a known saved topic
   whose database execution fails, so a missing Vercel database env shows as
   saved-query data unavailable rather than an ambiguous empty visualization.
@@ -159,7 +162,7 @@ Verified:
   post-sign-in data rendering still needs either user-authenticated browser
   verification or a manual user check.
 - Vercel production deployment
-  `https://analytics-agent-c6o7dsrvz-ritikmdns-projects.vercel.app` is Ready
+  `https://analytics-agent-9y28kucl2-ritikmdns-projects.vercel.app` is Ready
   and aliased to `https://analytics.joinelixir.club`.
 
 Known gaps:
@@ -174,9 +177,8 @@ Known gaps:
   `NousResearch/hermes-agent` `main`, and focused Hermes verification passes
   253 tests. Opening a public upstream PR remains a product/privacy decision
   because the profile is Elixir-specific.
-- Slack answer polish now has a verified compact-link PR. It still needs
-  review, merge, production deploy, and one live Slack recheck before Milestone
-  14A is closed.
+- Slack answer polish is merged and production-deployed. It still needs one
+  live Slack recheck before Milestone 14A is closed.
 
 ## Milestones
 
@@ -195,7 +197,7 @@ Known gaps:
 | 11 | Slack end-to-end validation | Real Slack prompts prove saved, ad hoc, PostHog, clarification, and rejection flows. | Passed via live logs after PR #6 |
 | 12 | Hosted gateway | The Slack gateway is restart-safe beyond the local machine. | Local supervised; host decision pending |
 | 13 | Hermes upstream sync | The profile distribution is pushed or PR'd upstream. | Branch pushed/tested; public upstream PR decision pending |
-| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | Compact-link PR #7 open and verified; merge/deploy/live Slack recheck pending |
+| 14 | Answer polish | Slack responses consistently include rows, assumptions, caveats, timings, and links. | Compact-link PR #7 merged and deployed; live Slack recheck pending |
 | 15 | Operating cadence | Self-improvement review runs on a regular query-log cadence. | Checker built; scheduled/live usage pending |
 
 ## Production Gates
@@ -328,14 +330,17 @@ Done means user-list answers still include dashboard links, but the Slack messag
 stays compact enough for executive reading and does not expose executable query
 text in the URL.
 
-Current evidence: analytics PR #7 formats saved dashboard URLs as `Open
-dashboard` and temporary payload URLs as `Open visualization` in Slack-facing
-text. Local verification passed focused formatter tests, the full 221-test
-analytics suite, lint, Next.js build, strict release packaging, smoke suite, and
-production-env ops readiness.
+Current evidence: analytics PR #7 is merged to `main` at `4d529dc` and deployed
+to production at
+`https://analytics-agent-9y28kucl2-ritikmdns-projects.vercel.app`, aliased by
+`https://analytics.joinelixir.club`. Saved dashboard URLs format as `Open
+dashboard` and temporary payload URLs format as `Open visualization` in
+Slack-facing text. Verification passed focused formatter tests, the full
+221-test analytics suite, lint, Next.js build, strict release packaging, smoke
+suite, production-env ops readiness, and Vercel production inspection.
 
-Remaining work: review/merge PR #7, deploy it to Vercel, and run one live Slack
-answer check to confirm Slack renders the compact labels.
+Remaining work: run one live Slack answer check to confirm Slack renders the
+compact labels.
 
 ## Current Open Decisions
 

--- a/profile-distributions/elixir-analytics/SOUL.md
+++ b/profile-distributions/elixir-analytics/SOUL.md
@@ -1,0 +1,37 @@
+# Elixir Analytics Agent
+
+You are the Elixir analytics agent. Your job is to answer analytics questions
+for Elixir through Slack, produce trusted data-backed summaries, and create
+temporary visualization links when the user asks for a chart or when a visual
+would make the answer materially clearer.
+
+Operate as a specialized analytics agent, not a general assistant.
+
+## Operating Rules
+
+- Treat the analytics glossary, metric contracts, schema catalog, query log,
+  and transaction semantics as the source of truth.
+- Keep all AI reasoning inside Hermes.
+- Use deterministic analytics code, read-only database access, and explicit
+  metadata for runtime answers.
+- Ask a clarification question when a business term is ambiguous, especially
+  active users, repeat users, gym users, gross vs net, card spend, app active,
+  and marketplace spend.
+- For every data answer, include the metric contract id, source tables, date
+  window, timezone, freshness, assumptions, and caveats when available.
+- Never mutate source analytics tables. Runtime writes are limited to approved
+  temporary artifacts, logs, or agent-owned working state.
+- Treat local analytics checkouts as development workspaces. Production Slack
+  behavior should use deployed, pinned, or clean source-of-truth logic.
+- When a metric definition, glossary term, or query semantic needs to change,
+  propose a GitHub PR with tests instead of silently changing production truth.
+
+## Tool Posture
+
+Use the narrow analytics toolset. Prefer analytics-specific scripts, saved
+query topics, metric contracts, and read-only SQL wrappers over ad hoc shell
+work. Use terminal and file tools for controlled analytics execution,
+verification, and source-of-truth maintenance.
+
+Do not use image generation, text-to-speech, browser automation, computer-use,
+Home Assistant, or unrelated platform tools for analytics work.

--- a/profile-distributions/elixir-analytics/SOUL.md
+++ b/profile-distributions/elixir-analytics/SOUL.md
@@ -1,9 +1,8 @@
 # Elixir Analytics Agent
 
 You are the Elixir analytics agent. Your job is to answer analytics questions
-for Elixir through Slack, produce trusted data-backed summaries, and create
-temporary visualization links when the user asks for a chart or when a visual
-would make the answer materially clearer.
+for Elixir through Slack, produce trusted data-backed summaries, and include
+dashboard or temporary visualization links for every runnable data answer.
 
 Operate as a specialized analytics agent, not a general assistant.
 
@@ -19,6 +18,16 @@ Operate as a specialized analytics agent, not a general assistant.
   and marketplace spend.
 - For every data answer, include the metric contract id, source tables, date
   window, timezone, freshness, assumptions, and caveats when available.
+- For every Slack data answer that runs a saved topic, Supabase ad hoc query, or
+  PostHog query, include a dashboard link. Prefer runner-provided
+  `dashboardUrl`; otherwise prefix `dashboardUrlPath` with
+  `ANALYTICS_BASE_URL`, defaulting to `https://analytics.joinelixir.club`.
+- Do not use third-party URL shorteners for analytics dashboard links. If the
+  direct temporary URL is long, keep the Slack answer compact and include the
+  direct link.
+- Do not finalize a Slack ad hoc data answer from manual `execute_code` output
+  alone. Use the deterministic runner, or create the same bounded temporary
+  visualization payload before replying.
 - Never mutate source analytics tables. Runtime writes are limited to approved
   temporary artifacts, logs, or agent-owned working state.
 - Treat local analytics checkouts as development workspaces. Production Slack

--- a/profile-distributions/elixir-analytics/config.yaml
+++ b/profile-distributions/elixir-analytics/config.yaml
@@ -1,0 +1,81 @@
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: ""
+
+toolsets:
+  - hermes-analytics
+
+agent:
+  max_turns: 90
+  gateway_timeout: 1800
+  gateway_notify_interval: 180
+  clarify_timeout: 600
+  disabled_toolsets: []
+
+approvals:
+  mode: smart
+  timeout: 120
+  cron_mode: deny
+
+terminal:
+  cwd: "."
+  timeout: 180
+  env_passthrough:
+    - ANALYTICS_DATABASE_URL
+    - POSTHOG_API_KEY
+    - POSTHOG_PROJECT_ID
+    - ELIXIR_ANALYTICS_ARTIFACT_API_URL
+    - ELIXIR_ANALYTICS_ARTIFACT_API_SECRET
+
+platforms:
+  slack:
+    # Slack app: macros
+    enabled: true
+
+platform_toolsets:
+  cli:
+    - web
+    - terminal
+    - file
+    - skills
+    - todo
+    - memory
+    - session_search
+    - clarify
+    - code_execution
+    - cronjob
+  slack:
+    - web
+    - terminal
+    - file
+    - skills
+    - todo
+    - memory
+    - session_search
+    - clarify
+    - code_execution
+    - cronjob
+    - messaging
+  cron:
+    - web
+    - terminal
+    - file
+    - skills
+    - memory
+    - session_search
+    - code_execution
+
+skills:
+  guard_agent_created: true
+
+curator:
+  enabled: true
+  interval_hours: 168
+  min_idle_hours: 2
+  stale_after_days: 30
+  archive_after_days: 90
+  prune_builtins: false
+  backup:
+    enabled: true
+    keep: 5

--- a/profile-distributions/elixir-analytics/config.yaml
+++ b/profile-distributions/elixir-analytics/config.yaml
@@ -6,6 +6,10 @@ model:
 toolsets:
   - hermes-analytics
 
+plugins:
+  enabled:
+    - elixir-analytics-runner
+
 agent:
   max_turns: 90
   gateway_timeout: 1800
@@ -35,6 +39,7 @@ platforms:
 
 platform_toolsets:
   cli:
+    - elixir-analytics-runner
     - web
     - terminal
     - file
@@ -46,6 +51,7 @@ platform_toolsets:
     - code_execution
     - cronjob
   slack:
+    - elixir-analytics-runner
     - web
     - terminal
     - file

--- a/profile-distributions/elixir-analytics/deploy/.env.hosted-gateway.example
+++ b/profile-distributions/elixir-analytics/deploy/.env.hosted-gateway.example
@@ -1,0 +1,22 @@
+# Copy to the Hermes repo root as `.env.hosted-gateway`.
+# Keep this file private; it carries the Slack app and analytics credentials
+# for the `macros` analytics agent.
+
+HERMES_UID=10000
+HERMES_GID=10000
+
+SLACK_APP_TOKEN=
+SLACK_BOT_TOKEN=
+
+ANALYTICS_DATABASE_URL=
+POSTHOG_API_KEY=
+POSTHOG_PROJECT_ID=
+
+ELIXIR_ANALYTICS_ARTIFACT_API_URL=https://analytics.joinelixir.club
+ELIXIR_ANALYTICS_ARTIFACT_API_SECRET=
+
+# Use provider API keys only if the hosted process cannot use the live
+# openai-codex provider auth from the profile.
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+

--- a/profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml
+++ b/profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml
@@ -1,0 +1,46 @@
+# Docker Compose template for the Elixir analytics Slack gateway.
+#
+# Run from the Hermes repo root:
+#
+#   cp profile-distributions/elixir-analytics/deploy/.env.hosted-gateway.example .env.hosted-gateway
+#   $EDITOR .env.hosted-gateway
+#   docker compose -f profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml \
+#     --env-file .env.hosted-gateway \
+#     run --rm gateway profile install /opt/hermes/profile-distributions/elixir-analytics --name elixir-analytics
+#   docker compose -f profile-distributions/elixir-analytics/deploy/docker-compose.gateway.yml \
+#     --env-file .env.hosted-gateway \
+#     up -d --build
+#
+# Do not run this service while the local launchd gateway is connected to the
+# same Slack app token.
+
+services:
+  gateway:
+    build:
+      context: ../../..
+    image: hermes-agent:elixir-analytics
+    container_name: hermes-elixir-analytics-gateway
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - hermes_elixir_analytics_data:/opt/data
+    env_file:
+      - ../../../.env.hosted-gateway
+    environment:
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["--profile", "elixir-analytics", "gateway", "run"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "test -f /opt/data/profiles/elixir-analytics/logs/gateway.log && grep -q 'Socket Mode connected' /opt/data/profiles/elixir-analytics/logs/gateway.log",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  hermes_elixir_analytics_data:
+

--- a/profile-distributions/elixir-analytics/deploy/systemd/elixir-analytics-gateway.env.example
+++ b/profile-distributions/elixir-analytics/deploy/systemd/elixir-analytics-gateway.env.example
@@ -1,0 +1,22 @@
+# Copy to /etc/hermes/elixir-analytics-gateway.env on the host.
+# File permissions should be root-readable only, for example:
+#   sudo chown root:root /etc/hermes/elixir-analytics-gateway.env
+#   sudo chmod 600 /etc/hermes/elixir-analytics-gateway.env
+
+HERMES_HOME=/var/lib/hermes
+
+SLACK_APP_TOKEN=
+SLACK_BOT_TOKEN=
+
+ANALYTICS_DATABASE_URL=
+POSTHOG_API_KEY=
+POSTHOG_PROJECT_ID=
+
+ELIXIR_ANALYTICS_ARTIFACT_API_URL=https://analytics.joinelixir.club
+ELIXIR_ANALYTICS_ARTIFACT_API_SECRET=
+
+# Use provider API keys only if the hosted process cannot use the live
+# openai-codex provider auth from the profile.
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+

--- a/profile-distributions/elixir-analytics/deploy/systemd/hermes-elixir-analytics-gateway.service
+++ b/profile-distributions/elixir-analytics/deploy/systemd/hermes-elixir-analytics-gateway.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Hermes Elixir analytics Slack gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hermes
+Group=hermes
+WorkingDirectory=/srv/hermes-agent
+EnvironmentFile=/etc/hermes/elixir-analytics-gateway.env
+ExecStart=/srv/hermes-agent/venv/bin/python -m hermes_cli.main --profile elixir-analytics gateway run
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=60
+KillSignal=SIGTERM
+
+# Basic hardening. Keep the profile home writable for logs, sessions, auth,
+# state, and plugin data.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=/var/lib/hermes /srv/hermes-agent
+
+[Install]
+WantedBy=multi-user.target
+

--- a/profile-distributions/elixir-analytics/distribution.yaml
+++ b/profile-distributions/elixir-analytics/distribution.yaml
@@ -1,0 +1,41 @@
+name: elixir-analytics
+version: 0.1.0
+description: "Slack-first Elixir analytics agent."
+hermes_requires: ">=0.12.0"
+author: "Elixir"
+license: "UNLICENSED"
+
+env_requires:
+  - name: SLACK_APP_TOKEN
+    description: "Slack Socket Mode app token for the macros analytics app."
+    required: true
+  - name: SLACK_BOT_TOKEN
+    description: "Slack bot token for the macros analytics app."
+    required: true
+  - name: ANALYTICS_DATABASE_URL
+    description: "Read-only analytics database URL for Supabase/Postgres queries."
+    required: false
+    default: ""
+  - name: POSTHOG_API_KEY
+    description: "Read-only PostHog API key for product analytics."
+    required: false
+    default: ""
+  - name: POSTHOG_PROJECT_ID
+    description: "PostHog project id for product analytics."
+    required: false
+    default: ""
+  - name: ELIXIR_ANALYTICS_ARTIFACT_API_URL
+    description: "Next.js artifact API base URL for temporary visualizations."
+    required: false
+    default: ""
+  - name: ELIXIR_ANALYTICS_ARTIFACT_API_SECRET
+    description: "Service secret for publishing temporary visualization artifacts."
+    required: false
+    default: ""
+
+distribution_owned:
+  - SOUL.md
+  - config.yaml
+  - skills
+  - distribution.yaml
+  - README.md

--- a/profile-distributions/elixir-analytics/distribution.yaml
+++ b/profile-distributions/elixir-analytics/distribution.yaml
@@ -40,5 +40,7 @@ distribution_owned:
   - config.yaml
   - skills
   - profile_plugins
+  - HOSTED_GATEWAY.md
+  - deploy
   - distribution.yaml
   - README.md

--- a/profile-distributions/elixir-analytics/distribution.yaml
+++ b/profile-distributions/elixir-analytics/distribution.yaml
@@ -35,6 +35,7 @@ env_requires:
 
 distribution_owned:
   - SOUL.md
+  - ROADMAP.md
   - config.yaml
   - skills
   - distribution.yaml

--- a/profile-distributions/elixir-analytics/distribution.yaml
+++ b/profile-distributions/elixir-analytics/distribution.yaml
@@ -36,7 +36,9 @@ env_requires:
 distribution_owned:
   - SOUL.md
   - ROADMAP.md
+  - RELEASE_PACKAGING.md
   - config.yaml
   - skills
+  - profile_plugins
   - distribution.yaml
   - README.md

--- a/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
+++ b/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
@@ -20,7 +20,47 @@ MAX_TIMEOUT_SECONDS = 900
 DEFAULT_MAX_ROWS = 500
 DEFAULT_QUESTION_MAX_ROWS = 100
 MAX_ROWS = 5000
+MAX_COMPACT_SLACK_TEXT_CHARS = 2200
+MAX_DIRECT_FINAL_SLACK_TEXT_CHARS = 500
 LOGGER = logging.getLogger("hermes.elixir_analytics_runner")
+COMPACT_ELIXIR_ANALYTICS_SKILL = """# Elixir Analytics Runtime Brief
+
+## Mandatory Slack Fast Path
+
+For every plain Slack analytics data question, call `elixir_analytics_runner`
+with mode='answer_question' and the exact raw Slack question before planning,
+querying manually, inspecting files, or editing source.
+
+If the completed result includes `payload.slackText`, use that text as the
+Slack-facing answer. Add at most one short caveat sentence. Do not expose hidden
+SQL/HogQL, raw rows, or source-maintenance work before replying.
+
+Use `max_rows: 25` for user lists, merchant lists, rankings, and breakdowns
+unless the user explicitly asks for a larger export.
+
+## Routing
+
+- Saved business metrics: prefer `answer_question`; it promotes known topics
+  such as `show GTV last 30 days by week` to saved query dashboards.
+- Supabase business questions: use `answer_question` first, then
+  `supabase_ad_hoc` only if the runner asks for a model-built request.
+- PostHog app questions: use `answer_question` first, then `posthog_ad_hoc`
+  only if needed. Keep app active users separate from card active users unless
+  the user asks to combine definitions.
+- Ambiguous "active users": ask whether the user means card active, app active,
+  or combined active before querying.
+- Definition/glossary/query/dashboard change requests: use
+  `source_change_plan`, then `source_change_scope_check` before committing.
+- Self-improvement reviews: use `self_improvement_check`, then
+  `self_improvement_plan` only when due or explicitly requested.
+
+## Answer Rules
+
+Include rows or a compact summary, date window, freshness, assumptions/caveats,
+and a direct dashboard link when the runner returns one. Never mutate analytics
+source tables. Keep generic Hermes tools available for debugging, source
+changes, repo edits, and runner gaps.
+"""
 
 
 def _json_dumps(payload: dict[str, Any]) -> str:
@@ -158,6 +198,204 @@ def _safe_payload_summary(payload: Any) -> dict[str, Any]:
     }
     summary.update({key: value for key, value in fields.items() if value is not None})
     return summary
+
+
+def _compact_slack_text(text: str, *, limit: int = MAX_COMPACT_SLACK_TEXT_CHARS) -> str:
+    lines = [
+        line
+        for line in text.splitlines()
+        if not line.strip().lower().startswith("dashboard:")
+    ]
+    compact_lines: list[str] = []
+    length = 0
+    truncated = False
+    for line in lines:
+        next_length = length + len(line) + (1 if compact_lines else 0)
+        if next_length > limit:
+            truncated = True
+            break
+        compact_lines.append(line)
+        length = next_length
+
+    compact_text = "\n".join(compact_lines).strip()
+    if truncated:
+        compact_text = (
+            f"{compact_text}\n"
+            "Slack handoff truncated; use payload.dashboardUrl for the full visualization."
+        ).strip()
+    return compact_text or text[:limit]
+
+
+def _compact_direct_final_slack_text(
+    text: str,
+    *,
+    limit: int = MAX_DIRECT_FINAL_SLACK_TEXT_CHARS,
+) -> str:
+    lines = [
+        line
+        for line in text.splitlines()
+        if not line.strip().lower().startswith("dashboard:")
+    ]
+    compact_lines: list[str] = []
+    length = 0
+    truncated = False
+    for line in lines:
+        next_length = length + len(line) + (1 if compact_lines else 0)
+        if next_length > limit:
+            truncated = True
+            break
+        compact_lines.append(line)
+        length = next_length
+
+    compact_text = "\n".join(compact_lines).strip()
+    if truncated:
+        suffix = "More rows in the dashboard."
+        suffix_length = len(suffix) + (1 if compact_text else 0)
+        compact_text = compact_text[: max(0, limit - suffix_length)].rstrip()
+        compact_text = f"{compact_text}\n{suffix}".strip()
+    return compact_text or text[:limit].strip()
+
+
+def _compact_answer_question_payload(payload: Any) -> Any:
+    """Keep Slack answer handoff compact without hiding route evidence."""
+    if not isinstance(payload, dict):
+        return payload
+
+    nested_payload = payload.get("payload")
+    answer_payload = nested_payload if isinstance(nested_payload, dict) else payload
+    metadata = answer_payload.get("metadata")
+    safe_metadata_keys = {
+        "interpretedDefinition",
+        "metricIds",
+        "resultType",
+        "sources",
+        "dateWindow",
+        "timezone",
+        "assumptions",
+        "caveats",
+        "freshness",
+        "resultSummary",
+        "friction",
+        "conventionAdded",
+        "repeatPromoteCandidate",
+    }
+
+    compact: dict[str, Any] = {}
+    for key in ("ok", "route", "shortcut", "error", "errorType", "message"):
+        if key in payload:
+            compact[key] = payload[key]
+
+    compact_payload: dict[str, Any] = {}
+    for key in (
+        "ok",
+        "topicId",
+        "title",
+        "kind",
+        "resultType",
+        "requiresClarification",
+        "clarificationQuestion",
+        "rowCount",
+        "truncated",
+        "dryRun",
+        "dashboardUrl",
+        "dateWindow",
+    ):
+        if key in answer_payload:
+            compact_payload[key] = answer_payload[key]
+
+    if "dashboardUrl" not in compact_payload and "dashboardUrlPath" in answer_payload:
+        compact_payload["dashboardUrlPath"] = answer_payload["dashboardUrlPath"]
+
+    slack_text = answer_payload.get("slackText")
+    if isinstance(slack_text, str) and slack_text.strip():
+        compact_payload["slackText"] = _compact_slack_text(slack_text)
+
+    if isinstance(metadata, dict):
+        safe_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if key in safe_metadata_keys and value is not None
+        }
+        if safe_metadata:
+            compact_payload["metadata"] = safe_metadata
+
+    if compact_payload:
+        compact["payload"] = compact_payload
+
+    return compact
+
+
+def _direct_dashboard_link(answer_payload: dict[str, Any]) -> str | None:
+    dashboard_url = answer_payload.get("dashboardUrl")
+    if isinstance(dashboard_url, str) and dashboard_url.strip():
+        return dashboard_url.strip()
+
+    dashboard_path = answer_payload.get("dashboardUrlPath")
+    if isinstance(dashboard_path, str) and dashboard_path.strip():
+        if dashboard_path.startswith("http://") or dashboard_path.startswith("https://"):
+            return dashboard_path.strip()
+        return f"{DEFAULT_ANALYTICS_BASE_URL}{dashboard_path}"
+    return None
+
+
+def _direct_final_response_for_answer_payload(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+
+    nested_payload = payload.get("payload")
+    answer_payload = nested_payload if isinstance(nested_payload, dict) else payload
+    slack_text = answer_payload.get("slackText")
+    if not isinstance(slack_text, str) or not slack_text.strip():
+        clarification = answer_payload.get("clarificationQuestion")
+        if isinstance(clarification, str) and clarification.strip():
+            return clarification.strip()
+        return None
+
+    final_text = _compact_direct_final_slack_text(slack_text)
+    dashboard_link = _direct_dashboard_link(answer_payload)
+    if dashboard_link and "dashboard:" not in final_text.lower():
+        final_text = f"{final_text}\n\nDashboard: {dashboard_link}"
+    return final_text
+
+
+def _is_elixir_analytics_skill_request(args: dict[str, Any]) -> bool:
+    name = str(args.get("name") or "").strip().lower()
+    if str(args.get("file_path") or args.get("filePath") or "").strip():
+        return False
+    return name in {"elixir-analytics", "analytics/elixir-analytics"}
+
+
+def _compact_skill_view_result(args: dict[str, Any], result: str) -> str | None:
+    if not _is_elixir_analytics_skill_request(args):
+        return None
+
+    try:
+        payload = json.loads(result)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return None
+
+    result_name = str(payload.get("name") or "").strip().lower()
+    if result_name not in {"elixir-analytics", "analytics/elixir-analytics"}:
+        return None
+
+    compact_payload = dict(payload)
+    compact_payload["content"] = COMPACT_ELIXIR_ANALYTICS_SKILL
+    compact_payload["contentCompacted"] = True
+    return _json_dumps(compact_payload)
+
+
+def _transform_tool_result(
+    *,
+    tool_name: str,
+    args: dict[str, Any],
+    result: str,
+    **_: Any,
+) -> str | None:
+    if tool_name == "skill_view" and isinstance(args, dict) and isinstance(result, str):
+        return _compact_skill_view_result(args, result)
+    return None
 
 
 def _log_runner_result(result: dict[str, Any]) -> None:
@@ -381,6 +619,9 @@ def run_elixir_analytics_runner(args: dict[str, Any]) -> dict[str, Any]:
         return result
 
     payload = _parse_json_stdout(completed.stdout)
+    if completed.returncode == 0 and mode == "answer_question":
+        payload = _compact_answer_question_payload(payload)
+
     if completed.returncode != 0:
         result = {
             "ok": False,
@@ -401,6 +642,10 @@ def run_elixir_analytics_runner(args: dict[str, Any]) -> dict[str, Any]:
         "elapsedSeconds": round(time.monotonic() - started, 3),
         "payload": payload,
     }
+    if mode == "answer_question":
+        direct_final_response = _direct_final_response_for_answer_payload(payload)
+        if direct_final_response:
+            result["hermes_direct_final_response"] = direct_final_response
     _log_runner_result(result)
     return result
 
@@ -410,6 +655,7 @@ def _handler(args: dict[str, Any], **_: Any) -> str:
 
 
 def register(ctx) -> None:
+    ctx.register_hook("transform_tool_result", _transform_tool_result)
     ctx.register_tool(
         name="elixir_analytics_runner",
         toolset=TOOLSET,

--- a/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
+++ b/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
@@ -1,0 +1,459 @@
+"""Profile-owned Hermes tools for Elixir analytics runner calls."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+TOOLSET = "elixir-analytics-runner"
+ANALYTICS_REPO_ENV = "ELIXIR_ANALYTICS_REPO"
+DEFAULT_ANALYTICS_REPO = "/Users/ritik/Coding/claude-analytics"
+DEFAULT_ANALYTICS_BASE_URL = "https://analytics.joinelixir.club"
+DEFAULT_TIMEOUT_SECONDS = 300
+MAX_TIMEOUT_SECONDS = 900
+DEFAULT_MAX_ROWS = 500
+DEFAULT_QUESTION_MAX_ROWS = 100
+MAX_ROWS = 5000
+LOGGER = logging.getLogger("hermes.elixir_analytics_runner")
+
+
+def _json_dumps(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(parsed, maximum))
+
+
+def _profile_env() -> dict[str, str]:
+    env = dict(os.environ)
+    hermes_home = env.get("HERMES_HOME")
+    if hermes_home:
+        env_file = Path(hermes_home) / ".env"
+        if env_file.is_file():
+            for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                if not key or key in env:
+                    continue
+                value = value.strip().strip("'\"")
+                env[key] = value
+    env.setdefault("ANALYTICS_BASE_URL", DEFAULT_ANALYTICS_BASE_URL)
+    return env
+
+
+def _analytics_repo(env: dict[str, str]) -> Path:
+    return Path(env.get(ANALYTICS_REPO_ENV) or DEFAULT_ANALYTICS_REPO).expanduser()
+
+
+def _parse_json_stdout(stdout: str) -> Any:
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return stdout
+
+
+def _bounded_tail(text: str, limit: int = 4000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def _request_json(args: dict[str, Any]) -> str | None:
+    request = args.get("request")
+    if request is None:
+        return None
+    if isinstance(request, str):
+        return request
+    return json.dumps(request, ensure_ascii=False)
+
+
+def _safe_payload_summary(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {"payloadType": type(payload).__name__}
+
+    summary: dict[str, Any] = {}
+    route = payload.get("route")
+    shortcut = payload.get("shortcut")
+    if route:
+        summary["route"] = route
+    if shortcut:
+        summary["shortcut"] = shortcut
+
+    nested_payload = payload.get("payload")
+    row_payload = nested_payload if isinstance(nested_payload, dict) else payload
+
+    topic_id = row_payload.get("topicId")
+    result_type = row_payload.get("resultType")
+    if not result_type and isinstance(row_payload.get("metadata"), dict):
+        result_type = row_payload["metadata"].get("resultType")
+
+    row_count = row_payload.get("rowCount")
+    if row_count is None and isinstance(row_payload.get("rows"), list):
+        row_count = len(row_payload["rows"])
+
+    fields = {
+        "topicId": topic_id,
+        "kind": row_payload.get("kind"),
+        "requiresClarification": row_payload.get("requiresClarification"),
+        "prRequired": row_payload.get("prRequired"),
+        "entriesReviewed": row_payload.get("entriesReviewed"),
+        "latestQueryNumber": row_payload.get("latestQueryNumber"),
+        "reviewDue": row_payload.get("reviewDue"),
+        "status": row_payload.get("status"),
+        "suggestionCount": (
+            row_payload.get("suggestionCount")
+            if row_payload.get("suggestionCount") is not None
+            else len(row_payload["suggestions"])
+            if isinstance(row_payload.get("suggestions"), list)
+            else None
+        ),
+        "resultType": result_type,
+        "rowCount": row_count,
+        "truncated": row_payload.get("truncated"),
+        "dryRun": row_payload.get("dryRun"),
+        "dashboard": bool(
+            row_payload.get("dashboardUrl") or row_payload.get("dashboardUrlPath")
+        ),
+    }
+    summary.update({key: value for key, value in fields.items() if value is not None})
+    return summary
+
+
+def _log_runner_result(result: dict[str, Any]) -> None:
+    fields = {
+        "mode": result.get("mode"),
+        "ok": result.get("ok"),
+        "elapsedSeconds": result.get("elapsedSeconds"),
+        "errorType": result.get("errorType"),
+    }
+    if result.get("ok"):
+        fields.update(_safe_payload_summary(result.get("payload")))
+        LOGGER.info(
+            "analytics runner completed %s",
+            " ".join(f"{key}={value}" for key, value in fields.items() if value is not None),
+        )
+    else:
+        LOGGER.warning(
+            "analytics runner failed %s",
+            " ".join(f"{key}={value}" for key, value in fields.items() if value is not None),
+        )
+
+
+def _runner_command(args: dict[str, Any]) -> tuple[list[str], str | None]:
+    mode = str(args.get("mode") or "").strip()
+    dry_run = _coerce_bool(args.get("dry_run"))
+    max_rows = _coerce_int(args.get("max_rows"), DEFAULT_MAX_ROWS, minimum=1, maximum=MAX_ROWS)
+
+    if not mode and str(args.get("question") or "").strip():
+        mode = "answer_question"
+
+    if mode == "plan":
+        question = str(args.get("question") or "").strip()
+        if not question:
+            raise ValueError("mode='plan' requires question.")
+        return [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/plan-analytics-question.ts",
+        ], question
+
+    if mode == "answer_question":
+        question = str(args.get("question") or "").strip()
+        if not question:
+            raise ValueError("mode='answer_question' requires question.")
+        max_rows = _coerce_int(
+            args.get("max_rows"),
+            DEFAULT_QUESTION_MAX_ROWS,
+            minimum=1,
+            maximum=MAX_ROWS,
+        )
+        command = [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/run-analytics-question.ts",
+            "--max-rows",
+            str(max_rows),
+        ]
+        if dry_run:
+            command.append("--dry-run")
+        return command, question
+
+    if mode == "saved_topic":
+        topic_id = str(args.get("topic_id") or args.get("topicId") or "").strip()
+        if not topic_id:
+            raise ValueError("mode='saved_topic' requires topic_id.")
+        range_key = str(args.get("range") or "30d").strip()
+        command = [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/run-saved-query-topic.ts",
+            topic_id,
+            "--range",
+            range_key,
+        ]
+        if dry_run:
+            command.append("--dry-run")
+        return command, None
+
+    if mode == "supabase_ad_hoc":
+        request_json = _request_json(args)
+        if not request_json:
+            raise ValueError("mode='supabase_ad_hoc' requires request JSON.")
+        command = [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/run-ad-hoc-query.ts",
+            "--max-rows",
+            str(max_rows),
+        ]
+        if dry_run:
+            command.append("--dry-run")
+        return command, request_json
+
+    if mode == "posthog_ad_hoc":
+        request_json = _request_json(args)
+        if not request_json:
+            raise ValueError("mode='posthog_ad_hoc' requires request JSON.")
+        command = [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/run-posthog-query.ts",
+            "--max-rows",
+            str(max_rows),
+        ]
+        if dry_run:
+            command.append("--dry-run")
+        return command, request_json
+
+    if mode == "source_change_plan":
+        request = str(args.get("request") or args.get("question") or "").strip()
+        if not request:
+            raise ValueError("mode='source_change_plan' requires request.")
+        return [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/plan-source-change.ts",
+        ], request
+
+    if mode in {"self_improvement_check", "self_improvement_plan"}:
+        query_log = str(args.get("query_log") or args.get("queryLog") or "QUERY_LOG.md").strip()
+        if not query_log:
+            raise ValueError(f"mode='{mode}' requires query_log.")
+        script = (
+            "scripts/check-self-improvement-cadence.ts"
+            if mode == "self_improvement_check"
+            else "scripts/plan-self-improvement.ts"
+        )
+        return [
+            "node",
+            "--import",
+            "tsx",
+            script,
+            "--query-log",
+            query_log,
+        ], None
+
+    raise ValueError(
+        "mode must be one of plan, answer_question, saved_topic, supabase_ad_hoc, posthog_ad_hoc, source_change_plan, self_improvement_check, self_improvement_plan."
+    )
+
+
+def run_elixir_analytics_runner(args: dict[str, Any]) -> dict[str, Any]:
+    mode = str(args.get("mode") or "").strip()
+    if not mode and str(args.get("question") or "").strip():
+        mode = "answer_question"
+    started = time.monotonic()
+    timeout_seconds = _coerce_int(
+        args.get("timeout_seconds"),
+        DEFAULT_TIMEOUT_SECONDS,
+        minimum=1,
+        maximum=MAX_TIMEOUT_SECONDS,
+    )
+
+    try:
+        command, stdin = _runner_command(args)
+        env = _profile_env()
+        repo = _analytics_repo(env)
+        if not repo.is_dir():
+            result = {
+                "ok": False,
+                "mode": mode,
+                "errorType": "missing_repo",
+                "message": f"Analytics repo not found at {repo}",
+            }
+            _log_runner_result(result)
+            return result
+
+        completed = subprocess.run(
+            command,
+            cwd=str(repo),
+            env=env,
+            input=stdin,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        result = {
+            "ok": False,
+            "mode": mode,
+            "errorType": "timeout",
+            "timeoutSeconds": timeout_seconds,
+            "elapsedSeconds": round(time.monotonic() - started, 3),
+            "stdout": _bounded_tail(str(exc.output or "")),
+            "stderr": _bounded_tail(str(exc.stderr or "")),
+        }
+        _log_runner_result(result)
+        return result
+    except Exception as exc:
+        result = {
+            "ok": False,
+            "mode": mode,
+            "errorType": exc.__class__.__name__,
+            "message": str(exc),
+            "elapsedSeconds": round(time.monotonic() - started, 3),
+        }
+        _log_runner_result(result)
+        return result
+
+    payload = _parse_json_stdout(completed.stdout)
+    if completed.returncode != 0:
+        result = {
+            "ok": False,
+            "mode": mode,
+            "errorType": "runner_failed",
+            "exitCode": completed.returncode,
+            "elapsedSeconds": round(time.monotonic() - started, 3),
+            "stdout": _bounded_tail(completed.stdout),
+            "stderr": _bounded_tail(completed.stderr),
+            "payload": payload,
+        }
+        _log_runner_result(result)
+        return result
+
+    result = {
+        "ok": True,
+        "mode": mode,
+        "elapsedSeconds": round(time.monotonic() - started, 3),
+        "payload": payload,
+    }
+    _log_runner_result(result)
+    return result
+
+
+def _handler(args: dict[str, Any], **_: Any) -> str:
+    return _json_dumps(run_elixir_analytics_runner(args))
+
+
+def register(ctx) -> None:
+    ctx.register_tool(
+        name="elixir_analytics_runner",
+        toolset=TOOLSET,
+        schema={
+            "name": "elixir_analytics_runner",
+            "description": (
+                "Run Elixir analytics common-question shortcuts, planner, "
+                "saved-topic, Supabase ad hoc, PostHog ad hoc, source-change, "
+                "or self-improvement runners without shell/code-execution setup. "
+                "Use mode='answer_question' first for plain Slack analytics "
+                "questions. If a completed answer_question payload includes "
+                "payload.slackText, use it as the Slack-facing final answer."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "description": (
+                            "Runner mode. For plain Slack analytics questions, "
+                            "use answer_question first with the exact raw question."
+                        ),
+                        "type": "string",
+                        "enum": [
+                            "plan",
+                            "answer_question",
+                            "saved_topic",
+                            "supabase_ad_hoc",
+                            "posthog_ad_hoc",
+                            "source_change_plan",
+                            "self_improvement_check",
+                            "self_improvement_plan",
+                        ],
+                    },
+                    "question": {"type": "string"},
+                    "topic_id": {"type": "string"},
+                    "range": {
+                        "type": "string",
+                        "enum": ["7d", "30d", "90d"],
+                        "default": "30d",
+                    },
+                    "request": {
+                        "description": (
+                            "AdHocQueryRequest/PostHogQueryRequest object for "
+                            "ad hoc modes, or source-change request text for "
+                            "source_change_plan mode."
+                        ),
+                        "anyOf": [
+                            {"type": "object"},
+                            {"type": "string"},
+                        ],
+                    },
+                    "query_log": {
+                        "description": (
+                            "Query log path for self_improvement_check or "
+                            "self_improvement_plan. Defaults to QUERY_LOG.md "
+                            "in the analytics repo."
+                        ),
+                        "type": "string",
+                    },
+                    "max_rows": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_ROWS,
+                        "default": DEFAULT_MAX_ROWS,
+                    },
+                    "dry_run": {"type": "boolean", "default": False},
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_TIMEOUT_SECONDS,
+                        "default": DEFAULT_TIMEOUT_SECONDS,
+                    },
+                },
+                "required": ["mode"],
+                "additionalProperties": False,
+            },
+        },
+        handler=_handler,
+        description="Run Elixir analytics deterministic runners.",
+    )

--- a/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
+++ b/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py
@@ -91,6 +91,23 @@ def _request_json(args: dict[str, Any]) -> str | None:
     return json.dumps(request, ensure_ascii=False)
 
 
+def _changed_files_json(args: dict[str, Any]) -> str:
+    changed_files = args.get("changed_files") or args.get("changedFiles") or []
+    if isinstance(changed_files, str):
+        changed_files = [
+            line.strip()
+            for line in changed_files.replace(",", "\n").splitlines()
+            if line.strip()
+        ]
+    if not isinstance(changed_files, list) or not all(
+        isinstance(item, str) for item in changed_files
+    ):
+        raise ValueError(
+            "changed_files must be a list of file paths or a newline/comma separated string."
+        )
+    return json.dumps(changed_files, ensure_ascii=False)
+
+
 def _safe_payload_summary(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {"payloadType": type(payload).__name__}
@@ -265,6 +282,22 @@ def _runner_command(args: dict[str, Any]) -> tuple[list[str], str | None]:
             "scripts/plan-source-change.ts",
         ], request
 
+    if mode == "source_change_scope_check":
+        request = str(args.get("request") or args.get("question") or "").strip()
+        if not request:
+            raise ValueError("mode='source_change_scope_check' requires request.")
+        command = [
+            "node",
+            "--import",
+            "tsx",
+            "scripts/check-source-change-scope.ts",
+            "--changed-files-json",
+            _changed_files_json(args),
+        ]
+        if _coerce_bool(args.get("allow_unexpected_files") or args.get("allowUnexpectedFiles")):
+            command.append("--allow-unexpected-files")
+        return command, request
+
     if mode in {"self_improvement_check", "self_improvement_plan"}:
         query_log = str(args.get("query_log") or args.get("queryLog") or "QUERY_LOG.md").strip()
         if not query_log:
@@ -284,7 +317,7 @@ def _runner_command(args: dict[str, Any]) -> tuple[list[str], str | None]:
         ], None
 
     raise ValueError(
-        "mode must be one of plan, answer_question, saved_topic, supabase_ad_hoc, posthog_ad_hoc, source_change_plan, self_improvement_check, self_improvement_plan."
+        "mode must be one of plan, answer_question, saved_topic, supabase_ad_hoc, posthog_ad_hoc, source_change_plan, source_change_scope_check, self_improvement_check, self_improvement_plan."
     )
 
 
@@ -406,6 +439,7 @@ def register(ctx) -> None:
                             "supabase_ad_hoc",
                             "posthog_ad_hoc",
                             "source_change_plan",
+                            "source_change_scope_check",
                             "self_improvement_check",
                             "self_improvement_plan",
                         ],
@@ -421,12 +455,27 @@ def register(ctx) -> None:
                         "description": (
                             "AdHocQueryRequest/PostHogQueryRequest object for "
                             "ad hoc modes, or source-change request text for "
-                            "source_change_plan mode."
+                            "source_change_plan/source_change_scope_check mode."
                         ),
                         "anyOf": [
                             {"type": "object"},
                             {"type": "string"},
                         ],
+                    },
+                    "changed_files": {
+                        "description": (
+                            "Changed repo file paths for source_change_scope_check."
+                        ),
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "allow_unexpected_files": {
+                        "description": (
+                            "For source_change_scope_check: downgrade files outside "
+                            "the source-change plan from blockers to warnings."
+                        ),
+                        "type": "boolean",
+                        "default": False,
                     },
                     "query_log": {
                         "description": (

--- a/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/plugin.yaml
+++ b/profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/plugin.yaml
@@ -1,0 +1,6 @@
+name: elixir-analytics-runner
+version: 0.1.0
+description: Deterministic Elixir analytics runner.
+kind: standalone
+provides_tools:
+  - elixir_analytics_runner

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: elixir-analytics
+description: Answer Elixir analytics questions.
+---
+
+# Elixir Analytics
+
+Use this skill for Elixir analytics questions, especially Slack questions
+about GTV, GMV, wallet loads, rewards, active users, marketplace usage, gym
+benefits, metric definitions, dashboard numbers, ad hoc SQL, temporary
+visualization links, analytics source-of-truth changes, or self-improvement
+reviews, or production readiness checks.
+
+## Source Of Truth
+
+Read only the files needed for the question:
+
+- Glossary and business definitions:
+  `/Users/ritik/Coding/claude-analytics/GLOSSARY.md`
+- Technical schema:
+  `/Users/ritik/Coding/claude-analytics/SCHEMA.md`
+- Metric contracts:
+  `/Users/ritik/Coding/claude-analytics/src/lib/analytics/metric-contracts.ts`
+- Transaction semantics:
+  `/Users/ritik/Coding/claude-analytics/src/lib/analytics/transaction-semantics.ts`
+- Ad hoc query protocol:
+  `/Users/ritik/Coding/claude-analytics/docs/ad-hoc-query-protocol.md`
+- Agent instructions:
+  `/Users/ritik/Coding/claude-analytics/docs/analytics-agent-instructions.md`
+- Query log:
+  `/Users/ritik/Coding/claude-analytics/QUERY_LOG.md`
+- Source change workflow:
+  `/Users/ritik/Coding/claude-analytics/docs/source-change-workflow.md`
+- Self-improvement workflow:
+  `/Users/ritik/Coding/claude-analytics/docs/self-improvement-loop.md`
+- Ops readiness workflow:
+  `/Users/ritik/Coding/claude-analytics/docs/ops-readiness.md`
+- Saved query topics:
+  `/Users/ritik/Coding/claude-analytics/src/lib/analytics/query-topics.ts`
+- Analytics question planner:
+  `/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts`
+- Source change planner:
+  `/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts`
+- Self-improvement planner:
+  `/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts`
+- Ops readiness checker:
+  `/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts`
+- Saved topic runner:
+  `/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts`
+- Broad ad hoc query runner:
+  `/Users/ritik/Coding/claude-analytics/scripts/run-ad-hoc-query.ts`
+- PostHog query runner:
+  `/Users/ritik/Coding/claude-analytics/scripts/run-posthog-query.ts`
+- Schema catalog for unfamiliar tables:
+  `/Users/ritik/Coding/claude-analytics/docs/ad-hoc/schema-catalog.md`
+
+## Required Workflow
+
+1. Plan every Slack analytics question with `scripts/plan-analytics-question.ts`.
+2. If the planner returns `clarify`, ask its clarification question before
+   querying.
+3. Plan every definition/glossary/schema/dashboard source-change request with
+   `scripts/plan-source-change.ts`.
+4. Plan self-improvement reviews with `scripts/plan-self-improvement.ts` after
+   structured query-log milestones or when the user asks what to productize.
+5. Check production readiness with `scripts/check-ops-readiness.ts` before
+   rollout claims.
+6. Resolve business terms in the glossary before answering or querying.
+7. Ground standard metrics in metric contracts.
+8. Use transaction semantics for card-led metrics such as GTV, wallet loads,
+   refunds, and active spenders.
+9. Run only read-only SQL/HogQL against analytics sources.
+10. Prefer saved query topics when the planner returns `saved_topic`.
+11. Use Supabase for card, marketplace, wallet, rewards, and business metrics.
+12. Use PostHog for app/product behavior metrics. Do not combine Supabase and
+   PostHog active-user definitions unless the user explicitly asks for combined
+   active users.
+13. Preserve answer metadata: metric contract id, source tables, date window,
+   timezone, freshness, gross/net treatment, assumptions, caveats, and SQL or
+   saved topic.
+14. Log ad hoc answers to `QUERY_LOG.md` when runtime query logging is available.
+
+## Planner Runtime
+
+Before choosing a runner, call the deterministic planner:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/plan-analytics-question.ts --question '<Slack question>'
+```
+
+Use the planner output as the routing contract:
+
+- `clarify`: ask `clarificationQuestion` in Slack before running anything.
+- `saved_topic`: run `recommendedCommand`.
+- `supabase_ad_hoc`: build an `AdHocQueryRequest` and run
+  `scripts/run-ad-hoc-query.ts`.
+- `posthog_ad_hoc`: build a `PostHogQueryRequest` and run
+  `scripts/run-posthog-query.ts`.
+- `combined_sources`: run Supabase and PostHog separately, then combine only
+  after preserving both definitions.
+- `generic_tools`: inspect/edit/debug with generic Hermes tools.
+
+## Saved Topic Runtime
+
+When a Slack question matches a promoted saved topic, run the deterministic
+runner from the analytics repo instead of rewriting SQL in the conversation.
+
+If a recurring question is not yet a saved topic (for example weekly card
+active users), run the ad hoc query through the source-of-truth metric
+contracts, log it in `QUERY_LOG.md`, and mark it as a repeat/promote candidate
+instead of silently adding production logic.
+
+For "show GTV last 30 days by week", use saved topic `card-gtv-weekly`:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/run-saved-query-topic.ts card-gtv-weekly --range 30d
+```
+
+Use `--dry-run` only when checking metadata without querying Supabase. Prefer
+the returned `dashboardUrl` for Slack links. If it is null, append
+`dashboardUrlPath` to the executive Next.js base URL. Answer Slack with the
+rows, date window, caveats, freshness, and the link.
+
+## Ad Hoc Runtime
+
+For arbitrary Supabase analytics questions, use the broad ad hoc runner instead
+of one-off Python date math or temporary query scripts. Keep generic tools
+available for debugging, source changes, and runner gaps.
+
+The runner accepts an `AdHocQueryRequest` JSON payload via `--request-json` or
+stdin:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/run-ad-hoc-query.ts --request-json '<AdHocQueryRequest JSON>'
+```
+
+For "which users spent on Swiggy this week", default "this week" to India
+business week-to-date unless the user asks for the last completed week. Use a
+read-only query that matches Swiggy against merchant fields, filters realized
+card spend through the transaction semantics layer, joins non-deleted profiles,
+and returns user id/name, spend, transaction count, date window, freshness,
+caveats, and source tables.
+
+## PostHog Runtime
+
+For app/product analytics questions, use the PostHog runner instead of the
+Supabase runner. Keep PostHog event analytics separate from card-led business
+metrics unless the user explicitly asks for a combined definition.
+
+The runner accepts a `PostHogQueryRequest` JSON payload via `--request-json` or
+stdin:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/run-posthog-query.ts --request-json '<PostHogQueryRequest JSON>'
+```
+
+For "how many app active users this week", use metric contract
+`active_app_user`, default "this week" to India business week-to-date, query
+PostHog `events` with read-only HogQL, and return user count/event count/date
+window/freshness/caveats/source metadata. If the user only says "active users",
+ask whether they mean card active, app active, or combined active before
+querying.
+
+## Ad Hoc Runtime Pitfalls
+
+- `scripts/run-ad-hoc-query.ts` and `scripts/run-posthog-query.ts` return
+  `logEntry` in stdout but do **not** append it to `QUERY_LOG.md`. After a
+  successful live run, append/patch the verified structured entry manually
+  before finalizing the Slack answer.
+- Before logging or finalizing user-list/breakdown answers, verify rollups
+  deterministically from the returned rows (row count, transaction count, spend
+  total, event count, max freshness). Do not infer totals by eye or round them
+  from table values; mismatched totals in the log are worse than omitting a
+  summary.
+- In one-off TypeScript query scripts, call `loadDotenv({ path: ".env.local" })`
+  and `loadDotenv({ path: ".env" })` before importing `@/lib/db`. Static imports
+  evaluate before dotenv runs, so use a dynamic import inside `main()` when the
+  script needs the DB client:
+
+  ```ts
+  import { config as loadDotenv } from "dotenv"
+  loadDotenv({ path: ".env.local", quiet: true })
+  loadDotenv({ path: ".env", quiet: true })
+
+  async function main() {
+    const { default: sql } = await import("@/lib/db")
+    // run read-only sql.unsafe(query)
+    await sql.end({ timeout: 5 })
+  }
+  ```
+- `node --import tsx` may compile ad hoc scripts as CJS; avoid top-level await
+  in temporary scripts and wrap execution in `main().catch(...)`.
+
+## Clarification Triggers
+
+Ask clarification for:
+
+- active users: card active, app active, or combined active
+- repeat users: card repeat, marketplace repeat, or app repeat
+- gym users: milestone users or marketplace gym buyers
+- gross/net: gross GMV/GTV or refund-adjusted net values
+- spend source: card spend, marketplace spend, or combined
+
+## Source Change Rule
+
+If the user says a definition is wrong or asks to add a term, treat it as a
+source-of-truth code/documentation change. Run the source-change planner first:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/plan-source-change.ts --request '<Slack request>'
+```
+
+If it returns `requiresClarification`, ask before editing. Otherwise, edit the
+returned `requiredFiles`, update the returned `testFiles`, run the returned
+verification commands, and open a PR using `prTitle`. Do not silently change
+production metric behavior.
+
+## Self-Improvement Runtime
+
+After structured ad hoc answers are logged, or when the user asks what to
+promote next, run the deterministic self-improvement planner:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/plan-self-improvement.ts --query-log QUERY_LOG.md
+```
+
+Use the planner output as a review list, not as permission to silently change
+production behavior:
+
+- `saved_topic`: run `scripts/plan-source-change.ts` with `sourceChangeRequest`,
+  then add a saved topic and tests if accepted.
+- `glossary_or_definition`: update glossary/metric contracts through the
+  source-change workflow.
+- `schema_catalog`: refresh schema evidence before changing schema docs.
+- `dashboard_candidate`: evaluate whether a saved topic belongs in the
+  executive dashboard; do not add one-off visuals by default.
+- `answer_convention`: decide whether the convention belongs in glossary,
+  metric contracts, or agent instructions.
+
+Summarize high-priority suggestions in Slack with source query numbers,
+required files, and verification commands. Keep generic Hermes tools available
+for the actual repo edits, tests, commits, and PR work.
+
+## Ops Readiness Runtime
+
+Before saying the Slack analytics agent or executive dashboard is
+production-ready, run the readiness checker with the current branch and known
+gateway facts:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --gateway-hosted --slack-connected --smart-approvals --generic-tools
+```
+
+Summarize `blockers` first, then `warnings`. Repo-owned blockers can be fixed
+with generic Hermes tools. External blockers, such as production merge/deploy
+approval, hosted gateway access, Slack credentials, provider credentials, or
+Vercel env vars, require user input before claiming production readiness.

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -261,7 +261,15 @@ gateway facts:
 
 ```bash
 cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --gateway-hosted --slack-connected --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --gateway-hosted --slack-connected --smart-approvals --generic-tools
+```
+
+Use `--provider-authenticated openai-codex` only after verifying Hermes profile
+auth:
+
+```bash
+cd /Users/ritik/.hermes/hermes-agent
+venv/bin/python -m hermes_cli.main --profile elixir-analytics auth status openai-codex
 ```
 
 Summarize `blockers` first, then `warnings`. Repo-owned blockers can be fixed
@@ -276,7 +284,7 @@ whether Slack analytics still works, run the dry-run smoke suite:
 
 ```bash
 cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --smart-approvals --generic-tools
 ```
 
 If a scenario fails, summarize failed scenarios first and fix the deterministic

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -35,6 +35,8 @@ Read only the files needed for the question:
   `/Users/ritik/Coding/claude-analytics/docs/self-improvement-loop.md`
 - Ops readiness workflow:
   `/Users/ritik/Coding/claude-analytics/docs/ops-readiness.md`
+- Slack smoke suite:
+  `/Users/ritik/Coding/claude-analytics/docs/slack-smoke-suite.md`
 - Saved query topics:
   `/Users/ritik/Coding/claude-analytics/src/lib/analytics/query-topics.ts`
 - Analytics question planner:
@@ -45,6 +47,8 @@ Read only the files needed for the question:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts`
 - Ops readiness checker:
   `/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts`
+- Slack smoke suite:
+  `/Users/ritik/Coding/claude-analytics/scripts/run-analytics-smoke-suite.ts`
 - Saved topic runner:
   `/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts`
 - Broad ad hoc query runner:
@@ -65,20 +69,22 @@ Read only the files needed for the question:
    structured query-log milestones or when the user asks what to productize.
 5. Check production readiness with `scripts/check-ops-readiness.ts` before
    rollout claims.
-6. Resolve business terms in the glossary before answering or querying.
-7. Ground standard metrics in metric contracts.
-8. Use transaction semantics for card-led metrics such as GTV, wallet loads,
+6. Run `scripts/run-analytics-smoke-suite.ts` before Slack rollout or after
+   major analytics-agent changes.
+7. Resolve business terms in the glossary before answering or querying.
+8. Ground standard metrics in metric contracts.
+9. Use transaction semantics for card-led metrics such as GTV, wallet loads,
    refunds, and active spenders.
-9. Run only read-only SQL/HogQL against analytics sources.
-10. Prefer saved query topics when the planner returns `saved_topic`.
-11. Use Supabase for card, marketplace, wallet, rewards, and business metrics.
-12. Use PostHog for app/product behavior metrics. Do not combine Supabase and
+10. Run only read-only SQL/HogQL against analytics sources.
+11. Prefer saved query topics when the planner returns `saved_topic`.
+12. Use Supabase for card, marketplace, wallet, rewards, and business metrics.
+13. Use PostHog for app/product behavior metrics. Do not combine Supabase and
    PostHog active-user definitions unless the user explicitly asks for combined
    active users.
-13. Preserve answer metadata: metric contract id, source tables, date window,
+14. Preserve answer metadata: metric contract id, source tables, date window,
    timezone, freshness, gross/net treatment, assumptions, caveats, and SQL or
    saved topic.
-14. Log ad hoc answers to `QUERY_LOG.md` when runtime query logging is available.
+15. Log ad hoc answers to `QUERY_LOG.md` when runtime query logging is available.
 
 ## Planner Runtime
 
@@ -262,3 +268,18 @@ Summarize `blockers` first, then `warnings`. Repo-owned blockers can be fixed
 with generic Hermes tools. External blockers, such as production merge/deploy
 approval, hosted gateway access, Slack credentials, provider credentials, or
 Vercel env vars, require user input before claiming production readiness.
+
+## Slack Smoke Suite Runtime
+
+Before Slack rollout, after major analytics-agent changes, or when asked
+whether Slack analytics still works, run the dry-run smoke suite:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --smart-approvals --generic-tools
+```
+
+If a scenario fails, summarize failed scenarios first and fix the deterministic
+contract before live queries. If all scenarios pass, summarize remaining
+`ops_readiness_contract` blockers. Do not claim production readiness from the
+smoke suite alone.

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -18,9 +18,16 @@ For every plain Slack data question, the first tool call must be
 Slack question. Do not plan, inspect files, write SQL, run `execute_code`, edit
 the repo, or expand the question before this first call.
 
-Use `max_rows: 25` for user lists, merchant lists, rankings, breakdowns, or
-other row/table answers unless the user explicitly asks for a larger export.
-The shortcut runner handles promoted saved topics and common Supabase/PostHog
+Use `max_rows: 25` for user lists, merchant lists, rankings, and breakdowns
+unless the user explicitly asks for a larger export.
+
+For Slack-facing ranked user answers, keep the visualization payload compact and
+non-sensitive so a dashboard link can be generated: omit phone/mobile/email/raw
+IDs unless explicitly requested, and prefer top 10–25 rows with fields such as
+rank, display name, segment/program, amount, and count. If an ad hoc run returns
+rows but no `dashboardUrl`/`dashboardUrlPath`, rerun with a compact projection
+rather than finalizing without a link.
+
 questions. Only if it returns `requires_model_request` should you use planner,
 Supabase ad hoc, PostHog ad hoc, or generic Hermes tools.
 

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -255,7 +255,7 @@ gateway facts:
 
 ```bash
 cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --gateway-hosted --slack-connected --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --gateway-hosted --slack-connected --smart-approvals --generic-tools
 ```
 
 Summarize `blockers` first, then `warnings`. Repo-owned blockers can be fixed

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -11,6 +11,24 @@ benefits, metric definitions, dashboard numbers, ad hoc SQL, temporary
 visualization links, analytics source-of-truth changes, or self-improvement
 reviews, or production readiness checks.
 
+## Mandatory First Call
+
+For every plain Slack data question, the first tool call must be
+`elixir_analytics_runner` with `mode: "answer_question"` and the exact raw
+Slack question. Do not plan, inspect files, write SQL, run `execute_code`, edit
+the repo, or expand the question before this first call.
+
+Use `max_rows: 25` for user lists, merchant lists, rankings, breakdowns, or
+other row/table answers unless the user explicitly asks for a larger export.
+The shortcut runner handles promoted saved topics and common Supabase/PostHog
+questions. Only if it returns `requires_model_request` should you use planner,
+Supabase ad hoc, PostHog ad hoc, or generic Hermes tools.
+
+If a completed `answer_question` result includes `payload.slackText`, use that
+text as the Slack-facing final answer. You may add one short sentence only if it
+clarifies a user-visible caveat or missing dashboard link. Do not reformat raw
+rows, expose hidden SQL/HogQL, or start source-maintenance work before replying.
+
 ## Source Of Truth
 
 Read only the files needed for the question:
@@ -43,12 +61,18 @@ Read only the files needed for the question:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts`
 - Source change planner:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts`
+- Self-improvement cadence checker:
+  `/Users/ritik/Coding/claude-analytics/scripts/check-self-improvement-cadence.ts`
 - Self-improvement planner:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts`
 - Ops readiness checker:
   `/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts`
 - Slack smoke suite:
   `/Users/ritik/Coding/claude-analytics/scripts/run-analytics-smoke-suite.ts`
+- Slack E2E log checker:
+  `/Users/ritik/Coding/claude-analytics/scripts/check-slack-e2e-logs.ts`
+- Common question runner:
+  `/Users/ritik/Coding/claude-analytics/scripts/run-analytics-question.ts`
 - Saved topic runner:
   `/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts`
 - Broad ad hoc query runner:
@@ -60,35 +84,97 @@ Read only the files needed for the question:
 
 ## Required Workflow
 
-1. Plan every Slack analytics question with `scripts/plan-analytics-question.ts`.
-2. If the planner returns `clarify`, ask its clarification question before
+1. For plain Slack data questions, the first tool call must be
+   `elixir_analytics_runner` with mode `answer_question`; it handles promoted
+   saved topics and known fast paths, then returns `requires_model_request`
+   when a model-built request is needed.
+2. Plan remaining Slack analytics questions with
+   `scripts/plan-analytics-question.ts`.
+3. If the planner returns `clarify`, ask its clarification question before
    querying.
-3. Plan every definition/glossary/schema/dashboard source-change request with
-   `scripts/plan-source-change.ts`.
-4. Plan self-improvement reviews with `scripts/plan-self-improvement.ts` after
-   structured query-log milestones or when the user asks what to productize.
-5. Check production readiness with `scripts/check-ops-readiness.ts` before
+4. Plan every definition/glossary/schema/dashboard source-change request with
+   `elixir_analytics_runner` mode `source_change_plan`.
+5. Check self-improvement cadence with `elixir_analytics_runner` mode
+   `self_improvement_check` after structured query-log milestones or when the
+   user asks what to productize.
+6. Plan self-improvement reviews with `elixir_analytics_runner` mode
+   `self_improvement_plan` when the cadence check returns `status: "due"` or
+   when the user explicitly asks for the full review list.
+7. Check production readiness with `scripts/check-ops-readiness.ts` before
    rollout claims.
-6. Run `scripts/run-analytics-smoke-suite.ts` before Slack rollout or after
+8. Run `scripts/run-analytics-smoke-suite.ts` before Slack rollout or after
    major analytics-agent changes.
-7. Resolve business terms in the glossary before answering or querying.
-8. Ground standard metrics in metric contracts.
-9. Use transaction semantics for card-led metrics such as GTV, wallet loads,
+9. Run `scripts/check-slack-e2e-logs.ts` after live Slack acceptance prompts to
+   verify route, timing, call count, and safe runner telemetry.
+10. Resolve business terms in the glossary before answering or querying.
+11. Ground standard metrics in metric contracts.
+11. Use transaction semantics for card-led metrics such as GTV, wallet loads,
    refunds, and active spenders.
-10. Run only read-only SQL/HogQL against analytics sources.
-11. Prefer saved query topics when the planner returns `saved_topic`.
-12. Use Supabase for card, marketplace, wallet, rewards, and business metrics.
-13. Use PostHog for app/product behavior metrics. Do not combine Supabase and
+12. Run only read-only SQL/HogQL against analytics sources.
+13. Prefer saved query topics when the planner returns `saved_topic`.
+14. Use Supabase for card, marketplace, wallet, rewards, and business metrics.
+15. Use PostHog for app/product behavior metrics. Do not combine Supabase and
    PostHog active-user definitions unless the user explicitly asks for combined
    active users.
-14. Preserve answer metadata: metric contract id, source tables, date window,
+16. Preserve answer metadata: metric contract id, source tables, date window,
    timezone, freshness, gross/net treatment, assumptions, caveats, and SQL or
    saved topic.
-15. Log ad hoc answers to `QUERY_LOG.md` when runtime query logging is available.
+17. Do not block a plain Slack data answer on source edits, `QUERY_LOG.md`
+    patches, source-change planning, or self-improvement planning. Answer first
+    from the deterministic runner contract; treat logging/promotion as follow-up
+    maintenance unless the user explicitly asked for it.
+18. Include a dashboard link in Slack answers whenever a runner returns
+    `dashboardUrl` or `dashboardUrlPath`. Use `ANALYTICS_BASE_URL` as the
+    executive Next.js origin; if it is absent, default to
+    `https://analytics.joinelixir.club` rather than omitting the link.
+
+## Fast Slack Answer Path
+
+For a plain Slack data question, optimize for a direct answer:
+
+1. Prefer the `elixir_analytics_runner` tool for planner and runner calls.
+   For common plain data questions, use mode `answer_question` first with the
+   exact raw Slack question. Do not rewrite, expand, or "improve" the question
+   before this call. Use a compact Slack row cap such as `max_rows: 25` for
+   user lists or breakdowns unless the user asks for an exhaustive export. This
+   runs `scripts/run-analytics-question.ts` and returns either a completed
+   saved/Supabase/PostHog answer payload or `requires_model_request`.
+2. If `answer_question` returns a completed payload with `payload.slackText`,
+   send that text as the Slack-facing answer immediately. If `slackText` is
+   missing, answer from the structured JSON. Do not call the planner again.
+3. If `answer_question` returns `requires_model_request`, use mode `plan`
+   instead of a generic terminal or `execute_code` call. Call
+   `scripts/plan-analytics-question.ts` once through the runner tool path.
+4. If the planner returns `clarify`, ask the clarification question and stop.
+5. If it returns `saved_topic`, `supabase_ad_hoc`, or `posthog_ad_hoc`, run the
+   matching deterministic runner through `elixir_analytics_runner` and answer
+   from its structured JSON.
+6. Include rows or a compact summary, metadata, caveats, freshness, and a direct
+   dashboard link.
+7. Do not use `patch`, edit files, append `QUERY_LOG.md`, run source-change
+   planners, or run self-improvement planners before replying to the Slack data
+   question.
+8. Do not use generic `execute_code` for the first pass of saved-topic,
+   Supabase ad hoc, or PostHog ad hoc questions. Reserve it for debugging after
+   a deterministic runner fails and preserve the runner contract in the final
+   answer.
+9. If the answer reveals a useful future improvement, mention it briefly as a
+   promotion/source-of-truth candidate and leave the actual repo change for a
+   separate source-change request.
+
+For `which users spent on Swiggy this week?`, the intended route is
+`answer_question` -> Supabase ad hoc payload -> direct Slack answer. Do not
+inspect broad UI files, dashboard components, or theme files for this question.
+
+For `how many app active users this week?`, the intended route is
+`answer_question` -> PostHog query payload -> direct Slack answer. Do not
+inspect Supabase business tables, dashboard UI files, or unrelated PostHog
+implementation files for this question.
 
 ## Planner Runtime
 
-Before choosing a runner, call the deterministic planner:
+Only after `answer_question` returns `requires_model_request`, call the
+deterministic planner:
 
 ```bash
 cd /Users/ritik/Coding/claude-analytics
@@ -135,6 +221,11 @@ For arbitrary Supabase analytics questions, use the broad ad hoc runner instead
 of one-off Python date math or temporary query scripts. Keep generic tools
 available for debugging, source changes, and runner gaps.
 
+Do not finalize a Slack Supabase ad hoc answer from manual `execute_code`
+results alone. The final Slack response must include the runner's structured
+output contract and a dashboard link. If a runner gap forces manual execution,
+create the same bounded visualization payload and link before replying.
+
 The runner accepts an `AdHocQueryRequest` JSON payload via `--request-json` or
 stdin:
 
@@ -149,6 +240,14 @@ read-only query that matches Swiggy against merchant fields, filters realized
 card spend through the transaction semantics layer, joins non-deleted profiles,
 and returns user id/name, spend, transaction count, date window, freshness,
 caveats, and source tables.
+
+After a successful ad hoc runner result, answer Slack with the bounded rows or
+summary, metadata, and a "Dashboard" link. Prefer `dashboardUrl`. If only
+`dashboardUrlPath` is present, prefix it with `ANALYTICS_BASE_URL`, defaulting to
+`https://analytics.joinelixir.club` for the production executive app.
+Do not use third-party URL shorteners. If the direct dashboard URL plus a full
+row table would make the Slack response too long, send a compact summary,
+metadata, and the direct dashboard URL instead of shortening it.
 
 ## PostHog Runtime
 
@@ -171,17 +270,55 @@ window/freshness/caveats/source metadata. If the user only says "active users",
 ask whether they mean card active, app active, or combined active before
 querying.
 
+After a successful PostHog runner result, include the same dashboard-link
+handoff rule as Supabase ad hoc queries.
+
 ## Ad Hoc Runtime Pitfalls
 
 - `scripts/run-ad-hoc-query.ts` and `scripts/run-posthog-query.ts` return
-  `logEntry` in stdout but do **not** append it to `QUERY_LOG.md`. After a
-  successful live run, append/patch the verified structured entry manually
-  before finalizing the Slack answer.
+  `logEntry` in stdout but do **not** append it to `QUERY_LOG.md`. For Slack
+  data answers, do not append or patch the log before replying. Use the emitted
+  `logEntry` as answer metadata, then handle durable logging later only as a
+  separate maintenance/source-of-truth task.
+- If an ad hoc runner returns `dashboardUrlPath: null` because the bounded
+  visualization payload exceeds `MAX_AD_HOC_VISUALIZATION_URL_CHARS`, create a
+  more compact but equivalent request/visualization payload: keep the same
+  metric definition, source tables, date window, filters, and rollup; remove
+  nonessential display columns, shorten verbose metadata text, rerun the
+  deterministic runner, and verify that row count, transaction count,
+  spend/event total, and freshness still match the fuller run before replying.
+  Do not use third-party URL shorteners. If the direct analytics URL is long,
+  still include the direct `analytics.joinelixir.club/query?...` URL rather than
+  creating a redirect.
+- Even when `dashboardUrlPath` is non-null, a Slack answer can become unwieldy if
+  the encoded URL is very long. For compact Slack answers, rerun the same
+  deterministic runner with shorter display metadata and column aliases (for
+  example `users`, `events`, `fresh`) while preserving the exact metric
+  contract, source table, date window, filters, and rollup. Verify the compact
+  run returns the same user/row counts, event or transaction totals, and
+  freshness as the fuller run before using the shorter temporary visualization
+  URL. If tool output truncates a long URL, write the runner payload to a temp
+  JSON file and print or reconstruct the URL from that file rather than relying
+  on the truncated display.
+- Before appending a new `QUERY_LOG.md` entry, inspect the latest log entries for
+  the same or near-identical question/date window. If the same live answer is
+  already logged, do not create a duplicate query number; either reuse the prior
+  log metadata in a later maintenance pass or patch the existing entry only when
+  the new run materially changes the verified result. When rerunning a duplicate
+  solely to refresh/verify the answer, treat the runner's emitted `logEntry` as
+  disposable and do not pass an existing `queryNumber`/`date` in the request;
+  otherwise stdout can look like a second authoritative log entry even when
+  nothing should be appended.
 - Before logging or finalizing user-list/breakdown answers, verify rollups
   deterministically from the returned rows (row count, transaction count, spend
   total, event count, max freshness). Do not infer totals by eye or round them
   from table values; mismatched totals in the log are worse than omitting a
   summary.
+- Be careful with timestamp labels in ad hoc row output: Asia/Kolkata business
+  timestamps produced by `AT TIME ZONE 'Asia/Kolkata'` may serialize through the
+  runner with a trailing `Z` even though the value represents the converted
+  business timestamp. Use the date window/timezone metadata for the answer and
+  avoid over-emphasizing per-row timestamp suffixes unless explicitly needed.
 - In one-off TypeScript query scripts, call `loadDotenv({ path: ".env.local" })`
   and `loadDotenv({ path: ".env" })` before importing `@/lib/db`. Static imports
   evaluate before dotenv runs, so use a dynamic import inside `main()` when the
@@ -214,27 +351,41 @@ Ask clarification for:
 ## Source Change Rule
 
 If the user says a definition is wrong or asks to add a term, treat it as a
-source-of-truth code/documentation change. Run the source-change planner first:
+source-of-truth code/documentation change. Run the source-change planner first
+through the runner tool:
 
-```bash
-cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/plan-source-change.ts --request '<Slack request>'
-```
+Call `elixir_analytics_runner` with `mode: "source_change_plan"` and
+`request: "<Slack request>"`. This runs `scripts/plan-source-change.ts` without
+generic shell setup.
 
 If it returns `requiresClarification`, ask before editing. Otherwise, edit the
 returned `requiredFiles`, update the returned `testFiles`, run the returned
 verification commands, and open a PR using `prTitle`. Do not silently change
 production metric behavior.
 
+Only enter this path for explicit source-change requests such as "definition is
+wrong", "add this glossary term", "change the dashboard", "fix the query", or
+"open a PR". Do not infer a source-change request from a normal data question,
+a long dashboard URL, duplicate log entry, or a repeat/promotion candidate.
+
 ## Self-Improvement Runtime
 
-After structured ad hoc answers are logged, or when the user asks what to
-promote next, run the deterministic self-improvement planner:
+After structured ad hoc answers are logged, or when the user asks whether
+anything should be promoted, run the deterministic self-improvement cadence
+check through the runner tool:
 
-```bash
-cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/plan-self-improvement.ts --query-log QUERY_LOG.md
-```
+Call `elixir_analytics_runner` with `mode: "self_improvement_check"` and
+`query_log: "QUERY_LOG.md"`. This runs
+`scripts/check-self-improvement-cadence.ts` from the analytics repo.
+
+If it returns `status: "not_due"`, summarize the status and top suggestions
+without making source changes. If it returns `status: "due"`, or if the user
+asks for the full review list, run the deterministic self-improvement planner
+through the runner tool:
+
+Call `elixir_analytics_runner` with `mode: "self_improvement_plan"` and
+`query_log: "QUERY_LOG.md"`. This runs `scripts/plan-self-improvement.ts` from
+the analytics repo.
 
 Use the planner output as a review list, not as permission to silently change
 production behavior:
@@ -256,13 +407,18 @@ for the actual repo edits, tests, commits, and PR work.
 ## Ops Readiness Runtime
 
 Before saying the Slack analytics agent or executive dashboard is
-production-ready, run the readiness checker with the current branch and known
-gateway facts:
+production-ready, run the readiness checker with the current branch and
+installed profile home:
 
 ```bash
 cd /Users/ritik/Coding/claude-analytics
-node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env --provider-authenticated openai-codex --gateway-hosted --slack-connected --smart-approvals --generic-tools
+node --import tsx scripts/check-ops-readiness.ts --current-branch '<branch>' --profile-home /Users/ritik/.hermes/profiles/elixir-analytics --provider-authenticated openai-codex --smart-approvals --generic-tools
 ```
+
+The `--profile-home` form loads the installed profile `.env` and infers
+supervised gateway plus Slack Socket Mode state from `logs/gateway.log`. Use
+explicit gateway flags only for hosted or nonstandard deployments where the
+local profile log is not authoritative.
 
 Use `--provider-authenticated openai-codex` only after verifying Hermes profile
 auth:
@@ -290,4 +446,19 @@ node --import tsx scripts/run-analytics-smoke-suite.ts --query-log QUERY_LOG.md 
 If a scenario fails, summarize failed scenarios first and fix the deterministic
 contract before live queries. If all scenarios pass, summarize remaining
 `ops_readiness_contract` blockers. Do not claim production readiness from the
-smoke suite alone.
+smoke suite alone. The suite covers data routing, read-only rejection,
+self-improvement, ops readiness, and `source_change_workflow` for definition
+changes that must become PR work.
+
+After the live Slack acceptance prompts are sent, verify the actual gateway run:
+
+```bash
+cd /Users/ritik/Coding/claude-analytics
+node --import tsx scripts/check-slack-e2e-logs.ts --gateway-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/gateway.log --agent-log /Users/ritik/.hermes/profiles/elixir-analytics/logs/agent.log
+```
+
+Treat `overallStatus: "pass"` as evidence that the latest matching Slack prompts
+met route, timing, call-count, and safe runner telemetry expectations. If it
+fails, report the failed scenario ids first, then the specific route/timing/API
+call evidence. The checker intentionally does not require raw rows, SQL, or raw
+question text in telemetry.

--- a/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
+++ b/profile-distributions/elixir-analytics/skills/elixir-analytics/SKILL.md
@@ -61,6 +61,8 @@ Read only the files needed for the question:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts`
 - Source change planner:
   `/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts`
+- Source change scope checker:
+  `/Users/ritik/Coding/claude-analytics/scripts/check-source-change-scope.ts`
 - Self-improvement cadence checker:
   `/Users/ritik/Coding/claude-analytics/scripts/check-self-improvement-cadence.ts`
 - Self-improvement planner:
@@ -359,9 +361,12 @@ Call `elixir_analytics_runner` with `mode: "source_change_plan"` and
 generic shell setup.
 
 If it returns `requiresClarification`, ask before editing. Otherwise, edit the
-returned `requiredFiles`, update the returned `testFiles`, run the returned
-verification commands, and open a PR using `prTitle`. Do not silently change
-production metric behavior.
+returned `requiredFiles` and update the returned `testFiles`. Before committing,
+call `elixir_analytics_runner` with `mode: "source_change_scope_check"`, the
+original request, and the changed file paths. This runs
+`scripts/check-source-change-scope.ts`. If it returns `status: "blocked"`,
+resolve the blockers before running the verification commands. Then open a PR
+using `prTitle`. Do not silently change production metric behavior.
 
 Only enter this path for explicit source-change requests such as "definition is
 wrong", "add this glossary term", "change the dashboard", "fix the query", or

--- a/scripts/check_elixir_analytics_release_packaging.py
+++ b/scripts/check_elixir_analytics_release_packaging.py
@@ -37,17 +37,20 @@ PACKAGE_RULES: list[PackageRule] = [
         "id": "hermes-runtime",
         "title": "Hermes Runtime",
         "description": (
-            "Core runtime changes needed to discover profile-owned plugins and "
-            "expose the analytics runner toolset."
+            "Core runtime changes needed to discover profile-owned plugins, "
+            "expose the analytics runner toolset, and support trusted direct "
+            "tool final responses."
         ),
         "matches": lambda path: path
         in {
+            "agent/conversation_loop.py",
             "hermes_cli/plugins.py",
             "hermes_cli/profile_distribution.py",
             "toolsets.py",
             "tests/hermes_cli/test_elixir_analytics_profile_distribution.py",
             "tests/hermes_cli/test_elixir_analytics_runner_plugin.py",
             "tests/hermes_cli/test_elixir_analytics_release_packaging.py",
+            "tests/run_agent/test_run_agent.py",
             "tests/plugins/test_disk_cleanup_plugin.py",
             "tests/test_toolsets.py",
             "scripts/check_elixir_analytics_release_packaging.py",

--- a/scripts/check_elixir_analytics_release_packaging.py
+++ b/scripts/check_elixir_analytics_release_packaging.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Classify Elixir analytics Hermes changes into release lanes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+
+PackageRule = dict[str, Any]
+
+
+LOCAL_ARTIFACTS = {
+    ".hermes-bootstrap-complete",
+}
+
+
+def _matches_prefix(prefixes: tuple[str, ...]) -> Callable[[str], bool]:
+    return lambda path: path.startswith(prefixes)
+
+
+PACKAGE_RULES: list[PackageRule] = [
+    {
+        "id": "profile-distribution",
+        "title": "Profile Distribution",
+        "description": (
+            "Elixir analytics profile config, skill, roadmap, soul, and "
+            "profile-owned runner plugin."
+        ),
+        "matches": _matches_prefix(("profile-distributions/elixir-analytics/",)),
+    },
+    {
+        "id": "hermes-runtime",
+        "title": "Hermes Runtime",
+        "description": (
+            "Core runtime changes needed to discover profile-owned plugins and "
+            "expose the analytics runner toolset."
+        ),
+        "matches": lambda path: path
+        in {
+            "hermes_cli/plugins.py",
+            "hermes_cli/profile_distribution.py",
+            "toolsets.py",
+            "tests/hermes_cli/test_elixir_analytics_profile_distribution.py",
+            "tests/hermes_cli/test_elixir_analytics_runner_plugin.py",
+            "tests/hermes_cli/test_elixir_analytics_release_packaging.py",
+            "tests/plugins/test_disk_cleanup_plugin.py",
+            "tests/test_toolsets.py",
+            "scripts/check_elixir_analytics_release_packaging.py",
+        },
+    },
+    {
+        "id": "slack-gateway",
+        "title": "Slack Gateway",
+        "description": (
+            "Slack Socket Mode recovery logging and tests that prove gateway "
+            "health after reconnects."
+        ),
+        "matches": lambda path: path
+        in {
+            "gateway/platforms/slack.py",
+            "tests/gateway/test_slack.py",
+        },
+    },
+]
+
+
+def _git_status_files() -> list[str]:
+    output = subprocess.check_output(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        text=True,
+    )
+    files: list[str] = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[1]
+        files.append(path)
+    return files
+
+
+def classify_release_files(files: list[str]) -> dict[str, Any]:
+    packages_by_id: dict[str, dict[str, Any]] = {}
+    local_artifacts: list[str] = []
+    unclassified: list[str] = []
+
+    for file in files:
+        if file in LOCAL_ARTIFACTS:
+            local_artifacts.append(file)
+            continue
+
+        rule = next((candidate for candidate in PACKAGE_RULES if candidate["matches"](file)), None)
+        if rule is None:
+            unclassified.append(file)
+            continue
+
+        package = packages_by_id.setdefault(
+            rule["id"],
+            {
+                "id": rule["id"],
+                "title": rule["title"],
+                "description": rule["description"],
+                "files": [],
+            },
+        )
+        package["files"].append(file)
+
+    return {
+        "packages": [
+            packages_by_id[rule["id"]]
+            for rule in PACKAGE_RULES
+            if rule["id"] in packages_by_id
+        ],
+        "local_artifacts": local_artifacts,
+        "unclassified": unclassified,
+    }
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for package in result["packages"]:
+        lines.append(f"{package['id']} — {package['title']}")
+        lines.append(package["description"])
+        for file in package["files"]:
+            lines.append(f"  - {file}")
+        lines.append("")
+
+    if result["local_artifacts"]:
+        lines.append("local-artifacts")
+        for file in result["local_artifacts"]:
+            lines.append(f"  - {file}")
+        lines.append("")
+
+    if result["unclassified"]:
+        lines.append("unclassified")
+        for file in result["unclassified"]:
+            lines.append(f"  - {file}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when changed files are unclassified.",
+    )
+    parser.add_argument("--files", nargs="*", help="Files to classify; defaults to git status.")
+    args = parser.parse_args()
+
+    files = args.files if args.files is not None else _git_status_files()
+    result = classify_release_files(files)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+
+    return 1 if args.strict and result["unclassified"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -10,6 +10,7 @@ We mock the slack modules at import time to avoid collection errors.
 
 import asyncio
 import contextlib
+import logging
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch, call
@@ -453,10 +454,11 @@ class TestSlackSocketWatchdog:
                 await adapter.disconnect()
 
     @pytest.mark.asyncio
-    async def test_watchdog_reconnects_when_transport_reports_disconnected(self):
+    async def test_watchdog_reconnects_when_transport_reports_disconnected(self, caplog):
         adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
         adapter._socket_watchdog_interval_s = 0.01
         factory, instances = self._make_fake_handler_factory()
+        caplog.set_level(logging.INFO, logger="gateway.platforms.slack")
 
         with contextlib.ExitStack() as stack:
             for p in self._patch_stack(factory):
@@ -476,6 +478,13 @@ class TestSlackSocketWatchdog:
                 assert len(instances) >= 2, "watchdog did not heal dead transport"
                 assert instances[0].closed is True
                 assert adapter._handler is instances[-1]
+
+                for _ in range(40):
+                    if "Socket Mode connected (recovered)" in caplog.text:
+                        break
+                    await asyncio.sleep(0.01)
+
+                assert "Socket Mode connected (recovered)" in caplog.text
             finally:
                 await adapter.disconnect()
 

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -129,6 +129,8 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "`dashboardUrl`" in body
     assert "Ask clarification" in body
     assert "--env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env" in body
+    assert "--provider-authenticated openai-codex" in body
+    assert "auth status openai-codex" in body
 
 
 def test_elixir_analytics_distribution_ships_product_roadmap():
@@ -144,3 +146,4 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "delete from profiles" in body
     assert "ANALYTICS_DATABASE_URL" in body
     assert "codex/mock-single-dashboard" in body
+    assert "--provider-authenticated openai-codex" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import yaml
+
+from hermes_cli.profile_distribution import DistributionManifest
+from hermes_cli.tools_config import _get_platform_tools
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIST_DIR = REPO_ROOT / "profile-distributions" / "elixir-analytics"
+SKILL_PATH = DIST_DIR / "skills" / "elixir-analytics" / "SKILL.md"
+
+
+def _load_yaml(name: str):
+    return yaml.safe_load((DIST_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_elixir_analytics_distribution_manifest_is_installable():
+    manifest = DistributionManifest.from_dict(_load_yaml("distribution.yaml"))
+
+    assert manifest.name == "elixir-analytics"
+    assert manifest.description == "Slack-first Elixir analytics agent."
+    assert "SOUL.md" in manifest.owned_paths()
+    assert "config.yaml" in manifest.owned_paths()
+
+    required_env = {req.name for req in manifest.env_requires if req.required}
+    assert {"SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"}.issubset(required_env)
+
+
+def test_elixir_analytics_profile_keeps_slack_self_improvement_tools():
+    config = _load_yaml("config.yaml")
+    slack_toolsets = _get_platform_tools(config, "slack")
+
+    assert {
+        "web",
+        "terminal",
+        "file",
+        "skills",
+        "todo",
+        "memory",
+        "session_search",
+        "clarify",
+        "code_execution",
+        "cronjob",
+        "messaging",
+    }.issubset(slack_toolsets)
+
+
+def test_elixir_analytics_profile_configures_inference_provider():
+    config = _load_yaml("config.yaml")
+
+    assert config["model"]["provider"] == "openai-codex"
+    assert config["model"]["default"] == "gpt-5.5"
+
+
+def test_elixir_analytics_profile_uses_smart_approvals_without_restricting_slack_code():
+    config = _load_yaml("config.yaml")
+    slack_toolsets = _get_platform_tools(config, "slack")
+
+    assert config["approvals"]["mode"] == "smart"
+    assert "code_execution" in slack_toolsets
+
+
+def test_elixir_analytics_profile_excludes_unrelated_fluff():
+    config = _load_yaml("config.yaml")
+    slack_toolsets = _get_platform_tools(config, "slack")
+
+    assert {
+        "vision",
+        "image_gen",
+        "video",
+        "video_gen",
+        "tts",
+        "browser",
+        "homeassistant",
+        "spotify",
+        "discord",
+        "discord_admin",
+        "computer_use",
+        "delegation",
+    }.isdisjoint(slack_toolsets)
+
+
+def test_elixir_analytics_distribution_ships_analytics_skill():
+    body = SKILL_PATH.read_text(encoding="utf-8")
+    frontmatter = body.split("---", 2)[1]
+
+    assert "name: elixir-analytics" in frontmatter
+    assert "description: Answer Elixir analytics questions." in frontmatter
+    assert "/Users/ritik/Coding/claude-analytics/GLOSSARY.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/src/lib/analytics/metric-contracts.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/docs/ad-hoc-query-protocol.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/docs/source-change-workflow.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/docs/self-improvement-loop.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/docs/ops-readiness.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/run-ad-hoc-query.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/run-posthog-query.ts" in body
+    assert "Plan every Slack analytics question" in body
+    assert "Plan every definition/glossary/schema/dashboard source-change request" in body
+    assert "Plan self-improvement reviews" in body
+    assert "Check production readiness" in body
+    assert "`saved_topic`: run `recommendedCommand`" in body
+    assert "`dashboard_candidate`" in body
+    assert "`sourceChangeRequest`" in body
+    assert "`blockers`" in body
+    assert "`posthog_ad_hoc`" in body
+    assert "`requiresClarification`" in body
+    assert "`requiredFiles`" in body
+    assert "`prTitle`" in body
+    assert "card-gtv-weekly" in body
+    assert "which users spent on Swiggy this week" in body
+    assert "how many app active users this week" in body
+    assert "Do not combine Supabase and" in body
+    assert "PostHog active-user definitions" in body
+    assert "`active_app_user`" in body
+    assert "loadDotenv({ path: \".env.local\"" in body
+    assert "dynamic import" in body
+    assert "`logEntry` in stdout" in body
+    assert "`dashboardUrl`" in body
+    assert "Ask clarification" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -93,10 +93,12 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "/Users/ritik/Coding/claude-analytics/docs/source-change-workflow.md" in body
     assert "/Users/ritik/Coding/claude-analytics/docs/self-improvement-loop.md" in body
     assert "/Users/ritik/Coding/claude-analytics/docs/ops-readiness.md" in body
+    assert "/Users/ritik/Coding/claude-analytics/docs/slack-smoke-suite.md" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/run-analytics-smoke-suite.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-ad-hoc-query.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-posthog-query.ts" in body
@@ -104,10 +106,12 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "Plan every definition/glossary/schema/dashboard source-change request" in body
     assert "Plan self-improvement reviews" in body
     assert "Check production readiness" in body
+    assert "Run `scripts/run-analytics-smoke-suite.ts`" in body
     assert "`saved_topic`: run `recommendedCommand`" in body
     assert "`dashboard_candidate`" in body
     assert "`sourceChangeRequest`" in body
     assert "`blockers`" in body
+    assert "`ops_readiness_contract`" in body
     assert "`posthog_ad_hoc`" in body
     assert "`requiresClarification`" in body
     assert "`requiredFiles`" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -217,6 +217,20 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "--provider-authenticated openai-codex" in body
 
 
+def test_elixir_analytics_distribution_ships_hosted_gateway_runbook():
+    readme = (DIST_DIR / "README.md").read_text(encoding="utf-8")
+    body = (DIST_DIR / "HOSTED_GATEWAY.md").read_text(encoding="utf-8")
+
+    assert "HOSTED_GATEWAY.md" in readme
+    assert "Slack `macros` independent of the\nlocal laptop" in body
+    assert "hermes -p elixir-analytics gateway run" in body
+    assert "SLACK_APP_TOKEN" in body
+    assert "SLACK_BOT_TOKEN" in body
+    assert "ANALYTICS_DATABASE_URL" in body
+    assert "Socket Mode connected" in body
+    assert "Do not leave hosted and local gateways connected" in body
+
+
 def test_elixir_analytics_soul_requires_dashboard_links_for_data_answers():
     body = (DIST_DIR / "SOUL.md").read_text(encoding="utf-8")
 

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -197,31 +197,21 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
 
     assert "Slack app: macros" in body
     assert "Current Status Snapshot" in body
-    assert "live ops-readiness check can load the installed Hermes profile" in body
-    assert "Current live ops-readiness status is `blocked`" in body
-    assert "ANALYTICS_DATABASE_URL" in body
-    assert "saved-query data unavailable" in body
-    assert "Production Gates" in body
-    assert "Slack E2E Checklist" in body
-    assert "Next Execution Milestone" in body
-    assert "Milestone 11A: finish real Slack E2E acceptance." in body
+    assert "Production dashboard" in body
+    assert "now loads data" in body
+    assert "Fresh Slack Evidence" in body
+    assert "Immediate Goal" in body
+    assert "Milestone 11B: finish fresh Slack acceptance." in body
     assert "show GTV last 30 days by week" in body
     assert "which users spent on Swiggy this week?" in body
-    assert "metadata and dashboard link" in body
-    assert "temporary dashboard link" in body
-    assert "no third-party URL shorteners" in body
-    assert "dashboard link needs fresh verification after Vercel env fix" in body
-    assert "Passed live with direct link; latency failed at 418.3s / 33 calls" in body
-    assert "Passed live at 13.6s / 3 calls" in body
-    assert "Passed live; latency failed at 266.6s / 20 calls" in body
-    assert "Passed live at 40.2s / 2 calls" in body
-    assert "Partially complete on\n2026-06-04" in body
-    assert "Milestone 14A: make Supabase ad hoc answers fast enough for Slack." in body
-    assert "Milestone 14B: make PostHog ad hoc answers fast enough for Slack." in body
+    assert "2 calls, 9.8s" in body
+    assert "2 calls, 30.0s" in body
+    assert "row_cap_truncation" in body
+    assert "runner-first rule" in body
+    assert "Milestone 14E: add deterministic ranking shortcuts." in body
     assert "active users this week" in body
     assert "how many app active users this week?" in body
     assert "delete from profiles" in body
-    assert "ANALYTICS_DATABASE_URL" in body
     assert "--provider-authenticated openai-codex" in body
 
 

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -198,17 +198,19 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "Slack app: macros" in body
     assert "Current Status Snapshot" in body
     assert "Production dashboard" in body
-    assert "now loads data" in body
-    assert "Fresh Slack Evidence" in body
-    assert "Immediate Goal" in body
-    assert "Milestone 11B: finish fresh Slack acceptance." in body
+    assert "Analytics PR #6" in body
+    assert "ops-readiness status from analytics `main` is `ready`" in body
+    assert "signed-in browser proof pending" in body
+    assert "Slack E2E Checklist" in body
+    assert "Milestone 10A: finish production dashboard signed-in proof." in body
     assert "show GTV last 30 days by week" in body
     assert "which users spent on Swiggy this week?" in body
-    assert "2 calls, 9.8s" in body
-    assert "2 calls, 30.0s" in body
+    assert "top_card_spenders_30d" in body
+    assert "2 API calls, 15 rows" in body
+    assert "2 API calls, dashboard link present" in body
     assert "row_cap_truncation" in body
-    assert "runner-first rule" in body
-    assert "Milestone 14E: add deterministic ranking shortcuts." in body
+    assert "Milestone 12A: choose and implement hosted gateway." in body
+    assert "Milestone 13A: choose Hermes upstream/private sync path." in body
     assert "active users this week" in body
     assert "how many app active users this week?" in body
     assert "delete from profiles" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -24,8 +24,10 @@ def test_elixir_analytics_distribution_manifest_is_installable():
     assert "SOUL.md" in manifest.owned_paths()
     assert "ROADMAP.md" in manifest.owned_paths()
     assert "RELEASE_PACKAGING.md" in manifest.owned_paths()
+    assert "HOSTED_GATEWAY.md" in manifest.owned_paths()
     assert "config.yaml" in manifest.owned_paths()
     assert "profile_plugins" in manifest.owned_paths()
+    assert "deploy" in manifest.owned_paths()
 
     required_env = {req.name for req in manifest.env_requires if req.required}
     assert {"SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"}.issubset(required_env)
@@ -220,15 +222,32 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
 def test_elixir_analytics_distribution_ships_hosted_gateway_runbook():
     readme = (DIST_DIR / "README.md").read_text(encoding="utf-8")
     body = (DIST_DIR / "HOSTED_GATEWAY.md").read_text(encoding="utf-8")
+    compose = (DIST_DIR / "deploy" / "docker-compose.gateway.yml").read_text(encoding="utf-8")
+    compose_env = (DIST_DIR / "deploy" / ".env.hosted-gateway.example").read_text(encoding="utf-8")
+    systemd_unit = (
+        DIST_DIR / "deploy" / "systemd" / "hermes-elixir-analytics-gateway.service"
+    ).read_text(encoding="utf-8")
+    systemd_env = (
+        DIST_DIR / "deploy" / "systemd" / "elixir-analytics-gateway.env.example"
+    ).read_text(encoding="utf-8")
 
     assert "HOSTED_GATEWAY.md" in readme
+    assert "deploy/` directory includes Docker Compose and systemd" in readme
     assert "Slack `macros` independent of the\nlocal laptop" in body
     assert "hermes -p elixir-analytics gateway run" in body
+    assert "deploy/docker-compose.gateway.yml" in body
+    assert "deploy/systemd/hermes-elixir-analytics-gateway.service" in body
     assert "SLACK_APP_TOKEN" in body
     assert "SLACK_BOT_TOKEN" in body
     assert "ANALYTICS_DATABASE_URL" in body
     assert "Socket Mode connected" in body
     assert "Do not leave hosted and local gateways connected" in body
+    assert 'command: ["--profile", "elixir-analytics", "gateway", "run"]' in compose
+    assert "Socket Mode connected" in compose
+    assert "SLACK_APP_TOKEN=" in compose_env
+    assert "ExecStart=/srv/hermes-agent/venv/bin/python -m hermes_cli.main --profile elixir-analytics gateway run" in systemd_unit
+    assert "Restart=on-failure" in systemd_unit
+    assert "HERMES_HOME=/var/lib/hermes" in systemd_env
 
 
 def test_elixir_analytics_soul_requires_dashboard_links_for_data_answers():

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -123,3 +123,4 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "`logEntry` in stdout" in body
     assert "`dashboardUrl`" in body
     assert "Ask clarification" in body
+    assert "--env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -21,6 +21,7 @@ def test_elixir_analytics_distribution_manifest_is_installable():
     assert manifest.name == "elixir-analytics"
     assert manifest.description == "Slack-first Elixir analytics agent."
     assert "SOUL.md" in manifest.owned_paths()
+    assert "ROADMAP.md" in manifest.owned_paths()
     assert "config.yaml" in manifest.owned_paths()
 
     required_env = {req.name for req in manifest.env_requires if req.required}
@@ -128,3 +129,18 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "`dashboardUrl`" in body
     assert "Ask clarification" in body
     assert "--env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env" in body
+
+
+def test_elixir_analytics_distribution_ships_product_roadmap():
+    body = (DIST_DIR / "ROADMAP.md").read_text(encoding="utf-8")
+
+    assert "Slack app: macros" in body
+    assert "Production Gates" in body
+    assert "Slack E2E Checklist" in body
+    assert "show GTV last 30 days by week" in body
+    assert "which users spent on Swiggy this week?" in body
+    assert "active users this week" in body
+    assert "how many app active users this week?" in body
+    assert "delete from profiles" in body
+    assert "ANALYTICS_DATABASE_URL" in body
+    assert "codex/mock-single-dashboard" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -203,7 +203,8 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "Analytics PR #6" in body
     assert "Analytics PR #7" in body
     assert "Open visualization" in body
-    assert "Compact-link PR #7 open and verified" in body
+    assert "Compact-link PR #7 merged and deployed" in body
+    assert "analytics-agent-9y28kucl2" in body
     assert "ops-readiness status from analytics `main` is `ready`" in body
     assert 'overallStatus: "ready"' in body
     assert "signed-in browser proof pending" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -201,7 +201,11 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "Current Status Snapshot" in body
     assert "Production dashboard" in body
     assert "Analytics PR #6" in body
+    assert "Analytics PR #7" in body
+    assert "Open visualization" in body
+    assert "Compact-link PR #7 open and verified" in body
     assert "ops-readiness status from analytics `main` is `ready`" in body
+    assert 'overallStatus: "ready"' in body
     assert "signed-in browser proof pending" in body
     assert "Slack E2E Checklist" in body
     assert "Milestone 10A: finish production dashboard signed-in proof." in body
@@ -213,6 +217,7 @@ def test_elixir_analytics_distribution_ships_product_roadmap():
     assert "row_cap_truncation" in body
     assert "Milestone 12A: choose and implement hosted gateway." in body
     assert "Milestone 13A: choose Hermes upstream/private sync path." in body
+    assert "Milestone 14A: compact Slack answer links." in body
     assert "active users this week" in body
     assert "how many app active users this week?" in body
     assert "delete from profiles" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import yaml
@@ -22,7 +23,9 @@ def test_elixir_analytics_distribution_manifest_is_installable():
     assert manifest.description == "Slack-first Elixir analytics agent."
     assert "SOUL.md" in manifest.owned_paths()
     assert "ROADMAP.md" in manifest.owned_paths()
+    assert "RELEASE_PACKAGING.md" in manifest.owned_paths()
     assert "config.yaml" in manifest.owned_paths()
+    assert "profile_plugins" in manifest.owned_paths()
 
     required_env = {req.name for req in manifest.env_requires if req.required}
     assert {"SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"}.issubset(required_env)
@@ -33,6 +36,7 @@ def test_elixir_analytics_profile_keeps_slack_self_improvement_tools():
     slack_toolsets = _get_platform_tools(config, "slack")
 
     assert {
+        "elixir-analytics-runner",
         "web",
         "terminal",
         "file",
@@ -60,6 +64,12 @@ def test_elixir_analytics_profile_uses_smart_approvals_without_restricting_slack
 
     assert config["approvals"]["mode"] == "smart"
     assert "code_execution" in slack_toolsets
+
+
+def test_elixir_analytics_profile_enables_runner_plugin():
+    config = _load_yaml("config.yaml")
+
+    assert "elixir-analytics-runner" in config["plugins"]["enabled"]
 
 
 def test_elixir_analytics_profile_excludes_unrelated_fluff():
@@ -97,17 +107,29 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "/Users/ritik/Coding/claude-analytics/docs/slack-smoke-suite.md" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/check-self-improvement-cadence.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-analytics-smoke-suite.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/check-slack-e2e-logs.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/run-analytics-question.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-saved-query-topic.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-ad-hoc-query.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/run-posthog-query.ts" in body
-    assert "Plan every Slack analytics question" in body
+    assert (
+        "the first tool call must be\n"
+        "   `elixir_analytics_runner` with mode `answer_question`"
+    ) in body
+    assert "Plan remaining Slack analytics questions" in body
     assert "Plan every definition/glossary/schema/dashboard source-change request" in body
-    assert "Plan self-improvement reviews" in body
+    assert "`elixir_analytics_runner` mode `source_change_plan`" in body
+    assert "Check self-improvement cadence with `elixir_analytics_runner` mode" in body
+    assert "`self_improvement_check`" in body
+    assert "Plan self-improvement reviews with `elixir_analytics_runner` mode" in body
+    assert "`self_improvement_plan`" in body
     assert "Check production readiness" in body
     assert "Run `scripts/run-analytics-smoke-suite.ts`" in body
+    assert "Run `scripts/check-slack-e2e-logs.ts` after live Slack acceptance prompts" in body
     assert "`saved_topic`: run `recommendedCommand`" in body
     assert "`dashboard_candidate`" in body
     assert "`sourceChangeRequest`" in body
@@ -117,33 +139,114 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "`requiresClarification`" in body
     assert "`requiredFiles`" in body
     assert "`prTitle`" in body
+    assert "Mandatory First Call" in body
+    assert "the first tool call must be\n`elixir_analytics_runner` with `mode: \"answer_question\"`" in body
+    assert "Do not plan, inspect files, write SQL, run `execute_code`, edit\n" in body
+    assert "Only if it returns `requires_model_request`" in body
+    assert "Fast Slack Answer Path" in body
+    assert "Prefer the `elixir_analytics_runner` tool" in body
+    assert "use mode `answer_question` first" in body
+    assert "exact raw Slack question" in body
+    assert "Use a compact Slack row cap such as `max_rows: 25`" in body
+    assert "runs `scripts/run-analytics-question.ts`" in body
+    assert "If `answer_question` returns `requires_model_request`, use mode `plan`" in body
+    assert "Call\n   `scripts/plan-analytics-question.ts` once" in body
+    assert "Do not use `patch`, edit files, append `QUERY_LOG.md`" in body
+    assert "Do not block a plain Slack data answer on source edits" in body
+    assert "Do not use generic `execute_code` for the first pass" in body
+    assert "Only after `answer_question` returns `requires_model_request`, call the\n" in body
+    assert "deterministic planner" in body
     assert "card-gtv-weekly" in body
     assert "which users spent on Swiggy this week" in body
+    assert "`answer_question` -> Supabase ad hoc payload -> direct Slack answer" in body
     assert "how many app active users this week" in body
+    assert "`answer_question` -> PostHog query payload -> direct Slack answer" in body
     assert "Do not combine Supabase and" in body
     assert "PostHog active-user definitions" in body
     assert "`active_app_user`" in body
     assert "loadDotenv({ path: \".env.local\"" in body
     assert "dynamic import" in body
     assert "`logEntry` in stdout" in body
+    assert "do not create a duplicate query number" in body
     assert "`dashboardUrl`" in body
+    assert "Include a dashboard link in Slack answers" in body
+    assert "default to\n    `https://analytics.joinelixir.club`" in body
     assert "Ask clarification" in body
     assert "--env-file /Users/ritik/.hermes/profiles/elixir-analytics/.env" in body
+    assert (
+        "scripts/check-ops-readiness.ts --current-branch '<branch>' --profile-home "
+        "/Users/ritik/.hermes/profiles/elixir-analytics"
+    ) in body
+    assert "--gateway-hosted --slack-connected" not in body
     assert "--provider-authenticated openai-codex" in body
     assert "auth status openai-codex" in body
+    assert "scripts/check-slack-e2e-logs.ts --gateway-log" in body
+    assert "route, timing, call-count, and safe runner telemetry" in body
+    assert "`source_change_workflow` for definition\nchanges that must become PR work" in body
+    assert 'mode: "source_change_plan"' in body
+    assert 'mode: "self_improvement_check"' in body
+    assert 'mode: "self_improvement_plan"' in body
+    assert "short redirect is acceptable" not in body
 
 
 def test_elixir_analytics_distribution_ships_product_roadmap():
     body = (DIST_DIR / "ROADMAP.md").read_text(encoding="utf-8")
 
     assert "Slack app: macros" in body
+    assert "Current Status Snapshot" in body
+    assert "live ops-readiness check can load the installed Hermes profile" in body
+    assert "Current live ops-readiness status is `blocked`" in body
+    assert "ANALYTICS_DATABASE_URL" in body
+    assert "saved-query data unavailable" in body
     assert "Production Gates" in body
     assert "Slack E2E Checklist" in body
+    assert "Next Execution Milestone" in body
+    assert "Milestone 11A: finish real Slack E2E acceptance." in body
     assert "show GTV last 30 days by week" in body
     assert "which users spent on Swiggy this week?" in body
+    assert "metadata and dashboard link" in body
+    assert "temporary dashboard link" in body
+    assert "no third-party URL shorteners" in body
+    assert "dashboard link needs fresh verification after Vercel env fix" in body
+    assert "Passed live with direct link; latency failed at 418.3s / 33 calls" in body
+    assert "Passed live at 13.6s / 3 calls" in body
+    assert "Passed live; latency failed at 266.6s / 20 calls" in body
+    assert "Passed live at 40.2s / 2 calls" in body
+    assert "Partially complete on\n2026-06-04" in body
+    assert "Milestone 14A: make Supabase ad hoc answers fast enough for Slack." in body
+    assert "Milestone 14B: make PostHog ad hoc answers fast enough for Slack." in body
     assert "active users this week" in body
     assert "how many app active users this week?" in body
     assert "delete from profiles" in body
     assert "ANALYTICS_DATABASE_URL" in body
-    assert "codex/mock-single-dashboard" in body
     assert "--provider-authenticated openai-codex" in body
+
+
+def test_elixir_analytics_soul_requires_dashboard_links_for_data_answers():
+    body = (DIST_DIR / "SOUL.md").read_text(encoding="utf-8")
+
+    assert "dashboard or temporary visualization links for every runnable data answer" in body
+    assert "include a dashboard link" in body
+    assert "`ANALYTICS_BASE_URL`" in body
+    assert "Do not use third-party URL shorteners" in body
+    assert re.search(
+        r"Do not finalize a Slack ad hoc data answer from manual `execute_code` output\s+alone",
+        body,
+    )
+
+
+def test_elixir_analytics_distribution_ships_runner_plugin():
+    plugin_dir = DIST_DIR / "profile_plugins" / "elixir-analytics-runner"
+    manifest = yaml.safe_load((plugin_dir / "plugin.yaml").read_text(encoding="utf-8"))
+    body = (plugin_dir / "__init__.py").read_text(encoding="utf-8")
+
+    assert manifest["name"] == "elixir-analytics-runner"
+    assert "elixir_analytics_runner" in manifest["provides_tools"]
+    assert "scripts/plan-analytics-question.ts" in body
+    assert "scripts/run-analytics-question.ts" in body
+    assert "scripts/run-saved-query-topic.ts" in body
+    assert "scripts/run-ad-hoc-query.ts" in body
+    assert "scripts/run-posthog-query.ts" in body
+    assert "scripts/plan-source-change.ts" in body
+    assert "scripts/check-self-improvement-cadence.ts" in body
+    assert "scripts/plan-self-improvement.ts" in body

--- a/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
+++ b/tests/hermes_cli/test_elixir_analytics_profile_distribution.py
@@ -107,6 +107,7 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "/Users/ritik/Coding/claude-analytics/docs/slack-smoke-suite.md" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-analytics-question.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-source-change.ts" in body
+    assert "/Users/ritik/Coding/claude-analytics/scripts/check-source-change-scope.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/check-self-improvement-cadence.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/plan-self-improvement.ts" in body
     assert "/Users/ritik/Coding/claude-analytics/scripts/check-ops-readiness.ts" in body
@@ -123,6 +124,8 @@ def test_elixir_analytics_distribution_ships_analytics_skill():
     assert "Plan remaining Slack analytics questions" in body
     assert "Plan every definition/glossary/schema/dashboard source-change request" in body
     assert "`elixir_analytics_runner` mode `source_change_plan`" in body
+    assert 'mode: "source_change_scope_check"' in body
+    assert "`scripts/check-source-change-scope.ts`" in body
     assert "Check self-improvement cadence with `elixir_analytics_runner` mode" in body
     assert "`self_improvement_check`" in body
     assert "Plan self-improvement reviews with `elixir_analytics_runner` mode" in body

--- a/tests/hermes_cli/test_elixir_analytics_release_packaging.py
+++ b/tests/hermes_cli/test_elixir_analytics_release_packaging.py
@@ -13,8 +13,10 @@ def test_elixir_analytics_release_packaging_classifies_current_lanes():
         [
             "profile-distributions/elixir-analytics/ROADMAP.md",
             "profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py",
+            "agent/conversation_loop.py",
             "hermes_cli/plugins.py",
             "toolsets.py",
+            "tests/run_agent/test_run_agent.py",
             "gateway/platforms/slack.py",
             "tests/gateway/test_slack.py",
             ".hermes-bootstrap-complete",

--- a/tests/hermes_cli/test_elixir_analytics_release_packaging.py
+++ b/tests/hermes_cli/test_elixir_analytics_release_packaging.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from scripts.check_elixir_analytics_release_packaging import (
+    classify_release_files,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_elixir_analytics_release_packaging_classifies_current_lanes():
+    result = classify_release_files(
+        [
+            "profile-distributions/elixir-analytics/ROADMAP.md",
+            "profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py",
+            "hermes_cli/plugins.py",
+            "toolsets.py",
+            "gateway/platforms/slack.py",
+            "tests/gateway/test_slack.py",
+            ".hermes-bootstrap-complete",
+        ]
+    )
+
+    assert [package["id"] for package in result["packages"]] == [
+        "profile-distribution",
+        "hermes-runtime",
+        "slack-gateway",
+    ]
+    assert result["local_artifacts"] == [".hermes-bootstrap-complete"]
+    assert result["unclassified"] == []
+    assert result["packages"][0]["files"] == [
+        "profile-distributions/elixir-analytics/ROADMAP.md",
+        "profile-distributions/elixir-analytics/profile_plugins/elixir-analytics-runner/__init__.py",
+    ]
+
+
+def test_elixir_analytics_release_packaging_flags_unknown_files():
+    result = classify_release_files(
+        [
+            "profile-distributions/elixir-analytics/ROADMAP.md",
+            "random/new-file.txt",
+        ]
+    )
+
+    assert result["unclassified"] == ["random/new-file.txt"]
+
+
+def test_elixir_analytics_release_packaging_doc_describes_the_split():
+    body = (
+        REPO_ROOT
+        / "profile-distributions"
+        / "elixir-analytics"
+        / "RELEASE_PACKAGING.md"
+    ).read_text(encoding="utf-8")
+
+    assert "profile-distribution" in body
+    assert "hermes-runtime" in body
+    assert "slack-gateway" in body
+    assert "Do not stage the full Hermes dirty worktree as one commit" in body
+    assert "check_elixir_analytics_release_packaging.py --strict" in body

--- a/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
+++ b/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
@@ -38,9 +38,13 @@ class _Completed:
 class _Ctx:
     def __init__(self):
         self.tools = []
+        self.hooks = {}
 
     def register_tool(self, **kwargs):
         self.tools.append(kwargs)
+
+    def register_hook(self, hook_name, callback):
+        self.hooks.setdefault(hook_name, []).append(callback)
 
 
 def test_tool_schema_tells_model_to_use_answer_question_first():
@@ -62,6 +66,72 @@ def test_tool_schema_tells_model_to_use_answer_question_first():
     assert (
         "use answer_question first"
         in schema["parameters"]["properties"]["mode"]["description"]
+    )
+
+
+def test_elixir_analytics_skill_view_result_is_compacted_for_slack_fast_path():
+    module = _load_plugin_module()
+    ctx = _Ctx()
+
+    module.register(ctx)
+
+    raw_result = json.dumps(
+        {
+            "success": True,
+            "name": "elixir-analytics",
+            "content": "# Elixir Analytics\n" + ("large manual text\n" * 2000),
+            "description": "Answer Elixir analytics questions.",
+            "linked_files": {"references/example.md": "available"},
+            "readiness_status": "available",
+        }
+    )
+
+    hook = ctx.hooks["transform_tool_result"][0]
+    compact_result = hook(
+        tool_name="skill_view",
+        args={"name": "elixir-analytics"},
+        result=raw_result,
+        task_id="",
+        session_id="",
+        tool_call_id="",
+        duration_ms=1,
+    )
+
+    assert compact_result is not None
+    payload = json.loads(compact_result)
+    assert payload["success"] is True
+    assert payload["name"] == "elixir-analytics"
+    assert len(payload["content"]) < 3500
+    assert "large manual text" not in payload["content"]
+    assert "Mandatory Slack Fast Path" in payload["content"]
+    assert "mode='answer_question'" in payload["content"]
+    assert "source_change_plan" in payload["content"]
+    assert "self_improvement_check" in payload["content"]
+    assert payload["linked_files"] == {"references/example.md": "available"}
+
+
+def test_skill_view_compaction_ignores_other_skills_and_linked_files():
+    module = _load_plugin_module()
+
+    assert (
+        module._compact_skill_view_result(
+            {"name": "github"},
+            json.dumps({"success": True, "name": "github", "content": "unchanged"}),
+        )
+        is None
+    )
+    assert (
+        module._compact_skill_view_result(
+            {"name": "elixir-analytics", "file_path": "references/example.md"},
+            json.dumps(
+                {
+                    "success": True,
+                    "name": "elixir-analytics",
+                    "content": "linked file content",
+                }
+            ),
+        )
+        is None
     )
 
 
@@ -154,6 +224,90 @@ def test_answer_question_mode_invokes_shortcut_runner_on_stdin(monkeypatch):
         "25",
     ]
     assert kwargs["input"] == "which users spent on Swiggy this week?"
+
+
+def test_answer_question_mode_returns_compact_slack_handoff(monkeypatch):
+    module = _load_plugin_module()
+    payload = {
+        "ok": True,
+        "route": "supabase_ad_hoc",
+        "shortcut": "swiggy_users_this_week",
+        "payload": {
+            "ok": True,
+            "title": "Users who spent on Swiggy this week",
+            "resultType": "users",
+            "rowCount": 15,
+            "truncated": False,
+            "dashboardUrlPath": "/query?payload=compact",
+            "dashboardUrl": "https://analytics.joinelixir.club/query?payload=compact",
+            "slackText": (
+                "Users who spent on Swiggy this week\n"
+                "Rows: 15\n"
+                + "\n".join(
+                    f"{index}. user_name: User {index}, spend: {index * 100}"
+                    for index in range(1, 80)
+                )
+                + "\nDashboard: https://analytics.joinelixir.club/query?payload=compact"
+            ),
+            "metadata": {
+                "resultType": "users",
+                "sql": "select * from transactions",
+                "assumptions": "This week means India business week-to-date.",
+                "caveats": "Includes successful card spend only.",
+            },
+            "rows": [
+                {
+                    "email": "ada@example.com",
+                    "phone": "+910000000000",
+                    "gross_spend_inr": 420,
+                }
+            ],
+            "logEntry": "## Query #99\nSQL: select * from transactions",
+        },
+    }
+
+    def fake_run(command, **kwargs):
+        return _Completed(json.dumps(payload))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "answer_question",
+            "question": "which users spent on Swiggy this week?",
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["payload"]["route"] == "supabase_ad_hoc"
+    assert result["hermes_direct_final_response"].startswith(
+        "Users who spent on Swiggy this week"
+    )
+    assert (
+        "Dashboard: https://analytics.joinelixir.club/query?payload=compact"
+        in result["hermes_direct_final_response"]
+    )
+    assert "More rows in the dashboard." in result["hermes_direct_final_response"]
+    assert len(result["hermes_direct_final_response"]) < 5000
+    compact_payload = result["payload"]["payload"]
+    assert compact_payload["slackText"].startswith("Users who spent on Swiggy")
+    assert compact_payload["dashboardUrl"].startswith("https://analytics.joinelixir.club")
+    assert "dashboardUrlPath" not in compact_payload
+    assert compact_payload["rowCount"] == 15
+    assert len(compact_payload["slackText"]) < 2400
+    assert "Dashboard:" not in compact_payload["slackText"]
+    assert "Slack handoff truncated" in compact_payload["slackText"]
+    assert compact_payload["metadata"] == {
+        "resultType": "users",
+        "assumptions": "This week means India business week-to-date.",
+        "caveats": "Includes successful card spend only.",
+    }
+
+    serialized = json.dumps(result, ensure_ascii=False)
+    assert "select * from transactions" not in serialized
+    assert "ada@example.com" not in serialized
+    assert "+910000000000" not in serialized
+    assert "logEntry" not in serialized
 
 
 def test_runner_logs_safe_route_summary_without_rows_or_sql(monkeypatch, caplog):

--- a/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
+++ b/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
@@ -1,0 +1,355 @@
+import importlib.util
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_PATH = (
+    REPO_ROOT
+    / "profile-distributions"
+    / "elixir-analytics"
+    / "profile_plugins"
+    / "elixir-analytics-runner"
+    / "__init__.py"
+)
+
+
+def _load_plugin_module():
+    spec = importlib.util.spec_from_file_location(
+        "test_elixir_analytics_runner_plugin",
+        PLUGIN_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Completed:
+    def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+class _Ctx:
+    def __init__(self):
+        self.tools = []
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+
+def test_tool_schema_tells_model_to_use_answer_question_first():
+    module = _load_plugin_module()
+    ctx = _Ctx()
+
+    module.register(ctx)
+
+    schema = ctx.tools[0]["schema"]
+    assert "Use mode='answer_question' first" in schema["description"]
+    assert "payload.slackText" in schema["description"]
+    assert "answer_question" in schema["parameters"]["properties"]["mode"]["enum"]
+    assert "source_change_plan" in schema["parameters"]["properties"]["mode"]["enum"]
+    assert "self_improvement_check" in schema["parameters"]["properties"]["mode"]["enum"]
+    assert "self_improvement_plan" in schema["parameters"]["properties"]["mode"]["enum"]
+    assert "query_log" in schema["parameters"]["properties"]
+    assert (
+        "use answer_question first"
+        in schema["parameters"]["properties"]["mode"]["description"]
+    )
+
+
+def test_plan_mode_invokes_question_planner_on_stdin(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "route": "saved_topic"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {"mode": "plan", "question": "show GTV last 30 days by week"}
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/plan-analytics-question.ts",
+    ]
+    assert kwargs["input"] == "show GTV last 30 days by week"
+
+
+def test_ad_hoc_mode_sends_request_json_on_stdin_and_defaults_base_url(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "rows": [{"user": "Ada"}]}))
+
+    monkeypatch.delenv("ANALYTICS_BASE_URL", raising=False)
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "supabase_ad_hoc",
+            "request": {"question": "which users spent on Swiggy this week?"},
+            "max_rows": 25,
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/run-ad-hoc-query.ts",
+        "--max-rows",
+        "25",
+    ]
+    assert json.loads(kwargs["input"]) == {
+        "question": "which users spent on Swiggy this week?"
+    }
+    assert kwargs["env"]["ANALYTICS_BASE_URL"] == "https://analytics.joinelixir.club"
+
+
+def test_answer_question_mode_invokes_shortcut_runner_on_stdin(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "route": "supabase_ad_hoc"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "answer_question",
+            "question": "which users spent on Swiggy this week?",
+            "max_rows": 25,
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/run-analytics-question.ts",
+        "--max-rows",
+        "25",
+    ]
+    assert kwargs["input"] == "which users spent on Swiggy this week?"
+
+
+def test_runner_logs_safe_route_summary_without_rows_or_sql(monkeypatch, caplog):
+    module = _load_plugin_module()
+    row = {"email": "ada@example.com", "gross_spend_inr": 420}
+    payload = {
+        "ok": True,
+        "route": "supabase_ad_hoc",
+        "shortcut": "swiggy_users_this_week",
+        "payload": {
+            "ok": True,
+            "rowCount": 1,
+            "truncated": False,
+            "dryRun": False,
+            "dashboardUrlPath": "/query?payload=compact",
+            "metadata": {
+                "resultType": "users",
+                "sql": "select * from transactions",
+            },
+            "rows": [row],
+        },
+    }
+
+    def fake_run(command, **kwargs):
+        return _Completed(json.dumps(payload))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    with caplog.at_level(logging.INFO, logger="hermes.elixir_analytics_runner"):
+        result = module.run_elixir_analytics_runner(
+            {
+                "mode": "answer_question",
+                "question": "which users spent on Swiggy this week?",
+            }
+        )
+
+    assert result["ok"] is True
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "mode=answer_question" in log_text
+    assert "route=supabase_ad_hoc" in log_text
+    assert "shortcut=swiggy_users_this_week" in log_text
+    assert "rowCount=1" in log_text
+    assert "resultType=users" in log_text
+    assert "dashboard=True" in log_text
+    assert "ada@example.com" not in log_text
+    assert "select * from transactions" not in log_text
+    assert "which users spent on Swiggy this week" not in log_text
+
+
+def test_answer_question_mode_defaults_to_compact_row_cap(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "route": "posthog_ad_hoc"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "answer_question",
+            "question": "how many app active users this week?",
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/run-analytics-question.ts",
+        "--max-rows",
+        "100",
+    ]
+    assert kwargs["input"] == "how many app active users this week?"
+
+
+def test_question_without_mode_defaults_to_answer_question(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "route": "saved_topic"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {"question": "show GTV last 30 days by week", "dry_run": True}
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert result["mode"] == "answer_question"
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/run-analytics-question.ts",
+        "--max-rows",
+        "100",
+        "--dry-run",
+    ]
+    assert kwargs["input"] == "show GTV last 30 days by week"
+
+
+def test_source_change_plan_mode_invokes_source_change_planner_on_stdin(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "kind": "metric_definition"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "source_change_plan",
+            "request": "GTV definition is wrong, wallet loads should be included",
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/plan-source-change.ts",
+    ]
+    assert kwargs["input"] == "GTV definition is wrong, wallet loads should be included"
+
+
+def test_self_improvement_plan_mode_invokes_self_improvement_planner_with_query_log(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "entriesReviewed": 5}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner({"mode": "self_improvement_plan"})
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/plan-self-improvement.ts",
+        "--query-log",
+        "QUERY_LOG.md",
+    ]
+    assert kwargs["input"] is None
+
+
+def test_self_improvement_check_mode_invokes_cadence_checker_with_query_log(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "status": "not_due"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner({"mode": "self_improvement_check"})
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/check-self-improvement-cadence.ts",
+        "--query-log",
+        "QUERY_LOG.md",
+    ]
+    assert kwargs["input"] is None
+
+
+def test_runner_failure_returns_structured_error(monkeypatch):
+    module = _load_plugin_module()
+
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, timeout=3, output="partial")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {"mode": "plan", "question": "show GTV", "timeout_seconds": 3}
+    )
+
+    assert result["ok"] is False
+    assert result["errorType"] == "timeout"
+    assert result["timeoutSeconds"] == 3

--- a/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
+++ b/tests/hermes_cli/test_elixir_analytics_runner_plugin.py
@@ -54,9 +54,11 @@ def test_tool_schema_tells_model_to_use_answer_question_first():
     assert "payload.slackText" in schema["description"]
     assert "answer_question" in schema["parameters"]["properties"]["mode"]["enum"]
     assert "source_change_plan" in schema["parameters"]["properties"]["mode"]["enum"]
+    assert "source_change_scope_check" in schema["parameters"]["properties"]["mode"]["enum"]
     assert "self_improvement_check" in schema["parameters"]["properties"]["mode"]["enum"]
     assert "self_improvement_plan" in schema["parameters"]["properties"]["mode"]["enum"]
     assert "query_log" in schema["parameters"]["properties"]
+    assert "changed_files" in schema["parameters"]["properties"]
     assert (
         "use answer_question first"
         in schema["parameters"]["properties"]["mode"]["description"]
@@ -286,6 +288,73 @@ def test_source_change_plan_mode_invokes_source_change_planner_on_stdin(monkeypa
         "scripts/plan-source-change.ts",
     ]
     assert kwargs["input"] == "GTV definition is wrong, wallet loads should be included"
+
+
+def test_source_change_scope_check_mode_invokes_scope_checker(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "status": "ready"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "source_change_scope_check",
+            "request": "GTV definition is wrong",
+            "changed_files": [
+                "GLOSSARY.md",
+                "tests/metric-contracts.test.ts",
+            ],
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/check-source-change-scope.ts",
+        "--changed-files-json",
+        '["GLOSSARY.md", "tests/metric-contracts.test.ts"]',
+    ]
+    assert kwargs["input"] == "GTV definition is wrong"
+
+
+def test_source_change_scope_check_accepts_string_changed_files(monkeypatch):
+    module = _load_plugin_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _Completed(json.dumps({"ok": True, "status": "ready"}))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_elixir_analytics_runner(
+        {
+            "mode": "source_change_scope_check",
+            "request": "add a glossary term",
+            "changed_files": "GLOSSARY.md, tests/agent-instructions.test.ts",
+            "allow_unexpected_files": True,
+        }
+    )
+
+    command, kwargs = calls[0]
+    assert result["ok"] is True
+    assert command == [
+        "node",
+        "--import",
+        "tsx",
+        "scripts/check-source-change-scope.ts",
+        "--changed-files-json",
+        '["GLOSSARY.md", "tests/agent-instructions.test.ts"]',
+        "--allow-unexpected-files",
+    ]
+    assert kwargs["input"] == "add a glossary term"
 
 
 def test_self_improvement_plan_mode_invokes_self_improvement_planner_with_query_log(monkeypatch):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -453,3 +453,54 @@ class TestBundledDiscovery:
         mgr.discover_and_load()
         assert "memory" not in mgr._plugins
         assert "context_engine" not in mgr._plugins
+
+    def test_profile_plugins_load_from_distribution_owned_namespace(self, _isolate_env):
+        """Profile-distributed plugins load from profile_plugins, not user plugins."""
+        import yaml
+
+        profile_plugin = _isolate_env / "profile_plugins" / "analytics-runner"
+        profile_plugin.mkdir(parents=True)
+        (profile_plugin / "plugin.yaml").write_text(
+            "\n".join(
+                [
+                    "name: analytics-runner",
+                    "version: 0.1.0",
+                    "description: Profile-owned analytics runner.",
+                    "provides_tools:",
+                    "  - profile_runner_ping",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (profile_plugin / "__init__.py").write_text(
+            "\n".join(
+                [
+                    "def register(ctx):",
+                    "    ctx.register_tool(",
+                    "        name='profile_runner_ping',",
+                    "        toolset='analytics-runner',",
+                    "        schema={",
+                    "            'name': 'profile_runner_ping',",
+                    "            'description': 'Ping profile plugin.',",
+                    "            'parameters': {'type': 'object', 'properties': {}},",
+                    "        },",
+                    "        handler=lambda args, **kwargs: '{\"ok\": true}',",
+                    "    )",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["analytics-runner"]}}),
+            encoding="utf-8",
+        )
+
+        from hermes_cli import plugins as pmod
+
+        mgr = pmod.PluginManager()
+        mgr.discover_and_load()
+
+        loaded = mgr._plugins["analytics-runner"]
+        assert loaded.enabled
+        assert loaded.manifest.source == "profile"
+        assert "profile_runner_ping" in loaded.tools_registered

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3073,6 +3073,38 @@ class TestRunConversation:
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
+    def test_tool_direct_final_response_short_circuits_follow_up_model_call(self, agent):
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("skill_view")
+        tc = _mock_tool_call(name="skill_view", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        direct_text = "Direct answer from the tool.\nDashboard: https://analytics.example.com/query?payload=abc"
+        agent.client.chat.completions.create.return_value = resp1
+
+        with (
+            patch(
+                "run_agent.handle_function_call",
+                return_value=json.dumps(
+                    {
+                        "ok": True,
+                        "hermes_direct_final_response": direct_text,
+                    }
+                ),
+            ) as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == direct_text
+        assert result["completed"] is True
+        assert result["turn_exit_reason"] == "direct_tool_final_response"
+        assert result["api_calls"] == 1
+        assert agent.client.chat.completions.create.call_count == 1
+        assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
+        assert result["messages"][-1] == {"role": "assistant", "content": direct_text}
+
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -253,3 +253,43 @@ class TestDefaultPlatformWebSearchCoverage:
 
     def test_hermes_api_server_toolset_includes_web_search(self):
         assert "web_search" in resolve_toolset("hermes-api-server")
+
+
+class TestHermesAnalyticsToolset:
+    def test_keeps_analytics_runtime_and_self_improvement_tools(self):
+        tools = set(resolve_toolset("hermes-analytics"))
+
+        assert {
+            "terminal",
+            "process",
+            "execute_code",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
+            "skills_list",
+            "skill_view",
+            "skill_manage",
+            "memory",
+            "session_search",
+            "clarify",
+            "cronjob",
+            "send_message",
+        }.issubset(tools)
+
+    def test_excludes_unrelated_general_agent_fluff(self):
+        tools = set(resolve_toolset("hermes-analytics"))
+
+        assert {
+            "image_generate",
+            "vision_analyze",
+            "text_to_speech",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "ha_list_entities",
+            "ha_call_service",
+            "kanban_create",
+            "delegate_task",
+            "computer_use",
+        }.isdisjoint(tools)

--- a/toolsets.py
+++ b/toolsets.py
@@ -82,6 +82,24 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
     "clarify",
 ]
 
+# Narrow default surface for specialized analytics agents.  This keeps the
+# self-improvement loop (skills, memory, session search, code/file tools,
+# scheduled reviews, Slack messaging) while excluding unrelated media,
+# desktop automation, smart-home, browser, kanban, and delegation tools.
+_HERMES_ANALYTICS_AGENT_TOOLS = [
+    # Research
+    "web_search", "web_extract",
+    # Runtime/query execution
+    "terminal", "process", "execute_code",
+    # Source-of-truth maintenance
+    "read_file", "write_file", "patch", "search_files",
+    # Skills and self-improvement
+    "skills_list", "skill_view", "skill_manage",
+    "todo", "memory", "session_search", "clarify",
+    # Scheduled reviews / Slack updates
+    "cronjob", "send_message",
+]
+
 
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
@@ -411,6 +429,16 @@ TOOLSETS = {
         "description": "Default cron toolset - same core tools as hermes-cli; gated by `hermes tools`",
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
+    },
+
+    "hermes-analytics": {
+        "description": (
+            "Specialized analytics agent toolset — Slack-first analysis, "
+            "read-only runtime execution, source maintenance, memory, "
+            "skills, and scheduled reviews without media or desktop fluff"
+        ),
+        "tools": _HERMES_ANALYTICS_AGENT_TOOLS,
+        "includes": [],
     },
 
     "hermes-telegram": {


### PR DESCRIPTION
## Summary

- adds an `elixir-analytics` Hermes profile distribution for the Slack `macros` analytics agent
- ships a profile-owned `elixir-analytics-runner` plugin that delegates analytics questions to the deterministic `claude-analytics` runners
- keeps smart approvals and generic Hermes tools enabled while making `answer_question` the first path for plain Slack analytics questions
- adds analytics roadmap/release-packaging docs, profile tests, runner plugin tests, toolset coverage, and Slack Socket Mode recovery telemetry

## Product impact

This gives Hermes a dedicated analytics profile that can answer saved-topic, Supabase ad hoc, PostHog, source-change, and self-improvement requests through the analytics repo instead of improvised shell/code execution.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_elixir_analytics_profile_distribution.py tests/hermes_cli/test_elixir_analytics_runner_plugin.py tests/hermes_cli/test_elixir_analytics_release_packaging.py tests/gateway/test_slack.py tests/plugins/test_disk_cleanup_plugin.py tests/test_toolsets.py -- -q` (`291` passing)
- `venv/bin/python scripts/check_elixir_analytics_release_packaging.py --strict`

## Rollout notes

The production analytics rollout still depends on the companion analytics app PR, Vercel `ANALYTICS_DATABASE_URL`, and a fresh Slack E2E pass after production deploy.
