### PR TITLE
fix(gateway): detect pip installs in /update instead of bare .git check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14962,7 +14962,10 @@ class GatewayRunner:
         # a *git* install whose `.git` directory is genuinely missing (a
         # corrupted checkout) should be short-circuited here.  Previously a
         # raw `.git`-presence check wrongly blocked every PyPI (pip) install.
-        if detect_install_method(project_root) == "git" and not (project_root / ".git").is_dir():
+        # Use `.exists()` (not `.is_dir()`) so git worktrees and submodules —
+        # where `.git` is a *file* holding a `gitdir:` pointer — are still
+        # treated as valid; only a genuinely-missing `.git` is rejected.
+        if detect_install_method(project_root) == "git" and not (project_root / ".git").exists():
             return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14932,7 +14932,11 @@ class GatewayRunner:
         import shutil
         import subprocess
         from datetime import datetime
-        from hermes_cli.config import is_managed, format_managed_message
+        from hermes_cli.config import (
+            detect_install_method,
+            is_managed,
+            format_managed_message,
+        )
 
         # Block non-messaging platforms (API server, webhooks, ACP)
         platform = event.source.platform
@@ -14951,9 +14955,14 @@ class GatewayRunner:
             return f"✗ {format_managed_message('update Hermes Agent')}"
 
         project_root = Path(__file__).parent.parent.resolve()
-        git_dir = project_root / '.git'
-
-        if not git_dir.exists():
+        # Mirror `hermes update`'s install-method resolution
+        # (detect_install_method precedence: .install_method stamp > managed
+        # system > .git dir > pip).  The spawned `hermes update --gateway`
+        # below already handles pip/docker/managed installs correctly, so only
+        # a *git* install whose `.git` directory is genuinely missing (a
+        # corrupted checkout) should be short-circuited here.  Previously a
+        # raw `.git`-presence check wrongly blocked every PyPI (pip) install.
+        if detect_install_method(project_root) == "git" and not (project_root / ".git").is_dir():
             return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -58,41 +58,26 @@ class TestHandleUpdateCommand:
 
     @pytest.mark.asyncio
     async def test_no_git_directory(self, tmp_path):
-        """Returns an error when .git does not exist."""
+        """Returns an error for a git install whose .git dir is missing (corrupt checkout).
+
+        The short-circuit only fires when the install method resolves to ``git``
+        AND ``.git`` is absent. A pip install with no ``.git`` must NOT be blocked,
+        so we force ``detect_install_method`` to ``"git"`` to exercise the
+        corrupted-git-checkout guard while ``.git`` stays absent.
+        """
         runner = _make_runner()
         event = _make_event()
-        # Point _hermes_home to tmp_path and project_root to a dir without .git
+
+        # Project root with a gateway/run.py but NO .git directory.
         fake_root = tmp_path / "project"
-        fake_root.mkdir()
+        (fake_root / "gateway").mkdir(parents=True)
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+
         with patch("gateway.run._hermes_home", tmp_path), \
-             patch("gateway.run.Path") as MockPath:
-            # Path(__file__).parent.parent.resolve() -> fake_root
-            MockPath.return_value = MagicMock()
-            MockPath.__truediv__ = Path.__truediv__
-            # Easier: just patch the __file__ resolution in the method
-            pass
-
-        # Simpler approach — mock at method level using a wrapper
-        runner = _make_runner()
-
-        with patch("gateway.run._hermes_home", tmp_path):
-            # The handler does Path(__file__).parent.parent.resolve()
-            # We need to make project_root / '.git' not exist.
-            # Since Path(__file__) resolves to the real gateway/run.py,
-            # project_root will be the real hermes-agent dir (which HAS .git).
-            # Patch Path to control this.
-            original_path = Path
-
-            class FakePath(type(Path())):
-                pass
-
-            # Actually, simplest: just patch the specific file attr
-            fake_file = str(fake_root / "gateway" / "run.py")
-            (fake_root / "gateway").mkdir(parents=True)
-            (fake_root / "gateway" / "run.py").touch()
-
-            with patch("gateway.run.__file__", fake_file):
-                result = await runner._handle_update_command(event)
+             patch("gateway.run.__file__", fake_file), \
+             patch("hermes_cli.config.detect_install_method", return_value="git"):
+            result = await runner._handle_update_command(event)
 
         assert "Not a git repository" in result
 

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -240,9 +240,37 @@ class TestUpdateCommandGatewayFlag:
         assert "status=$?" not in cmd_string
         assert "stream progress" in result
 
+    @staticmethod
+    def _make_install_layout(tmp_path):
+        """Build a fake install tree and return (fake_root, fake_file, hermes_home).
+
+        Shared by the install-method detection tests so each only has to add
+        the `.git` shape it cares about (dir / file / absent).
+        """
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        return fake_root, fake_file, hermes_home
+
+    async def _run_update(self, fake_file, hermes_home, install_method, mock_popen):
+        """Invoke _handle_update_command with detect_install_method stubbed."""
+        runner = _make_runner()
+        event = _make_event()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("hermes_cli.config.detect_install_method", return_value=install_method), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch("subprocess.Popen", mock_popen):
+            return await runner._handle_update_command(event)
+
     @pytest.mark.asyncio
     async def test_pip_install_reaches_spawn_not_git_repo(self, tmp_path):
-        """A pip install (no .git dir) must NOT be blocked as 'not a git repo'.
+        """A pip install (no .git) must NOT be blocked as 'not a git repo'.
 
         The spawned `hermes update --gateway` already handles pip installs;
         the handler must fall through to it instead of short-circuiting on a
@@ -251,26 +279,9 @@ class TestUpdateCommandGatewayFlag:
         """
         from gateway.run import t
 
-        runner = _make_runner()
-        event = _make_event()
-
-        # Project root WITHOUT a .git dir — a PyPI/pip install.
-        fake_root = tmp_path / "project"
-        fake_root.mkdir()
-        (fake_root / "gateway").mkdir()
-        (fake_root / "gateway" / "run.py").touch()
-        fake_file = str(fake_root / "gateway" / "run.py")
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir()
-
+        _, fake_file, hermes_home = self._make_install_layout(tmp_path)  # no .git
         mock_popen = MagicMock()
-        with patch("gateway.run._hermes_home", hermes_home), \
-             patch("gateway.run.__file__", fake_file), \
-             patch("hermes_cli.config.detect_install_method", return_value="pip"), \
-             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
-             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
-             patch("subprocess.Popen", mock_popen):
-            result = await runner._handle_update_command(event)
+        result = await self._run_update(fake_file, hermes_home, "pip", mock_popen)
 
         # Must NOT be blocked; must reach the spawn path.
         assert result != t("gateway.update.not_git_repo")
@@ -278,8 +289,27 @@ class TestUpdateCommandGatewayFlag:
         assert mock_popen.called
 
     @pytest.mark.asyncio
+    async def test_git_worktree_with_dotgit_file_reaches_spawn(self, tmp_path):
+        """A git worktree/submodule (`.git` is a *file*) must NOT be blocked.
+
+        In worktrees and submodules `.git` is a file holding a `gitdir:`
+        pointer, not a directory. The handler uses `.exists()` so such installs
+        fall through to the spawn path. Regression for #39104.
+        """
+        from gateway.run import t
+
+        fake_root, fake_file, hermes_home = self._make_install_layout(tmp_path)
+        (fake_root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+        mock_popen = MagicMock()
+        result = await self._run_update(fake_file, hermes_home, "git", mock_popen)
+
+        assert result != t("gateway.update.not_git_repo")
+        assert "stream progress" in result
+        assert mock_popen.called
+
+    @pytest.mark.asyncio
     async def test_broken_git_checkout_still_blocked(self, tmp_path):
-        """A genuine git install with a missing .git dir is still rejected.
+        """A genuine git install with a missing .git is still rejected.
 
         Only a corrupted git checkout (method == 'git' AND `.git` absent)
         should short-circuit with 'not a git repository'. Regression for
@@ -287,26 +317,9 @@ class TestUpdateCommandGatewayFlag:
         """
         from gateway.run import t
 
-        runner = _make_runner()
-        event = _make_event()
-
-        # method resolves to 'git' but the .git dir is genuinely missing.
-        fake_root = tmp_path / "project"
-        fake_root.mkdir()
-        (fake_root / "gateway").mkdir()
-        (fake_root / "gateway" / "run.py").touch()
-        fake_file = str(fake_root / "gateway" / "run.py")
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir()
-
+        _, fake_file, hermes_home = self._make_install_layout(tmp_path)  # no .git
         mock_popen = MagicMock()
-        with patch("gateway.run._hermes_home", hermes_home), \
-             patch("gateway.run.__file__", fake_file), \
-             patch("hermes_cli.config.detect_install_method", return_value="git"), \
-             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
-             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
-             patch("subprocess.Popen", mock_popen):
-            result = await runner._handle_update_command(event)
+        result = await self._run_update(fake_file, hermes_home, "git", mock_popen)
 
         assert result == t("gateway.update.not_git_repo")
         assert not mock_popen.called

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -240,6 +240,77 @@ class TestUpdateCommandGatewayFlag:
         assert "status=$?" not in cmd_string
         assert "stream progress" in result
 
+    @pytest.mark.asyncio
+    async def test_pip_install_reaches_spawn_not_git_repo(self, tmp_path):
+        """A pip install (no .git dir) must NOT be blocked as 'not a git repo'.
+
+        The spawned `hermes update --gateway` already handles pip installs;
+        the handler must fall through to it instead of short-circuiting on a
+        bare `.git`-presence check. Mirrors the CLI's detect_install_method
+        resolution. Regression for #39104.
+        """
+        from gateway.run import t
+
+        runner = _make_runner()
+        event = _make_event()
+
+        # Project root WITHOUT a .git dir — a PyPI/pip install.
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("hermes_cli.config.detect_install_method", return_value="pip"), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        # Must NOT be blocked; must reach the spawn path.
+        assert result != t("gateway.update.not_git_repo")
+        assert "stream progress" in result
+        assert mock_popen.called
+
+    @pytest.mark.asyncio
+    async def test_broken_git_checkout_still_blocked(self, tmp_path):
+        """A genuine git install with a missing .git dir is still rejected.
+
+        Only a corrupted git checkout (method == 'git' AND `.git` absent)
+        should short-circuit with 'not a git repository'. Regression for
+        #39104 — the fix must not silently update a broken git checkout.
+        """
+        from gateway.run import t
+
+        runner = _make_runner()
+        event = _make_event()
+
+        # method resolves to 'git' but the .git dir is genuinely missing.
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("hermes_cli.config.detect_install_method", return_value="git"), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert result == t("gateway.update.not_git_repo")
+        assert not mock_popen.called
+
 
 # ---------------------------------------------------------------------------
 # _watch_update_progress — output streaming


### PR DESCRIPTION
## What does this PR do?

- Fixes the gateway `/update` command rejecting PyPI (pip) installs with "Not a git repository — cannot update", even though `hermes update` from the terminal already updates pip installs correctly.
- Replaces the raw `.git`-presence gate in `_handle_update_command` with the same install-method resolution the CLI uses. Mirrors `hermes_cli.config.detect_install_method` precedence: `~/.hermes/.install_method` stamp > managed system (NixOS/Homebrew) > `.git` dir > pip. Only a genuinely-broken *git* checkout (method == git, `.git` missing) is short-circuited; pip/docker/managed fall through to the `hermes update --gateway` spawn that already handles them.

## Related Issue

Fixes #39104

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: gate `/update` on `detect_install_method(project_root)` instead of bare `.git` existence; only short-circuit `not_git_repo` when method == `git` and the `.git` dir is genuinely missing.
- `tests/gateway/test_update_streaming.py`: regression tests for a pip install reaching the spawn path, and a broken-git checkout still being blocked.

## How to Test

1. On a pip/PyPI install (no `.git` dir in the package root), send `/update` to the gateway — it should proceed to spawn `hermes update --gateway` instead of replying "Not a git repository".
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_update_streaming.py -v`
3. Regression proof: reverting the production hunk to the old bare `.git` check makes `test_pip_install_reaches_spawn_not_git_repo` fail (handler returns `not_git_repo`); the fix makes it pass while `test_broken_git_checkout_still_blocked` keeps a corrupted git checkout blocked.

> Sibling code paths that may need the same fix: the CLI's `hermes doctor` / update-check surfaces already consume `detect_install_method`; only the gateway `/update` handler still used a raw `.git` check. Intentionally scoped to that one handler to keep the diff small — happy to widen if preferred.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused gateway update tests and they pass (23 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure path/method logic, no platform-specific calls

## Related / Positioning

Two other PRs target #39104 in the same window — #39155 and #39158. Both fix the symptom by **deleting the `.git` guard outright**. This PR keeps the safety the guard was there for while fixing the bug:

- **Preserves the corrupted-checkout signal.** A genuine `git` install whose `.git` is missing is still reported as `not_git_repo` instead of silently spawning an update that cannot work. The bare-removal PRs drop that case entirely.
- **Mirrors the CLI resolver.** Gates on `hermes_cli.config.detect_install_method` (stamp > managed > `.git` > pip) — the same precedence `hermes update` / `hermes doctor` already use — instead of inventing a one-off rule, so the gateway and CLI now agree on what an install *is*.
- **Worktrees/submodules covered explicitly** via `.exists()` (a `.git` *file* with a `gitdir:` pointer), with a dedicated regression test.
- Scoped to the single handler, no unrelated file changes.

Happy to defer if a maintainer prefers the simpler removal — flagging the trade-off so the decision is explicit.
