### PR TITLE
fix(update): avoid source-building uv on Termux

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9461,7 +9461,13 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return None
     try:
         print("  → Termux detected: trying to install uv for faster dependency updates...")
-        subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False)
+        result = subprocess.run(
+            pip_cmd + ["install", "uv", "--only-binary", ":all:"],
+            cwd=PROJECT_ROOT,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
     except Exception:
         pass
     # After pip install, check managed path first, then PATH

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -114,6 +114,36 @@ class TestCmdUpdatePip:
         assert "env" not in mock_run.call_args.kwargs
 
 
+class TestCmdUpdateTermuxUvBootstrap:
+    """Regression tests for Termux-specific uv bootstrap behavior."""
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_termux_uv_bootstrap_uses_binary_only_install(
+        self, mock_run, _mock_which, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="")
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+
+        uv_bin = hm._ensure_uv_for_termux(["/termux/python", "-m", "pip"])
+
+        assert uv_bin is None
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0] == [
+            "/termux/python",
+            "-m",
+            "pip",
+            "install",
+            "uv",
+            "--only-binary",
+            ":all:",
+        ]
+        assert mock_run.call_args.kwargs["cwd"] == PROJECT_ROOT
+        assert mock_run.call_args.kwargs["check"] is False
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Termux uv bootstrap path so it never falls back to building `uv` from source when no compatible wheel exists. `_ensure_uv_for_termux()` now asks pip for binary distributions only and returns `None` when that install fails, letting the existing update flow continue with pip instead of triggering a Rust build on Android.

## Related Issue

Fixes #39118

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py`: add `--only-binary :all:` to the Termux `uv` bootstrap install and skip uv when pip reports no compatible binary distribution.
- `tests/hermes_cli/test_cmd_update.py`: add a regression test covering the Termux fallback command shape and no-uv fallback.

## How to Test

1. `uv sync --extra dev --frozen`
2. `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -- -q -k termux_uv_bootstrap`
3. `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -- -q`
4. `scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py -- -q`
5. `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
6. `uv run ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
7. `git diff --check`

The new focused test failed before the production change because the command was only `pip install uv`; it passes after the fix with the binary-only flags present.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout; Termux behavior covered by unit test, not a physical Termux device

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Termux-only fallback path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A.

Full `pytest tests/ -q` was not run locally; the focused update-path suites above passed.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
