### PR TITLE
fix(wecom): use constant-time comparison for the callback signature

### DIFF
--- a/gateway/platforms/wecom_crypto.py
+++ b/gateway/platforms/wecom_crypto.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import os
 import secrets
 import socket
@@ -87,7 +88,12 @@ class WXBizMsgCrypt:
 
     def decrypt(self, msg_signature: str, timestamp: str, nonce: str, encrypt: str) -> bytes:
         expected = _sha1_signature(self.token, timestamp, nonce, encrypt)
-        if expected != msg_signature:
+        # Constant-time comparison to avoid a timing side-channel on the
+        # callback signature. Consistent with hmac.compare_digest used in
+        # webhook.py and api_server.py for the same purpose.
+        if not isinstance(msg_signature, str) or not hmac.compare_digest(
+            expected, msg_signature
+        ):
             raise SignatureError("signature mismatch")
         try:
             cipher_text = base64.b64decode(encrypt)


### PR DESCRIPTION
`WXBizMsgCrypt.decrypt()` checks the callback signature with `expected != msg_signature`. String `!=` returns at the first byte that differs, so the time it takes leaks how much of the signature matched. By replaying a chosen `(timestamp, nonce, encrypt)` an attacker can recover the expected signature a byte at a time and forge a callback without knowing the token.

This switches to `hmac.compare_digest`, which `webhook.py` and `api_server.py` already use for the same checks. Low severity since the digest still mixes in the secret token and the attack needs a lot of timed requests, but there is no reason to leave the side channel in.