### PR TITLE
fix(gateway): remove .git check blocking /update on pip installs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14865,12 +14865,6 @@ class GatewayRunner:
         if is_managed():
             return f"✗ {format_managed_message('update Hermes Agent')}"
 
-        project_root = Path(__file__).parent.parent.resolve()
-        git_dir = project_root / '.git'
-
-        if not git_dir.exists():
-            return t("gateway.update.not_git_repo")
-
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:
             return t("gateway.update.hermes_cmd_not_found")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -135,6 +135,7 @@ AUTHOR_MAP = {
     "soju06@users.noreply.github.com": "Soju06",
     "34199905+Soju06@users.noreply.github.com": "Soju06",
     "98262967+Bihruze@users.noreply.github.com": "Bihruze",
+    "wuyang9311@users.noreply.github.com": "wuyang9311",
     "189280367+Lempkey@users.noreply.github.com": "Lempkey",
     "34853915+m0n3r0@users.noreply.github.com": "m0n3r0",
     "leeseoki@makestar.com": "leeseoki0",

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -86,10 +86,8 @@ class TestHandleUpdateCommand:
         runner = _make_runner()
         event = _make_event()
 
-        # Create project dir WITH .git
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -111,7 +109,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -177,7 +174,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -213,7 +209,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -238,7 +233,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -267,7 +261,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -307,7 +300,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")
@@ -333,7 +325,6 @@ class TestHandleUpdateCommand:
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        (fake_root / ".git").mkdir()
         (fake_root / "gateway").mkdir()
         (fake_root / "gateway" / "run.py").touch()
         fake_file = str(fake_root / "gateway" / "run.py")

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -57,44 +57,28 @@ class TestHandleUpdateCommand:
         assert "brew upgrade hermes-agent" in result
 
     @pytest.mark.asyncio
-    async def test_no_git_directory(self, tmp_path):
-        """Returns an error when .git does not exist."""
+    async def test_no_git_directory_proceeds_with_update(self, tmp_path):
+        """Proceeds with update even when .git does not exist (pip installs)."""
         runner = _make_runner()
         event = _make_event()
-        # Point _hermes_home to tmp_path and project_root to a dir without .git
+
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        with patch("gateway.run._hermes_home", tmp_path), \
-             patch("gateway.run.Path") as MockPath:
-            # Path(__file__).parent.parent.resolve() -> fake_root
-            MockPath.return_value = MagicMock()
-            MockPath.__truediv__ = Path.__truediv__
-            # Easier: just patch the __file__ resolution in the method
-            pass
+        (fake_root / "gateway").mkdir(parents=True)
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
 
-        # Simpler approach — mock at method level using a wrapper
-        runner = _make_runner()
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
 
-        with patch("gateway.run._hermes_home", tmp_path):
-            # The handler does Path(__file__).parent.parent.resolve()
-            # We need to make project_root / '.git' not exist.
-            # Since Path(__file__) resolves to the real gateway/run.py,
-            # project_root will be the real hermes-agent dir (which HAS .git).
-            # Patch Path to control this.
-            original_path = Path
-
-            class FakePath(type(Path())):
-                pass
-
-            # Actually, simplest: just patch the specific file attr
-            fake_file = str(fake_root / "gateway" / "run.py")
-            (fake_root / "gateway").mkdir(parents=True)
-            (fake_root / "gateway" / "run.py").touch()
-
-            with patch("gateway.run.__file__", fake_file):
-                result = await runner._handle_update_command(event)
-
-        assert "Not a git repository" in result
+        assert "Starting Hermes update" in result
+        assert "stream progress" in result
 
     @pytest.mark.asyncio
     async def test_no_hermes_binary(self, tmp_path):


### PR DESCRIPTION
## Problem

The gateway's `/update` handler checked for a `.git` directory before proceeding, which blocked all pip (PyPI) installs from using `/update` on any messaging platform.

## Root Cause

`gateway/run.py` had an early `.git` check. For pip installs, `project_root` resolves to `site-packages/` while the CLI already handles pip updates via `detect_install_method()`.

## Fix

Removed the early `.git` check.

## Testing

- Updated `test_no_git_directory` to `test_no_git_directory_proceeds_with_update`
- Removed dead `.git` dir creation from 8 test fixtures
- All 48 tests pass

Fixes #39104