### PR TITLE
fix(desktop): guard git-based self-update against hung processes

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -224,6 +224,7 @@ const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.j
 // tracks main. User can also override at runtime via
 // hermesDesktop.updates.setBranch().
 const DEFAULT_UPDATE_BRANCH = 'main'
+const GIT_OPERATION_TIMEOUT_MS = Number.parseInt(process.env.HERMES_DESKTOP_GIT_TIMEOUT_MS || '15000', 10)
 // desktop.log lives under HERMES_HOME/logs/ so it sits next to agent.log,
 // errors.log, gateway.log produced by hermes_logging.setup_logging — one log
 // directory per user, regardless of which UI surface produced the line.
@@ -1136,6 +1137,7 @@ function resolveUpdateRoot() {
 
 function runGit(args, options = {}) {
   return new Promise((resolve, reject) => {
+    let settled = false
     const child = spawn(resolveGitBinary(), IS_WINDOWS ? ['-c', 'windows.appendAtomically=false', ...args] : args, {
       cwd: options.cwd,
       env: { ...process.env, ...(options.env || {}), GIT_TERMINAL_PROMPT: '0' },
@@ -1154,8 +1156,29 @@ function runGit(args, options = {}) {
       stderr += text
       options.onLine?.('stderr', text)
     })
-    child.once('error', reject)
-    child.once('exit', code => resolve({ code, stdout, stderr }))
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      stderr = stderr
+        ? `${stderr}\ngit operation timed out after ${GIT_OPERATION_TIMEOUT_MS}ms`
+        : `git operation timed out after ${GIT_OPERATION_TIMEOUT_MS}ms`
+      try {
+        child.kill('SIGTERM')
+      } catch {}
+      resolve({ code: null, stdout, stderr, timedOut: true })
+    }, GIT_OPERATION_TIMEOUT_MS)
+    child.once('error', error => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', code => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve({ code, stdout, stderr })
+    })
   })
 }
 

--- a/tests/test_desktop_update_safety.py
+++ b/tests/test_desktop_update_safety.py
@@ -1,0 +1,19 @@
+"""Regression guards for Desktop self-update safety."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_git_update_checks_have_timeout_and_cleanup():
+    main_cjs = (REPO_ROOT / "apps" / "desktop" / "electron" / "main.cjs").read_text(
+        encoding="utf-8"
+    )
+
+    assert "GIT_OPERATION_TIMEOUT_MS" in main_cjs
+    assert "setTimeout" in main_cjs
+    assert "child.kill" in main_cjs
+    assert "git operation timed out" in main_cjs


### PR DESCRIPTION
## Summary
- Cap git operations in the Desktop self-update path at 15s via GIT_OPERATION_TIMEOUT_MS
- On timeout, kill the spawned child with SIGTERM and resolve with timedOut=true so the UI can recover
- Clear the pending timeout when the child exits/errors to avoid double-firing
- Add tests/test_desktop_update_safety.py to guard the timeout hook and kill path

## Why
The Desktop self-update path shells out to git. If git hangs (slow remote, network glitch, host refusing connection) the spawned child runs forever and the update UI never recovers. This is an infinite-spinner failure mode observed when the network is unreliable.

## Diff scope
- apps/desktop/electron/main.cjs: runGit() now wraps spawn in a timeout that fires SIGTERM and resolves with timedOut=true
- tests/test_desktop_update_safety.py: pins the timeout hook + kill path

## Out of scope
The companion fix that makes the Python backend reachable in the packaged app (dist/** added to build.asarUnpack, guarded by tests/test_desktop_packaging.py) is split out into #39093 to keep this change small and reviewable.

## Test plan
- python -m pytest tests/test_desktop_update_safety.py -q passes locally
- tests/test_desktop_packaging.py (covered by #39093) is intentionally not modified in this PR