### PR TITLE
fix(tools): honor execute code permanent approvals

### DIFF
--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -347,3 +347,55 @@ def test_env_scrub_no_log_when_nothing_dropped(caplog):
             is_windows=False,
         )
     assert "dropped" not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 3b. Permanent allowlist regression (#39187)
+# ---------------------------------------------------------------------------
+
+def test_guard_honours_permanent_allowlist(gw_session):
+    """Regression for #39187: execute_code "Always" (permanent allowlist) must
+    be respected on subsequent calls."""
+    # Add execute_code to the permanent allowlist (simulating a previous
+    # "Always" click that populated command_allowlist in config.yaml).
+    A.approve_permanent("execute_code")
+    try:
+        # Even with a denier registered, the permanent allowlist check should
+        # short-circuit before reaching the gateway approval prompt.
+        _register_resolver(gw_session, "deny")
+        res = A.check_execute_code_guard("import os; print(1)", "local")
+        assert res["approved"] is True, (
+            f"Permanent allowlist entry for 'execute_code' was not honoured; "
+            f"got {res}"
+        )
+    finally:
+        with A._lock:
+            A._permanent_approved.discard("execute_code")
+
+
+def test_guard_permanent_allowlist_does_not_need_yolo(gw_session, monkeypatch):
+    """Regression for #39187: permanent allowlist takes effect in manual mode
+    without relying on the separate yolo/off bypass."""
+    A.approve_permanent("execute_code")
+    try:
+        monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+        res = A.check_execute_code_guard("import os; print(1)", "local")
+        assert res["approved"] is True
+    finally:
+        with A._lock:
+            A._permanent_approved.discard("execute_code")
+
+
+def test_guard_cron_deny_still_blocks_permanent_allowlist(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")
+    A.approve_permanent("execute_code")
+    try:
+        res = A.check_execute_code_guard("import os", "local")
+        assert res["approved"] is False
+        assert res["outcome"] == "blocked"
+    finally:
+        with A._lock:
+            A._permanent_approved.discard("execute_code")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1580,6 +1580,9 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
+    if is_approved(session_key, pattern_key):
+        return {"approved": True, "message": None}
+
     # Built only now (past the early-return gates) so the common non-approval
     # paths don't pay to copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"


### PR DESCRIPTION
## Summary

- Honor persisted `execute_code` permanent approvals before showing the gateway approval prompt again.
- Keep existing early-return safety behavior intact: container backends, yolo/off, cron-deny, and non-gateway local execution keep their existing precedence.
- Add focused regression coverage for the WebUI "Always" path and for cron-deny still blocking even if `execute_code` is permanently allowlisted.

Fixes #39187

## Real Behavior Proof

Behavior addressed: clicking "Always" for `execute_code` in the WebUI writes `execute_code` into the permanent allowlist, but the next gateway `execute_code` call still prompted because `check_execute_code_guard()` did not consult that allowlist.

Exact setup: Hermes source checkout on macOS, branch `tui-39187-execute-code-allowlist`, Python managed by `uv`.

Direct before/after guard proof:

```bash
uv run python - <<'PY'
import os
from tools import approval as A

session = 'proof-39187'
token = A.set_current_session_key(session)
try:
    os.environ['HERMES_GATEWAY_SESSION'] = '1'
    os.environ.pop('HERMES_CRON_SESSION', None)
    with A._lock:
        A._gateway_queues.pop(session, None)
        A._gateway_notify_cbs.pop(session, None)
        A._permanent_approved.discard('execute_code')
    before = A.check_execute_code_guard('print(1)', 'local')
    A.approve_permanent('execute_code')
    after = A.check_execute_code_guard('print(1)', 'local')
    os.environ['HERMES_CRON_SESSION'] = '1'
    original_cron_mode = A._get_cron_approval_mode
    A._get_cron_approval_mode = lambda: 'deny'
    try:
        cron = A.check_execute_code_guard('print(1)', 'local')
    finally:
        A._get_cron_approval_mode = original_cron_mode
    print('before_approved=', before.get('approved'), 'status=', before.get('status'))
    print('after_approved=', after.get('approved'))
    print('cron_approved=', cron.get('approved'), 'outcome=', cron.get('outcome'))
finally:
    A.reset_current_session_key(token)
    with A._lock:
        A._gateway_queues.pop(session, None)
        A._gateway_notify_cbs.pop(session, None)
        A._permanent_approved.discard('execute_code')
    os.environ.pop('HERMES_GATEWAY_SESSION', None)
    os.environ.pop('HERMES_CRON_SESSION', None)
PY
```

```text
before_approved= False status= pending_approval
after_approved= True
cron_approved= False outcome= blocked
```

Verification:

```bash
uv run --with pytest --with pytest-timeout pytest tests/tools/test_execute_code_approval_cluster.py -q
```

```text
20 passed in 1.18s
```

```bash
uv run --with ruff ruff check tools/approval.py tests/tools/test_execute_code_approval_cluster.py
```

```text
All checks passed!
```

```bash
python3 -m py_compile tools/approval.py tests/tools/test_execute_code_approval_cluster.py
```

Completed without syntax errors.

## Platforms Tested

- macOS local source checkout with `uv` using CPython 3.11.13

## Limitations

I did not run a live browser WebUI click-through. The direct guard proof exercises the same backend state transition: before permanent allowlist, gateway execution waits for approval; after `approve_permanent("execute_code")`, the guard auto-approves; cron-deny still wins.
