### PR TITLE
fix: keep initially blocked kanban tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1750,6 +1750,13 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -99,6 +99,33 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         assert kb.get_task(conn, child).status == "blocked"
 
 
+def test_initial_status_blocked_task_is_sticky_and_not_auto_promoted(kanban_home: Path) -> None:
+    """A task explicitly created as blocked is an operator safety hold.
+
+    It must not be promoted by the next dispatcher recompute just because it
+    has no parents. This protects create-only staging/no-dispatch workflows
+    where `hermes kanban create --initial-status blocked` is used as the
+    safety boundary before any worker can claim the task.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="staged candidate only",
+            assignee="default",
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+
+        after_recompute = kb.get_task(conn, tid)
+        assert after_recompute is not None
+        assert promoted == 0
+        assert after_recompute.status == "blocked"
+
+
 # ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve the initial blocked Kanban state as sticky metadata when tasks are inserted.
- Add regression coverage for initially blocked tasks so dispatcher/status transitions do not accidentally treat them as ordinary queued work.

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py

## Notes
- Branch pushed from fork: JVibez-D:jovex/kanban-initial-blocked-sticky