### PR TITLE
feat: add channel-scoped gateway worker routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -128,6 +128,61 @@ def _reply_anchor_for_event(event) -> str | None:
     return getattr(event, "message_id", None)
 
 
+def _gateway_response_splitter_config(config: dict, platform: str, chat_id: str) -> dict:
+    """Return response_splitters[platform][chat_id] with gateway.<key> fallback."""
+    if not isinstance(config, dict):
+        return {}
+    platform = _platform_name(platform)
+    chat_id = str(chat_id or "")
+    candidates = [config.get("response_splitters")]
+    gateway_cfg = config.get("gateway")
+    if isinstance(gateway_cfg, dict):
+        candidates.append(gateway_cfg.get("response_splitters"))
+    for root in candidates:
+        if not isinstance(root, dict):
+            continue
+        platform_map = root.get(platform)
+        if not isinstance(platform_map, dict):
+            continue
+        value = platform_map.get(chat_id)
+        if isinstance(value, dict):
+            return dict(value)
+    return {}
+
+
+def split_gateway_response_text(
+    text: str,
+    *,
+    platform: str,
+    chat_id: str,
+    config: dict,
+) -> list[str]:
+    """Split a final gateway response according to per-channel config."""
+    if not text:
+        return []
+    splitter = _gateway_response_splitter_config(config, platform, chat_id)
+    marker_regex = splitter.get("marker_regex") if isinstance(splitter, dict) else None
+    if not marker_regex:
+        return [text]
+    try:
+        match = re.search(str(marker_regex), text)
+    except re.error:
+        logger.warning("Invalid gateway response splitter regex for %s/%s", platform, chat_id)
+        return [text]
+    if not match:
+        return [text]
+
+    keep_marker = bool(splitter.get("keep_marker_with_head", True))
+    strip_marker = bool(splitter.get("strip_marker_from_tail", True))
+    head = text[:match.start()].rstrip()
+    marker = match.group(0).strip()
+    tail_start = match.end() if strip_marker else match.start()
+    tail = text[tail_start:].strip()
+    if keep_marker and marker:
+        head = (head + "\n\n" + marker).strip() if head else marker
+    return [part for part in (head, tail) if part]
+
+
 def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bool:
     """Return True when a media file should use the platform's audio sender.
 
@@ -5323,13 +5378,33 @@ class BasePlatformAdapter(ABC):
                         except Exception:
                             logger.debug("delivery ledger record failed", exc_info=True)
                             _obligation_id = None
-                    result = await delivery_adapter._send_with_retry(
-                        chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
+
+                    try:
+                        from hermes_cli.config import load_config as _load_config
+                        _splitter_config = _load_config()
+                    except Exception:
+                        _splitter_config = {}
+
+                    text_parts = split_gateway_response_text(
+                        text_content,
+                        platform=_platform_name(self.platform),
+                        chat_id=str(event.source.chat_id or ""),
+                        config=_splitter_config,
                     )
-                    _record_delivery(result)
+
+                    result = None
+                    _send_failed = False
+                    for _text_part in text_parts:
+                        result = await delivery_adapter._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=_text_part,
+                            reply_to=_reply_anchor,
+                            metadata=_final_thread_metadata,
+                        )
+                        _record_delivery(result)
+                        if not getattr(result, "success", False):
+                            _send_failed = True
+
                     if _obligation_id is not None:
                         try:
                             from gateway.delivery_ledger import (
@@ -5337,12 +5412,12 @@ class BasePlatformAdapter(ABC):
                                 mark_failed,
                             )
 
-                            if getattr(result, "success", False):
+                            if not _send_failed and getattr(result, "success", False):
                                 mark_delivered(_obligation_id)
                             else:
                                 mark_failed(
                                     _obligation_id,
-                                    str(getattr(result, "error", "") or ""),
+                                    str(getattr(result, "error", "") or "split send failed"),
                                 )
                         except Exception:
                             logger.debug(
@@ -5354,6 +5429,7 @@ class BasePlatformAdapter(ABC):
                     if (
                         _ephemeral_ttl
                         and _ephemeral_ttl > 0
+                        and result is not None
                         and result.success
                         and result.message_id
                     ):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2832,6 +2832,84 @@ def _load_gateway_runtime_config() -> dict:
     return expanded if isinstance(expanded, dict) else {}
 
 
+def _nested_channel_config(config: dict, key: str, platform: str, chat_id: str) -> dict:
+    """Return config[key][platform][chat_id] with gateway.<key> fallback."""
+    if not isinstance(config, dict):
+        return {}
+    platform = str(platform or "").lower()
+    chat_id = str(chat_id or "")
+    candidates = [config.get(key)]
+    gateway_cfg = config.get("gateway")
+    if isinstance(gateway_cfg, dict):
+        candidates.append(gateway_cfg.get(key))
+    for root in candidates:
+        if not isinstance(root, dict):
+            continue
+        platform_map = root.get(platform) or root.get(str(platform))
+        if not isinstance(platform_map, dict):
+            continue
+        value = platform_map.get(chat_id)
+        if isinstance(value, dict):
+            return dict(value)
+        if value is not None:
+            return {"mode": value}
+    return {}
+
+
+def _channel_worker_options(config: dict, platform: str, chat_id: str) -> dict:
+    """Resolve per-channel gateway worker/session options.
+
+    Preferred shape:
+      channel_routes:
+        discord:
+          "123":
+            mode: fresh_per_message
+            enabled_toolsets: [web, file]
+            skip_memory: true
+            skip_context_files: true
+
+    Legacy compatibility:
+      channel_session_modes:
+        discord:
+          "123": fresh_per_message
+      channel_agent_options:
+        discord:
+          "123": {enabled_toolsets: [...], skip_memory: true, ...}
+    """
+    route = _nested_channel_config(config, "channel_routes", platform, chat_id)
+    legacy_agent = _nested_channel_config(config, "channel_agent_options", platform, chat_id)
+    legacy_session = _nested_channel_config(config, "channel_session_modes", platform, chat_id)
+
+    merged: dict = {}
+    if legacy_session:
+        merged.update(legacy_session)
+    if legacy_agent:
+        merged.update(legacy_agent)
+    if route:
+        merged.update(route)
+    if not merged:
+        return {}
+
+    mode = str(merged.get("mode") or merged.get("session_mode") or "").strip().lower()
+    if not mode and str(merged.get("fresh_per_message", "")).strip().lower() in {"1", "true", "yes", "on"}:
+        mode = "fresh_per_message"
+    merged["fresh_per_message"] = mode == "fresh_per_message"
+
+    toolsets = merged.get("enabled_toolsets")
+    if isinstance(toolsets, str):
+        toolsets = [t.strip() for t in toolsets.split(",") if t.strip()]
+    elif isinstance(toolsets, (list, tuple, set)):
+        toolsets = [str(t).strip() for t in toolsets if str(t).strip()]
+    else:
+        toolsets = None
+    if toolsets is not None:
+        merged["enabled_toolsets"] = sorted(toolsets)
+
+    merged["skip_context_files"] = bool(merged.get("skip_context_files", False))
+    merged["skip_memory"] = bool(merged.get("skip_memory", False))
+    return merged
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -12641,6 +12719,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    async def _resolve_channel_routed_session_entry(self, event, source, platform_name: str):
+        """Create the session entry for a message, applying channel routes.
+
+        Kept as a focused async helper so the gateway runtime path can be tested
+        without driving a full LLM turn. All SessionStore access stays behind
+        ``async_session_store``; calling the synchronous store from this inbound
+        path can block Discord heartbeats when SQLite is slow.
+        """
+        _force_new_session = False
+        try:
+            _channel_cfg = _load_gateway_config()
+            _worker_options = _channel_worker_options(
+                _channel_cfg,
+                platform_name,
+                str(source.chat_id or ""),
+            )
+            _force_new_session = bool(_worker_options.get("fresh_per_message"))
+        except Exception:
+            logger.debug("Failed to resolve channel worker options", exc_info=True)
+            _force_new_session = False
+
+        if _force_new_session:
+            logger.info(
+                "Starting fresh per-message session for %s",
+                self._session_key_for_source(source),
+            )
+
+        session_entry = await self.async_session_store.get_or_create_session(
+            source,
+            force_new=_force_new_session,
+        )
+        session_key = session_entry.session_key
+        pinned_session_id = str(
+            (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
+        ).strip()
+        if pinned_session_id:
+            resolved_entry = await self._resolve_async_delegation_session(
+                session_entry,
+                pinned_session_id,
+            )
+            if resolved_entry is None:
+                return None, session_key, _force_new_session
+            session_entry = resolved_entry
+        if _force_new_session:
+            # The session key is intentionally stable for the channel/user, but
+            # the session_id is new. Evict any cached AIAgent tied to the old
+            # session so the system prompt/tools rebuild with the lightweight
+            # channel options below.
+            self._evict_cached_agent(session_key)
+        return session_entry, session_key, _force_new_session
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -12670,19 +12799,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
-        session_key = session_entry.session_key
-        pinned_session_id = str(
-            (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
-        ).strip()
-        if pinned_session_id:
-            resolved_entry = await self._resolve_async_delegation_session(
-                session_entry,
-                pinned_session_id,
-            )
-            if resolved_entry is None:
-                return
-            session_entry = resolved_entry
+        session_entry, session_key, _force_new_session = await self._resolve_channel_routed_session_entry(
+            event,
+            source,
+            _platform_name,
+        )
+        if session_entry is None:
+            return
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:
@@ -19949,6 +20072,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 
+        # Per-channel worker options let narrow gateway channels run as compact
+        # agents. This intentionally happens after platform toolset lookup so
+        # the channel can override a broad platform default with a small set such
+        # as web/browser/file/code_execution.
+        channel_skip_context_files = False
+        channel_skip_memory = False
+        channel_worker_options = {}
+        try:
+            channel_worker_options = _channel_worker_options(
+                user_config,
+                platform_key,
+                str(source.chat_id or ""),
+            )
+            _configured_toolsets = channel_worker_options.get("enabled_toolsets")
+            if isinstance(_configured_toolsets, list):
+                enabled_toolsets = _configured_toolsets
+            channel_skip_context_files = bool(channel_worker_options.get("skip_context_files", False))
+            channel_skip_memory = bool(channel_worker_options.get("skip_memory", False))
+            if channel_worker_options:
+                logger.info(
+                    "Applying channel worker options: platform=%s chat=%s fresh_per_message=%s skip_context_files=%s skip_memory=%s enabled_toolsets=%s",
+                    platform_key,
+                    source.chat_id or "",
+                    bool(channel_worker_options.get("fresh_per_message")),
+                    channel_skip_context_files,
+                    channel_skip_memory,
+                    enabled_toolsets,
+                )
+        except Exception:
+            logger.debug("Failed to resolve channel worker options", exc_info=True)
+
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
             display_config = {}
@@ -21161,7 +21315,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys={
+                    **self._extract_cache_busting_config(user_config),
+                    "channel.skip_context_files": channel_skip_context_files,
+                    "channel.skip_memory": channel_skip_memory,
+                },
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
@@ -21375,6 +21533,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
+                    skip_context_files=channel_skip_context_files,
+                    skip_memory=channel_skip_memory,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
                     reasoning_config=reasoning_config,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -935,6 +935,14 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    # Optional gateway channel-lane routing. A channel route can turn a busy
+    # event/workflow channel into a compact worker lane with fresh sessions,
+    # narrow tools, and disabled heavyweight context/memory.
+    "channel_routes": {},
+    # Backward-compatible split config for final gateway replies. Used by
+    # workflow channels that need analysis and copy-ready drafts delivered as
+    # separate platform messages.
+    "response_splitters": {},
     "toolsets": ["hermes-cli"],
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.

--- a/tests/gateway/test_channel_worker_routing.py
+++ b/tests/gateway/test_channel_worker_routing.py
@@ -1,0 +1,187 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SessionSource, split_gateway_response_text
+from gateway.run import GatewayRunner, _channel_worker_options
+
+
+def test_channel_routes_resolve_fresh_worker_options():
+    cfg = {
+        "channel_routes": {
+            "discord": {
+                "123": {
+                    "mode": "fresh_per_message",
+                    "enabled_toolsets": ["file", "web", "browser"],
+                    "skip_memory": True,
+                    "skip_context_files": True,
+                }
+            }
+        }
+    }
+
+    opts = _channel_worker_options(cfg, "discord", "123")
+
+    assert opts["fresh_per_message"] is True
+    assert opts["enabled_toolsets"] == ["browser", "file", "web"]
+    assert opts["skip_memory"] is True
+    assert opts["skip_context_files"] is True
+
+
+def test_channel_routes_override_legacy_channel_options():
+    cfg = {
+        "channel_session_modes": {"discord": {"123": "fresh_per_message"}},
+        "channel_agent_options": {
+            "discord": {
+                "123": {
+                    "enabled_toolsets": ["terminal"],
+                    "skip_memory": False,
+                    "skip_context_files": False,
+                }
+            }
+        },
+        "channel_routes": {
+            "discord": {
+                "123": {
+                    "mode": "default",
+                    "enabled_toolsets": "web,file",
+                    "skip_memory": True,
+                }
+            }
+        },
+    }
+
+    opts = _channel_worker_options(cfg, "discord", "123")
+
+    assert opts["fresh_per_message"] is False
+    assert opts["enabled_toolsets"] == ["file", "web"]
+    assert opts["skip_memory"] is True
+    assert opts["skip_context_files"] is False
+
+
+def test_gateway_nested_channel_routes_are_supported():
+    cfg = {
+        "gateway": {
+            "channel_routes": {
+                "discord": {
+                    "123": {"fresh_per_message": True, "enabled_toolsets": ["web"]}
+                }
+            }
+        }
+    }
+
+    opts = _channel_worker_options(cfg, "discord", "123")
+
+    assert opts["fresh_per_message"] is True
+    assert opts["enabled_toolsets"] == ["web"]
+
+
+def test_unmatched_channel_routes_fall_back_to_default_options():
+    cfg = {
+        "channel_routes": {
+            "discord": {
+                "123": {
+                    "mode": "fresh_per_message",
+                    "enabled_toolsets": ["web"],
+                    "skip_memory": True,
+                    "skip_context_files": True,
+                }
+            }
+        }
+    }
+
+    assert _channel_worker_options(cfg, "discord", "999") == {}
+
+
+def test_response_splitter_sends_tail_as_copy_ready_message():
+    cfg = {
+        "response_splitters": {
+            "discord": {
+                "123": {
+                    "marker_regex": r"(?im)^\s*(Comment draft:|Draft reply:)\s*$",
+                    "keep_marker_with_head": True,
+                    "strip_marker_from_tail": True,
+                }
+            }
+        }
+    }
+    text = "Analysis paragraph.\n\nComment draft:\n\nCopy this comment only."
+
+    parts = split_gateway_response_text(text, platform="discord", chat_id="123", config=cfg)
+
+    assert parts == ["Analysis paragraph.\n\nComment draft:", "Copy this comment only."]
+
+
+def test_response_splitter_leaves_unconfigured_channels_unchanged():
+    cfg = {
+        "response_splitters": {
+            "discord": {
+                "123": {"marker_regex": r"(?im)^Comment draft:$"}
+            }
+        }
+    }
+    text = "Analysis\n\nComment draft:\n\nCopy"
+
+    assert split_gateway_response_text(text, platform="discord", chat_id="999", config=cfg) == [text]
+
+
+class _FakeAsyncSessionStore:
+    def __init__(self, entry):
+        self._store = object()
+        self.entry = entry
+        self.calls = []
+
+    async def get_or_create_session(self, source, *, force_new=False):
+        self.calls.append((source, force_new))
+        return self.entry
+
+
+@pytest.mark.asyncio
+async def test_channel_route_runtime_uses_async_store_force_new_and_evicts(monkeypatch):
+    from gateway import run as gateway_run
+
+    entry = SimpleNamespace(session_key="discord:channel:123:user:u1", session_id="sess-new")
+    store = _FakeAsyncSessionStore(entry)
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store._store
+    runner._async_session_store = store
+    evicted = []
+    runner._evict_cached_agent = evicted.append
+    runner._session_key_for_source = lambda source: entry.session_key
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="channel",
+        user_id="u1",
+    )
+    event = SimpleNamespace(metadata={})
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "channel_routes": {
+                "discord": {
+                    "123": {
+                        "mode": "fresh_per_message",
+                        "enabled_toolsets": ["web"],
+                        "skip_context_files": True,
+                        "skip_memory": True,
+                    }
+                }
+            }
+        },
+    )
+
+    resolved, session_key, force_new = await runner._resolve_channel_routed_session_entry(
+        event,
+        source,
+        "discord",
+    )
+
+    assert resolved is entry
+    assert session_key == entry.session_key
+    assert force_new is True
+    assert store.calls == [(source, True)]
+    assert evicted == [entry.session_key]


### PR DESCRIPTION
## Summary
- add config-driven channel worker routing for gateway messages
- support fresh per-message sessions, scoped toolsets, and memory/context-file skipping per channel
- add generic response splitters so copy-ready drafts can be sent as separate gateway messages
- retain backward compatibility with legacy channel session/agent option config

## Test Plan
- `python -m pytest tests/gateway/test_channel_worker_routing.py tests/gateway/test_platform_base.py -q -o 'addopts='`
