### PR TITLE
fix(cli): use Termux extras during zip update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5756,12 +5756,20 @@ def _update_via_zip(args):
     pip_cmd = [sys.executable, "-m", "pip"]
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
+    install_group = "all"
     if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+            install_group = "termux-all"
+            print("  → Termux detected: using uv + curated termux-all optional profile...")
+        if _is_termux_env(uv_env) and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, group=install_group
+        )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -5780,7 +5788,13 @@ def _update_via_zip(args):
                 cwd=PROJECT_ROOT,
                 check=True,
             )
-        _install_python_dependencies_with_optional_fallback(pip_cmd)
+        if _is_termux_env():
+            install_group = "termux-all"
+            print("  → Termux detected: using curated termux-all optional profile...")
+        if _is_termux_env() and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
     _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1496,6 +1496,7 @@ AUTHOR_MAP = {
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
     "josephjohnson.joel@gmail.com": "JoelJJohnson",  # PR #39913 salvage (Windows ConPTY dashboard chat bridge)
     "andreas@schwarz-ketsch.de": "Nea74",  # PR #40022 co-author credit (same Windows ConPTY bridge design)
+    "sahibzada@fastino.ai": "sahibzada-allahyar",  # PR #39135 (Termux extras during zip update)
 }
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -825,3 +825,143 @@ termux = ["rich>=14"]
 
     assert hm._load_installable_optional_extras(group="all") == ["mcp"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
+
+
+class TestCmdUpdateTermuxExtrasGroup:
+    """_cmd_update_impl selects the correct extras group on Termux."""
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_uv_branch_termux_passes_termux_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        monkeypatch.setattr(hm, "_is_android_python", lambda: False)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["cmd_prefix"] = list(cmd_prefix)
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "termux-all"
+        assert recorded.get("cmd_prefix") == ["/usr/bin/uv", "pip"]
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_uv_branch_non_termux_passes_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: False)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "all"
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_pip_branch_termux_passes_termux_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        import subprocess as sp
+        from hermes_cli import main as hm
+
+        base_side = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        def combined(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "pip" in joined and "--version" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="pip 24.0\n", stderr="")
+            if "ensurepip" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return base_side(cmd, **kwargs)
+
+        mock_run.side_effect = combined
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        monkeypatch.setattr(hm, "_is_android_python", lambda: False)
+        monkeypatch.setattr(hm, "_ensure_uv_for_termux", lambda pip_cmd: None)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "termux-all"
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_pip_branch_non_termux_passes_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        import subprocess as sp
+        from hermes_cli import main as hm
+
+        base_side = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        def combined(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "pip" in joined and "--version" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="pip 24.0\n", stderr="")
+            if "ensurepip" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return base_side(cmd, **kwargs)
+
+        mock_run.side_effect = combined
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: False)
+        monkeypatch.setattr(hm, "_ensure_uv_for_termux", lambda pip_cmd: None)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "all"


### PR DESCRIPTION
Summary
- Fixes #39106.
- Ports the existing Termux optional-dependency selection from the setup path to the zip update dependency install path.
- When Termux is detected during `hermes update`, the update path now installs `.[termux-all]` instead of falling back to the default `.[all]` optional profile.
- Preserves the existing Termux environment cleanup and Android psutil prebuild behavior before dependency installation.

Behavior Proof
- Before: `_update_via_zip` detected Termux only to sanitize `PYTHONPATH` / `PYTHONHOME`, then called `_install_python_dependencies_with_optional_fallback(... )` without `group=`, so the helper defaulted to `group="all"`.
- After: `_update_via_zip` initializes `install_group = "all"`, switches it to `"termux-all"` when `_is_termux_env(...)` is true, and passes `group=install_group` into both uv and pip fallback install calls.
- The setup/install path already used this `termux-all` behavior; this makes the update path consistent with it.

Verification
- `python3 -m py_compile hermes_cli/main.py`
  - passed
- `uv run --with ruff ruff check hermes_cli/main.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_cmd_update.py`
  - `All checks passed!`
- `uv run --with pytest --with pytest-timeout pytest tests/hermes_cli/test_update_autostash.py -q`
  - `27 passed in 131.40s`
- `uv run --with pytest --with pytest-timeout pytest tests/hermes_cli/test_cmd_update.py -q`
  - `25 passed in 173.82s`

Platform Tested
- macOS arm64 with uv-managed Python 3.11 test environment

Limitations
- I did not run on a physical Termux device. The proof verifies the update-path branch now passes the same `termux-all` group used by the existing setup path, and the nearby update suites pass.