### PR TITLE
fix(anthropic): suppress thinking + forced temperature for step-3.7-flash

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -445,6 +445,26 @@ def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> 
     return False
 
 
+def _is_stepfun_reasoning_model(model: str | None) -> bool:
+    """Return True for StepFun reasoning models that don't speak Anthropic thinking.
+
+    ``step-3.7-flash`` (and future ``step-3.7*`` variants) drive reasoning
+    server-side via StepFun's own ``reasoning_effort`` and do not implement
+    Anthropic's manual ``thinking``/``budget_tokens`` protocol.  On the
+    ``anthropic_messages`` path (the default for the Nous Portal) the generic
+    third-party handling strips the unsigned thinking blocks on replay while
+    still advertising ``thinking.enabled`` and force-setting ``temperature=1``,
+    which degrades output and breaks multi-turn tool calls.  Same failure mode
+    as Kimi (#17455); suppress the thinking kwarg here.  See #39124.
+
+    Anchored on the ``step-3.7`` token (not a bare ``3.7``) so unrelated
+    version strings like ``step-13.7-*`` are not matched; vendor-prefixed
+    ``stepfun/step-3.7-flash:free`` still matches since the token is a
+    substring.
+    """
+    return "step-3.7" in (model or "").strip().lower()
+
+
 def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for DeepSeek's Anthropic-compatible endpoint.
 
@@ -2245,7 +2265,8 @@ def build_anthropic_kwargs(
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
-    if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
+    _suppress_thinking = _is_kimi_coding or _is_stepfun_reasoning_model(model)
+    if reasoning_config and isinstance(reasoning_config, dict) and not _suppress_thinking:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)

--- a/tests/agent/test_stepfun_anthropic_thinking.py
+++ b/tests/agent/test_stepfun_anthropic_thinking.py
@@ -1,0 +1,125 @@
+"""Regression guard: don't send Anthropic ``thinking`` to StepFun step-3.7-flash.
+
+StepFun's ``step-3.7-flash`` is surfaced over the ``anthropic_messages``
+transport (the default for the Nous Portal). It does not speak Anthropic's
+manual extended-thinking protocol: it drives reasoning server-side via its own
+``reasoning_effort``. When ``build_anthropic_kwargs`` injects
+``thinking={type: enabled, budget_tokens: N}`` and forces ``temperature: 1``,
+the model degrades and multi-turn tool calls break -- the generic third-party
+path strips the (unsigned) thinking blocks on replay while still advertising
+``thinking.enabled``.
+
+This is the same failure mode that #17455 fixed for Kimi. step-3.7-flash needs
+its own carve-out. See #39124.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestStepFunSkipsAnthropicThinking:
+    """build_anthropic_kwargs must not inject thinking for step-3.7 models."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "step-3.7-flash",
+            "stepfun/step-3.7-flash",
+            "stepfun/step-3.7-flash:free",
+            "step-3.7-flash-2506",
+        ],
+    )
+    def test_step_37_omits_thinking(self, model: str) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="https://inference-api.nousresearch.com/v1",
+        )
+        assert "thinking" not in kwargs, (
+            "Anthropic thinking must not be sent to step-3.7-flash -- the "
+            "model doesn't speak the protocol and tool-call replay breaks."
+        )
+        assert "output_config" not in kwargs
+
+    def test_step_37_does_not_force_temperature(self) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="stepfun/step-3.7-flash:free",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="https://inference-api.nousresearch.com/v1",
+        )
+        assert kwargs.get("temperature") != 1, (
+            "step-3.7-flash must not be force-set to temperature=1; that knob "
+            "belongs to Anthropic manual-thinking models only."
+        )
+
+    def test_step_37_with_reasoning_disabled_also_omits(self) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="stepfun/step-3.7-flash:free",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": False},
+            base_url="https://inference-api.nousresearch.com/v1",
+        )
+        assert "thinking" not in kwargs
+
+
+class TestStepFunGateIsNarrow:
+    """The carve-out is anchored on the step-3.7 token, nothing wider."""
+
+    def test_minimax_third_party_still_gets_thinking(self) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="MiniMax-M2.7",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="https://api.minimax.io/anthropic",
+        )
+        assert "thinking" in kwargs
+        assert kwargs["thinking"]["type"] == "enabled"
+
+    def test_native_anthropic_still_gets_thinking(self) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url=None,
+        )
+        assert "thinking" in kwargs
+
+    def test_bare_version_lookalike_not_matched(self) -> None:
+        """A bare ``3.7`` or an unrelated ``step-13.7`` must not trip the gate."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="vendor/step-13.7-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="https://api.example.com/anthropic",
+        )
+        assert "thinking" in kwargs, (
+            "Only the step-3.7 token should be suppressed; step-13.7 must keep "
+            "its existing behavior."
+        )


### PR DESCRIPTION
Closes #39124.

## Summary

`step-3.7-flash` over the `anthropic_messages` transport (the Nous Portal default: `provider: nous`, `base_url: https://inference-api.nousresearch.com/v1`) was being handed Anthropic's manual extended-thinking parameters and a forced `temperature: 1`. StepFun's model does not speak Anthropic's `thinking`/`reasoning_content` protocol, so this degrades output and breaks multi-turn tool calls.

This is the same failure mode #17455 fixed for Kimi. step-3.7-flash just never got a carve-out.

## Root cause

`build_anthropic_kwargs()` maps `reasoning_config` to Anthropic thinking, with carve-outs only for Kimi-coding and Haiku:

```python
_is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
    if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
        ...
        if _supports_adaptive_thinking(model):   # Claude 4.6+ only
            ...
        else:                                    # step-3.7-flash lands here
            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
            kwargs["temperature"] = 1
            kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
```

`_supports_adaptive_thinking()` matches Claude 4.6+ substrings only, so `stepfun/step-3.7-flash:free` returns False and drops into the legacy "older Claude" branch. There's no model-family gate there, only the kimi/haiku exclusions.

## Symptoms this produces

- **Degraded / weird answers** from the force-set `temperature: 1` plus a thinking protocol the model doesn't implement.
- **Breaks on tool use**: once `thinking.enabled` is sent, replayed assistant tool-call turns are expected to carry signed thinking blocks. On a third-party endpoint those have no valid signature and get stripped by `convert_messages_to_anthropic`, so the next tool turn is rejected. Exactly what #17455 describes for Kimi.

## Fix

Add `_is_stepfun_reasoning_model()` next to `_is_kimi_family_endpoint`, and OR it into the existing thinking gate. When it matches, the whole thinking/temperature/max_tokens block is skipped and StepFun drives reasoning server-side via its own `reasoning_effort` (which the Anthropic Messages wire format cannot carry anyway).

The gate anchors on the `step-3.7` token, not a bare `3.7`, so unrelated strings like `step-13.7-*` are unaffected. `stepfun/step-3.7-flash:free` matches via substring.

## Validation

|  | Before | After |
|---|---|---|
| `stepfun/step-3.7-flash:free` + thinking | `thinking` sent, `temperature=1` | both omitted |
| `step-3.7-flash-2506` + thinking | `thinking` sent | omitted |
| MiniMax on custom `/anthropic` | `thinking` sent | `thinking` sent (unchanged) |
| native Claude | `thinking` sent | `thinking` sent (unchanged) |
| `step-13.7-*` lookalike | `thinking` sent | `thinking` sent (unchanged) |

- `tests/agent/test_stepfun_anthropic_thinking.py`: 9 new tests, all passing.
- `tests/agent/test_kimi_coding_anthropic_thinking.py`: 17/17 still passing (no regression to the sibling carve-out).
- Both files green under `scripts/run_tests.sh` (hermetic: TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0, clean env).

## Related

- #17455: the Kimi precedent this mirrors.
- #36942: `reasoning_effort` on the native `stepfun` provider (a different code path; not affected by this).
- #37044: reasoning blocks not surfaced to downstream API-server clients (same model, separate issue).
