### PR TITLE
fix(agent): preserve copilot routed headers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -762,6 +762,8 @@ def init_agent(
                 # _default_headers instead.
                 _routed_headers = getattr(_routed_client, "_custom_headers", None)
                 if not _routed_headers:
+                    _routed_headers = getattr(_routed_client, "default_headers", None)
+                if not _routed_headers:
                     _routed_headers = getattr(_routed_client, "_default_headers", None)
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
@@ -814,6 +816,8 @@ def init_agent(
                             if _provider_timeout is not None:
                                 client_kwargs["timeout"] = _provider_timeout
                             _fb_headers = getattr(_fb_client, "_custom_headers", None)
+                            if not _fb_headers:
+                                _fb_headers = getattr(_fb_client, "default_headers", None)
                             if not _fb_headers:
                                 _fb_headers = getattr(_fb_client, "_default_headers", None)
                             if _fb_headers:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3230,6 +3230,9 @@ class AIAgent:
             import httpx as _httpx
             import socket as _socket
 
+            if "api.githubcopilot.com" in str(base_url or "").lower():
+                return _httpx.Client()
+
             _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
             if hasattr(_socket, "TCP_KEEPIDLE"):
                 _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -145,6 +145,27 @@ def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
     http_client.close()
 
 
+@patch("run_agent.OpenAI")
+def test_create_openai_client_uses_plain_httpx_client_for_copilot(mock_openai, monkeypatch):
+    """Copilot Claude chat-completions rejects the custom socket-options transport."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": "https://api.githubcopilot.com",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = _extract_http_client(forwarded)
+    assert isinstance(http_client, httpx.Client)
+    assert getattr(http_client._transport._pool, "_socket_options", None) is None
+    http_client.close()
+
+
 def test_get_proxy_for_base_url_returns_none_when_host_bypassed(monkeypatch):
     """NO_PROXY must suppress the proxy for matching base_urls.
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -110,6 +110,31 @@ def test_routed_client_preserves_openai_sdk_custom_headers(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_routed_client_preserves_openai_sdk_default_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    routed_client = SimpleNamespace(
+        api_key="test-key",
+        base_url="https://api.githubcopilot.com",
+        default_headers={"copilot-integration-id": "vscode-chat"},
+    )
+
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(
+        routed_client,
+        "claude-opus-4.7",
+    )):
+        agent = AIAgent(
+            provider="copilot",
+            model="claude-opus-4.7",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["copilot-integration-id"] == "vscode-chat"
+
+
+@patch("run_agent.OpenAI")
 def test_gmi_base_url_picks_up_profile_user_agent(mock_openai):
     """GMI declares User-Agent on its ProviderProfile.default_headers.
 


### PR DESCRIPTION
## What does this PR do?

Fixes Copilot Claude chat-completions failures where Hermes rebuilt a routed OpenAI client without provider-specific headers and then used a custom socket-options httpx transport that Copilot rejects on `api.githubcopilot.com`.

## Related Issue

Fixes #12066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py`: Preserve routed client headers from `_custom_headers`, public `default_headers`, or legacy `_default_headers` when rebuilding primary and fallback provider clients.
- `run_agent.py`: Use a plain `httpx.Client()` for `api.githubcopilot.com` so Copilot Claude chat-completions do not receive Hermes' custom socket-options transport.
- `tests/run_agent/test_provider_attribution_headers.py`: Add a regression for routed SDK v2 `default_headers` preservation.
- `tests/run_agent/test_create_openai_client_proxy_env.py`: Add a regression proving Copilot gets a plain httpx client without custom socket options.

## How to Test

1. `HERMES_HOME=/private/tmp/hermes-agent-test-home /opt/homebrew/bin/timeout -k 30 480 pytest tests/run_agent/test_provider_attribution_headers.py tests/run_agent/test_create_openai_client_proxy_env.py -q` (passes: 20 passed)
2. `HERMES_HOME=/private/tmp/hermes-agent-test-home /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` (stopped during unrelated collection: `ModuleNotFoundError: No module named 'fastapi'` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py`, before reaching the changed run-agent tests)
3. `ruff check agent/agent_init.py run_agent.py tests/run_agent/test_create_openai_client_proxy_env.py tests/run_agent/test_provider_attribution_headers.py` (passes; emits a pre-existing warning about invalid `# noqa` on `run_agent.py:93`)
4. `python scripts/check-windows-footguns.py agent/agent_init.py run_agent.py tests/run_agent/test_create_openai_client_proxy_env.py tests/run_agent/test_provider_attribution_headers.py` (passes)
5. `git diff --check` (passes)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64 (local sandbox)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-d28c264a kind=pr-open -->