### PR TITLE
fix(desktop): salvage AhmetArif0 desktop/dashboard fixes (#38289, #38291, #38294)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4069,9 +4069,26 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
   writeDesktopConnectionConfig(config)
-  resetHermesConnection()
-  setTimeout(() => mainWindow?.reload(), 150)
 
+  // Capture the reference before resetHermesConnection() nulls hermesProcess,
+  // so we can wait for actual exit rather than assuming a fixed delay is enough.
+  const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
+  resetHermesConnection()
+
+  if (dying) {
+    await new Promise(resolve => {
+      const timer = setTimeout(() => {
+        try { dying.kill('SIGKILL') } catch {}
+        resolve()
+      }, 5000)
+      dying.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+
+  mainWindow?.reload()
   return sanitizeDesktopConnectionConfig(config)
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -333,6 +333,10 @@ export default function ProfilesPage() {
   // Tracks the latest description request (save / auto-describe) so a late
   // response can't overwrite state for a different, newly-opened editor.
   const activeDescRequest = useRef<string | null>(null);
+  // Counts in-flight save / auto-describe requests so the saving indicator
+  // is only cleared when the last concurrent request settles.
+  const descSavingCount = useRef(0);
+  const describingCount = useRef(0);
 
   // Inline model editor state
   const [editingModelFor, setEditingModelFor] = useState<string | null>(null);
@@ -551,6 +555,7 @@ export default function ProfilesPage() {
   );
 
   const handleSaveDesc = async (name: string) => {
+    descSavingCount.current += 1;
     setDescSaving(true);
     activeDescRequest.current = name;
     try {
@@ -577,11 +582,13 @@ export default function ProfilesPage() {
         showToast(`${t.status.error}: ${e}`, "error");
       }
     } finally {
-      setDescSaving(false);
+      descSavingCount.current -= 1;
+      if (descSavingCount.current === 0) setDescSaving(false);
     }
   };
 
   const handleAutoDescribe = async (name: string) => {
+    describingCount.current += 1;
     setDescribing(true);
     activeDescRequest.current = name;
     try {
@@ -609,7 +616,8 @@ export default function ProfilesPage() {
         showToast(`${t.status.error}: ${e}`, "error");
       }
     } finally {
-      setDescribing(false);
+      describingCount.current -= 1;
+      if (describingCount.current === 0) setDescribing(false);
     }
   };
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -414,7 +414,7 @@ export default function ProfilesPage() {
             (c) => `${c.provider}\u0000${c.model}` === modelChoice,
           )
         : undefined;
-      await api.createProfile({
+      const res = await api.createProfile({
         name,
         clone_from_default: cloneAll ? false : cloneFromDefault,
         clone_all: cloneAll,
@@ -424,6 +424,12 @@ export default function ProfilesPage() {
         model: picked?.model,
       });
       showToast(`${t.profiles.created}: ${name}`, "success");
+      if (picked && res.model_set === false) {
+        showToast(
+          `Profile created, but the model could not be saved — set it from the profile editor.`,
+          "error",
+        );
+      }
       setNewName("");
       setNewDescription("");
       setNoSkills(false);


### PR DESCRIPTION
## Summary
Salvages three desktop/dashboard bug fixes from @AhmetArif0 onto current `main`, with authorship preserved per-commit.

## Changes
- **`apps/desktop/electron/main.cjs`** (#38289): `connection-config:apply` now waits for the old backend process to actually exit (5s SIGKILL fallback) before reloading, instead of a blind 150ms timer that could reload while the port was still bound.
- **`web/src/pages/ProfilesPage.tsx`** (#38291): profile creation now reads `model_set` from the API response and surfaces an error toast when the model write silently failed (previously a success toast hid the failure).
- **`web/src/pages/ProfilesPage.tsx`** (#38294): `handleSaveDesc` / `handleAutoDescribe` use in-flight counters so overlapping requests don't clear the saving indicator early.

## Validation
| Check | Result |
|---|---|
| `node --check main.cjs` | OK |
| `tsc --noEmit` ProfilesPage | no errors |
| diff vs origin/main | 2 files, +35/-4 |

Cherry-picked from PRs #38289, #38291, #38294. Closes those PRs with credit.

## Infographic

![desktop-fixes-x3](https://v3b.fal.media/files/b/0a9cf292/Pisoa5X-vxib_dQYC6NMy_vTCwYVlk.png)
