### PR TITLE
fix(feishu): allow DM approval clicks without group allowlist

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2583,7 +2583,10 @@ class FeishuAdapter(BasePlatformAdapter):
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        approval_chat_id = state.get("chat_id", "")
+        cached_chat = self._chat_info_cache.get(approval_chat_id) if approval_chat_id else None
+        is_dm = cached_chat is not None and cached_chat.get("type") == "dm"
+        if not is_dm and not self._allow_group_message(sender_id, approval_chat_id, is_bot=False):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -615,6 +615,66 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_dm_approval_allows_user_without_group_allowlist(self, _patch_callback_card_types):
+        """DM approval clicks should bypass group policy (allowlist) checks.
+
+        Regression test: when FEISHU_ALLOWED_USERS is unset and the default
+        group policy is 'allowlist', approval buttons in DMs were rejected as
+        'Unauthorized' because _allow_group_message was applied to DM chats.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        # Empty allowlist — would block the user in a group context
+        adapter._allowed_group_users = set()
+        adapter._admins = set()
+        # Mark the chat as a DM in the cache
+        adapter._chat_info_cache["oc_dm_chat"] = {"type": "dm", "name": "DM"}
+        adapter._approval_state[10] = {
+            "session_key": "sess-dm",
+            "message_id": "msg-dm",
+            "chat_id": "oc_dm_chat",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 10},
+            chat_id="oc_dm_chat",
+            open_id="ou_any_user",
+        )
+        adapter._sender_name_cache["ou_any_user"] = ("Alice", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved once" in card["header"]["title"]["content"]
+
+    def test_dm_approval_still_enforces_chat_mismatch(self, _patch_callback_card_types):
+        """Even in DMs, approval clicks from a different chat should be rejected."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._chat_info_cache["oc_dm_chat"] = {"type": "dm", "name": "DM"}
+        adapter._approval_state[11] = {
+            "session_key": "sess-dm2",
+            "message_id": "msg-dm2",
+            "chat_id": "oc_dm_chat",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 11},
+            chat_id="oc_other_chat",
+            open_id="ou_any_user",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
     def test_rejects_approval_click_when_callback_chat_mismatches(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()


### PR DESCRIPTION
## Summary

Fixes a bug where approval button clicks (Allow Once / Session / Always / Deny) in **DM (p2p) chats** were silently rejected with `Unauthorized approval click` when `FEISHU_ALLOWED_USERS` is unset.

## Root Cause

`_handle_approval_card_action()` unconditionally calls `_allow_group_message()` to authorize the operator. This function enforces the group policy (default: `allowlist`), but DM chats should bypass group policy entirely — same as how `_admit()` handles DM messages at line 4053.

The approval callback path was missing this DM bypass, causing a deadlock: every command execution in DM requires approval, but approval clicks are themselves rejected, making the bot unusable.

## Fix

Look up the chat type in `_chat_info_cache` and skip `_allow_group_message()` when the approval originated from a DM. Chat binding and operator auth checks are preserved — only the group allowlist gate is bypassed for DMs.

**Changes:** `gateway/platforms/feishu.py` (+4 lines, -1 line)

## Tests

Added 2 regression tests to `test_feishu_approval_buttons.py`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_dm_approval_allows_user_without_group_allowlist` | DM chat, empty allowlist, user clicks Allow Once | Approved |
| `test_dm_approval_still_enforces_chat_mismatch` | DM chat, callback from different chat_id | Rejected |

All 37 tests pass.

## Steps to Reproduce

1. Fresh Hermes install with Feishu enabled
2. Do NOT set FEISHU_ALLOWED_USERS (default allowlist is empty)
3. Send a message that triggers a command approval in DM
4. Click Allow Once - silently rejected, Unauthorized approval click in gateway.log
5. Bot becomes unusable - every command requires approval, but approvals are blocked