### PR TITLE
fix(gateway): use owned executor for agent work

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
     pass
 
 import asyncio
+import concurrent.futures
 import dataclasses
 import inspect
 import json
@@ -1875,6 +1876,8 @@ class GatewayRunner:
         self._restart_via_service = False
         self._restart_command_source: Optional[SessionSource] = None
         self._stop_task: Optional[asyncio.Task] = None
+        self._executor_lock = threading.Lock()
+        self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
@@ -6676,6 +6679,7 @@ class GatewayRunner:
                     _db.close()
                 except Exception as _e:
                     logger.debug("SessionDB close error: %s", _e)
+            GatewayRunner._shutdown_executor(self)
             logger.info(
                 "Shutdown phase: SessionDB close done at +%.2fs",
                 _phase_elapsed(),
@@ -15594,7 +15598,47 @@ class GatewayRunner:
         """Run blocking work in the thread pool while preserving session contextvars."""
         loop = asyncio.get_running_loop()
         ctx = copy_context()
-        return await loop.run_in_executor(None, ctx.run, func, *args)
+        return await loop.run_in_executor(
+            self._get_executor(),
+            ctx.run,
+            func,
+            *args,
+        )
+
+    def _get_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return the gateway-owned executor for blocking agent work."""
+        lock = getattr(self, "_executor_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._executor_lock = lock
+
+        with lock:
+            executor = getattr(self, "_executor", None)
+            if executor is None or getattr(executor, "_shutdown", False):
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=10,
+                    thread_name_prefix="hermes-gateway",
+                )
+                self._executor = executor
+            return executor
+
+    def _shutdown_executor(self) -> None:
+        """Stop the gateway-owned executor without touching the loop default."""
+        lock = getattr(self, "_executor_lock", None)
+        if lock is None:
+            return
+
+        with lock:
+            executor = getattr(self, "_executor", None)
+            self._executor = None
+
+        if executor is None:
+            return
+
+        try:
+            executor.shutdown(wait=False, cancel_futures=True)
+        except TypeError:
+            executor.shutdown(wait=False)
 
     def _decide_image_input_mode(self) -> str:
         """Resolve the image-input routing for the currently active model.

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -291,6 +291,7 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
         )
     finally:
         runner._clear_session_env(tokens)
+        runner._shutdown_executor()
 
     assert result == {
         "platform": "telegram",
@@ -308,7 +309,10 @@ async def test_run_in_executor_with_context_forwards_args():
     def add(a, b):
         return a + b
 
-    result = await runner._run_in_executor_with_context(add, 3, 7)
+    try:
+        result = await runner._run_in_executor_with_context(add, 3, 7)
+    finally:
+        runner._shutdown_executor()
     assert result == 10
 
 
@@ -320,5 +324,45 @@ async def test_run_in_executor_with_context_propagates_exceptions():
     def blow_up():
         raise ValueError("boom")
 
-    with pytest.raises(ValueError, match="boom"):
-        await runner._run_in_executor_with_context(blow_up)
+    try:
+        with pytest.raises(ValueError, match="boom"):
+            await runner._run_in_executor_with_context(blow_up)
+    finally:
+        runner._shutdown_executor()
+
+
+@pytest.mark.asyncio
+async def test_run_in_executor_with_context_survives_default_executor_shutdown():
+    """Gateway agent work should not depend on asyncio's default executor."""
+    runner = object.__new__(GatewayRunner)
+    loop = asyncio.get_running_loop()
+
+    await loop.run_in_executor(None, lambda: None)
+    await loop.shutdown_default_executor()
+
+    try:
+        result = await runner._run_in_executor_with_context(lambda: "ok")
+    finally:
+        runner._shutdown_executor()
+
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_in_executor_with_context_recreates_shutdown_gateway_executor():
+    """A stopped gateway-owned executor should be replaced on the next use."""
+    runner = object.__new__(GatewayRunner)
+
+    try:
+        first = await runner._run_in_executor_with_context(lambda: "first")
+        first_executor = runner._executor
+        runner._shutdown_executor()
+
+        second = await runner._run_in_executor_with_context(lambda: "second")
+        second_executor = runner._executor
+    finally:
+        runner._shutdown_executor()
+
+    assert first == "first"
+    assert second == "second"
+    assert second_executor is not first_executor


### PR DESCRIPTION
This gives the gateway its own managed thread pool for blocking agent work so message handling no longer depends on asyncio's default executor after that executor has been shut down.

## What changed and why
- `gateway/run.py`: add a lazily-created gateway-owned `ThreadPoolExecutor`, route `_run_in_executor_with_context()` through it, and shut it down during gateway stop.
- `tests/gateway/test_session_env.py`: cover context propagation cleanup, default-executor shutdown survival, and gateway executor recreation after shutdown.

## How to test
- `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_session_env.py -q` -> 14 passed.
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped during collection because local Python 3.14 environment is missing optional `fastapi` for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
- Rerun with that file ignored stopped on the same missing optional dependency in `tests/hermes_cli/test_dashboard_auth_cookies.py`.
- `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_session_env.py tests/gateway/test_shutdown_cache_cleanup.py -q` -> 22 passed.
- `ruff check gateway/run.py tests/gateway/test_session_env.py` -> passed.
- `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_session_env.py` -> passed.
- `git diff --check` -> passed.

## What platforms tested on
- macOS on darwin-arm64 (local), Python 3.14.
- Linux/Windows not run locally; the change uses `concurrent.futures.ThreadPoolExecutor` and avoids POSIX-only APIs.

Refs #10849

<!-- autocontrib:worker-id=issue-new-f5624ce5 kind=pr-open -->