### PR TITLE
fix(cron): keep memory tools without automatic memory IO

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -190,6 +190,8 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    skip_memory_prompt: bool = False,
+    skip_memory_sync: bool = False,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -278,6 +280,8 @@ def init_agent(
     agent.background_review_callback = None  # Optional sync callback for gateway delivery
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
+    agent.skip_memory_prompt = skip_memory_prompt
+    agent.skip_memory_sync = skip_memory_sync
     agent.pass_session_id = pass_session_id
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -555,7 +555,8 @@ def run_conversation(
     _should_review_memory = False
     if (agent._memory_nudge_interval > 0
             and "memory" in agent.valid_tool_names
-            and agent._memory_store):
+            and agent._memory_store
+            and not getattr(agent, "skip_memory_sync", False)):
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             _should_review_memory = True
@@ -764,7 +765,7 @@ def run_conversation(
     # Notify memory providers of the new turn so cadence tracking works.
     # Must happen BEFORE prefetch_all() so providers know which turn it is
     # and can gate context/dialectic refresh via contextCadence/dialecticCadence.
-    if agent._memory_manager:
+    if agent._memory_manager and not getattr(agent, "skip_memory_sync", False):
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
             agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
@@ -777,7 +778,7 @@ def run_conversation(
     # Use original_user_message (clean input) — user_message may contain
     # injected skill content that bloats / breaks provider queries.
     _ext_prefetch_cache = ""
-    if agent._memory_manager:
+    if agent._memory_manager and not getattr(agent, "skip_memory_sync", False):
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             _ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -300,7 +300,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
 
-    if agent._memory_store:
+    if agent._memory_store and not getattr(agent, "skip_memory_prompt", False):
         if agent._memory_enabled:
             mem_block = agent._memory_store.format_for_system_prompt("memory")
             if mem_block:
@@ -312,7 +312,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 volatile_parts.append(user_block)
 
     # External memory provider system prompt block (additive to built-in)
-    if agent._memory_manager:
+    if agent._memory_manager and not getattr(agent, "skip_memory_prompt", False):
         try:
             _ext_mem_block = agent._memory_manager.build_system_prompt()
             if _ext_mem_block:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1755,7 +1755,16 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            # Keep memory tools/provider available for explicit jobs such as
+            # nightly scope-recall digests, but do not inject durable memory
+            # blocks into the cron system prompt and do not let automatic
+            # provider hooks (turn-start, prefetch, sync) or background
+            # memory review write the cron prompt/report into memory.
+            # ``skip_memory=True`` disables the provider entirely, which
+            # makes ``scope_recall_*`` unavailable.
+            skip_memory=False,
+            skip_memory_prompt=True,
+            skip_memory_sync=True,
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/run_agent.py
+++ b/run_agent.py
@@ -396,6 +396,8 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
+        skip_memory_prompt: bool = False,
+        skip_memory_sync: bool = False,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -466,6 +468,8 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            skip_memory_prompt=skip_memory_prompt,
+            skip_memory_sync=skip_memory_sync,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -2820,6 +2824,8 @@ class AIAgent:
         backend must not block the user from seeing their response.
         """
         if interrupted:
+            return
+        if getattr(self, "skip_memory_sync", False):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -17,6 +17,8 @@ def _make_agent(**overrides):
         _kanban_worker_guidance="",
         _memory_store=None,
         _memory_manager=None,
+        _memory_enabled=True,
+        _user_profile_enabled=True,
         model="",
         provider="",
         platform="",
@@ -55,3 +57,58 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+class TestMemoryPromptSkip:
+    def test_skip_memory_prompt_suppresses_builtin_and_external_memory_blocks(self):
+        class FakeMemoryStore:
+            def format_for_system_prompt(self, target):
+                return f"BUILTIN-{target}-BLOCK"
+
+        class FakeMemoryManager:
+            def build_system_prompt(self):
+                return "EXTERNAL-MEMORY-BLOCK"
+
+        agent = _make_agent(
+            _memory_store=FakeMemoryStore(),
+            _memory_manager=FakeMemoryManager(),
+            skip_memory_prompt=True,
+        )
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert "BUILTIN-memory-BLOCK" not in parts["volatile"]
+        assert "BUILTIN-user-BLOCK" not in parts["volatile"]
+        assert "EXTERNAL-MEMORY-BLOCK" not in parts["volatile"]
+
+    def test_memory_prompt_includes_memory_blocks_by_default(self):
+        class FakeMemoryStore:
+            def format_for_system_prompt(self, target):
+                return f"BUILTIN-{target}-BLOCK"
+
+        class FakeMemoryManager:
+            def build_system_prompt(self):
+                return "EXTERNAL-MEMORY-BLOCK"
+
+        agent = _make_agent(
+            _memory_store=FakeMemoryStore(),
+            _memory_manager=FakeMemoryManager(),
+        )
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert "BUILTIN-memory-BLOCK" in parts["volatile"]
+        assert "BUILTIN-user-BLOCK" in parts["volatile"]
+        assert "EXTERNAL-MEMORY-BLOCK" in parts["volatile"]

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1021,6 +1021,32 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_keeps_memory_tools_without_memory_prompt_or_sync(self, tmp_path):
+        """Cron jobs need explicit memory tools (scope_recall_*) without
+        polluting prompts or auto-syncing cron transcripts into memory.
+
+        Regression: scheduler passed ``skip_memory=True`` to AIAgent, which
+        disabled the memory provider entirely. Nightly digest jobs then saw
+        ``Memory is not available`` and could not write scope-recall entries.
+        """
+        job = {
+            "id": "memory-digest-job",
+            "name": "memory digest",
+            "prompt": "write durable memories",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is False
+        assert kwargs["skip_memory_prompt"] is True
+        assert kwargs["skip_memory_sync"] is True
+
     def test_run_job_disabled_toolsets_layer_user_config_on_baseline(self, tmp_path):
         """agent.disabled_toolsets must be honoured in cron — issue #25752.
 

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -91,6 +91,22 @@ class TestSyncExternalMemoryForTurn:
             session_id="test_session_001",
         )
 
+    def test_skip_memory_sync_disables_sync_and_prefetch(self):
+        """Cron jobs may use memory tools explicitly while suppressing
+        automatic transcript sync of the cron prompt/report pair.
+        """
+        agent = _bare_agent()
+        setattr(agent, "skip_memory_sync", True)
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="nightly digest prompt",
+            final_response="digest report",
+            interrupted=False,
+        )
+
+        agent._memory_manager.sync_all.assert_not_called()
+        agent._memory_manager.queue_prefetch_all.assert_not_called()
+
     def test_completed_turn_syncs_messages_when_present(self):
         agent = _bare_agent()
         messages = [

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6374,3 +6374,26 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+    def test_skip_memory_sync_guards_automatic_external_memory_hooks(self):
+        """Cron can keep memory tools available while suppressing automatic
+        external-memory provider hooks for the cron prompt/report turn.
+        """
+        import inspect
+        from agent.conversation_loop import run_conversation as _rc
+
+        src = inspect.getsource(_rc)
+        guarded = 'if agent._memory_manager and not getattr(agent, "skip_memory_sync", False):'
+        assert src.count(guarded) >= 2
+        assert "agent._memory_manager.on_turn_start" in src
+        assert "agent._memory_manager.prefetch_all" in src
+
+    def test_skip_memory_sync_disables_background_memory_nudge(self):
+        """The built-in memory-review nudge is also automatic memory IO and
+        must stay off for cron memory-digest jobs unless they call memory tools.
+        """
+        import inspect
+        from agent.conversation_loop import run_conversation as _rc
+
+        src = inspect.getsource(_rc)
+        assert 'and not getattr(agent, "skip_memory_sync", False))' in src


### PR DESCRIPTION
## Summary
- keep the memory provider initialized for cron jobs so explicit memory tools such as `scope_recall_*` remain available
- add separate cron controls to suppress durable memory prompt injection and automatic memory provider IO
- guard automatic turn-start, prefetch, sync, and background memory-review paths while preserving normal user-session behavior

## Test plan
- `python -m py_compile run_agent.py agent/agent_init.py agent/system_prompt.py agent/conversation_loop.py cron/scheduler.py tests/cron/test_scheduler.py tests/agent/test_system_prompt.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_run_agent.py`
- `python -m pytest -q -o addopts='' tests/cron/test_scheduler.py tests/agent/test_system_prompt.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_run_agent.py::TestMemoryProviderTurnStart`
- `git diff --check`
- `python -m ruff check agent/agent_init.py agent/system_prompt.py agent/conversation_loop.py cron/scheduler.py run_agent.py tests/cron/test_scheduler.py tests/agent/test_system_prompt.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_run_agent.py`
- added-lines secret scan: 0 findings

## Notes
This fixes cron jobs that intentionally write durable memories via explicit memory tools while avoiding accidental prompt/report ingestion from automatic memory hooks.