### PR TITLE
feat(tools): make Mixture-of-Agents configurable via config.yaml

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1165,3 +1165,46 @@ display:
 #   # default — works on Fly.io out of the box).
 #   #
 #   #   public_url: "https://example.com/hermes"
+
+# =============================================================================
+# Mixture-of-Agents (mixture_of_agents tool)
+# =============================================================================
+# Overrides the models and sampling used by the `mixture_of_agents` tool
+# (tools/mixture_of_agents_tool.py). Every key is OPTIONAL and an empty/None
+# value falls back to the module's hardcoded default, so leaving this section
+# out (or empty) preserves the current behavior exactly.
+#
+# Precedence at call time: tool call-arg > this config > module constant.
+#
+# moa:
+#   # Layer-1 reference models queried in parallel. [] = module defaults.
+#   reference_models:
+#     - "anthropic/claude-opus-4.6"
+#     - "openai/gpt-5.4-pro"
+#     - "google/gemini-3-pro-preview"
+#
+#   # Layer-2 model that synthesizes the final answer. "" = module default.
+#   aggregator_model: "anthropic/claude-opus-4.6"
+#
+#   # Sampling temperatures. null = module defaults (0.6 / 0.4).
+#   reference_temperature: 0.6
+#   aggregator_temperature: 0.4
+#
+#   # Minimum reference models that must succeed before aggregating.
+#   # null = module default.
+#   min_successful_references: 2
+#
+#   # OpenRouter reasoning effort for both layers. The value is normalized:
+#   # whitespace-trimmed and lowercased before it is sent (so "XHIGH" == "xhigh").
+#   # "" or "none" (any case) DISABLES reasoning — the reasoning block is omitted
+#   # entirely, which is required for LiteLLM bridges and local OpenAI-compatible
+#   # models that reject extra_body.reasoning.
+#   reasoning_effort: "xhigh"
+#
+#   # Route the tool's calls at a custom OpenAI-compatible endpoint instead of
+#   # OpenRouter — e.g. a LiteLLM proxy, vLLM, or a local server. Leave empty
+#   # for the default OpenRouter path. When base_url is set, api_key is used
+#   # directly (and OPENROUTER_API_KEY is no longer required); local servers
+#   # that need no auth can leave api_key empty.
+#   #   base_url: "http://localhost:4000/v1"   # e.g. a LiteLLM proxy
+#   #   api_key:  "sk-litellm-..."             # paired with base_url

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1692,6 +1692,24 @@ DEFAULT_CONFIG = {
         "subagent_auto_approve": False,
     },
 
+    # Mixture-of-Agents (tools/mixture_of_agents_tool.py) — override the models
+    # and sampling used by the `mixture_of_agents` tool. Every key is optional;
+    # an empty/None value falls back to the module's hardcoded default, so an
+    # absent or empty `moa:` section preserves the current behavior exactly.
+    # Precedence at call time: tool call-arg > this config > module constant.
+    "moa": {
+        "reference_models": [],            # [] = module defaults (REFERENCE_MODELS)
+        "aggregator_model": "",            # "" = module default (AGGREGATOR_MODEL)
+        "reference_temperature": None,     # None = module default (REFERENCE_TEMPERATURE)
+        "aggregator_temperature": None,    # None = module default (AGGREGATOR_TEMPERATURE)
+        "min_successful_references": None, # None = module default (MIN_SUCCESSFUL_REFERENCES)
+        "reasoning_effort": "xhigh",       # "" / "none" => omit the extra_body reasoning block
+                                           # (lets LiteLLM / local models that don't support it work)
+        "base_url": "",                    # "" = default OpenRouter path; set to route the tool's
+                                           # calls at an OpenAI-compatible endpoint (LiteLLM, vLLM, etc.)
+        "api_key": "",                     # "" = default OPENROUTER_API_KEY; paired with base_url
+    },
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
@@ -3937,7 +3955,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming",
+    "sessions", "streaming", "moa",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -83,3 +83,291 @@ async def test_moa_top_level_error_logs_single_traceback_on_aggregator_failure(m
     assert "Error in MoA processing" in result["error"]
     err.assert_called_once()
     assert err.call_args.kwargs.get("exc_info") is True
+
+
+# ── Configurability (issue #38952) ─────────────────────────────────────────
+
+
+def _set_moa_config(monkeypatch, section):
+    """Point _get_moa_config() at a fixed ``moa:`` section for one test.
+
+    _get_moa_config() reads live through load_config() (no local cache layer),
+    so patching load_config is immediately reflected — no cache to clear.
+    """
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": section})
+
+
+def test_get_moa_config_reads_moa_section(monkeypatch):
+    # The resolver pulls the moa: section from the standard loader, not a
+    # bespoke reader — patching load_config must be reflected in _get_moa_config.
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {"aggregator_model": "vendor/agg"}})
+    assert moa._get_moa_config() == {"aggregator_model": "vendor/agg"}
+
+
+def test_get_moa_config_empty_on_loader_failure(monkeypatch):
+    # A config load failure must not break MoA — it falls back to module defaults.
+    def _boom():
+        raise RuntimeError("no config")
+
+    monkeypatch.setattr(moa, "load_config", _boom)
+    assert moa._get_moa_config() == {}
+
+
+def test_get_moa_config_reflects_config_change_between_calls(monkeypatch):
+    # Regression for the dropped @lru_cache(maxsize=1) staleness bug: a
+    # long-lived process that serves sessions with different config (e.g. a new
+    # HERMES_HOME) must see the SECOND config, not the first one pinned forever.
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {"aggregator_model": "first/agg"}})
+    assert moa._get_moa_config() == {"aggregator_model": "first/agg"}
+
+    # Swap the underlying config (simulates a HERMES_HOME / profile switch) and
+    # confirm the next read reflects it — no stale process-lifetime cache.
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {"aggregator_model": "second/agg"}})
+    assert moa._get_moa_config() == {"aggregator_model": "second/agg"}
+
+
+def test_resolve_precedence_call_arg_over_config_over_default(monkeypatch):
+    _set_moa_config(monkeypatch, {"aggregator_model": "cfg/model"})
+    # call-arg beats config
+    assert moa._resolve("arg/model", "aggregator_model", "default/model") == "arg/model"
+    # config beats default when no call-arg
+    assert moa._resolve(None, "aggregator_model", "default/model") == "cfg/model"
+    # empty call-arg / empty config fall through to default
+    assert moa._resolve("", "missing_key", "default/model") == "default/model"
+    assert moa._resolve([], "missing_key", ["a"]) == ["a"]
+
+
+def test_reasoning_extra_body_guard_omits_when_disabled():
+    # Falsy or "none" => no extra_body block (LiteLLM / local models reject it).
+    assert moa._reasoning_extra_body("") == {}
+    assert moa._reasoning_extra_body("none") == {}
+    assert moa._reasoning_extra_body("NONE") == {}
+    assert moa._reasoning_extra_body(None) == {}
+    # A real effort produces the OpenRouter reasoning payload.
+    body = moa._reasoning_extra_body("xhigh")
+    assert body["extra_body"]["reasoning"]["effort"] == "xhigh"
+    assert body["extra_body"]["reasoning"]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_models_and_reasoning_reach_runners(monkeypatch):
+    # End-to-end: a moa: config with no call-args must drive the models,
+    # temperatures, and reasoning effort actually passed to the runners.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    _set_moa_config(
+        monkeypatch,
+        {
+            "reference_models": ["cfg/ref-a", "cfg/ref-b"],
+            "aggregator_model": "cfg/agg",
+            "reference_temperature": 0.9,
+            "aggregator_temperature": 0.2,
+            "reasoning_effort": "none",
+        },
+    )
+
+    ref_mock = AsyncMock(return_value=("cfg/ref-a", "ok", True))
+    agg_mock = AsyncMock(return_value="final answer")
+    monkeypatch.setattr(moa, "_run_reference_model_safe", ref_mock)
+    monkeypatch.setattr(moa, "_run_aggregator_model", agg_mock)
+    monkeypatch.setattr(
+        moa, "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result["success"] is True
+    assert result["models_used"]["reference_models"] == ["cfg/ref-a", "cfg/ref-b"]
+    assert result["models_used"]["aggregator_model"] == "cfg/agg"
+
+    # Both config reference models were dispatched with the configured temp
+    # and reasoning effort.
+    assert ref_mock.call_count == 2
+    ref_models_called = {c.args[0] for c in ref_mock.call_args_list}
+    assert ref_models_called == {"cfg/ref-a", "cfg/ref-b"}
+    first_ref = ref_mock.call_args_list[0]
+    assert first_ref.args[2] == 0.9  # reference_temperature
+    assert first_ref.kwargs["reasoning_effort"] == "none"
+
+    # Aggregator received the configured model, temperature, and effort.
+    assert agg_mock.call_args.kwargs["aggregator_model"] == "cfg/agg"
+    assert agg_mock.call_args.args[2] == 0.2  # aggregator_temperature
+    assert agg_mock.call_args.kwargs["reasoning_effort"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_call_arg_overrides_config(monkeypatch):
+    # An explicit call-arg must win over the moa: config (precedence top tier).
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    _set_moa_config(monkeypatch, {"aggregator_model": "cfg/agg"})
+
+    ref_mock = AsyncMock(return_value=("arg/ref", "ok", True))
+    agg_mock = AsyncMock(return_value="final")
+    monkeypatch.setattr(moa, "_run_reference_model_safe", ref_mock)
+    monkeypatch.setattr(moa, "_run_aggregator_model", agg_mock)
+    monkeypatch.setattr(
+        moa, "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(
+        await moa.mixture_of_agents_tool(
+            "q",
+            reference_models=["arg/ref"],
+            aggregator_model="arg/agg",
+        )
+    )
+
+    assert result["models_used"]["aggregator_model"] == "arg/agg"
+    assert agg_mock.call_args.kwargs["aggregator_model"] == "arg/agg"
+    assert ref_mock.call_count == 1
+    assert ref_mock.call_args.args[0] == "arg/ref"
+
+
+@pytest.mark.asyncio
+async def test_no_config_matches_legacy_defaults(monkeypatch):
+    # With an empty moa: section, the tool must behave exactly as before:
+    # module-constant models, default temperatures, default reasoning effort.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    _set_moa_config(monkeypatch, {})
+
+    ref_mock = AsyncMock(return_value=("x", "ok", True))
+    agg_mock = AsyncMock(return_value="final")
+    monkeypatch.setattr(moa, "_run_reference_model_safe", ref_mock)
+    monkeypatch.setattr(moa, "_run_aggregator_model", agg_mock)
+    monkeypatch.setattr(
+        moa, "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("q"))
+
+    assert result["models_used"]["reference_models"] == moa.REFERENCE_MODELS
+    assert result["models_used"]["aggregator_model"] == moa.AGGREGATOR_MODEL
+    assert ref_mock.call_count == len(moa.REFERENCE_MODELS)
+    # Default reference temperature + reasoning effort were used.
+    assert ref_mock.call_args_list[0].args[2] == moa.REFERENCE_TEMPERATURE
+    assert ref_mock.call_args_list[0].kwargs["reasoning_effort"] == "xhigh"
+    assert agg_mock.call_args.kwargs["aggregator_model"] == moa.AGGREGATOR_MODEL
+
+
+def test_registration_handler_forwards_model_overrides(monkeypatch):
+    # Regression guard for the registration lambda that previously stripped
+    # reference_models / aggregator_model: the handler must forward both so
+    # caller-supplied overrides reach mixture_of_agents_tool().
+    from tools.registry import registry
+
+    captured = {}
+
+    def _fake_tool(**kwargs):
+        captured.update(kwargs)
+        return "sentinel"
+
+    monkeypatch.setattr(moa, "mixture_of_agents_tool", _fake_tool)
+
+    handler = registry.get_entry("mixture_of_agents").handler
+    result = handler({
+        "user_prompt": "hi",
+        "reference_models": ["a/b"],
+        "aggregator_model": "c/d",
+    })
+
+    assert result == "sentinel"
+    assert captured["user_prompt"] == "hi"
+    assert captured["reference_models"] == ["a/b"]
+    assert captured["aggregator_model"] == "c/d"
+
+
+# ── Adversarial-review regressions ─────────────────────────────────────────
+
+
+def _empty_content_response():
+    """A chat-completions response that extract_content_or_reasoning sees as empty.
+
+    content=None with no reasoning/reasoning_content/reasoning_details fields →
+    extract_content_or_reasoning returns "". Mirrors a reasoning-only / blank
+    upstream response.
+    """
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None))]
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_content_on_last_attempt_returns_failure_not_blank_success(monkeypatch):
+    # Bug: when the FINAL attempt yielded empty content, the code fell through
+    # to `return model, content, True` — a "success" carrying "" that the
+    # aggregator would then ingest as a blank reference. The last attempt must
+    # instead fail explicitly. max_retries=1 makes the first attempt the last,
+    # so there is no retry/backoff sleep to wait on.
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=_empty_content_response())
+            )
+        )
+    )
+    # Patch accepts base_url=/api_key= kwargs (the runner always passes them).
+    monkeypatch.setattr(moa, "_get_openrouter_client", lambda *a, **k: fake_client)
+
+    model, message, success = await moa._run_reference_model_safe(
+        "vendor/reasoner", "hello", max_retries=1
+    )
+
+    assert model == "vendor/reasoner"
+    assert success is False           # NOT a blank success
+    assert message != ""              # carries a diagnostic, not empty content
+    assert "empty content" in message
+
+
+@pytest.mark.asyncio
+async def test_empty_content_retries_then_fails_across_attempts(monkeypatch):
+    # The non-last-attempt path must still `continue` (retry), and only the
+    # terminal attempt converts the empty content into a failure. Patch sleep so
+    # the backoff between attempts is instant.
+    create = AsyncMock(return_value=_empty_content_response())
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+    monkeypatch.setattr(moa, "_get_openrouter_client", lambda *a, **k: fake_client)
+
+    async def _no_sleep(_):
+        return None
+
+    monkeypatch.setattr(moa.asyncio, "sleep", _no_sleep)
+
+    model, message, success = await moa._run_reference_model_safe(
+        "vendor/reasoner", "hello", max_retries=3
+    )
+
+    assert success is False
+    assert create.await_count == 3    # all attempts were made (retried, not short-circuited)
+    assert "after 3 attempts" in message
+
+
+def test_check_moa_requirements_true_with_base_url_no_openrouter_key(monkeypatch):
+    # Headline use case: a local / LiteLLM deploy sets moa.base_url and has NO
+    # OPENROUTER_API_KEY. The tool must report itself available (gating it on the
+    # OpenRouter key made it silently disappear for exactly this deployment).
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {"base_url": "http://localhost:4000/v1"}})
+
+    assert moa.check_moa_requirements() is True
+
+
+def test_check_moa_requirements_false_with_no_key_and_no_base_url(monkeypatch):
+    # The negative: with neither an OpenRouter key nor a base_url, the default
+    # path has no usable auth and the tool must report itself unavailable.
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {}})
+
+    assert moa.check_moa_requirements() is False
+
+
+def test_check_moa_requirements_true_with_openrouter_key_and_no_base_url(monkeypatch):
+    # The default OpenRouter path stays intact: a key alone (no base_url) is
+    # still sufficient — the base_url branch is additive, not a replacement.
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(moa, "load_config", lambda: {"moa": {}})
+
+    assert moa.check_moa_requirements() is True

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -53,6 +53,7 @@ import datetime
 from typing import Dict, Any, List, Optional
 from tools.openrouter_client import get_async_client as _get_openrouter_client, check_api_key as check_openrouter_api_key
 from agent.auxiliary_client import extract_content_or_reasoning
+from hermes_cli.config import load_config
 from tools.debug_helpers import DebugSession
 import sys
 
@@ -87,6 +88,68 @@ Responses from models:"""
 _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
+def _get_moa_config() -> Dict[str, Any]:
+    """Return the ``moa:`` section of config.yaml.
+
+    Why: the MoA tool may be invoked across many sessions in one long-lived
+    gateway process; an extra process-lifetime ``@lru_cache`` here pinned the
+    FIRST config forever, so a later session with a different ``HERMES_HOME``
+    (or an edited config) silently got stale MoA settings. ``load_config()``
+    is itself cached on the config file's ``(path, mtime_ns, size)``, so it
+    already amortizes the deep-merge AND refreshes when the file or profile
+    changes — there is no work to save by wrapping it again, only a staleness
+    bug to introduce.
+    What: loads config via the project's standard ``load_config()`` and returns
+    its ``moa`` dict (empty dict if the section or loader is unavailable).
+    Test: monkeypatch ``load_config`` to return a known ``moa`` section and
+    assert the returned dict matches; swap ``load_config`` between two calls and
+    assert the second call reflects the new value (no stale cache); on loader
+    failure assert an empty dict is returned (no raise).
+    """
+    try:
+        return load_config().get("moa", {}) or {}
+    except Exception:
+        # Config is best-effort here — a load failure must not break MoA, it
+        # just falls back to the module-constant defaults.
+        return {}
+
+
+def _resolve(call_arg: Any, config_key: str, default: Any) -> Any:
+    """Resolve one MoA setting by precedence: call-arg > moa: config > default.
+
+    Why: every configurable MoA knob follows the same three-tier precedence;
+    centralizing it keeps the resolution consistent and the call site small.
+    What: returns *call_arg* when it is not None and not an empty list/string;
+    otherwise the ``moa:`` config value for *config_key* when that is non-empty;
+    otherwise *default* (the module constant).
+    Test: assert call-arg wins over a config value; config wins over default
+    when call-arg is None; default is used when both are absent/empty.
+    """
+    if call_arg is not None and call_arg != "" and call_arg != []:
+        return call_arg
+    cfg_val = _get_moa_config().get(config_key)
+    if cfg_val is not None and cfg_val != "" and cfg_val != []:
+        return cfg_val
+    return default
+
+
+def _reasoning_extra_body(reasoning_effort: Any) -> Dict[str, Any]:
+    """Build the ``extra_body`` reasoning block, or empty when disabled.
+
+    Why: LiteLLM bridges and local models reject the OpenRouter-style
+    ``extra_body.reasoning`` payload, so it must be omittable.
+    What: returns ``{"extra_body": {"reasoning": {...}}}`` for a truthy effort
+    other than ``"none"``; returns ``{}`` otherwise so the caller sends no
+    reasoning block at all.
+    Test: assert ``""`` and ``"none"`` yield ``{}``; assert ``"xhigh"`` yields a
+    dict whose ``extra_body.reasoning.effort == "xhigh"`` and ``enabled`` True.
+    """
+    effort = str(reasoning_effort or "").strip().lower()
+    if not effort or effort == "none":
+        return {}
+    return {"extra_body": {"reasoning": {"enabled": True, "effort": effort}}}
+
+
 def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
     """
     Construct the final system prompt for the aggregator including all model responses.
@@ -107,52 +170,60 @@ async def _run_reference_model_safe(
     user_prompt: str,
     temperature: float = REFERENCE_TEMPERATURE,
     max_tokens: int = 32000,
-    max_retries: int = 6
+    max_retries: int = 6,
+    reasoning_effort: Any = "xhigh",
+    base_url: str = "",
+    api_key: str = "",
 ) -> tuple[str, str, bool]:
     """
     Run a single reference model with retry logic and graceful failure handling.
-    
+
     Args:
         model (str): Model identifier to use
         user_prompt (str): The user's query
         temperature (float): Sampling temperature for response generation
         max_tokens (int): Maximum tokens in response
         max_retries (int): Maximum number of retry attempts
-        
+        reasoning_effort (Any): OpenRouter reasoning effort; falsy or "none"
+            omits the extra_body reasoning block (for LiteLLM/local models).
+        base_url (str): Optional OpenAI-compatible endpoint override.
+        api_key (str): Optional API key paired with base_url.
+
     Returns:
         tuple[str, str, bool]: (model_name, response_content_or_error, success_flag)
     """
     for attempt in range(max_retries):
         try:
             logger.info("Querying %s (attempt %s/%s)", model, attempt + 1, max_retries)
-            
-            # Build parameters for the API call
+
+            # Build parameters for the API call.  The reasoning block is omitted
+            # entirely for falsy / "none" effort so LiteLLM and local models that
+            # reject extra_body.reasoning still work.
             api_params = {
                 "model": model,
                 "messages": [{"role": "user", "content": user_prompt}],
                 "max_tokens": max_tokens,
-                "extra_body": {
-                    "reasoning": {
-                        "enabled": True,
-                        "effort": "xhigh"
-                    }
-                }
+                **_reasoning_extra_body(reasoning_effort),
             }
-            
+
             # GPT models (especially gpt-4o-mini) don't support custom temperature values
             # Only include temperature for non-GPT models
             if not model.lower().startswith('gpt-'):
                 api_params["temperature"] = temperature
-            
-            response = await _get_openrouter_client().chat.completions.create(**api_params)
+
+            response = await _get_openrouter_client(base_url=base_url, api_key=api_key).chat.completions.create(**api_params)
             
             content = extract_content_or_reasoning(response)
             if not content:
-                # Reasoning-only response — let the retry loop handle it
+                # Reasoning-only / empty response. Retry while attempts remain;
+                # on the FINAL attempt fail explicitly instead of falling
+                # through to the success path — a blank "success" here makes the
+                # aggregator ingest an empty reference (false-success bug).
                 logger.warning("%s returned empty content (attempt %s/%s), retrying", model, attempt + 1, max_retries)
                 if attempt < max_retries - 1:
                     await asyncio.sleep(min(2 ** (attempt + 1), 60))
                     continue
+                return model, f"{model} returned empty content after {max_retries} attempts", False
             logger.info("%s responded (%s characters)", model, len(content))
             return model, content, True
             
@@ -177,56 +248,67 @@ async def _run_reference_model_safe(
                 logger.error("%s", error_msg, exc_info=True)
                 return model, error_msg, False
 
+    # Loop-exhaustion guard: every path inside the loop returns, but the loop
+    # body never runs when max_retries <= 0. Without this the function could
+    # implicitly return None, violating the -> tuple[str, str, bool] contract
+    # (ty: invalid-return-type).
+    return model, f"{model} returned no response after {max_retries} attempts", False
+
 
 async def _run_aggregator_model(
     system_prompt: str,
     user_prompt: str,
     temperature: float = AGGREGATOR_TEMPERATURE,
-    max_tokens: int = None
+    max_tokens: Optional[int] = None,
+    aggregator_model: str = AGGREGATOR_MODEL,
+    reasoning_effort: Any = "xhigh",
+    base_url: str = "",
+    api_key: str = "",
 ) -> str:
     """
     Run the aggregator model to synthesize the final response.
-    
+
     Args:
         system_prompt (str): System prompt with all reference responses
         user_prompt (str): Original user query
         temperature (float): Focused temperature for consistent aggregation
         max_tokens (int): Maximum tokens in final response
-        
+        aggregator_model (str): Model used to synthesize the final response.
+        reasoning_effort (Any): OpenRouter reasoning effort; falsy or "none"
+            omits the extra_body reasoning block (for LiteLLM/local models).
+        base_url (str): Optional OpenAI-compatible endpoint override.
+        api_key (str): Optional API key paired with base_url.
+
     Returns:
         str: Synthesized final response
     """
-    logger.info("Running aggregator model: %s", AGGREGATOR_MODEL)
+    logger.info("Running aggregator model: %s", aggregator_model)
 
-    # Build parameters for the API call
+    # Build parameters for the API call.  The reasoning block is omitted
+    # entirely for falsy / "none" effort so LiteLLM and local models work.
     api_params = {
-        "model": AGGREGATOR_MODEL,
+        "model": aggregator_model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt}
         ],
         "max_tokens": max_tokens,
-        "extra_body": {
-            "reasoning": {
-                "enabled": True,
-                "effort": "xhigh"
-            }
-        }
+        **_reasoning_extra_body(reasoning_effort),
     }
 
     # GPT models (especially gpt-4o-mini) don't support custom temperature values
     # Only include temperature for non-GPT models
-    if not AGGREGATOR_MODEL.lower().startswith('gpt-'):
+    if not aggregator_model.lower().startswith('gpt-'):
         api_params["temperature"] = temperature
 
-    response = await _get_openrouter_client().chat.completions.create(**api_params)
+    response = await _get_openrouter_client(base_url=base_url, api_key=api_key).chat.completions.create(**api_params)
 
     content = extract_content_or_reasoning(response)
 
     # Retry once on empty content (reasoning-only response)
     if not content:
         logger.warning("Aggregator returned empty content, retrying once")
-        response = await _get_openrouter_client().chat.completions.create(**api_params)
+        response = await _get_openrouter_client(base_url=base_url, api_key=api_key).chat.completions.create(**api_params)
         content = extract_content_or_reasoning(response)
 
     logger.info("Aggregation complete (%s characters)", len(content))
@@ -254,11 +336,15 @@ async def mixture_of_agents_tool(
     1. Layer 1: Multiple reference models generate diverse responses in parallel (temp=0.6)
     2. Layer 2: Aggregator model synthesizes the best elements into final response (temp=0.4)
     
+    Settings resolve by precedence: explicit call-arg > ``moa:`` section in
+    config.yaml > module-constant default. An absent/empty ``moa:`` section
+    therefore preserves the original hardcoded behavior exactly.
+
     Args:
         user_prompt (str): The complex query or problem to solve
         reference_models (Optional[List[str]]): Custom reference models to use
         aggregator_model (Optional[str]): Custom aggregator model to use
-    
+
     Returns:
         str: JSON string containing the MoA results with the following structure:
              {
@@ -275,15 +361,30 @@ async def mixture_of_agents_tool(
         Exception: If MoA processing fails or API key is not set
     """
     start_time = datetime.datetime.now()
-    
-    debug_call_data = {
+
+    # Resolve every setting once by precedence (call-arg > moa: config > default).
+    # An absent/empty moa: section leaves these equal to the module constants,
+    # so behavior is identical to before when nothing is configured.
+    ref_models = _resolve(reference_models, "reference_models", REFERENCE_MODELS)
+    agg_model = _resolve(aggregator_model, "aggregator_model", AGGREGATOR_MODEL)
+    ref_temperature = _resolve(None, "reference_temperature", REFERENCE_TEMPERATURE)
+    agg_temperature = _resolve(None, "aggregator_temperature", AGGREGATOR_TEMPERATURE)
+    min_successful = _resolve(None, "min_successful_references", MIN_SUCCESSFUL_REFERENCES)
+    reasoning_effort = _resolve(None, "reasoning_effort", "xhigh")
+    moa_base_url = _resolve(None, "base_url", "")
+    moa_api_key = _resolve(None, "api_key", "")
+
+    # Annotated Dict[str, Any] because this accumulator is later assigned
+    # str / int / float / list values for keys whose literal-inferred type
+    # would otherwise be a narrower union (ty: invalid-assignment).
+    debug_call_data: Dict[str, Any] = {
         "parameters": {
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "reference_models": reference_models or REFERENCE_MODELS,
-            "aggregator_model": aggregator_model or AGGREGATOR_MODEL,
-            "reference_temperature": REFERENCE_TEMPERATURE,
-            "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-            "min_successful_references": MIN_SUCCESSFUL_REFERENCES
+            "reference_models": ref_models,
+            "aggregator_model": agg_model,
+            "reference_temperature": ref_temperature,
+            "aggregator_temperature": agg_temperature,
+            "min_successful_references": min_successful
         },
         "error": None,
         "success": False,
@@ -298,21 +399,23 @@ async def mixture_of_agents_tool(
     try:
         logger.info("Starting Mixture-of-Agents processing...")
         logger.info("Query: %s", user_prompt[:100])
-        
-        # Validate API key availability
-        if not os.getenv("OPENROUTER_API_KEY"):
+
+        # Validate API key availability. Only required on the default OpenRouter
+        # path — a custom base_url (LiteLLM / local) carries its own auth (or
+        # none), so don't block it on OPENROUTER_API_KEY.
+        if not moa_base_url and not os.getenv("OPENROUTER_API_KEY"):
             raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        
-        # Use provided models or defaults
-        ref_models = reference_models or REFERENCE_MODELS
-        agg_model = aggregator_model or AGGREGATOR_MODEL
-        
+
         logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_models))
-        
+
         # Layer 1: Generate diverse responses from reference models (with failure handling)
         logger.info("Layer 1: Generating reference responses...")
         model_results = await asyncio.gather(*[
-            _run_reference_model_safe(model, user_prompt, REFERENCE_TEMPERATURE)
+            _run_reference_model_safe(
+                model, user_prompt, ref_temperature,
+                reasoning_effort=reasoning_effort,
+                base_url=moa_base_url, api_key=moa_api_key,
+            )
             for model in ref_models
         ])
         
@@ -335,8 +438,8 @@ async def mixture_of_agents_tool(
             logger.warning("Failed models: %s", ', '.join(failed_models))
         
         # Check if we have enough successful responses to proceed
-        if successful_count < MIN_SUCCESSFUL_REFERENCES:
-            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses.")
+        if successful_count < min_successful:
+            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {min_successful} successful responses.")
         
         debug_call_data["reference_responses_count"] = successful_count
         debug_call_data["failed_models_count"] = failed_count
@@ -352,7 +455,11 @@ async def mixture_of_agents_tool(
         final_response = await _run_aggregator_model(
             aggregator_system_prompt,
             user_prompt,
-            AGGREGATOR_TEMPERATURE
+            agg_temperature,
+            aggregator_model=agg_model,
+            reasoning_effort=reasoning_effort,
+            base_url=moa_base_url,
+            api_key=moa_api_key,
         )
         
         # Calculate processing time
@@ -395,8 +502,8 @@ async def mixture_of_agents_tool(
             "success": False,
             "response": "MoA processing failed. Please try again or use a single model for this query.",
             "models_used": {
-                "reference_models": reference_models or REFERENCE_MODELS,
-                "aggregator_model": aggregator_model or AGGREGATOR_MODEL
+                "reference_models": ref_models,
+                "aggregator_model": agg_model
             },
             "error": error_msg
         }
@@ -410,13 +517,23 @@ async def mixture_of_agents_tool(
 
 
 def check_moa_requirements() -> bool:
+    """Report whether the MoA tool is usable in the current environment.
+
+    Why: the tool has two auth paths. The DEFAULT path talks to OpenRouter and
+    needs ``OPENROUTER_API_KEY``. But a local / LiteLLM deploy sets
+    ``moa.base_url`` to its own OpenAI-compatible endpoint, which carries its
+    own auth (or none) — gating that case on ``OPENROUTER_API_KEY`` made the
+    tool silently unavailable for the PR's headline use case. So a configured
+    ``moa.base_url`` is sufficient on its own.
+    What: returns True when an OpenRouter key is present OR a ``moa.base_url`` is
+    configured (read via the merged ``moa:`` config); False otherwise.
+    Test: with no ``OPENROUTER_API_KEY`` in env and ``moa.base_url`` set in
+    config, assert this returns True; with neither, assert False.
     """
-    Check if all requirements for MoA tools are met.
-    
-    Returns:
-        bool: True if requirements are met, False otherwise
-    """
-    return check_openrouter_api_key()
+    # _resolve reads the merged moa: config (config_path/mtime-cached via
+    # load_config); cheap enough for registry.get_definitions() probing, which
+    # additionally TTL-caches check_fn results. No heavy work at definition time.
+    return check_openrouter_api_key() or bool(_resolve(None, "base_url", ""))
 
 
 
@@ -530,12 +647,26 @@ MOA_SCHEMA = {
     }
 }
 
+# MOA_SCHEMA is intentionally left exposing only ``user_prompt`` — surfacing
+# reference_models / aggregator_model as model-facing schema params is a
+# separate, deferred change. The handler still forwards them so any caller
+# that supplies them (e.g. config-driven or programmatic) reaches the function
+# instead of being silently dropped.
 registry.register(
     name="mixture_of_agents",
     toolset="moa",
     schema=MOA_SCHEMA,
-    handler=lambda args, **kw: mixture_of_agents_tool(user_prompt=args.get("user_prompt", "")),
+    handler=lambda args, **kw: mixture_of_agents_tool(
+        user_prompt=args.get("user_prompt", ""),
+        reference_models=args.get("reference_models"),
+        aggregator_model=args.get("aggregator_model"),
+    ),
     check_fn=check_moa_requirements,
+    # requires_env is DISPLAY/diagnostic metadata for the default OpenRouter
+    # path only. The actual availability gate is check_fn above, which also
+    # accepts a configured moa.base_url (LiteLLM / local) with no OpenRouter
+    # key — so OPENROUTER_API_KEY is the default-path requirement, optional when
+    # moa.base_url is set.
     requires_env=["OPENROUTER_API_KEY"],
     is_async=True,
     emoji="🧠",

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -8,24 +8,56 @@ consistently.
 
 import os
 
-_client = None
+# Client cache keyed by (base_url, api_key) so a custom endpoint never reuses
+# the default OpenRouter client (and vice versa).  The default path uses the
+# ("", "") key and caches/behaves exactly as the previous single-global did.
+_clients: dict = {}
 
 
-def get_async_client():
+def get_async_client(base_url: str = "", api_key: str = ""):
     """Return a shared async OpenAI-compatible client for OpenRouter.
 
-    The client is created lazily on first call and reused thereafter.
-    Uses the centralized provider router for auth and client construction.
-    Raises ValueError if OPENROUTER_API_KEY is not set.
+    Why: lets MoA (and any tool) point its calls at a custom OpenAI-compatible
+    endpoint (LiteLLM, vLLM, a local proxy) via *base_url*/*api_key* without
+    every call rebuilding a client — while the default empty-args path keeps
+    the original single-shared-client behavior.
+    What: lazily builds and caches one client per (base_url, api_key) pair.
+    When *base_url* is set the request is routed through the ``custom``
+    provider (explicit_base_url/explicit_api_key); otherwise it uses
+    ``openrouter`` exactly as before.
+    Test: call twice with the same args → assert the same object is returned
+    (cache hit); call with a distinct base_url → assert a different object;
+    with no args and no OPENROUTER_API_KEY → assert ValueError is raised.
+
+    Raises ValueError if no usable credentials are available for the resolved
+    provider (e.g. OPENROUTER_API_KEY unset on the default path).
     """
-    global _client
-    if _client is None:
+    base_url = (base_url or "").strip()
+    api_key = (api_key or "").strip()
+    cache_key = (base_url, api_key)
+    if cache_key not in _clients:
         from agent.auxiliary_client import resolve_provider_client
-        client, _model = resolve_provider_client("openrouter", async_mode=True)
+        # A custom base_url is an OpenAI-compatible endpoint, not OpenRouter —
+        # the openrouter branch ignores explicit_base_url, so route through the
+        # custom provider which honors both overrides (and rewraps Anthropic-wire
+        # endpoints automatically).
+        provider = "custom" if base_url else "openrouter"
+        # Pass the already-stripped strings ("" when unset) rather than `… or None`:
+        # resolve_provider_client treats "" and None identically on every path
+        # it takes here — the custom branch gates on `if explicit_base_url:` and
+        # coalesces `explicit_api_key or ""`, and the openrouter branch only does
+        # `explicit_api_key or env`. Passing str (not str|None) also matches the
+        # upstream `explicit_base_url: str` / `explicit_api_key: str` annotations.
+        client, _model = resolve_provider_client(
+            provider,
+            async_mode=True,
+            explicit_base_url=base_url,
+            explicit_api_key=api_key,
+        )
         if client is None:
             raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        _client = client
-    return _client
+        _clients[cache_key] = client
+    return _clients[cache_key]
 
 
 def check_api_key() -> bool:


### PR DESCRIPTION
Closes #38952.

## What
Adds an optional `moa:` section to `config.yaml` so the `mixture_of_agents` (`moa`) tool isn't hardcoded to a fixed set of frontier models at `xhigh` reasoning on every call. Configurable:
- `reference_models`, `aggregator_model`, `reference_temperature`, `aggregator_temperature`, `min_successful_references`
- `reasoning_effort` — `""`/`"none"` omits the `extra_body` reasoning block, so non-reasoning / OpenAI-compatible / local models work
- `base_url` / `api_key` — point MoA at any OpenAI-compatible endpoint (OpenRouter by default)

Resolution precedence: **call-arg > `moa:` config > existing hardcoded defaults**. With no `moa:` section, behavior is byte-identical to today.

Also fixes the tool registration that silently stripped the `reference_models`/`aggregator_model` parameters the handler already accepts.

## Why
MoA is ~$1–3/call and off-by-default for cost reasons, and the only customization path today is editing the constants at the top of `tools/mixture_of_agents_tool.py`. This makes it cost/quality-tunable without forking — e.g. a cheap multi-model consensus over an OpenAI-compatible proxy.

## Scope (intentionally minimal)
Config layer only. Deferred to follow-ups (per the issue): named profiles, `/moa` slash commands + session toggles, `/moa estimate`, config guardrails, delegation inheritance, and exposing the override params in the tool schema.

## Backward compatibility
- No `moa:` section ⇒ identical current behavior.
- All new config keys and function params are optional.
- No `_config_version` bump (a new top-level section is handled by the deep-merge).
- No new dependencies.

## Testing
- `tests/tools/test_mixture_of_agents_tool.py`: 17 pass — config load, merge precedence, schema-forward regression, `reasoning_effort` guard, no-config==legacy, and the local-provider availability gate.
- `ty check` clean on the changed tool files.
- Functionally verified end-to-end: a real MoA consensus run over an OpenAI-compatible (LiteLLM) proxy with inexpensive models, including the orchestrator invoking the tool through a full agent loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)