### PR TITLE
fix: harden gateway watchdog liveness checks

### DIFF
--- a/hermes_cli/gateway_watchdog.py
+++ b/hermes_cli/gateway_watchdog.py
@@ -1,0 +1,242 @@
+"""macOS launchd watchdog for the Hermes gateway.
+
+This intentionally runs outside the gateway process.  It recovers both the
+rare failure where the launchd job is removed from the gui/<uid> domain and the
+silent failure where the job is still loaded but no gateway process is live.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+DEFAULT_LABEL = "ai.hermes.gateway"
+DEFAULT_PLIST = "ai.hermes.gateway.plist"
+LOG_NAME = "gateway-domain-watchdog.log"
+ALERT_COOLDOWN_SECONDS = 30 * 60
+
+
+def _account_home() -> Path:
+    try:
+        import pwd
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return Path.home()
+
+
+def _hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or _account_home() / ".hermes").expanduser()
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _plist_path() -> Path:
+    return _account_home() / "Library" / "LaunchAgents" / DEFAULT_PLIST
+
+
+def _log(message: str) -> None:
+    home = _hermes_home()
+    log_dir = home / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with (log_dir / LOG_NAME).open("a", encoding="utf-8") as f:
+        f.write(f"{ts} {message}\n")
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return values
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+def _telegram_chat_id(home: Path, env: dict[str, str]) -> str | None:
+    for key in ("TELEGRAM_ALERT_CHAT_ID", "TELEGRAM_ALLOWED_CHATS", "TELEGRAM_CHAT_ID"):
+        raw = env.get(key) or os.environ.get(key)
+        if raw:
+            return raw.split(",", 1)[0].strip()
+
+    cfg = home / "config.yaml"
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(cfg.read_text(encoding="utf-8")) or {}
+        allowed = (data.get("telegram") or {}).get("allowed_chats")
+        if isinstance(allowed, (list, tuple)) and allowed:
+            return str(allowed[0])
+        if isinstance(allowed, str) and allowed.strip():
+            return allowed.split(",", 1)[0].strip()
+    except Exception:
+        return None
+    return None
+
+
+def _alert_state_path(home: Path) -> Path:
+    return home / "state" / "gateway-domain-watchdog-alert.json"
+
+
+def _alert_allowed(home: Path, now: float) -> bool:
+    path = _alert_state_path(home)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        last = float(data.get("last_alert_at") or 0)
+    except Exception:
+        last = 0.0
+    if now - last < ALERT_COOLDOWN_SECONDS:
+        return False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"last_alert_at": now}), encoding="utf-8")
+    except OSError:
+        pass
+    return True
+
+
+def _send_telegram_alert(message: str) -> bool:
+    home = _hermes_home()
+    env = {**_load_env(home / ".env"), **_load_env(Path.home() / ".hermes" / ".env")}
+    token = os.environ.get("TELEGRAM_BOT_TOKEN") or env.get("TELEGRAM_BOT_TOKEN")
+    chat_id = _telegram_chat_id(home, env)
+    if not token or not chat_id:
+        _log("alert skipped: missing Telegram token or chat id")
+        return False
+    if not _alert_allowed(home, time.time()):
+        _log("alert suppressed: cooldown active")
+        return False
+
+    body = urllib.parse.urlencode({"chat_id": chat_id, "text": message}).encode("utf-8")
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        with urllib.request.urlopen(url, data=body, timeout=10) as resp:  # noqa: S310 - configured Telegram API endpoint
+            ok = 200 <= getattr(resp, "status", 0) < 300
+            _log(f"alert sent: {ok}")
+            return ok
+    except Exception as exc:
+        # Never log urllib exception text: it can include the bot-token URL.
+        _log(f"alert failed: {type(exc).__name__}")
+        return False
+
+
+def _run(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+
+def is_gateway_loaded(run: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] = _run) -> bool:
+    return read_gateway_launchd_status(run).loaded
+
+
+def read_gateway_launchd_status(
+    run: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] = _run,
+) -> "LaunchdGatewayStatus":
+    result = run(["launchctl", "print", f"{_domain()}/{DEFAULT_LABEL}"])
+    if result.returncode != 0:
+        return LaunchdGatewayStatus(loaded=False, state=None, pid=None)
+    return LaunchdGatewayStatus.from_launchctl_print(result.stdout or "")
+
+
+class LaunchdGatewayStatus:
+    """Small parsed view of `launchctl print` for watchdog decisions."""
+
+    def __init__(self, *, loaded: bool, state: str | None, pid: int | None) -> None:
+        self.loaded = loaded
+        self.state = state
+        self.pid = pid
+
+    @classmethod
+    def from_launchctl_print(cls, output: str) -> "LaunchdGatewayStatus":
+        state_match = re.search(r"^\s*state\s*=\s*(.+?)\s*$", output, re.MULTILINE)
+        pid_match = re.search(r"^\s*pid\s*=\s*(\d+)\s*$", output, re.MULTILINE)
+        pid = int(pid_match.group(1)) if pid_match else None
+        state = state_match.group(1).strip() if state_match else None
+        return cls(loaded=True, state=state, pid=pid)
+
+    @property
+    def live(self) -> bool:
+        if not self.loaded:
+            return False
+        if self.state is None and self.pid is None:
+            # `launchctl print` succeeded but the text shape was not recognized.
+            # Treat that as healthy so macOS output-format drift cannot cause a
+            # destructive bootout/bootstrap loop on an otherwise loaded gateway.
+            return True
+        return self.state == "running" and self.pid is not None
+
+    @property
+    def summary(self) -> str:
+        return f"loaded={self.loaded} state={self.state or 'unknown'} pid={self.pid or 'none'}"
+
+
+def recover_gateway(run: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] = _run) -> bool:
+    plist = _plist_path()
+    if not plist.exists():
+        _log(f"recover failed: missing plist {plist}")
+        return False
+
+    domain = _domain()
+    run(["launchctl", "bootout", f"{domain}/{DEFAULT_LABEL}"])
+    run(["launchctl", "bootstrap", domain, str(plist)])
+    run(["launchctl", "kickstart", f"{domain}/{DEFAULT_LABEL}"])
+    for attempt in range(5):
+        if attempt:
+            time.sleep(0.2)
+        if read_gateway_launchd_status(run).live:
+            return True
+    return False
+
+
+def check_once(*, alert: bool = True, run: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] = _run) -> int:
+    """Return 0 when healthy/recovered, 2 when recovery failed."""
+    status = read_gateway_launchd_status(run)
+    if status.live:
+        return 0
+
+    if status.loaded:
+        _log(f"loaded but not live: {_domain()}/{DEFAULT_LABEL} {status.summary}; attempting bootstrap")
+    else:
+        _log(f"domain missing: {_domain()}/{DEFAULT_LABEL}; attempting bootstrap")
+
+    recovered = recover_gateway(run)
+    if recovered:
+        msg = "⚠️ Hermes default gateway was not live in launchd; watchdog re-bootstrapped it."
+        _log("recovered default gateway launchd liveness")
+        if alert:
+            _send_telegram_alert(msg)
+        return 0
+
+    msg = "🔴 Hermes default gateway launchd watchdog failed to re-bootstrap a live ai.hermes.gateway."
+    _log("recovery failed")
+    if alert:
+        _send_telegram_alert(msg)
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or []
+    alert = "--no-alert" not in argv
+    return check_once(alert=alert)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/hermes_cli/test_gateway_watchdog.py
+++ b/tests/hermes_cli/test_gateway_watchdog.py
@@ -1,0 +1,211 @@
+"""Tests for macOS launchd-domain gateway watchdog."""
+
+import subprocess
+import urllib.error
+
+from hermes_cli import gateway_watchdog
+
+
+def _result(code: int = 0):
+    return subprocess.CompletedProcess(["launchctl"], code, "", "")
+
+
+def _print_result(state: str = "running", pid: int | None = 1234, code: int = 0):
+    pid_line = f"\n\tpid = {pid}" if pid is not None else ""
+    return subprocess.CompletedProcess(
+        ["launchctl", "print"],
+        code,
+        f"gui/501/ai.hermes.gateway = {{\n\tstate = {state}{pid_line}\n}}\n",
+        "",
+    )
+
+
+def test_watchdog_silent_when_gateway_loaded(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(list(cmd))
+        return _print_result(state="running", pid=1234)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    assert calls == [["launchctl", "print", f"gui/{gateway_watchdog.os.getuid()}/ai.hermes.gateway"]]
+
+
+def test_watchdog_recovers_manual_bootout_without_alert_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    plist = launch_agents / "ai.hermes.gateway.plist"
+    plist.write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    calls = []
+    loaded = {"value": False}
+
+    def fake_run(cmd):
+        cmd = list(cmd)
+        calls.append(cmd)
+        if cmd[:2] == ["launchctl", "print"]:
+            if not loaded["value"]:
+                return _result(113)
+            return _print_result(state="running", pid=2468)
+        if cmd[:2] == ["launchctl", "bootout"]:
+            loaded["value"] = False
+            return _result(0)
+        if cmd[:2] == ["launchctl", "bootstrap"]:
+            loaded["value"] = True
+            return _result(0)
+        if cmd[:2] == ["launchctl", "kickstart"]:
+            return _result(0)
+        raise AssertionError(cmd)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    domain = f"gui/{gateway_watchdog.os.getuid()}"
+    assert calls == [
+        ["launchctl", "print", f"{domain}/ai.hermes.gateway"],
+        ["launchctl", "bootout", f"{domain}/ai.hermes.gateway"],
+        ["launchctl", "bootstrap", domain, str(plist)],
+        ["launchctl", "kickstart", f"{domain}/ai.hermes.gateway"],
+        ["launchctl", "print", f"{domain}/ai.hermes.gateway"],
+    ]
+    log = tmp_path / "logs" / gateway_watchdog.LOG_NAME
+    assert "recovered default gateway" in log.read_text(encoding="utf-8")
+
+
+def test_watchdog_recovers_loaded_but_not_running_gateway(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    plist = launch_agents / "ai.hermes.gateway.plist"
+    plist.write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    calls = []
+    healthy = {"value": False}
+
+    def fake_run(cmd):
+        cmd = list(cmd)
+        calls.append(cmd)
+        if cmd[:2] == ["launchctl", "print"]:
+            if healthy["value"]:
+                return _print_result(state="running", pid=4321)
+            return _print_result(state="not running", pid=None)
+        if cmd[:2] == ["launchctl", "bootout"]:
+            healthy["value"] = False
+            return _result(0)
+        if cmd[:2] == ["launchctl", "bootstrap"]:
+            healthy["value"] = True
+            return _result(0)
+        if cmd[:2] == ["launchctl", "kickstart"]:
+            return _result(0)
+        raise AssertionError(cmd)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    assert ["launchctl", "bootstrap", f"gui/{gateway_watchdog.os.getuid()}", str(plist)] in calls
+    log = tmp_path / "logs" / gateway_watchdog.LOG_NAME
+    assert "loaded but not live" in log.read_text(encoding="utf-8")
+
+
+def test_watchdog_treats_unparseable_loaded_launchctl_output_as_healthy(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(["launchctl", "print"], 0, "unexpected format\n", "")
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    assert calls == [["launchctl", "print", f"gui/{gateway_watchdog.os.getuid()}/ai.hermes.gateway"]]
+
+
+def test_watchdog_retries_after_kickstart_before_declaring_recovery_failed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_watchdog.time, "sleep", lambda _seconds: None)
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    (launch_agents / "ai.hermes.gateway.plist").write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    prints = {"count": 0}
+
+    def fake_run(cmd):
+        cmd = list(cmd)
+        if cmd[:2] == ["launchctl", "print"]:
+            prints["count"] += 1
+            if prints["count"] < 3:
+                return _print_result(state="not running", pid=None)
+            return _print_result(state="running", pid=24680)
+        return _result(0)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    assert prints["count"] == 3
+
+
+def test_watchdog_recovers_loaded_running_without_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    (launch_agents / "ai.hermes.gateway.plist").write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    calls = []
+    healthy = {"value": False}
+
+    def fake_run(cmd):
+        cmd = list(cmd)
+        calls.append(cmd)
+        if cmd[:2] == ["launchctl", "print"]:
+            if healthy["value"]:
+                return _print_result(state="running", pid=9876)
+            return _print_result(state="running", pid=None)
+        if cmd[:2] == ["launchctl", "bootstrap"]:
+            healthy["value"] = True
+        return _result(0)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 0
+    assert any(cmd[:2] == ["launchctl", "bootstrap"] for cmd in calls)
+
+
+def test_watchdog_returns_failure_when_recovery_leaves_loaded_but_not_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_watchdog.time, "sleep", lambda _seconds: None)
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    (launch_agents / "ai.hermes.gateway.plist").write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    def fake_run(cmd):
+        if list(cmd)[:2] == ["launchctl", "print"]:
+            return _print_result(state="not running", pid=None)
+        return _result(0)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 2
+
+
+def test_watchdog_returns_failure_when_recovery_cannot_load(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    (launch_agents / "ai.hermes.gateway.plist").write_text("plist", encoding="utf-8")
+    monkeypatch.setattr(gateway_watchdog, "_account_home", lambda: tmp_path)
+
+    def fake_run(cmd):
+        return _result(113 if list(cmd)[1] == "print" else 0)
+
+    assert gateway_watchdog.check_once(alert=False, run=fake_run) == 2
+
+
+def test_alert_failure_log_redacts_bot_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "SECRET_TOKEN_SHOULD_NOT_LOG")
+    (tmp_path / "config.yaml").write_text("telegram:\n  allowed_chats:\n    - 170258889\n", encoding="utf-8")
+
+    def fake_urlopen(url, data=None, timeout=None):
+        raise urllib.error.URLError(url)
+
+    monkeypatch.setattr(gateway_watchdog.urllib.request, "urlopen", fake_urlopen)
+    assert gateway_watchdog._send_telegram_alert("test") is False
+    log = (tmp_path / "logs" / gateway_watchdog.LOG_NAME).read_text(encoding="utf-8")
+    assert "SECRET_TOKEN_SHOULD_NOT_LOG" not in log
+    assert "bot" not in log


### PR DESCRIPTION
## Summary
- Harden Hermes macOS gateway watchdog from launchd-domain membership only to actual launchd liveness (`state = running` plus pid).
- Recover loaded-but-not-live gateway states by bootout/bootstrap/kickstart, while preserving domain-missing recovery.
- Fail open for unparseable `launchctl print` output to avoid destructive recovery loops if macOS output format drifts.
- Add post-kickstart liveness polling to avoid transient false failure alerts.

## Proof
Local/runtime checkout:
- `venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_gateway_watchdog.py -q` → 10 passed.
- `venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_gateway_watchdog.py tests/hermes_cli/test_gateway_service.py -q` → 143 passed.
- `venv/bin/python -m py_compile hermes_cli/gateway_watchdog.py tests/hermes_cli/test_gateway_watchdog.py` → pass.
- `venv/bin/python -m ruff check hermes_cli/gateway_watchdog.py tests/hermes_cli/test_gateway_watchdog.py` → pass.
- Live-safe watchdog probe: `scripts/hermes-gateway-watchdog --no-alert` returned 0 and default gateway PID stayed `15395` before/after.
- Live readback: default gateway launchd state running; watchdog launchd job periodic with last exit 0.
- Independent Claude Max cold review verdict: PASS, no blockers.

Rebased PR branch against upstream `origin/main`:
- `tests/hermes_cli/test_gateway_watchdog.py` → 9 passed.
- py_compile + ruff on changed files → pass.
- The upstream branch no longer has the local launchd-plist generator test target, so that local-only test was omitted from the PR branch.

## Safety notes
- No duplicate launchd jobs added.
- No gateway restart required; watchdog runs as a separate periodic launchd job and imports the updated code on each tick.
- Existing unrelated dirty files preserved: `agent/auxiliary_client.py`, `tests/agent/test_auxiliary_main_first.py`.

Linear: AGENTS-156
