### PR TITLE
fix(dashboard): clean stale processes at dashboard startup (#39136)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7592,6 +7592,11 @@ def _find_stale_dashboard_pids(
         "hermes dashboard",
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
+        # Older TUI/dashboard launchers can appear in ps output without the
+        # leading `hermes` executable name. Keep these specific so chat/log
+        # processes that merely mention "dashboard" are not swept up.
+        "dashboard --tui",
+        "dashboard --no-open",
     ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
@@ -12304,6 +12309,16 @@ def cmd_dashboard(args):
         _setup_logging_gui(mode="gui")
     except Exception:
         pass
+
+    # Clean up stale dashboard processes before starting a new instance.
+    # The dashboard has no service manager, so processes left by desktop-app
+    # updates or direct binary replacement keep running with stale Python
+    # backends, consuming ports and causing frontend/backend mismatches.
+    # `hermes update` already does this for CLI updates; this covers the
+    # desktop-app and general dashboard-start paths (#39136).
+    _kill_stale_dashboard_processes(
+        reason="cleaning up before starting a new dashboard instance"
+    )
 
     try:
         import fastapi  # noqa: F401

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -179,3 +179,67 @@ class TestArgparseWiring:
              pytest.raises(SystemExit) as exc:
             mod.cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+
+class TestDashboardStartupCleanup:
+    """Verify stale dashboard processes are cleaned up when starting a new one.
+
+    Regression for #39136: ``_kill_stale_dashboard_processes()`` was only
+    called at the end of ``hermes update``, so processes left by desktop-app
+    updates or direct binary replacement were never cleaned.  Adding the
+    call to ``cmd_dashboard`` ensures every dashboard start begins with a
+    clean process table.
+    """
+
+    def test_startup_calls_kill_stale_before_server(self):
+        """Normal dashboard start (no --stop/--status) must clean stale
+        processes before binding ports."""
+        with patch(
+            "hermes_cli.main._kill_stale_dashboard_processes"
+        ) as mock_kill, patch(
+            "hermes_cli.main._build_web_ui", return_value=True
+        ), patch(
+            "hermes_cli.main._sync_bundled_skills_quietly"
+        ), patch(
+            # prevent actual server startup
+            "hermes_cli.web_server.start_server",
+            side_effect=SystemExit(0),
+        ), patch(
+            "hermes_cli.plugins.discover_plugins"
+        ), patch(
+            "hermes_cli.main.PROJECT_ROOT",
+            __import__("pathlib").Path("/tmp"),
+        ), pytest.raises(SystemExit):
+            cmd_dashboard(_ns())
+
+        mock_kill.assert_called_once()
+
+    def test_startup_does_not_call_kill_for_stop_flag(self):
+        """When --stop is passed and stale processes exist, the kill is
+        handled inside the stop block.  The startup cleanup must stay in
+        the server-start path only (after the stop/status early returns)."""
+        # Use two separate scan results: first finds a PID, second (post-kill)
+        # returns empty so stop exits with code 0.
+        scans = iter([[12345], []])
+        with patch(
+            "hermes_cli.main._find_stale_dashboard_pids",
+            side_effect=lambda: next(scans),
+        ), patch(
+            "hermes_cli.main._kill_stale_dashboard_processes"
+        ) as mock_kill, pytest.raises(SystemExit):
+            cmd_dashboard(_ns(stop=True))
+
+        # Kill is called exactly once inside the stop block.  If the
+        # startup cleanup path also fired, call_count would be 2.
+        assert mock_kill.call_count == 1
+
+    def test_startup_does_not_call_kill_for_status_flag(self):
+        """--status must remain a read-only scan — no kill should fire."""
+        with patch(
+            "hermes_cli.main._find_stale_dashboard_pids", return_value=[]
+        ), patch(
+            "hermes_cli.main._kill_stale_dashboard_processes"
+        ) as mock_kill, pytest.raises(SystemExit):
+            cmd_dashboard(_ns(status=True))
+
+        mock_kill.assert_not_called()

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -112,10 +112,33 @@ class TestFindStaleDashboardPids:
                     _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
                     _ps_line(12346, "hermes dashboard --port 9120 --no-open"),
                     _ps_line(12347, "python /home/x/hermes_cli/main.py dashboard"),
+                    _ps_line(12348, "python -m legacy_dashboard dashboard --tui --port 9121"),
+                    _ps_line(12349, "python -m legacy_dashboard dashboard --no-open --port 9122"),
                 ]) + "\n",
                 stderr="",
             )
-            assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
+            assert sorted(_find_stale_dashboard_pids()) == [
+                12345,
+                12346,
+                12347,
+                12348,
+                12349,
+            ]
+
+    def test_legacy_dashboard_tui_patterns_are_specific(self):
+        """Old dashboard launchers can lack a leading `hermes` token, but
+        unrelated processes that merely mention dashboard/TUI stay ignored."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(12348, "python -m legacy_dashboard dashboard --tui --port 9121"),
+                    _ps_line(12349, "python -m legacy_dashboard dashboard --no-open --port 9122"),
+                    _ps_line(22222, "python notes.py 'dashboard tui cleanup'"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert sorted(_find_stale_dashboard_pids()) == [12348, 12349]
 
     def test_self_pid_excluded(self):
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## What

Fixes #39136 by cleaning up stale dashboard backend processes whenever a new `hermes dashboard` instance starts, not only after `hermes update` or `hermes dashboard --stop`.

This prevents old `hermes dashboard --tui` / legacy dashboard processes from lingering across Desktop updates, holding ports 9120-9126, and serving mismatched backend code against newer frontend bundles.

## Details

- Calls `_kill_stale_dashboard_processes()` in the normal `cmd_dashboard` startup path before dependency checks/server binding.
- Leaves `--status` read-only and keeps `--stop` on its existing single kill path.
- Extends stale-process matching for older dashboard launchers that can appear as `dashboard --tui` / `dashboard --no-open` without a leading `hermes` token.
- Keeps matching specific so unrelated processes merely mentioning "dashboard" are not killed.

## Verification

Focused tests after rebase onto current upstream/main:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/hermes_cli/test_dashboard_lifecycle_flags.py \
  tests/hermes_cli/test_update_stale_dashboard.py \
  -v -o "addopts=" --tb=short
```

Result: `36 passed in 0.39s`.

RED proof from build artifacts: the startup cleanup regression test fails on upstream/main with `_kill_stale_dashboard_processes` called 0 times.

## Competitor PR check

Open PR #39190 addresses the same issue and suggested broadening process patterns. I evaluated it before publication: it has a useful one-file approach but no regression tests, so it did not block publishing. This PR includes both the startup cleanup and the process-pattern coverage with tests.

Auto-published by Moonsong via Path B automated pipeline.
