### PR TITLE
fix(cli): skip tool re-prompts in full setup after Tool Gateway

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2102,6 +2102,11 @@ def _toolset_needs_configuration_prompt(
         browser_cfg = config.get("browser", {})
         return not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg
     if ts_key == "image_gen":
+        image_cfg = config.get("image_gen", {})
+        if isinstance(image_cfg, dict) and is_truthy_value(
+            image_cfg.get("use_gateway"), default=False
+        ):
+            return False
         # Satisfied when the in-tree FAL backend is configured OR any
         # plugin-registered image gen provider is available.
         if fal_key_is_configured():
@@ -2121,6 +2126,11 @@ def _toolset_needs_configuration_prompt(
             pass
         return True
     if ts_key == "video_gen":
+        video_cfg = config.get("video_gen", {})
+        if isinstance(video_cfg, dict) and is_truthy_value(
+            video_cfg.get("use_gateway"), default=False
+        ):
+            return False
         # Satisfied when any plugin-registered video gen provider reports
         # available — no in-tree fallback (every backend is a plugin).
         try:
@@ -3368,14 +3378,17 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
                 print(color(f"  ✓ {label}: using your Nous subscription defaults", Colors.GREEN))
 
-            # Walk through ALL selected tools that have provider options or
-            # need API keys.  This ensures browser (Local vs Browserbase),
-            # TTS (Edge vs OpenAI vs ElevenLabs), etc. are shown even when
-            # a free provider exists.
+            # Walk through selected tools that still need provider/API setup.
+            # Skip toolsets already satisfied (e.g. Tool Gateway defaults from
+            # `hermes model` / Nous onboarding) — same gate as the returning-user
+            # path below so full setup does not re-ask web/TTS/browser pickers.
             to_configure = [
                 ts_key for ts_key in sorted(new_enabled)
                 if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key))
                 and ts_key not in auto_configured
+                and _toolset_needs_configuration_prompt(
+                    ts_key, config, force_fresh=True
+                )
             ]
 
             if to_configure:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -823,6 +823,48 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
     assert configured == []
 
 
+def test_first_install_skips_tools_already_configured_via_gateway(monkeypatch):
+    """Full setup must not re-prompt web/TTS/browser after Nous Tool Gateway.
+
+    Regression: the first-install path built ``to_configure`` from every
+    enabled toolset minus ``auto_configured``, but ignored
+    ``_toolset_needs_configuration_prompt``. Users who enabled tools during
+    ``hermes model`` / Nous onboarding were asked again in ``hermes setup``.
+    """
+    monkeypatch.setattr("hermes_cli.nous_subscription.managed_nous_tools_enabled", lambda: True)
+    config = {
+        "model": {"provider": "nous"},
+        "platform_toolsets": {"cli": []},
+        "web": {"backend": "firecrawl", "use_gateway": True},
+        "tts": {"provider": "openai", "use_gateway": True},
+        "browser": {"cloud_provider": "browser-use", "use_gateway": True},
+        "image_gen": {"use_gateway": True},
+    }
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_toolset_checklist",
+        lambda *args, **kwargs: {"web", "image_gen", "tts", "browser"},
+    )
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_enabled_platforms",
+        lambda: ["cli"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.nous_subscription.apply_nous_managed_defaults",
+        lambda *args, **kwargs: set(),
+    )
+
+    configured = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_toolset",
+        lambda ts_key, config: configured.append(ts_key),
+    )
+
+    tools_command(first_install=True, config=config)
+
+    assert configured == []
+
+
 def test_first_install_nous_auto_configures_video_gen(monkeypatch):
     """When a Nous subscriber checks video_gen in the toolset checklist,
     apply_nous_managed_defaults must write video_gen.provider and
@@ -960,6 +1002,11 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 
 
 # ─── Imagegen Backend Picker Wiring ────────────────────────────────────────
+
+def test_image_gen_gateway_opt_in_skips_configuration_prompt():
+    config = {"image_gen": {"use_gateway": True}}
+    assert _toolset_needs_configuration_prompt("image_gen", config) is False
+
 
 def test_toolset_has_keys_treats_no_key_providers_as_configured():
     config = {}


### PR DESCRIPTION
First-install tools setup now uses `_toolset_needs_configuration_prompt` so web/TTS/browser/image are not asked again after Nous onboarding. Treat `image_gen`/`video_gen` with `use_gateway` as already configured.

## What does this PR do?

During **first-time full setup** (`hermes setup` → Full setup), the tools section walks every enabled toolset and opens provider/API configuration. That path did **not** call `_toolset_needs_configuration_prompt`, unlike the returning-user flow in `hermes tools`.

Users who already configured tools via **Nous Tool Gateway** during model onboarding (OAuth + model pick + gateway checklist) were prompted again for web search, TTS, browser, and image backends — duplicate questions with no new information.

This PR aligns first-install `to_configure` with the same gate used elsewhere, and extends `_toolset_needs_configuration_prompt` so `image_gen` / `video_gen` with `use_gateway: true` count as satisfied (matching gateway opt-in from `prompt_enable_tool_gateway`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py` — filter first-install `to_configure` with `_toolset_needs_configuration_prompt`; skip `image_gen` / `video_gen` when `use_gateway` is set
- `tests/hermes_cli/test_tools_config.py` — regression tests for gateway-preconfigured skip and `image_gen` gateway gate

## How to Test

1. Fresh or reset profile: `hermes setup` → choose **Full setup** (not Quick Setup).
2. Select **Nous Portal**, complete OAuth, pick a model, and enable Tool Gateway tools (web, TTS, browser, image) in the checklist.
3. Continue through terminal/gateway as desired until the **Tools** section runs.
4. **Expected:** no second round of provider pickers for web/TTS/browser/image (toolset checklist may still appear; per-tool provider menus should not).
5. Automated:

   ```bash
   .venv/Scripts/python.exe -m pytest tests/hermes_cli/test_tools_config.py::test_first_install_skips_tools_already_configured_via_gateway \
     tests/hermes_cli/test_tools_config.py::test_image_gen_gateway_opt_in_skips_configuration_prompt \
     tests/hermes_cli/test_tools_config.py::test_first_install_nous_auto_configures_managed_defaults -q \
     -o "addopts=-m 'not integration'"
   ```

   On Linux/macOS with `scripts/run_tests.sh`:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Git Bash), Python 3.12 venv

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A** (logic-only; no new platform APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

## Screenshots / Logs

N/A — behavior change is interactive CLI flow; verification is manual steps + pytest above.
