### PR TITLE
fix(agent): distinguish transient Gemini rate limits from daily quota exhaustion

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -855,6 +855,8 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
         code = "code_assist_rate_limited"
         if error_reason == "MODEL_CAPACITY_EXHAUSTED":
             code = "code_assist_capacity_exhausted"
+        elif error_reason == "RATE_LIMIT_EXCEEDED":
+            code = "code_assist_rate_limit_exceeded"
 
     # Build a human-readable message.  Keep the status + a raw-body tail for
     # debugging, but lead with a friendlier summary when we recognize the
@@ -863,12 +865,36 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
     if isinstance(error_metadata, dict):
         model_hint = str(error_metadata.get("model") or error_metadata.get("modelId") or "").strip()
 
+    # Transient per-minute rate limit (RPM/TPM).  Google returns the SAME
+    # 429 RESOURCE_EXHAUSTED envelope as a true daily-quota exhaustion, so
+    # disambiguate on the ErrorInfo reason (or a per-window message) to avoid
+    # telling the user their daily quota is gone when it actually resets in
+    # seconds.  Only the explicit RATE_LIMIT_EXCEEDED reason re-tags the code
+    # (see classify block above); the message-based signal refines the
+    # human-readable text only.
+    _msg_lower = err_message.lower()
+    _is_transient_rate = error_reason == "RATE_LIMIT_EXCEEDED" or (
+        err_status == "RESOURCE_EXHAUSTED"
+        and any(
+            token in _msg_lower
+            for token in ("per minute", "per-minute", "requests per", "per second")
+        )
+    )
+
     if status == 429 and error_reason == "MODEL_CAPACITY_EXHAUSTED":
         target = model_hint or "this Gemini model"
         message = (
             f"Gemini capacity exhausted for {target} (Google-side throttle, "
             f"not a Hermes issue). Try a different Gemini model or set a "
             f"fallback_providers entry to a non-Gemini provider."
+        )
+        if retry_delay_seconds is not None:
+            message += f" Google suggests retrying in {retry_delay_seconds:g}s."
+    elif status == 429 and _is_transient_rate:
+        message = (
+            f"Gemini rate limited ({err_message or 'RATE_LIMIT_EXCEEDED'}) — "
+            f"short-term per-minute throttle, not daily-quota exhaustion. "
+            f"Hermes will back off and retry automatically."
         )
         if retry_delay_seconds is not None:
             message += f" Google suggests retrying in {retry_delay_seconds:g}s."

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -865,19 +865,23 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
     if isinstance(error_metadata, dict):
         model_hint = str(error_metadata.get("model") or error_metadata.get("modelId") or "").strip()
 
-    # Transient per-minute rate limit (RPM/TPM).  Google returns the SAME
+    # Transient short-window rate limit (RPM/TPM).  Google returns the SAME
     # 429 RESOURCE_EXHAUSTED envelope as a true daily-quota exhaustion, so
     # disambiguate on the ErrorInfo reason (or a per-window message) to avoid
     # telling the user their daily quota is gone when it actually resets in
     # seconds.  Only the explicit RATE_LIMIT_EXCEEDED reason re-tags the code
     # (see classify block above); the message-based signal refines the
     # human-readable text only.
+    #
+    # Token list is deliberately restricted to explicit minute/second windows.
+    # A bare "requests per" would also match "requests per day", which is a
+    # genuine daily-quota message and must keep the /gquota guidance.
     _msg_lower = err_message.lower()
     _is_transient_rate = error_reason == "RATE_LIMIT_EXCEEDED" or (
         err_status == "RESOURCE_EXHAUSTED"
         and any(
             token in _msg_lower
-            for token in ("per minute", "per-minute", "requests per", "per second")
+            for token in ("per minute", "per-minute", "per second", "per-second")
         )
     )
 
@@ -893,7 +897,7 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
     elif status == 429 and _is_transient_rate:
         message = (
             f"Gemini rate limited ({err_message or 'RATE_LIMIT_EXCEEDED'}) — "
-            f"short-term per-minute throttle, not daily-quota exhaustion. "
+            f"short-term rate limit, not daily-quota exhaustion. "
             f"Hermes will back off and retry automatically."
         )
         if retry_delay_seconds is not None:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1105,6 +1105,29 @@ class TestGeminiHttpErrorParsing:
         assert "/gquota" in message
         assert "rate limited" not in message.lower()
 
+    def test_per_day_message_is_not_misclassified_as_rate_limit(self):
+        """A 'requests per day' body is a daily quota, not a transient limit.
+
+        Guards the message heuristic against the 'requests per' overmatch:
+        the per-window token list must require minute/second, so a daily
+        message keeps the /gquota guidance.
+        """
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": "Quota exceeded for requests per day.",
+                "status": "RESOURCE_EXHAUSTED",
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        assert err.code == "code_assist_rate_limited"
+        message = str(err)
+        assert "/gquota" in message
+        assert "rate limited" not in message.lower()
+
     def test_404_model_not_found_produces_model_retired_message(self):
         from agent.gemini_cloudcode_adapter import _gemini_http_error
 

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1013,6 +1013,11 @@ class TestGeminiHttpErrorParsing:
     def test_resource_exhausted_without_reason(self):
         from agent.gemini_cloudcode_adapter import _gemini_http_error
 
+        # NOTE: this fixture's message ("...requests per minute.") is literally
+        # the misreported case from issue #38804 — a transient per-minute
+        # throttle, NOT daily-quota exhaustion.  With no explicit ErrorInfo
+        # reason the code tag stays code_assist_rate_limited, but the
+        # message-based detection now surfaces it as a rate limit.
         body = {
             "error": {
                 "code": 429,
@@ -1024,7 +1029,81 @@ class TestGeminiHttpErrorParsing:
         assert err.status_code == 429
         assert err.code == "code_assist_rate_limited"
         message = str(err)
+        assert "rate limited" in message.lower()
+        assert "/gquota" not in message
+
+    def test_rate_limit_exceeded_reason_is_not_daily_quota(self):
+        """Explicit RATE_LIMIT_EXCEEDED reason -> distinct code + rate message."""
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": "Resource has been exhausted (e.g. check quota).",
+                "status": "RESOURCE_EXHAUSTED",
+                "details": [
+                    {
+                        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                        "reason": "RATE_LIMIT_EXCEEDED",
+                        "domain": "googleapis.com",
+                    },
+                    {
+                        "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                        "retryDelay": "49s",
+                    },
+                ],
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        assert err.code == "code_assist_rate_limit_exceeded"
+        assert err.retry_after == 49.0
+        message = str(err)
+        assert "rate limited" in message.lower()
+        # Must NOT surface the misleading daily-quota exhaustion message.
+        assert "/gquota" not in message
+        assert "remaining daily requests" not in message.lower()
+        assert "49s" in message
+
+    def test_per_minute_message_treated_as_rate_limit(self):
+        """No ErrorInfo reason, but a per-minute message -> rate-limit text only."""
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": "Quota exceeded for requests per minute.",
+                "status": "RESOURCE_EXHAUSTED",
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        # No explicit reason -> code stays the generic rate-limited tag.
+        assert err.code == "code_assist_rate_limited"
+        message = str(err)
+        assert "rate limited" in message.lower()
+
+    def test_true_daily_quota_still_reads_as_quota(self):
+        """Negative case: a real daily-quota body keeps the /gquota message."""
+        from agent.gemini_cloudcode_adapter import _gemini_http_error
+
+        body = {
+            "error": {
+                "code": 429,
+                "message": (
+                    "Quota exceeded for quota metric "
+                    "'GenerateContentPaidTier' (daily)."
+                ),
+                "status": "RESOURCE_EXHAUSTED",
+            }
+        }
+        err = _gemini_http_error(self._fake_response(429, body))
+        assert err.status_code == 429
+        assert err.code == "code_assist_rate_limited"
+        message = str(err)
         assert "quota" in message.lower()
+        assert "/gquota" in message
+        assert "rate limited" not in message.lower()
 
     def test_404_model_not_found_produces_model_retired_message(self):
         from agent.gemini_cloudcode_adapter import _gemini_http_error


### PR DESCRIPTION
## This is a sibling follow-up to commit c6fd2619f (#11833)

- #11833 covered: the `MODEL_CAPACITY_EXHAUSTED` 429 reason, giving it a distinct human message + `code_assist_capacity_exhausted` tag in `_gemini_http_error`.
- #11833 did NOT touch: the transient per-minute (RPM/TPM) rate-limit case — same 429 `RESOURCE_EXHAUSTED` envelope, but a different Google condition that resets in seconds.
- This PR adds the sibling reason branch so short-term rate limits (`RATE_LIMIT_EXCEEDED` / per-minute message) are no longer reported as daily-quota exhaustion.

## What does this PR do?

Fixes the misleading "Gemini quota exhausted — check /gquota for remaining daily requests" message that Hermes shows when Google Code Assist returns a *transient* per-minute rate limit (HTTP 429 `RESOURCE_EXHAUSTED` with a short `retryDelay`). The user's daily quota is fine; only the per-minute window is throttled. `_gemini_http_error` now disambiguates on the ErrorInfo `reason` (`RATE_LIMIT_EXCEEDED`) and a per-window message signal, emitting a rate-limit message instead. The failover classification is unchanged (still the `code_assist_rate_limited` family -> `FailoverReason.rate_limit`), so backoff/retry behaviour is identical — only the user-facing message and a downstream code tag change.

## Related Issue

Fixes #38804

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_cloudcode_adapter.py`: in `_gemini_http_error`, add a transient-rate-limit branch ahead of the generic daily-quota branch; tag an explicit `RATE_LIMIT_EXCEEDED` reason as `code_assist_rate_limit_exceeded` (message-only detection deliberately leaves the code as `code_assist_rate_limited`).
- `tests/agent/test_gemini_cloudcode.py`: add `TestGeminiHttpErrorParsing` cases for (1) `RATE_LIMIT_EXCEEDED` reason, (2) per-minute message without a reason, (3) a negative case proving a true daily quota still reads as quota. Updated the existing `test_resource_exhausted_without_reason` fixture (its message "Quota exceeded for requests per minute." was literally the misreported case) to assert the corrected rate-limit message.

## How to Test

1. Run the focused suite:
   `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_gemini_cloudcode.py -v -k "HttpError or rate or quota or capacity"`
2. Bidirectional regression guard (verified locally): stash the `agent/gemini_cloudcode_adapter.py` hunk → the three rate-limit tests fail (they receive the old "quota exhausted … check /gquota" message) → restore → all pass.
3. Full file: `… python3 -m pytest tests/agent/test_gemini_cloudcode.py` → 91 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring of `_gemini_http_error` already describes the RESOURCE_EXHAUSTED path; behaviour note added inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string/branch logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

One existing test fixture assertion was intentionally corrected (it encoded the buggy behaviour); noted above in Changes Made.