### PR TITLE
fix(telegram): finalize sealed overflow chunk so split streamed replies render formatting

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -530,7 +530,19 @@ class GatewayStreamConsumer:
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
+                        # finalize=True so the adapter applies platform-specific
+                        # rich-text markup (e.g. Telegram MarkdownV2). This
+                        # sealed chunk will never be edited again — _message_id
+                        # is reset to None right below — so it must receive its
+                        # final formatting pass now, or early split messages
+                        # render raw markdown while only the last chunk renders.
+                        # is_turn_final=False: this is the first of several split
+                        # messages, NOT the turn-final answer, so the fresh-final
+                        # path (opt-in fresh_final_after_seconds) must not mark
+                        # the turn delivered on it (#29346 semantics).
+                        ok = await self._send_or_edit(
+                            chunk, finalize=True, is_turn_final=False,
+                        )
                         if self._fallback_final_send or not ok:
                             # Edit failed (or backed off due to flood control)
                             # while attempting to split an oversized message.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",
+    "ali.zakaee.1997@gmail.com": "ITheEqualizer",
     "copii.list@gmail.com": "stremtec",
     "solaiagent@gmail.com": "solaitken",
     "prostoandrei9@gmail.com": "vladkvlchk",


### PR DESCRIPTION
## Summary
Long multi-part streamed Telegram replies now render formatting on every split message, not just the last one.

Root cause: in the existing-message overflow path, `stream_consumer.run()` sealed the first chunk with `_send_or_edit(chunk)` (`finalize=False`) and then reset `_message_id = None` on the next line. That sealed chunk was never edited again, so it never received the adapter's finalize pass — and Telegram applies MarkdownV2 formatting on the finalize edit. Result: early split messages showed raw markdown (`##`, `**bold**`, code fences) while only the final chunk rendered correctly.

## Changes
- `gateway/stream_consumer.py`: seal the overflow chunk with `finalize=True` so it gets its final formatting pass before `_message_id` is cleared.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| | Before | After |
|---|---|---|
| Early split chunk on Telegram | raw markdown (no finalize pass) | finalized → MarkdownV2 rendered |
| `tests/gateway/test_stream_consumer.py` | 92 passed | 92 passed |

## Provenance
Salvaged from #32609 by @ITheEqualizer (authorship preserved). Only the streaming-format one-liner is carried over:
- The PR's `send_draft` `parse_mode` change is already superseded on current `main` (which formats drafts with a MarkdownV2→plaintext fallback the PR lacks).
- The PR's media-delivery-roots change conflicts with the current denylist + recency-window delivery model — adding `/tmp`/`~` to the unconditional allowlist would defeat strict mode, which already trusts freshly-produced files in those dirs.

No new unit test: the StreamConsumer mock harness short-circuits inside `_send_or_edit` (draft path, identical-text skip, fresh-final) such that patched and unpatched code produce identical observable adapter calls in the synthetic setup — a test there would pass on both. The fix is verified by source inspection + execution trace (the overflow `while` body runs, the chunk is sealed and abandoned, so finalizing it is strictly correct). Relies on the existing suite + CI.

## Infographic

![telegram-finalize-sealed-overflow-chunk](https://v3b.fal.media/files/b/0a9cf2ab/IcEIzt2yVcKsCK6vdArja_sxft1lrD.png)
