### PR TITLE
Add opt-in "reasoning off for local models" preference

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -263,12 +263,26 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    const fastSwitch = await screen.findByRole('switch')
+    const fastSwitch = await screen.findByRole('switch', { name: /fast/i })
     fireEvent.click(fastSwitch)
 
     await waitFor(() =>
       expect(saveHermesConfig).toHaveBeenCalledWith(
         expect.objectContaining({ agent: expect.objectContaining({ service_tier: 'fast' }) })
+      )
+    )
+  })
+
+  it('writes default_reasoning_off_for_local when the local-reasoning switch is toggled', async () => {
+    await renderModelSettings()
+    await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
+
+    const localSwitch = await screen.findByRole('switch', { name: /local/i })
+    fireEvent.click(localSwitch)
+
+    await waitFor(() =>
+      expect(saveHermesConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ agent: expect.objectContaining({ default_reasoning_off_for_local: true }) })
       )
     )
   })

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -91,6 +91,11 @@ const isFastTier = (tier: unknown): boolean =>
       .toLowerCase()
   )
 
+// Truthy coercion mirroring the backend's is_truthy_value, so a real YAML
+// boolean and a hand-edited `"true"`/`yes`/`on`/`1` both read back as on.
+const isTruthyFlag = (v: unknown): boolean =>
+  v === true || ['1', 'on', 'true', 'yes'].includes(String(v ?? '').trim().toLowerCase())
+
 // A provider row is "ready" to pick a model from when it reports models. The
 // backend now surfaces the full `hermes model` universe (every canonical
 // provider), so unconfigured providers come back with `authenticated:false`
@@ -513,10 +518,16 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
   const fastOn = isFastTier(getNested(config ?? {}, 'agent.service_tier'))
 
+  // Opt-in: start NEW local-model chats with Thinking off. Off by default, so
+  // reasoning stays on (upstream default) until the user turns this on. The
+  // backend applies it at session creation for loopback endpoints only
+  // (tui_gateway `_startup_reasoning_config`).
+  const localReasoningOff = isTruthyFlag(getNested(config ?? {}, 'agent.default_reasoning_off_for_local'))
+
   // Persist a single agent.* default by round-tripping the whole config record
   // (PUT /api/config replaces it) — optimistic, with rollback on failure.
   const writeAgentDefault = useCallback(
-    async (key: string, value: string) => {
+    async (key: string, value: boolean | string) => {
       if (!config) {
         return
       }
@@ -855,6 +866,18 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   </SelectContent>
                 </Select>
               </div>
+            )}
+            {reasoningSupported && (
+              <label className="flex items-center gap-2 text-xs">
+                {m.localReasoningOff}
+                <Switch
+                  checked={localReasoningOff}
+                  onCheckedChange={checked =>
+                    void writeAgentDefault('agent.default_reasoning_off_for_local', checked)
+                  }
+                  size="xs"
+                />
+              </label>
             )}
             {fastSupported && (
               <label className="flex items-center gap-2 text-xs">

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -806,6 +806,7 @@ export const en: Translations = {
       defaultsLabel: 'Defaults',
       reasoning: 'Reasoning',
       reasoningOff: 'Off',
+      localReasoningOff: 'Reasoning off for local models',
       defaultsFailed: 'Failed to save model defaults',
       auxiliaryTitle: 'Auxiliary models',
       resetAllToMain: 'Reset all to main',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -695,6 +695,7 @@ export interface Translations {
       defaultsLabel: string
       reasoning: string
       reasoningOff: string
+      localReasoningOff: string
       defaultsFailed: string
       auxiliaryTitle: string
       resetAllToMain: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1010,6 +1010,7 @@ export const zh: Translations = {
       defaultsLabel: '默认值',
       reasoning: '推理',
       reasoningOff: '关闭',
+      localReasoningOff: '本地模型关闭推理',
       defaultsFailed: '保存模型默认值失败',
       auxiliaryTitle: '辅助模型',
       resetAllToMain: '全部重置为主模型',

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3346,6 +3346,77 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     assert captured["platform"] == "tui"
 
 
+def _make_agent_env(monkeypatch, base_url, cfg):
+    """Minimal _make_agent harness capturing the AIAgent kwargs, with the
+    runtime provider pinned to ``base_url`` and config to ``cfg``."""
+    captured = {}
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=kwargs.get("model"))
+
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": "custom",
+            "base_url": base_url,
+            "api_key": "token",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    return captured
+
+
+def test_make_agent_local_reasoning_off_opt_in(monkeypatch):
+    # Preference on + loopback endpoint → a brand-new local session starts with
+    # Thinking off (the opt-in the desktop toggle turns on).
+    captured = _make_agent_env(
+        monkeypatch,
+        "http://127.0.0.1:11434/v1",
+        {
+            "model": {"default": "llama3", "provider": "custom"},
+            "agent": {"default_reasoning_off_for_local": True},
+        },
+    )
+    server._make_agent("sid", "session-key")
+    assert captured["reasoning_config"] == {"enabled": False}
+
+
+def test_make_agent_local_reasoning_off_defaults_to_upstream(monkeypatch):
+    # Preference OFF (the default) → upstream behavior preserved: an empty
+    # reasoning_effort resolves to the provider default (reasoning stays on),
+    # so _make_agent hands AIAgent ``reasoning_config=None``.
+    captured = _make_agent_env(
+        monkeypatch,
+        "http://127.0.0.1:11434/v1",
+        {"model": {"default": "llama3", "provider": "custom"}},
+    )
+    server._make_agent("sid", "session-key")
+    assert captured["reasoning_config"] is None
+
+
+def test_make_agent_local_reasoning_off_skips_remote_models(monkeypatch):
+    # Preference on but a REMOTE endpoint → unchanged; the opt-in is local-only.
+    captured = _make_agent_env(
+        monkeypatch,
+        "https://openrouter.ai/api/v1",
+        {
+            "model": {"default": "gpt-5.5", "provider": "openrouter"},
+            "agent": {"default_reasoning_off_for_local": True},
+        },
+    )
+    server._make_agent("sid", "session-key")
+    assert captured["reasoning_config"] is None
+
+
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     chain = [
         {"provider": "openrouter", "model": "openai/gpt-5.5"},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -30,7 +30,7 @@ from hermes_constants import (
     set_hermes_home_override,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import is_truthy_value
+from utils import base_url_hostname, is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
@@ -3607,6 +3607,46 @@ def _load_reasoning_config(model: str = "") -> dict | None:
     return resolve_reasoning_config(_load_cfg(), model)
 
 
+# Loopback hosts that mark a runtime as a locally-run model server — Ollama,
+# llama.cpp, vLLM, LM Studio and other localhost OpenAI-compatible endpoints.
+_LOCAL_MODEL_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def _default_reasoning_off_for_local() -> bool:
+    """Opt-in preference (default False): start NEW local-model sessions with
+    Thinking off.
+
+    Off by default, so upstream's reasoning-on default is unchanged — an empty
+    ``agent.reasoning_effort`` still resolves to the provider default (Medium)
+    for every model — unless the user turns this on in Settings → Model.
+    """
+    return is_truthy_value(
+        (_load_cfg().get("agent") or {}).get("default_reasoning_off_for_local", False)
+    )
+
+
+def _runtime_is_local_model(runtime: dict | None) -> bool:
+    """True when the resolved runtime points at a loopback model endpoint."""
+    if not isinstance(runtime, dict):
+        return False
+    return base_url_hostname(str(runtime.get("base_url") or "")) in (
+        _LOCAL_MODEL_LOOPBACK_HOSTS
+    )
+
+
+def _startup_reasoning_config(runtime: dict | None, model: str = "") -> dict | None:
+    """Reasoning config for a brand-new session that carries no explicit
+    per-session pick.
+
+    Honors the opt-in ``default_reasoning_off_for_local`` preference for local
+    models; otherwise returns the global default (upstream behavior — thinking
+    stays on unless the user configured an explicit effort/``none``).
+    """
+    if _default_reasoning_off_for_local() and _runtime_is_local_model(runtime):
+        return {"enabled": False}
+    return _load_reasoning_config(model)
+
+
 def _load_service_tier() -> str | None:
     raw = (
         str((_load_cfg().get("agent") or {}).get("service_tier", "") or "")
@@ -5994,7 +6034,7 @@ def _make_agent(
         reasoning_config=(
             reasoning_config_override
             if reasoning_config_override is not None
-            else _load_reasoning_config(str(model or ""))
+            else _startup_reasoning_config(runtime, str(model or ""))
         ),
         service_tier=(
             service_tier_override


### PR DESCRIPTION
## Summary

Reworked to be **opt-in** — this no longer changes the default. Upstream keeps reasoning **on** by default (empty effort = provider default = Medium), and that is untouched here.

A new persisted preference, `agent.default_reasoning_off_for_local` (default **false**), lets local-model users who want quiet chats turn thinking off for **new local sessions**:

- **Off (default):** behavior is exactly upstream's today — reasoning stays on for every model.
- **On:** a NEW local-model session starts with reasoning effort `none`.

## What changed

- `tui_gateway/server.py`: `_startup_reasoning_config()` applies the preference at session creation, gated to **loopback endpoints only** (Ollama / llama.cpp / vLLM / LM Studio) and **only when there is no explicit per-session reasoning override**. `_make_agent` calls it in place of the bare `_load_reasoning_config()` fallback. `_load_reasoning_config` and the global default are left as-is, so the upstream default is preserved.
- `apps/desktop`: a "Reasoning off for local models" toggle in **Settings → Model**, grouped with the existing reasoning/fast defaults and persisted through the shared config record.

The prior sticky-pick fix (`enabled is False` -> `"none"` in `session.info`) is dropped — it is already present on `main` in `tui_gateway/server.py` `_session_info`.

## Verification

- `npm --prefix apps/desktop run typecheck` — passes.
- `python3 -m py_compile tui_gateway/server.py` — passes.
- `python3 -m pytest tests/test_tui_gateway_server.py -k "reasoning or make_agent"` and `tests/tui_gateway/test_reasoning_session_scope.py` — pass, including three new `_make_agent` opt-in tests (on for local, off by default, skipped for remote endpoints) and a desktop toggle test.
