### PR TITLE
fix: handle launchd gateway restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10829,7 +10829,9 @@ class GatewayRunner:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or bool(
+            os.environ.get("HERMES_GATEWAY_SERVICE")
+        )
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3076,6 +3076,8 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>HERMES_GATEWAY_SERVICE</key>
+        <string>launchd</string>
     </dict>
     
     <key>RunAtLoad</key>

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -16,9 +16,9 @@ from tests.gateway.restart_test_helpers import make_restart_runner, make_restart
 
 @pytest.mark.asyncio
 async def test_restart_command_while_busy_requests_drain_without_interrupt(monkeypatch):
-    # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,
-    # which changes the restart call signature.
+    # Ensure service-manager markers are NOT set — they change the restart call signature.
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SERVICE", raising=False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     event = MessageEvent(

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -99,10 +99,33 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_restart_command_uses_service_restart_under_launchd_marker(tmp_path, monkeypatch):
+    """Under launchd (HERMES_GATEWAY_SERVICE=launchd), /restart uses via_service=True."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SERVICE", "launchd")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
 async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
     """Without systemd, /restart uses the detached subprocess approach."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SERVICE", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1629,6 +1629,19 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
+    def test_launchd_plist_marks_gateway_as_launchd_service(self, tmp_path, monkeypatch):
+        """launchd plist should mark the process so /restart uses the service path."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>HERMES_GATEWAY_SERVICE</key>" in plist
+        assert "<string>launchd</string>" in plist
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- mark macOS launchd gateway processes with HERMES_GATEWAY_SERVICE=launchd
- route gateway /restart through the service-managed restart path when that marker is present
- add regression coverage for launchd plist generation and /restart behaviour

## Validation
- ./venv/bin/python -m pytest tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway_service.py::TestProfileArg -q -o 'addopts=' — 54 passed
- hermes gateway start
- hermes gateway restart
- launchctl print confirms HERMES_GATEWAY_SERVICE => launchd and state = running
- gateway logs confirm Connected to Telegram (polling mode) and Gateway running with 1 platform(s)