### PR TITLE
feat(kanban): add label auto-dispatch dry run

### DIFF
--- a/docs/kanban-label-auto-dispatch-dry-run-sample.json
+++ b/docs/kanban-label-auto-dispatch-dry-run-sample.json
@@ -1,0 +1,95 @@
+{
+  "auto_close_enabled": false,
+  "auto_merge_enabled": false,
+  "controlled_writeback_enabled": false,
+  "dry_run_only": true,
+  "full_unattended_ready": false,
+  "labels": [
+    "gm2:dispatch-007",
+    "gm2:fix"
+  ],
+  "mode": "dry_run_only",
+  "packet": {
+    "acceptance": [
+      "packet includes all required fields",
+      "dry-run report lists routing decision and matched labels",
+      "no external writeback or actor dispatch occurs"
+    ],
+    "allowed_scope": [
+      "read source issue/pr record",
+      "generate dry-run actor packet",
+      "produce preview/report only"
+    ],
+    "assigned_agent": "007",
+    "current_state": "ready_for_dry_run_dispatch",
+    "evidence_required": [
+      "dry-run preview JSON",
+      "routing decision",
+      "matched dispatch labels and control flags"
+    ],
+    "forbidden_actions": [
+      "send actor task",
+      "write GitHub comment",
+      "modify labels",
+      "move Kanban card",
+      "merge PR",
+      "close issue",
+      "enable runtime execution",
+      "touch production/payment/credits/webhook/customer data/secret",
+      "claim full_unattended_ready"
+    ],
+    "formal_record": "https://github.com/kiddhu/aion-governance/issues/501",
+    "from_gm": "GM2",
+    "next_report_expected": "dry-run preview only; await GM2/八府巡按 gate",
+    "objective": "Execute bounded implementation/build/fix task: Implement bounded GM2 label router\n\nSource summary:\nBuild only the dry-run preview path. Do not write back to GitHub.",
+    "packet_type": "007_task_packet",
+    "priority": "P1",
+    "project_id": "aion-kanban",
+    "source_name": "kiddhu/aion-governance#501 (issue)",
+    "stop_conditions": [
+      "any control flag is present",
+      "multiple dispatch classes match",
+      "source record lacks enough identity fields to form a formal record"
+    ],
+    "task_id": "issue-501"
+  },
+  "required_packet_fields": [
+    "from_gm",
+    "source_name",
+    "project_id",
+    "task_id",
+    "priority",
+    "formal_record",
+    "current_state",
+    "assigned_agent",
+    "objective",
+    "allowed_scope",
+    "forbidden_actions",
+    "acceptance",
+    "evidence_required",
+    "stop_conditions",
+    "next_report_expected"
+  ],
+  "routing": {
+    "blocked": false,
+    "conflict": false,
+    "control_flags": [],
+    "dispatch_type": "dispatch_007",
+    "matched_dispatch_labels": {
+      "dispatch_007": [
+        "gm2:dispatch-007",
+        "gm2:fix"
+      ]
+    },
+    "reason": "dispatch_label_matched",
+    "will_close_issue": false,
+    "will_merge_pr": false,
+    "will_modify_labels": false,
+    "will_move_kanban": false,
+    "will_send_to_actor": false,
+    "will_write_github_comment": false
+  },
+  "runtime_execution_allowed": false,
+  "source_name": "kiddhu/aion-governance#501 (issue)",
+  "task_id": "issue-501"
+}

--- a/hermes_cli/kanban_label_dispatch.py
+++ b/hermes_cli/kanban_label_dispatch.py
@@ -1,0 +1,329 @@
+"""Dry-run label router for Kanban task packet generation.
+
+This module intentionally has no GitHub/Kanban side effects.  It accepts a
+pre-fetched issue/PR-like record, classifies labels, and returns a preview
+report that can be audited before any controlled writeback is introduced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DISPATCH_LABELS: dict[str, set[str]] = {
+    "dispatch_007": {
+        "gm2:dispatch-007",
+        "gm2:build",
+        "gm2:implement",
+        "gm2:fix",
+    },
+    "dispatch_audit": {
+        "gm2:dispatch-audit",
+        "gm2:audit",
+        "gm2:review",
+        "gm2:verify",
+    },
+    "dispatch_closeout": {
+        "gm2:dispatch-closeout",
+        "gm2:closeout",
+        "gm2:handoff",
+        "gm2:summary",
+    },
+}
+
+CONTROL_FLAGS: set[str] = {
+    "gm2:blocked",
+    "gm2:needs-info",
+    "gm2:no-ack",
+    "gm2:timeout",
+    "gm2:audit-missing",
+    "gm2:audit-fail",
+}
+
+ACTOR_BY_DISPATCH: dict[str, str] = {
+    "dispatch_007": "007",
+    "dispatch_audit": "八府巡按",
+    "dispatch_closeout": "GM2",
+}
+
+PACKET_TYPE_BY_DISPATCH: dict[str, str] = {
+    "dispatch_007": "007_task_packet",
+    "dispatch_audit": "audit_packet",
+    "dispatch_closeout": "gm2_closeout_packet",
+}
+
+DRY_RUN_GUARDS: dict[str, bool] = {
+    "dry_run_only": True,
+    "controlled_writeback_enabled": False,
+    "auto_merge_enabled": False,
+    "auto_close_enabled": False,
+    "runtime_execution_allowed": False,
+    "full_unattended_ready": False,
+}
+
+REQUIRED_PACKET_FIELDS: tuple[str, ...] = (
+    "from_gm",
+    "source_name",
+    "project_id",
+    "task_id",
+    "priority",
+    "formal_record",
+    "current_state",
+    "assigned_agent",
+    "objective",
+    "allowed_scope",
+    "forbidden_actions",
+    "acceptance",
+    "evidence_required",
+    "stop_conditions",
+    "next_report_expected",
+)
+
+DEFAULT_ALLOWED_SCOPE: list[str] = [
+    "read source issue/pr record",
+    "generate dry-run actor packet",
+    "produce preview/report only",
+]
+
+DEFAULT_FORBIDDEN_ACTIONS: list[str] = [
+    "send actor task",
+    "write GitHub comment",
+    "modify labels",
+    "move Kanban card",
+    "merge PR",
+    "close issue",
+    "enable runtime execution",
+    "touch production/payment/credits/webhook/customer data/secret",
+    "claim full_unattended_ready",
+]
+
+DEFAULT_ACCEPTANCE: list[str] = [
+    "packet includes all required fields",
+    "dry-run report lists routing decision and matched labels",
+    "no external writeback or actor dispatch occurs",
+]
+
+DEFAULT_EVIDENCE_REQUIRED: list[str] = [
+    "dry-run preview JSON",
+    "routing decision",
+    "matched dispatch labels and control flags",
+]
+
+DEFAULT_STOP_CONDITIONS: list[str] = [
+    "any control flag is present",
+    "multiple dispatch classes match",
+    "source record lacks enough identity fields to form a formal record",
+]
+
+
+@dataclass(frozen=True)
+class LabelRoute:
+    dispatch_type: str | None
+    matched_dispatch_labels: dict[str, list[str]]
+    control_flags: list[str]
+    conflict: bool
+    blocked: bool
+    reason: str
+
+
+def _normalise_labels(labels: list[Any]) -> list[str]:
+    normalised: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            name = label
+        elif isinstance(label, dict):
+            name = str(label.get("name", ""))
+        else:
+            name = str(label)
+        name = name.strip()
+        if name:
+            normalised.append(name)
+    return normalised
+
+
+def classify_labels(labels: list[Any]) -> LabelRoute:
+    """Classify labels into one dispatch route, conflict, or blocked state."""
+
+    label_set = set(_normalise_labels(labels))
+    matched = {
+        dispatch: sorted(label_set & dispatch_labels)
+        for dispatch, dispatch_labels in DISPATCH_LABELS.items()
+        if label_set & dispatch_labels
+    }
+    controls = sorted(label_set & CONTROL_FLAGS)
+
+    if controls:
+        return LabelRoute(
+            dispatch_type=None,
+            matched_dispatch_labels=matched,
+            control_flags=controls,
+            conflict=False,
+            blocked=True,
+            reason="control_flag_present",
+        )
+
+    if len(matched) > 1:
+        return LabelRoute(
+            dispatch_type=None,
+            matched_dispatch_labels=matched,
+            control_flags=[],
+            conflict=True,
+            blocked=True,
+            reason="multiple_dispatch_labels_matched",
+        )
+
+    if len(matched) == 1:
+        dispatch_type = next(iter(matched))
+        return LabelRoute(
+            dispatch_type=dispatch_type,
+            matched_dispatch_labels=matched,
+            control_flags=[],
+            conflict=False,
+            blocked=False,
+            reason="dispatch_label_matched",
+        )
+
+    return LabelRoute(
+        dispatch_type=None,
+        matched_dispatch_labels={},
+        control_flags=[],
+        conflict=False,
+        blocked=False,
+        reason="no_dispatch_label_matched",
+    )
+
+
+def _source_name(record: dict[str, Any]) -> str:
+    if record.get("source_name"):
+        return str(record["source_name"])
+    repo = record.get("repo") or record.get("repository") or "unknown/repo"
+    number = record.get("number") or record.get("id") or "unknown"
+    source_type = record.get("source_type") or record.get("type") or "issue"
+    return f"{repo}#{number} ({source_type})"
+
+
+def _task_id(record: dict[str, Any]) -> str:
+    if record.get("task_id"):
+        return str(record["task_id"])
+    source_type = record.get("source_type") or record.get("type") or "issue"
+    number = record.get("number") or record.get("id") or "unknown"
+    return f"{source_type}-{number}"
+
+
+def _formal_record(record: dict[str, Any]) -> str:
+    return str(record.get("formal_record") or record.get("html_url") or record.get("url") or _source_name(record))
+
+
+def _objective(record: dict[str, Any], route: LabelRoute) -> str:
+    if record.get("objective"):
+        return str(record["objective"])
+    title = str(record.get("title") or "Untitled GitHub task")
+    body = str(record.get("body") or "").strip()
+    prefix = {
+        "dispatch_007": "Execute bounded implementation/build/fix task",
+        "dispatch_audit": "Audit and verify the formal record",
+        "dispatch_closeout": "Prepare closeout/handoff/summary packet",
+    }.get(route.dispatch_type or "", "Stop automatic dispatch and surface failure state")
+    if body:
+        return f"{prefix}: {title}\n\nSource summary:\n{body[:1200]}"
+    return f"{prefix}: {title}"
+
+
+def build_packet(record: dict[str, Any], route: LabelRoute) -> dict[str, Any] | None:
+    """Build an actor/failure packet for a routed record.
+
+    Returns ``None`` for records with no dispatch label and no failure state.
+    """
+
+    if not route.dispatch_type and not route.blocked:
+        return None
+
+    if route.blocked:
+        assigned_agent = "GM2"
+        packet_type = "failure_packet"
+        current_state = "blocked"
+    else:
+        assigned_agent = ACTOR_BY_DISPATCH[route.dispatch_type or ""]
+        packet_type = PACKET_TYPE_BY_DISPATCH[route.dispatch_type or ""]
+        current_state = str(record.get("current_state") or "ready_for_dry_run_dispatch")
+
+    packet = {
+        "packet_type": packet_type,
+        "from_gm": str(record.get("from_gm") or "GM2"),
+        "source_name": _source_name(record),
+        "project_id": str(record.get("project_id") or record.get("repo") or "unknown-project"),
+        "task_id": _task_id(record),
+        "priority": str(record.get("priority") or "P2"),
+        "formal_record": _formal_record(record),
+        "current_state": current_state,
+        "assigned_agent": assigned_agent,
+        "objective": _objective(record, route),
+        "allowed_scope": list(record.get("allowed_scope") or DEFAULT_ALLOWED_SCOPE),
+        "forbidden_actions": list(record.get("forbidden_actions") or DEFAULT_FORBIDDEN_ACTIONS),
+        "acceptance": list(record.get("acceptance") or DEFAULT_ACCEPTANCE),
+        "evidence_required": list(record.get("evidence_required") or DEFAULT_EVIDENCE_REQUIRED),
+        "stop_conditions": list(record.get("stop_conditions") or DEFAULT_STOP_CONDITIONS),
+        "next_report_expected": str(record.get("next_report_expected") or "dry-run preview only; await GM2/八府巡按 gate"),
+    }
+
+    missing = [field for field in REQUIRED_PACKET_FIELDS if field not in packet or packet[field] in (None, "")]
+    if missing:
+        raise ValueError(f"packet missing required fields: {', '.join(missing)}")
+    return packet
+
+
+def build_dry_run_report(record: dict[str, Any]) -> dict[str, Any]:
+    labels = _normalise_labels(list(record.get("labels") or []))
+    route = classify_labels(labels)
+    packet = build_packet(record, route)
+
+    return {
+        "mode": "dry_run_only",
+        **DRY_RUN_GUARDS,
+        "source_name": _source_name(record),
+        "task_id": _task_id(record),
+        "labels": labels,
+        "routing": {
+            "dispatch_type": route.dispatch_type,
+            "reason": route.reason,
+            "matched_dispatch_labels": route.matched_dispatch_labels,
+            "control_flags": route.control_flags,
+            "conflict": route.conflict,
+            "blocked": route.blocked,
+            "will_send_to_actor": False,
+            "will_write_github_comment": False,
+            "will_modify_labels": False,
+            "will_move_kanban": False,
+            "will_merge_pr": False,
+            "will_close_issue": False,
+        },
+        "packet": packet,
+        "required_packet_fields": list(REQUIRED_PACKET_FIELDS),
+    }
+
+
+def load_record(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("source record must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Dry-run GitHub label to Kanban actor packet router")
+    parser.add_argument("record", help="Path to issue/PR JSON record")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    args = parser.parse_args(argv)
+
+    report = build_dry_run_report(load_record(args.record))
+    indent = 2 if args.pretty else None
+    print(json.dumps(report, ensure_ascii=False, indent=indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/kanban_label_dispatch_dry_run.py
+++ b/scripts/kanban_label_dispatch_dry_run.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Dry-run wrapper for GitHub label to Kanban actor packet preview."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli.kanban_label_dispatch import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/kanban_label_dispatch/conflict_issue.json
+++ b/tests/fixtures/kanban_label_dispatch/conflict_issue.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "issue",
+  "repo": "kiddhu/aion-governance",
+  "number": 504,
+  "title": "Conflicting labels must not auto-dispatch",
+  "body": "This record deliberately has implement and audit labels.",
+  "labels": ["gm2:dispatch-007", "gm2:dispatch-audit"],
+  "project_id": "aion-kanban",
+  "priority": "P0",
+  "formal_record": "https://github.com/kiddhu/aion-governance/issues/504"
+}

--- a/tests/fixtures/kanban_label_dispatch/control_flag_pr.json
+++ b/tests/fixtures/kanban_label_dispatch/control_flag_pr.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "pull_request",
+  "repo": "kiddhu/aion-governance",
+  "number": 505,
+  "title": "Blocked route must produce failure packet",
+  "body": "Needs more information before dispatch.",
+  "labels": ["gm2:dispatch-007", "gm2:needs-info"],
+  "project_id": "aion-kanban",
+  "priority": "P1",
+  "formal_record": "https://github.com/kiddhu/aion-governance/pull/505"
+}

--- a/tests/fixtures/kanban_label_dispatch/dispatch_007_issue.json
+++ b/tests/fixtures/kanban_label_dispatch/dispatch_007_issue.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "issue",
+  "repo": "kiddhu/aion-governance",
+  "number": 501,
+  "title": "Implement bounded GM2 label router",
+  "body": "Build only the dry-run preview path. Do not write back to GitHub.",
+  "labels": ["gm2:dispatch-007", "gm2:fix"],
+  "project_id": "aion-kanban",
+  "priority": "P1",
+  "formal_record": "https://github.com/kiddhu/aion-governance/issues/501"
+}

--- a/tests/fixtures/kanban_label_dispatch/dispatch_audit_pr.json
+++ b/tests/fixtures/kanban_label_dispatch/dispatch_audit_pr.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "pull_request",
+  "repo": "kiddhu/aion-governance",
+  "number": 502,
+  "title": "Audit dry-run dispatch packet",
+  "body": "Verify actor packet fields and dry-run boundaries.",
+  "labels": ["gm2:dispatch-audit", "gm2:verify"],
+  "project_id": "aion-kanban",
+  "priority": "P1",
+  "formal_record": "https://github.com/kiddhu/aion-governance/pull/502"
+}

--- a/tests/fixtures/kanban_label_dispatch/dispatch_closeout_issue.json
+++ b/tests/fixtures/kanban_label_dispatch/dispatch_closeout_issue.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "issue",
+  "repo": "kiddhu/aion-governance",
+  "number": 503,
+  "title": "Close out completed dry-run route",
+  "body": "Prepare summary only after audit evidence exists.",
+  "labels": ["gm2:dispatch-closeout", "gm2:summary"],
+  "project_id": "aion-kanban",
+  "priority": "P2",
+  "formal_record": "https://github.com/kiddhu/aion-governance/issues/503"
+}

--- a/tests/hermes_cli/test_kanban_label_dispatch.py
+++ b/tests/hermes_cli/test_kanban_label_dispatch.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli.kanban_label_dispatch import (
+    CONTROL_FLAGS,
+    DISPATCH_LABELS,
+    REQUIRED_PACKET_FIELDS,
+    build_dry_run_report,
+    main,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "kanban_label_dispatch"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def assert_dry_run_guards(report: dict) -> None:
+    assert report["mode"] == "dry_run_only"
+    assert report["dry_run_only"] is True
+    assert report["controlled_writeback_enabled"] is False
+    assert report["auto_merge_enabled"] is False
+    assert report["auto_close_enabled"] is False
+    assert report["runtime_execution_allowed"] is False
+    assert report["full_unattended_ready"] is False
+    routing = report["routing"]
+    assert routing["will_send_to_actor"] is False
+    assert routing["will_write_github_comment"] is False
+    assert routing["will_modify_labels"] is False
+    assert routing["will_move_kanban"] is False
+    assert routing["will_merge_pr"] is False
+    assert routing["will_close_issue"] is False
+
+
+def assert_required_packet_fields(packet: dict) -> None:
+    missing = [field for field in REQUIRED_PACKET_FIELDS if field not in packet]
+    assert missing == []
+
+
+def test_dispatch_007_issue_generates_007_packet() -> None:
+    report = build_dry_run_report(load_fixture("dispatch_007_issue.json"))
+
+    assert_dry_run_guards(report)
+    assert report["routing"]["dispatch_type"] == "dispatch_007"
+    assert report["routing"]["blocked"] is False
+    packet = report["packet"]
+    assert_required_packet_fields(packet)
+    assert packet["packet_type"] == "007_task_packet"
+    assert packet["assigned_agent"] == "007"
+    assert packet["from_gm"] == "GM2"
+
+
+def test_dispatch_audit_pr_generates_audit_packet() -> None:
+    report = build_dry_run_report(load_fixture("dispatch_audit_pr.json"))
+
+    assert_dry_run_guards(report)
+    assert report["routing"]["dispatch_type"] == "dispatch_audit"
+    packet = report["packet"]
+    assert_required_packet_fields(packet)
+    assert packet["packet_type"] == "audit_packet"
+    assert packet["assigned_agent"] == "八府巡按"
+
+
+def test_dispatch_closeout_issue_generates_gm2_closeout_packet() -> None:
+    report = build_dry_run_report(load_fixture("dispatch_closeout_issue.json"))
+
+    assert_dry_run_guards(report)
+    assert report["routing"]["dispatch_type"] == "dispatch_closeout"
+    packet = report["packet"]
+    assert_required_packet_fields(packet)
+    assert packet["packet_type"] == "gm2_closeout_packet"
+    assert packet["assigned_agent"] == "GM2"
+
+
+def test_multiple_dispatch_labels_create_conflict_failure_packet() -> None:
+    report = build_dry_run_report(load_fixture("conflict_issue.json"))
+
+    assert_dry_run_guards(report)
+    routing = report["routing"]
+    assert routing["dispatch_type"] is None
+    assert routing["conflict"] is True
+    assert routing["blocked"] is True
+    assert routing["reason"] == "multiple_dispatch_labels_matched"
+    assert set(routing["matched_dispatch_labels"]) == {"dispatch_007", "dispatch_audit"}
+    packet = report["packet"]
+    assert_required_packet_fields(packet)
+    assert packet["packet_type"] == "failure_packet"
+    assert packet["current_state"] == "blocked"
+    assert packet["assigned_agent"] == "GM2"
+
+
+def test_control_flag_blocks_dispatch_even_with_valid_dispatch_label() -> None:
+    report = build_dry_run_report(load_fixture("control_flag_pr.json"))
+
+    assert_dry_run_guards(report)
+    routing = report["routing"]
+    assert routing["dispatch_type"] is None
+    assert routing["blocked"] is True
+    assert routing["reason"] == "control_flag_present"
+    assert routing["control_flags"] == ["gm2:needs-info"]
+    assert routing["matched_dispatch_labels"] == {"dispatch_007": ["gm2:dispatch-007"]}
+    packet = report["packet"]
+    assert_required_packet_fields(packet)
+    assert packet["packet_type"] == "failure_packet"
+    assert packet["current_state"] == "blocked"
+
+
+def test_supported_label_taxonomy_matches_mvp_contract() -> None:
+    assert DISPATCH_LABELS == {
+        "dispatch_007": {"gm2:dispatch-007", "gm2:build", "gm2:implement", "gm2:fix"},
+        "dispatch_audit": {"gm2:dispatch-audit", "gm2:audit", "gm2:review", "gm2:verify"},
+        "dispatch_closeout": {"gm2:dispatch-closeout", "gm2:closeout", "gm2:handoff", "gm2:summary"},
+    }
+    assert CONTROL_FLAGS == {
+        "gm2:blocked",
+        "gm2:needs-info",
+        "gm2:no-ack",
+        "gm2:timeout",
+        "gm2:audit-missing",
+        "gm2:audit-fail",
+    }
+
+
+def test_cli_emits_dry_run_preview(capsys) -> None:
+    assert main([str(FIXTURES / "dispatch_007_issue.json"), "--pretty"]) == 0
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    assert report["mode"] == "dry_run_only"
+    assert report["packet"]["assigned_agent"] == "007"


### PR DESCRIPTION
## Summary
- Add dry-run-only Kanban label auto-dispatch router for GitHub issue/PR records.
- Support MVP dispatch groups: `dispatch_007`, `dispatch_audit`, `dispatch_closeout`.
- Support control flags that produce blocked/failure packets instead of continuing automatic routing.
- Add packet generation with required fields, fixtures, tests, script wrapper, and sample dry-run report.

## Dry-run / safety boundary
- Dry-run preview/report only.
- Does not send actor tasks.
- Does not write GitHub comments.
- Does not modify labels.
- Does not move Kanban cards.
- Does not merge PRs.
- Does not close issues.
- Does not enable runtime execution.
- Does not touch production/payment/credits/webhook/customer data/secret.
- `full_unattended_ready=false`.

## Supported labels
```yaml
dispatch_007:
  - gm2:dispatch-007
  - gm2:build
  - gm2:implement
  - gm2:fix
dispatch_audit:
  - gm2:dispatch-audit
  - gm2:audit
  - gm2:review
  - gm2:verify
dispatch_closeout:
  - gm2:dispatch-closeout
  - gm2:closeout
  - gm2:handoff
  - gm2:summary
control_flags:
  - gm2:blocked
  - gm2:needs-info
  - gm2:no-ack
  - gm2:timeout
  - gm2:audit-missing
  - gm2:audit-fail
```

## Test plan
- `python -m pytest tests/hermes_cli/test_kanban_label_dispatch.py -q -o 'addopts='`
- `python -m ruff check hermes_cli/kanban_label_dispatch.py scripts/kanban_label_dispatch_dry_run.py tests/hermes_cli/test_kanban_label_dispatch.py`
- `python -m py_compile hermes_cli/kanban_label_dispatch.py scripts/kanban_label_dispatch_dry_run.py`

## Next gate
八府巡按 audit
