### PR TITLE
fix: normalize model picker ids and desktop API URLs

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -65,6 +65,24 @@ function buildGatewayWsUrlWithTicket(baseUrl, ticket) {
   return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}`
 }
 
+function buildBackendApiUrl(baseUrl, requestPath) {
+  const base = normalizeRemoteBaseUrl(baseUrl)
+  const rawPath = String(requestPath || '')
+
+  if (!rawPath.startsWith('/') || rawPath.startsWith('//')) {
+    throw new Error('Hermes backend API path must start with a single /.')
+  }
+
+  const parsed = new URL(base)
+  const requestUrl = new URL(rawPath, 'http://hermes.local')
+  const prefix = parsed.pathname.replace(/\/+$/, '')
+  const suffix = requestUrl.pathname.replace(/^\/+/, '')
+  parsed.pathname = `${prefix}/${suffix}`
+  parsed.search = requestUrl.search
+
+  return parsed.toString()
+}
+
 function tokenPreview(value) {
   const raw = String(value || '')
 
@@ -109,6 +127,7 @@ function cookiesHaveSession(cookies) {
 module.exports = {
   AT_COOKIE_VARIANTS,
   authModeFromStatus,
+  buildBackendApiUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   cookiesHaveSession,

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -16,6 +16,7 @@ const assert = require('node:assert/strict')
 const {
   AT_COOKIE_VARIANTS,
   authModeFromStatus,
+  buildBackendApiUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   cookiesHaveSession,
@@ -78,6 +79,25 @@ test('buildGatewayWsUrlWithTicket uses ?ticket= not ?token=', () => {
 
 test('buildGatewayWsUrlWithTicket url-encodes the ticket', () => {
   assert.equal(buildGatewayWsUrlWithTicket('https://host', 'a+b/c'), 'wss://host/api/ws?ticket=a%2Bb%2Fc')
+})
+
+// --- buildBackendApiUrl ---
+
+test('buildBackendApiUrl joins a backend base URL and API path', () => {
+  assert.equal(buildBackendApiUrl('http://127.0.0.1:9120', '/api/model/set'), 'http://127.0.0.1:9120/api/model/set')
+})
+
+test('buildBackendApiUrl preserves remote gateway path prefixes', () => {
+  assert.equal(
+    buildBackendApiUrl('https://gw.example.com/hermes/', '/api/model/options?provider=openai-codex'),
+    'https://gw.example.com/hermes/api/model/options?provider=openai-codex'
+  )
+})
+
+test('buildBackendApiUrl rejects renderer paths that are not absolute API paths', () => {
+  assert.throws(() => buildBackendApiUrl('https://gw.example.com', 'api/model/set'), /must start with/)
+  assert.throws(() => buildBackendApiUrl('https://gw.example.com', '//evil.example.com/api/model/set'), /must start with/)
+  assert.throws(() => buildBackendApiUrl('https://gw.example.com', undefined), /must start with/)
 })
 
 // --- authModeFromStatus ---

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -29,6 +29,7 @@ const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const {
   authModeFromStatus,
+  buildBackendApiUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   cookiesHaveSession,
@@ -4114,7 +4115,7 @@ ipcMain.handle('hermes:requestMicrophoneAccess', async () => {
 ipcMain.handle('hermes:api', async (_event, request) => {
   const connection = await startHermes()
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
-  const url = `${connection.baseUrl}${request.path}`
+  const url = buildBackendApiUrl(connection.baseUrl, request.path)
   // OAuth gateways authenticate REST via the HttpOnly session cookie held in
   // the OAuth partition — route through Electron's net stack bound to that
   // session so the cookie attaches automatically. Token/local modes keep using

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -83,6 +83,7 @@ def load_picker_context() -> ConfigContext:
     ``tui_gateway/server.py`` (×2 sites) used to do.
     """
     from hermes_cli.config import get_compatible_custom_providers, load_config
+    from hermes_cli.model_normalize import normalize_model_for_provider
 
     cfg = load_config()
     model_cfg = cfg.get("model", {})
@@ -95,6 +96,16 @@ def load_picker_context() -> ConfigContext:
         current_model = str(model_cfg) if model_cfg else ""
         current_provider = ""
         current_base_url = ""
+    if current_model and current_provider:
+        # Mirror runtime normalization before exposing the value to pickers.
+        # Stale configs may contain user-facing aggregator-style IDs such as
+        # ``openai/gpt-5.5`` while the selected provider (``openai-codex``)
+        # and its model list use the native bare slug (``gpt-5.5``). Returning
+        # the raw config value makes Desktop/TUI unable to mark the row as
+        # selected even though the agent itself starts with the normalized
+        # model. Keep config writes untouched; this is only the display/runtime
+        # context every inventory consumer shares.
+        current_model = normalize_model_for_provider(current_model, current_provider)
     raw = cfg.get("providers")
     return ConfigContext(
         current_provider=current_provider,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1846,6 +1846,19 @@ def get_model_info():
             base_url = ""
             config_ctx = None
 
+        if provider and model_name:
+            # Keep dashboard/Desktop model state in the same provider-native
+            # form the runtime and model picker use. Older configs can contain
+            # aggregator-style slugs like ``openai/gpt-5.5`` for openai-codex;
+            # the agent normalizes those to ``gpt-5.5`` on startup, so returning
+            # the raw config value here makes the UI think no picker row matches.
+            try:
+                from hermes_cli.model_normalize import normalize_model_for_provider
+
+                model_name = normalize_model_for_provider(model_name, provider)
+            except Exception:
+                pass
+
         if not model_name:
             return dict(_EMPTY_MODEL_INFO, provider=provider)
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -91,6 +91,20 @@ def test_load_picker_context_empty_config():
     assert ctx.custom_providers == []
 
 
+def test_load_picker_context_normalizes_current_model_for_provider():
+    """Pickers should expose the same provider-native model the runtime uses.
+
+    Regression: stale configs could keep ``openai/gpt-5.5`` while
+    ``openai-codex`` model rows contain bare ``gpt-5.5``. Desktop then could
+    not mark the selected row even though startup normalized the model.
+    """
+    cfg = _cfg(model={"default": "openai/gpt-5.5", "provider": "openai-codex"})
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        ctx = load_picker_context()
+    assert ctx.current_model == "gpt-5.5"
+    assert ctx.current_provider == "openai-codex"
+
+
 # ─── with_overrides ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes two related model-picker/Desktop backend edge cases:

1. Provider-qualified model IDs can leak from config into picker/API state. For example, a config value such as `openai/gpt-5.5` is normalized by the OpenAI Codex provider to `gpt-5.5`, but the Desktop/Web model picker previously received the raw configured value as `current_model`. That makes the current selection fail to match the provider option list even though the runtime model is valid.

2. Desktop's `hermes:api` IPC handler built backend REST URLs with string concatenation (`baseUrl + request.path`). This is fragile for remote gateways with path prefixes and gives Electron's `net` stack less validation around renderer-provided paths. The PR moves URL joining into the existing pure `connection-config.cjs` helper and validates that renderer requests are absolute backend paths.

The fix normalizes the displayed/current model at the backend inventory/API boundary rather than mutating the user's config, so existing config files remain untouched while all picker consumers see a provider-native model ID.

## Related Issue

No issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/inventory.py`
  - Normalize `current_model` for the active provider when building picker context.
- `hermes_cli/web_server.py`
  - Normalize `model` returned by `/api/model/info` for the configured provider.
- `tests/hermes_cli/test_inventory.py`
  - Add regression coverage for provider-qualified config values (`openai/gpt-5.5`) matching provider-native picker options (`gpt-5.5`).
- `apps/desktop/electron/connection-config.cjs`
  - Add `buildBackendApiUrl(baseUrl, requestPath)` to safely join backend base URLs with API paths while preserving remote path prefixes and query strings.
  - Reject renderer paths that are not absolute single-slash backend paths.
- `apps/desktop/electron/main.cjs`
  - Use `buildBackendApiUrl()` in the `hermes:api` IPC handler instead of string concatenation.
- `apps/desktop/electron/connection-config.test.cjs`
  - Add unit coverage for local backend URL joining, remote prefix preservation, query preservation, and invalid renderer path rejection.

## How to Test

1. Configure a provider/model combination where the stored model is provider-qualified but the provider option list uses the normalized model ID, for example:
   - provider: `openai-codex`
   - model: `openai/gpt-5.5`
2. Open the Desktop/Web model picker and confirm the current model is shown as selected against the provider's normalized option (`gpt-5.5`).
3. Run the targeted regressions:

```bash
venv/bin/python -m pytest tests/hermes_cli/test_inventory.py
node --test apps/desktop/electron/connection-config.test.cjs
```

Observed locally:

```text
tests/hermes_cli/test_inventory.py: 19 passed
apps/desktop/electron/connection-config.test.cjs: 29 passed
scripts/check-windows-footguns.py --diff origin/main: ✓ No Windows footguns found (3 file(s) scanned)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Targeted test output:

```text
$ venv/bin/python -m pytest tests/hermes_cli/test_inventory.py
19 passed

$ node --test apps/desktop/electron/connection-config.test.cjs
29 passed

$ venv/bin/python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (3 file(s) scanned)
```
