### PR TITLE
feat(gateway): optionally forward subagent events on run SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3519,6 +3519,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        # Opt-in: forward subagent lifecycle events on the run SSE. Off by default so existing
+        # API consumers see no behavior change; subagent.* event types are otherwise dropped.
+        subagent_events = os.getenv("API_SERVER_SUBAGENT_EVENTS", "").lower() in ("1", "true", "yes")
+
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
@@ -3559,7 +3563,39 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "text": preview or "",
                 })
-            # _thinking and subagent_progress are intentionally not forwarded
+            elif subagent_events and event_type == "subagent.start":
+                _push({
+                    "event": "subagent.start",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "subagent_id": kwargs.get("subagent_id"),
+                    "parent_id": kwargs.get("parent_id"),
+                    "depth": kwargs.get("depth"),
+                    "goal": kwargs.get("goal"),
+                    "task_index": kwargs.get("task_index"),
+                    "model": kwargs.get("model"),
+                })
+            elif subagent_events and event_type == "subagent.tool":
+                _push({
+                    "event": "subagent.tool",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "subagent_id": kwargs.get("subagent_id"),
+                    "tool": tool_name,
+                    "preview": preview,
+                    "goal": kwargs.get("goal"),
+                })
+            elif subagent_events and event_type == "subagent.complete":
+                _push({
+                    "event": "subagent.complete",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "subagent_id": kwargs.get("subagent_id"),
+                    "status": kwargs.get("status"),
+                    "summary": preview,
+                })
+            # _thinking and batched subagent_progress are intentionally not forwarded
+            # (we forward fine-grained subagent.tool instead, when subagent_events is on)
 
         return _callback
 


### PR DESCRIPTION
Add an opt-in API_SERVER_SUBAGENT_EVENTS env flag (default off). When enabled, the run event stream (GET /v1/runs/{id}/events) forwards the subagent lifecycle events that already reach the run event callback — subagent.start, subagent.tool (per real tool, e.g. web_search), and subagent.complete — each with its identity fields (subagent_id, parent_id, depth, goal). Previously these were dropped, so consumers could only see the top-level delegate_task and never what a delegated subagent actually did.

This lets external API consumers visualize delegated subagent activity per run. Backward-compatible: off by default, so existing consumers see no change in event volume or shape.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

