### PR TITLE
fix(mcp): guard .get(key, {}) against None values in mcp_serve.py

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -166,7 +166,7 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype == "image":
-                url = part.get("url", part.get("source", {}).get("url", ""))
+                url = part.get("url", (part.get("source") or {}).get("url", ""))
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype not in {"text",}:
@@ -489,7 +489,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         conversations = []
 
         for key, entry in entries.items():
-            origin = entry.get("origin", {})
+            origin = entry.get("origin") or {}
             entry_platform = entry.get("platform") or origin.get("platform", "")
 
             if platform and entry_platform.lower() != platform.lower():
@@ -538,7 +538,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         if not entry:
             return json.dumps({"error": f"Conversation not found: {session_key}"})
 
-        origin = entry.get("origin", {})
+        origin = entry.get("origin") or {}
         return json.dumps({
             "session_key": session_key,
             "session_id": entry.get("session_id", ""),
@@ -782,7 +782,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             targets = []
             seen = set()
             for key, entry in entries.items():
-                origin = entry.get("origin", {})
+                origin = entry.get("origin") or {}
                 p = entry.get("platform") or origin.get("platform", "")
                 chat_id = origin.get("chat_id", "")
                 if not p or not chat_id:
@@ -802,7 +802,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             return json.dumps({"count": len(targets), "channels": targets}, indent=2)
 
         channels = []
-        for plat, entries_list in directory.get("platforms", {}).items():
+        for plat, entries_list in (directory.get("platforms") or {}).items():
             if platform and plat.lower() != platform.lower():
                 continue
             if isinstance(entries_list, list):


### PR DESCRIPTION
## Summary

Fixes 5 `.get("key", {})` chained calls in `mcp_serve.py` that crash when the key exists with a `None` value.

## Problem

`.get("key", {})` only applies the default `{}` when the key is **missing** from the dict. When the key **exists** with value `None` (null in JSON), `.get()` returns `None`, and the downstream `.get()` or `.items()` call raises `AttributeError`.

This can happen when:
- Session state is partially loaded/corrupted
- A platform adapter stores `None` for optional fields
- JSON round-trips produce null values

## Fixed Locations

1. **Line 169**: `part.get("source", {}).get("url", "")` → `(part.get("source") or {}).get("url", "")`
   - Crash: `AttributeError: 'NoneType' object has no attribute 'get'`

2. **Lines 492, 541, 785**: `entry.get("origin", {})` → `entry.get("origin") or {}`
   - Crash: downstream `origin.get("platform", "")` raises `AttributeError`

3. **Line 805**: `directory.get("platforms", {}).items()` → `(directory.get("platforms") or {}).items()`
   - Crash: `AttributeError: 'NoneType' object has no attribute 'items'`

## Fix Pattern

Replace `.get("key", default)` with `.get("key") or default` — the `or` catches both missing keys AND `None` values.