### PR TITLE
fix(i18n): include locales in PyPI package and add fallback paths

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,8 @@ graft optional-skills
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data
 # below covers the wheel; this covers the sdist. See #34034 / #28149.
 recursive-include plugins plugin.yaml plugin.yml
+# Locale catalogs (locales/*.yaml) — required for i18n to work in PyPI installs.
+# package-data in pyproject.toml covers the wheel; this covers the sdist.
+recursive-include locales *.yaml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -87,11 +87,43 @@ _catalog_lock = threading.Lock()
 def _locales_dir() -> Path:
     """Return the directory containing locale YAML files.
 
-    Lives next to the repo root so both the bundled install and editable
-    checkouts find it without PYTHONPATH gymnastics.
+    Search order:
+    1. Sibling of the repo root / site-packages (``<parent>/locales/`` -- works
+       for git clones, editable installs, AND wheels where ``agent/`` and
+       ``locales/`` are sibling packages under the same prefix).
+    2. ``$HERMES_HOME/locales/`` -- works when the user has placed or symlinked
+       locale files under the Hermes data directory.
+    3. ``<agent_package>/locales/`` -- last resort for non-standard layouts
+       where locales were copied inside the ``agent/`` directory.
+
+    Falls back to the original computed path even if it does not exist, so
+    ``_load_catalog`` gets a clean "catalog missing" debug log rather than an
+    opaque crash.
     """
-    # agent/i18n.py -> agent/ -> repo root
-    return Path(__file__).resolve().parent.parent / "locales"
+    # agent/i18n.py -> agent/ -> <prefix>/locales/
+    primary = Path(__file__).resolve().parent.parent / "locales"
+    if primary.is_dir():
+        return primary
+
+    # Fallback: $HERMES_HOME/locales/
+    try:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        if isinstance(hermes_home, Path) and hermes_home.name == "locales" and hermes_home.is_dir():
+            return hermes_home
+        fallback = hermes_home / "locales"
+        if fallback.is_dir():
+            return fallback
+    except Exception:
+        pass
+
+    # Fallback: <agent_package>/locales/ (non-standard layout)
+    pkg_sibling = Path(__file__).resolve().parent / "locales"
+    if pkg_sibling.is_dir():
+        return pkg_sibling
+
+    return primary  # let _load_catalog log the "catalog missing" message
 
 
 def _normalize_lang(value: Any) -> str:

--- a/locales/__init__.py
+++ b/locales/__init__.py
@@ -1,0 +1,2 @@
+# locales package marker — makes setuptools find_packages() discover this
+# directory so that *.yaml locale catalogs ship as package data in wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,9 +245,10 @@ plugins = [
   "**/plugin.yaml",
   "**/plugin.yml",
 ]
+locales = ["*.yaml"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "locales"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -167,3 +167,22 @@ def test_t_missing_key_in_non_english_falls_back_to_english(tmp_path, monkeypatc
 def test_t_unknown_language_uses_english():
     """Unknown lang codes normalize to English, not to a key-path fallback."""
     assert i18n.t("approval.denied", lang="klingon") == i18n.t("approval.denied", lang="en")
+
+
+# ---------------------------------------------------------------------------
+# _locales_dir resolution
+# ---------------------------------------------------------------------------
+
+
+def test_locales_dir_primary_path_exists():
+    """The primary path (parent.parent / 'locales') resolves for git/wheel installs."""
+    result = i18n._locales_dir()
+    assert result.is_dir(), f"Primary locales dir does not exist: {result}"
+    assert (result / "en.yaml").is_file(), "en.yaml missing from locales dir"
+
+
+def test_locales_dir_has_all_supported_languages():
+    """The locales directory contains a YAML file for every supported language."""
+    locales_dir = i18n._locales_dir()
+    for lang in i18n.SUPPORTED_LANGUAGES:
+        assert (locales_dir / f"{lang}.yaml").is_file(), f"missing locales/{lang}.yaml"


### PR DESCRIPTION
## Problem

The `locales/` directory containing translation YAML files was not included in the PyPI distribution of `hermes-agent`. Installing via `pip install hermes-agent` resulted in i18n returning raw dotted keys (e.g. `gateway.model.switched`) instead of translated messages because `_locales_dir()` resolved to a non-existent `site-packages/locales/` path.

`agent/i18n.py:94` computed the locales directory as `Path(__file__).resolve().parent.parent / "locales"`. For PyPI installs, `__file__` resolves to `site-packages/agent/i18n.py`, so the computed path was `site-packages/locales/` — which didn't exist because the locale YAMLs were never shipped in the wheel.

## Changes

- **agent/i18n.py**: Updated `_locales_dir()` with multi-path fallback resolution:
  1. `<prefix>/locales/` — works for git clones, editable installs, AND wheels where `agent/` and `locales/` are sibling packages under the same prefix
  2. `/root/.hermes/locales/` — fallback for PyPI installs when the user has placed or symlinked locale files under the Hermes data directory
  3. `<agent_package>/locales/` — last resort for non-standard layouts
- **pyproject.toml**: Added `locales` to `packages.find.include` and declared `locales/*.yaml` as `package-data` so translation files ship in wheels
- **locales/__init__.py**: Package marker required for setuptools to discover `locales/` as a package (without this, `find_packages()` ignores the directory and the `package-data` glob has no effect)
- **MANIFEST.in**: Added `recursive-include locales *.yaml` to ensure locale files are included in sdists (for downstream packagers like Homebrew)
- **tests/agent/test_i18n.py**: Added two tests:
  - `test_locales_dir_primary_path_exists` — verifies the primary path resolves and contains `en.yaml`
  - `test_locales_dir_has_all_supported_languages` — verifies every language in `SUPPORTED_LANGUAGES` has a corresponding YAML file on disk

## Testing

All 45 i18n tests pass (including 2 new), and the 17 gateway restart drain tests that exercise i18n also pass.

Fixes #39105