### PR TITLE
fix(slack): pass thread_ts in standalone send_message tool path

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "dirtyren@users.noreply.github.com": "dirtyren",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -595,6 +595,7 @@ class TestSendToPlatformChunking:
             "***",
             "C123",
             "*hello* from <https://example.com|Hermes>",
+            thread_ts=None,
         )
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -767,7 +767,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_ts=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1049,7 +1049,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_ts=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1063,6 +1063,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_ts:
+                payload["thread_ts"] = thread_ts
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
The `send_message` tool (and cron-delivery fallback) now posts Slack messages inside threads instead of always landing in the top-level channel.

Root cause: the standalone `_send_slack()` HTTP path never included `thread_ts` in the `chat.postMessage` payload. The live `SlackAdapter.send()` path threaded correctly via metadata; only the standalone path was missing it.

## Changes
- `tools/send_message_tool.py`: `_send_slack()` accepts `thread_ts` and includes it in the payload when set; `_send_to_platform()` forwards `thread_id` as `thread_ts`.
- `tests/tools/test_send_message_tool.py`: assertion updated for the new kwarg.
- `scripts/release.py`: AUTHOR_MAP entry for @dirtyren.

## Validation
| | Before | After |
|---|---|---|
| `send_message` → `slack:CHANNEL:THREAD_TS` | posts to channel | posts in thread |
| `_send_slack(..., thread_ts=None)` | n/a | no `thread_ts` key |

- `pytest tests/tools/test_send_message_tool.py -k slack` — 14 passed
- E2E: verified `thread_ts` is forwarded into the `chat.postMessage` payload when set and omitted when None.

Salvage of #38177 by @dirtyren — cherry-picked onto current main with authorship preserved.

## Infographic

![slack-thread-fix](https://v3b.fal.media/files/b/0a9cf285/ucNl8NULf9Xor7i3MPVuy_IE1qJHYO.png)
