### PR TITLE
[codex] Stream live token usage into desktop context meter

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -117,6 +117,41 @@ def _ra():
     return run_agent
 
 
+def _emit_preflight_token_usage(agent: Any, request_tokens: int) -> None:
+    """Send the current request-size estimate through the live usage channel."""
+    if request_tokens <= 0:
+        return
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return
+
+    try:
+        previous = getattr(compressor, "last_prompt_tokens", 0) or 0
+        if request_tokens > previous:
+            compressor.last_prompt_tokens = request_tokens
+    except Exception:
+        logger.debug("could not update preflight context estimate", exc_info=True)
+
+    emit = getattr(agent, "_emit_token_usage", None)
+    if not callable(emit):
+        return
+
+    try:
+        emit(
+            input_tokens=getattr(agent, "session_input_tokens", 0)
+            or getattr(agent, "session_prompt_tokens", 0)
+            or 0,
+            output_tokens=getattr(agent, "session_output_tokens", 0)
+            or getattr(agent, "session_completion_tokens", 0)
+            or 0,
+            total_tokens=getattr(agent, "session_total_tokens", 0) or 0,
+            context_tokens=request_tokens,
+            context_length=getattr(compressor, "context_length", 0) or 0,
+        )
+    except Exception:
+        logger.debug("could not emit preflight token usage", exc_info=True)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -1089,6 +1124,7 @@ def run_conversation(
         approx_request_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        _emit_preflight_token_usage(agent, approx_request_tokens)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1923,6 +1923,19 @@ def run_conversation(
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
 
+                    # Emit structured token usage for real-time context bar updates.
+                    # Fire-and-forget: the target may not have a status_callback wired,
+                    # and we never want to block the conversation loop.
+                    agent._emit_token_usage(
+                        input_tokens=agent.session_input_tokens,
+                        output_tokens=agent.session_output_tokens,
+                        total_tokens=agent.session_total_tokens,
+                        context_tokens=agent.context_compressor.last_prompt_tokens
+                        if agent.context_compressor else 0,
+                        context_length=agent.context_compressor.context_length
+                        if agent.context_compressor else 0,
+                    )
+
                     # Log API call details for debugging/observability
                     _cache_pct = ""
                     if canonical_usage.cache_read_tokens and prompt_tokens:

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $currentUsage } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './use-message-stream'
+
+let handleEvent: (event: RpcEvent) => void = () => undefined
+
+function MessageStreamHarness({ activeSessionId = 'session-1' }: { activeSessionId?: string }) {
+  const activeSessionIdRef = useRef<string | null>(activeSessionId)
+  const queryClientRef = useRef(new QueryClient())
+  const statesRef = useRef(new Map<string, ClientSessionState>())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    updateSessionState: (sessionId, updater) => {
+      const previous = statesRef.current.get(sessionId) ?? createClientSessionState(null)
+      const next = updater(previous)
+      statesRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream token usage events', () => {
+  beforeEach(() => {
+    handleEvent = () => undefined
+    $currentUsage.set({ calls: 0, input: 0, output: 0, total: 0 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    $currentUsage.set({ calls: 0, input: 0, output: 0, total: 0 })
+    vi.restoreAllMocks()
+  })
+
+  it('updates current usage from token.usage before message.complete', () => {
+    render(<MessageStreamHarness />)
+
+    act(() =>
+      handleEvent({
+        payload: {},
+        session_id: 'session-1',
+        type: 'message.start'
+      } as RpcEvent)
+    )
+
+    act(() =>
+      handleEvent({
+        payload: {
+          context_length: 131_072,
+          context_pct: 49.9,
+          context_tokens: 65_432,
+          input_tokens: 1_200,
+          output_tokens: 34,
+          total_tokens: 1_234
+        },
+        session_id: 'session-1',
+        type: 'token.usage'
+      } as RpcEvent)
+    )
+
+    expect($currentUsage.get()).toMatchObject({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
+  it('ignores token.usage events for inactive sessions', () => {
+    $currentUsage.set({ calls: 1, input: 10, output: 5, total: 15 })
+    render(<MessageStreamHarness />)
+
+    act(() =>
+      handleEvent({
+        payload: {
+          context_length: 131_072,
+          context_tokens: 70_000,
+          input_tokens: 70_000,
+          total_tokens: 70_000
+        },
+        session_id: 'session-2',
+        type: 'token.usage'
+      } as RpcEvent)
+    )
+
+    expect($currentUsage.get()).toEqual({ calls: 1, input: 10, output: 5, total: 15 })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -16,6 +16,7 @@ import {
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { mergeTokenUsagePayload, type TokenUsagePayload } from '@/lib/token-usage'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -705,6 +706,10 @@ export function useMessageStream({
           void queryClient.invalidateQueries({
             queryKey: explicitSid && sessionId ? ['model-options', sessionId] : ['model-options']
           })
+        }
+      } else if (event.type === 'token.usage') {
+        if (!explicitSid || isActiveEvent) {
+          setCurrentUsage(current => mergeTokenUsagePayload(current, event.payload as TokenUsagePayload | undefined))
         }
       } else if (event.type === 'message.start') {
         if (!sessionId) {

--- a/apps/desktop/src/lib/token-usage.test.ts
+++ b/apps/desktop/src/lib/token-usage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeTokenUsagePayload, usageFromTokenUsagePayload } from './token-usage'
+
+describe('usageFromTokenUsagePayload', () => {
+  it('maps gateway token.usage payload fields into statusbar usage stats', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 131_072,
+        context_pct: 49.9,
+        context_tokens: 65_432,
+        input_tokens: 1_200,
+        output_tokens: 34,
+        total_tokens: 1_234
+      })
+    ).toEqual({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
+  it('derives context percent when the backend omits context_pct', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 200_000,
+        context_tokens: 50_000,
+        input_tokens: 50_000,
+        total_tokens: 50_000
+      })
+    ).toMatchObject({
+      context_max: 200_000,
+      context_percent: 25,
+      context_used: 50_000
+    })
+  })
+
+  it('preserves existing usage when a malformed payload arrives', () => {
+    const current = { calls: 2, input: 10, output: 20, total: 30 }
+
+    expect(mergeTokenUsagePayload(current, { input_tokens: Number.NaN })).toBe(current)
+  })
+})

--- a/apps/desktop/src/lib/token-usage.ts
+++ b/apps/desktop/src/lib/token-usage.ts
@@ -1,6 +1,13 @@
-import type { TokenUsagePayload, Usage } from '../types.js'
+import type { UsageStats } from '@/types/hermes'
 
-export const ZERO: Usage = { calls: 0, input: 0, output: 0, total: 0 }
+export interface TokenUsagePayload {
+  context_length?: unknown
+  context_pct?: unknown
+  context_tokens?: unknown
+  input_tokens?: unknown
+  output_tokens?: unknown
+  total_tokens?: unknown
+}
 
 function finiteNumber(value: unknown): number | undefined {
   if (typeof value === 'number') {
@@ -41,12 +48,12 @@ function percentFrom(payload: TokenUsagePayload): number | undefined {
   return used !== undefined && max !== undefined ? Math.min(100, (used / max) * 100) : undefined
 }
 
-export function usageFromTokenUsagePayload(payload: null | TokenUsagePayload | undefined): Partial<Usage> | null {
+export function usageFromTokenUsagePayload(payload: TokenUsagePayload | null | undefined): Partial<UsageStats> | null {
   if (!payload) {
     return null
   }
 
-  const usage: Partial<Usage> = {}
+  const usage: Partial<UsageStats> = {}
   const input = nonNegativeNumber(payload.input_tokens)
   const output = nonNegativeNumber(payload.output_tokens)
   const total = nonNegativeNumber(payload.total_tokens)
@@ -81,7 +88,10 @@ export function usageFromTokenUsagePayload(payload: null | TokenUsagePayload | u
   return Object.keys(usage).length ? usage : null
 }
 
-export function mergeTokenUsagePayload(current: Usage, payload: null | TokenUsagePayload | undefined): Usage {
+export function mergeTokenUsagePayload(
+  current: UsageStats,
+  payload: TokenUsagePayload | null | undefined
+): UsageStats {
   const usage = usageFromTokenUsagePayload(payload)
 
   return usage ? { ...current, ...usage } : current

--- a/run_agent.py
+++ b/run_agent.py
@@ -795,6 +795,31 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    def _emit_token_usage(self, input_tokens: int, output_tokens: int,
+                          total_tokens: int, context_tokens: int,
+                          context_length: int) -> None:
+        """Emit structured token usage data to the gateway for real-time UI updates.
+
+        The gateway forwards this as a structured ``token.usage`` event so the
+        desktop app's context bar can update smoothly during a turn rather than
+        jumping to the final value at end-of-turn.
+        """
+        if not self.status_callback:
+            return
+        import json
+        payload = json.dumps({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "context_tokens": context_tokens,
+            "context_length": context_length,
+            "context_pct": round(context_tokens / context_length * 100, 1) if context_length > 0 else 0,
+        })
+        try:
+            self.status_callback("token_usage", payload)
+        except Exception:
+            logger.debug("status_callback error in _emit_token_usage", exc_info=True)
+
     # ── Buffered retry/fallback status ────────────────────────────────────
     # Retry and fallback chains were flooding the CLI/gateway with status
     # noise that users found confusing: a single transient 429 could produce

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -132,6 +132,7 @@ AUTHOR_MAP = {
     "saeed919@pm.me": "falasi",
     "chrisdlc119@outlook.com": "chdlc",
     "omar@techdeveloper.site": "nycomar",
+    "omar@kostudios.io": "OmarB97",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "adityargadgil@gmail.com": "AdityaRajeshGadgil",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3292,6 +3292,38 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_preflight_token_usage_emits_before_api_response(self, agent):
+        self._setup_agent(agent)
+        agent.context_compressor = SimpleNamespace(
+            context_length=131072,
+            last_prompt_tokens=0,
+        )
+        events = []
+
+        def _status(kind, text=None):
+            if kind == "token_usage":
+                events.append(json.loads(text))
+
+        def _create(*_args, **_kwargs):
+            assert events
+            assert events[-1]["context_tokens"] == 12345
+            assert events[-1]["context_length"] == 131072
+            return _mock_response(content="Final answer", finish_reason="stop")
+
+        agent.status_callback = _status
+        agent.client.chat.completions.create.side_effect = _create
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=12345),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Final answer"
+        assert agent.context_compressor.last_prompt_tokens == 12345
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -109,6 +109,24 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_status_update_token_usage_emits_structured_event(monkeypatch):
+    events: list[tuple[str, str, dict | None]] = []
+    payload = {
+        "context_length": 131072,
+        "context_pct": 49.9,
+        "context_tokens": 65432,
+        "input_tokens": 1200,
+        "output_tokens": 34,
+        "total_tokens": 1234,
+    }
+
+    monkeypatch.setattr(server, "_emit", lambda event, sid, body=None: events.append((event, sid, body)))
+
+    server._status_update("sid", "token_usage", json.dumps(payload))
+
+    assert events == [("token.usage", "sid", payload)]
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -396,6 +396,16 @@ def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
+    # Structured token_usage events are JSON-encoded; unpack and re-emit
+    # as a typed event so the desktop app can consume them directly.
+    if kind == "token_usage":
+        import json
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, TypeError):
+            return
+        _emit("token.usage", sid, payload)
+        return
     _emit(
         "status.update",
         sid,

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type SpawnOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,9 +32,9 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: SpawnOptions['stdio'] = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
     const child = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -105,6 +105,33 @@ describe('createGatewayEventHandler', () => {
     })
   })
 
+  it('updates usage from token.usage before message.complete', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    patchUiState({ sid: 'session-1' })
+    onEvent({
+      payload: {
+        context_length: 131_072,
+        context_pct: 49.9,
+        context_tokens: 65_432,
+        input_tokens: 1_200,
+        output_tokens: 34,
+        total_tokens: 1_234
+      },
+      session_id: 'session-1',
+      type: 'token.usage'
+    })
+
+    expect(getUiState().usage).toMatchObject({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
   it('keeps the current todo list visible when the next message starts', () => {
     const appended: Msg[] = []
     const todos = [{ content: 'Boil water', id: 'boil', status: 'in_progress' }]

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,7 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
+import { mergeTokenUsagePayload } from '../domain/usage.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -397,6 +398,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }))
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
+
+        return
+      }
+
+      case 'token.usage': {
+        patchUiState(state => {
+          const usage = mergeTokenUsagePayload(state.usage, ev.payload)
+
+          return usage === state.usage ? state : { ...state, usage }
+        })
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
+import type { SessionInfo, SlashCategory, SubagentStatus, TokenUsagePayload, Usage } from './types.js'
 
 export interface GatewaySkin {
   banner_hero?: string
@@ -509,6 +509,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
+  | { payload?: TokenUsagePayload; session_id?: string; type: 'token.usage' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -176,6 +176,15 @@ export interface Usage {
   total: number
 }
 
+export interface TokenUsagePayload {
+  context_length?: unknown
+  context_pct?: unknown
+  context_tokens?: unknown
+  input_tokens?: unknown
+  output_tokens?: unknown
+  total_tokens?: unknown
+}
+
 export interface SudoReq {
   requestId: string
 }


### PR DESCRIPTION
## Summary

- emit token usage snapshots from the agent loop after provider usage is recorded and bridge them through the gateway as `token.usage` events
- emit a preflight `token.usage` snapshot before each API call using the already-computed request-size estimate, so providers that only report usage at completion still move the desktop context meter during the active turn
- consume those events in the desktop session hook so the context meter can move before `message.complete`
- add focused backend, desktop, and TUI coverage, plus a small spawn stdio typing fix so `ui-tui` type-checks cleanly

## Why

The first live-usage patch handled final/canonical provider usage, but the official macOS app could still sit at `0/131.1k` while a turn was running because many providers expose usage only at completion. The new preflight snapshot sends the current request/context estimate at call start, then the final provider usage corrects totals afterward.

## Fork / install follow-up

- Fork PR OmarB97/hermes-agent#85 merged the backend preflight patch; its post-merge CI exposed a fork-only CLI flag-hoisting regression.
- Fork PR OmarB97/hermes-agent#86 fixed that parser regression and all fork CI checks are green.
- The official macOS app on this machine was rebuilt from fork `main` at `c0c1bcd093eb10249cfd972e9f4146452c4534d6` with a clean install stamp.

## Verification

- `python3 -m pytest tests/tui_gateway/test_token_usage_events.py`
- `python3 -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_preflight_token_usage_emits_before_api_response tests/run_agent/test_run_agent.py::TestRunConversation::test_stop_finish_reason_returns_response`
- `python3 -m py_compile agent/conversation_loop.py`
- `npx vitest run --environment jsdom src/lib/token-usage.test.ts src/app/session/hooks/use-message-stream.test.tsx` from `apps/desktop`
- `npm run type-check --workspace ui-tui`
- Installed-code gateway canary on macOS: `token.usage` arrived at ~2.1s and `message.complete` arrived at ~11.9s for the same turn, proving the desktop can receive usage before end-of-turn.
