### PR TITLE
fix: fall back on non-streaming provider timeout

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -50,6 +50,8 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
 
+from agent.error_classifier import FailoverReason, classify_api_error
+
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # openai SDK pulls a large type tree (~240 ms cold, including responses/*,
 # graders/*). We expose `OpenAI` here as a thin proxy that imports the SDK on
@@ -5324,22 +5326,39 @@ def call_llm(
         # When the provider returns a 429 rate-limit (not billing), fall
         # back to an alternative provider instead of exhausting retries
         # against the same rate-limited endpoint.
+        classified = classify_api_error(first_err, provider=resolved_provider, model=final_model)
+        is_provider_timeout = classified.reason == FailoverReason.provider_timeout
         should_fallback = (
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or is_provider_timeout
         )
         # Respect explicit provider choice for transient errors (auth, request
         # validation, etc.) but allow fallback when the provider clearly cannot
-        # serve the request due to capacity: payment/quota exhaustion and
-        # connection failures are capacity problems, not request constraints.
+        # serve the request due to capacity: payment/quota exhaustion,
+        # provider no-response timeouts, and connection failures are capacity
+        # problems, not request constraints.
         # See #26803: daily token quota (429 + "too many tokens per day") must
         # fall back just like a 402 credit error.
         is_auto = resolved_provider in {"auto", "", None}
         # Capacity errors bypass the explicit-provider gate: the provider
         # literally cannot serve this request regardless of user intent.
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err) or is_provider_timeout
         if should_fallback and (is_auto or is_capacity_error):
+            audit_event_type = "provider_timeout_fallback" if is_provider_timeout else "auxiliary_provider_fallback"
+            audit = {
+                "event_type": audit_event_type,
+                "model": final_model,
+                "provider": resolved_provider or "auto",
+                "timeout_seconds": classified.error_context.get("timeout_seconds") if is_provider_timeout else effective_timeout,
+                "retry_count": 0,
+                "fallback_attempted": False,
+                "fallback_result": "not_attempted",
+                "next_action": "attempt_fallback",
+                "merge_allowed": False,
+                "full_unattended_ready": False,
+            }
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -5349,6 +5368,8 @@ def call_llm(
                 _mark_provider_unhealthy(
                     _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime) or resolved_provider
                 )
+            elif is_provider_timeout:
+                reason = "provider timeout"
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
             else:
@@ -5373,6 +5394,7 @@ def call_llm(
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
+            audit["fallback_attempted"] = True
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
@@ -5380,11 +5402,24 @@ def call_llm(
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
-                return _validate_llm_response(
-                    fb_client.chat.completions.create(**fb_kwargs), task)
+                try:
+                    response = _validate_llm_response(
+                        fb_client.chat.completions.create(**fb_kwargs), task)
+                except Exception:
+                    audit["fallback_result"] = "failed"
+                    audit["next_action"] = "surface_fallback_failure_to_operator"
+                    logger.warning("fallback_audit %s", audit)
+                    raise
+                audit["fallback_result"] = "success"
+                audit["next_action"] = "continue_with_fallback"
+                logger.warning("fallback_audit %s", audit)
+                return response
             # All fallback layers exhausted — emit a single user-visible
             # warning so the operator knows aux task is about to fail.
             # (#26882) The error itself is re-raised below.
+            audit["fallback_result"] = "unavailable"
+            audit["next_action"] = "surface_original_error_to_operator"
+            logger.warning("fallback_audit %s", audit)
             logger.warning(
                 "Auxiliary %s: %s on %s and all fallbacks exhausted "
                 "(fallback_chain + main agent model). Raising original error.",

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -38,6 +39,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    provider_timeout = "PROVIDER_TIMEOUT"  # Provider produced no non-streaming response before timeout — fallback
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
@@ -362,6 +364,18 @@ _TIMEOUT_MESSAGE_PATTERNS = [
     "deadline exceeded",
     "operation timed out",
     "upstream timed out",
+]
+
+# Narrow fingerprints for the named P1 defect: non-streaming provider calls
+# timing out with no response were being treated as generic timeouts/unknowns,
+# which could skip the provider fallback/audit path. Keep these separate from
+# ordinary connection errors so connection reset / rate-limit behavior remains
+# unchanged.
+_PROVIDER_TIMEOUT_MESSAGE_PATTERNS = [
+    "non-streaming api call timed out",
+    "provider no response timeout",
+    "no response timeout",
+    "timed out after 180s with no response",
 ]
 
 # Transport error type names
@@ -1202,6 +1216,29 @@ def _classify_by_message(
             FailoverReason.model_not_found,
             retryable=False,
             should_fallback=True,
+        )
+
+    # Named provider timeout defect: non-streaming/no-response timeouts must
+    # be explicit PROVIDER_TIMEOUT and must opt into fallback/audit. This runs
+    # before the generic timeout bucket so the recovery layer can distinguish
+    # provider no-response from an ordinary socket hiccup.
+    if any(p in error_msg for p in _PROVIDER_TIMEOUT_MESSAGE_PATTERNS):
+        timeout_match = re.search(r"(\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?", error_msg)
+        timeout_seconds = None
+        if timeout_match:
+            raw_timeout = float(timeout_match.group(1))
+            timeout_seconds = int(raw_timeout) if raw_timeout.is_integer() else raw_timeout
+        return result_fn(
+            FailoverReason.provider_timeout,
+            retryable=True,
+            should_fallback=True,
+            should_compress=False,
+            error_context={
+                "defect_code": "non_streaming_provider_timeout_not_falling_back",
+                "category": "provider_timeout",
+                "severity": "recoverable",
+                "timeout_seconds": timeout_seconds,
+            },
         )
 
     # Timeout message patterns — generic exception types (e.g. RuntimeError)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1603,6 +1603,84 @@ class TestCallLlmPaymentFallback:
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
 
+    def test_non_streaming_provider_timeout_triggers_fallback_with_audit(self, monkeypatch, caplog):
+        """Non-streaming provider no-response timeout must enter fallback and emit audit fields."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = RuntimeError(
+            "Non-streaming API call timed out after 180s with no response"
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")), \
+             caplog.at_level("WARNING", logger="agent.auxiliary_client"):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+                timeout=180,
+            )
+
+        assert result is not None
+        assert fallback_client.chat.completions.create.called
+        audit_records = [r for r in caplog.records if "fallback_audit" in r.message]
+        assert audit_records, f"Expected fallback_audit log, got: {[r.message for r in caplog.records]}"
+        audit = audit_records[-1].args
+        assert audit["event_type"] == "provider_timeout_fallback"
+        assert audit["model"] == "gpt-5.5"
+        assert audit["provider"] == "auto"
+        assert audit["timeout_seconds"] == 180
+        assert audit["retry_count"] == 0
+        assert audit["fallback_attempted"] is True
+        assert audit["fallback_result"] == "success"
+        assert audit["next_action"] == "continue_with_fallback"
+        assert audit["merge_allowed"] is False
+        assert audit["full_unattended_ready"] is False
+
+    def test_non_streaming_provider_timeout_fallback_failure_logs_next_action(self, monkeypatch, caplog):
+        """Fallback failure must not fail silently: audit includes fallback_result and next_action."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = RuntimeError(
+            "Provider no response timeout after 180s"
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.side_effect = RuntimeError("fallback unavailable")
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")), \
+             caplog.at_level("WARNING", logger="agent.auxiliary_client"):
+            with pytest.raises(RuntimeError, match="fallback unavailable"):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hello"}],
+                    timeout=180,
+                )
+
+        audit_records = [r for r in caplog.records if "fallback_audit" in r.message]
+        assert audit_records, f"Expected fallback_audit log, got: {[r.message for r in caplog.records]}"
+        audit = audit_records[-1].args
+        assert audit["fallback_attempted"] is True
+        assert audit["fallback_result"] == "failed"
+        assert audit["next_action"] == "surface_fallback_failure_to_operator"
+        assert audit["merge_allowed"] is False
+        assert audit["full_unattended_ready"] is False
+
 
 class TestAuxiliaryFallbackLayering:
     """Explicit-provider users get layered fallback: configured_chain → main agent → warn."""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -53,7 +53,7 @@ class TestFailoverReason:
     def test_enum_members_exist(self):
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
-            "overloaded", "server_error", "timeout",
+            "overloaded", "server_error", "timeout", "PROVIDER_TIMEOUT",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
@@ -832,6 +832,26 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
+
+    @pytest.mark.parametrize("message", [
+        "Non-streaming API call timed out after 180s with no response",
+        "Provider no response timeout after 180s",
+        "180s no response timeout waiting for provider",
+    ])
+    def test_non_streaming_provider_timeout_classifies_as_provider_timeout(self, message):
+        result = classify_api_error(
+            RuntimeError(message),
+            provider="openai-codex",
+            model="gpt-5.5",
+        )
+
+        assert result.reason == FailoverReason.provider_timeout
+        assert result.reason.value == "PROVIDER_TIMEOUT"
+        assert result.retryable is True
+        assert result.should_fallback is True
+        assert result.should_compress is False
+        assert result.error_context["defect_code"] == "non_streaming_provider_timeout_not_falling_back"
+        assert result.error_context["timeout_seconds"] == 180
 
     def test_runtime_error_deadline_exceeded_classifies_as_timeout(self):
         e = RuntimeError("deadline exceeded")


### PR DESCRIPTION
## P1 named runtime change candidate

```yaml
proposed_change_name: non_streaming_provider_timeout_not_falling_back
change_type: defect
runtime_execution_allowed: false
full_unattended_ready: false
merge_allowed: false
next_gate: 八府巡按 audit
```

## Summary

Minimal runtime candidate for the named defect only:

- classify non-streaming / provider no-response / 180s no-response timeouts as `PROVIDER_TIMEOUT`
- mark the classification as retryable and fallback-eligible
- route the sync auxiliary fallback path through provider timeout classification
- emit structured fallback audit fields, including `fallback_attempted`, `fallback_result`, `next_action`, `merge_allowed: false`, and `full_unattended_ready: false`

## Scope compliance

Touched only allowed files:

- `agent/error_classifier.py`
- `agent/auxiliary_client.py`
- `tests/agent/test_error_classifier.py`
- `tests/agent/test_auxiliary_client.py`

No production, payment, credits, webhook, customer data, secrets, runtime/gateway mutation, live scanner, source writeback, cron Required Mode, global refactor, or unrelated cleanup.

## Local test evidence

```bash
python -m pytest tests/agent/test_error_classifier.py::TestClassifyApiError::test_non_streaming_provider_timeout_classifies_as_provider_timeout tests/agent/test_auxiliary_client.py::TestCallLlmPaymentFallback::test_non_streaming_provider_timeout_triggers_fallback_with_audit tests/agent/test_auxiliary_client.py::TestCallLlmPaymentFallback::test_non_streaming_provider_timeout_fallback_failure_logs_next_action -q -o 'addopts='
# 5 passed, 1 warning in 1.18s

python -m pytest tests/agent/test_error_classifier.py tests/agent/test_auxiliary_client.py -q -o 'addopts='
# 367 passed, 1 warning in 5.18s

git diff --check
# passed
```

## Rollback plan

Revert this PR/commit to restore the prior generic timeout classification and prior auxiliary fallback logging behavior. No data migration or runtime state change is required.

## Gate

Merge is not allowed from this candidate alone. Next gate: 八府巡按 audit.
