### PR TITLE
fix(vllm): include tool_choice parameter in API requests

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -315,6 +315,14 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            # tool_choice defaults to "none" in the OpenAI Chat Completions API
+            # when tools are present but tool_choice is omitted.  This causes
+            # the model to never invoke tools — it always returns
+            # finish_reason="stop" instead of "tool_calls".  vLLM (and other
+            # strict OpenAI-compatible backends) respect this default and will
+            # never call tools without an explicit tool_choice.  Set to "auto"
+            # so the model can decide when to use tools.  (#39099)
+            api_kwargs.setdefault("tool_choice", "auto")
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")
@@ -503,6 +511,7 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            api_kwargs.setdefault("tool_choice", "auto")
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -161,6 +161,37 @@ class TestChatCompletionsBuildKwargs:
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
         kw = transport.build_kwargs(model="gpt-4o", messages=msgs, tools=tools)
         assert kw["tools"] == tools
+        assert kw["tool_choice"] == "auto"
+
+    def test_tools_included_profile_path(self, transport):
+        """Profile path must also set tool_choice when tools are present."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="llama3", messages=msgs, tools=tools, provider_profile=profile,
+        )
+        assert kw["tools"] == tools
+        assert kw["tool_choice"] == "auto"
+
+    def test_tools_omitted_tool_choice_not_set(self, transport):
+        """When no tools are provided, tool_choice must not appear in kwargs."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(model="gpt-4o", messages=msgs)
+        assert "tools" not in kw
+        assert "tool_choice" not in kw
+
+    def test_tool_choice_respects_request_overrides(self, transport):
+        """If request_overrides sets tool_choice explicitly, it must not be
+        overwritten by the default."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, tools=tools,
+            request_overrides={"tool_choice": "required"},
+        )
+        assert kw["tool_choice"] == "required"
 
     def test_openrouter_provider_prefs(self, transport):
         from providers import get_provider_profile


### PR DESCRIPTION
tool_choice defaults to "none" in the OpenAI Chat Completions API when tools are present but tool_choice is omitted. This causes vLLM (and other strict OpenAI-compatible backends) to never invoke tools — they always return finish_reason="stop" instead of "tool_calls".

The Codex transport already handles this correctly. This fix adds api_kwargs.setdefault("tool_choice", "auto") to both the legacy build_kwargs path and the profile path (_build_kwargs_from_profile), using setdefault so explicit user overrides via request_overrides are preserved.

Fixes #39099