### PR TITLE
docs: make dashboard/gateway prerequisites explicit for desktop remote-backend

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -110,6 +110,10 @@ The packaged app ships only the Electron shell. On first launch it installs the 
 
 By default the app starts and manages its own **local** backend. You can instead point it at a Hermes backend running on another machine — a VPS, a home server, or a Mini behind Tailscale.
 
+:::info The remote backend is a running `hermes dashboard` process
+"Remote backend" means a **`hermes dashboard`** server running on the remote machine — that is the process the desktop app connects to. Nothing in this section works unless that dashboard is actually up and reachable. The desktop app does not start it for you; you (or a `systemd` service) keep `hermes dashboard` running on the remote host, and the app attaches to it. If you also use messaging channels (Telegram, Discord, etc.), the **gateway** is a *separate* long-running process you start independently — see the note after the setup steps.
+:::
+
 The connection has two halves: on the backend you protect the dashboard with a **username and password**, and in the app you enter the backend's URL and sign in with those credentials. Binding the dashboard to a non-loopback address automatically engages its auth gate, so the username/password provider is what lets the desktop app through.
 
 ### On the backend (the remote machine)
@@ -133,7 +137,9 @@ chmod 600 ~/.hermes/.env
 hermes dashboard --no-open --host 0.0.0.0 --port 9119
 ```
 
-Make sure the **gateway is running** on the remote host as well if you rely on messaging channels — the desktop app drives the agent, but your gateway sessions are managed separately. See [Messaging](./messaging/index.md) for gateway setup.
+Keep that `hermes dashboard` process running for as long as you want the desktop app to be able to connect — if it stops, the app can no longer reach the backend. Run it under `systemd`, `tmux`, or your process manager of choice so it survives logout and reboots.
+
+Separately, make sure the **gateway is running** on the remote host if you rely on messaging channels — the dashboard backend is what the desktop app talks to, but your Telegram/Discord/Slack gateway sessions are a different process that you start and keep running on their own. See [Messaging](./messaging/index.md) for gateway setup.
 
 Prefer not to keep a plaintext password at rest? Set `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH` to a scrypt hash instead — compute it with `python -c "from plugins.dashboard_auth.basic import hash_password; print(hash_password('PW'))"`. Full configuration surface (config.yaml keys, every env var, the rate limiter): [Web Dashboard → Username/password provider](./features/web-dashboard.md#usernamepassword-provider-no-oauth-idp).
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -95,6 +95,10 @@ To point [Hermes Desktop](#connecting-hermes-desktop-to-a-remote-backend) at a d
 
 Hermes Desktop normally launches its own local backend, but it can also attach to a dashboard running on a remote machine (a VM, a homelab box, etc.) via **Settings → Gateway → Remote gateway**. This is the most common source of "Desktop says the backend is ready but chat never works" reports, because Desktop's readiness check verifies less than the live chat connection actually needs.
 
+:::info Prerequisite: a `hermes dashboard` must be running on the remote host
+The "remote backend" Desktop connects to **is** a `hermes dashboard` process running on the remote machine — the same server this page documents. It has to be up and reachable before any of the steps below matter; Desktop attaches to it, it doesn't start it for you. Keep it running under `systemd`/`tmux`/etc. so it survives logout and reboots. The **gateway** (Telegram/Discord/Slack/etc.) is a *separate* long-running process — start it independently if you rely on messaging channels; it is not the thing the desktop app connects to.
+:::
+
 Desktop's "remote backend is ready" probe only hits `GET /api/status`, which is a public endpoint — it answers as soon as *any* dashboard is running on the host. The live chat connection is a **separate** WebSocket to `/api/ws` (and `/api/pty`), and that socket is gated by two more checks the status probe never touches:
 
 1. **You must be authenticated.** When the dashboard is bound to a non-loopback address it engages its auth gate. Protect it with a username and password (the bundled [username/password provider](#usernamepassword-provider-no-oauth-idp)); Desktop signs in once and reuses the resulting session for the WebSocket via a single-use ticket. Without a configured provider, a non-loopback dashboard **fails closed at startup**.


### PR DESCRIPTION
## Summary
Both remote-backend docs now state up front that the "remote backend" Desktop connects to is a running `hermes dashboard` process — and that the gateway is a separate process needed only for messaging.

## Changes
- `desktop.md`: added an `:::info` callout at the top of *Connecting to a remote backend* clarifying the backend is a `hermes dashboard` server the app attaches to (it does not start it for you). Strengthened the existing gateway note with keep-it-running guidance and a clearer dashboard-vs-gateway distinction.
- `web-dashboard.md`: added a matching `:::info` prerequisite at the top of *Connecting Hermes Desktop to a remote backend* so the same point lands on the connected page.

## Why
A reader following either page could miss that the dashboard backend must actually be running for the remote connection to work, and could conflate it with the gateway. Both are now explicit and obvious.

## Validation
- Admonition fences balanced in both files (even `:::` count).
- Content-only markdown; all referenced links pre-existed in these docs.

## Infographic
![remote-backend-prerequisites](https://v3b.fal.media/files/b/0a9cf47f/Go6wXjmm8F7aibheakcVu_fvZdNQMM.png)
