### PR TITLE
chore(deps): bump PyJWT to 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).
   "croniter==6.0.0",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
-  "PyJWT[crypto]==2.12.1",  # CVE-2026-32597
+  "PyJWT[crypto]==2.13.0",  # CVE-2026-32597; bumped to 2.13.0 for PYSEC-2026-177/178/179
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package


### PR DESCRIPTION
`PyJWT[crypto]==2.12.1` is affected by PYSEC-2026-177/178/179; 2.13.0 fixes them.

Heads up for maintainers: the lockfile also pins `aiohttp 3.13.3` (GHSA-63hf-3vf5-4wqf) and `urllib3 2.6.3` (PYSEC-2026-141/142), both fixed upstream. Those are transitive, so they need a `uv lock` regen rather than a pyproject edit — I left that out rather than hand you a half-regenerated lockfile, since CI runs `uv lock --check`.