### PR TITLE
fix(cron): add threading.Lock to _on_done callback to prevent race condition

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2184,10 +2184,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         # sweep still happens after jobs finish without stalling the tick.
         if _all_futures:
             _remaining = [len(_all_futures)]
+            _done_lock = threading.Lock()
 
             def _on_done(_f: concurrent.futures.Future) -> None:
-                _remaining[0] -= 1
-                if _remaining[0] <= 0:
+                with _done_lock:
+                    _remaining[0] -= 1
+                    should_sweep = _remaining[0] <= 0
+                if should_sweep:
                     _sweep_mcp_orphans()
 
             for _f in _all_futures:


### PR DESCRIPTION
## Summary

Fixes a race condition in the cron scheduler's async `_on_done` callback that can prevent MCP orphan cleanup.

## Problem

In `cron/scheduler.py`, the async (gateway ticker) mode uses a done-callback pattern to sweep MCP orphan processes after all cron jobs complete:

```python
_remaining = [len(_all_futures)]

def _on_done(_f):
    _remaining[0] -= 1
    if _remaining[0] <= 0:
        _sweep_mcp_orphans()
```

The `_remaining[0] -= 1` is a non-atomic read-modify-write operation. When multiple `ThreadPoolExecutor` futures complete nearly simultaneously, the done-callbacks run concurrently in different worker threads. Two threads can both read the same value, decrement, and write back, causing the counter to skip zero. This means `_sweep_mcp_orphans()` never fires, leaving orphaned MCP stdio subprocesses unreaped.

## Fix

Wrap the decrement and comparison in a `threading.Lock` to make the read-modify-write atomic:

```python
_remaining = [len(_all_futures)]
_done_lock = threading.Lock()

def _on_done(_f):
    with _done_lock:
        _remaining[0] -= 1
        should_sweep = _remaining[0] <= 0
    if should_sweep:
        _sweep_mcp_orphans()
```

The sweep decision (`should_sweep`) is computed inside the lock, but the actual sweep runs outside to minimize lock hold time. `threading` is already imported in the module.