### PR TITLE
fix(gateway): clear zombie agent slot when session_reset races in-flight run

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,18 +8470,14 @@ class GatewayRunner:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # If _run_agent replaced the sentinel with a real agent and
-            # then cleaned it up, this is a no-op.  If we exited early
-            # (exception, command fallthrough, etc.) the sentinel must
-            # not linger or the session would be permanently locked out.
-            if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
-                self._release_running_agent_state(_quick_key)
-            else:
-                # Agent path already cleaned _running_agents; make sure
-                # the paired metadata dicts are gone too.
-                self._running_agents_ts.pop(_quick_key, None)
-                if hasattr(self, "_busy_ack_ts"):
-                    self._busy_ack_ts.pop(_quick_key, None)
+            # Unconditional release covers every exit path. _release_running_agent_state
+            # is idempotent (pop-on-absent is harmless) and, called without a
+            # run_generation guard, always clears the slot regardless of which
+            # generation it holds. This evicts the zombie left when session_reset
+            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
+            # inside _run_agent returns False, and the old sentinel-only check here
+            # missed the leftover real agent — locking the session out forever (#28686).
+            self._release_running_agent_state(_quick_key)
 
     async def _prepare_inbound_message_text(
         self,
@@ -9978,6 +9974,12 @@ class GatewayRunner:
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
+        # Evict the running-agent slot now that the generation is bumped. The
+        # in-flight run's own guarded release (run_generation=old) will return
+        # False and leave its dead agent behind; clearing here keeps the slot
+        # from becoming a zombie that silently drops all later messages (#28686).
+        # Idempotent, so the run's finally calling it again is harmless.
+        self._release_running_agent_state(session_key)
 
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.

--- a/tests/gateway/test_session_state_cleanup.py
+++ b/tests/gateway/test_session_state_cleanup.py
@@ -228,3 +228,54 @@ class TestSessionDbCloseOnShutdown:
 
         flaky_db.close.assert_called_once()
         healthy_db.close.assert_called_once()
+
+
+class TestSessionResetZombieRace:
+    """Regression for #28686 — a session_reset racing the in-flight run's
+    guarded release must not leave a dead agent locking the slot forever.
+    """
+
+    def test_generation_guard_blocks_then_unconditional_release_evicts(self):
+        runner = _make_runner()
+        runner._session_run_generation = {}
+        key = "agent:main:telegram:private:1"
+
+        gen_n = runner._begin_session_run_generation(key)
+        dead_agent = MagicMock()
+        runner._running_agents[key] = dead_agent
+        runner._running_agents_ts[key] = 1.0
+        runner._busy_ack_ts[key] = 1.0
+
+        # session_reset bumps the generation while gen-N is still in flight.
+        runner._invalidate_session_run_generation(key, reason="session_reset")
+
+        # gen-N's own guarded release is correctly blocked — slot would be a
+        # zombie if nothing else cleared it (the pre-fix behaviour).
+        assert runner._release_running_agent_state(key, run_generation=gen_n) is False
+        assert runner._running_agents.get(key) is dead_agent
+
+        # The fix: unconditional release (no run_generation) always clears it.
+        assert runner._release_running_agent_state(key) is True
+        assert key not in runner._running_agents
+        assert key not in runner._running_agents_ts
+        assert key not in runner._busy_ack_ts
+
+    def test_normal_completion_is_not_evicted_by_outer_release(self):
+        """Guarded release with the current generation succeeds; the outer
+        unconditional release that follows is a harmless no-op.
+        """
+        runner = _make_runner()
+        runner._session_run_generation = {}
+        key = "agent:main:telegram:private:2"
+
+        gen = runner._begin_session_run_generation(key)
+        runner._running_agents[key] = MagicMock()
+        runner._running_agents_ts[key] = 1.0
+        runner._busy_ack_ts[key] = 1.0
+
+        assert runner._release_running_agent_state(key, run_generation=gen) is True
+        assert key not in runner._running_agents
+        # Outer finally runs the unconditional release after — nothing stranded.
+        assert runner._release_running_agent_state(key) is True
+        assert key not in runner._running_agents_ts
+        assert key not in runner._busy_ack_ts


### PR DESCRIPTION
## Summary
A session reset (`/new`, `/cc`) that races an in-flight agent turn no longer leaves the session permanently locked — it now clears the running-agent slot deterministically.

Root cause: when `session_reset` bumps the run generation (N → N+1) mid-flight, the in-flight run's own `_release_running_agent_state(key, run_generation=N)` is correctly blocked by the generation guard (stale gen). The outer `_process_message_or_command` finally then checked only for the `_AGENT_PENDING_SENTINEL` — the slot actually held a leftover *real* gen-N agent, so it fell into the `else` branch, popping the paired metadata but not `_running_agents[key]`. The dead agent stayed in the slot and every subsequent message was silently dropped as "agent busy" until a full gateway restart. (#28686)

## Changes
- `gateway/run.py` — `_process_message_or_command` outer finally now calls the unconditional, idempotent `_release_running_agent_state(key)` on all exit paths, replacing the sentinel-vs-else branch that could strand a dead agent.
- `gateway/run.py` — `_handle_reset_command` evicts the slot immediately after bumping the generation, so the zombie is cleared at reset time regardless of how the in-flight run unwinds. Idempotent, so the run's own finally calling it again is harmless.
- `tests/gateway/test_session_state_cleanup.py` — regression tests for the generation-guard-blocked zombie path and the normal-completion no-eviction path.

## Validation
| Scenario | Before | After |
|---|---|---|
| reset bumps gen, guarded release blocked | dead agent stays in slot → session locked out | unconditional release evicts it + paired metadata |
| idempotent re-release | n/a | no-op, no raise |
| normal completion + outer release | clears | still clears, outer release is no-op (live agent never evicted) |
| sentinel early-exit | cleared | cleared |

Targeted gateway suite: `tests/gateway/test_session_state_cleanup.py` 12 passed; broader running-agent/reset/generation selection 161 passed, 2 skipped. E2E harness driving the real `_release_running_agent_state` + generation logic confirms the zombie forms on the pre-fix branch and is evicted by the patch.

Salvaged from #30834 by @CryptoByz with authorship preserved; outer-finally hunk re-anchored to current `main` and regression tests added.

## Infographic

![zombie-slot-killed](https://v3b.fal.media/files/b/0a9cf268/PN47RQi-ckBR9BG58gAoH_pYBOLmFf.png)
