### PR TITLE
feat(honcho): add sessionAiPeerPrefix to isolate sessions per AI peer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28166,6 +28166,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.pin_peer_name",
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
+        "honcho.session_peer_prefix",
+        "honcho.session_ai_peer_prefix",
     )
     _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
 
@@ -28197,6 +28199,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "honcho.pin_peer_name": bool(hcfg.pin_peer_name),
                 "honcho.runtime_peer_prefix": hcfg.runtime_peer_prefix or "",
                 "honcho.user_peer_aliases": sorted(aliases.items()) if isinstance(aliases, dict) else [],
+                "honcho.session_peer_prefix": bool(hcfg.session_peer_prefix),
+                "honcho.session_ai_peer_prefix": bool(hcfg.session_ai_peer_prefix),
             }
             cls._HONCHO_CACHE_BUSTING_MEMO = {memo_key: values}
             return dict(values)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21425,6 +21425,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.pin_peer_name",
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
+        "honcho.session_peer_prefix",
+        "honcho.session_ai_peer_prefix",
     )
     _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
 
@@ -21456,6 +21458,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "honcho.pin_peer_name": bool(hcfg.pin_peer_name),
                 "honcho.runtime_peer_prefix": hcfg.runtime_peer_prefix or "",
                 "honcho.user_peer_aliases": sorted(aliases.items()) if isinstance(aliases, dict) else [],
+                "honcho.session_peer_prefix": bool(hcfg.session_peer_prefix),
+                "honcho.session_ai_peer_prefix": bool(hcfg.session_ai_peer_prefix),
             }
             cls._HONCHO_CACHE_BUSTING_MEMO = {memo_key: values}
             return dict(values)

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -222,7 +222,8 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `sessionStrategy` | string | `"per-directory"` | `"per-directory"`, `"per-session"`, `"per-repo"` (git root), `"global"` |
-| `sessionPeerPrefix` | bool | `false` | Prepend peer name to session keys |
+| `sessionPeerPrefix` | bool | `false` | Prepend the user peer name to session keys |
+| `sessionAiPeerPrefix` | bool | `false` | Prepend the AI peer (`aiPeer`) to session keys — keeps sessions disjoint when multiple AI peers share a workspace |
 | `sessions` | object | `{}` | Manual directory-to-session-name mappings |
 
 #### Session Name Resolution
@@ -241,7 +242,9 @@ The Honcho session name determines which conversation bucket memory lands in. Re
 
 Gateway platforms always resolve via priority 3 (per-chat isolation) regardless of `sessionStrategy`. The strategy setting only affects CLI sessions.
 
-If `sessionPeerPrefix` is `true`, the peer name is prepended: `alice-hermes-agent`.
+If `sessionPeerPrefix` is `true`, the user peer name is prepended: `alice-hermes-agent`.
+
+If `sessionAiPeerPrefix` is `true`, the AI peer (`aiPeer`) is prepended to the final name on **every** path — including priority 3. This is the symmetric counterpart to `sessionPeerPrefix` and exists because the gateway session key is AI-peer-agnostic: when several AI peers share one workspace, peer name, and gateway chat key, they would otherwise collide on a single session. With `aiPeer: ivy`, priority 3 becomes `ivy-agent-main-telegram-dm-8439114563`.
 
 #### What each strategy produces
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -453,6 +453,13 @@ class HonchoClientConfig:
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
+    # When True, the resolved session name is additionally prefixed with the
+    # AI peer id (``{ai_peer}-``). Symmetric counterpart to
+    # ``session_peer_prefix`` (which prefixes the user peer). This keeps
+    # sessions disjoint when several AI peers share one workspace + peerName +
+    # gateway chat key; without it the gateway_session_key branch in
+    # resolve_session_name() yields the same name for every AI peer.
+    session_ai_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
@@ -584,6 +591,11 @@ class HonchoClientConfig:
         session_peer_prefix = (
             host_prefix if host_prefix is not None
             else raw.get("sessionPeerPrefix", False)
+        )
+        host_ai_prefix = host_block.get("sessionAiPeerPrefix")
+        session_ai_peer_prefix = (
+            host_ai_prefix if host_ai_prefix is not None
+            else raw.get("sessionAiPeerPrefix", False)
         )
 
         return cls(
@@ -729,6 +741,7 @@ class HonchoClientConfig:
             ),
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
+            session_ai_peer_prefix=session_ai_peer_prefix,
             sessions=raw.get("sessions", {}),
             raw=raw,
             explicitly_configured=_explicitly_configured,
@@ -791,7 +804,43 @@ class HonchoClientConfig:
         session_id: str | None = None,
         gateway_session_key: str | None = None,
     ) -> str | None:
-        """Resolve Honcho session name.
+        """Resolve the Honcho session name, applying the AI-peer prefix.
+
+        Delegates to :meth:`_resolve_session_name_base` for the core
+        resolution order, then — when ``session_ai_peer_prefix`` is set and an
+        ``ai_peer`` is configured — prefixes the result with ``{ai_peer}-``.
+
+        The prefix is applied to *every* resolution path (including the
+        ``gateway_session_key`` branch, which otherwise returns an
+        AI-peer-agnostic name), so sessions stay disjoint when multiple AI
+        peers share a workspace + peerName + gateway chat key. This is the
+        symmetric counterpart to the user-side ``session_peer_prefix``. The
+        prefixed result is re-run through the session-id length limit so the
+        prefix can never push a name over Honcho's cap.
+        """
+        result = self._resolve_session_name_base(
+            cwd=cwd,
+            session_title=session_title,
+            session_id=session_id,
+            gateway_session_key=gateway_session_key,
+        )
+        if result and self.session_ai_peer_prefix and self.ai_peer:
+            import re
+
+            ai = re.sub(r'[^a-zA-Z0-9_-]+', '-', self.ai_peer).strip('-')
+            if ai:
+                prefixed = f"{ai}-{result}"
+                return self._enforce_session_id_limit(prefixed, prefixed)
+        return result
+
+    def _resolve_session_name_base(
+        self,
+        cwd: str | None = None,
+        session_title: str | None = None,
+        session_id: str | None = None,
+        gateway_session_key: str | None = None,
+    ) -> str | None:
+        """Core session-name resolution (no AI-peer prefixing).
 
         Resolution order:
           1. Gateway session key (stable per-chat identifier from gateway platforms)
@@ -802,6 +851,9 @@ class HonchoClientConfig:
           5. per-repo strategy — git repo root directory name
           6. per-directory strategy — directory basename
           7. global strategy — workspace name
+
+        See :meth:`resolve_session_name` for the public entry point that
+        post-processes this result with the optional ``ai_peer`` prefix.
         """
         import re
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -474,6 +474,13 @@ class HonchoClientConfig:
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
+    # When True, the resolved session name is additionally prefixed with the
+    # AI peer id (``{ai_peer}-``). Symmetric counterpart to
+    # ``session_peer_prefix`` (which prefixes the user peer). This keeps
+    # sessions disjoint when several AI peers share one workspace + peerName +
+    # gateway chat key; without it the gateway_session_key branch in
+    # resolve_session_name() yields the same name for every AI peer.
+    session_ai_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
@@ -667,6 +674,11 @@ class HonchoClientConfig:
             host_prefix if host_prefix is not None
             else raw.get("sessionPeerPrefix", False)
         )
+        host_ai_prefix = host_block.get("sessionAiPeerPrefix")
+        session_ai_peer_prefix = (
+            host_ai_prefix if host_ai_prefix is not None
+            else raw.get("sessionAiPeerPrefix", False)
+        )
 
         return cls(
             host=resolved_host,
@@ -811,6 +823,7 @@ class HonchoClientConfig:
             ),
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
+            session_ai_peer_prefix=session_ai_peer_prefix,
             sessions=raw.get("sessions", {}),
             raw=raw,
             explicitly_configured=_explicitly_configured,
@@ -875,7 +888,43 @@ class HonchoClientConfig:
         session_id: str | None = None,
         gateway_session_key: str | None = None,
     ) -> str | None:
-        """Resolve Honcho session name.
+        """Resolve the Honcho session name, applying the AI-peer prefix.
+
+        Delegates to :meth:`_resolve_session_name_base` for the core
+        resolution order, then — when ``session_ai_peer_prefix`` is set and an
+        ``ai_peer`` is configured — prefixes the result with ``{ai_peer}-``.
+
+        The prefix is applied to *every* resolution path (including the
+        ``gateway_session_key`` branch, which otherwise returns an
+        AI-peer-agnostic name), so sessions stay disjoint when multiple AI
+        peers share a workspace + peerName + gateway chat key. This is the
+        symmetric counterpart to the user-side ``session_peer_prefix``. The
+        prefixed result is re-run through the session-id length limit so the
+        prefix can never push a name over Honcho's cap.
+        """
+        result = self._resolve_session_name_base(
+            cwd=cwd,
+            session_title=session_title,
+            session_id=session_id,
+            gateway_session_key=gateway_session_key,
+        )
+        if result and self.session_ai_peer_prefix and self.ai_peer:
+            import re
+
+            ai = re.sub(r'[^a-zA-Z0-9_-]+', '-', self.ai_peer).strip('-')
+            if ai:
+                prefixed = f"{ai}-{result}"
+                return self._enforce_session_id_limit(prefixed, prefixed)
+        return result
+
+    def _resolve_session_name_base(
+        self,
+        cwd: str | None = None,
+        session_title: str | None = None,
+        session_id: str | None = None,
+        gateway_session_key: str | None = None,
+    ) -> str | None:
+        """Core session-name resolution (no AI-peer prefixing).
 
         Resolution order:
           1. Gateway session key (stable per-chat identifier from gateway platforms)
@@ -886,6 +935,9 @@ class HonchoClientConfig:
           5. per-repo strategy — git repo root directory name
           6. per-directory strategy — directory basename
           7. global strategy — workspace name
+
+        See :meth:`resolve_session_name` for the public entry point that
+        post-processes this result with the optional ``ai_peer`` prefix.
         """
         import re
 

--- a/plugins/memory/honcho/config_schema.py
+++ b/plugins/memory/honcho/config_schema.py
@@ -164,6 +164,14 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             group="Session",
         ),
         ProviderField(
+            key="sessionAiPeerPrefix",
+            label="Session AI peer prefix",
+            kind=KIND_BOOL,
+            default="false",
+            description="Prefix session names with the AI peer. Keeps sessions disjoint when several AI peers share a workspace.",
+            group="Session",
+        ),
+        ProviderField(
             key="sessions",
             label="Session overrides",
             kind=KIND_JSON,

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -529,6 +529,34 @@ class TestPinTransition:
 
         assert sig_pinned["honcho.pin_peer_name"] != sig_unpinned["honcho.pin_peer_name"]
 
+    def test_cache_busting_signature_reflects_session_prefixes(self, tmp_path, monkeypatch):
+        """Flipping either session prefix mid-flight must invalidate the cached agent.
+
+        Both prefixes feed the same ``resolve_session_name`` output into the
+        provider's ``_session_key``, which is frozen at construction. Without
+        busting, a live flip leaves an existing gateway session bound to its
+        old Honcho session until an unrelated eviction or restart — the same
+        staleness contract covered above for ``pinPeerName``.
+        """
+        from gateway.run import GatewayRunner
+
+        cfg_path = tmp_path / "honcho.json"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        base = {"apiKey": "k", "peerName": "Igor", "aiPeer": "hermes"}
+
+        cfg_path.write_text(json.dumps(
+            {**base, "sessionPeerPrefix": False, "sessionAiPeerPrefix": False}
+        ))
+        sig_off = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
+
+        cfg_path.write_text(json.dumps(
+            {**base, "sessionPeerPrefix": True, "sessionAiPeerPrefix": True}
+        ))
+        sig_on = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
+
+        assert sig_off["honcho.session_peer_prefix"] != sig_on["honcho.session_peer_prefix"]
+        assert sig_off["honcho.session_ai_peer_prefix"] != sig_on["honcho.session_ai_peer_prefix"]
+
 
 class TestProfilePeerUniqueness:
     """Each Hermes profile can pin to its own unique peerName.

--- a/tests/honcho_plugin/test_session_ai_peer_prefix.py
+++ b/tests/honcho_plugin/test_session_ai_peer_prefix.py
@@ -1,0 +1,137 @@
+"""Tests for the ``sessionAiPeerPrefix`` config flag.
+
+``sessionPeerPrefix`` prefixes a resolved session name with the *user* peer
+(``peerName``).  ``sessionAiPeerPrefix`` is the symmetric counterpart for the
+*AI* peer (``aiPeer``): when several AI peers share one workspace + peerName +
+gateway chat key, the ``gateway_session_key`` branch of
+``resolve_session_name`` returns an AI-peer-agnostic name and every peer
+collides on the same Honcho session.  Setting ``sessionAiPeerPrefix: true``
+prefixes the final name with ``{ai_peer}-`` so the sessions stay disjoint.
+
+Tests cover config parsing (``client.py::from_global_config``) and the public
+resolver wrapper across every resolution path, including the length cap.
+"""
+
+import json
+
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAiPeerPrefixConfigParsing:
+    def test_default_is_false(self):
+        """Default preserves existing behaviour."""
+        config = HonchoClientConfig()
+        assert config.session_ai_peer_prefix is False
+
+    def test_root_level_true(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "k",
+            "peerName": "eli",
+            "aiPeer": "ivy",
+            "sessionAiPeerPrefix": True,
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "isolated"))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.session_ai_peer_prefix is True
+        assert config.ai_peer == "ivy"
+
+    def test_host_block_true(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "k",
+            "peerName": "eli",
+            "hosts": {
+                "hermes": {"aiPeer": "ivy", "sessionAiPeerPrefix": True},
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "isolated"))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.session_ai_peer_prefix is True
+
+    def test_host_block_overrides_root(self, tmp_path, monkeypatch):
+        """Host block wins over root — matches every other flag."""
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "k",
+            "peerName": "eli",
+            "sessionAiPeerPrefix": True,
+            "hosts": {
+                "hermes": {"sessionAiPeerPrefix": False},
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "isolated"))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.session_ai_peer_prefix is False
+
+
+# ---------------------------------------------------------------------------
+# Resolver behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAiPeerPrefixResolver:
+    def _config(self, **overrides):
+        base = dict(
+            ai_peer="ivy",
+            peer_name="eli",
+            session_ai_peer_prefix=True,
+        )
+        base.update(overrides)
+        return HonchoClientConfig(**base)
+
+    def test_gateway_key_gets_ai_peer_prefix(self):
+        """The motivating case: gateway_session_key is AI-peer-agnostic."""
+        cfg = self._config()
+        name = cfg.resolve_session_name(
+            gateway_session_key="agent:main:telegram:dm:8055661863",
+        )
+        assert name.startswith("ivy-")
+        assert "telegram-dm-8055661863" in name
+
+    def test_disabled_leaves_name_untouched(self):
+        """Regression guard — default behaviour is unchanged."""
+        cfg = self._config(session_ai_peer_prefix=False)
+        name = cfg.resolve_session_name(
+            gateway_session_key="agent:main:telegram:dm:8055661863",
+        )
+        assert not name.startswith("ivy-")
+
+    def test_two_ai_peers_stay_disjoint(self):
+        """Same workspace + chat key, different aiPeer -> different sessions."""
+        key = "agent:main:telegram:dm:8055661863"
+        ivy = self._config(ai_peer="ivy").resolve_session_name(gateway_session_key=key)
+        holly = self._config(ai_peer="holly").resolve_session_name(gateway_session_key=key)
+        assert ivy != holly
+        assert ivy.startswith("ivy-")
+        assert holly.startswith("holly-")
+
+    def test_applies_across_strategy_paths(self, tmp_path):
+        """Prefix is not limited to the gateway-key branch."""
+        cfg = self._config(session_strategy="per-directory")
+        name = cfg.resolve_session_name(cwd=str(tmp_path / "myproject"))
+        assert name == "ivy-myproject"
+
+    def test_no_ai_peer_no_prefix(self):
+        """An empty aiPeer must not produce a stray leading hyphen."""
+        cfg = self._config(ai_peer="")
+        name = cfg.resolve_session_name(gateway_session_key="agent:main:dm:1")
+        assert not name.startswith("-")
+
+    def test_prefix_respects_session_id_length_cap(self):
+        """A long base + prefix stays within Honcho's 100-char session-id cap,
+        and remains disjoint per AI peer (hash incorporates the prefix)."""
+        long_key = "agent:main:telegram:dm:" + "9" * 200
+        ivy = self._config(ai_peer="ivy").resolve_session_name(gateway_session_key=long_key)
+        holly = self._config(ai_peer="holly").resolve_session_name(gateway_session_key=long_key)
+        assert len(ivy) <= HonchoClientConfig._HONCHO_SESSION_ID_MAX_LEN
+        assert len(holly) <= HonchoClientConfig._HONCHO_SESSION_ID_MAX_LEN
+        assert ivy != holly


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `sessionAiPeerPrefix` config flag for the Honcho memory plugin. When set, the resolved Honcho session name is prefixed with `{aiPeer}-` so that multiple AI peers sharing one `workspace` + `peerName` + gateway chat key stay on **disjoint** sessions instead of colliding on a single one.

It is the symmetric counterpart to the existing `sessionPeerPrefix` (which prefixes the *user* peer). The motivating case is the `gateway_session_key` branch of `resolve_session_name()`, which is AI-peer-agnostic — so without this flag there is no way to isolate two agents that share a workspace and peer name.

## Related Issue

Fixes #39129

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

Default is `false`; when unset, session-name resolution is byte-for-byte unchanged.

## Changes Made

- `plugins/memory/honcho/client.py`
  - new `session_ai_peer_prefix` config field
  - host-first / root-fallback parsing of `sessionAiPeerPrefix` (mirrors `sessionPeerPrefix`)
  - `resolve_session_name()` is now a thin wrapper that delegates to a new `_resolve_session_name_base()` (the existing resolution ladder, unchanged) and then applies the `{aiPeer}-` prefix on **every** path. The prefixed name is re-run through `_enforce_session_id_limit()` so the prefix can never push a name past Honcho's session-id cap.
- `tests/honcho_plugin/test_session_ai_peer_prefix.py` (new)
- `plugins/memory/honcho/README.md` — config table + resolution notes

## How to Test

```
pytest tests/honcho_plugin/test_session_ai_peer_prefix.py
```

Tests cover: config parsing (default/root/host/host-overrides-root), the gateway-key collision case, cross-peer disjointness (same chat key + different `aiPeer` → different sessions), the session-id length cap, and a disabled-by-default regression guard. Existing honcho suites (`test_honcho_client_config.py`, `test_pin_peer_name.py`) still pass — 61 green locally.

## Checklist

- [x] Tests added/updated
- [x] Docs updated
- [x] Backward compatible (opt-in, default `false`)
