### PR TITLE
fix(opencode-go): restore Hermes transport parity

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,16 +1,20 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
-  "authors": ["Nous Research"],
+  "authors": [
+    "Nous Research"
+  ],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
-      "args": ["hermes-acp"]
+      "package": "hermes-agent[acp]==0.15.2",
+      "args": [
+        "hermes-acp"
+      ]
     }
   }
 }

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -369,21 +369,19 @@ def _normalize_base_url_text(base_url) -> str:
 def _normalize_anthropic_client_base_url(base_url: str | None) -> str:
     """Normalize base URLs before handing them to the Anthropic SDK.
 
-    Most Anthropic-compatible endpoints want the exact root passed through.
-    OpenCode's Anthropic-wire routes are the exception: Hermes stores the Go/Zen
-    profile base URLs with a trailing ``/v1`` for OpenAI-compatible transports,
-    but Anthropic's SDK appends its own ``/v1/messages`` suffix. Leaving the
-    stored ``/v1`` intact yields ``.../v1/v1/messages`` and a 404.
+    Anthropic's SDK appends its own ``/v1/messages`` suffix. Hermes often keeps
+    provider roots in an OpenAI-compatible form ending in ``/v1`` (OpenCode
+    Go/Zen, self-hosted Anthropic relays, some Azure-compatible proxies, etc.).
+    Passing that ``/v1`` through would produce ``.../v1/v1/messages`` and a 404,
+    so strip only the trailing transport suffix while preserving any earlier path
+    segments.
     """
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return ""
-    lowered = normalized.rstrip("/").lower()
-    if lowered.endswith("/zen/go/v1") or lowered.endswith("/zen/v1"):
-        import re as _re
+    import re as _re
 
-        return _re.sub(r"/v1/?$", "", normalized.rstrip("/"))
-    return normalized
+    return _re.sub(r"/v1/?$", "", normalized.rstrip("/"))
 
 
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -359,11 +359,31 @@ def _normalize_base_url_text(base_url) -> str:
     """Normalize SDK/base transport URL values to a plain string for inspection.
 
     Some client objects expose ``base_url`` as an ``httpx.URL`` instead of a raw
-    string.  Provider/auth detection should accept either shape.
+    string. Provider/auth detection should accept either shape.
     """
     if not base_url:
         return ""
     return str(base_url).strip()
+
+
+def _normalize_anthropic_client_base_url(base_url: str | None) -> str:
+    """Normalize base URLs before handing them to the Anthropic SDK.
+
+    Most Anthropic-compatible endpoints want the exact root passed through.
+    OpenCode's Anthropic-wire routes are the exception: Hermes stores the Go/Zen
+    profile base URLs with a trailing ``/v1`` for OpenAI-compatible transports,
+    but Anthropic's SDK appends its own ``/v1/messages`` suffix. Leaving the
+    stored ``/v1`` intact yields ``.../v1/v1/messages`` and a 404.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return ""
+    lowered = normalized.rstrip("/").lower()
+    if lowered.endswith("/zen/go/v1") or lowered.endswith("/zen/v1"):
+        import re as _re
+
+        return _re.sub(r"/v1/?$", "", normalized.rstrip("/"))
+    return normalized
 
 
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
@@ -606,11 +626,9 @@ def _build_anthropic_client_with_bearer_hook(
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
     timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
 
-    # Strip any trailing /v1 — the Anthropic SDK appends /v1/messages.
-    normalized_base_url = _normalize_base_url_text(base_url)
-    if normalized_base_url:
-        import re as _re
-        normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
+    # Anthropic SDK appends /v1/messages. Normalize provider roots that store
+    # an OpenAI-compatible /v1 suffix in config/runtime state.
+    normalized_base_url = _normalize_anthropic_client_base_url(base_url)
 
     http_client = build_bearer_http_client(token_provider, timeout=timeout_obj)
 
@@ -694,7 +712,7 @@ def build_anthropic_client(
 
     from httpx import Timeout
 
-    normalized_base_url = _normalize_base_url_text(base_url)
+    normalized_base_url = _normalize_anthropic_client_base_url(base_url)
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3090,12 +3090,18 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     - GPT-5 / Codex models on Zen use ``/v1/responses``
     - Claude models on Zen use ``/v1/messages``
-    - MiniMax models on Go use ``/v1/messages``
     - GLM / Kimi on Go use ``/v1/chat/completions``
+    - MiniMax on Go is empirically chat-completions compatible in Hermes
+      (the ``/v1/messages`` route currently 404s in live smoke tests)
     - Other Zen models (Gemini, GLM, Kimi, MiniMax, Qwen, etc.) use
       ``/v1/chat/completions``
 
-    This follows the published OpenCode docs for Zen and Go endpoints.
+    Notes from live smoke tests on 2026-06-04:
+    - ``minimax-m2.7`` succeeded via ``chat_completions`` and failed via
+      ``anthropic_messages`` on the Hermes transport.
+    - ``qwen3.7-max`` still does not fit Hermes' current OpenAI-compat nor
+      Anthropic transports even though ``opencode run`` can serve it, so it
+      remains special-cased separately pending a dedicated transport fix.
     """
     provider = normalize_provider(provider_id)
     normalized = normalize_opencode_model_id(provider_id, model_id).lower()
@@ -3103,8 +3109,6 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         return "chat_completions"
 
     if provider == "opencode-go":
-        if normalized.startswith("minimax-"):
-            return "anthropic_messages"
         if normalized.startswith("qwen3.7-max"):
             return "anthropic_messages"
         return "chat_completions"

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -3,8 +3,8 @@
 Both use per-model api_mode routing:
   - OpenCode Zen: Claude → anthropic_messages, GPT-5/Codex → codex_responses,
     everything else → chat_completions (this profile)
-  - OpenCode Go: MiniMax → anthropic_messages, GLM/Kimi → chat_completions
-    (this profile)
+  - OpenCode Go: GLM/Kimi/MiniMax → chat_completions (this profile)
+    while qwen3.7-max remains a special case outside the generic transport
 """
 
 from __future__ import annotations
@@ -56,24 +56,17 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # OpenCode Go's Kimi relay rejects requests that include BOTH
+            # extra_body.thinking and top-level reasoning_effort. Native
+            # ``opencode run`` succeeds with thinking-only, so mirror that
+            # wire shape here and let the relay/provider choose its default
+            # reasoning depth when thinking is enabled.
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
-            if not enabled:
-                return extra_body, top_level
-
-            effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max"}:
-                top_level["reasoning_effort"] = "high"
-            elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/scripts/opencode_go_smoke_matrix.py
+++ b/scripts/opencode_go_smoke_matrix.py
@@ -53,19 +53,33 @@ def _load_key() -> str:
 
 def _run(cmd: list[str], *, timeout: int = 180) -> dict[str, Any]:
     started = time.time()
-    proc = subprocess.run(
-        cmd,
-        cwd=ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        timeout=timeout,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+        )
+        output = proc.stdout
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        output = f"{stdout}{stderr}\nTIMEOUT after {timeout}s"
+        exit_code = 124
+    except FileNotFoundError as exc:
+        output = f"MISSING_CMD: {exc}"
+        exit_code = 127
+    except OSError as exc:
+        output = f"OSERROR: {type(exc).__name__}: {exc}"
+        exit_code = 1
     return {
         "cmd": cmd,
-        "exit_code": proc.returncode,
+        "exit_code": exit_code,
         "seconds": round(time.time() - started, 2),
-        "output": proc.stdout,
+        "output": output,
     }
 
 
@@ -125,8 +139,8 @@ def probe_aiagent(model: str) -> dict[str, Any]:
 
     started = time.time()
     api_mode = opencode_model_api_mode("opencode-go", model)
-    key = _load_key()
     try:
+        key = _load_key()
         agent = AIAgent(
             api_key=key,
             base_url="https://opencode.ai/zen/go/v1",

--- a/scripts/opencode_go_smoke_matrix.py
+++ b/scripts/opencode_go_smoke_matrix.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Compare OpenCode Go model behavior across Hermes and the native opencode CLI.
+
+This is a local smoke harness for provider/plugin refinement, not a unit test.
+It runs three probes per model:
+  1) `opencode run` direct
+  2) `hermes chat` with a realistic /goal-capable toolset (terminal,file)
+  3) direct AIAgent with the provider's resolved api_mode and the same toolset
+
+Use it to quickly spot provider-routing regressions and CLI/runtime mismatches.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTH_JSON = Path.home() / ".local/share/opencode/auth.json"
+PROMPT = "Respond with exactly: SMOKE_OK"
+DEFAULT_MODELS = [
+    "glm-5.1",
+    "qwen3.7-plus",
+    "qwen3.7-max",
+    "kimi-k2.6",
+    "minimax-m2.7",
+]
+
+
+def _stub_module(name: str, **attrs: Any) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _ensure_repo_imports() -> None:
+    sys.path.insert(0, str(ROOT))
+    sys.modules.setdefault("fire", _stub_module("fire", Fire=lambda *a, **k: None))
+    sys.modules.setdefault("firecrawl", _stub_module("firecrawl", Firecrawl=object))
+    sys.modules.setdefault("fal_client", _stub_module("fal_client"))
+
+
+def _load_key() -> str:
+    data = json.loads(AUTH_JSON.read_text())
+    return data["opencode-go"]["key"]
+
+
+def _run(cmd: list[str], *, timeout: int = 180) -> dict[str, Any]:
+    started = time.time()
+    proc = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    return {
+        "cmd": cmd,
+        "exit_code": proc.returncode,
+        "seconds": round(time.time() - started, 2),
+        "output": proc.stdout,
+    }
+
+
+def _summarize(output: str, ok_token: str = "SMOKE_OK") -> str:
+    text = (output or "").strip()
+    if (
+        text.endswith(ok_token)
+        or f"'final_response': '{ok_token}'" in text
+        or f'"final_response": "{ok_token}"' in text
+        or f"\n{ok_token}\n" in text
+        or f"\n    {ok_token}\n" in text
+    ):
+        return "ok"
+    lowered = text.lower()
+    if "cannot specify both 'thinking' and 'reasoning_effort'" in lowered:
+        return "reasoning_conflict"
+    if "not supported for format oa-compat" in lowered:
+        return "unsupported_oa_compat"
+    if "404" in lowered and "not found" in lowered:
+        return "not_found"
+    if "api call failed after 3 retries" in lowered:
+        return "retry_exhausted"
+    if "error code:" in lowered or "error:" in lowered:
+        return "error"
+    return "unknown"
+
+
+def probe_opencode(model: str) -> dict[str, Any]:
+    result = _run(["opencode", "run", PROMPT, "--model", f"opencode-go/{model}"])
+    result["status"] = _summarize(result["output"])
+    return result
+
+
+def probe_hermes_chat(model: str) -> dict[str, Any]:
+    result = _run(
+        [
+            "hermes",
+            "chat",
+            "--provider",
+            "opencode-go",
+            "--toolsets",
+            "terminal,file",
+            "-m",
+            f"opencode-go/{model}",
+            "-q",
+            PROMPT,
+        ]
+    )
+    result["status"] = _summarize(result["output"])
+    return result
+
+
+def probe_aiagent(model: str) -> dict[str, Any]:
+    _ensure_repo_imports()
+    from run_agent import AIAgent
+    from hermes_cli.models import opencode_model_api_mode
+
+    started = time.time()
+    api_mode = opencode_model_api_mode("opencode-go", model)
+    key = _load_key()
+    try:
+        agent = AIAgent(
+            api_key=key,
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            api_mode=api_mode,
+            model=model,
+            max_iterations=1,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=["terminal", "file"],
+        )
+        reply = str(agent.run_conversation(PROMPT))
+        output = reply
+        exit_code = 0
+    except Exception as exc:  # pragma: no cover - smoke utility
+        output = f"EXC: {type(exc).__name__}: {exc}"
+        exit_code = 1
+    return {
+        "api_mode": api_mode,
+        "exit_code": exit_code,
+        "seconds": round(time.time() - started, 2),
+        "output": output,
+        "status": _summarize(output),
+    }
+
+
+def main(argv: list[str]) -> int:
+    models = argv or DEFAULT_MODELS
+    rows = []
+    for model in models:
+        row = {
+            "model": model,
+            "opencode": probe_opencode(model),
+            "hermes_chat": probe_hermes_chat(model),
+            "aiagent": probe_aiagent(model),
+        }
+        rows.append(row)
+    print(json.dumps(rows, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -119,6 +119,12 @@ class TestBuildAnthropicClient:
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://opencode.ai/zen/go"
 
+    def test_generic_anthropic_compatible_base_url_also_strips_trailing_v1(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("relay-key", base_url="https://relay.example.com/anthropic/v1")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://relay.example.com/anthropic"
+
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -106,12 +106,18 @@ class TestBuildAnthropicClient:
 
     def test_custom_base_url(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("sk-ant-api03-x", base_url="https://custom.api.com")
+            build_anthropic_client("***", base_url="https://custom.api.com")
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
             assert kwargs["default_headers"] == {
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
+
+    def test_opencode_go_base_url_strips_openai_v1_suffix(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("opencode-key", base_url="https://opencode.ai/zen/go/v1")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://opencode.ai/zen/go"
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -380,8 +380,8 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "kimi-k2.5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "opencode-go/kimi-k2.5") == "chat_completions"
-        assert opencode_model_api_mode("opencode-go", "minimax-m2.5") == "anthropic_messages"
-        assert opencode_model_api_mode("opencode-go", "opencode-go/minimax-m2.5") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-go", "minimax-m2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/minimax-m2.5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "qwen3.7-max") == "anthropic_messages"
         assert opencode_model_api_mode("opencode-go", "opencode-go/qwen3.7-max") == "anthropic_messages"
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,15 +17,19 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 models on OpenCode Go use thinking-only controls.
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    The relay rejects requests that include both ``extra_body.thinking`` and
+    top-level ``reasoning_effort``, so Hermes must omit the latter.
+    """
+
+    def test_high_effort_emits_thinking_without_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
-        assert top_level == {"reasoning_effort": "high"}
+        assert top_level == {}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
@@ -36,7 +40,6 @@ class TestOpenCodeGoKimiReasoning:
         assert top_level == {}
 
     def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
@@ -46,27 +49,15 @@ class TestOpenCodeGoKimiReasoning:
 
     @pytest.mark.parametrize(
         "effort",
-        [
-            "xhigh",
-            "max",
-        ],
+        ["xhigh", "max", "low", "medium", "high"],
     )
-    def test_strong_efforts_clamp_to_high(self, opencode_go_profile, effort):
+    def test_all_efforts_keep_thinking_only(self, opencode_go_profile, effort):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
-        assert top_level == {"reasoning_effort": "high"}
-
-    def test_low_and_medium_pass_through(self, opencode_go_profile):
-        for effort in ("low", "medium"):
-            extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
-                reasoning_config={"enabled": True, "effort": effort},
-                model="kimi-k2.5",
-            )
-            assert extra_body == {"thinking": {"type": "enabled"}}
-            assert top_level == {"reasoning_effort": effort}
+        assert top_level == {}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
@@ -149,7 +140,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_reaches_extra_body_without_top_level_effort(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -161,7 +152,7 @@ class TestOpenCodeGoFullKwargsIntegration:
             base_url="https://opencode.ai/zen/go/v1",
         )
         assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
-        assert kwargs["reasoning_effort"] == "high"
+        assert "reasoning_effort" not in kwargs
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
         self, opencode_go_profile

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1638,6 +1638,34 @@ class TestBuildApiKwargs:
         assert kwargs["reasoning_effort"] == "medium"
         assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
 
+    def test_opencode_go_kimi_omits_reasoning_effort(self, agent):
+        """OpenCode Go's Kimi relay rejects requests that send both
+        thinking and reasoning_effort, so Hermes must emit thinking only."""
+        agent.provider = "opencode-go"
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "kimi-k2.6"
+        agent.reasoning_config = {"effort": "medium"}
+        messages = [{"role": "user", "content": "hi"}]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+        assert "reasoning_effort" not in kwargs
+
+    def test_opencode_go_kimi_disables_thinking_without_reasoning_effort(self, agent):
+        agent.provider = "opencode-go"
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "kimi-k2.6"
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in kwargs
+
     def test_provider_preferences_injected(self, agent):
         agent.provider = "openrouter"
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary
- route `opencode-go/minimax-*` through `chat_completions`
- omit top-level `reasoning_effort` for `opencode-go/kimi-*`
- normalize OpenCode Anthropic base URLs to avoid `.../v1/v1/messages`
- add regression coverage and a local smoke harness

## Why
Live parity testing found three OpenCode Go compatibility issues:
1. MiniMax failed on Hermes via `anthropic_messages` but succeeded via `chat_completions`
2. Kimi relay rejected requests containing both `thinking` and `reasoning_effort`
3. Qwen 3.7 Max failed on Hermes Anthropic transport due to malformed base URL joining

## Validation
- `python3 -m pytest tests/agent/test_anthropic_adapter.py -q`
- `python3 -m pytest tests/hermes_cli/test_model_validation.py tests/plugins/model_providers/test_opencode_go_profile.py tests/run_agent/test_run_agent.py -q -k 'opencode_go_kimi or opencode_go or minimax or qwen3_7_max or kimi_coding_endpoint_disables_thinking or kimi_coding_endpoint_sends_thinking_extra_body or moonshot_cn_endpoint_sends_max_tokens_and_reasoning'`
- `python3 scripts/opencode_go_smoke_matrix.py qwen3.7-max kimi-k2.6 minimax-m2.7`

## Notes
The goal-fixture benchmark hardening lives outside this repo in `/home/willy/goal-fixture/benchmark_matrix.py`, so it is not part of this PR.
