### PR TITLE
chore: ignore local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 .venv/
 .vscode/
 .env
+.env.*
+!.env.example
+.envrc
+.envrc.*
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
Adds ignore rules for local .env and .envrc variants while keeping .env.example tracked.