### PR TITLE
fix(update): use termux-all extras on Termux in the update path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8035,12 +8035,26 @@ def _update_via_zip(args):
     pip_cmd = [sys.executable, "-m", "pip"]
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
+    # Mirror cmd_setup's Termux handling: on Termux/Android the ``.[all]`` extras
+    # have no prebuilt aarch64 wheels and trigger a full Rust/C source compile
+    # (cargo build of uv, jemalloc/openssl/zstd) that can exhaust swap and freeze
+    # the device. The curated ``termux-all`` profile avoids that. This detection
+    # lived only in the setup path — keep it in sync here so `hermes update`
+    # doesn't reintroduce the heavy install. (issue #39106)
+    install_group = "all"
     if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+            install_group = "termux-all"
+            print("  → Termux detected: using uv + curated termux-all optional profile...")
+        if _is_termux_env(uv_env) and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, group=install_group
+        )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -8059,7 +8073,13 @@ def _update_via_zip(args):
                 cwd=PROJECT_ROOT,
                 check=True,
             )
-        _install_python_dependencies_with_optional_fallback(pip_cmd)
+        if _is_termux_env():
+            install_group = "termux-all"
+            print("  → Termux detected: using curated termux-all optional profile...")
+        if _is_termux_env() and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
     _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -830,3 +830,53 @@ termux = ["rich>=14"]
 
     assert hm._load_installable_optional_extras(group="all") == ["mcp"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
+
+
+class TestCmdUpdateTermuxExtras:
+    """Regression for #39106.
+
+    On Termux/Android the ``.[all]`` extras have no prebuilt aarch64 wheels and
+    trigger a full Rust/C source compile (cargo build of uv, jemalloc/openssl/
+    zstd) that can exhaust swap and freeze the device. ``cmd_setup`` already
+    selected the curated ``termux-all`` profile on Termux, but ``cmd_update``
+    did not â€” so updating reintroduced the heavy install. These drive
+    ``cmd_update`` end-to-end (git/uv/npm/subprocess mocked) and assert the
+    extras group that reaches the dependency installer, for both the uv branch
+    and the pip-fallback branch.
+    """
+
+    def _run_update(self, mock_args, *, uv_available, termux):
+        from hermes_cli import main as hm
+        import subprocess as _subprocess
+
+        which_map = {"npm": "/usr/bin/npm"}
+        if uv_available:
+            which_map["uv"] = "/usr/bin/uv"
+        build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch("shutil.which", side_effect=which_map.get), \
+             patch("subprocess.run", side_effect=_make_run_side_effect(
+                 branch="main", verify_ok=True, commit_count="1")), \
+             patch.object(hm, "_is_termux_env", return_value=termux), \
+             patch.object(hm, "_is_android_python", return_value=False), \
+             patch.object(hm, "_ensure_uv_for_termux", return_value=None), \
+             patch.object(hm, "_install_psutil_android_compat"), \
+             patch.object(hm, "_run_with_idle_timeout", return_value=build_ok), \
+             patch.object(hm, "_install_python_dependencies_with_optional_fallback") as mock_install:
+            cmd_update(mock_args)
+
+        mock_install.assert_called_once()
+        return mock_install.call_args.kwargs.get("group")
+
+    def test_uv_branch_uses_termux_all_on_termux(self, mock_args):
+        assert self._run_update(mock_args, uv_available=True, termux=True) == "termux-all"
+
+    def test_uv_branch_uses_all_off_termux(self, mock_args):
+        assert self._run_update(mock_args, uv_available=True, termux=False) == "all"
+
+    def test_pip_fallback_uses_termux_all_on_termux(self, mock_args):
+        # uv unavailable -> the pip-fallback branch (the second buggy call site)
+        assert self._run_update(mock_args, uv_available=False, termux=True) == "termux-all"
+
+    def test_pip_fallback_uses_all_off_termux(self, mock_args):
+        assert self._run_update(mock_args, uv_available=False, termux=False) == "all"


### PR DESCRIPTION
## What does this PR do?

`hermes update` on Termux/Android installed the `.[all]` extras, which have no prebuilt aarch64 wheels and trigger a full Rust/C source compile (cargo build of uv, plus jemalloc/openssl/zstd) — exhausting swap and freezing the device (the reporter's Pixel 8a froze ~45 min). `cmd_setup` already detected Termux and selected the curated `termux-all` profile, but that handling was never ported to `cmd_update`, so every update reintroduced the heavy install.

## Related Issue

Fixes #39106

(Context: prior PRs #10325 / #18012 / #18015 were closed as "already fixed on main" citing the setup path — but the update-path call site still defaulted to `all`.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` (`cmd_update`) — mirror `cmd_setup`'s Termux handling at **both** update-path install call sites (the uv branch and the pip-fallback branch): initialize `install_group="all"`, switch to `"termux-all"` when `_is_termux_env()`, run the `_install_psutil_android_compat` prebuild on Termux/Android, and pass `group=install_group` to `_install_python_dependencies_with_optional_fallback`. The setup and update paths are now identical for Termux, so they can't silently re-diverge.
- `tests/hermes_cli/test_cmd_update.py` — new `TestCmdUpdateTermuxExtras`.

## How to Test

1. `pytest tests/hermes_cli/test_cmd_update.py -q` — the new `TestCmdUpdateTermuxExtras` drives `cmd_update` end-to-end (git/uv/npm/subprocess mocked) and asserts the extras group reaching the installer is `termux-all` on Termux and `all` otherwise, for **both** the uv branch and the pip-fallback branch (4 cases).
2. On a real Termux device: `hermes update` now prints "Termux detected: using … termux-all optional profile" and no longer compiles uv/native deps from source.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected module (`test_cmd_update.py`: 4 new pass; 1 unrelated pre-existing failure, `test_update_on_fork_checks_upstream_when_origin_up_to_date`, is a Windows-only git-flag assertion that fails identically on clean `main`) + `py_compile`; full suite not run in my Windows dev env
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (unit/e2e tests; no Termux device available)

### Documentation & Housekeeping
- [x] Documentation — N/A (behavior parity fix; no user-facing docs surface)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Considered cross-platform impact — Termux/Android-gated; no change on other platforms
- [x] Tool descriptions/schemas — N/A

## Notes

Out of scope: the secondary failure in the report — managed-uv bootstrap compiling uv from source when `pip install uv` finds no aarch64 wheel — is a separate root cause and left for a follow-up PR so this stays focused.