### PR TITLE
fix(update): use termux-all extras on Termux in the update path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8035,12 +8035,20 @@ def _update_via_zip(args):
     pip_cmd = [sys.executable, "-m", "pip"]
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
+    install_group = "all"
     if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+            install_group = "termux-all"
+            print("  → Termux detected: using uv + curated termux-all optional profile...")
+        if _is_termux_env(uv_env) and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, group=install_group
+        )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -8059,7 +8067,13 @@ def _update_via_zip(args):
                 cwd=PROJECT_ROOT,
                 check=True,
             )
-        _install_python_dependencies_with_optional_fallback(pip_cmd)
+        if _is_termux_env():
+            install_group = "termux-all"
+            print("  → Termux detected: using curated termux-all optional profile...")
+        if _is_termux_env() and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
     _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -830,3 +830,143 @@ termux = ["rich>=14"]
 
     assert hm._load_installable_optional_extras(group="all") == ["mcp"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
+
+
+class TestCmdUpdateTermuxExtrasGroup:
+    """_cmd_update_impl selects the correct extras group on Termux."""
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_uv_branch_termux_passes_termux_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        monkeypatch.setattr(hm, "_is_android_python", lambda: False)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["cmd_prefix"] = list(cmd_prefix)
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "termux-all"
+        assert recorded.get("cmd_prefix") == ["/usr/bin/uv", "pip"]
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_uv_branch_non_termux_passes_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: False)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "all"
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_pip_branch_termux_passes_termux_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        import subprocess as sp
+        from hermes_cli import main as hm
+
+        base_side = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        def combined(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "pip" in joined and "--version" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="pip 24.0\n", stderr="")
+            if "ensurepip" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return base_side(cmd, **kwargs)
+
+        mock_run.side_effect = combined
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+        monkeypatch.setattr(hm, "_is_android_python", lambda: False)
+        monkeypatch.setattr(hm, "_ensure_uv_for_termux", lambda pip_cmd: None)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "termux-all"
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_pip_branch_non_termux_passes_all(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        import subprocess as sp
+        from hermes_cli import main as hm
+
+        base_side = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        def combined(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "pip" in joined and "--version" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="pip 24.0\n", stderr="")
+            if "ensurepip" in joined:
+                return sp.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return base_side(cmd, **kwargs)
+
+        mock_run.side_effect = combined
+        monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: False)
+        monkeypatch.setattr(hm, "_ensure_uv_for_termux", lambda pip_cmd: None)
+
+        recorded = {}
+
+        def fake_install(cmd_prefix, *, env=None, group="all"):
+            recorded["group"] = group
+
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            fake_install,
+        )
+
+        hm.cmd_update(mock_args)
+
+        assert recorded.get("group") == "all"


### PR DESCRIPTION
## Summary
Ports the Termux extras group selection from the setup path to the update path, fixing hermes update on Android/Termux.

---

## Root cause
`_cmd_update_impl` in `hermes_cli/main.py` detected Termux (to sanitize `PYTHONPATH`/`PYTHONHOME`) but never passed `group="termux-all"` to `_install_python_dependencies_with_optional_fallback`. The helper defaulted to `group="all"`, triggering native compilation of uv and C extensions — causing swap exhaustion and a frozen device on aarch64 Termux.

The fix already existed in the update dependency install block (lines 10247-10287 in `_cmd_update_impl`) but was never ported to the earlier dependency install block.

---

## Behavioral change
Before: `hermes update` on Termux installs `.[all]` extras, triggering Rust/C compilation from source, swap exhaustion, device freeze.

After: `hermes update` on Termux installs `.[termux-all]` extras, consistent with the reference block in `_cmd_update_impl`.

---

## What changed

**`hermes_cli/main.py`**
- Added `install_group = "all"` before the uv/pip branch in `_cmd_update_impl`
- uv branch: sets `install_group = "termux-all"` + print log + `_install_psutil_android_compat` + passes `group=install_group`
- pip branch: same Termux detection, same group selection, same psutil prebuild

**`tests/hermes_cli/test_cmd_update.py`**
- 4 new tests in `TestCmdUpdateTermuxExtrasGroup` covering uv and pip branches x termux and non-termux modes

---

## What is NOT changed
- The already-correct Termux handling inside `_cmd_update_impl` (lines 10247-10287) is untouched

---

Note: #39135 covers the same fix but without tests. This PR adds test coverage 4 tests in `TestCmdUpdateTermuxExtrasGroup` (`test_cmd_update.py`) covering uv and pip branches x termux and non-termux modes.

Fixes #39106.