### PR TITLE
fix(cli): accept launcher flags after dashboard command

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12350,6 +12350,114 @@ _TOP_LEVEL_VALUE_FLAGS = frozenset(
     }
 )
 
+_POST_SUBCOMMAND_TOP_LEVEL_BOOL_FLAGS = frozenset(
+    {
+        "-w", "--worktree",
+        "--accept-hooks",
+        "--yolo",
+        "--pass-session-id",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--tui",
+        "--cli",
+        "--dev",
+    }
+)
+
+_POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS = frozenset(
+    {
+        "-m", "--model",
+        "--provider",
+        "-t", "--toolsets",
+        "-s", "--skills",
+    }
+)
+
+
+def _hoist_post_subcommand_global_flags(
+    argv: list[str],
+    known_cmds: set[str] | frozenset[str],
+) -> list[str]:
+    """Move known top-level launcher flags before the subcommand.
+
+    ``argparse`` only accepts parent-parser options before a subcommand unless
+    each child parser repeats them. That is easy to forget in launchers and
+    relaunch paths: ``hermes dashboard --no-open --tui`` should not die just
+    because ``--tui`` trails the dashboard command. Keep this deliberately
+    conservative: hoist only top-level flags whose values remain meaningful at
+    the parent level, and leave command-specific flags untouched.
+    """
+    if not argv:
+        return argv
+
+    try:
+        separator_index = argv.index("--")
+    except ValueError:
+        separator_index = len(argv)
+
+    head = argv[:separator_index]
+    tail = argv[separator_index:]
+
+    command_index = None
+    i = 0
+    while i < len(head):
+        token = head[i]
+        if token.startswith("-"):
+            if "=" in token:
+                i += 1
+                continue
+            if token in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(head):
+                i += 2
+                continue
+            i += 1
+            continue
+        if token in known_cmds:
+            command_index = i
+            break
+        return argv
+
+    if command_index is None:
+        return argv
+
+    prefix = head[:command_index]
+    command_and_args = head[command_index:]
+    hoisted: list[str] = []
+    remainder: list[str] = []
+    i = 0
+    while i < len(command_and_args):
+        token = command_and_args[i]
+        if i > 0 and token in _POST_SUBCOMMAND_TOP_LEVEL_BOOL_FLAGS:
+            hoisted.append(token)
+            i += 1
+            continue
+
+        if i > 0:
+            inline_value_match = next(
+                (
+                    flag
+                    for flag in _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS
+                    if token.startswith(f"{flag}=")
+                ),
+                None,
+            )
+            if inline_value_match:
+                hoisted.append(token)
+                i += 1
+                continue
+
+            if token in _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS and i + 1 < len(command_and_args):
+                hoisted.extend([token, command_and_args[i + 1]])
+                i += 2
+                continue
+
+        remainder.append(token)
+        i += 1
+
+    if not hoisted:
+        return argv
+
+    return [*prefix, *hoisted, *remainder, *tail]
+
 
 def _first_positional_argv() -> str | None:
     """Return the first non-flag, non-flag-value token in ``sys.argv[1:]``.
@@ -15772,8 +15880,6 @@ Examples:
         # and raises OSError on failure (which propagates as a traceback).
         sys.exit(1)
 
-    _processed_argv = _coalesce_session_name_args(sys.argv[1:])
-
     # ── Defensive subparser routing (bpo-9338 workaround) ───────────
     # On some Python versions (notably <3.11), argparse fails to route
     # subcommand tokens when the parent parser has nargs='?' optional
@@ -15788,6 +15894,10 @@ Examples:
 
     _known_cmds = (
         set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
+    )
+    _processed_argv = _hoist_post_subcommand_global_flags(
+        _coalesce_session_name_args(sys.argv[1:]),
+        _known_cmds,
     )
     _has_cmd_token = any(
         t in _known_cmds for t in _processed_argv if not t.startswith("-")

--- a/tests/hermes_cli/test_default_interface_resolution.py
+++ b/tests/hermes_cli/test_default_interface_resolution.py
@@ -182,6 +182,53 @@ class TestParserFlags:
         assert "--tui" in inherited
 
 
+class TestPostSubcommandGlobalFlagHoisting:
+    def _dashboard_parser(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, subparsers, _chat = build_top_level_parser()
+        dashboard = subparsers.add_parser("dashboard")
+        dashboard.add_argument("--port", type=int, default=9119)
+        dashboard.add_argument("--host", default="127.0.0.1")
+        dashboard.add_argument("--no-open", action="store_true")
+        return parser, set(subparsers.choices.keys())
+
+    def test_dashboard_accepts_trailing_tui_flag(self):
+        parser, known_cmds = self._dashboard_parser()
+        argv = m._hoist_post_subcommand_global_flags(
+            ["dashboard", "--no-open", "--host", "127.0.0.1", "--port", "65535", "--tui"],
+            known_cmds,
+        )
+
+        args = parser.parse_args(argv)
+
+        assert args.command == "dashboard"
+        assert args.tui is True
+        assert args.no_open is True
+        assert args.host == "127.0.0.1"
+        assert args.port == 65535
+
+    def test_dashboard_accepts_trailing_skills_and_tui_flags(self):
+        parser, known_cmds = self._dashboard_parser()
+        argv = m._hoist_post_subcommand_global_flags(
+            ["dashboard", "--no-open", "--skills", "desktop-backend", "--tui"],
+            known_cmds,
+        )
+
+        args = parser.parse_args(argv)
+
+        assert args.command == "dashboard"
+        assert args.skills == ["desktop-backend"]
+        assert args.tui is True
+        assert args.no_open is True
+
+    def test_double_dash_stops_global_flag_hoisting(self):
+        _parser, known_cmds = self._dashboard_parser()
+        argv = ["dashboard", "--", "--tui"]
+
+        assert m._hoist_post_subcommand_global_flags(argv, known_cmds) == argv
+
+
 # ---------------------------------------------------------------------------
 # config default — shipped default preserves classic behavior
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize known top-level launcher flags when they appear after a subcommand before argparse runs
- keeps desktop/dashboard launchers from failing on shapes like `hermes dashboard --no-open --tui`
- adds parser coverage for trailing `--tui` and `--skills ... --tui` on dashboard launches

## Root Cause
The macOS desktop app can launch the local backend as `dashboard ... --tui`. `--tui` is a top-level Hermes flag, but argparse rejected it after the `dashboard` subcommand, causing the backend to exit with rc 2 before readiness.

## Validation
- `python -m pytest tests/hermes_cli/test_default_interface_resolution.py tests/hermes_cli/test_subparser_routing_fallback.py tests/hermes_cli/test_startup_plugin_gating.py -q`
- `python -m hermes_cli.main dashboard --status --tui`
- live `~/.hermes/hermes-agent` cherry-pick: `venv/bin/python -m pytest tests/hermes_cli/test_default_interface_resolution.py tests/hermes_cli/test_subparser_routing_fallback.py tests/hermes_cli/test_startup_plugin_gating.py -q`
- direct `/api/status` returned `gateway_running=True`, `gateway_state=running`
- direct `/api/ws` probe opened and received `gateway.ready`
- normal `/Applications/Hermes.app` relaunch opened past `CONNECTING` into the chat shell with backend command `dashboard --no-open --tui --host 127.0.0.1 --port 9120`

## Related
Fork PR: OmarB97/hermes-agent#79.

OmarB97/hermes-agent#76 / NousResearch/hermes-agent#38446 is separate and still needed for macOS bootstrap installer re-signing after copying to `~/.hermes`; it is not this dashboard argument-order crash.
