### PR TITLE
fix(desktop): unpack dist/** so Python backend can serve the web bundle

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -164,6 +164,7 @@
     "asar": true,
     "afterSign": "scripts/notarize.cjs",
     "asarUnpack": [
+      "dist/**",
       "**/*.node",
       "**/prebuilds/**"
     ],

--- a/tests/test_desktop_packaging.py
+++ b/tests/test_desktop_packaging.py
@@ -1,0 +1,19 @@
+"""Regression guards for the packaged Hermes Desktop bundle config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_dist_is_unpacked_for_python_backend():
+    package_json = json.loads(
+        (REPO_ROOT / "apps" / "desktop" / "package.json").read_text(encoding="utf-8")
+    )
+
+    asar_unpack = package_json.get("build", {}).get("asarUnpack", [])
+
+    assert "dist/**" in asar_unpack


### PR DESCRIPTION
## Summary
- Add dist/** to build.asarUnpack in apps/desktop/package.json so Electron Builder keeps the built web bundle outside app.asar.
- Add tests/test_desktop_packaging.py to guard against silent drift of the unpack list.

## Why
Electron Builder packs dist/ into app.asar by default, but the Python backend expects to serve the web bundle from the unpacked path:

- HERMES_WEB_DIST=/Applications/Hermes.app/Contents/Resources/app.asar.unpacked/dist

Without this entry the in-app BrowserWindow shows a white screen because index.html is unreachable from the Python backend.

## Test plan
- python -m pytest tests/test_desktop_packaging.py -q passes locally.
- After repackaging, /Applications/Hermes.app/Contents/Resources/app.asar.unpacked/dist/index.html exists.
- curl -fsS http://127.0.0.1:9120/ returns the bundled HTML.

Refs: rebased local codex/hermes-desktop-asarunpack-dist onto current main.