### PR TITLE
feat(desktop): remote workspace + terminal over SSH (#38671, #38369, #38464)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -21,6 +21,7 @@ const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
 const net = require('node:net')
+const os = require('node:os')
 const path = require('node:path')
 const { fileURLToPath, pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -31,6 +32,7 @@ const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
+const remoteSsh = require('./remote-ssh.cjs')
 const {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -4002,7 +4004,10 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
     remoteTokenSet: Boolean(remoteToken),
     // The env override only forces the global/primary connection; a per-profile
     // scope is never overridden by HERMES_DESKTOP_REMOTE_URL.
-    envOverride
+    envOverride,
+    sshUser: String(block.sshUser || ''),
+    sshPort: Number(block.sshPort) || 22,
+    sshKey: String(block.sshKey || '')
   }
 }
 
@@ -4033,6 +4038,19 @@ function coerceDesktopConnectionConfig(input = {}, existing = readDesktopConnect
       : { encoding: 'plain', value: incomingToken }
     : existingBlock.token
 
+  // SSH workspace settings live on the global remote block only (the File
+  // Explorer / Terminal follow the active connection). Preserve existing values
+  // unless explicitly provided.
+  const sshUser = input.sshUser !== undefined ? String(input.sshUser).trim() : existing.remote?.sshUser
+  const sshKey = input.sshKey !== undefined ? String(input.sshKey).trim() : existing.remote?.sshKey
+  const sshPortRaw = input.sshPort !== undefined ? input.sshPort : existing.remote?.sshPort
+  const sshPort = Number(sshPortRaw) || undefined
+  const sshFields = {
+    ...(sshUser ? { sshUser } : {}),
+    ...(sshKey ? { sshKey } : {}),
+    ...(sshPort && sshPort !== 22 ? { sshPort } : {})
+  }
+
   if (key) {
     // Per-profile scope: a remote entry pins this profile to its own backend; a
     // local entry clears the override so the profile inherits the default.
@@ -4047,8 +4065,8 @@ function coerceDesktopConnectionConfig(input = {}, existing = readDesktopConnect
 
   const nextRemote =
     mode === 'remote'
-      ? buildRemoteBlock(remoteUrl, authMode, nextToken)
-      : { url: remoteUrl ? normalizeRemoteBaseUrl(remoteUrl) : remoteUrl, authMode, token: nextToken }
+      ? { ...buildRemoteBlock(remoteUrl, authMode, nextToken), ...sshFields }
+      : { url: remoteUrl ? normalizeRemoteBaseUrl(remoteUrl) : remoteUrl, authMode, token: nextToken, ...sshFields }
 
   // Preserve per-profile overrides when saving the global connection.
   return { mode, remote: nextRemote, profiles: existing.profiles || {} }
@@ -4260,6 +4278,44 @@ async function probeRemoteAuthMode(rawUrl) {
     version: status?.version || null,
     error: null
   }
+}
+
+// SSH coordinates for routing the desktop's File Explorer / Terminal to the
+// remote workspace (#38671). Returns null when not in remote mode, so callers
+// fall back to local fs/PTY. The host comes from the gateway URL; user/port/key
+// come from env overrides, the saved connection config, or sensible defaults
+// (current OS user, port 22, the SSH agent / default key).
+async function resolveRemoteSshConfig() {
+  let remote = null
+
+  try {
+    remote = await resolveRemoteBackend()
+  } catch {
+    return null
+  }
+
+  if (!remote) {
+    return null
+  }
+
+  let host = ''
+
+  try {
+    host = new URL(remote.baseUrl).hostname
+  } catch {
+    return null
+  }
+
+  if (!host) {
+    return null
+  }
+
+  const config = readDesktopConnectionConfig()
+  const user = process.env.HERMES_DESKTOP_SSH_USER || config.remote?.sshUser || os.userInfo().username
+  const port = Number(process.env.HERMES_DESKTOP_SSH_PORT || config.remote?.sshPort || 22) || 22
+  const keyPath = process.env.HERMES_DESKTOP_SSH_KEY || config.remote?.sshKey || ''
+
+  return { host, user, port, keyPath }
 }
 
 async function testDesktopConnectionConfig(input = {}) {
@@ -5373,7 +5429,39 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   return true
 })
 
+// File previews must read from the machine that actually holds the file. A
+// remote *workspace* file (opened from the File Explorer) resolves to an
+// absolute POSIX path (/home/…) on the gateway host and is read over SSH. But a
+// file the user attached from their own disk while connected to a remote
+// gateway carries a client-OS path (e.g. C:\Users\…\Downloads\…) that the
+// remote host can't see — reading it over SSH fails with "cannot read C:\…".
+// The remote side is always POSIX (see remote-ssh.cjs), so only absolute POSIX
+// paths are remote; everything else (Windows drive/UNC paths, relative paths)
+// is a local-client file and must be read here. (#38369)
+function previewReadsFromRemote(filePath) {
+  return String(filePath || '').startsWith('/')
+}
+
 ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
+  const ssh = previewReadsFromRemote(filePath) ? await resolveRemoteSshConfig() : null
+
+  if (ssh) {
+    const remotePath = String(filePath || '')
+    const info = await remoteSsh.statFile(ssh, remotePath)
+
+    if (!info || !info.isFile) {
+      throw new Error(`File preview unavailable: cannot read ${remotePath}`)
+    }
+
+    if (info.size > DATA_URL_READ_MAX_BYTES) {
+      throw new Error('File is too large to preview.')
+    }
+
+    const buffer = await remoteSsh.readFileBytes(ssh, remotePath, DATA_URL_READ_MAX_BYTES)
+
+    return `data:${mimeTypeForPath(remotePath)};base64,${buffer.toString('base64')}`
+  }
+
   const { resolvedPath } = await resolveReadableFileForIpc(filePath, {
     maxBytes: DATA_URL_READ_MAX_BYTES,
     purpose: 'File preview'
@@ -5383,6 +5471,30 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
 })
 
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
+  const ssh = previewReadsFromRemote(filePath) ? await resolveRemoteSshConfig() : null
+
+  if (ssh) {
+    const remotePath = String(filePath || '')
+    const info = await remoteSsh.statFile(ssh, remotePath)
+
+    if (!info || !info.isFile) {
+      throw new Error(`Text preview unavailable: cannot read ${remotePath}`)
+    }
+
+    const buffer = await remoteSsh.readFileBytes(ssh, remotePath, TEXT_PREVIEW_MAX_BYTES)
+    const remoteExt = path.extname(remotePath).toLowerCase()
+
+    return {
+      binary: looksBinary(buffer.subarray(0, Math.min(buffer.length, 4096))),
+      byteSize: info.size,
+      language: PREVIEW_LANGUAGE_BY_EXT[remoteExt] || 'text',
+      mimeType: mimeTypeForPath(remotePath),
+      path: remotePath,
+      text: buffer.toString('utf8'),
+      truncated: info.size > TEXT_PREVIEW_MAX_BYTES
+    }
+  }
+
   const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
     maxBytes: TEXT_PREVIEW_SOURCE_MAX_BYTES,
     purpose: 'Text preview'
@@ -5767,6 +5879,12 @@ function disposeTerminalSession(id) {
 }
 
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.readDir(ssh, dirPath)
+  }
+
   const resolved = path.resolve(String(dirPath || ''))
 
   if (!resolved) {
@@ -5794,6 +5912,12 @@ ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => {
 })
 
 ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.gitRoot(ssh, startPath)
+  }
+
   const input = String(startPath || '')
   const resolved = input.startsWith('file:') ? fileURLToPath(input) : path.resolve(input)
 
@@ -5807,6 +5931,97 @@ ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => {
   }
 })
 
+// File Explorer mutations. Each routes to the remote host over SSH/SCP when a
+// remote gateway is selected (#38671), otherwise operates on the local fs.
+
+ipcMain.handle('hermes:fs:mkdir', async (_event, dirPath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.mkdir(ssh, dirPath)
+  }
+
+  try {
+    await fs.promises.mkdir(path.resolve(String(dirPath || '')), { recursive: true })
+
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error?.code || 'mkdir-failed' }
+  }
+})
+
+ipcMain.handle('hermes:fs:newFile', async (_event, filePath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.newFile(ssh, filePath)
+  }
+
+  try {
+    // 'wx' fails when the file already exists, so we never truncate one.
+    const handle = await fs.promises.open(path.resolve(String(filePath || '')), 'wx')
+    await handle.close()
+
+    return { ok: true }
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      return { ok: true }
+    }
+
+    return { ok: false, error: error?.code || 'create-failed' }
+  }
+})
+
+ipcMain.handle('hermes:fs:rename', async (_event, fromPath, toPath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.rename(ssh, fromPath, toPath)
+  }
+
+  try {
+    await fs.promises.rename(path.resolve(String(fromPath || '')), path.resolve(String(toPath || '')))
+
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error?.code || 'rename-failed' }
+  }
+})
+
+ipcMain.handle('hermes:fs:delete', async (_event, targetPath) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.remove(ssh, targetPath)
+  }
+
+  try {
+    await fs.promises.rm(path.resolve(String(targetPath || '')), { recursive: true, force: true })
+
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error?.code || 'delete-failed' }
+  }
+})
+
+ipcMain.handle('hermes:fs:upload', async (_event, localPath, destDir) => {
+  const ssh = await resolveRemoteSshConfig()
+
+  if (ssh) {
+    return remoteSsh.upload(ssh, localPath, destDir)
+  }
+
+  try {
+    const src = path.resolve(String(localPath || ''))
+    const dest = path.join(path.resolve(String(destDir || '')), path.basename(src))
+    await fs.promises.copyFile(src, dest)
+
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error?.code || 'upload-failed' }
+  }
+})
+
 ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   if (!nodePty) {
     throw new Error('PTY support is unavailable. Reinstall desktop dependencies and restart Hermes.')
@@ -5815,13 +6030,31 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   ensureSpawnHelperExecutable()
 
   const id = crypto.randomUUID()
-  const { args, command, name } = terminalShellCommand()
-  const cwd = safeTerminalCwd(payload?.cwd)
+  const ssh = await resolveRemoteSshConfig()
   const cols = Math.max(2, Number.parseInt(String(payload?.cols || 80), 10) || 80)
   const rows = Math.max(2, Number.parseInt(String(payload?.rows || 24), 10) || 24)
+
+  // Remote mode: node-pty owns a local PTY wrapping `ssh -tt`, which allocates
+  // the remote PTY and forwards resizes. The requested cwd is a *remote* path,
+  // so it's applied by the remote shell (in terminalSpawn), not validated
+  // locally; the local ssh client process just runs from the user's home.
+  let command
+  let args
+  let name
+  let cwd
+
+  if (ssh) {
+    ;({ command, args } = remoteSsh.terminalSpawn(ssh, String(payload?.cwd || '')))
+    name = `ssh:${ssh.host}`
+    cwd = String(payload?.cwd || '')
+  } else {
+    ;({ args, command, name } = terminalShellCommand())
+    cwd = safeTerminalCwd(payload?.cwd)
+  }
+
   const ptyProcess = nodePty.spawn(command, args, {
     cols,
-    cwd,
+    cwd: ssh ? app.getPath('home') : cwd,
     env: terminalShellEnv(),
     name: 'xterm-256color',
     rows
@@ -6142,6 +6375,15 @@ ipcMain.handle('hermes:vscode-theme:fetch', async (_event, id) => fetchMarketpla
 
 // Search the Marketplace for color-theme extensions (empty query = top installs).
 ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMarketplaceThemes(String(query || ''), 20))
+
+// Identity of the machine the desktop's Terminal and File Explorer actually run
+// on. These surfaces use local Node fs/PTY (see hermes:fs:* and hermes:terminal:*
+// above), so when the chat session targets a remote gateway the UI must say so
+// explicitly rather than imply everything shares one host (#38369).
+ipcMain.handle('hermes:host:info', async () => ({
+  hostname: os.hostname(),
+  platform: process.platform
+}))
 
 app.whenReady().then(() => {
   if (IS_MAC) {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -52,6 +52,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
+  getHostInfo: () => ipcRenderer.invoke('hermes:host:info'),
+  mkdir: dirPath => ipcRenderer.invoke('hermes:fs:mkdir', dirPath),
+  newFile: filePath => ipcRenderer.invoke('hermes:fs:newFile', filePath),
+  renamePath: (fromPath, toPath) => ipcRenderer.invoke('hermes:fs:rename', fromPath, toPath),
+  deletePath: targetPath => ipcRenderer.invoke('hermes:fs:delete', targetPath),
+  uploadFile: (localPath, destDir) => ipcRenderer.invoke('hermes:fs:upload', localPath, destDir),
   terminal: {
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),
     resize: (id, size) => ipcRenderer.invoke('hermes:terminal:resize', id, size),

--- a/apps/desktop/electron/remote-ssh.cjs
+++ b/apps/desktop/electron/remote-ssh.cjs
@@ -1,0 +1,352 @@
+// Remote workspace access over SSH for the desktop's File Explorer and Terminal.
+//
+// When the chat session targets a remote gateway, these surfaces should operate
+// on the machine the agent actually runs on — not the local Electron host
+// (#38671). Rather than add a new HTTP/WebSocket API to the gateway, we mirror
+// how Hermes' own SSH execution backend works (tools/environments/ssh.py): shell
+// out to the OpenSSH client with the same ControlMaster connection-reuse
+// conventions and the same socket naming. That means when the agent's backend is
+// itself `ssh`, the desktop rides the very same multiplexed connection the agent
+// already opened, instead of standing up a parallel mechanism.
+//
+// Scope/assumptions for this first cut:
+//   * The remote host runs Linux with GNU find (uses `find -printf`). dev08 and
+//     the typical self-hosted gateway qualify.
+//   * Auth reuses the user's existing SSH key / agent (BatchMode=yes, no prompts).
+//   * ControlMaster is POSIX-only; the Windows OpenSSH client does not support it,
+//     so those options are omitted there (each call is its own connection).
+
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { execFile } = require('node:child_process')
+
+const IS_WINDOWS = process.platform === 'win32'
+
+// Mirror the hidden-entry filtering the local hermes:fs:readDir handler applies
+// so the remote tree looks the same as the local one.
+const FS_READDIR_HIDDEN = new Set(['.git', '.DS_Store'])
+
+// Same socket path scheme as ssh.py so we share its ControlMaster master when
+// the agent's SSH backend is live: <tmp>/hermes-ssh/<sha256(user@host:port)[:16]>.sock
+function controlSocketPath(user, host, port) {
+  const dir = path.join(os.tmpdir(), 'hermes-ssh')
+
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+  } catch {
+    // Best-effort; ssh will surface a clear error if the socket can't be made.
+  }
+
+  const id = crypto.createHash('sha256').update(`${user}@${host}:${port}`).digest('hex').slice(0, 16)
+
+  return path.join(dir, `${id}.sock`)
+}
+
+function sshBaseArgs(cfg) {
+  const args = []
+
+  if (!IS_WINDOWS) {
+    args.push(
+      '-o',
+      `ControlPath=${controlSocketPath(cfg.user, cfg.host, cfg.port)}`,
+      '-o',
+      'ControlMaster=auto',
+      '-o',
+      'ControlPersist=300'
+    )
+  }
+
+  args.push(
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'StrictHostKeyChecking=accept-new',
+    '-o',
+    'ConnectTimeout=10'
+  )
+
+  if (cfg.port && Number(cfg.port) !== 22) {
+    args.push('-p', String(cfg.port))
+  }
+
+  if (cfg.keyPath) {
+    args.push('-i', cfg.keyPath)
+  }
+
+  return args
+}
+
+function sshTarget(cfg) {
+  return `${cfg.user}@${cfg.host}`
+}
+
+// Single-quote for the remote POSIX shell: close, escaped quote, reopen.
+function shQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+// node-pty (used for the remote terminal) does NOT search PATH on Windows, so a
+// bare "ssh" fails there with "File not found". Resolve an absolute path on
+// Windows; on POSIX node-pty execvp's through PATH so the bare name is fine.
+let _sshBinary
+function sshBinary() {
+  if (process.env.HERMES_DESKTOP_SSH_BIN) {
+    return process.env.HERMES_DESKTOP_SSH_BIN
+  }
+
+  if (_sshBinary) {
+    return _sshBinary
+  }
+
+  if (IS_WINDOWS) {
+    const candidates = [
+      path.join(process.env.WINDIR || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe'),
+      path.join(process.env.LOCALAPPDATA || '', 'Microsoft', 'WinGet', 'Links', 'ssh.exe')
+    ]
+    for (const candidate of candidates) {
+      try {
+        if (candidate && fs.existsSync(candidate)) {
+          _sshBinary = candidate
+          return _sshBinary
+        }
+      } catch {
+        // ignore and fall through
+      }
+    }
+  }
+
+  _sshBinary = 'ssh'
+  return _sshBinary
+}
+
+function runRemote(cfg, remoteCommand, { timeout = 15_000, maxBuffer = 8 * 1024 * 1024 } = {}) {
+  return new Promise(resolve => {
+    const args = [...sshBaseArgs(cfg), sshTarget(cfg), remoteCommand]
+
+    execFile(
+      sshBinary(),
+      args,
+      { timeout, maxBuffer, windowsHide: true },
+      (error, stdout, stderr) => {
+        resolve({
+          code: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+          stdout: stdout || '',
+          stderr: stderr || '',
+          timedOut: Boolean(error && error.killed),
+          error: error || null
+        })
+      }
+    )
+  })
+}
+
+// List a remote directory. Returns the same shape as the local fs:readDir handler:
+// { entries: [{ name, path, isDirectory }], error? }.
+async function readDir(cfg, dirPath) {
+  const resolved = String(dirPath || '').trim()
+
+  if (!resolved) {
+    return { entries: [], error: 'invalid-path' }
+  }
+
+  // Portable across Linux and macOS/BSD: `ls -1Ap` prints one entry per line and
+  // appends `/` to directories (GNU `find -printf` would be Linux-only). The
+  // QUOTING_STYLE=literal prefix disables GNU coreutils' shell-quoting of names
+  // with special characters (harmless on BSD ls, which doesn't quote).
+  const cmd = `QUOTING_STYLE=literal ls -1Ap ${shQuote(resolved)} 2>/dev/null`
+  const { code, stdout, timedOut } = await runRemote(cfg, cmd)
+
+  if (timedOut) {
+    return { entries: [], error: 'timeout' }
+  }
+
+  if (code !== 0 && !stdout) {
+    return { entries: [], error: 'read-error' }
+  }
+
+  const base = resolved.replace(/\/+$/, '')
+  const entries = stdout
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const isDirectory = line.endsWith('/')
+      const name = isDirectory ? line.slice(0, -1) : line
+
+      return { name, path: `${base}/${name}`, isDirectory }
+    })
+    .filter(entry => entry.name && !FS_READDIR_HIDDEN.has(entry.name))
+    .sort((a, b) => Number(b.isDirectory) - Number(a.isDirectory) || a.name.localeCompare(b.name))
+
+  return { entries }
+}
+
+// Remote equivalent of the local gitRoot probe.
+async function gitRoot(cfg, startPath) {
+  const resolved = String(startPath || '').trim()
+
+  if (!resolved) {
+    return null
+  }
+
+  const cmd = `git -C ${shQuote(resolved)} rev-parse --show-toplevel 2>/dev/null`
+  const { code, stdout } = await runRemote(cfg, cmd)
+  const root = stdout.trim()
+
+  return code === 0 && root ? root : null
+}
+
+// Stat a remote path. Returns { size, isFile, isDirectory } or null if missing.
+async function statFile(cfg, filePath) {
+  const resolved = String(filePath || '').trim()
+
+  if (!resolved) {
+    return null
+  }
+
+  // Portable test instead of GNU `stat -c` (BSD/macOS stat uses a different
+  // syntax). `wc -c < file` gives the byte size on every POSIX system.
+  const q = shQuote(resolved)
+  const cmd = `if [ -d ${q} ]; then echo 'd 0'; elif [ -f ${q} ]; then echo "f $(wc -c < ${q})"; else echo 'x 0'; fi`
+  const { code, stdout } = await runRemote(cfg, cmd)
+
+  if (code !== 0 || !stdout.trim()) {
+    return null
+  }
+
+  const parts = stdout.trim().split(/\s+/)
+  const type = parts[0]
+
+  if (type === 'x') {
+    return null
+  }
+
+  return {
+    size: Number.parseInt(parts[parts.length - 1], 10) || 0,
+    isDirectory: type === 'd',
+    isFile: type === 'f'
+  }
+}
+
+// Read up to maxBytes of a remote file, returned as a Buffer. Transferred as
+// base64 so binary content survives the text stdout channel intact.
+async function readFileBytes(cfg, filePath, maxBytes) {
+  const resolved = String(filePath || '').trim()
+
+  if (!resolved) {
+    return Buffer.alloc(0)
+  }
+
+  const cmd = `head -c ${Math.max(0, Number(maxBytes) || 0)} ${shQuote(resolved)} | base64`
+  // base64 inflates ~4/3 and adds newlines; give the buffer generous headroom.
+  const maxBuffer = Math.ceil((Number(maxBytes) || 0) * 1.4) + 64 * 1024
+  const { code, stdout, error } = await runRemote(cfg, cmd, { timeout: 30_000, maxBuffer })
+
+  if (code !== 0 || error) {
+    throw new Error(`remote read failed: ${resolved}`)
+  }
+
+  return Buffer.from(stdout.replace(/\s+/g, ''), 'base64')
+}
+
+// ---------------------------------------------------------------------------
+// Mutations (create / rename / delete / upload) — local fs equivalents live in
+// main.cjs; these run the same operation on the remote host over SSH/SCP.
+// ---------------------------------------------------------------------------
+
+async function mkdir(cfg, dirPath) {
+  const q = shQuote(String(dirPath || ''))
+  const { code } = await runRemote(cfg, `mkdir -p -- ${q}`)
+
+  return { ok: code === 0 }
+}
+
+async function newFile(cfg, filePath) {
+  const q = shQuote(String(filePath || ''))
+  // Create only when absent so we never clobber an existing file.
+  const { code } = await runRemote(cfg, `[ -e ${q} ] || : > ${q}`)
+
+  return { ok: code === 0 }
+}
+
+async function rename(cfg, fromPath, toPath) {
+  const { code, stderr } = await runRemote(cfg, `mv -- ${shQuote(fromPath)} ${shQuote(toPath)}`)
+
+  return { ok: code === 0, error: code === 0 ? undefined : stderr.trim() || 'rename-failed' }
+}
+
+async function remove(cfg, targetPath) {
+  const { code, stderr } = await runRemote(cfg, `rm -rf -- ${shQuote(targetPath)}`)
+
+  return { ok: code === 0, error: code === 0 ? undefined : stderr.trim() || 'delete-failed' }
+}
+
+function scpBinary() {
+  if (process.env.HERMES_DESKTOP_SCP_BIN) {
+    return process.env.HERMES_DESKTOP_SCP_BIN
+  }
+
+  // Derive scp from the configured ssh path so both come from the same install.
+  const sshBin = sshBinary()
+
+  return sshBin === 'ssh' ? 'scp' : sshBin.replace(/ssh(\.exe)?$/i, (_m, ext) => `scp${ext || ''}`)
+}
+
+function scpBaseArgs(cfg) {
+  const args = []
+
+  if (!IS_WINDOWS) {
+    args.push('-o', `ControlPath=${controlSocketPath(cfg.user, cfg.host, cfg.port)}`, '-o', 'ControlMaster=auto')
+  }
+
+  args.push('-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=accept-new', '-o', 'ConnectTimeout=10')
+
+  if (cfg.port && Number(cfg.port) !== 22) {
+    args.push('-P', String(cfg.port))
+  }
+
+  if (cfg.keyPath) {
+    args.push('-i', cfg.keyPath)
+  }
+
+  return args
+}
+
+// Upload a local file into a remote directory via scp. Returns { ok, error }.
+function upload(cfg, localPath, remoteDir) {
+  return new Promise(resolve => {
+    const dest = `${sshTarget(cfg)}:${String(remoteDir || '').replace(/\/+$/, '')}/`
+    const args = [...scpBaseArgs(cfg), String(localPath), dest]
+
+    execFile(scpBinary(), args, { timeout: 120_000, windowsHide: true }, (error, _stdout, stderr) => {
+      resolve({ ok: !error, error: error ? stderr.trim() || String(error.message || error) : undefined })
+    })
+  })
+}
+
+// Argv for an interactive remote shell, spawned through node-pty. node-pty owns
+// the *local* PTY; `ssh -tt` allocates the *remote* PTY and forwards window-size
+// changes, so node-pty's resize() reaches the remote shell as a normal SIGWINCH.
+function terminalSpawn(cfg, cwd) {
+  const remoteCommand =
+    `cd ${cwd ? shQuote(cwd) : '~'} 2>/dev/null; exec "\${SHELL:-/bin/bash}" -l`
+  const args = [...sshBaseArgs(cfg), '-tt', sshTarget(cfg), remoteCommand]
+
+  return { command: sshBinary(), args }
+}
+
+module.exports = {
+  controlSocketPath,
+  gitRoot,
+  mkdir,
+  newFile,
+  readDir,
+  readFileBytes,
+  remove,
+  rename,
+  sshBaseArgs,
+  statFile,
+  terminalSpawn,
+  upload
+}

--- a/apps/desktop/src/app/right-sidebar/exec-target-badge.tsx
+++ b/apps/desktop/src/app/right-sidebar/exec-target-badge.tsx
@@ -1,0 +1,91 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+import type { DesktopHostInfo } from '@/global'
+import { $connection, $currentCwd } from '@/store/session'
+
+/**
+ * Execution-target badge for the Terminal / File Explorer surfaces.
+ *
+ * Both surfaces run against the *local* machine — the desktop's Terminal spawns
+ * a local PTY and the File Explorer reads the local filesystem (see the
+ * `hermes:terminal:*` and `hermes:fs:*` handlers in electron/main.cjs). When the
+ * chat session targets a remote gateway, that creates a split-brain where chat,
+ * terminal, and files can appear to share one machine while actually targeting
+ * different ones. This badge makes the local scope explicit, and warns loudly
+ * when the chat backend is remote so commands/files here aren't mistaken for
+ * remote ones (#38369).
+ */
+
+// Host identity never changes within a run, so fetch it once and share the
+// promise across every mount instead of re-hitting IPC per badge.
+let hostInfoPromise: Promise<DesktopHostInfo | null> | null = null
+
+function loadHostInfo(): Promise<DesktopHostInfo | null> {
+  if (!hostInfoPromise) {
+    const getHostInfo = window.hermesDesktop?.getHostInfo
+    hostInfoPromise = getHostInfo ? getHostInfo().catch(() => null) : Promise.resolve(null)
+  }
+
+  return hostInfoPromise
+}
+
+function remoteHostLabel(baseUrl: string | undefined): string {
+  if (!baseUrl) {
+    return 'remote backend'
+  }
+
+  try {
+    return new URL(baseUrl).host || 'remote backend'
+  } catch {
+    return 'remote backend'
+  }
+}
+
+export function ExecTargetBadge({ className }: { className?: string }) {
+  const connection = useStore($connection)
+  const cwd = useStore($currentCwd).trim()
+  const [hostInfo, setHostInfo] = useState<DesktopHostInfo | null>(null)
+
+  useEffect(() => {
+    let active = true
+    void loadHostInfo().then(info => {
+      if (active) {
+        setHostInfo(info)
+      }
+    })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const isRemote = connection?.mode === 'remote'
+  const hostname = hostInfo?.hostname?.trim() || 'this machine'
+  const remoteHost = remoteHostLabel(connection?.baseUrl)
+
+  // In remote mode the Terminal and File Explorer now route over SSH to the
+  // machine the agent runs on, so they genuinely target the remote host — the
+  // badge says so (green). In local mode they run on this machine (neutral).
+  const title = isRemote
+    ? `Terminal & file browser run on the remote backend (${remoteHost}) over SSH — ` +
+      `the same machine the chat session targets.` +
+      (cwd ? `\nWorking directory: ${cwd}` : '')
+    : `Terminal & file browser run on this machine (${hostname}).` + (cwd ? `\nWorking directory: ${cwd}` : '')
+
+  return (
+    <span
+      className={cn(
+        'flex min-w-0 items-center gap-1 rounded px-1 text-[0.6875rem]',
+        isRemote ? 'text-emerald-500' : 'text-(--ui-text-tertiary)',
+        className
+      )}
+      title={title}
+    >
+      <Codicon className="shrink-0" name={isRemote ? 'remote' : 'device-desktop'} size="0.75rem" />
+      <span className="truncate">{isRemote ? `Remote · ${remoteHost}` : 'Local'}</span>
+    </span>
+  )
+}

--- a/apps/desktop/src/app/right-sidebar/files/remote-folder-picker.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-folder-picker.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { notifyError } from '@/store/notifications'
+
+// The OS-native folder dialog (selectPaths → dialog.showOpenDialog) can only
+// browse the *local* machine. When the workspace lives on a remote gateway the
+// File Explorer reads the remote filesystem over SSH (hermes:fs:readDir), so the
+// folder picker must browse there too — otherwise "change folder" would silently
+// offer local directories that the remote agent can't see (#38369). This dialog
+// reuses the same remote-aware readDir to navigate and pick a remote directory.
+
+interface RemoteEntry {
+  name: string
+  path: string
+}
+
+// POSIX parent of a remote path (remote hosts are POSIX; the local OS may not
+// be, so we never use Node path semantics here).
+function parentDir(input: string): string {
+  const trimmed = input.replace(/\/+$/, '')
+  const idx = trimmed.lastIndexOf('/')
+
+  return idx <= 0 ? '/' : trimmed.slice(0, idx)
+}
+
+interface RemoteFolderPickerProps {
+  hostLabel: string
+  initialPath: string
+  onClose: () => void
+  onSelect: (path: string) => void
+  open: boolean
+}
+
+export function RemoteFolderPicker({ hostLabel, initialPath, onClose, onSelect, open }: RemoteFolderPickerProps) {
+  const [path, setPath] = useState(initialPath || '/')
+  const [dirs, setDirs] = useState<RemoteEntry[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const load = useCallback(async (target: string) => {
+    setLoading(true)
+
+    try {
+      const result = await window.hermesDesktop?.readDir(target)
+
+      if (result?.error) {
+        throw new Error(result.error)
+      }
+
+      const folders = (result?.entries ?? [])
+        .filter(entry => entry.isDirectory)
+        .map(entry => ({ name: entry.name, path: entry.path }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      setDirs(folders)
+      setPath(target)
+    } catch (error) {
+      notifyError(error, `Could not open ${target}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // (Re)load from the initial path each time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      void load(initialPath || '/')
+    }
+  }, [open, initialPath, load])
+
+  const atRoot = path === '/' || path === ''
+
+  return (
+    <Dialog onOpenChange={next => (next ? undefined : onClose())} open={open}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Open remote folder</DialogTitle>
+          <DialogDescription>Browse {hostLabel} over SSH and pick a working directory.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2">
+          <Button
+            disabled={loading || atRoot}
+            onClick={() => void load(parentDir(path))}
+            size="xs"
+            type="button"
+            variant="secondary"
+          >
+            <Codicon name="arrow-up" size="0.75rem" />
+            Up
+          </Button>
+          <span className="min-w-0 flex-1 truncate font-mono text-[0.6875rem] text-(--ui-text-secondary)" title={path}>
+            {path}
+          </span>
+        </div>
+
+        <div className="max-h-72 min-h-32 overflow-auto rounded border border-(--ui-stroke-secondary)">
+          {loading ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">Loading…</div>
+          ) : dirs.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">No subfolders here.</div>
+          ) : (
+            dirs.map(entry => (
+              <button
+                className={cn(
+                  'flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-xs text-(--ui-text-primary)',
+                  'hover:bg-(--chrome-action-hover)'
+                )}
+                key={entry.path}
+                onClick={() => void load(entry.path)}
+                type="button"
+              >
+                <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder" size="0.875rem" />
+                <span className="truncate">{entry.name}</span>
+              </button>
+            ))
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose} type="button" variant="text">
+            Cancel
+          </Button>
+          <Button disabled={loading} onClick={() => onSelect(path)} type="button">
+            Use this folder
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -1,16 +1,66 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState, type DragEvent as ReactDragEvent } from 'react'
 import { type NodeApi, type NodeRendererProps, Tree, type TreeApi } from 'react-arborist'
 
 import { PageLoader } from '@/components/page-loader'
+import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
 
 import type { TreeNode } from './use-project-tree'
 
 const ROW_HEIGHT = 22
 const INDENT = 10
+
+// Paths may be POSIX (remote) or Windows (local); split on either separator.
+function parentDirOf(p: string): string {
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+
+  return idx > 0 ? p.slice(0, idx) : p
+}
+
+function baseNameOf(p: string): string {
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+
+  return idx >= 0 ? p.slice(idx + 1) : p
+}
+
+// Always join with '/'. Node's fs accepts forward slashes on Windows, and the
+// remote host is POSIX, so this is safe for both execution targets.
+function joinPath(dir: string, name: string): string {
+  return `${dir.replace(/[/\\]+$/, '')}/${name}`
+}
+
+type FsAction =
+  | { dir: string; kind: 'newFile'; name: string }
+  | { dir: string; kind: 'newFolder'; name: string }
+  | { dir: string; kind: 'rename'; name: string; targetPath: string }
+  | { dir: string; kind: 'delete'; name: string; targetPath: string }
+
+const DIALOG_COPY: Record<FsAction['kind'], { title: string; label: string; confirm: string }> = {
+  newFile: { title: 'New file', label: 'File name', confirm: 'Create' },
+  newFolder: { title: 'New folder', label: 'Folder name', confirm: 'Create' },
+  rename: { title: 'Rename', label: 'New name', confirm: 'Rename' },
+  delete: { title: 'Delete', label: '', confirm: 'Delete' }
+}
 
 interface ProjectTreeProps {
   collapseNonce: number
@@ -21,6 +71,7 @@ interface ProjectTreeProps {
   onLoadChildren: (id: string) => void | Promise<void>
   onNodeOpenChange: (id: string, open: boolean) => void
   onPreviewFile?: (path: string) => void
+  onRefreshDir?: (dirPath: string) => void | Promise<void>
   openState: Record<string, boolean>
 }
 
@@ -33,11 +84,18 @@ export function ProjectTree({
   onLoadChildren,
   onNodeOpenChange,
   onPreviewFile,
+  onRefreshDir,
   openState
 }: ProjectTreeProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)
   const [size, setSize] = useState({ height: 0, width: 0 })
+  const [action, setAction] = useState<FsAction | null>(null)
+  const [actionName, setActionName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [dropActive, setDropActive] = useState(false)
+
+  const canMutate = Boolean(window.hermesDesktop?.mkdir)
 
   const syncTreeSize = useCallback(() => {
     const el = containerRef.current
@@ -48,13 +106,7 @@ export function ProjectTree({
 
     const { height, width } = el.getBoundingClientRect()
 
-    setSize(prev => {
-      if (prev.height === height && prev.width === width) {
-        return prev
-      }
-
-      return { height, width }
-    })
+    setSize(prev => (prev.height === height && prev.width === width ? prev : { height, width }))
   }, [])
 
   useResizeObserver(syncTreeSize, containerRef)
@@ -85,8 +137,122 @@ export function ProjectTree({
     [onPreviewFile]
   )
 
+  const openAction = useCallback((next: FsAction) => {
+    setAction(next)
+    setActionName(next.kind === 'rename' ? next.name : '')
+  }, [])
+
+  const runAction = useCallback(async () => {
+    if (!action) {
+      return
+    }
+
+    const desktop = window.hermesDesktop
+    const trimmed = actionName.trim()
+
+    if (action.kind !== 'delete' && !trimmed) {
+      return
+    }
+
+    setBusy(true)
+
+    try {
+      let result: { ok: boolean; error?: string } | undefined
+
+      if (action.kind === 'newFolder') {
+        result = await desktop?.mkdir?.(joinPath(action.dir, trimmed))
+      } else if (action.kind === 'newFile') {
+        result = await desktop?.newFile?.(joinPath(action.dir, trimmed))
+      } else if (action.kind === 'rename') {
+        result = await desktop?.renamePath?.(action.targetPath, joinPath(action.dir, trimmed))
+      } else {
+        result = await desktop?.deletePath?.(action.targetPath)
+      }
+
+      if (result && !result.ok) {
+        throw new Error(result.error || 'Operation failed')
+      }
+
+      await onRefreshDir?.(action.dir)
+      notify({ kind: 'success', title: `${DIALOG_COPY[action.kind].title} done`, message: trimmed || action.name })
+      setAction(null)
+    } catch (error) {
+      notifyError(error, `${DIALOG_COPY[action.kind].title} failed`)
+    } finally {
+      setBusy(false)
+    }
+  }, [action, actionName, onRefreshDir])
+
+  // Drag-drop upload: dropping OS files onto the tree copies/SCP-uploads them
+  // into the current working directory, then refreshes it (#38464).
+  const handleDrop = useCallback(
+    async (event: ReactDragEvent<HTMLDivElement>) => {
+      const files = Array.from(event.dataTransfer?.files ?? [])
+
+      if (files.length === 0 || !cwd) {
+        return
+      }
+
+      // OS file drop — handle it here, don't let the chat composer also catch it.
+      event.preventDefault()
+      event.stopPropagation()
+      setDropActive(false)
+
+      const getPath = window.hermesDesktop?.getPathForFile
+      const upload = window.hermesDesktop?.uploadFile
+
+      if (!getPath || !upload) {
+        return
+      }
+
+      const localPaths = files.map(file => getPath(file)).filter(Boolean)
+
+      if (localPaths.length === 0) {
+        return
+      }
+
+      setBusy(true)
+
+      try {
+        const results = await Promise.all(localPaths.map(localPath => upload(localPath, cwd)))
+        const failed = results.filter(r => !r?.ok).length
+
+        await onRefreshDir?.(cwd)
+
+        if (failed > 0) {
+          notify({ kind: 'warning', title: `Uploaded ${results.length - failed}/${results.length}`, message: `${failed} failed` })
+        } else {
+          notify({
+            kind: 'success',
+            title: `Uploaded ${results.length} file${results.length === 1 ? '' : 's'}`,
+            message: cwd
+          })
+        }
+      } catch (error) {
+        notifyError(error, 'Upload failed')
+      } finally {
+        setBusy(false)
+      }
+    },
+    [cwd, onRefreshDir]
+  )
+
+  const handleDragOver = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
+    if (Array.from(event.dataTransfer?.types ?? []).includes('Files')) {
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+      setDropActive(true)
+    }
+  }, [])
+
   return (
-    <div className="min-h-0 flex-1 overflow-hidden" ref={containerRef}>
+    <div
+      className={cn('relative min-h-0 flex-1 overflow-hidden', dropActive && 'ring-1 ring-inset ring-primary/60')}
+      onDragLeave={() => setDropActive(false)}
+      onDragOver={canMutate ? handleDragOver : undefined}
+      onDrop={canMutate ? event => void handleDrop(event) : undefined}
+      ref={containerRef}
+    >
       {size.height > 0 && size.width > 0 ? (
         <Tree<TreeNode>
           childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}
@@ -109,15 +275,57 @@ export function ProjectTree({
           {props => (
             <ProjectTreeRow
               {...props}
+              canMutate={canMutate}
               onAttachFile={onActivateFile}
               onAttachFolder={onActivateFolder}
               onPreviewFile={onPreviewFile}
+              onRequestAction={openAction}
             />
           )}
         </Tree>
       ) : (
         <TreeSizingState />
       )}
+
+      <Dialog open={action !== null} onOpenChange={open => (open ? undefined : setAction(null))}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{action ? DIALOG_COPY[action.kind].title : ''}</DialogTitle>
+            {action?.kind === 'delete' ? (
+              <DialogDescription>Delete “{action.name}”? This cannot be undone.</DialogDescription>
+            ) : null}
+          </DialogHeader>
+
+          {action && action.kind !== 'delete' ? (
+            <Input
+              autoFocus
+              onChange={event => setActionName(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  void runAction()
+                }
+              }}
+              placeholder={DIALOG_COPY[action.kind].label}
+              value={actionName}
+            />
+          ) : null}
+
+          <DialogFooter>
+            <Button disabled={busy} onClick={() => setAction(null)} size="sm" variant="text">
+              Cancel
+            </Button>
+            <Button
+              disabled={busy || (action?.kind !== 'delete' && !actionName.trim())}
+              onClick={() => void runAction()}
+              size="sm"
+              variant={action?.kind === 'delete' ? 'destructive' : 'default'}
+            >
+              {action ? DIALOG_COPY[action.kind].confirm : ''}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }
@@ -129,16 +337,20 @@ function TreeSizingState() {
 }
 
 function ProjectTreeRow({
+  canMutate,
   dragHandle,
   node,
   onAttachFile,
   onAttachFolder,
   onPreviewFile,
+  onRequestAction,
   style
 }: NodeRendererProps<TreeNode> & {
+  canMutate: boolean
   onAttachFile: (path: string) => void
   onAttachFolder: (path: string) => void
   onPreviewFile?: (path: string) => void
+  onRequestAction: (action: FsAction) => void
 }) {
   if (!node.data) {
     return <div style={style} />
@@ -146,8 +358,11 @@ function ProjectTreeRow({
 
   const isFolder = node.data.isDirectory
   const isPlaceholder = node.data.id.endsWith('::__loading__')
+  const path = node.data.id
+  // New items land inside a folder; for a file, they land alongside it.
+  const targetDir = isFolder ? path : parentDirOf(path)
 
-  return (
+  const row = (
     <div
       aria-expanded={isFolder ? node.isOpen : undefined}
       aria-selected={node.isSelected}
@@ -220,5 +435,39 @@ function ProjectTreeRow({
       </span>
       <span className="min-w-0 flex-1 truncate">{node.data.name}</span>
     </div>
+  )
+
+  if (!canMutate || isPlaceholder) {
+    return row
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent className="w-44">
+        <ContextMenuItem onSelect={() => onRequestAction({ kind: 'newFile', dir: targetDir, name: '' })}>
+          New file…
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => onRequestAction({ kind: 'newFolder', dir: targetDir, name: '' })}>
+          New folder…
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onSelect={() =>
+            onRequestAction({ kind: 'rename', dir: parentDirOf(path), name: baseNameOf(path), targetPath: path })
+          }
+        >
+          Rename…
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={() =>
+            onRequestAction({ kind: 'delete', dir: parentDirOf(path), name: baseNameOf(path), targetPath: path })
+          }
+        >
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { clearProjectDirCache, readProjectDir } from './ipc'
+import { clearProjectDirCache, type ProjectTreeEntry, readProjectDir } from './ipc'
 
 export interface TreeNode {
   /** Absolute filesystem path. Doubles as react-arborist node id. */
@@ -22,6 +22,27 @@ const PLACEHOLDER_ID = '__loading__'
 
 function makeNode(path: string, name: string, isDirectory: boolean): TreeNode {
   return { id: path, isDirectory, name }
+}
+
+// react-arborist throws during render — taking out the *entire* tree with a
+// "Tree error" — if two nodes share an id. Node ids are filesystem paths, which
+// are unique within a directory, but we never want a single malformed readDir
+// entry (an empty path, or a duplicate from an odd remote `ls`) to blank the
+// whole browser. Drop empty-path/duplicate entries defensively. (#38369)
+function entriesToNodes(entries: ProjectTreeEntry[]): TreeNode[] {
+  const seen = new Set<string>()
+  const nodes: TreeNode[] = []
+
+  for (const entry of entries) {
+    if (!entry?.path || seen.has(entry.path)) {
+      continue
+    }
+
+    seen.add(entry.path)
+    nodes.push(makeNode(entry.path, entry.name, entry.isDirectory))
+  }
+
+  return nodes
 }
 
 function patchNode(nodes: TreeNode[] | undefined | null, id: string, patch: (n: TreeNode) => TreeNode): TreeNode[] {
@@ -56,6 +77,7 @@ export interface UseProjectTreeResult {
   collapseAll: () => void
   loadChildren: (id: string) => Promise<void>
   refreshRoot: () => Promise<void>
+  refreshDir: (dirPath: string) => Promise<void>
   setNodeOpen: (id: string, open: boolean) => void
 }
 
@@ -136,7 +158,7 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
 
     return {
       ...latest,
-      data: error ? [] : entries.map(e => makeNode(e.path, e.name, e.isDirectory)),
+      data: error ? [] : entriesToNodes(entries),
       loaded: true,
       rootError: error || null,
       rootLoading: false
@@ -227,12 +249,33 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
             ...n,
             loading: false,
             error: error || undefined,
-            children: error ? [] : entries.map(e => makeNode(e.path, e.name, e.isDirectory))
+            children: error ? [] : entriesToNodes(entries)
           }))
         }
       })
     },
     [cwd]
+  )
+
+  // Reload a single directory after a mutation (create/rename/delete/upload).
+  // Root changes go through loadRoot; a nested folder just refetches its own
+  // children so the rest of the tree's expand state is untouched.
+  const refreshDir = useCallback(
+    async (dirPath: string) => {
+      clearProjectDirCache(dirPath)
+
+      const norm = (p: string) => p.replace(/[/\\]+$/, '')
+
+      if (!dirPath || norm(dirPath) === norm(cwd)) {
+        await loadRoot(cwd, { force: true })
+
+        return
+      }
+
+      inflight.delete(dirPath)
+      await loadChildren(dirPath)
+    },
+    [cwd, loadChildren]
   )
 
   useEffect(() => {
@@ -247,6 +290,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       loadChildren,
       openState: state.cwd === cwd ? state.openState : {},
       refreshRoot,
+      refreshDir,
       rootError: state.cwd === cwd ? state.rootError : null,
       rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd),
       setNodeOpen
@@ -256,6 +300,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       cwd,
       loadChildren,
       refreshRoot,
+      refreshDir,
       setNodeOpen,
       state.collapseNonce,
       state.cwd,

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import type { ReactNode } from 'react'
+import { type ReactNode, useState } from 'react'
 
 import { ErrorBoundary } from '@/components/error-boundary'
 import { Button } from '@/components/ui/button'
@@ -12,10 +12,12 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { setCurrentSessionPreviewTarget } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $connection, $currentCwd } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
+import { ExecTargetBadge } from './exec-target-badge'
+import { RemoteFolderPicker } from './files/remote-folder-picker'
 import { ProjectTree } from './files/tree'
 import { useProjectTree } from './files/use-project-tree'
 
@@ -29,8 +31,24 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
+  const connection = useStore($connection)
   const currentCwd = useStore($currentCwd).trim()
   const hasCwd = currentCwd.length > 0
+
+  // In remote mode the File Explorer reads the remote host over SSH, so the
+  // folder picker must browse there too — the OS-native dialog only sees the
+  // local disk (#38369).
+  const isRemote = connection?.mode === 'remote'
+
+  const remoteHost = (() => {
+    try {
+      return connection?.baseUrl ? new URL(connection.baseUrl).host || 'remote backend' : 'remote backend'
+    } catch {
+      return 'remote backend'
+    }
+  })()
+
+  const [remotePickerOpen, setRemotePickerOpen] = useState(false)
 
   const cwdName = hasCwd
     ? (currentCwd
@@ -45,6 +63,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
     data,
     loadChildren,
     openState,
+    refreshDir,
     refreshRoot,
     rootError,
     rootLoading,
@@ -54,6 +73,13 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const canCollapse = Object.values(openState).some(Boolean)
 
   const chooseFolder = async () => {
+    // Remote workspace: browse the remote host (the native dialog can't).
+    if (isRemote) {
+      setRemotePickerOpen(true)
+
+      return
+    }
+
     const selected = await window.hermesDesktop?.selectPaths({
       defaultPath: hasCwd ? currentCwd : undefined,
       directories: true,
@@ -107,7 +133,19 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
         onRefresh={() => void refreshRoot()}
+        onRefreshDir={refreshDir}
         openState={openState}
+      />
+
+      <RemoteFolderPicker
+        hostLabel={remoteHost}
+        initialPath={currentCwd}
+        onClose={() => setRemotePickerOpen(false)}
+        onSelect={path => {
+          setRemotePickerOpen(false)
+          void onChangeCwd(path)
+        }}
+        open={remotePickerOpen}
       />
     </aside>
   )
@@ -147,6 +185,7 @@ function FilesystemTab({
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
+  onRefreshDir,
   openState
 }: FilesystemTabProps) {
   const { t } = useI18n()
@@ -164,6 +203,7 @@ function FilesystemTab({
             <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
           </button>
         </Tip>
+        <ExecTargetBadge className="max-w-44 shrink-0" />
         <Button
           aria-label={r.refreshTree}
           className={HEADER_ACTION_CLASS}
@@ -205,6 +245,7 @@ function FilesystemTab({
         onLoadChildren={onLoadChildren}
         onNodeOpenChange={onNodeOpenChange}
         onPreviewFile={onPreviewFile}
+        onRefreshDir={onRefreshDir}
         openState={openState}
       />
     </div>
@@ -226,6 +267,7 @@ interface FileTreeBodyProps {
   onLoadChildren: (id: string) => void | Promise<void>
   onNodeOpenChange: (id: string, open: boolean) => void
   onPreviewFile?: (path: string) => void
+  onRefreshDir?: (dirPath: string) => void | Promise<void>
   openState: ReturnType<typeof useProjectTree>['openState']
 }
 
@@ -240,6 +282,7 @@ function FileTreeBody({
   onLoadChildren,
   onNodeOpenChange,
   onPreviewFile,
+  onRefreshDir,
   openState
 }: FileTreeBodyProps) {
   const { t } = useI18n()
@@ -287,6 +330,7 @@ function FileTreeBody({
         onLoadChildren={onLoadChildren}
         onNodeOpenChange={onNodeOpenChange}
         onPreviewFile={onPreviewFile}
+        onRefreshDir={onRefreshDir}
         openState={openState}
       />
     </ErrorBoundary>

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -25,6 +25,9 @@ interface GatewaySettingsState {
   remoteTokenPreview: string | null
   remoteTokenSet: boolean
   remoteUrl: string
+  sshUser: string
+  sshPort: number
+  sshKey: string
 }
 
 const EMPTY_STATE: GatewaySettingsState = {
@@ -34,7 +37,10 @@ const EMPTY_STATE: GatewaySettingsState = {
   remoteOauthConnected: false,
   remoteTokenPreview: null,
   remoteTokenSet: false,
-  remoteUrl: ''
+  remoteUrl: '',
+  sshUser: '',
+  sshPort: 22,
+  sshKey: ''
 }
 
 function ModeCard({
@@ -284,7 +290,10 @@ export function GatewaySettings() {
     profile: scope ?? undefined,
     remoteAuthMode: authMode,
     remoteToken: authMode === 'token' ? remoteToken.trim() || undefined : undefined,
-    remoteUrl: trimmedUrl
+    remoteUrl: trimmedUrl,
+    sshUser: state.sshUser.trim(),
+    sshPort: state.sshPort,
+    sshKey: state.sshKey.trim()
   })
 
   const save = async (apply: boolean) => {
@@ -580,6 +589,64 @@ export function GatewaySettings() {
           />
         ) : null}
       </div>
+
+      {state.mode === 'remote' ? (
+        <div className="mt-5">
+          <div className="mb-2 flex items-center gap-2 text-[length:var(--conversation-text-font-size)] font-medium">
+            <Monitor className="size-4 text-muted-foreground" />
+            Remote workspace (SSH)
+          </div>
+          <p className="mb-3 max-w-2xl text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
+            The File Explorer and Terminal connect to the remote machine over SSH so they operate on the same
+            filesystem the agent uses. The host is taken from the Remote URL above; authentication uses your existing
+            SSH key / agent. Leave blank to disable and keep these surfaces local.
+          </p>
+          <div className="grid gap-1">
+            <ListRow
+              action={
+                <Input
+                  className={cn('h-8', CONTROL_TEXT)}
+                  disabled={state.envOverride}
+                  onChange={event => setState(current => ({ ...current, sshUser: event.target.value }))}
+                  placeholder="e.g. ubuntu"
+                  value={state.sshUser}
+                />
+              }
+              description="SSH login user on the remote host. Required to browse files and open a remote terminal."
+              title="SSH user"
+            />
+            <ListRow
+              action={
+                <Input
+                  className={cn('h-8', CONTROL_TEXT)}
+                  disabled={state.envOverride}
+                  onChange={event =>
+                    setState(current => ({ ...current, sshPort: Number(event.target.value) || 22 }))
+                  }
+                  placeholder="22"
+                  type="number"
+                  value={String(state.sshPort)}
+                />
+              }
+              description="SSH port. Defaults to 22."
+              title="SSH port"
+            />
+            <ListRow
+              action={
+                <Input
+                  className={cn('h-8 font-mono', CONTROL_TEXT)}
+                  disabled={state.envOverride}
+                  onChange={event => setState(current => ({ ...current, sshKey: event.target.value }))}
+                  placeholder="Default key / agent (leave blank)"
+                  value={state.sshKey}
+                />
+              }
+              description="Optional path to a private key. Leave blank to use the SSH agent or your default key."
+              title="SSH key path"
+            />
+          </div>
+        </div>
+      ) : null}
 
       {lastTest ? <div className="mt-4 text-xs text-primary">{lastTest}</div> : null}
 

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -14,6 +14,9 @@ function config(overrides: Partial<DesktopConnectionConfig> = {}): DesktopConnec
     remoteTokenPreview: null,
     remoteTokenSet: false,
     remoteUrl: 'https://box:9119',
+    sshUser: '',
+    sshPort: 22,
+    sshKey: '',
     ...overrides
   }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -65,6 +65,12 @@ declare global {
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
       readDir: (path: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
+      getHostInfo?: () => Promise<DesktopHostInfo>
+      mkdir?: (path: string) => Promise<HermesFsMutationResult>
+      newFile?: (path: string) => Promise<HermesFsMutationResult>
+      renamePath?: (fromPath: string, toPath: string) => Promise<HermesFsMutationResult>
+      deletePath?: (path: string) => Promise<HermesFsMutationResult>
+      uploadFile?: (localPath: string, destDir: string) => Promise<HermesFsMutationResult>
       terminal: {
         dispose: (id: string) => Promise<boolean>
         onData: (id: string, callback: (payload: string) => void) => () => void
@@ -268,6 +274,23 @@ export interface DesktopConnectionConfig {
   remoteTokenPreview: string | null
   remoteTokenSet: boolean
   remoteUrl: string
+  sshUser: string
+  sshPort: number
+  sshKey: string
+}
+
+// Identity of the machine the desktop's Terminal/File Explorer run on (always
+// local, even when the chat session targets a remote gateway). See #38369.
+export interface DesktopHostInfo {
+  hostname: string
+  platform: NodeJS.Platform
+}
+
+// Result of a File Explorer mutation (create/rename/delete/upload), local or
+// remote-over-SSH. See #38671.
+export interface HermesFsMutationResult {
+  ok: boolean
+  error?: string
 }
 
 export interface DesktopConnectionConfigInput {
@@ -278,6 +301,9 @@ export interface DesktopConnectionConfigInput {
   remoteAuthMode?: 'oauth' | 'token'
   remoteToken?: string
   remoteUrl?: string
+  sshUser?: string
+  sshPort?: number
+  sshKey?: string
 }
 
 export interface DesktopConnectionTestResult {


### PR DESCRIPTION
## Summary

When the desktop connects to a **remote gateway**, chat runs on the remote
backend but the **File Explorer and Terminal** kept operating on the **local**
machine (local Node `fs` / `node-pty`). The result was a split-brain where the
file browser, terminal, and chat could appear to target one machine while
actually targeting different ones — e.g. the file tree showing `UNREADABLE
(ENOENT)` because the session's working directory only exists on the remote
host (#38671, #38369).

This routes the File Explorer and Terminal to the **remote backend over SSH**,
mirroring the conventions of `tools/environments/ssh.py` (OpenSSH client +
ControlMaster, same socket-naming scheme) so the desktop rides the agent's own
SSH connection when the backend uses the `ssh` environment. For the common
`local` backend, it connects to the gateway host directly.

## What changed

- **`electron/remote-ssh.cjs`** (new): SSH/SFTP/PTY helpers — `readDir`,
  `statFile`, `readFileBytes`, `gitRoot`, `mkdir`, `newFile`, `rename`,
  `remove`, `upload` (scp), `terminalSpawn`. Commands are POSIX-portable
  (`ls -1Ap`, `test -d`, `wc -c`, `head -c`, `base64`) so both Linux and
  macOS remotes work.
- **`electron/main.cjs`**: route `hermes:fs:*` and `hermes:terminal:*` to the
  remote host over SSH when a remote gateway is selected (otherwise unchanged
  local behavior); add `hermes:host:info`; add file-mutation IPC
  (`mkdir`/`newFile`/`rename`/`delete`/`upload`) with local + remote impls.
  The remote terminal is `node-pty` wrapping `ssh -tt`, so resize/SIGWINCH
  propagate to the remote PTY.
- **Execution-target badge** (`exec-target-badge.tsx`, new): shows a green
  "Remote · &lt;host&gt;" target (over SSH) vs a neutral "Local", with a
  hostname/working-directory tooltip — makes the execution target explicit
  (#38369).
- **File Explorer**: right-click context menu (new file, new folder, rename,
  delete) with a confirm dialog for delete, plus **drag-drop upload** to the
  remote workspace (#38464). A `refreshDir` reloads only the affected folder
  after a mutation.
- **Gateway settings**: SSH user / port / key fields for remote mode (auth
  otherwise uses the existing SSH agent / default key).

## Verification

Rebased onto the latest `main`; the conflict resolution and the rebased build
were re-verified end-to-end against a remote Linux host (driven through the
Chrome DevTools Protocol against the renderer, with each result independently
confirmed on the remote host):

- Badge renders green "Remote · &lt;host&gt;" with the correct tooltip/cwd.
- File tree lists the remote working directory (ENOENT gone).
- New file / new folder / rename / delete via the context menu — each
  reflected on the remote host.
- Terminal tab spawns a live `ssh -tt` PTY to the remote host.
- Drag-drop upload (scp) places the file on the remote host.

## Notes / limitations

- Remote hosts are assumed POSIX (Linux/macOS); a Windows remote shell is not
  targeted.
- `ControlMaster` connection reuse is POSIX-only; the Windows OpenSSH client
  connects without multiplexing.
- Drag-drop currently uploads into the current working directory (not a
  hovered sub-folder).

Closes #38671
Closes #38369
Addresses #38464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
