### PR TITLE
[codex] Fix packaged Desktop self-update frontend path

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -224,6 +224,7 @@ const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.j
 // tracks main. User can also override at runtime via
 // hermesDesktop.updates.setBranch().
 const DEFAULT_UPDATE_BRANCH = 'main'
+const GIT_OPERATION_TIMEOUT_MS = Number.parseInt(process.env.HERMES_DESKTOP_GIT_TIMEOUT_MS || '15000', 10)
 // desktop.log lives under HERMES_HOME/logs/ so it sits next to agent.log,
 // errors.log, gateway.log produced by hermes_logging.setup_logging — one log
 // directory per user, regardless of which UI surface produced the line.
@@ -1136,6 +1137,7 @@ function resolveUpdateRoot() {
 
 function runGit(args, options = {}) {
   return new Promise((resolve, reject) => {
+    let settled = false
     const child = spawn(resolveGitBinary(), IS_WINDOWS ? ['-c', 'windows.appendAtomically=false', ...args] : args, {
       cwd: options.cwd,
       env: { ...process.env, ...(options.env || {}), GIT_TERMINAL_PROMPT: '0' },
@@ -1154,8 +1156,29 @@ function runGit(args, options = {}) {
       stderr += text
       options.onLine?.('stderr', text)
     })
-    child.once('error', reject)
-    child.once('exit', code => resolve({ code, stdout, stderr }))
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      stderr = stderr
+        ? `${stderr}\ngit operation timed out after ${GIT_OPERATION_TIMEOUT_MS}ms`
+        : `git operation timed out after ${GIT_OPERATION_TIMEOUT_MS}ms`
+      try {
+        child.kill('SIGTERM')
+      } catch {}
+      resolve({ code: null, stdout, stderr, timedOut: true })
+    }, GIT_OPERATION_TIMEOUT_MS)
+    child.once('error', error => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', code => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve({ code, stdout, stderr })
+    })
   })
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -164,6 +164,7 @@
     "asar": true,
     "afterSign": "scripts/notarize.cjs",
     "asarUnpack": [
+      "dist/**",
       "**/*.node",
       "**/prebuilds/**"
     ],

--- a/tests/test_desktop_packaging.py
+++ b/tests/test_desktop_packaging.py
@@ -1,0 +1,19 @@
+"""Regression guards for the packaged Hermes Desktop bundle config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_dist_is_unpacked_for_python_backend():
+    package_json = json.loads(
+        (REPO_ROOT / "apps" / "desktop" / "package.json").read_text(encoding="utf-8")
+    )
+
+    asar_unpack = package_json.get("build", {}).get("asarUnpack", [])
+
+    assert "dist/**" in asar_unpack

--- a/tests/test_desktop_update_safety.py
+++ b/tests/test_desktop_update_safety.py
@@ -1,0 +1,19 @@
+"""Regression guards for Desktop self-update safety."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_git_update_checks_have_timeout_and_cleanup():
+    main_cjs = (REPO_ROOT / "apps" / "desktop" / "electron" / "main.cjs").read_text(
+        encoding="utf-8"
+    )
+
+    assert "GIT_OPERATION_TIMEOUT_MS" in main_cjs
+    assert "setTimeout" in main_cjs
+    assert "child.kill" in main_cjs
+    assert "git operation timed out" in main_cjs


### PR DESCRIPTION
## Summary

- unpack the Desktop renderer `dist/**` alongside `app.asar` so the Python dashboard backend can serve the packaged frontend path Electron passes via `HERMES_WEB_DIST`
- add a Desktop packaging regression guard for the required `asarUnpack` entry
- add a timeout around Desktop self-update git operations so a stuck fetch/check cannot hang the update flow indefinitely

## Root cause

Packaged Electron builds rewrite `app.asar/...` paths to `app.asar.unpacked/...` before passing the frontend dist path to the backend. Without `dist/**` in `asarUnpack`, the backend receives a path that does not exist after a self-update, causing the Desktop dashboard surface to fail or serve 404 instead of the Hermes app.

## Validation

- `/Users/foras/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_desktop_packaging.py tests/test_desktop_update_safety.py -q`
- `npm run --workspace apps/desktop type-check` passed in the main local checkout with the same Desktop update timeout change and installed workspace dependencies
- local rebuilt `/Applications/Hermes.app` opens successfully and `http://127.0.0.1:9120/` returns Hermes HTML
