### PR TITLE
fix(file): verify file exists after write to catch CWD-drift (salvage #26336)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,6 +60,8 @@ AUTHOR_MAP = {
     "david.gutowsky@gmail.com": "davidgut1982",
     "drpelagik@gmail.com": "SeaXen",
     "lengr@users.noreply.github.com": "LengR",
+    "Kewe63@users.noreply.github.com": "Kewe63",
+    "kewe.3217@gmail.com": "Kewe63",
     "17255546+CharZhou@users.noreply.github.com": "CharZhou",
     "metalclaudbot@gmail.com": "HashClawAI",
     "tonybear55665566@gmail.com": "TonyPepeBear",

--- a/tests/tools/test_file_staleness.py
+++ b/tests/tools/test_file_staleness.py
@@ -65,7 +65,20 @@ def _make_fake_ops(read_content="hello\n", file_size=6):
     fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
         content=read_content, total_lines=1, file_size=file_size,
     )
-    fake.write_file = lambda path, content: _FakeWriteResult()
+
+    def _fake_write(path, content):
+        # Actually create the file on disk so post-write verification
+        # (_verify_file_written) finds it — mirrors a real write. Without
+        # this the verification would emit a spurious "could not be
+        # verified" warning for paths the fake never created.
+        try:
+            with open(path, "w") as _f:
+                _f.write(content)
+        except OSError:
+            pass
+        return _FakeWriteResult()
+
+    fake.write_file = _fake_write
     fake.patch_replace = lambda path, old, new, replace_all=False: _FakePatchResult()
     return fake
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -192,6 +192,27 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
         return None
 
 
+def _verify_file_written(filepath: str, task_id: str = "default") -> str | None:
+    """Verify a file exists at the resolved absolute path after writing.
+
+    Uses the task's live terminal CWD to resolve *filepath*, then checks
+    whether the resulting path exists on the filesystem.  Returns the
+    resolved path on failure (write targeted a different CWD than expected)
+    or ``None`` on success.
+
+    This detects CWD drift (from ``cd`` commands or environment cleanup +
+    recreation) that causes ``write_file`` to silently place files in an
+    unexpected directory.
+    """
+    try:
+        resolved = str(_resolve_path_for_task(filepath, task_id))
+    except Exception:
+        return filepath
+    if os.path.exists(resolved):
+        return None
+    return resolved
+
+
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd paths that can hang reads."""
     normalized = os.path.expanduser(path)
@@ -1079,6 +1100,18 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             _update_read_timestamp(path, task_id)
+            # Post-write verification: ensure the file exists at the expected
+            # absolute path.  The write may have targeted a different CWD than
+            # the user expects (e.g. after environment cleanup + recreation or
+            # CWD drift from cd commands in long conversations).
+            if not result_dict.get("error"):
+                _verify_path = _verify_file_written(path, task_id)
+                if _verify_path:
+                    result_dict["_warning"] = (
+                        f"File was written but could not be verified at the expected "
+                        f"location. It may exist at a different path. "
+                        f"Use an absolute path to avoid CWD-dependent writes."
+                    )
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
@@ -1109,6 +1142,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
+                # Post-write verification: check the resolved path exists.
+                _verify_path = _verify_file_written(path, task_id)
+                if _verify_path:
+                    result_dict["_warning"] = (
+                        f"File was written but could not be verified at the expected "
+                        f"location ({_resolved}). It may exist at a different path. "
+                        f"Use an absolute path to avoid CWD-dependent writes."
+                    )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):


### PR DESCRIPTION
## Summary
`write_file` now warns when a written file can't be found at its expected resolved location — catching silent CWD-drift failures in long conversations.

Salvage of #26336 by @Kewe63, cherry-picked onto current main with authorship preserved.

Root cause: in long-running sessions the terminal CWD can drift (`cd` commands, or environment recreation after a cleanup-thread inactivity timeout). A relative-path `write_file` then lands in a different directory than expected, but the tool reported success because the shell write itself succeeded.

## Changes
- `tools/file_tools.py`: add `_verify_file_written()` — resolves the path against the task's live terminal CWD and checks `os.path.exists()`. After a successful write, if the file isn't found at the expected absolute path, attach a `_warning` advising an absolute path. Returns `None` (no warning) when the file exists.
- `scripts/release.py`: add @Kewe63 to AUTHOR_MAP

## Validation
| | Result |
|---|---|
| File exists at resolved path | returns `None` — no warning (E2E) |
| File missing at resolved path | returns the resolved path → `_warning` fires (E2E) |
| Real successful `write_file_tool` | no false-positive warning (E2E) |
| `tests/tools/test_file_tools.py` | 36/36 pass |

Closes #26336 via salvage.

## Infographic

![post-write-verification](https://v3b.fal.media/files/b/0a9cf27e/fKP50VtwRPJXFSKk8q5k8_V1dhBN3u.png)
