### PR TITLE
fix(gateway): allow update for pip installs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14862,12 +14862,6 @@ class GatewayRunner:
         if is_managed():
             return f"✗ {format_managed_message('update Hermes Agent')}"
 
-        project_root = Path(__file__).parent.parent.resolve()
-        git_dir = project_root / '.git'
-
-        if not git_dir.exists():
-            return t("gateway.update.not_git_repo")
-
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:
             return t("gateway.update.hermes_cmd_not_found")

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -57,44 +57,40 @@ class TestHandleUpdateCommand:
         assert "brew upgrade hermes-agent" in result
 
     @pytest.mark.asyncio
-    async def test_no_git_directory(self, tmp_path):
-        """Returns an error when .git does not exist."""
+    async def test_pip_install_without_git_proceeds(self, tmp_path):
+        """Starts the updater even when the install tree has no .git directory."""
         runner = _make_runner()
         event = _make_event()
-        # Point _hermes_home to tmp_path and project_root to a dir without .git
+
         fake_root = tmp_path / "project"
         fake_root.mkdir()
-        with patch("gateway.run._hermes_home", tmp_path), \
-             patch("gateway.run.Path") as MockPath:
-            # Path(__file__).parent.parent.resolve() -> fake_root
-            MockPath.return_value = MagicMock()
-            MockPath.__truediv__ = Path.__truediv__
-            # Easier: just patch the __file__ resolution in the method
-            pass
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
 
-        # Simpler approach — mock at method level using a wrapper
-        runner = _make_runner()
+        mock_popen = MagicMock()
 
-        with patch("gateway.run._hermes_home", tmp_path):
-            # The handler does Path(__file__).parent.parent.resolve()
-            # We need to make project_root / '.git' not exist.
-            # Since Path(__file__) resolves to the real gateway/run.py,
-            # project_root will be the real hermes-agent dir (which HAS .git).
-            # Patch Path to control this.
-            original_path = Path
+        def which_no_setsid(name):
+            if name == "hermes":
+                return "/usr/bin/hermes"
+            if name == "setsid":
+                return None
+            return None
 
-            class FakePath(type(Path())):
-                pass
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=which_no_setsid), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
 
-            # Actually, simplest: just patch the specific file attr
-            fake_file = str(fake_root / "gateway" / "run.py")
-            (fake_root / "gateway").mkdir(parents=True)
-            (fake_root / "gateway" / "run.py").touch()
-
-            with patch("gateway.run.__file__", fake_file):
-                result = await runner._handle_update_command(event)
-
-        assert "Not a git repository" in result
+        assert "Starting Hermes update" in result
+        assert "Not a git repository" not in result
+        call_args = mock_popen.call_args[0][0]
+        assert call_args[0] == "bash"
+        assert "/usr/bin/hermes" in call_args[2]
+        assert "update --gateway" in call_args[2]
 
     @pytest.mark.asyncio
     async def test_no_hermes_binary(self, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Removes the gateway `/update` command's early `.git` directory gate so pip/PyPI installs can reach the existing `hermes update --gateway` install-method handling. This fixes the reported behavior where messaging-platform `/update` returned `Not a git repository` before the CLI updater could handle a pip install.

The managed-install short-circuit remains unchanged, and the existing updater command remains the single source of truth for git, pip, Docker, Homebrew, and NixOS update behavior.

## Related Issue

Fixes #39104

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: remove the `.git` existence check from `_handle_update_command` so `/update` proceeds to spawn `hermes update --gateway` for non-managed installs.
- `tests/gateway/test_update_command.py`: replace the old `test_no_git_directory` assertion, which encoded the bug, with a regression test that verifies a no-`.git` install tree still starts `hermes update --gateway`.
- Left `gateway.update.not_git_repo` locale strings in place intentionally to keep the fix focused and avoid broad i18n churn.

## How to Test

1. Install Hermes via pip/PyPI.
2. Connect a messaging platform that supports `/update`.
3. Send `/update` and verify it returns the update-starting message instead of `Not a git repository`.
4. Confirm the update process invokes `hermes update --gateway` and streams progress normally.

Local validation performed:

- [x] `scripts/run_tests.sh tests/gateway/test_update_command.py -- -q` — 28 tests passed.
- [x] `.venv/bin/ruff check gateway/run.py tests/gateway/test_update_command.py` — passed.
- [ ] `scripts/run_tests.sh -- -q` — attempted locally, but the full run was not usable in this sandbox: many unrelated failures came from missing optional extras (`acp`, `aiohttp`, `anthropic`, media/provider SDKs), blocked socket binds/process signals, and denied writes to `~/.hermes`; the run was stopped after it hung in a tail test attempting a lazy `pip install`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local sandbox

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused regression test:

```text
scripts/run_tests.sh tests/gateway/test_update_command.py -- -q
28 tests passed
```

Lint:

```text
.venv/bin/ruff check gateway/run.py tests/gateway/test_update_command.py
All checks passed!
```
