### PR TITLE
feat(tts): apply global style config for Gemini and xAI

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1129,6 +1129,28 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     )
     if auto_speech_tags:
         text = _apply_xai_auto_speech_tags(text)
+
+    # User-configured default wrap tags. Lets the user pick a global voice
+    # personality (e.g. "lower-pitch,fast") so every session — and every
+    # agent run, including new ones that don't remember to wrap — gets the
+    # same delivery. Skipped when the text already contains xAI speech tags,
+    # so the agent can still override per-message if it wants to.
+    default_wrap = str(xai_config.get("default_wrap_tags", "")).strip()
+    if default_wrap and not _XAI_SPEECH_TAG_RE.search(text):
+        wrap_tags = [t.strip().lower() for t in default_wrap.split(",") if t.strip()]
+        valid = [t for t in wrap_tags if t in _XAI_WRAPPING_SPEECH_TAGS]
+        if valid:
+            opening = "".join(f"<{t}>" for t in valid)
+            closing = "".join(f"</{t}>" for t in reversed(valid))
+            text = f"{opening}{text}{closing}"
+
+    # Optional outer padding (e.g. "…") to keep the audio from clipping at
+    # the start/end. Applied outside the wrap tags.
+    prepend_pad = str(xai_config.get("prepend_padding", "")).strip()
+    append_pad = str(xai_config.get("append_padding", "")).strip()
+    if prepend_pad or append_pad:
+        text = f"{prepend_pad}{text}{append_pad}"
+
     base_url = str(
         xai_config.get("base_url")
         or creds.get("base_url")
@@ -1425,6 +1447,36 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
 
+    # Apply user-configured system instruction (global voice personality).
+    # Without this, every Gemini TTS call renders the same default delivery
+    # regardless of how nice a system_instruction the user has set in
+    # config. We also fold the optional `speed` hint in as a textual
+    # instruction, since the Gemini TTS API has no direct numeric speed
+    # field — the prompt is the only knob.
+    system_instruction = str(gemini_config.get("system_instruction", "")).strip()
+    speed_hint = gemini_config.get("speed")
+    if speed_hint is not None:
+        try:
+            speed_val = float(speed_hint)
+            if speed_val > 0:
+                # Translate numeric speed into natural-language pacing the
+                # model can follow. Skip when speed is at the default 1.0
+                # — neutral pacing is implicit.
+                if speed_val >= 1.2:
+                    pace = "Speak at a notably fast, energetic pace."
+                elif speed_val > 1.0:
+                    pace = "Speak at a slightly faster than average pace."
+                elif speed_val <= 0.7:
+                    pace = "Speak at a slow, deliberate pace."
+                elif speed_val < 1.0:
+                    pace = "Speak at a slightly slower, calmer pace."
+                else:
+                    pace = ""
+                if pace:
+                    system_instruction = f"{system_instruction} {pace}".strip() if system_instruction else pace
+        except (TypeError, ValueError):
+            pass
+
     payload: Dict[str, Any] = {
         "contents": [{"parts": [{"text": text}]}],
         "generationConfig": {
@@ -1436,6 +1488,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             },
         },
     }
+    if system_instruction:
+        payload["systemInstruction"] = {"parts": [{"text": system_instruction}]}
 
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(


### PR DESCRIPTION
Two related fixes so a user's voice personality in `config.yaml` actually reaches the model — not just the voice name and rate. The change is language-agnostic; any TTS user benefits, not just one locale.

## Why

When a user sets a thoughtful TTS style in `config.yaml` (e.g. a system instruction with a particular tone, or a wrapper like `lower-pitch,fast` for xAI), the configuration is silently dropped. The voice ID lands, but the *style* never makes it to the provider, so:

- Gemini TTS always sounds the same default delivery, regardless of `tts.gemini.system_instruction`.
- xAI TTS only picks up wrapping tags (`<lower-pitch><fast>...</fast></lower-pitch>`) when the agent explicitly writes them — which means a new agent run, or any session that doesn't remember the convention, sounds different from the user's reference.

Both make the per-user voice personality un-reproducible across sessions, in any language.

## Changes

**`_generate_gemini_tts`**

- Read `tts.gemini.system_instruction` and pass it as `systemInstruction` in the `generateContent` payload. The model receives the user's voice direction in any language.
- Read `tts.gemini.speed` (numeric) and translate it to a natural-language pacing hint folded into the system instruction. Gemini's TTS API has no direct numeric speed field, so the prompt is the only knob. The translation is language-neutral; the model maps the hint onto whatever locale `tts.gemini.language` (or the implicit default) implies.

**`_generate_xai_tts`**

- Read `tts.xai.default_wrap_tags` (e.g. `lower-pitch,fast`) and apply it as a global wrap when the text contains no xAI speech tags. Skipped if the assistant has already wrapped, so per-message overrides still work. Wrapping tags are xAI-side and language-agnostic; the audio effect is relative to the voice's natural pitch and cadence.
- Read `tts.xai.prepend_padding` / `append_padding` (e.g. `…`) for outer boundary padding against audio clipping. Applied outside the wrap tags.

## Behavior

After this lands, the style a user has in their `config.yaml` will:

1. Persist across sessions and agent runs (no per-message wrapping required).
2. Be applied to every TTS call by default, with a clean escape hatch for one-off overrides.
3. Match the existing global-ness of `voice_id`, `language`, `sample_rate`, and `bit_rate`.

## Test plan

- Set `tts.gemini.system_instruction` to a voice direction (e.g. Dutch, English, Japanese — any locale) → confirm the Gemini TTS response honors the direction.
- Set `tts.gemini.speed: 1.15` → confirm the rendered audio paces faster.
- Set `tts.xai.default_wrap_tags: lower-pitch,fast` → confirm the text is wrapped before being sent to the API.
- Set `tts.xai.prepend_padding: …` / `append_padding: …` → confirm padding lands outside the wrap tags.
- Pass a text argument that already contains xAI speech tags → confirm `default_wrap_tags` is *not* double-applied.

## Diff

```
tools/tts_tool.py | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
1 file changed, 54 insertions(+)
```
