### PR TITLE
fix(agent): refund api_call_count when all retries are exhausted

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3415,6 +3415,13 @@ def run_conversation(
                         agent._dump_api_request_debug(
                             api_kwargs, reason="max_retries_exhausted", error=api_error,
                         )
+                    # Refund the optimistic api_call_count bump made at the top
+                    # of this iteration: this API call never succeeded, so it
+                    # must not inflate the successful-call total that is
+                    # logged/returned/persisted below.  Mirrors the refund the
+                    # Ollama-context abort path already performs.
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
                     agent._persist_session(messages, conversation_history)
                     if classified.reason == FailoverReason.billing:
                         _final_response = f"Billing or credits exhausted: {_final_summary}"

--- a/tests/run_agent/test_api_call_count_refund_on_exhausted_retries.py
+++ b/tests/run_agent/test_api_call_count_refund_on_exhausted_retries.py
@@ -1,0 +1,155 @@
+"""Regression test for issue #38445 — the successful-API-call counter must be
+refunded when every retry is exhausted.
+
+``run_conversation`` increments ``api_call_count`` optimistically at the top of
+each loop iteration (before the API call is actually made/succeeds).  When a
+call ultimately fails after all retries are exhausted, that optimistic bump must
+be refunded so the count that is logged/returned/persisted reflects only the
+*successful* API calls — not the failed attempt.
+
+Before the fix, a turn whose single API call failed after exhausting retries
+returned ``api_calls == 1`` instead of ``0``: one too high.
+
+The mocking style (the ``agent`` fixture, ``_mock_response``, forced backoff
+short-circuit) mirrors ``tests/run_agent/test_413_compression.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+import run_agent
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    """Make retry backoff instant so the test does not actually wait."""
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    # conversation_loop imports jittered_backoff directly, so patch it there.
+    monkeypatch.setattr(
+        "agent.conversation_loop.jittered_backoff", lambda *a, **k: 0.0
+    )
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    resp = SimpleNamespace(choices=[choice], model="test/model")
+    resp.usage = None
+    return resp
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        # Keep retries low so the exhausted-retries path is reached quickly.
+        a._api_max_retries = 2
+        return a
+
+
+def _retryable_error():
+    """A transient transport error: no status_code → classified retryable,
+    routed through the normal retry/backoff path (not compression/auth/4xx)."""
+    return ConnectionError("Connection reset by peer")
+
+
+class TestApiCallCountRefundOnExhaustedRetries:
+    def test_api_calls_refunded_when_all_retries_fail(self, agent):
+        """A turn whose only API call fails after exhausting retries must report
+        ``api_calls == 0`` — the optimistic bump is refunded."""
+        agent.client.chat.completions.create.side_effect = _retryable_error()
+
+        with (
+            # Force the terminal "max retries exhausted" path: no transport
+            # recovery and no fallback provider to switch to.
+            patch.object(agent, "_try_recover_primary_transport", return_value=False),
+            patch.object(agent, "_try_activate_fallback", return_value=False),
+            patch.object(agent, "_has_pending_fallback", return_value=False),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result.get("failed") is True
+        assert result["completed"] is False
+        # The single attempt failed → zero successful API calls.
+        assert result["api_calls"] == 0, (
+            f"api_calls should be refunded to 0 when all retries fail, "
+            f"got {result['api_calls']}"
+        )
+        # The mirror attribute on the agent must match the returned count.
+        assert agent._api_call_count == 0
+
+    def test_api_calls_count_accurate_after_one_success_then_exhaustion(self, agent):
+        """After one successful call, a second turn that fully fails must not
+        leave the count inflated: success counts once, the failed attempt is
+        refunded."""
+        ok_resp = _mock_response(content="done", finish_reason="stop")
+        # First the turn succeeds in a single call.
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            ok_result = agent.run_conversation("hello")
+
+        assert ok_result["completed"] is True
+        assert ok_result["api_calls"] == 1
+
+        # Now a fresh turn that fails after exhausting retries.
+        agent.client.chat.completions.create.side_effect = _retryable_error()
+        with (
+            patch.object(agent, "_try_recover_primary_transport", return_value=False),
+            patch.object(agent, "_try_activate_fallback", return_value=False),
+            patch.object(agent, "_has_pending_fallback", return_value=False),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            fail_result = agent.run_conversation("again")
+
+        assert fail_result.get("failed") is True
+        assert fail_result["api_calls"] == 0


### PR DESCRIPTION
## What does this PR do?

In `run_conversation`, `api_call_count` is incremented optimistically at the top of each loop iteration, before the API call actually succeeds. When a call fails after exhausting all retries â€” with no transport recovery and no fallback provider available â€” the terminal path counted that failed attempt as a successful API call, so the logged / returned / persisted count was one too high.

## Related Issue

Fixes #38445

## Type of Change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` â€” on the exhausted-retries terminal path, refund the optimistic bump before the count is logged, persisted, and returned (`api_call_count -= 1; agent._api_call_count = api_call_count`). Mirrors the refund the Ollama-context abort path already performs (`conversation_loop.py:1102`).
- `tests/run_agent/test_api_call_count_refund_on_exhausted_retries.py` â€” new regression test.

## How to Test

1. `pytest tests/run_agent/test_api_call_count_refund_on_exhausted_retries.py -q` â†’ 2 passing. Drives `run_conversation` with a mocked LLM that always raises a retryable transport error and asserts `api_calls == 0` (plus a case verifying the count stays accurate after a prior successful call).
2. Verified the tests fail on `main` and pass with the fix.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass â€” ran the new module (2 passed) + `py_compile`; full suite not run in my Windows dev env
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] Documentation â€” N/A (internal accounting fix, no user-facing surface)
- [x] `cli-config.yaml.example` â€” N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` â€” N/A
- [x] Considered cross-platform impact â€” pure Python, platform-agnostic
- [x] Tool descriptions/schemas â€” N/A

## Notes

Intentionally scoped to the exhausted-retries terminal path the issue describes; other terminal/abort paths in `run_conversation` were left untouched (focused-PR rule). If any has a similar off-by-one it would be a separate issue.
