### PR TITLE
feat(gateway): add generic context anchors

### DIFF
--- a/gateway/context_anchors.py
+++ b/gateway/context_anchors.py
@@ -1,0 +1,181 @@
+"""Persistent context anchors for messaging chats and threads."""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+_CONTEXT_ANCHOR_RE = re.compile(
+    r"\[context:(?P<type>[a-z][a-z0-9_-]{0,63}):(?P<id>[^\]\s][^\]]*?)\]",
+    re.IGNORECASE,
+)
+_URL_RE = re.compile(r"^https?://", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ContextAnchor:
+    """A durable reference that helps recover context for a chat lane."""
+
+    anchor_type: str
+    anchor_id: str
+    title: str = ""
+    url: str = ""
+    source: str = "manual"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.anchor_type,
+            "id": self.anchor_id,
+            "title": self.title,
+            "url": self.url,
+            "source": self.source,
+            "metadata": dict(self.metadata or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "ContextAnchor | None":
+        if not isinstance(data, dict):
+            return None
+        anchor_type = str(data.get("type") or data.get("anchor_type") or "").strip().lower()
+        anchor_id = str(data.get("id") or data.get("anchor_id") or "").strip()
+        if not anchor_type or not anchor_id:
+            return None
+        metadata = data.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        return cls(
+            anchor_type=anchor_type,
+            anchor_id=anchor_id,
+            title=str(data.get("title") or "").strip(),
+            url=str(data.get("url") or "").strip(),
+            source=str(data.get("source") or "manual").strip() or "manual",
+            metadata=dict(metadata),
+        )
+
+
+def parse_context_anchor_marker(text: str | None) -> ContextAnchor | None:
+    """Parse a generic ``[context:<type>:<id>]`` marker from text."""
+
+    if not text:
+        return None
+    match = _CONTEXT_ANCHOR_RE.search(text)
+    if not match:
+        return None
+    anchor_type = (match.group("type") or "").strip().lower()
+    anchor_id = (match.group("id") or "").strip()
+    if not anchor_type or not anchor_id:
+        return None
+    return ContextAnchor(anchor_type=anchor_type, anchor_id=anchor_id, source="thread-title")
+
+
+def infer_anchor_type(anchor_id: str) -> str:
+    """Infer a useful type for URL/freeform anchors when users omit one."""
+
+    value = (anchor_id or "").strip()
+    if _URL_RE.match(value):
+        return "url"
+    return "reference"
+
+
+class ContextAnchorStore:
+    """Durable mapping from platform chat/thread lanes to context anchors."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._lock = threading.RLock()
+
+    def bind(
+        self,
+        source: SessionSource,
+        *,
+        anchor_type: str,
+        anchor_id: str,
+        title: str = "",
+        url: str = "",
+        source_label: str = "manual",
+        metadata: dict[str, Any] | None = None,
+    ) -> ContextAnchor:
+        anchor_type = str(anchor_type or "").strip().lower()
+        anchor_id = str(anchor_id or "").strip()
+        if not anchor_type:
+            raise ValueError("anchor_type is required")
+        if not anchor_id:
+            raise ValueError("anchor_id is required")
+        anchor = ContextAnchor(
+            anchor_type=anchor_type,
+            anchor_id=anchor_id,
+            title=str(title or "").strip(),
+            url=str(url or "").strip(),
+            source=str(source_label or "manual").strip() or "manual",
+            metadata=dict(metadata or {}),
+        )
+        with self._lock:
+            data = self._read()
+            data[self._source_key(source)] = anchor.to_dict()
+            self._write(data)
+        return anchor
+
+    def unbind(self, source: SessionSource) -> ContextAnchor | None:
+        with self._lock:
+            data = self._read()
+            raw = data.pop(self._source_key(source), None)
+            if raw is None:
+                return None
+            self._write(data)
+        return ContextAnchor.from_dict(raw)
+
+    def resolve_for_source(self, source: SessionSource) -> ContextAnchor | None:
+        with self._lock:
+            data = self._read()
+            anchor = ContextAnchor.from_dict(data.get(self._source_key(source)))
+        if anchor:
+            return anchor
+        return parse_context_anchor_marker(getattr(source, "chat_name", None)) or parse_context_anchor_marker(
+            getattr(source, "chat_topic", None)
+        )
+
+    def _read(self) -> dict[str, dict[str, Any]]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        anchors = raw.get("anchors", raw)
+        if not isinstance(anchors, dict):
+            return {}
+        return {str(key): value for key, value in anchors.items() if isinstance(value, dict)}
+
+    def _write(self, anchors: dict[str, dict[str, Any]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"version": 1, "anchors": anchors}
+        with NamedTemporaryFile("w", encoding="utf-8", dir=self.path.parent, delete=False) as tmp:
+            json.dump(payload, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(self.path)
+
+    @staticmethod
+    def _source_key(source: SessionSource) -> str:
+        platform = getattr(getattr(source, "platform", None), "value", None) or str(
+            getattr(source, "platform", "") or Platform.LOCAL.value
+        )
+        parts = [
+            platform,
+            str(getattr(source, "guild_id", None) or ""),
+            str(getattr(source, "parent_chat_id", None) or ""),
+            str(getattr(source, "chat_id", "") or ""),
+            str(getattr(source, "thread_id", None) or ""),
+        ]
+        return ":".join(part.replace(":", "%3A") for part in parts)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1146,6 +1146,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.context_anchors import ContextAnchorStore, infer_anchor_type
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -1898,6 +1899,7 @@ class GatewayRunner:
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
         )
         self.delivery_router = DeliveryRouter(self.config)
+        self.context_anchors = ContextAnchorStore(_hermes_home / "context_anchors.json")
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
         self._shutdown_event = asyncio.Event()
@@ -7895,6 +7897,13 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # Context anchors are control-plane metadata for future turns; they
+            # should not interrupt the active agent turn.
+            if _cmd_def_inner and _cmd_def_inner.name in {"bind-context", "recover"}:
+                if _cmd_def_inner.name == "bind-context":
+                    return await self._handle_bind_context_command(event)
+                return await self._handle_recover_command(event)
+
             # /kanban must bypass the guard. It writes to a profile-agnostic
             # DB (kanban.db), not to the running agent's state. In fact
             # /kanban unblock is often the only way to free a worker that
@@ -8313,6 +8322,12 @@ class GatewayRunner:
 
         if canonical == "title":
             return await self._handle_title_command(event)
+
+        if canonical == "bind-context":
+            return await self._handle_bind_context_command(event)
+
+        if canonical == "recover":
+            return await self._handle_recover_command(event)
 
         if canonical == "resume":
             return await self._handle_resume_command(event)
@@ -8971,6 +8986,8 @@ class GatewayRunner:
             })
         
         # Build session context
+        source = self._source_with_context_anchor(source)
+        event.source = source
         context = build_session_context(source, self.config, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
@@ -10064,6 +10081,110 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    def _get_context_anchor_store(self) -> ContextAnchorStore:
+        store = getattr(self, "context_anchors", None)
+        if store is None:
+            store = ContextAnchorStore(_hermes_home / "context_anchors.json")
+            self.context_anchors = store
+        return store
+
+    def _source_with_context_anchor(self, source: SessionSource) -> SessionSource:
+        """Attach durable context-anchor metadata before prompt injection."""
+
+        try:
+            anchor = self._get_context_anchor_store().resolve_for_source(source)
+        except Exception:
+            logger.debug("Failed to resolve context anchor", exc_info=True)
+            return source
+        if not anchor:
+            return source
+        return dataclasses.replace(source, context_anchor=anchor.to_dict())
+
+    async def _handle_bind_context_command(self, event: MessageEvent) -> str:
+        """Bind, show, or remove a context anchor for the current chat/thread."""
+
+        source = event.source
+        raw_args = event.get_command_args().strip()
+        store = self._get_context_anchor_store()
+        if not raw_args or raw_args.lower() in {"show", "status"}:
+            anchor = store.resolve_for_source(source)
+            if not anchor:
+                return (
+                    "No context anchor is bound to this chat/thread. "
+                    "Use `/bind-context <type> <id-or-url> [title]`."
+                )
+            title = f" — {anchor.title}" if anchor.title else ""
+            url = f"\n{anchor.url}" if anchor.url else ""
+            return f"Bound context anchor: `{anchor.anchor_type}:{anchor.anchor_id}`{title}{url}"
+        if raw_args.lower() in {"off", "clear", "remove", "unbind"}:
+            removed = store.unbind(source)
+            if removed:
+                return (
+                    f"Removed context anchor `{removed.anchor_type}:{removed.anchor_id}` "
+                    "from this chat/thread."
+                )
+            fallback = store.resolve_for_source(source)
+            if fallback and fallback.source == "thread-title":
+                return (
+                    "No manual context anchor was set; this chat/thread still has "
+                    "a context marker in its title. Remove `[context:<type>:<id>]` "
+                    "from the title to disable title fallback."
+                )
+            return "No context anchor was set for this chat/thread."
+
+        parts = raw_args.split(maxsplit=2)
+        if len(parts) == 1:
+            anchor_id = parts[0].strip()
+            anchor_type = infer_anchor_type(anchor_id)
+            title = ""
+        elif len(parts) >= 2:
+            anchor_type = parts[0].strip().lower()
+            anchor_id = parts[1].strip()
+            title = parts[2].strip() if len(parts) == 3 else ""
+        else:
+            anchor_type = ""
+            anchor_id = ""
+            title = ""
+        if not anchor_type or not anchor_id:
+            return "Usage: /bind-context <type> <id-or-url> [optional title]"
+        url = anchor_id if anchor_type == "url" and anchor_id.lower().startswith(("http://", "https://")) else ""
+        try:
+            anchor = store.bind(
+                source,
+                anchor_type=anchor_type,
+                anchor_id=anchor_id,
+                title=title,
+                url=url,
+                source_label="manual",
+            )
+        except ValueError:
+            return "Usage: /bind-context <type> <id-or-url> [optional title]"
+        title_suffix = f" — {anchor.title}" if anchor.title else ""
+        url_suffix = f"\n{anchor.url}" if anchor.url else ""
+        return (
+            f"Bound this chat/thread to context anchor `{anchor.anchor_type}:{anchor.anchor_id}`{title_suffix}.\n"
+            "Future turns will include this anchor in session context."
+            f"{url_suffix}"
+        )
+
+    async def _handle_recover_command(self, event: MessageEvent) -> str:
+        """Show the durable context-recovery anchor for the current chat/thread."""
+
+        anchor = self._get_context_anchor_store().resolve_for_source(event.source)
+        if not anchor:
+            return (
+                "No context anchor found for this chat/thread. "
+                "Add `[context:<type>:<id>]` to the thread title or run "
+                "`/bind-context <type> <id-or-url> [title]`."
+            )
+        title = f"\nTitle: {anchor.title}" if anchor.title else ""
+        url = f"\nURL: {anchor.url}" if anchor.url else ""
+        return (
+            "Recovery anchor for this chat/thread:\n"
+            f"Context anchor: `{anchor.anchor_type}:{anchor.anchor_id}`{title}{url}\n"
+            "I will inject this into future session context automatically."
+        )
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,7 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    context_anchor: Optional[Dict[str, Any]] = None  # Durable context anchor bound to this chat/thread lane
     
     @property
     def description(self) -> str:
@@ -134,6 +135,8 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.context_anchor:
+            d["context_anchor"] = self.context_anchor
         return d
 
     @classmethod
@@ -152,6 +155,7 @@ class SessionSource:
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            context_anchor=data.get("context_anchor") if isinstance(data.get("context_anchor"), dict) else None,
         )
     
 
@@ -292,6 +296,25 @@ def build_session_context_prompt(
     # Channel topic (if available - provides context about the channel's purpose)
     if context.source.chat_topic:
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
+
+    context_anchor = context.source.context_anchor if isinstance(context.source.context_anchor, dict) else None
+    if context_anchor:
+        anchor_type = str(context_anchor.get("type") or "").strip()
+        anchor_id = str(context_anchor.get("id") or "").strip()
+        if anchor_type and anchor_id:
+            lines.append("")
+            lines.append("**Bound Context Anchor:**")
+            lines.append(f"  - Type: `{anchor_type}`")
+            lines.append(f"  - ID: `{anchor_id}`")
+            title = str(context_anchor.get("title") or "").strip()
+            if title:
+                lines.append(f"  - Title: {title}")
+            url = str(context_anchor.get("url") or "").strip()
+            if url:
+                lines.append(f"  - URL: {url}")
+            source_label = str(context_anchor.get("source") or "").strip()
+            if source_label:
+                lines.append(f"  - Binding source: {source_label}")
 
     # User identity.
     # In shared multi-user sessions (shared threads OR shared non-thread groups

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -116,6 +116,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("bind-context", "Bind or inspect a durable context anchor for this chat/thread", "Session",
+               gateway_only=True, aliases=("bind_context",), args_hint="[type id-or-url [title] | show | clear]"),
+    CommandDef("recover", "Show the durable context anchor for this chat/thread", "Session",
+               gateway_only=True),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/tests/gateway/test_context_anchors.py
+++ b/tests/gateway/test_context_anchors.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.context_anchors import ContextAnchorStore
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource, build_session_context_prompt
+
+
+def _source(**overrides) -> SessionSource:
+    values = {
+        "platform": Platform.DISCORD,
+        "chat_id": "channel-1",
+        "chat_type": "thread",
+        "thread_id": "thread-1",
+        "chat_name": "Context Anchor Thread",
+        "guild_id": "guild-1",
+        "parent_chat_id": "parent-1",
+    }
+    values.update(overrides)
+    return SessionSource(**values)
+
+
+def _event(text: str, **source_overrides) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(**source_overrides),
+    )
+
+
+def test_context_anchor_store_resolves_manual_thread_binding(tmp_path):
+    store = ContextAnchorStore(tmp_path / "context_anchors.json")
+    source = _source()
+
+    anchor = store.bind(
+        source,
+        anchor_type="github",
+        anchor_id="NousResearch/hermes-agent#123",
+        title="Generic context anchor PR",
+        url="https://github.com/NousResearch/hermes-agent/pull/123",
+    )
+
+    resolved = store.resolve_for_source(source)
+    assert resolved == anchor
+    assert resolved.to_dict() == {
+        "type": "github",
+        "id": "NousResearch/hermes-agent#123",
+        "title": "Generic context anchor PR",
+        "url": "https://github.com/NousResearch/hermes-agent/pull/123",
+        "source": "manual",
+        "metadata": {},
+    }
+
+
+def test_context_anchor_store_uses_title_fallback_without_manual_binding(tmp_path):
+    store = ContextAnchorStore(tmp_path / "context_anchors.json")
+    source = _source(chat_name="Hermes PRs [context:github:NousResearch/hermes-agent#456]")
+
+    resolved = store.resolve_for_source(source)
+
+    assert resolved is not None
+    assert resolved.anchor_type == "github"
+    assert resolved.anchor_id == "NousResearch/hermes-agent#456"
+    assert resolved.source == "thread-title"
+
+
+def test_session_source_serializes_context_anchor():
+    source = _source(
+        context_anchor={
+            "type": "github",
+            "id": "NousResearch/hermes-agent#123",
+            "title": "Generic context anchor PR",
+            "url": "https://github.com/NousResearch/hermes-agent/pull/123",
+            "source": "manual",
+        }
+    )
+
+    round_tripped = SessionSource.from_dict(source.to_dict())
+
+    assert round_tripped.context_anchor == source.context_anchor
+
+
+def test_session_context_prompt_includes_bound_context_anchor():
+    source = _source(
+        context_anchor={
+            "type": "github",
+            "id": "NousResearch/hermes-agent#123",
+            "title": "Generic context anchor PR",
+            "url": "https://github.com/NousResearch/hermes-agent/pull/123",
+            "source": "manual",
+        }
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    prompt = build_session_context_prompt(context)
+
+    assert "**Bound Context Anchor:**" in prompt
+    assert "Type: `github`" in prompt
+    assert "ID: `NousResearch/hermes-agent#123`" in prompt
+    assert "Title: Generic context anchor PR" in prompt
+    assert "URL: https://github.com/NousResearch/hermes-agent/pull/123" in prompt
+
+
+@pytest.mark.asyncio
+async def test_bind_context_command_binds_and_recovers_anchor(tmp_path):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.context_anchors = ContextAnchorStore(tmp_path / "context_anchors.json")
+    runner.config = SimpleNamespace()
+
+    bind_response = await runner._handle_bind_context_command(
+        _event("/bind-context github NousResearch/hermes-agent#123 Generic context anchor PR")
+    )
+    recover_response = await runner._handle_recover_command(_event("/recover"))
+
+    assert "Bound this chat/thread to context anchor `github:NousResearch/hermes-agent#123`" in bind_response
+    assert "Future turns will include this anchor" in bind_response
+    assert "Context anchor: `github:NousResearch/hermes-agent#123`" in recover_response
+    assert "Title: Generic context anchor PR" in recover_response
+
+
+@pytest.mark.asyncio
+async def test_bind_context_command_clears_manual_binding_but_reports_title_fallback(tmp_path):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.context_anchors = ContextAnchorStore(tmp_path / "context_anchors.json")
+    runner.config = SimpleNamespace()
+    source = _source(chat_name="Hermes PRs [context:github:NousResearch/hermes-agent#456]")
+
+    response = await runner._handle_bind_context_command(MessageEvent(text="/bind-context clear", source=source))
+
+    assert "No manual context anchor was set" in response
+    assert "[context:<type>:<id>]" in response
+
+
+def test_source_with_context_anchor_attaches_resolved_binding(tmp_path):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.context_anchors = ContextAnchorStore(tmp_path / "context_anchors.json")
+    source = _source()
+    runner.context_anchors.bind(source, anchor_type="github", anchor_id="NousResearch/hermes-agent#123")
+
+    enriched = runner._source_with_context_anchor(source)
+
+    assert enriched is not source
+    assert enriched.context_anchor == {
+        "type": "github",
+        "id": "NousResearch/hermes-agent#123",
+        "title": "",
+        "url": "",
+        "source": "manual",
+        "metadata": {},
+    }


### PR DESCRIPTION
## What does this PR do?

Adds a generic gateway context-anchor layer so a chat/thread can carry durable, provider-agnostic context across turns without baking Todoist or any other service into core gateway state.

The new `ContextAnchor` model supports typed references such as GitHub issues/PRs, Linear tasks, Notion pages, URLs, or plain references. Gateway turns now inject a bound anchor into the session context prompt, and users can manage the binding with `/bind-context` and inspect it with `/recover`. Thread titles can also provide a lightweight fallback marker via `[context:type:id]`.

## Related Issue

Related: #30498, #35465, #16617

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `gateway/context_anchors.py` with a durable `ContextAnchor` model/store and `[context:type:id]` title-marker fallback.
- Extended `SessionSource` serialization and `build_session_context_prompt()` to carry and display bound context-anchor metadata.
- Registered gateway-only `/bind-context` and `/recover` commands for explicit anchor management.
- Enriched gateway session sources with resolved context anchors before session prompt construction.
- Added gateway tests for manual binding, title fallback, prompt injection, command handling, and source enrichment.

## Documentation Status

No user-guide docs are included in this branch yet. The command behavior is covered by tests and gateway command registration; a docs follow-up for `/bind-context`, `/recover`, and `[context:type:id]` title markers would be appropriate if maintainers want user-facing docs before merge.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_context_anchors.py tests/gateway/test_gateway_command_help.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_session.py`.
2. Run `uv run --extra dev ruff check gateway/context_anchors.py gateway/session.py gateway/run.py hermes_cli/commands.py tests/gateway/test_context_anchors.py`.
3. Run `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile gateway/context_anchors.py gateway/session.py gateway/run.py hermes_cli/commands.py tests/gateway/test_context_anchors.py`.
4. Run `git diff --check`.

Full-suite note: `uv run --extra dev python -m pytest tests/ -q` failed during collection in this environment because optional `acp` and `aiohttp` packages were missing. Retrying with `--extra acp --extra messaging` reached the suite but failed first at unrelated ACP approval test `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` before the context-anchor tests were involved; an unconstrained run was later killed with exit 137 after reaching 13%.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (related context/recovery issues are linked above; no duplicate generic anchor implementation found)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; blocked by environment issues noted above)
- [x] I've added tests for my changes (gateway context-anchor, command, prompt, and source-enrichment coverage)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — user-facing docs for the new gateway commands are not included yet; see Documentation Status
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys were added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-agnostic Python/gateway state logic; no filesystem path or subprocess behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schemas changed

## Screenshots / Logs

Focused validation passed:

```text
scripts/run_tests.sh tests/gateway/test_context_anchors.py tests/gateway/test_gateway_command_help.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_session.py

=== Summary: 4 files, 125 tests passed, 0 failed (100% complete) in 3.5s (16 workers) ===
```

```text
uv run --extra dev ruff check gateway/context_anchors.py gateway/session.py gateway/run.py hermes_cli/commands.py tests/gateway/test_context_anchors.py
All checks passed!
```
