### PR TITLE
fix(web): clamp dashboard session list pagination params

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -657,6 +657,28 @@ except (ValueError, TypeError):
     )
     _GATEWAY_HEALTH_TIMEOUT = 3.0
 
+_SESSION_LIST_DEFAULT_LIMIT = 20
+_SESSION_LIST_MAX_LIMIT = 100
+
+
+def _clamp_sessions_list_limit(value: int) -> int:
+    """Clamp dashboard session list page size to a safe positive range."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return _SESSION_LIST_DEFAULT_LIMIT
+    return max(1, min(_SESSION_LIST_MAX_LIMIT, parsed))
+
+
+def _clamp_sessions_list_offset(value: int) -> int:
+    """Clamp dashboard session list offset to a non-negative integer."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
 # DEPRECATED (scheduled for removal): GATEWAY_HEALTH_URL / GATEWAY_HEALTH_TIMEOUT.
 # Cross-container / cross-host gateway liveness detection will be folded into a
 # first-class dashboard config key so it's no longer Docker-adjacent lore buried
@@ -1573,6 +1595,8 @@ async def get_sessions(
             status_code=400,
             detail="order must be one of: created, recent",
         )
+    limit = _clamp_sessions_list_limit(limit)
+    offset = _clamp_sessions_list_offset(offset)
     try:
         from hermes_state import SessionDB
         db = SessionDB()

--- a/tests/hermes_cli/test_web_server_sessions_list.py
+++ b/tests/hermes_cli/test_web_server_sessions_list.py
@@ -1,0 +1,46 @@
+"""Tests for dashboard session list pagination clamping."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.web_server import (
+    _clamp_sessions_list_limit,
+    _clamp_sessions_list_offset,
+    get_sessions,
+)
+
+
+class TestClampSessionsListLimit:
+    def test_invalid_value_uses_default(self):
+        assert _clamp_sessions_list_limit("bad") == 20
+
+    def test_zero_clamped_to_one(self):
+        assert _clamp_sessions_list_limit(0) == 1
+
+    def test_excessive_limit_capped(self):
+        assert _clamp_sessions_list_limit(9999) == 100
+
+
+class TestClampSessionsListOffset:
+    def test_invalid_value_uses_zero(self):
+        assert _clamp_sessions_list_offset("bad") == 0
+
+    def test_negative_offset_clamped_to_zero(self):
+        assert _clamp_sessions_list_offset(-5) == 0
+
+
+class TestGetSessionsEndpoint:
+    def test_passes_clamped_pagination_to_session_db(self):
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+        mock_db.session_count.return_value = 0
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            result = asyncio.run(get_sessions(limit=9999, offset=-10))
+
+        mock_db.list_sessions_rich.assert_called_once()
+        assert mock_db.list_sessions_rich.call_args.kwargs["limit"] == 100
+        assert mock_db.list_sessions_rich.call_args.kwargs["offset"] == 0
+        assert result["limit"] == 100
+        assert result["offset"] == 0
+        mock_db.close.assert_called_once()


### PR DESCRIPTION
he dashboard session list endpoint accepted unbounded limit and negative offset query parameters, which could force expensive SQLite session scans. This change clamps pagination before calling SessionDB.list_sessions_rich, matching the intended page size (default 20, max 100) and a non-negative offset.

