### PR TITLE
fix(auth): honor global active_provider in is_provider_explicitly_configured for profiles

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1360,7 +1360,9 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     """Return True only if the user has explicitly configured this provider.
 
     Checks:
-      1. active_provider in auth.json matches
+      1. active_provider in auth.json matches (in profile mode, the
+         global-root active_provider is honored when the profile has none
+         of its own — see ``_active_provider_from_store``)
       2. model.provider in config.yaml matches
       3. Provider-specific env vars are set (e.g. ANTHROPIC_API_KEY)
 
@@ -1371,10 +1373,13 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     """
     normalized = (provider_id or "").strip().lower()
 
-    # 1. Check auth.json active_provider
+    # 1. Check auth.json active_provider. Mirror get_active_provider() /
+    # resolve_provider(): a named profile that never selected its own
+    # provider still counts the global-root active_provider as the user's
+    # explicit choice. See issue #18594 follow-up.
     try:
         auth_store = _load_auth_store()
-        active = (auth_store.get("active_provider") or "").strip().lower()
+        active = (_active_provider_from_store(auth_store) or "").strip().lower()
         if active and active == normalized:
             return True
     except Exception:

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -554,3 +554,67 @@ def test_resolve_provider_uses_global_active_provider(profile_env, monkeypatch):
     )
 
     assert auth.resolve_provider("auto") == "nous"
+
+
+# ---------------------------------------------------------------------------
+# is_provider_explicitly_configured — global active_provider fallback
+# (issue #18594 follow-up)
+#
+# ``is_provider_explicitly_configured`` gates auto-discovery of external
+# credentials (Claude Code's ~/.claude/.credentials.json) behind the user's
+# explicit provider choice. Its step-1 active_provider read must use the same
+# global-root fallback as ``get_active_provider`` / ``resolve_provider``;
+# otherwise a named profile that inherits the global active_provider resolves
+# (and selects) that provider via ``resolve_provider('auto')`` yet the
+# credential-pool seeding (agent/credential_pool.py) and auxiliary fallback
+# (agent/auxiliary_client.py) treat it as "not explicit" and skip it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _no_anthropic_env(monkeypatch):
+    """Strip Anthropic env vars so step 3 cannot mask the step-1 fallback."""
+    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_explicitly_configured_honors_global_active_provider(profile_env, _no_anthropic_env):
+    """Empty profile + global active_provider: anthropic counts as explicit."""
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        providers={"anthropic": {"access_token": "ant-global"}},
+        active_provider="anthropic",
+    ))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    assert is_provider_explicitly_configured("anthropic") is True
+
+
+def test_explicitly_configured_profile_active_provider_shadows_global(profile_env, _no_anthropic_env):
+    """A profile's own active_provider shadows global — global choice is not explicit here."""
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(
+        providers={"anthropic": {"access_token": "ant-global"}},
+        active_provider="anthropic",
+    ))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(
+        providers={"openrouter": {"access_token": "or-profile"}},
+        active_provider="openrouter",
+    ))
+
+    # Profile selected openrouter, so anthropic (the global choice) is NOT
+    # the profile's explicit provider; the profile's own selection is.
+    assert is_provider_explicitly_configured("anthropic") is False
+    assert is_provider_explicitly_configured("openrouter") is True
+
+
+def test_explicitly_configured_false_when_neither_selects_provider(profile_env, _no_anthropic_env):
+    """No active_provider anywhere → the fallback must not invent one."""
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    assert is_provider_explicitly_configured("anthropic") is False


### PR DESCRIPTION
## What & why

`is_provider_explicitly_configured()` gates auto-discovery of external credentials (e.g. Claude Code's `~/.claude/.credentials.json`) behind the user's explicit provider choice. Its step-1 `active_provider` check still read `auth_store.get("active_provider")` directly:

```python
active = (auth_store.get("active_provider") or "").strip().lower()
```

The #18594 follow-up (commit `3858cf430`) introduced the shared `_active_provider_from_store()` helper — which, in profile mode, falls back to the global-root `active_provider` when the profile hasn't selected its own — and applied it to `get_active_provider()` and `resolve_provider()`. This third read site was missed (it's wrapped in `.strip().lower()`, so the sweep didn't catch it).

**Impact:** a named profile with an empty `auth.json` and a global `active_provider: anthropic` has `get_active_provider()` and `resolve_provider("auto")` both resolve `anthropic`, yet `is_provider_explicitly_configured("anthropic")` returns `False`. The two consumers — `agent/auxiliary_client.py` and `agent/credential_pool.py` — then treat anthropic as "not explicit" and skip seeding/using it, contradicting the resolved active provider.

## Fix

Use `_active_provider_from_store(auth_store)` in step 1 so the explicit-config gate mirrors `get_active_provider()` / `resolve_provider()`. A profile's own `active_provider` still wins; the global-root fallback only fires when the profile has none. Classic mode is unchanged (`_load_global_auth_store()` returns `{}` when profile == global root).

No security regression: the global `active_provider` is only treated as explicit when the user actually set it globally — exactly what classic mode already does. Users who never selected anthropic get no credential auto-discovery.

## Testing

Added 3 behavioral regression tests in `tests/hermes_cli/test_auth_profile_fallback.py`:

- `test_explicitly_configured_honors_global_active_provider` — empty profile + global `active_provider: anthropic` ⇒ explicit.
- `test_explicitly_configured_profile_active_provider_shadows_global` — profile's own selection shadows global.
- `test_explicitly_configured_false_when_neither_selects_provider` — no selection anywhere ⇒ the fallback must not invent one.

```bash
python -m pytest tests/hermes_cli/test_auth_profile_fallback.py \
                 tests/hermes_cli/test_auth_provider_gate.py \
                 tests/agent/test_auxiliary_client.py \
                 tests/agent/test_credential_pool.py
```

Results:

- Auth gate + profile-fallback suites: **30 passed**
- Including both consumers (`auxiliary_client`, `credential_pool`): **315 passed**