### PR TITLE
feat: sort skills_list by readiness (available first)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -564,3 +564,79 @@ def is_valid_namespace(candidate: Optional[str]) -> bool:
     if not candidate:
         return False
     return bool(_NAMESPACE_RE.match(candidate))
+
+
+def get_skill_readiness_status(skill_name: str) -> str:
+    """Return the readiness status of a skill: 'available', 'setup_needed', or 'unsupported'.
+
+    Checks required_environment_variables and required_credential_files
+    from the skill's frontmatter against the current .env and filesystem.
+    """
+    from hermes_constants import get_hermes_home
+    from tools.skills_tool import (
+        SkillReadinessStatus,
+        _get_required_environment_variables,
+        _parse_frontmatter,
+        load_env,
+    )
+
+    skills_dir = get_hermes_home() / "skills"
+    env_snapshot = load_env()
+
+    # Search all skill directories for the skill's SKILL.md
+    dirs_to_scan = [skills_dir]
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+        dirs_to_scan.extend(get_external_skills_dirs())
+    except Exception:
+        pass
+
+    skill_md = None
+    for scan_dir in dirs_to_scan:
+        candidate = scan_dir / skill_name
+        if candidate.is_dir() and (candidate / "SKILL.md").exists():
+            skill_md = candidate / "SKILL.md"
+            break
+        # Also try category/skill_name
+        parts = skill_name.split("/")
+        if len(parts) == 2:
+            candidate = scan_dir / skill_name
+            if candidate.is_dir() and (candidate / "SKILL.md").exists():
+                skill_md = candidate / "SKILL.md"
+                break
+
+    if skill_md is None:
+        return "setup_needed"
+
+    try:
+        content = skill_md.read_text(encoding="utf-8")[:4000]
+        frontmatter, _ = _parse_frontmatter(content)
+    except Exception:
+        return "setup_needed"
+
+    required_env_vars = _get_required_environment_variables(frontmatter)
+    if not required_env_vars:
+        return "available"
+
+    # Check which required env vars are missing
+    missing_entries = []
+    for entry in required_env_vars:
+        name = entry.get("name") or entry.get("env_var") or ""
+        if name and not _is_env_var_persisted(name, env_snapshot):
+            missing_entries.append(entry)
+
+    if missing_entries:
+        return "setup_needed"
+    return "available"
+
+
+def _is_env_var_persisted(
+    var_name: str, env_snapshot: Dict[str, str] | None = None
+) -> bool:
+    """Check if an environment variable is set (from env_snapshot or os.environ)."""
+    if env_snapshot is None:
+        from tools.skills_tool import load_env
+        env_snapshot = load_env()
+    if var_name in env_snapshot:
+        return bool(env_snapshot.get(var_name))
+    return bool(os.getenv(var_name))

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -624,9 +624,26 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     return skills
 
 
+def _get_skill_readiness(skill_name: str) -> str:
+    """Determine if a skill is configured (available) or needs setup."""
+    try:
+        from agent.skill_utils import get_skill_readiness_status
+        return get_skill_readiness_status(skill_name)
+    except Exception:
+        return "setup_needed"
+
+
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Keep every skill listing path ordered the same way."""
-    return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
+    """Sort by readiness (available first), then by category, then name."""
+    readiness_order = {"available": 0, "setup_needed": 1, "unsupported": 2}
+    return sorted(
+        skills,
+        key=lambda s: (
+            readiness_order.get(_get_skill_readiness(s["name"]), 1),
+            s.get("category") or "",
+            s["name"],
+        ),
+    )
 
 
 def skills_list(category: str = None, task_id: str = None) -> str:
@@ -674,8 +691,12 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
 
-        # Sort by category then name
+        # Sort by readiness (available first), then by category, then name
         all_skills = _sort_skills(all_skills)
+
+        # Add readiness_status to each skill for the agent
+        for skill in all_skills:
+            skill["readiness_status"] = _get_skill_readiness(skill["name"])
 
         # Extract unique categories
         categories = sorted(


### PR DESCRIPTION
## Problem

The `skills_list` tool sorts all skills alphabetically by (category, name), regardless of whether they are configured or not. This causes the agent to waste turns trying unconfigured tools (e.g., trying `himalaya` before `google-workspace` for Gmail access).

## Solution

- **agent/skill_utils.py**: Add `get_skill_readiness_status(skill_name)` that checks a skill's `required_environment_variables` against `.env`/os.environ and returns `'available'` or `'setup_needed'`.

- **tools/skills_tool.py**: 
  - Add `_get_skill_readiness()` helper
  - Update `_sort_skills()` to sort by readiness (available > setup_needed > unsupported), then category, then name
  - Add `readiness_status` field to each skill in `skills_list()` output

## Testing

```bash
cd ~/.hermes/hermes-agent
venv/bin/python3 tools/skills_tool.py
```

Verifies that configured (available) skills appear before unconfigured (setup_needed) ones.

## Files Changed

- `agent/skill_utils.py` (+76 lines): new `get_skill_readiness_status()` and `_is_env_var_persisted()`
- `tools/skills_tool.py` (+20 lines, -3 lines): updated `_sort_skills()` and `skills_list()`