### PR TITLE
fix(gateway): visually expire Discord interactive views on timeout

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4101,6 +4101,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:
@@ -4140,6 +4141,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -4217,6 +4219,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 view = None
 
             msg = await channel.send(embed=embed, view=view) if view else await channel.send(embed=embed)
+            if view:
+                view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
@@ -4252,6 +4256,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -4311,6 +4316,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:
@@ -5141,6 +5147,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass  # message deleted or too old to edit
 
     class SlashConfirmView(discord.ui.View):
         """Three-button view for generic slash-command confirmations.
@@ -5245,6 +5262,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
     class UpdatePromptView(discord.ui.View):
         """Interactive Yes/No buttons for ``hermes update`` prompts.
@@ -5330,6 +5358,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
     class ModelPickerView(discord.ui.View):
         """Interactive select-menu view for model switching.
@@ -5555,6 +5594,18 @@ def _define_discord_view_classes() -> None:
         async def on_timeout(self):
             self.resolved = True
             self.clear_items()
+            # Visually update the Discord message so it appears expired.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = discord.Embed(
+                        title="⚙ Model Configuration",
+                        description="⏱ Selection expired — no model change.",
+                        color=discord.Color.greyple(),
+                    )
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
 
     class ClarifyChoiceView(discord.ui.View):
@@ -5740,6 +5791,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 if DISCORD_AVAILABLE:
     _define_discord_view_classes()
 


### PR DESCRIPTION
Timed-out Discord interactive views now visually expire — the message embed greys out and shows a "⏱ Prompt expired" footer, instead of leaving clickable buttons that throw a generic "Interaction failed".

Salvages #38132 by @kyssta-exe onto current `main` (single clean commit, authorship preserved). Fixes #38022.

## Changes
- `plugins/platforms/discord/adapter.py`: store `view._message = msg` after each `channel.send` (5 send sites), and edit the message in each view's `on_timeout` — greyple embed + expired footer, wrapped in try/except for deleted/old messages. Covers ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView.

## Root cause
`on_timeout` only flipped `child.disabled = True` on the in-memory `View`; the actual Discord message was never edited, so buttons stayed clickable.

## Validation
| | Before | After |
|---|---|---|
| `tests/gateway/test_discord_clarify_buttons.py` | 14 pass | 14 pass |
| E2E: fire `on_timeout` on all 5 views with a fake message | message never edited | edit called, embed greyple, expired footer/desc, view re-passed — all 5 |
| E2E: `_message = None` (deleted msg) | n/a | no-ops cleanly via getattr + try/except |

Duplicate #38038 (@iborazzi, filed earlier) targets the same issue but its branch is unsalvageable (vendored a git submodule, committed a binary `.db`, broke a CI workflow, deleted unrelated skill files) — closed separately with credit for filing first.


## Infographic

![discord-views-expire-on-timeout](https://v3b.fal.media/files/b/0a9cf253/a4hetBdd5sBqhXBYYlUem_uBBOnXBR.png)
