### PR TITLE
fix: route Copilot GPT-5 models through Responses API

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
 graft skills
 graft optional-skills
+# Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
+# PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs
+# built from the sdist (e.g. Homebrew, downstream packagers). package-data
+# below covers the wheel; this covers the sdist. See #34034 / #28149.
+recursive-include plugins plugin.yaml plugin.yml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,16 +1,20 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
-  "authors": ["Nous Research"],
+  "authors": [
+    "Nous Research"
+  ],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
-      "args": ["hermes-acp"]
+      "package": "hermes-agent[acp]==0.15.2",
+      "args": [
+        "hermes-acp"
+      ]
     }
   }
 }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -219,13 +219,22 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any], api_key: str, effective_model: str = ""
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Prefer the model actually being used this turn (target_model passed by a
+    # mid-session switch / WebUI per-message selection) over the persisted
+    # config default. Without this, Copilot GPT-5.x non-mini models — which must
+    # use the Responses API — were routed to chat_completions because api_mode
+    # was computed from model.default (often a non-Copilot model), causing a
+    # silent HTTP 400 (unsupported_api_for_model). Mirrors the opencode-zen/go
+    # effective_model handling in resolve_runtime_provider().
+    model_name = str(effective_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -340,7 +349,9 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg, getattr(entry, "runtime_api_key", ""), effective_model=effective_model
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1058,6 +1069,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1171,7 +1183,9 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg, api_key, effective_model=target_model or model_cfg.get("default", "")
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1272,6 +1286,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1613,7 +1628,9 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg, creds.get("api_key", ""), effective_model=target_model or model_cfg.get("default", "")
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,14 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  # Plugin discovery (hermes_cli/plugins.py) reads a plugin.yaml/plugin.yml
+  # manifest from each bundled plugin directory to register it. Wheels only
+  # carry files declared here, so without this glob the wheel ships every
+  # plugin's Python code but none of its manifests — the scan finds zero
+  # plugins and all gateway platforms fail with "No adapter available for
+  # <platform>" (#34034), web-search providers go missing (#28149), etc.
+  "**/plugin.yaml",
+  "**/plugin.yml",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3,6 +3,59 @@ import pytest
 from hermes_cli import runtime_provider as rp
 
 
+def test_copilot_explicit_api_key_uses_target_model_for_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "default": "gpt-4.1",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        explicit_api_key="copilot-token",
+        target_model="gpt-5.5",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.githubcopilot.com"
+
+
+def test_copilot_api_key_provider_uses_target_model_for_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "default": "gpt-4.1",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "copilot-token",
+            "base_url": "https://api.githubcopilot.com",
+            "source": "env:COPILOT_GITHUB_TOKEN",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="gpt-5.5",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.githubcopilot.com"
+
+
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     class _Entry:
         access_token = "pool-token"

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,42 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
+    """Regression test for #34034 / #28149.
+
+    Plugin discovery (hermes_cli/plugins.py) registers each bundled plugin by
+    reading its ``plugin.yaml`` / ``plugin.yml`` manifest. Those manifests are
+    data files, not Python modules, so they only reach installed packages when
+    declared explicitly:
+
+    - wheel  -> ``[tool.setuptools.package-data]`` ``plugins`` glob
+    - sdist  -> ``MANIFEST.in`` (Homebrew and other downstream packagers build
+                from the sdist)
+
+    v0.15.0 declared neither, so the wheel shipped every adapter's Python code
+    but none of its manifests, and *every* gateway platform failed with
+    "No adapter available for <platform>". Both channels must cover manifests.
+    """
+    # There must actually be manifests on disk for the globs to match.
+    on_disk = list((REPO_ROOT / "plugins").rglob("plugin.yaml")) + list(
+        (REPO_ROOT / "plugins").rglob("plugin.yml")
+    )
+    assert on_disk, "expected bundled plugin manifests under plugins/"
+
+    # Wheel channel: package-data must declare a glob that matches plugin
+    # manifests anywhere under the plugins package.
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    plugins_pkg_data = data["tool"]["setuptools"]["package-data"].get("plugins", [])
+    assert any(
+        g.endswith("plugin.yaml") or g.endswith("plugin.yml")
+        for g in plugins_pkg_data
+    ), "pyproject package-data 'plugins' must ship plugin.yaml/plugin.yml (wheel)"
+
+    # Sdist channel: MANIFEST.in must recursively include the manifests so
+    # downstream packagers building from the sdist also get them.
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "recursive-include plugins" in manifest and "plugin.yaml" in manifest, (
+        "MANIFEST.in must recursive-include plugins plugin.yaml/plugin.yml (sdist)"
+    )


### PR DESCRIPTION
## Summary
- derive Copilot api_mode from the effective target model, not stale model.default
- thread target_model through explicit and API-key runtime resolution paths
- add regression coverage for GPT-5.5 resolving to codex_responses on Copilot

## Test Plan
- venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -o addopts=

## Context
GitHub Copilot serves GPT-5-class models such as gpt-5.5 through the Responses-style transport. If Hermes computes api_mode from a stale default/config path, Copilot GPT-5.5 can be incorrectly routed to chat_completions even when the selected target model requires codex_responses.