### PR TITLE
feat(prompt_builder): optimize skill index and enforce skill-matching workflow

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1235,36 +1235,40 @@ def build_skills_system_prompt(
             else:
                 index_lines.append(f"  {category}:")
             # Deduplicate and sort skills within each category
+            # NOTE: descriptions are intentionally omitted from the index to keep
+            # the system prompt small.  The agent must call skill_view(name) to
+            # load full instructions for any skill it thinks might match.
             seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+            for name, _desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                index_lines.append(f"    - {name}")
 
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
+            "Before replying, follow this workflow:\n"
+            "  1. Classify the user's task (what domain? file type? system?).\n"
+            "  2. Check if a skill exists for this domain from the list below.\n"
+            "  3. If a skill matches, load it with skill_view(name) BEFORE taking any action.\n"
+            "  4. Follow the loaded skill's instructions exactly.\n"
+            "  5. Only use raw tools if genuinely no skill matches.\n"
+            "The list below contains skill names only — full instructions are loaded on-demand\n"
+            "via skill_view(). Do NOT skip skill loading and jump straight to raw tools.\n"
+            "Skills contain specialized knowledge — API endpoints, tool-specific commands,\n"
+            "and proven workflows that outperform general-purpose approaches. Load the skill\n"
+            "even if you think you could handle the task with basic tools like web_search or terminal.\n"
+            "Skills also encode the user's preferred approach, conventions, and quality standards\n"
+            "for tasks like code review, planning, and testing — load them even for tasks you\n"
             "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+            "Whenever the user asks you to configure, set up, install, enable, disable, modify,\n"
+            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools,\n"
+            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill\n"
+            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`,\n"
             "`hermes setup`) so you don't have to guess or invent workarounds.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
+            "After difficult/iterative tasks, offer to save as a skill.\n"
+            "If a skill you loaded was missing steps, had wrong commands, or needed\n"
             "pitfalls you discovered, update it before finishing.\n"
             "\n"
             "<available_skills>\n"


### PR DESCRIPTION
## Problem

When Hermes builds the system prompt, `build_skills_system_prompt()` in `agent/prompt_builder.py` dumps **all 80+ skill descriptions** into every conversation's context. This causes two problems:

1. **Wasted context**: The skills index takes ~10.6 KB (45% of the ~23 KB system prompt). Every conversation carries this overhead even when the user's task has nothing to do with most skills.

2. **Skipped skill-matching**: The agent sees all 80+ skill names and descriptions as a flat menu, not a decision tree. It frequently ignores available skills and goes straight to raw tools (e.g., using a generic OCR server instead of a specialized schedule-extraction skill that was literally listed in context).

## Solution

Two changes to `build_skills_system_prompt()`:

### 1. Strip descriptions from the `<available_skills>` index

Instead of:
```
    - extract_timetable_schedule: Extract class schedules perfectly...
```

The index now lists only names:
```
    - extract_timetable_schedule
```

Full instructions are loaded **on-demand** via `skill_view(name)`. This reduces:
- Skills index: **10.6 KB → 4.9 KB** (53% smaller)
- Total system prompt: **23.3 KB → 17.8 KB** (24% smaller)

### 2. Replace "scan the skills below" with a 5-step workflow

```
  1. Classify the user's task (what domain? file type? system?).
  2. Check if a skill exists for this domain from the list below.
  3. If a skill matches, load it with skill_view(name) BEFORE taking any action.
  4. Follow the loaded skill's instructions exactly.
  5. Only use raw tools if genuinely no skill matches.
```

The old instruction said "scan the skills below" — scanning is not matching. The new numbered workflow forces a **classify → match → load → follow** discipline.

## Rationale

The old approach had a fundamental flaw: it said "MUST load skills" but provided no enforcement. The agent could see a relevant skill in the dumped list and still choose a different path, because nothing stopped it.

By stripping descriptions:
- The agent **cannot** follow a skill's instructions without calling `skill_view()` — it literally doesn't have them until it asks.
- The context is ~5.5 KB smaller per conversation, leaving more room for actual task data.
- The explicit 5-step workflow replaces vague advisory language with a concrete decision procedure.

## Testing

Verified with `hermes prompt-size`:
- **Before**: Skills index 10,849 B, system prompt 23,917 B
- **After**: Skills index 4,985 B, system prompt 18,254 B

No functional changes to skill discovery or `skill_view()` behavior — only the system prompt generation is affected.
