### PR TITLE
feat(tts): make ElevenLabs base URL configurable

### DIFF
--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -45,7 +45,16 @@ class TestDotenvFallbackPerProvider:
     def test_elevenlabs_reads_dotenv_key(self, tmp_path):
         from tools import tts_tool
 
-        with patch.object(tts_tool, "get_env_value", return_value="el-dotenv-key"), \
+        # Selective mock: only the API key is dotenv-backed here. Returning the
+        # key for *every* lookup would also satisfy ELEVENLABS_BASE_URL and send
+        # the client down the custom-environment branch, which this test isn't
+        # about. base_url resolution is covered in test_tts_elevenlabs_base_url.
+        def fake_get_env_value(name, default=None):
+            if name == "ELEVENLABS_API_KEY":
+                return "el-dotenv-key"
+            return default
+
+        with patch.object(tts_tool, "get_env_value", side_effect=fake_get_env_value), \
              patch.object(tts_tool, "_import_elevenlabs") as mock_import:
             mock_client = MagicMock()
             mock_client.text_to_speech.convert.return_value = iter([b"audio"])

--- a/tests/tools/test_tts_elevenlabs_base_url.py
+++ b/tests/tools/test_tts_elevenlabs_base_url.py
@@ -1,0 +1,161 @@
+"""Tests for the configurable ElevenLabs TTS base URL.
+
+Covers ``_build_elevenlabs_client`` (the resolver used by both the sync
+``_generate_elevenlabs`` handler and the streaming ``stream_tts_to_speaker``
+path) and the end-to-end wiring through ``_generate_elevenlabs``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "ELEVENLABS_API_KEY",
+        "ELEVENLABS_BASE_URL",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def mock_elevenlabs_module():
+    """Patch the lazy SDK import + environment class.
+
+    ``_build_elevenlabs_client`` calls ``_import_elevenlabs()`` for the client
+    class and imports ``elevenlabs.environment.ElevenLabsEnvironment`` for the
+    custom-origin branch. We stub both so the tests need no real SDK install.
+    """
+    mock_client = MagicMock()
+    mock_cls = MagicMock(return_value=mock_client)
+
+    class FakeEnvironment:
+        def __init__(self, *, base, wss):
+            self.base = base
+            self.wss = wss
+
+    fake_env_module = MagicMock()
+    fake_env_module.ElevenLabsEnvironment = FakeEnvironment
+
+    with patch("tools.tts_tool._import_elevenlabs", return_value=mock_cls), patch.dict(
+        "sys.modules", {"elevenlabs.environment": fake_env_module}
+    ):
+        yield mock_cls, mock_client, FakeEnvironment
+
+
+class TestBuildElevenLabsClient:
+    def test_default_omits_environment(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {})
+
+        mock_cls.assert_called_once_with(api_key="key")
+
+    def test_explicit_default_url_omits_environment(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {"base_url": "https://api.elevenlabs.io"})
+
+        mock_cls.assert_called_once_with(api_key="key")
+
+    def test_config_base_url_sets_environment(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, FakeEnvironment = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {"base_url": "https://proxy.example.com"})
+
+        _name, kwargs = mock_cls.call_args
+        assert kwargs["api_key"] == "key"
+        env = kwargs["environment"]
+        assert isinstance(env, FakeEnvironment)
+        assert env.base == "https://proxy.example.com"
+        assert env.wss == "wss://proxy.example.com"
+
+    def test_trailing_v1_is_stripped(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {"base_url": "https://proxy.example.com/v1/"})
+
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "https://proxy.example.com"
+
+    def test_trailing_slash_is_stripped(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {"base_url": "https://proxy.example.com/"})
+
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "https://proxy.example.com"
+
+    def test_env_var_used_when_config_absent(self, mock_elevenlabs_module, monkeypatch):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        monkeypatch.setenv("ELEVENLABS_BASE_URL", "https://env.example.com")
+        _build_elevenlabs_client("key", {})
+
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "https://env.example.com"
+
+    def test_config_overrides_env_var(self, mock_elevenlabs_module, monkeypatch):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        monkeypatch.setenv("ELEVENLABS_BASE_URL", "https://env.example.com")
+        _build_elevenlabs_client("key", {"base_url": "https://config.example.com"})
+
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "https://config.example.com"
+
+    def test_http_origin_derives_ws_scheme(self, mock_elevenlabs_module):
+        from tools.tts_tool import _build_elevenlabs_client
+
+        mock_cls, _client, _env = mock_elevenlabs_module
+        _build_elevenlabs_client("key", {"base_url": "http://localhost:8080"})
+
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "http://localhost:8080"
+        assert env.wss == "ws://localhost:8080"
+
+
+class TestGenerateElevenLabsUsesBaseUrl:
+    def test_generate_passes_environment(self, tmp_path, mock_elevenlabs_module, monkeypatch):
+        from tools.tts_tool import _generate_elevenlabs
+
+        mock_cls, mock_client, _env = mock_elevenlabs_module
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        mock_client.text_to_speech.convert.return_value = [b"audio-bytes"]
+
+        output_path = str(tmp_path / "out.mp3")
+        config = {"elevenlabs": {"base_url": "https://proxy.example.com"}}
+        result = _generate_elevenlabs("Hello", output_path, config)
+
+        assert result == output_path
+        assert (tmp_path / "out.mp3").read_bytes() == b"audio-bytes"
+        env = mock_cls.call_args[1]["environment"]
+        assert env.base == "https://proxy.example.com"
+
+    def test_generate_default_omits_environment(
+        self, tmp_path, mock_elevenlabs_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_elevenlabs
+
+        mock_cls, mock_client, _env = mock_elevenlabs_module
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        mock_client.text_to_speech.convert.return_value = [b"audio-bytes"]
+
+        _generate_elevenlabs("Hello", str(tmp_path / "out.mp3"), {})
+
+        mock_cls.assert_called_once_with(api_key="test-key")
+
+    def test_missing_api_key_raises(self, tmp_path, mock_elevenlabs_module):
+        from tools.tts_tool import _generate_elevenlabs
+
+        with pytest.raises(ValueError, match="ELEVENLABS_API_KEY"):
+            _generate_elevenlabs("Hello", str(tmp_path / "out.mp3"), {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -115,6 +115,55 @@ def _import_elevenlabs():
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
+
+def _build_elevenlabs_client(api_key: str, el_config: Dict[str, Any]):
+    """Instantiate the ElevenLabs SDK client, honoring a configurable base URL.
+
+    Resolution order for the API root:
+      1. ``tts.elevenlabs.base_url`` in config.yaml
+      2. ``ELEVENLABS_BASE_URL`` env var
+      3. ``DEFAULT_ELEVENLABS_BASE_URL`` (https://api.elevenlabs.io)
+
+    The ElevenLabs SDK appends the ``/v1/...`` path itself, so the configured
+    value is normalized to a bare origin: any trailing slashes and a trailing
+    ``/v1`` segment are stripped. This makes the knob forgiving of users who
+    paste either ``https://host`` or ``https://host/v1`` (the latter matching
+    the shape STT's ``ELEVENLABS_STT_BASE_URL`` expects).
+
+    When the resolved root equals the default, the client is created without an
+    explicit ``environment`` so behavior is byte-for-byte identical to before.
+    """
+    base_url = str(
+        (el_config or {}).get("base_url")
+        or get_env_value("ELEVENLABS_BASE_URL")
+        or DEFAULT_ELEVENLABS_BASE_URL
+    ).strip()
+
+    # Normalize: drop trailing slashes, then a trailing "/v1" if present.
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized[: -len("/v1")]
+    normalized = normalized.rstrip("/")
+
+    ElevenLabs = _import_elevenlabs()
+
+    if not normalized or normalized == DEFAULT_ELEVENLABS_BASE_URL:
+        return ElevenLabs(api_key=api_key)
+
+    # Point the SDK at a custom origin. Derive a best-effort wss endpoint from
+    # the same host (https -> wss, http -> ws) for any websocket-based calls.
+    from elevenlabs.environment import ElevenLabsEnvironment
+
+    if normalized.startswith("https://"):
+        wss = "wss://" + normalized[len("https://"):]
+    elif normalized.startswith("http://"):
+        wss = "ws://" + normalized[len("http://"):]
+    else:
+        wss = normalized
+
+    environment = ElevenLabsEnvironment(base=normalized, wss=wss)
+    return ElevenLabs(api_key=api_key, environment=environment)
+
 def _import_openai_client():
     """Lazy import OpenAI client. Returns the class or raises ImportError."""
     from openai import OpenAI as OpenAIClient
@@ -170,6 +219,11 @@ DEFAULT_EDGE_VOICE = "en-US-AriaNeural"
 DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
+# API root for the ElevenLabs SDK (no ``/v1`` suffix -- the SDK appends it).
+# Override via ``tts.elevenlabs.base_url`` in config.yaml or the
+# ``ELEVENLABS_BASE_URL`` env var to point at a proxy / self-hosted gateway /
+# residency endpoint (e.g. https://api.eu.residency.elevenlabs.io).
+DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
@@ -957,8 +1011,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     else:
         output_format = "mp3_44100_128"
 
-    ElevenLabs = _import_elevenlabs()
-    client = ElevenLabs(api_key=api_key)
+    client = _build_elevenlabs_client(api_key, el_config)
     audio_generator = client.text_to_speech.convert(
         text=text,
         voice_id=voice_id,
@@ -2318,8 +2371,7 @@ def stream_tts_to_speaker(
             logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
         else:
             try:
-                ElevenLabs = _import_elevenlabs()
-                client = ElevenLabs(api_key=api_key)
+                client = _build_elevenlabs_client(api_key, el_config)
             except ImportError:
                 logger.warning("elevenlabs package not installed; streaming TTS disabled")
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -144,6 +144,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `FAL_KEY` | Image generation ([fal.ai](https://fal.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
+| `ELEVENLABS_BASE_URL` | Override the ElevenLabs TTS API root (proxy / residency endpoint). A trailing `/v1` is stripped automatically. Also settable via `tts.elevenlabs.base_url` |
+| `ELEVENLABS_STT_BASE_URL` | Override the ElevenLabs Scribe STT endpoint. Also settable via `stt.elevenlabs.base_url` |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -51,6 +51,7 @@ tts:
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"  # Adam
     model_id: "eleven_multilingual_v2"
+    base_url: "https://api.elevenlabs.io"  # Optional: proxy / residency endpoint (or set ELEVENLABS_BASE_URL). A trailing "/v1" is stripped automatically.
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer


### PR DESCRIPTION
## What does this PR do?

Makes the **ElevenLabs TTS base URL configurable**, so it can be pointed at a proxy, self-hosted gateway, or regional residency endpoint (e.g. `https://api.eu.residency.elevenlabs.io`).

Today the ElevenLabs TTS handler hardcodes `ElevenLabs(api_key=...)` with no way to override the endpoint — even though the ElevenLabs **STT** handler already supports `stt.elevenlabs.base_url` / `ELEVENLABS_STT_BASE_URL`. This PR restores symmetry between the two sides.

## Related Issue

N/A — small, self-contained enhancement.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`:
  - New `DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io"` constant.
  - New `_build_elevenlabs_client(api_key, el_config)` resolver. Resolution order: `tts.elevenlabs.base_url` → `ELEVENLABS_BASE_URL` env → default. The SDK appends `/v1` itself, so the value is normalized to a bare origin (trailing slashes and a trailing `/v1` are stripped — forgiving of either shape). A best-effort `wss://` endpoint is derived for websocket calls.
  - Both call sites now use the resolver: the sync `_generate_elevenlabs` handler and the streaming `stream_tts_to_speaker` path.
  - **Zero behavior change at the default**: when the resolved root equals the default, the client is constructed without an explicit `environment=`, identical to before.
- `tests/tools/test_tts_elevenlabs_base_url.py`: 11 new tests (resolver branches, `/v1` + slash normalization, env-vs-config precedence, http→ws scheme, end-to-end through `_generate_elevenlabs`).
- `tests/tools/test_tts_dotenv_fallback.py`: updated the elevenlabs dotenv test to a key-selective env mock (the old "return the key for every lookup" mock would otherwise also satisfy `ELEVENLABS_BASE_URL` and exercise the custom-origin branch unintentionally).
- Docs: `website/docs/user-guide/features/tts.md` (config block) and `website/docs/reference/environment-variables.md` (`ELEVENLABS_BASE_URL` + documented the existing `ELEVENLABS_STT_BASE_URL`).

## How to Test

1. Set `tts.provider: elevenlabs` and `tts.elevenlabs.base_url: https://your-proxy/v1` (or `ELEVENLABS_BASE_URL`).
2. Generate a voice note — requests go to the configured origin (the `/v1` suffix is normalized away).
3. Leave `base_url` unset → behavior is unchanged (hits `api.elevenlabs.io`).
4. `pytest tests/tools/test_tts_elevenlabs_base_url.py -q` → 11 passed.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`feat(tts): ...`)
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant tests and they pass (`tests/tools -k "tts or transcription"` → 468 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/`, docstrings)
- [x] `cli-config.yaml.example` — N/A (no TTS provider stanza is present in the example file)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure config/string handling, no platform-specific code
- [x] Tool descriptions/schemas — N/A (tool behavior unchanged at the default)
