### PR TITLE
fix(mcp): ensure server.shutdown() on probe iteration failure

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -225,13 +225,15 @@ def _probe_single_server(
         server = await asyncio.wait_for(
             _connect_server(name, config), timeout=connect_timeout
         )
-        for t in server._tools:
-            desc = getattr(t, "description", "") or ""
-            # Truncate long descriptions for display
-            if len(desc) > 80:
-                desc = desc[:77] + "..."
-            tools_found.append((t.name, desc))
-        await server.shutdown()
+        try:
+            for t in server._tools:
+                desc = getattr(t, "description", "") or ""
+                # Truncate long descriptions for display
+                if len(desc) > 80:
+                    desc = desc[:77] + "..."
+                tools_found.append((t.name, desc))
+        finally:
+            await server.shutdown()
 
     try:
         _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)


### PR DESCRIPTION
## Summary
MCP server connections no longer leak when listing a server's tools hits a bad tool object.

`_probe_single_server()` in `hermes_cli/mcp_config.py` connected, iterated `server._tools`, then called `server.shutdown()`. If the iteration raised, `shutdown()` was skipped and the connection leaked until `_stop_mcp_loop()` tore down the whole event loop. Wrapping the loop in `try/finally` guarantees cleanup.

## Changes
- `hermes_cli/mcp_config.py`: `_probe()` iteration wrapped in `try/finally` so `server.shutdown()` always runs.

## Validation
| | Iteration raises | shutdown() called |
|---|---|---|
| Before (no finally) | yes | 0 — connection leaks |
| After (finally) | yes | 1 — error still propagates |

E2E: forced `tool.name` to raise mid-iteration; confirmed `shutdown()` runs exactly once and the error propagates. Targeted tests: `tests/tools/test_mcp_probe.py` + `tests/hermes_cli/test_mcp_config.py` → 50/50 pass.

Salvaged from #38609 by @annguyenNous (commit cherry-picked, authorship preserved).

## Infographic

![always-shut-down-the-probe](https://v3b.fal.media/files/b/0a9cf5b8/cMotF3PBCEyYhysAG8PXm_9So7nXZX.png)
