### PR TITLE
feat(feishu): add configurable render modes for gateway replies

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -893,7 +893,9 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                if plat == Platform.FEISHU and "render_mode" in platform_cfg:
+                    bridged["render_mode"] = platform_cfg["render_mode"]
+                if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -160,6 +160,9 @@ _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$"
+)
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
@@ -390,6 +393,7 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    render_mode: str = "auto"  # "auto" | "raw" | "card"
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -543,13 +547,18 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     return default if parsed is None else parsed
 
 
+def _normalize_render_mode(value: Any, default: str = "auto") -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized if normalized in {"auto", "raw", "card"} else default
+
+
 # ---------------------------------------------------------------------------
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
 
 
 def _build_markdown_post_payload(content: str) -> str:
-    rows = _build_markdown_post_rows(content)
+    rows = _build_markdown_post_rows(_wrap_markdown_tables(content))
     return json.dumps(
         {
             "zh_cn": {
@@ -558,6 +567,81 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _build_markdown_card_payload(content: str) -> str:
+    return json.dumps(
+        {
+            "schema": "2.0",
+            "config": {
+                "width_mode": "fill",
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": content,
+                    }
+                ],
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _is_table_row(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped) and "|" in stripped
+
+
+def _wrap_markdown_tables(text: str) -> str:
+    """Wrap GFM pipe tables in fenced code blocks for Feishu rendering.
+
+    Feishu post markdown does not reliably render GFM tables.  A fenced block
+    gives users a stable, monospace table while preserving the original cells.
+    Existing fenced code blocks are left unchanged.
+    """
+    if "|" not in text or "-" not in text:
+        return text
+
+    lines = text.split("\n")
+    out: List[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+
+        if (
+            "|" in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            table_block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and _is_table_row(lines[j]):
+                table_block.append(lines[j])
+                j += 1
+            out.append("```")
+            out.extend(table_block)
+            out.append("```")
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    return "\n".join(out)
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -581,7 +665,7 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
         nonlocal current
         if not current:
             return
-        segment = "\n".join(current)
+        segment = "\n".join(current).strip("\n")
         if segment.strip():
             rows.append([{"tag": "md", "text": segment}])
         current = []
@@ -1412,6 +1496,7 @@ class FeishuAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
+    STREAM_SEGMENTS_IN_SINGLE_MESSAGE = False
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.
@@ -1566,6 +1651,9 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
+            render_mode=_normalize_render_mode(
+                extra.get("render_mode") or os.getenv("HERMES_FEISHU_RENDER_MODE", "auto")
+            ),
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
@@ -1603,6 +1691,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._render_mode = settings.render_mode
+        self.STREAM_SEGMENTS_IN_SINGLE_MESSAGE = settings.render_mode == "card"
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
 
@@ -4308,14 +4398,13 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+        if self._render_mode == "card":
+            return "interactive", _build_markdown_card_payload(content)
+        if self._render_mode == "raw":
+            return "text", json.dumps({"text": content}, ensure_ascii=False)
+        markdown_content = _wrap_markdown_tables(content)
+        if markdown_content != content or _MARKDOWN_HINT_RE.search(markdown_content):
+            return "post", _build_markdown_post_payload(markdown_content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -164,6 +164,9 @@ class GatewayStreamConsumer:
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
+        self._keep_segments_in_one_message: bool = (
+            getattr(adapter, "STREAM_SEGMENTS_IN_SINGLE_MESSAGE", False) is True
+        )
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
@@ -602,6 +605,8 @@ class GatewayStreamConsumer:
 
                 # Tool boundary: reset message state so the next text chunk
                 # creates a fresh message below any tool-progress messages.
+                # Card-style adapters can opt out and keep editing the same
+                # message across tool boundaries.
                 #
                 # Exception: when _message_id is "__no_edit__" the platform
                 # never returned a real message ID (e.g. Signal, webhook with
@@ -614,7 +619,7 @@ class GatewayStreamConsumer:
                 # (When editing fails mid-stream due to flood control the id is
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
-                if got_segment_break:
+                if got_segment_break and not self._keep_segments_in_one_message:
                     # If the segment-break edit failed to deliver the
                     # accumulated content (flood control that has not yet
                     # promoted to fallback mode, or fallback mode itself),

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -417,6 +417,47 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_updates_card_when_render_mode_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"render_mode": "card"}))
+        captured = {}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_card",
+                    content="更新后的 **卡片** 回复",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertEqual(payload["body"]["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload["body"]["elements"][0]["content"], "更新后的 **卡片** 回复")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -503,6 +544,20 @@ class TestAdapterModule(unittest.TestCase):
 
         self.assertIsNone(settings.ws_ping_interval)
         self.assertIsNone(settings.ws_ping_timeout)
+
+    def test_load_settings_accepts_card_render_mode(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({"render_mode": "card"})
+
+        self.assertEqual(settings.render_mode, "card")
+
+    def test_load_settings_defaults_invalid_render_mode_to_auto(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({"render_mode": "sparkles"})
+
+        self.assertEqual(settings.render_mode, "auto")
 
     def test_runtime_ws_overrides_reapply_after_sdk_configure(self):
         import sys
@@ -2705,6 +2760,129 @@ class TestAdapterBehavior(unittest.TestCase):
                 [{"tag": "md", "text": "after"}],
             ],
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_wraps_markdown_tables_as_code_blocks(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        payload = json.loads(
+            adapter._build_post_payload(
+                "结果如下：\n"
+                "| 名称 | 数量 |\n"
+                "| --- | ---: |\n"
+                "| 苹果 | 3 |\n"
+                "| 梨 | 12 |\n"
+                "\n说明结束。"
+            )
+        )
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [{"tag": "md", "text": "结果如下："}],
+                [{"tag": "md", "text": "```\n| 名称 | 数量 |\n| --- | ---: |\n| 苹果 | 3 |\n| 梨 | 12 |\n```"}],
+                [{"tag": "md", "text": "说明结束。"}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_leaves_tables_inside_code_blocks_unchanged(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        payload = json.loads(
+            adapter._build_post_payload(
+                "before\n```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```\nafter"
+            )
+        )
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [{"tag": "md", "text": "before"}],
+                [{"tag": "md", "text": "```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```"}],
+                [{"tag": "md", "text": "after"}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_post_for_markdown_table_only_messages(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "| 名称 | 数量 |\n| --- | ---: |\n| 苹果 | 3 |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [[{"tag": "md", "text": "```\n| 名称 | 数量 |\n| --- | ---: |\n| 苹果 | 3 |\n```"}]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_when_render_mode_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"render_mode": "card"}))
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content="卡片 **回复**"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertEqual(payload["config"]["width_mode"], "fill")
+        self.assertEqual(payload["body"]["elements"], [{"tag": "markdown", "content": "卡片 **回复**"}])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_falls_back_to_text_when_post_payload_is_rejected(self):

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -401,6 +401,32 @@ class TestSegmentBreakOnToolBoundary:
         assert "results" in second_text
 
     @pytest.mark.asyncio
+    async def test_segment_break_can_continue_editing_same_message(self):
+        """Card-style adapters can keep one editable message across tool boundaries."""
+        adapter = MagicMock()
+        adapter.STREAM_SEGMENTS_IN_SINGLE_MESSAGE = True
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Let me search for that...")
+        consumer.on_delta(None)
+        consumer.on_delta("Here are the results.")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.call_count == 1
+        assert adapter.edit_message.call_count >= 1
+        final_edit = adapter.edit_message.call_args_list[-1][1]
+        assert final_edit["message_id"] == "msg_1"
+        assert "search" in final_edit["content"]
+        assert "results" in final_edit["content"]
+
+    @pytest.mark.asyncio
     async def test_segment_break_no_text_before(self):
         """A None boundary with no preceding text is a no-op."""
         adapter = MagicMock()


### PR DESCRIPTION
## Problem

Feishu `post`-type messages with `md` elements have limited markdown support:
- Tables are not rendered (messages appear blank)
- Occasional `card table number over limit` API errors from the Feishu backend

## Solution

Add a `render_mode` config option under `feishu:` in `config.yaml`:

- **`auto`** (default): post-type with `md` elements; GFM tables are wrapped in fenced code blocks so they render as monospace blocks rather than blank messages
- **`card`**: Feishu interactive card with `markdown` element (schema 2.0) — full markdown support including tables
- **`raw`**: plain text, no formatting

### Config

```yaml
feishu:
  render_mode: card  # auto | raw | card
```

Or via env var: `HERMES_FEISHU_RENDER_MODE=card`

## Changes

- `gateway/platforms/feishu.py`:
  - Add `_build_markdown_card_payload()` — schema 2.0 card with markdown element
  - Add `_wrap_markdown_tables()` — wraps GFM pipe tables in fenced code blocks for `auto` mode
  - Add `render_mode` field to `FeishuAdapterSettings`
  - Modify `_build_outbound_payload()` to route by render mode
  - Set `STREAM_SEGMENTS_IN_SINGLE_MESSAGE = False` for card mode (single-message delivery)
- `gateway/config.py`: bridge `feishu.render_mode` from config.yaml
- `gateway/stream_consumer.py`: respect `STREAM_SEGMENTS_IN_SINGLE_MESSAGE` override
- `tests/gateway/test_feishu.py`: tests for all three render modes and table wrapping
- `tests/gateway/test_stream_consumer.py`: test for single-message stream override