### PR TITLE
fix(google-workspace): anchor OAuth client secret to default Hermes root

### DIFF
--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -39,7 +39,9 @@ except (ModuleNotFoundError, ImportError):
         ``HERMES_HOME`` is a profile path (``<root>/profiles/<name>``) or sits
         under ``~/.hermes``, return the native root so host-wide files (the
         shared OAuth client secret) are found regardless of active profile.
-        Docker/custom roots return ``HERMES_HOME`` directly.
+        A custom root that uses profiles returns its own root
+        (``<root>/profiles/<name>`` → ``<root>``); a custom non-profile
+        ``HERMES_HOME`` is returned unchanged.
         """
         native_home = Path.home() / ".hermes"
         env_home = os.environ.get("HERMES_HOME", "").strip()
@@ -64,3 +66,22 @@ except (ModuleNotFoundError, ImportError):
             return "~/" + str(home.relative_to(Path.home()))
         except ValueError:
             return str(home)
+
+
+def client_secret_path() -> Path:
+    """Resolve the shared OAuth ``google_client_secret.json`` (host-wide app
+    credential).
+
+    Anchored at the default Hermes root so a gateway running under a named
+    profile sees the one-time host setup; a profile-local copy wins when it is
+    an actual file. Centralizes the precedence so the standalone scripts
+    (``setup.py``/``google_api.py``) cannot drift. Mirrors the google_chat fix
+    in commit fff056144.
+
+    ``is_file()`` (not ``exists()``) gates the profile-local override so a
+    same-named *directory* never shadows the real default-root secret.
+    """
+    profile_local = get_hermes_home() / "google_client_secret.json"
+    if profile_local.is_file():
+        return profile_local
+    return get_default_hermes_root() / "google_client_secret.json"

--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 try:
     from hermes_constants import display_hermes_home as display_hermes_home
+    from hermes_constants import get_default_hermes_root as get_default_hermes_root
     from hermes_constants import get_hermes_home as get_hermes_home
 except (ModuleNotFoundError, ImportError):
 
@@ -30,6 +31,29 @@ except (ModuleNotFoundError, ImportError):
         Mirrors ``hermes_constants.get_hermes_home()``."""
         val = os.environ.get("HERMES_HOME", "").strip()
         return Path(val) if val else Path.home() / ".hermes"
+
+    def get_default_hermes_root() -> Path:
+        """Return the root Hermes dir for profile-level / host-wide files.
+
+        Mirrors ``hermes_constants.get_default_hermes_root()``: when
+        ``HERMES_HOME`` is a profile path (``<root>/profiles/<name>``) or sits
+        under ``~/.hermes``, return the native root so host-wide files (the
+        shared OAuth client secret) are found regardless of active profile.
+        Docker/custom roots return ``HERMES_HOME`` directly.
+        """
+        native_home = Path.home() / ".hermes"
+        env_home = os.environ.get("HERMES_HOME", "").strip()
+        if not env_home:
+            return native_home
+        env_path = Path(env_home)
+        try:
+            env_path.resolve().relative_to(native_home.resolve())
+            return native_home
+        except ValueError:
+            pass
+        if env_path.parent.name == "profiles":
+            return env_path.parent.parent
+        return env_path
 
     def display_hermes_home() -> str:
         """Return a user-friendly ``~/``-shortened display string.

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -36,25 +36,11 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-from _hermes_home import get_default_hermes_root, get_hermes_home
+from _hermes_home import client_secret_path as _client_secret_path
+from _hermes_home import get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
-
-
-def _client_secret_path() -> Path:
-    """Shared OAuth client secret (host-wide app credential).
-
-    Anchored at the default Hermes root so a gateway running under a named
-    profile sees the one-time host setup; a profile-local copy wins when
-    present. Mirrors hermes_constants.get_default_hermes_root() precedence
-    and the google_chat fix in commit fff056144.
-    """
-    profile_local = get_hermes_home() / "google_client_secret.json"
-    if profile_local.exists():
-        return profile_local
-    return get_default_hermes_root() / "google_client_secret.json"
-
 
 CLIENT_SECRET_PATH = _client_secret_path()
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -36,11 +36,27 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-from _hermes_home import get_hermes_home
+from _hermes_home import get_default_hermes_root, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
-CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+
+
+def _client_secret_path() -> Path:
+    """Shared OAuth client secret (host-wide app credential).
+
+    Anchored at the default Hermes root so a gateway running under a named
+    profile sees the one-time host setup; a profile-local copy wins when
+    present. Mirrors hermes_constants.get_default_hermes_root() precedence
+    and the google_chat fix in commit fff056144.
+    """
+    profile_local = get_hermes_home() / "google_client_secret.json"
+    if profile_local.exists():
+        return profile_local
+    return get_default_hermes_root() / "google_client_secret.json"
+
+
+CLIENT_SECRET_PATH = _client_secret_path()
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -35,25 +35,11 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-from _hermes_home import display_hermes_home, get_default_hermes_root, get_hermes_home
+from _hermes_home import client_secret_path as _client_secret_path
+from _hermes_home import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
-
-
-def _client_secret_path() -> Path:
-    """Shared OAuth client secret (host-wide app credential).
-
-    Anchored at the default Hermes root so a gateway running under a named
-    profile sees the one-time host setup; a profile-local copy wins when
-    present. Mirrors hermes_constants.get_default_hermes_root() precedence
-    and the google_chat fix in commit fff056144.
-    """
-    profile_local = get_hermes_home() / "google_client_secret.json"
-    if profile_local.exists():
-        return profile_local
-    return get_default_hermes_root() / "google_client_secret.json"
-
 
 CLIENT_SECRET_PATH = _client_secret_path()
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -35,11 +35,27 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-from _hermes_home import display_hermes_home, get_hermes_home
+from _hermes_home import display_hermes_home, get_default_hermes_root, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
-CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+
+
+def _client_secret_path() -> Path:
+    """Shared OAuth client secret (host-wide app credential).
+
+    Anchored at the default Hermes root so a gateway running under a named
+    profile sees the one-time host setup; a profile-local copy wins when
+    present. Mirrors hermes_constants.get_default_hermes_root() precedence
+    and the google_chat fix in commit fff056144.
+    """
+    profile_local = get_hermes_home() / "google_client_secret.json"
+    if profile_local.exists():
+        return profile_local
+    return get_default_hermes_root() / "google_client_secret.json"
+
+
+CLIENT_SECRET_PATH = _client_secret_path()
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
 
 SCOPES = [

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -391,3 +391,27 @@ class TestClientSecretDefaultRoot:
 
         module = self._load_setup(monkeypatch)
         assert module._client_secret_path() == root / "google_client_secret.json"
+
+    def test_profile_local_directory_does_not_shadow_default_root(
+        self, monkeypatch, tmp_path
+    ):
+        """A *directory* named google_client_secret.json must not win precedence.
+
+        ``exists()`` matches directories too, so a same-named directory in the
+        profile dir would shadow the real default-root secret and break the
+        OAuth flow at file-open time. The resolver gates on ``is_file()``, so it
+        skips the directory and falls back to the default-root file.
+        """
+        root = tmp_path / ".hermes"
+        profile = root / "profiles" / "bot1"
+        profile.mkdir(parents=True)
+        # Real secret lives at the default root.
+        (root / "google_client_secret.json").write_text("{}")
+        # A *directory* of the same name sits in the profile dir.
+        (profile / "google_client_secret.json").mkdir()
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        module = self._load_setup(monkeypatch)
+        assert module._client_secret_path() == root / "google_client_secret.json"

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -322,3 +322,72 @@ class TestHermesConstantsFallback:
         import hermes_constants
         assert module.get_hermes_home is hermes_constants.get_hermes_home
         assert module.display_hermes_home is hermes_constants.display_hermes_home
+        assert module.get_default_hermes_root is hermes_constants.get_default_hermes_root
+
+
+class TestClientSecretDefaultRoot:
+    """Regression tests for anchoring the shared OAuth client secret.
+
+    Sibling of commit ``fff056144`` (google_chat): the host-wide
+    ``google_client_secret.json`` must be visible to a gateway running under a
+    named profile (``HERMES_HOME=<root>/profiles/<name>``), so it resolves to
+    the default Hermes root unless a profile-local copy is present.
+    """
+
+    SCRIPT_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "skills/productivity/google-workspace/scripts/setup.py"
+    )
+
+    def _load_setup(self, monkeypatch):
+        """Load setup.py with hermes_constants blocked so the stdlib
+        ``get_default_hermes_root`` fallback (the path this fix adds) runs."""
+        monkeypatch.setitem(sys.modules, "hermes_constants", None)
+        # setup.py imports google_auth_oauthlib lazily inside _ensure_deps, so
+        # module import itself only needs _hermes_home on sys.path (added by
+        # the script's own bootstrap).
+        spec = importlib.util.spec_from_file_location(
+            "google_workspace_setup_secret_test", self.SCRIPT_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_client_secret_shared_across_profiles(self, monkeypatch, tmp_path):
+        """A profile gateway resolves the client secret at the default root."""
+        root = tmp_path / ".hermes"
+        (root / "profiles" / "bot1").mkdir(parents=True)
+        (root / "google_client_secret.json").write_text("{}")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "bot1"))
+
+        module = self._load_setup(monkeypatch)
+        assert module._client_secret_path() == root / "google_client_secret.json"
+
+    def test_profile_local_client_secret_takes_precedence(self, monkeypatch, tmp_path):
+        """A profile-local copy wins over the default-root secret when present."""
+        root = tmp_path / ".hermes"
+        profile = root / "profiles" / "bot1"
+        profile.mkdir(parents=True)
+        (root / "google_client_secret.json").write_text("{}")
+        (profile / "google_client_secret.json").write_text("{}")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        module = self._load_setup(monkeypatch)
+        assert module._client_secret_path() == profile / "google_client_secret.json"
+
+    def test_default_root_used_when_no_profile_local(self, monkeypatch, tmp_path):
+        """With no profile-local copy, the resolver returns the default-root path."""
+        root = tmp_path / ".hermes"
+        profile = root / "profiles" / "bot1"
+        profile.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        module = self._load_setup(monkeypatch)
+        assert module._client_secret_path() == root / "google_client_secret.json"


### PR DESCRIPTION
## This is a sibling follow-up to commit fff056144

- `fff056144` (Frowtek) covered: the **google_chat** plugin's shared OAuth client secret (`google_chat_user_client_secret.json`) — anchored it to the default Hermes root so every profile sees the one-time host setup.
- `fff056144` did NOT touch: the **google-workspace skill** (`skills/productivity/google-workspace/scripts/{google_api,setup}.py`), which has the identical bug — `CLIENT_SECRET_PATH` is scoped to the active profile's `HERMES_HOME`, so a gateway under `-p <name>` can't find a client secret seeded at the default root.
- This PR adds the same default-root anchoring (with profile-local precedence) for the google-workspace `google_client_secret.json`, via a `get_default_hermes_root()` export on the shared `_hermes_home` shim.

## What does this PR do?

Anchors the google-workspace OAuth **client secret** (host-wide app credential) to the default Hermes root, mirroring `hermes_constants.get_default_hermes_root()` precedence: a profile-local `$HERMES_HOME/google_client_secret.json` wins when present, otherwise it resolves to `<default-root>/google_client_secret.json` (default `~/.hermes`, or the Docker root). The per-user `google_token.json` stays profile-scoped — only the shared client secret moves.

Runtime-resolver mirror: matches `_client_secret_path()` in `fff056144` — profile-local copy wins, else `get_default_hermes_root() / "google_client_secret.json"`.

## Related Issue

<!-- No linked issue — sibling-widening of merged commit fff056144. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/productivity/google-workspace/scripts/_hermes_home.py`: export `get_default_hermes_root()` (prefers `hermes_constants`; stdlib fallback mirrors its profile/Docker logic).
- `skills/productivity/google-workspace/scripts/google_api.py` + `setup.py`: resolve `CLIENT_SECRET_PATH` via a profile-local-precedence `_client_secret_path()` helper. `store_client_secret()` writes through the same module-level path, so host setup and profile reads stay consistent.
- `tests/skills/test_google_oauth_setup.py`: 3 resolver regression cases (cross-profile share, profile-local precedence, default-root fallback).

## How to Test

1. `python skills/productivity/google-workspace/scripts/setup.py --client-secret <path>` under default `HERMES_HOME`.
2. Run a google-workspace command under `HERMES_HOME=~/.hermes/profiles/<name>` — the client secret is now found (was: "No client secret stored").
3. `pytest tests/skills/test_google_oauth_setup.py -q` — the 3 new cases (`TestClientSecretDefaultRoot`) pass. Bidirectional guard verified: reverting the resolver to the profile-scoped path turns `test_client_secret_shared_across_profiles` + `test_default_root_used_when_no_profile_local` RED.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite (`pytest tests/skills/test_google_oauth_setup.py -q`) and all 18 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (path-resolution only; mirrors landed `fff056144` which was cross-platform-reviewed)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new resolver + shim export; user-facing behavior is unchanged for default installs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — path resolution mirrors `hermes_constants.get_default_hermes_root()`, which is cross-platform

> Audited siblings: confirmed google_chat (fff056144) is already fixed; the google-workspace skill was the remaining profile-scoped `google_client_secret.json`. No other platform persists a *file-based* shared OAuth client secret (teams uses the `TEAMS_CLIENT_SECRET` env var). No further widening needed.