### PR TITLE
fix(patch): unescape \n in fuzzy matcher when file region has newlines

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -488,35 +488,37 @@ class TestEscapeNormalizedNewString:
         assert strategy == "escape_normalized"
         assert "replaced\r" in new
 
-    def test_newline_in_new_string_NOT_unescaped(self):
-        """``\\n`` is intentionally left alone — newlines serialize correctly
-        through JSON, and unescaping would corrupt source-code escape
-        sequences far more often than help.
-        """
+    def test_newline_in_new_string_unescaped_when_region_has_newlines(self):
+        """When the matched file region contains real newlines, literal
+        ``\\n`` in new_string is unescaped to a real newline.  This fixes
+        the case where serialisation layers double-escape JSON."""
         content = "line1\nline2\n"
         old_string = "line1\nline2"
         new_string = "alpha\\nbeta"                 # literal backslash + n
         new, count, _, err = fuzzy_find_and_replace(content, old_string, new_string)
         assert err is None, f"Unexpected error: {err}"
         assert count == 1
-        # The literal two-character sequence ``\n`` must survive verbatim.
-        assert "alpha\\nbeta" in new
-        # And there should be no real newline added where ``\\n`` sat.
-        assert "alpha\nbeta" not in new
+        # The literal ``\\n`` is converted to a real newline because the
+        # matched region contains newlines.
+        assert "alpha\\nbeta" not in new, repr(new)
+        assert "alpha\nbeta" in new
 
     def test_mixed_tab_and_newline_only_tab_unescaped(self):
-        """When new_string contains both \\t and \\n, only \\t is converted."""
+        """When new_string contains both \\t and \\n and the file region
+        has both real tabs and real newlines, both escape sequences are
+        converted to their real control characters."""
         content = "def foo():\n\tpass\n"
         old_string = "def foo():\n\tpass\n"
         new_string = "def bar():\\n\\treturn 1\\n"
         new, count, _, err = fuzzy_find_and_replace(content, old_string, new_string)
         assert err is None, f"Unexpected error: {err}"
         assert count == 1
-        # \t -> real tab
+        # \\t -> real tab
         assert "\treturn 1" in new
         assert "\\t" not in new
-        # \n preserved as literal backslash-n
-        assert "\\n" in new
+        # \\n -> real newline (matched region contains real newlines)
+        assert "\\n" not in new
+        assert "def bar():\n\treturn 1\n" in new
 
     def test_exact_match_preserves_literal_backslash_t_in_string_literal(self):
         """If the matched region of the file does NOT contain a real tab,

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -503,6 +503,21 @@ class TestEscapeNormalizedNewString:
         assert "alpha\\nbeta" not in new, repr(new)
         assert "alpha\nbeta" in new
 
+    def test_literal_backslash_n_preserved_when_in_matched_region(self):
+        """When the matched file region already contains literal ``\\n``
+        (e.g. inside a regex or string literal), ``\\n`` in new_string is
+        preserved — it is an intentional part of the source code, not a
+        serialisation artifact."""
+        content = 'pattern = r"\\n\\s*"\nprint("ok")\n'
+        old_string = 'pattern = r"\\n\\s*"\nprint("ok")'
+        new_string = 'pattern = r"\\n\\s+"\nprint("done")'
+        new, count, _, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        # The literal ``\\n`` in the regex must NOT be converted to a real newline.
+        assert "\\n" in new
+        assert 'pattern = r"\\n\\s+"\nprint("done")' in new
+
     def test_mixed_tab_and_newline_only_tab_unescaped(self):
         """When new_string contains both \\t and \\n and the file region
         has both real tabs and real newlines, both escape sequences are

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -292,7 +292,7 @@ def _maybe_unescape_new_string(new_string: str,
     """
     # Cheap pre-check — bail out unless new_string actually contains one of
     # the suspect sequences. Keeps the common case free.
-    if "\\t" not in new_string and "\\r" not in new_string:
+    if "\\t" not in new_string and "\\r" not in new_string and "\\n" not in new_string:
         return new_string
 
     matched_regions = "".join(content[start:end] for start, end in matches)
@@ -301,6 +301,12 @@ def _maybe_unescape_new_string(new_string: str,
         out = out.replace("\\t", "\t")
     if "\\r" in out and "\r" in matched_regions:
         out = out.replace("\\r", "\r")
+    # LLMs can emit literal \\n (two-char backslash-n) when serialisation
+    # layers double-escape JSON.  Only unescape when the matched file
+    # region actually contains newline bytes — source-code regex/string
+    # constants with literal \\n on disk are left untouched.
+    if "\\n" in out and "\n" in matched_regions:
+        out = out.replace("\\n", "\n")
     return out
 
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -302,10 +302,10 @@ def _maybe_unescape_new_string(new_string: str,
     if "\\r" in out and "\r" in matched_regions:
         out = out.replace("\\r", "\r")
     # LLMs can emit literal \\n (two-char backslash-n) when serialisation
-    # layers double-escape JSON.  Only unescape when the matched file
-    # region actually contains newline bytes — source-code regex/string
-    # constants with literal \\n on disk are left untouched.
-    if "\\n" in out and "\n" in matched_regions:
+    # layers double-escape JSON.  Only unescape when the matched file region
+    # contains real newlines AND does NOT contain any literal backslash-n —
+    # source-code regex/string constants with \\n on disk are left untouched.
+    if "\\n" in out and "\n" in matched_regions and "\\n" not in matched_regions:
         out = out.replace("\\n", "\n")
     return out
 


### PR DESCRIPTION
## Summary

LLMs can emit literal `\n` (two-char backslash-n) in JSON tool-call arguments when serialisation layers double-escape. Previously the `_maybe_unescape_new_string` function only handled `\t` and `\r`, leaving `\n` sequences to be written literally into files — corrupting every line break in the patched region.

## Changes

- **`tools/fuzzy_match.py`**: Added `\n` unescaping when the matched file region contains real newline bytes. The cheap pre-check now also tests for `\n`.
- **`tests/tools/test_fuzzy_match.py`**: Updated tests to expect `\n` unescaping when the matched region has real newlines.

## Testing

```bash
python3 -m pytest tests/tools/test_fuzzy_match.py -q
47 passed in 0.40s
```