### PR TITLE
fix(discord): fetch a specific message by id in fetch_messages

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -393,6 +393,29 @@ class TestFetchMessages:
         assert call_params["before"] == "999"
         assert call_params["limit"] == "10"
 
+    @patch("tools.discord_tool._discord_request")
+    def test_fetch_messages_by_id(self, mock_req, monkeypatch):
+        """message_id fetches that exact message (e.g. from a message link)."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "2002",
+            "content": "Linked message",
+            "author": {"id": "7", "username": "linker", "global_name": "Linker", "bot": False},
+            "timestamp": "2024-02-02T08:00:00Z",
+            "edited_timestamp": None,
+            "attachments": [],
+            "pinned": False,
+        }
+        result = json.loads(
+            discord_core(action="fetch_messages", channel_id="11", message_id="2002")
+        )
+        # Hits the single-message endpoint, not the channel history list.
+        assert mock_req.call_args[0][0] == "GET"
+        assert mock_req.call_args[0][1] == "/channels/11/messages/2002"
+        assert result["count"] == 1
+        assert result["messages"][0]["id"] == "2002"
+        assert result["messages"][0]["content"] == "Linked message"
+
 
 # ---------------------------------------------------------------------------
 # Action: list_pins

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -351,19 +351,30 @@ def _search_members(token: str, guild_id: str, query: str, limit: int = 20, **_k
 def _fetch_messages(
     token: str, channel_id: str, limit: int = 50,
     before: Optional[str] = None, after: Optional[str] = None,
+    message_id: Optional[str] = None,
     **_kwargs: Any,
 ) -> str:
-    """Fetch recent messages from a channel."""
-    try:
-        limit = int(limit)
-    except (TypeError, ValueError):
-        limit = 50
-    params: Dict[str, str] = {"limit": str(min(limit, 100))}
-    if before:
-        params["before"] = before
-    if after:
-        params["after"] = after
-    messages = _discord_request("GET", f"/channels/{channel_id}/messages", token, params=params)
+    """Fetch recent messages from a channel, or one specific message by id.
+
+    When message_id is provided (e.g. resolved from a Discord message
+    link), fetch that exact message directly instead of recent history.
+    """
+    if message_id:
+        msg = _discord_request(
+            "GET", f"/channels/{channel_id}/messages/{message_id}", token
+        )
+        messages = [msg]
+    else:
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 50
+        params: Dict[str, str] = {"limit": str(min(limit, 100))}
+        if before:
+            params["before"] = before
+        if after:
+            params["after"] = after
+        messages = _discord_request("GET", f"/channels/{channel_id}/messages", token, params=params)
     result = []
     for msg in messages:
         author = msg.get("author", {})
@@ -505,7 +516,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("list_roles", "(guild_id)", "roles sorted by position"),
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
-    ("fetch_messages", "(channel_id)", "recent messages; optional before/after snowflakes"),
+    ("fetch_messages", "(channel_id)", "recent messages; optional before/after snowflakes; pass message_id to fetch one specific message (e.g. from a link)"),
     ("list_pins", "(channel_id)", "pinned messages in a channel"),
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
@@ -683,7 +694,7 @@ def _build_schema(
         },
         "message_id": {
             "type": "string",
-            "description": "Discord message ID.",
+            "description": "Discord message ID. With fetch_messages, returns that single message (e.g. resolved from a message link).",
         },
         "query": {
             "type": "string",


### PR DESCRIPTION
## What
`fetch_messages` can now resolve a **specific message by `message_id`** (e.g. one parsed from a Discord message link `discord.com/channels/<guild>/<channel>/<message>`), instead of only ever returning recent channel history.

## Why
The `message_id` field was already declared in the tool's JSON schema, but `_fetch_messages` swallowed it via `**_kwargs` and always called `GET /channels/{id}/messages` (the recent list). Resolving a link to a specific — often older — message was therefore impossible, because the target usually isn't in the most recent page. In practice the agent would "fail to see" a message a user linked and asked it to look at.

## How
- When `message_id` is provided, fetch it directly via `GET /channels/{channel_id}/messages/{message_id}` and return just that message. Behaviour is **unchanged** when `message_id` is omitted (recent/paginated history via `before`/`after`).
- Updated the action manifest line and the `message_id` schema description so the model knows it can pass a `message_id` to read one specific message.

## Test plan
- Added `TestFetchMessages::test_fetch_messages_by_id` — asserts the single-message endpoint (`/channels/{c}/messages/{m}`) is hit and exactly that message is returned.
- `pytest tests/tools/test_discord_tool.py -o addopts=""` → **91 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)