### PR TITLE
fix(desktop): bootstrap from the repository the app was built from

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -11,7 +11,9 @@ import {
   cachedScriptPath,
   hasExistingGitCheckout,
   installedAgentInstallScript,
+  installerRepoEnv,
   installRefForStamp,
+  installRepositoryForStamp,
   isPinnedCommit,
   resolveInstallScript,
   resolveMarkerPinnedCommit,
@@ -117,7 +119,8 @@ test('fallback install stamps use an unpinned branch ref', () => {
   assert.deepEqual(installRefForStamp(stamp), {
     ref: 'main',
     cacheKey: 'fallback-main',
-    pinned: false
+    pinned: false,
+    repository: 'NousResearch/hermes-agent'
   })
   // Must NOT pass -Commit / --commit for the all-zero placeholder.
   assert.deepEqual(buildPinArgs(stamp), ['-Branch', 'main'])
@@ -268,6 +271,67 @@ test('resolveInstallScript rethrows when the 404 fallback is unavailable', async
       }),
       /HTTP 404|Failed to download/
     )
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('install refs default to the canonical repository', () => {
+  assert.equal(installRepositoryForStamp(null), 'NousResearch/hermes-agent')
+  assert.equal(installRepositoryForStamp({ commit: 'a'.repeat(40) }), 'NousResearch/hermes-agent')
+  // Anything that isn't a clean owner/name slug must not reach a fetch URL.
+  assert.equal(installRepositoryForStamp({ repository: 'ForkOwner/hermes-agent/../evil' }), 'NousResearch/hermes-agent')
+  assert.equal(installRepositoryForStamp({ repository: 'https://evil.example/x/y' }), 'NousResearch/hermes-agent')
+  // Canonical builds pass no installer env, so install.sh/ps1 keep their defaults.
+  assert.deepEqual(installerRepoEnv(null), {})
+  assert.deepEqual(installerRepoEnv({ repository: 'NousResearch/hermes-agent' }), {})
+})
+
+test('fork-stamped builds resolve refs and installer env against the fork', () => {
+  const commit = 'a'.repeat(40)
+
+  assert.equal(installRepositoryForStamp({ repository: 'ForkOwner/hermes-agent' }), 'ForkOwner/hermes-agent')
+  assert.deepEqual(installRefForStamp({ commit, repository: 'ForkOwner/hermes-agent' }), {
+    ref: commit,
+    cacheKey: `ForkOwner_hermes-agent-${commit}`,
+    pinned: true,
+    repository: 'ForkOwner/hermes-agent'
+  })
+  // Unpinned fork stamps must not share a cache entry with the canonical repo.
+  assert.deepEqual(installRefForStamp({ commit: ZERO_COMMIT, branch: 'main', repository: 'ForkOwner/hermes-agent' }), {
+    ref: 'main',
+    cacheKey: 'ForkOwner_hermes-agent-fallback-main',
+    pinned: false,
+    repository: 'ForkOwner/hermes-agent'
+  })
+  assert.deepEqual(installerRepoEnv({ repository: 'ForkOwner/hermes-agent' }), {
+    HERMES_INSTALL_REPO_ARCHIVE_BASE: 'https://github.com/ForkOwner/hermes-agent',
+    HERMES_INSTALL_REPO_URL_HTTPS: 'https://github.com/ForkOwner/hermes-agent.git',
+    HERMES_INSTALL_REPO_URL_SSH: 'git@github.com:ForkOwner/hermes-agent.git'
+  })
+})
+
+test('resolveInstallScript downloads from the stamped fork repository', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-fork-'))
+  const seen: any[] = []
+
+  try {
+    const result: any = await resolveInstallScript({
+      installStamp: { commit: 'b'.repeat(40), branch: 'main', repository: 'ForkOwner/hermes-agent' },
+      sourceRepoRoot: null,
+      hermesHome: home,
+      emit: () => {},
+      _download: async (ref, destPath, repository) => {
+        seen.push({ ref, repository })
+        fs.mkdirSync(path.dirname(destPath), { recursive: true })
+        fs.writeFileSync(destPath, '# installer\n')
+
+        return destPath
+      }
+    })
+
+    assert.equal(result.source, 'download')
+    assert.deepEqual(seen, [{ ref: 'b'.repeat(40), repository: 'ForkOwner/hermes-agent' }])
   } finally {
     fs.rmSync(home, { recursive: true, force: true })
   }

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -46,8 +46,49 @@ const STAMP_COMMIT_RE = /^[0-9a-f]{7,40}$/i
 const FALLBACK_COMMIT_RE = /^0{7,40}$/
 const FALLBACK_BRANCH = 'main'
 
+// Canonical upstream repository. A desktop app built from a fork stamps its own
+// `owner/name` so first-launch bootstrap fetches install.sh/ps1 -- and clones
+// the agent checkout -- from the repo the app was actually built from.
+const DEFAULT_INSTALL_REPOSITORY = 'NousResearch/hermes-agent'
+const INSTALL_REPOSITORY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
 function isPinnedCommit(commit) {
   return typeof commit === 'string' && STAMP_COMMIT_RE.test(commit) && !FALLBACK_COMMIT_RE.test(commit)
+}
+
+/**
+ * The GitHub `owner/name` an install stamp points at, defaulting to the
+ * canonical repo so official builds and pre-`repository` stamps are unchanged.
+ * Anything that isn't a plain, well-formed slug is rejected rather than
+ * interpolated into a URL.
+ */
+function installRepositoryForStamp(installStamp) {
+  const value = installStamp && installStamp.repository
+
+  if (typeof value === 'string' && INSTALL_REPOSITORY_RE.test(value.trim())) {
+    return value.trim()
+  }
+
+  return DEFAULT_INSTALL_REPOSITORY
+}
+
+/**
+ * Environment handed to install.sh / install.ps1 so the installer clones the
+ * same repository the desktop app was built from. Empty for canonical builds --
+ * the scripts keep their own hardcoded defaults.
+ */
+function installerRepoEnv(installStamp) {
+  const repository = installRepositoryForStamp(installStamp)
+
+  if (repository === DEFAULT_INSTALL_REPOSITORY) {
+    return {}
+  }
+
+  return {
+    HERMES_INSTALL_REPO_ARCHIVE_BASE: `https://github.com/${repository}`,
+    HERMES_INSTALL_REPO_URL_HTTPS: `https://github.com/${repository}.git`,
+    HERMES_INSTALL_REPO_URL_SSH: `git@github.com:${repository}.git`
+  }
 }
 
 type ExecGitFn = (args: string[], cwd: string) => string
@@ -131,11 +172,18 @@ function resolveMarkerPinnedCommit(
  * never asks GitHub for commit 0000000... (#50823).
  */
 function installRefForStamp(installStamp) {
+  const repository = installRepositoryForStamp(installStamp)
+  // Fork refs live in a different namespace than canonical ones, so keep their
+  // cached scripts separate (an unpinned `fallback-main` key would otherwise
+  // collide across repositories).
+  const scope = repository === DEFAULT_INSTALL_REPOSITORY ? '' : `${repository.replace(/[^0-9A-Za-z._-]/g, '_')}-`
+
   if (installStamp && isPinnedCommit(installStamp.commit)) {
     return {
       ref: installStamp.commit,
-      cacheKey: installStamp.commit,
-      pinned: true
+      cacheKey: `${scope}${installStamp.commit}`,
+      pinned: true,
+      repository
     }
   }
 
@@ -144,8 +192,9 @@ function installRefForStamp(installStamp) {
 
     return {
       ref,
-      cacheKey: `fallback-${String(ref).replace(/[^0-9A-Za-z._-]/g, '_')}`,
-      pinned: false
+      cacheKey: `${scope}fallback-${String(ref).replace(/[^0-9A-Za-z._-]/g, '_')}`,
+      pinned: false,
+      repository
     }
   }
 
@@ -227,13 +276,14 @@ function cachedScriptPath(hermesHome, commit) {
   return path.join(bootstrapCacheDir(hermesHome), `install-${commit}.${process.platform === 'win32' ? 'ps1' : 'sh'}`)
 }
 
-function downloadInstallScript(ref, destPath) {
+function downloadInstallScript(ref, destPath, repository = DEFAULT_INSTALL_REPOSITORY) {
   // Fetch from GitHub raw at the install ref. Normal production builds pass a
   // pinned SHA (immutable). Non-git fallback builds pass an unpinned branch
   // ref so local builds can still bootstrap without pretending the all-zero
-  // placeholder is a real GitHub commit.
+  // placeholder is a real GitHub commit. Fork-built apps pass their own
+  // repository so the ref resolves in the repo it actually came from.
   const scriptName = installScriptName()
-  const url = `https://raw.githubusercontent.com/NousResearch/hermes-agent/${ref}/scripts/${scriptName}`
+  const url = `https://raw.githubusercontent.com/${repository}/${ref}/scripts/${scriptName}`
 
   return new Promise((resolve, reject) => {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
@@ -362,12 +412,12 @@ async function resolveInstallScript({
   emit({
     type: 'log',
     line:
-      `[bootstrap] fetching ${installScriptName()} for ${installRef.ref.slice(0, 12)} from GitHub` +
+      `[bootstrap] fetching ${installScriptName()} for ${installRef.ref.slice(0, 12)} from ${installRef.repository}` +
       (installRef.pinned ? '' : ' (fallback, unpinned)')
   })
 
   try {
-    await _download(installRef.ref, cached)
+    await _download(installRef.ref, cached, installRef.repository)
     emit({ type: 'log', line: `[bootstrap] saved to ${cached}` })
 
     return { path: cached, source: 'download', commit: resolvedCommit, kind: installScriptKind() }
@@ -456,7 +506,7 @@ function resolveWindowsPowerShell() {
   return 'powershell.exe'
 }
 
-function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, hermesHome }: any = {}) {
+function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, hermesHome, installerEnv }: any = {}) {
   return new Promise<any>((resolve, reject) => {
     const ps = process.platform === 'win32' ? resolveWindowsPowerShell() : 'pwsh'
     const fullArgs = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath, ...args]
@@ -468,6 +518,7 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
         stdio: ['ignore', 'pipe', 'pipe'],
         env: {
           ...process.env,
+          ...(installerEnv || {}),
           // Pass HERMES_HOME through so install.ps1 respects the caller's
           // choice rather than re-computing the default.
           HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
@@ -560,12 +611,13 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
   })
 }
 
-function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome }: any = {}) {
+function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome, installerEnv }: any = {}) {
   return new Promise<any>((resolve, reject) => {
     const child = spawn('bash', [scriptPath, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...(installerEnv || {}),
         HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
       }
     })
@@ -700,7 +752,8 @@ async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, acti
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: '__manifest__',
-    hermesHome
+    hermesHome,
+    installerEnv: installerRepoEnv(installStamp)
   })
 
   if (result.code !== 0) {
@@ -782,7 +835,8 @@ async function runStage({
     emit,
     stageName: stage.name,
     abortSignal,
-    hermesHome
+    hermesHome,
+    installerEnv: installerRepoEnv(installStamp)
   })
 
   const durationMs = Date.now() - startedAt
@@ -1025,7 +1079,9 @@ export {
   cachedScriptPath,
   hasExistingGitCheckout,
   installedAgentInstallScript,
+  installerRepoEnv,
   installRefForStamp,
+  installRepositoryForStamp,
   isPinnedCommit,
   // Exposed for testability
   parseStageResult,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -448,7 +448,7 @@ const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')
 // build hasn't been invoked, or schema mismatch). Callers must handle null.
 //
 // Schema:
-//   { schemaVersion: 1, commit, branch, builtAt, dirty, source }
+//   { schemaVersion: 1, commit, branch, repository, builtAt, dirty, source }
 const INSTALL_STAMP_SCHEMA_VERSION = 1
 
 function loadInstallStamp() {
@@ -479,6 +479,11 @@ function loadInstallStamp() {
           schemaVersion: parsed.schemaVersion,
           commit: parsed.commit,
           branch: parsed.branch || null,
+          // GitHub owner/name this build came from; bootstrap fetches the
+          // installer (and clones the agent) from here so fork-built apps do
+          // not chase refs that only exist in their own repo. Absent on
+          // pre-repository stamps -- bootstrap defaults to the canonical repo.
+          repository: parsed.repository || null,
           builtAt: parsed.builtAt || null,
           dirty: Boolean(parsed.dirty),
           source: parsed.source || null,

--- a/apps/desktop/scripts/write-build-stamp.mjs
+++ b/apps/desktop/scripts/write-build-stamp.mjs
@@ -9,6 +9,7 @@
  *     "schemaVersion": 1,
  *     "commit":        "<40-char SHA>",
  *     "branch":        "<branch name>",
+ *     "repository":    "<owner/name>",   // GitHub repo the build came from
  *     "builtAt":       "<ISO 8601 UTC timestamp>",
  *     "dirty":         true|false,
  *     "source":        "ci" | "local" | "fallback"
@@ -37,6 +38,27 @@ const STAMP_SCHEMA_VERSION = 1
 /** All-zero placeholder used when no real commit can be resolved. */
 export const FALLBACK_COMMIT = "0000000000000000000000000000000000000000"
 export const FALLBACK_BRANCH = "main"
+/** Canonical upstream repo; forks stamp their own so bootstrap follows them. */
+export const DEFAULT_REPOSITORY = "NousResearch/hermes-agent"
+
+const REPOSITORY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/**
+ * Reduce a GitHub remote URL (or an already-plain slug) to `owner/name`.
+ * Returns null for anything that isn't GitHub, so non-GitHub remotes fall back
+ * to the canonical repository rather than producing a bogus fetch URL.
+ */
+export function normalizeGitHubRepository(value) {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim().replace(/\/+$/, "")
+  if (!trimmed) return null
+
+  const ssh = trimmed.match(/^(?:ssh:\/\/)?git@github\.com[:/](.+?)(?:\.git)?$/i)
+  const https = trimmed.match(/^https?:\/\/(?:[^@/]+@)?github\.com\/(.+?)(?:\.git)?$/i)
+  const slug = ssh?.[1] ?? https?.[1] ?? (trimmed.includes("://") || trimmed.includes("@") ? null : trimmed)
+
+  return typeof slug === "string" && REPOSITORY_RE.test(slug) ? slug : null
+}
 
 const DESKTOP_ROOT = resolve(import.meta.dirname, "..")
 const REPO_ROOT = resolve(DESKTOP_ROOT, "..", "..")
@@ -58,6 +80,7 @@ export function fromCI(env = process.env) {
   return {
     commit: sha,
     branch: branch,
+    repository: normalizeGitHubRepository(env.GITHUB_REPOSITORY),
     dirty: false, // CI builds from a checkout-of-ref by definition
     source: "ci"
   }
@@ -75,9 +98,13 @@ export function fromLocalGit(repoRoot = REPO_ROOT, execFn = tryExec) {
   // differs from the commit being pinned.
   const status = execFn("git status --porcelain -uno", { cwd: repoRoot })
   const dirty = status !== null && status.length > 0
+  // A fork-built app must bootstrap from the fork: its branches and commits do
+  // not exist upstream.  `origin` is the remote the checkout was cloned from.
+  const remote = execFn("git remote get-url origin", { cwd: repoRoot })
   return {
     commit: sha,
     branch: branch === "HEAD" ? null : branch, // detached HEAD -> null
+    repository: normalizeGitHubRepository(remote),
     dirty: dirty,
     source: "local"
   }
@@ -92,6 +119,7 @@ export function fromFallback(branch = FALLBACK_BRANCH) {
   return {
     commit: FALLBACK_COMMIT,
     branch: branch || FALLBACK_BRANCH,
+    repository: null,
     dirty: false,
     source: "fallback"
   }
@@ -153,6 +181,7 @@ function main() {
     schemaVersion: STAMP_SCHEMA_VERSION,
     commit: stamp.commit,
     branch: stamp.branch,
+    repository: stamp.repository || DEFAULT_REPOSITORY,
     builtAt: new Date().toISOString(),
     dirty: stamp.dirty,
     source: stamp.source

--- a/apps/desktop/scripts/write-build-stamp.test.mjs
+++ b/apps/desktop/scripts/write-build-stamp.test.mjs
@@ -8,13 +8,14 @@ import {
   fromFallback,
   fromLocalGit,
   isFallbackCommit,
+  normalizeGitHubRepository,
   resolveStamp
 } from './write-build-stamp.mjs'
 
 test('fromCI reads GITHUB_SHA / GITHUB_REF_NAME', () => {
   assert.deepEqual(
     fromCI({ GITHUB_SHA: 'a'.repeat(40), GITHUB_REF_NAME: 'release' }),
-    { commit: 'a'.repeat(40), branch: 'release', dirty: false, source: 'ci' }
+    { commit: 'a'.repeat(40), branch: 'release', repository: null, dirty: false, source: 'ci' }
   )
   assert.equal(fromCI({}), null)
 })
@@ -36,6 +37,7 @@ test('fromLocalGit reads HEAD + branch + dirty status', () => {
   assert.deepEqual(fromLocalGit('/repo', execFn), {
     commit: 'b'.repeat(40),
     branch: 'main',
+    repository: null,
     dirty: true,
     source: 'local'
   })
@@ -46,6 +48,7 @@ test('fromFallback uses the all-zero placeholder commit', () => {
   assert.deepEqual(fromFallback(), {
     commit: FALLBACK_COMMIT,
     branch: FALLBACK_BRANCH,
+    repository: null,
     dirty: false,
     source: 'fallback'
   })
@@ -80,7 +83,32 @@ test('resolveStamp falls back when neither CI nor git is available', () => {
   assert.deepEqual(stamp, {
     commit: FALLBACK_COMMIT,
     branch: FALLBACK_BRANCH,
+    repository: null,
     dirty: false,
     source: 'fallback'
   })
+})
+
+test('normalizeGitHubRepository reduces remote URLs to owner/name', () => {
+  assert.equal(normalizeGitHubRepository('git@github.com:ForkOwner/hermes-agent.git'), 'ForkOwner/hermes-agent')
+  assert.equal(normalizeGitHubRepository('https://github.com/NousResearch/hermes-agent.git'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('https://github.com/NousResearch/hermes-agent/'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('ForkOwner/hermes-agent'), 'ForkOwner/hermes-agent')
+  // Non-GitHub / malformed remotes must not become a fetch URL.
+  assert.equal(normalizeGitHubRepository('https://gitlab.com/ForkOwner/hermes-agent.git'), null)
+  assert.equal(normalizeGitHubRepository('/srv/mirrors/hermes-agent.git'), null)
+  assert.equal(normalizeGitHubRepository(undefined), null)
+})
+
+test('stamps record the repository the build came from', () => {
+  assert.equal(fromCI({ GITHUB_SHA: 'a'.repeat(40), GITHUB_REPOSITORY: 'ForkOwner/hermes-agent' }).repository, 'ForkOwner/hermes-agent')
+
+  const forkLocal = fromLocalGit('/repo', (cmd) => {
+    if (cmd === 'git rev-parse HEAD') return 'b'.repeat(40)
+    if (cmd === 'git rev-parse --abbrev-ref HEAD') return 'fix/desktop'
+    if (cmd === 'git status --porcelain -uno') return ''
+    if (cmd === 'git remote get-url origin') return 'git@github.com:ForkOwner/hermes-agent.git'
+    return null
+  })
+  assert.equal(forkLocal.repository, 'ForkOwner/hermes-agent')
 })

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -136,8 +136,12 @@ foreach ($tmpVar in @('TEMP', 'TMP')) {
 # Configuration
 # ============================================================================
 
-$RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
-$RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
+# Overridable so a desktop app built from a fork bootstraps against the repo it
+# was actually built from (HERMES_INSTALL_REPO_* is set by the desktop
+# bootstrap runner from the build stamp).  Unset -> canonical upstream.
+$RepoUrlSsh = if ($env:HERMES_INSTALL_REPO_URL_SSH) { $env:HERMES_INSTALL_REPO_URL_SSH } else { "git@github.com:NousResearch/hermes-agent.git" }
+$RepoUrlHttps = if ($env:HERMES_INSTALL_REPO_URL_HTTPS) { $env:HERMES_INSTALL_REPO_URL_HTTPS } else { "https://github.com/NousResearch/hermes-agent.git" }
+$RepoArchiveBase = if ($env:HERMES_INSTALL_REPO_ARCHIVE_BASE) { $env:HERMES_INSTALL_REPO_ARCHIVE_BASE.TrimEnd("/") } else { $RepoUrlHttps -replace "\.git$", "" }
 $PythonVersion = "3.11"
 # Minor versions the installer accepts when the requested $PythonVersion isn't
 # available, in preference order.  uv discovers both uv-managed and system
@@ -1663,13 +1667,13 @@ function Install-Repository {
                 # for.  GitHub supports archive URLs for commits, tags, and
                 # branches; we honour Commit > Tag > Branch.
                 if ($Commit) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
+                    $zipUrl = "$RepoArchiveBase/archive/$Commit.zip"
                     $zipLabel = $Commit
                 } elseif ($Tag) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
+                    $zipUrl = "$RepoArchiveBase/archive/refs/tags/$Tag.zip"
                     $zipLabel = $Tag
                 } else {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
+                    $zipUrl = "$RepoArchiveBase/archive/refs/heads/$Branch.zip"
                     $zipLabel = $Branch
                 }
                 $zipPath = "$env:TEMP\hermes-agent-$zipLabel.zip"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,8 +43,11 @@ NC='\033[0m' # No Color
 BOLD='\033[1m'
 
 # Configuration
-REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
-REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+# Overridable so a desktop app built from a fork bootstraps against the repo it
+# was actually built from (HERMES_INSTALL_REPO_* is set by the desktop
+# bootstrap runner from the build stamp).  Unset -> canonical upstream.
+REPO_URL_SSH="${HERMES_INSTALL_REPO_URL_SSH:-git@github.com:NousResearch/hermes-agent.git}"
+REPO_URL_HTTPS="${HERMES_INSTALL_REPO_URL_HTTPS:-https://github.com/NousResearch/hermes-agent.git}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an


### PR DESCRIPTION
## What changed

A desktop app built from a fork bootstraps against a hardcoded `NousResearch/hermes-agent`. Its stamped commit and branch exist only in the fork, so the GitHub raw fetch of `install.sh` / `install.ps1` 404s — and even when an installer is found via the installed-agent fallback, it clones the agent checkout from upstream rather than the fork the app was built from.

This records the build's repository on the install stamp and threads it through the stamp-pinning contract already on `main`:

- `write-build-stamp.mjs` resolves `owner/name` from `$GITHUB_REPOSITORY` (CI) or `git remote get-url origin` (local), defaulting to the canonical repo. Non-GitHub remotes normalize to `null` instead of a bogus URL.
- `installRefForStamp` carries `repository` alongside `ref` / `cacheKey` / `pinned`, and scopes fork cache keys so an unpinned `fallback-main` script cannot collide across repositories.
- `downloadInstallScript(ref, destPath, repository)` — repository defaults to the canonical repo.
- The bootstrap runner exports `HERMES_INSTALL_REPO_URL_SSH` / `HERMES_INSTALL_REPO_URL_HTTPS` / `HERMES_INSTALL_REPO_ARCHIVE_BASE` to the installer **only** for non-canonical builds; `install.sh` and `install.ps1` fall back to their existing hardcoded upstream URLs when the variables are unset.

## Root cause

The install stamp records *which ref* a packaged app was built from but not *which repository*. Every consumer therefore assumes upstream. That assumption is correct for official builds and wrong for every fork-built app, whose refs are not reachable from `NousResearch/hermes-agent` at all.

## Scope

This branch was rewritten on top of current `main` and reduced to fork-repository support alone. The earlier revision carried a competing stamp-pinning model (`installScriptRef`, `commitPinned`, a `ref` field on the resolved-script result, a separate `install-stamp.ts` with its own normalizer) that duplicated and conflicted with the `installRefForStamp` / `FALLBACK_COMMIT` / `resolveMarkerPinnedCommit` model `main` has since landed. That work is dropped: its core motivation — a locally-built app pinned to an unpushed HEAD 404ing at bootstrap — is already solved on `main` by the all-zero fallback ref plus the installed-agent fallback. The CLI-side `hermes update` / banner tracking-remote changes are dropped from this PR as separate concerns.

## Safety

Repository values that are not a clean `owner/name` slug are rejected and fall back to the canonical repo, so nothing untrusted is interpolated into a fetch or clone URL. All-zero / fallback commit semantics are untouched. For canonical builds the refs, cache keys, and installer environment are byte-identical to `main` — the installer env is empty unless the stamp names a different repository.

## Validation

- `npx vitest run --project electron` — 872 passed, 2 skipped (74 files)
- `npm run typecheck` — clean
- `npm run check:lint` — 0 errors (67 pre-existing warnings in unrelated files)
- `bash -n scripts/install.sh`; PowerShell AST parse of `scripts/install.ps1` — both clean
- End-to-end: ran `node apps/desktop/scripts/write-build-stamp.mjs` from a fork checkout; stamp records `"repository": "OmarB97/hermes-agent"`

## Risk

First-launch bootstrap code, so the diff is deliberately minimal — 7 files, additive fields with canonical defaults. The main residual risk is a fork whose `origin` points somewhere unexpected; that path degrades to the canonical repo rather than failing.
