### PR TITLE
fix(api-server): guard json.loads against corrupted SQLite data in response cache

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -423,7 +423,19 @@ class ResponseStore:
             (time.time(), response_id),
         )
         self._conn.commit()
-        return json.loads(row[0])
+        try:
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Corrupted JSON in response store for id=%s, evicting entry",
+                response_id,
+            )
+            self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?",
+                (response_id,),
+            )
+            self._conn.commit()
+            return None
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""


### PR DESCRIPTION
## Summary
A corrupted-JSON row in the Responses API SQLite cache no longer crashes the gateway — `ResponseStore.get()` now logs, evicts the bad entry, and returns `None`.

Root cause: `json.loads(row[0])` was unguarded, so a row written partially during a crash (or corrupted on disk) raised an unhandled `JSONDecodeError` straight into the Responses API handler.

## Changes
- `gateway/platforms/api_server.py`: wrap the `json.loads` in `ResponseStore.get()` in `try/except (json.JSONDecodeError, TypeError)` — warn, `DELETE` the corrupt row, return `None`. Matches the existing guard pattern in `gateway/status.py`.

## Validation
E2E against a real SQLite-backed `ResponseStore`:

| Case | Result |
|---|---|
| Valid JSON round-trip | returns dict |
| Corrupt row | returns `None`, no crash |
| Corrupt row | evicted from table |
| Other valid entry | survives eviction |
| Missing id | returns `None` |

All pass.

Salvaged from #38125 by @annguyenNous (authorship preserved via cherry-pick). Closes #38125.

## Infographic

![guard-corrupted-response-cache](https://v3b.fal.media/files/b/0a9cf253/rHqs2i7sfcy9TNFohZqrR_uQOPZdLj.png)
