### PR TITLE
Add the Hepburn Theme for Hermes Desktop.

### DIFF
--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, hepburnTheme, nousTheme } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,29 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+})
+
+describe('desktop theme presets', () => {
+  it('ports Hepburn colors from the Hermes WebUI skin', () => {
+    expect(BUILTIN_THEMES.hepburn).toBe(hepburnTheme)
+    expect(hepburnTheme.description).toContain('Hermes WebUI')
+
+    expect(hepburnTheme.colors).toMatchObject({
+      background: '#fff3f7',
+      foreground: '#3d1a28',
+      primary: '#d44a7a',
+      sidebarBackground: '#fbe4ed'
+    })
+
+    expect(hepburnTheme.darkColors).toMatchObject({
+      background: '#110a0f',
+      foreground: '#f2e4ee',
+      card: '#241420',
+      primary: '#f278ad',
+      sidebarBackground: '#1e0f19'
+    })
+
+    expect(hepburnTheme.typography).toEqual(nousTheme.typography)
   })
 })

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -278,13 +278,80 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+/** Magenta rose palette ported from hermes-webui-nesquena's Hepburn skin. */
+export const hepburnTheme: DesktopTheme = {
+  name: 'hepburn',
+  label: 'Hepburn',
+  description: 'Magenta rose from the Hermes WebUI Hepburn skin',
+  colors: {
+    background: '#fff3f7',
+    foreground: '#3d1a28',
+    card: '#fff9fb',
+    cardForeground: '#3d1a28',
+    muted: '#fbe6ef',
+    mutedForeground: '#906270',
+    popover: '#fff9fb',
+    popoverForeground: '#3d1a28',
+    primary: '#d44a7a',
+    primaryForeground: '#ffffff',
+    secondary: 'rgba(242,120,173,0.10)',
+    secondaryForeground: '#3d1a28',
+    accent: 'rgba(242,120,173,0.10)',
+    accentForeground: '#3d1a28',
+    border: '#ecc8d5',
+    input: 'rgba(242,120,173,0.06)',
+    ring: '#d44a7a',
+    midground: '#d44a7a',
+    composerRing: '#d44a7a',
+    destructive: '#c0392b',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#fbe4ed',
+    sidebarBorder: '#ecc8d5',
+    userBubble: '#fbe4ed',
+    userBubbleBorder: '#ecc8d5'
+  },
+  darkColors: {
+    background: '#110a0f',
+    foreground: '#f2e4ee',
+    card: '#241420',
+    cardForeground: '#f2e4ee',
+    muted: '#1e0f19',
+    mutedForeground: '#c8a4b8',
+    popover: '#241420',
+    popoverForeground: '#f2e4ee',
+    primary: '#f278ad',
+    primaryForeground: '#110a0f',
+    secondary: 'rgba(242,120,173,0.14)',
+    secondaryForeground: '#f2e4ee',
+    accent: 'rgba(242,120,173,0.14)',
+    accentForeground: '#f2e4ee',
+    border: '#311a28',
+    input: 'rgba(242,120,173,0.08)',
+    ring: '#f278ad',
+    midground: '#f278ad',
+    composerRing: '#f278ad',
+    destructive: '#ff5c5c',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#1e0f19',
+    sidebarBorder: '#311a28',
+    userBubble: '#241420',
+    userBubbleBorder: '#311a28'
+  },
+  typography: {
+    fontSans: SYSTEM_SANS,
+    fontMono: `"Courier Prime", ${SYSTEM_MONO}`,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
-  slate: slateTheme
+  slate: slateTheme,
+  hepburn: hepburnTheme
 }
 
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)


### PR DESCRIPTION
## What does this PR do?

Adds the Hermes desktop Hepburn theme preset. The preset includes the WebUI light and dark rose palettes, registers the skin in the desktop theme list, and keeps Hepburn typography aligned with Nous by using Courier Prime for mono/code text.

## Type of Change

- [x] Bug fix / visual parity fix
- [x] Tests

## Changes Made

- Added `hepburnTheme` to `apps/desktop/src/themes/presets.ts`.
- Ported the WebUI Hepburn light and dark color tokens into the desktop theme model.
- Set Hepburn typography to match Nous: system sans plus Courier Prime mono.
- Added `apps/desktop/src/themes/presets.test.ts` to lock the WebUI color values and typography mapping.

## How to Test

1. Switch desktop appearance to the Hepburn theme in dark mode.
2. Confirm the dark palette uses the WebUI black-rose surfaces (`#110a0f`, `#1e0f19`, `#241420`) and rose accent (`#f278ad`).
3. Confirm mono/code text uses Courier Prime like the Nous theme.

## Validation

Passed:

- `npm run test:ui -- src/themes/presets.test.ts`
- `npm run type-check`
- `npx eslint src/themes/presets.ts src/themes/presets.test.ts`
- `npm run build`
- `git diff --check -- apps/desktop/src/themes/presets.ts apps/desktop/src/themes/presets.test.ts`

Local broader checks run for merge-readiness:

- `npm run lint` currently fails on existing unrelated desktop/electron lint violations outside this PR scope.
- `npm run test:ui` currently fails because local build/release native-deps node-pty test files are collected, plus existing failures in `src/components/pane-shell/pane-shell.test.tsx` and `src/app/settings/model-settings.test.tsx`. The new Hepburn preset test passes when run directly.

GitHub Actions in this repository currently run Python tests and Python lint/footgun checks for PRs; no workflow match was found that directly invokes desktop `npm run lint`, `npm run test:ui`, or `npm run build`.

## Checklist

- [x] PR contains only the Hepburn desktop theme files.
- [x] Added focused test coverage for the theme preset.
- [x] Tested on macOS local checkout.
- [x] Documentation/config/schema updates are N/A.