### PR TITLE
fix: mcp test respects server config timeout

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -580,7 +580,8 @@ def cmd_mcp_test(args):
     # Attempt connection
     start = time.monotonic()
     try:
-        tools = _probe_single_server(name, cfg)
+        timeout = float(cfg.get("timeout", cfg.get("connect_timeout", 30)))
+        tools = _probe_single_server(name, cfg, connect_timeout=timeout)
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000


### PR DESCRIPTION
## Problem

`hermes mcp test` hard-codes a 30s `connect_timeout` in `_probe_single_server`, ignoring the server's `timeout`/ `connect_timeout` from config. Some MCP servers need longer to complete `tools/list` (e.g., desktop-pilot scans the full macOS accessibility tree, taking 12-21s).

The error message shows "configured timeout: 40.0s" but this comes from `_run_on_mcp_loop(connect_timeout + 10)` with the hard-coded default, NOT from the config.

## Fix

Read `timeout` (or `connect_timeout`) from the server config, defaulting to 30s, and pass it through to `_probe_single_server`.



## Verification

With a server configured with `timeout: 120`, the test command now allows 120s (not 40s) for tool discovery.