### PR TITLE
fix(mcp): forward HERMES_HOME to stdio subprocesses

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -263,9 +263,18 @@ _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
 
-# Environment variables that are safe to pass to stdio subprocesses
+# Environment variables that are safe to pass to stdio subprocesses.
+#
+# HERMES_HOME must be forwarded alongside HOME: profile-isolated runs override
+# the process HOME to "{HERMES_HOME}/home" (see get_subprocess_home), so a child
+# that inherits the overridden HOME but loses HERMES_HOME will recompute paths
+# from Path.home() and land in a doubly-nested "{HERMES_HOME}/home/.hermes/home"
+# directory. For stdio servers launched via npx/mcp-remote this manifests as a
+# bogus, empty ".mcp-auth" cache, forcing a fresh OAuth flow (and a new browser
+# tab) on every connect/reconnect.
 _SAFE_ENV_KEYS = frozenset({
-    "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
+    "PATH", "HOME", "HERMES_HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL",
+    "TMPDIR",
 })
 
 # Regex for credential patterns to strip from error messages


### PR DESCRIPTION
## Summary

Profile-isolated runs override the process `HOME` to `{HERMES_HOME}/home` (via `get_subprocess_home`). When a stdio MCP subprocess inherits that overridden `HOME` but **loses `HERMES_HOME`**, it recomputes paths from `Path.home()` and lands in a doubly-nested `{HERMES_HOME}/home/.hermes/home` directory.

For stdio servers launched via `npx` / `mcp-remote` (Notion, Runway, etc.) this manifests as a bogus, **empty `.mcp-auth` cache**, so every connect/reconnect fails to find the cached OAuth token and triggers a **fresh OAuth flow + a new browser tab**.

The fix adds `HERMES_HOME` to `_SAFE_ENV_KEYS` in `tools/mcp_tool.py` so child processes resolve cache paths correctly.

## Observed impact

Reproduced independently on **macOS and Windows**:

- `mcp-remote` process leak — up to **33** orphaned processes (failed reconnects spawned new pairs that never got reaped).
- **23 Notion OAuth browser tabs** piled up — one per re-auth.
- A bogus `~/.hermes/home/.hermes/home/.mcp-auth` tree (~15 MB / 1200+ files) accumulated, while the real cache at `~/.hermes/home/.mcp-auth` (with valid tokens) was never consulted.

## Root cause

`tools/mcp_tool.py` sanitizes the environment for stdio subprocesses via an allowlist `_SAFE_ENV_KEYS`. The list included `HOME` but not `HERMES_HOME`. Because profile isolation rewrites `HOME` to `{HERMES_HOME}/home`, a child that gets the rewritten `HOME` without `HERMES_HOME` falls back to `Path.home()` and double-nests the cache path.

## The fix

```diff
-# Environment variables that are safe to pass to stdio subprocesses
+# Environment variables that are safe to pass to stdio subprocesses.
+#
+# HERMES_HOME must be forwarded alongside HOME: profile-isolated runs override
+# the process HOME to "{HERMES_HOME}/home" (see get_subprocess_home), so a child
+# that inherits the overridden HOME but loses HERMES_HOME will recompute paths
+# from Path.home() and land in a doubly-nested "{HERMES_HOME}/home/.hermes/home"
+# directory. For stdio servers launched via npx/mcp-remote this manifests as a
+# bogus, empty ".mcp-auth" cache, forcing a fresh OAuth flow (and a new browser
+# tab) on every connect/reconnect.
 _SAFE_ENV_KEYS = frozenset({
-    "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
+    "PATH", "HOME", "HERMES_HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL",
+    "TMPDIR",
 })
```

## Test plan (verified locally on macOS)

- [x] After applying the fix and restarting the gateway, `mcp-remote` process count settled at exactly one connection per vendor (notion/runway/ga4 = 6 procs total = 2 per pair), down from a leaked 10+ (peak 33).
- [x] No new doubly-nested `~/.hermes/home/.hermes/home` cache directory is created on (re)connect.
- [x] Notion MCP authenticates from the existing cached token — no new browser OAuth tab on reconnect.
- [x] `notion_get_users(self)` returns the correct authenticated user after the fix.

## Notes

There is a separate, secondary issue not addressed here: orphan reaping of the two-stage `npm exec → mcp-remote` process tree (killing the parent TUI leaves the actual `mcp-remote` adopted/alive). That is a distinct problem worth a follow-up issue; this PR fixes only the env-propagation root cause that drives the OAuth-tab/process explosion.
