### PR TITLE
fix(cli): pass --clear to uv venv in rebuild_venv to avoid Windows brick

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -110,8 +110,14 @@ def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> b
         print(f"  → Rebuilding venv (old Python may lack FTS5)...")
         shutil.rmtree(venv_dir, ignore_errors=True)
 
+    # Pass --clear so uv replaces the directory even when shutil.rmtree above
+    # couldn't fully delete it. On Windows the running interpreter often lives
+    # inside the very venv we're rebuilding, locking python.exe; rmtree then
+    # leaves a half-deleted shell (pyvenv.cfg gone, Scripts/python.exe stays)
+    # and uv venv without --clear aborts with "A directory already exists",
+    # which bricks the install (issue #37881).
     result = subprocess.run(
-        [uv_bin, "venv", str(venv_dir), "--python", python_version],
+        [uv_bin, "venv", str(venv_dir), "--python", python_version, "--clear"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -145,6 +145,58 @@ class TestRebuildVenv:
             result = rebuild_venv(uv_bin, venv_dir)
             assert result is False
 
+    def test_uv_venv_called_with_clear_flag(self, tmp_path):
+        """uv venv must be invoked with --clear so a half-deleted venv on
+        Windows (locked python.exe leaves residue) is replaced rather than
+        rejected with "A directory already exists" — regression for #37881.
+        """
+        venv_dir = tmp_path / "venv"
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        with patch("hermes_cli.managed_uv.subprocess.run") as mock_run, \
+             patch("hermes_cli.managed_uv.shutil.rmtree"):
+            mock_run.return_value = MagicMock(returncode=1, stderr="ignored")
+            from hermes_cli.managed_uv import rebuild_venv
+            rebuild_venv(uv_bin, venv_dir)
+
+            venv_calls = [c for c in mock_run.call_args_list if c.args[0][1] == "venv"]
+            assert len(venv_calls) == 1, "expected exactly one `uv venv` invocation"
+            cmd = venv_calls[0].args[0]
+            assert "--clear" in cmd, f"`uv venv` missing --clear flag: {cmd}"
+
+    def test_rebuild_succeeds_when_rmtree_leaves_residue(self, tmp_path):
+        """Models the Windows brick scenario from #37881: the existing venv
+        cannot be fully removed (running interpreter locks files), so
+        shutil.rmtree silently leaves a residual directory. rebuild_venv must
+        still succeed because --clear lets uv replace the leftover.
+        """
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        (venv_dir / "leftover_binary").write_text("locked stub")
+        uv_bin = str(tmp_path / "bin" / "uv")
+
+        def noop_rmtree(_path, ignore_errors=False):
+            # Simulate Windows: rmtree(ignore_errors=True) eats the lock error
+            # and returns; the directory survives.
+            return None
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock(returncode=0)
+            if cmd[1] == "venv":
+                bin_dir = venv_dir / "bin"
+                bin_dir.mkdir(parents=True, exist_ok=True)
+                (bin_dir / "python").write_text("#!/bin/sh\necho Python 3.11.0")
+            elif "--version" in cmd:
+                m.stdout = "Python 3.11.0"
+            return m
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.managed_uv.shutil.rmtree", side_effect=noop_rmtree), \
+             patch("hermes_cli.managed_uv.platform.system", return_value="Linux"):
+            from hermes_cli.managed_uv import rebuild_venv
+            result = rebuild_venv(uv_bin, venv_dir)
+            assert result is True
+
 
 # ---------------------------------------------------------------------------
 # update_managed_uv


### PR DESCRIPTION
`hermes update` no longer bricks the install on Windows when it rebuilds the venv.

When the running interpreter lives inside the venv being rebuilt, Windows locks `python.exe`, so `shutil.rmtree(..., ignore_errors=True)` silently leaves a half-deleted directory (pyvenv.cfg gone, Scripts/python.exe still present). The subsequent `uv venv` then aborts with `A directory already exists`, leaving a broken venv → `ModuleNotFoundError: hermes_cli`.

## Changes
- `hermes_cli/managed_uv.py`: pass `--clear` to `uv venv` in `rebuild_venv()` so uv replaces any leftover directory rmtree couldn't fully remove.
- `tests/hermes_cli/test_managed_uv.py`: 2 regression tests (`--clear` is passed; rebuild succeeds when rmtree leaves residue).

## Validation
| | Before | After |
|---|---|---|
| `uv venv` over leftover residue | `error: A directory already exists` (brick) | succeeds, valid pyvenv.cfg |

Verified live with a real `uv` binary: no-`--clear` returns exit 2 with the exact "A directory already exists" error; `--clear` returns 0 and produces a working venv. 17/17 `test_managed_uv.py` pass.

Fixes #37881.

Salvaged from #37895 by @jackjin1997 (clean implementation against current `managed_uv.py`); also supersedes @kyssta-exe's #37965 / #38051, which fixed the same bug from a stale fork base. Credit to both contributors.

## Infographic

![windows-venv-brick-fix](https://v3b.fal.media/files/b/0a9cf22c/BznunBssqimkQgumA4Q1J_Jp9XXaAW.png)
