### PR TITLE
fix(cli): clean stale dashboard processes on startup and broaden TUI pattern detection

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7592,6 +7592,8 @@ def _find_stale_dashboard_pids(
         "hermes dashboard",
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
+        "dashboard --tui",          # TUI dashboard processes (#39136)
+        "dashboard --no-open",      # No-open flag, always used with TUI (#39136)
     ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
@@ -12353,6 +12355,13 @@ def cmd_dashboard(args):
         # log and proceed; the gate's fail-closed branch will surface
         # the missing-provider state if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
+
+    # Kill any existing dashboard processes before starting a new one to
+    # prevent stale process accumulation and port conflicts (#39136).
+    existing = _find_stale_dashboard_pids()
+    if existing:
+        print(f"  Stopping {len(existing)} existing dashboard process(es)...")
+        _kill_stale_dashboard_processes(reason="starting fresh dashboard")
 
     from hermes_cli.web_server import start_server
 


### PR DESCRIPTION
When `hermes dashboard --tui` processes from old versions survive an update, they accumulate on different ports and cause port conflicts. The existing scanner only matched command lines containing "hermes dashboard" or "hermes_cli.main dashboard", but old TUI dashboard processes show up with just "dashboard --tui" or "dashboard --no-open" in the ps output, so the scanner missed them.

Two changes:

1. Added "dashboard --tui" and "dashboard --no-open" to the scan patterns so TUI dashboard processes are caught.

2. Added a startup cleanup in cmd_dashboard that kills stale dashboard processes before starting a fresh one. This prevents stale process accumulation and port conflicts whenever `hermes dashboard` is invoked.

Fixes #39136
