### PR TITLE
fix(browser): apply vision embed-time pixel/byte caps in browser_vision

### DIFF
--- a/tests/tools/test_browser_vision_embed_cap.py
+++ b/tests/tools/test_browser_vision_embed_cap.py
@@ -1,0 +1,113 @@
+"""Regression tests for the embed-time byte/pixel cap in ``browser_vision``.
+
+When the active main model supports native vision, ``browser_vision`` attaches
+the screenshot directly to the conversation as a multimodal tool result. That
+image is baked into immutable history and re-sent on every subsequent turn, so
+Anthropic's per-image limits (5 MB base64 OR 8000px per side) apply to it
+permanently — an oversized embed wedges the session with a non-retryable 400.
+
+A full-page screenshot can be tall and low-byte (e.g. 1200×12000 at 0.06 MB):
+it passes any byte check but trips the pixel ceiling. ``browser_vision`` must
+mirror ``_vision_analyze_native`` and proactively resize down to the embed
+target (4 MB / 7900px) BEFORE embedding, on EITHER limit.
+
+These tests fail without the proactive cap and skip when Pillow is unavailable
+(the dimension resize is a no-op without it — the documented soft-dep posture).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from unittest.mock import patch
+
+import pytest
+
+from tools.browser_tool import browser_vision
+from tools.vision_tools import _EMBED_MAX_DIMENSION, _EMBED_TARGET_BYTES
+
+
+def _decode_data_url(data_url: str) -> bytes:
+    assert data_url.startswith("data:image/"), data_url[:40]
+    return base64.b64decode(data_url.split(",", 1)[1])
+
+
+def _run_browser_vision_native(screenshot_path):
+    """Invoke browser_vision forcing the native fast path with a fixed screenshot."""
+    def _fake_run_browser_command(*args, **kwargs):
+        return {"success": True, "data": {"path": str(screenshot_path)}}
+
+    with patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+            patch("tools.browser_tool._get_browser_engine", return_value="chrome"), \
+            patch("tools.browser_tool._run_browser_command",
+                  side_effect=_fake_run_browser_command), \
+            patch("tools.vision_tools._should_use_native_vision_fast_path",
+                  return_value=True):
+        return browser_vision("describe what you see")
+
+
+def _extract_embedded_url(result) -> str:
+    assert isinstance(result, dict), f"expected multimodal envelope, got {type(result).__name__}: {str(result)[:200]}"
+    assert result.get("_multimodal") is True
+    return next(
+        p["image_url"]["url"]
+        for p in result["content"]
+        if p.get("type") == "image_url"
+    )
+
+
+def test_tall_low_byte_screenshot_resized_under_pixel_cap(tmp_path):
+    """A tall, small-byte full-page screenshot must be downscaled under 8000px.
+
+    This is the parity gap: the byte check alone lets a 200×9000 PNG (a few KB)
+    slip into immutable history at 9000px, and Anthropic rejects it with a
+    non-retryable 400 that bricks the session.
+    """
+    Image = pytest.importorskip("PIL.Image")
+
+    shot = tmp_path / "tall.png"
+    Image.new("RGB", (200, 9000), "white").save(shot, format="PNG")
+    # Sanity: low byte size but over the pixel ceiling — only the pixel arm fires.
+    assert shot.stat().st_size * 4 // 3 < _EMBED_TARGET_BYTES, "test image unexpectedly large in bytes"
+    assert max(Image.open(shot).size) > _EMBED_MAX_DIMENSION
+
+    result = _run_browser_vision_native(shot)
+    url = _extract_embedded_url(result)
+
+    with Image.open(io.BytesIO(_decode_data_url(url))) as embedded:
+        assert max(embedded.size) <= _EMBED_MAX_DIMENSION, (
+            f"embedded screenshot is {embedded.size} — longest side exceeds the "
+            f"{_EMBED_MAX_DIMENSION}px embed cap and would wedge the session on Anthropic"
+        )
+
+
+def test_oversized_byte_screenshot_resized_under_embed_cap(tmp_path):
+    """A heavy-byte screenshot must be downscaled under the 4 MB embed byte cap."""
+    Image = pytest.importorskip("PIL.Image")
+
+    shot = tmp_path / "heavy.png"
+    # Noisy PNG that base64-encodes well over the embed byte cap (won't compress).
+    Image.effect_noise((2600, 2600), 80).convert("RGB").save(shot, format="PNG")
+    assert shot.stat().st_size * 4 // 3 > _EMBED_TARGET_BYTES, "test image not big enough in bytes"
+
+    result = _run_browser_vision_native(shot)
+    url = _extract_embedded_url(result)
+
+    assert len(url) <= _EMBED_TARGET_BYTES, (
+        f"embedded screenshot {len(url) / 1024 / 1024:.1f} MB exceeds the embed cap "
+        f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — would wedge sessions on Anthropic"
+    )
+
+
+def test_small_screenshot_embedded_unchanged(tmp_path):
+    """A small in-bounds screenshot is embedded as-is (no needless resize)."""
+    Image = pytest.importorskip("PIL.Image")
+
+    shot = tmp_path / "small.png"
+    Image.new("RGB", (320, 240), "white").save(shot, format="PNG")
+    original = shot.read_bytes()
+
+    result = _run_browser_vision_native(shot)
+    url = _extract_embedded_url(result)
+
+    assert _decode_data_url(url) == original, "in-bounds screenshot should not be re-encoded"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3216,6 +3216,47 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         )
 
         if _should_use_native_vision_fast_path():
+            # Proactive embed cap: this screenshot gets baked into conversation
+            # history and re-sent on every subsequent turn. Anthropic rejects
+            # any single base64 image over 5 MB OR over 8000px per side with a
+            # 400, and because history is immutable an oversized embed
+            # permanently wedges the session — retries can't clear bytes (or
+            # pixels) already in the request. A full-page screenshot can be tall
+            # and low-byte (e.g. 1200×12000 at 0.06 MB), passing the byte check
+            # yet tripping the pixel ceiling. Mirror _vision_analyze_native:
+            # resize DOWN to the embed target (4 MB / 7900px, headroom under
+            # both ceilings) whenever the payload exceeds either limit, not just
+            # at the 20 MB hard ceiling the reactive retry below handles.
+            from tools.vision_tools import (
+                _EMBED_MAX_DIMENSION,
+                _EMBED_TARGET_BYTES,
+                _MAX_BASE64_BYTES,
+                _image_exceeds_dimension,
+                _resize_image_for_vision,
+            )
+
+            if (len(data_url) > _EMBED_TARGET_BYTES
+                    or _image_exceeds_dimension(screenshot_path, _EMBED_MAX_DIMENSION)):
+                data_url = _resize_image_for_vision(
+                    screenshot_path, mime_type="image/png",
+                    max_base64_bytes=_EMBED_TARGET_BYTES,
+                    max_dimension=_EMBED_MAX_DIMENSION,
+                )
+                # If even resizing can't get under the absolute hard ceiling,
+                # reject rather than embed a session-wedging payload.
+                if len(data_url) > _MAX_BASE64_BYTES:
+                    return json.dumps({
+                        "success": False,
+                        "error": (
+                            f"Screenshot too large for native vision: base64 "
+                            f"payload is {len(data_url) / (1024 * 1024):.1f} MB "
+                            f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
+                            f"even after resizing. Install Pillow "
+                            f"(`pip install Pillow`) for better auto-resize."
+                        ),
+                        "screenshot_path": str(screenshot_path),
+                    }, ensure_ascii=False)
+
             native_result = _build_native_vision_tool_result(
                 image_url=str(screenshot_path),
                 question=question,


### PR DESCRIPTION


### What
`browser_vision`'s native fast path passed the raw, full-resolution screenshot
straight to `_build_native_vision_tool_result`, skipping the proactive embed cap
that the sibling `_vision_analyze_native` already applies.

### Why
The native multimodal envelope is baked into immutable conversation history and
re-sent on every subsequent turn. Anthropic rejects any single image over **5 MB**
base64 **or** over **8000px** per side with a non-retryable 400 — once an oversized
image is in history, retries can't clear it and the session is permanently wedged.
`browser_vision` captures full-page screenshots, which can be tall and low-byte
(e.g. `1200×12000` at ~0.06 MB): they pass the byte check but trip the pixel
ceiling and brick the session.

### Change
In the native fast path only (the path that embeds into history), mirror
`_vision_analyze_native`: resize down to the embed target (**4 MB / 7900px**) when
the payload exceeds either limit, and reject if it still can't get under the hard
ceiling after resizing. The auxiliary path is unchanged — it matches
`vision_analyze_tool` (reactive resize only) and does not embed into history.

- `tools/browser_tool.py` — proactive byte/pixel cap before `_build_native_vision_tool_result`

### Tests
Added `tests/tools/test_browser_vision_embed_cap.py`:

- `test_tall_low_byte_screenshot_resized_under_pixel_cap` — tall, low-byte
  screenshot is downscaled under the 7900px embed cap
- `test_oversized_byte_screenshot_resized_under_embed_cap` — heavy-byte screenshot
  is downscaled under the 4 MB embed cap
- `test_small_screenshot_embedded_unchanged` — in-bounds screenshot is embedded
  as-is (no needless re-encode)

Both cap tests were confirmed to fail without the fix. Tests skip when Pillow is
unavailable (resize is a documented no-op).

### Results
- New tests: **3 passed**
- `tests/tools/ -k "browser or vision"`: **496 passed, 24 skipped**

No new dependencies. One focused, behavior-only change.