### PR TITLE
fix(desktop): remove undone exchange from the visible transcript on /undo

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -2,10 +2,17 @@ import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
-import { getProfiles, transcribeAudio } from '@/hermes'
+import { requestComposerInsert } from '@/app/chat/composer/focus'
+import { getProfiles, getSessionMessages, transcribeAudio } from '@/hermes'
 import { translateNow, type Translations, useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
-import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import {
+  branchGroupForUser,
+  type ChatMessage,
+  chatMessageText,
+  textPart,
+  toChatMessages
+} from '@/lib/chat-messages'
 import {
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -901,6 +908,40 @@ export function usePromptActions({
             return
           }
 
+          if (dispatch.type === 'prefill') {
+            // /undo returns a prefill directive. The server has already
+            // soft-deleted the backed-up turns (active=0), so re-sync the
+            // visible transcript to the server's active history first — without
+            // this the undone exchange stays on screen even though it's gone
+            // from the agent's context (issue #39019). This is a wholesale
+            // replace (unlike resume's reconcile), which intentionally drops
+            // any local-only rows: /undo is a "discard" and runs on an idle
+            // session. The notice is surfaced *after* the replace so it isn't
+            // clobbered by it, then we drop the backed-up text into the
+            // composer for editing — matching the Ink TUI's prefill handling.
+            try {
+              const refreshed = await getSessionMessages(sessionId)
+
+              updateSessionState(
+                sessionId,
+                state => ({ ...state, messages: toChatMessages(refreshed.messages) }),
+                selectedStoredSessionIdRef.current
+              )
+            } catch (err) {
+              renderSlashOutput(`/${name}: could not refresh history — ${err instanceof Error ? err.message : String(err)}`)
+            }
+
+            if (dispatch.notice?.trim()) {
+              renderSlashOutput(dispatch.notice)
+            }
+
+            if (dispatch.message) {
+              requestComposerInsert(dispatch.message, { target: 'main' })
+            }
+
+            return
+          }
+
           const message = ('message' in dispatch ? dispatch.message : '')?.trim() ?? ''
 
           if (!message) {
@@ -1196,8 +1237,10 @@ export function usePromptActions({
       refreshSessions,
       requestGateway,
       resumeStoredSession,
+      selectedStoredSessionIdRef,
       startFreshSessionDraft,
-      submitPromptText
+      submitPromptText,
+      updateSessionState
     ]
   )
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.undo.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.undo.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { requestComposerInsert } from '@/app/chat/composer/focus'
+import { getSessionMessages } from '@/hermes'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
+import type { SessionMessage } from '@/types/hermes'
+
+import type { ClientSessionState } from '../../types'
+
+import { usePromptActions } from './use-prompt-actions'
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  getSessionMessages: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  transcribeAudio: vi.fn()
+}))
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerInsert: vi.fn()
+}))
+
+const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+function baseState(messages: ClientSessionState['messages']): ClientSessionState {
+  return {
+    storedSessionId: 'sess-1',
+    messages,
+    branch: '',
+    cwd: '',
+    busy: false
+  } as ClientSessionState
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('usePromptActions /undo prefill handling', () => {
+  it('re-syncs the visible transcript to the server active history and prefills the composer', async () => {
+    // After /undo the server returns the truncated active history (the undone
+    // user+assistant exchange is gone).
+    const activeMessages: SessionMessage[] = [{ role: 'user', content: 'first turn that survives' }]
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: activeMessages, session_id: 'sess-1' })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        // /undo is a pending-input command — slash.exec rejects it so the
+        // client falls through to command.dispatch.
+        throw new Error('pending-input command')
+      }
+
+      if (method === 'command.dispatch') {
+        return { type: 'prefill', message: 'the undone message', notice: '↶ Undid 1 turn (2 messages).' }
+      }
+
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    // Stateful reducer so the sequential updateSessionState calls compose,
+    // letting us assert the *final* transcript — this is what catches a
+    // notice that gets clobbered by the history replace (ordering bug).
+    let sessionState = baseState([
+      { id: 'u1', role: 'user', parts: [textPart('first turn that survives')] },
+      { id: 'a1', role: 'assistant', parts: [textPart('reply 1')] },
+      { id: 'u2', role: 'user', parts: [textPart('the undone message')] },
+      { id: 'a2', role: 'assistant', parts: [textPart('reply that gets undone')] }
+    ])
+
+    const updateSessionState = vi.fn((_sessionId: string, updater: (state: ClientSessionState) => ClientSessionState) => {
+      sessionState = updater(sessionState)
+
+      return sessionState
+    })
+
+    const { result } = renderHook(() =>
+      usePromptActions({
+        activeSessionId: 'sess-1',
+        activeSessionIdRef: ref<string | null>('sess-1'),
+        busyRef: ref(false),
+        branchCurrentSession: vi.fn(async () => true),
+        createBackendSessionForSend: vi.fn(async () => 'sess-1'),
+        handleSkinCommand: vi.fn(() => ''),
+        requestGateway: requestGateway as never,
+        resumeStoredSession: vi.fn(async () => undefined),
+        selectedStoredSessionIdRef: ref<string | null>('sess-1'),
+        startFreshSessionDraft: vi.fn(),
+        sttEnabled: false,
+        refreshSessions: vi.fn(async () => undefined),
+        updateSessionState
+      })
+    )
+
+    await result.current.submitText('/undo')
+
+    expect(getSessionMessages).toHaveBeenCalledWith('sess-1')
+
+    // The undone exchange (u2/a2) is gone — the transcript now holds the
+    // server's active history (one surviving user turn) plus the confirmation
+    // notice. The notice surviving proves the replace ran *before* it.
+    const texts = sessionState.messages.map(chatMessageText)
+
+    expect(texts.some(t => t.includes('the undone message') && !t.includes('first turn'))).toBe(false)
+    expect(texts.some(t => t.includes('first turn that survives'))).toBe(true)
+
+    const last = sessionState.messages.at(-1)
+
+    expect(last?.role).toBe('system')
+    expect(chatMessageText(last!)).toContain('Undid 1 turn (2 messages).')
+
+    expect(requestComposerInsert).toHaveBeenCalledWith('the undone message', { target: 'main' })
+  })
+})

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -102,11 +102,18 @@ export interface SendCommandDispatchResponse {
   message: string
 }
 
+export interface PrefillCommandDispatchResponse {
+  type: 'prefill'
+  message?: string
+  notice?: string
+}
+
 export type CommandDispatchResponse =
   | ExecCommandDispatchResponse
   | AliasCommandDispatchResponse
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
+  | PrefillCommandDispatchResponse
 
 export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -35,6 +35,24 @@ describe('optimisticAttachmentRef', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'
     )
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('parses the prefill directive returned by /undo', () => {
+    expect(parseCommandDispatch({ message: 'edit me', notice: '↶ Undid 1 turn', type: 'prefill' })).toEqual({
+      message: 'edit me',
+      notice: '↶ Undid 1 turn',
+      type: 'prefill'
+    })
+  })
+
+  it('parses a prefill directive with no message or notice', () => {
+    expect(parseCommandDispatch({ type: 'prefill' })).toEqual({ type: 'prefill' })
+  })
+
+  it('returns null for unknown directive types', () => {
+    expect(parseCommandDispatch({ type: 'mystery' })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -240,6 +240,9 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
     case 'send':
       return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
 
+    case 'prefill':
+      return { type: 'prefill', message: str(row.message), notice: str(row.notice) }
+
     default:
       return null
   }


### PR DESCRIPTION
## Summary
Fixes #39019. In the desktop app, `/undo` cleared the agent's context but left the undone user/assistant exchange visible on screen, with no confirmation — so it looked like nothing happened.

## Root cause
`/undo` is a pending-input command, so `slash.exec` rejects it and the client falls through to `command.dispatch`, which returns a `{type: "prefill", message, notice}` directive *after* soft-deleting the backed-up turns server-side (`active=0`). The desktop's `parseCommandDispatch` (`apps/desktop/src/lib/chat-runtime.ts`) had no `prefill` case, so it returned `null` and `executeSlashCommand` rendered `error: invalid response: command.dispatch`. The directive was dropped entirely:
- no notice (the reporter's "no visual feedback"),
- no composer prefill,
- and the soft-deleted exchange was never removed from the rendered transcript (the core complaint).

The Ink TUI already handles `prefill` (`ui-tui/src/app/createSlashHandler.ts`); the desktop client just never did.

## Fix
Teach the desktop slash pipeline to handle the `prefill` directive:
- add `PrefillCommandDispatchResponse` to the dispatch union and a `prefill` case to `parseCommandDispatch`;
- in `executeSlashCommand`, on `prefill`: surface the notice, **re-sync the visible transcript to the server's active history** via the existing `getSessionMessages` endpoint (this removes the undone exchange), and drop the backed-up text into the composer via the existing external-insert bus (`requestComposerInsert`) for editing.

This matches the `/undo` command's own description — "Remove the last user/assistant exchange" — and the server's soft-delete truth (the exchange is already gone on next session load).

## Tests
`apps/desktop` vitest (`npm run test:ui`):
- `parseCommandDispatch` now parses the `prefill` directive (with and without message/notice) — 3 new cases.
- new hook test (`use-prompt-actions.undo.test.tsx`): `/undo` re-syncs the rendered transcript to the server active history and prefills the composer.
- `tsc -b` + `eslint` clean on all changed files.

(Note: the desktop vitest suite has ~52 pre-existing failures in this local environment from a jsdom/Node `localStorage` quirk, identical with and without this change — unrelated to this PR.)

## Scope
- **Desktop client only.** The Ink TUI has the same "messages stay visible" gap on `/undo` (it handles `prefill` but doesn't re-sync the transcript either); left out of this PR to keep the blast radius small — happy to follow up if maintainers want TUI parity.
- No backend / `command.dispatch` changes — the `prefill` contract is unchanged.

## Follow-up
- TUI transcript re-sync on `/undo` (see Scope).
- `requestComposerInsert` appends; for `/undo` the composer is normally empty so this is effectively a set. A dedicated "replace composer" affordance could be cleaner if other prefill sources appear.