### PR TITLE
fix(tui): type spawn stdio as StdioOptions so ui-tui type-check passes

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,9 +32,9 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
     const child = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,


### PR DESCRIPTION
## What does this PR do?

Fixes the 18 TypeScript errors in `ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts` that make `npm run type-check -w ui-tui` fail on `main` today.

`stdioConfig` is a union of two `as const` literals — `['pipe','ignore','ignore']` (when `resolveOnExit`) or `'pipe'`. That union leaves TypeScript unable to resolve `spawn()`'s overloads, so the return type collapses to `never` and every subsequent `child.*` access errors (`Property 'stdout' does not exist on type 'never'`, implicit-`any` callback params, etc.). The recent `@types/node@25` bump surfaced it.

Annotating `stdioConfig` as `StdioOptions` (the type `spawn`'s options expect) selects a single overload and resolves all 18 errors. **Runtime values are unchanged — this is type-only.**

## Related Issue

No issue filed — standalone type-check correctness fix (`ui-tui` type-check is red on `main` today). Happy to file one if preferred.

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts`: import `type StdioOptions`; annotate `stdioConfig: StdioOptions` and drop the two now-unnecessary `as const`s.

## How to Test

1. `npm run type-check -w ui-tui` -> **18 errors -> 0** (verified clean on both `typescript@5.9` and `@6.0`)
2. `npm run build -w ui-tui` (esbuild) -> clean
3. `npm test -w ui-tui` -> unchanged vs `main` (same pre-existing platform-specific failures; verified by diffing the failure set with and without this change — vitest transforms with esbuild, not tsc, so it is unaffected)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (none open for this)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: TypeScript-only change, no Python touched. Ran the ui-tui build + tests instead.
- [ ] I've added tests for my changes — N/A: type-only fix with no runtime behavior to assert; it is verified by `type-check` going from 18 errors to 0 (a build-level check).
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior or API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — N/A (type annotation only; no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

```
# before (on main)
$ npm run type-check -w ui-tui
packages/hermes-ink/src/utils/execFileNoThrow.ts(42,7): error TS2769: No overload matches this call.
... 18 errors

# after (this PR)
$ npm run type-check -w ui-tui
(no output — 0 errors)
```