### PR TITLE
fix(tools): add raise_for_status for MiniMax t2a_v2 TTS path

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1261,6 +1261,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
     if is_t2a_v2:
         # t2a_v2 returns JSON with hex-encoded audio
+        response.raise_for_status()
         result = response.json()
         base_resp = result.get("base_resp", {})
         status_code = base_resp.get("status_code", -1)


### PR DESCRIPTION
## Summary
The MiniMax `t2a_v2` TTS path now surfaces a clear `HTTPError` on a 4xx/5xx response instead of an opaque `JSONDecodeError`.

Previously, on an HTTP error with a non-JSON body, `response.json()` raised a confusing `JSONDecodeError`. The sibling `text_to_speech` path already guarded with `raise_for_status()`; this brings `t2a_v2` to parity.

## Changes
- `tools/tts_tool.py`: add `response.raise_for_status()` before `response.json()` in the `t2a_v2` branch.

## Validation
| | Before | After |
|---|---|---|
| 4xx/5xx, non-JSON body | opaque `JSONDecodeError` | clear `HTTPError` |
| compile | — | `py_compile` OK |

Salvage of #38142 by @annguyenNous, cherry-picked onto current main with authorship preserved.

## Infographic

![minimax-tts-clear-errors](https://v3b.fal.media/files/b/0a9cf25a/32Hbgk8Y42189CNm8MA3q_b1iKDpXD.png)
