### PR TITLE
fix(desktop): prefer configured workspace cwd

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react'
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getHermesConfig } from '@/hermes'
+import { persistString } from '@/lib/storage'
+import { $currentCwd, setCurrentCwd } from '@/store/session'
+
+import { useHermesConfig } from './use-hermes-config'
+
+vi.mock('@/hermes', () => ({
+  getHermesConfig: vi.fn(),
+  getHermesConfigDefaults: vi.fn().mockResolvedValue({}),
+}))
+
+const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+
+describe('useHermesConfig refreshHermesConfig', () => {
+  beforeEach(() => {
+    // Reset atoms and localStorage between tests
+    setCurrentCwd('')
+    persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('applies terminal.cwd from config even when localStorage has a stale value', async () => {
+    // Simulate a stale remembered workspace cwd
+    persistString(WORKSPACE_CWD_KEY, '/Users/old/stale-project')
+    setCurrentCwd('/Users/old/stale-project')
+
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '/Users/example/new-workspace' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    // The configured terminal.cwd must override the stale localStorage value
+    expect($currentCwd.get()).toBe('/Users/example/new-workspace')
+  })
+
+  it('uses empty string when terminal.cwd is not set and localStorage is empty', async () => {
+    vi.mocked(getHermesConfig).mockResolvedValue({} as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  it('ignores terminal.cwd when it is "."', async () => {
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '.' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  it('calls refreshProjectBranch with the configured cwd', async () => {
+    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
+    setCurrentCwd('')
+
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '/workspace/project-a' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch,
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/project-a')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -3,7 +3,6 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import {
-  $currentCwd,
   setAvailablePersonalities,
   setCurrentCwd,
   setCurrentFastMode,
@@ -52,8 +51,8 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       const cwd = (config.terminal?.cwd ?? '').trim()
 
       if (cwd && cwd !== '.') {
-        setCurrentCwd(prev => prev || cwd)
-        void refreshProjectBranch($currentCwd.get() || cwd)
+        setCurrentCwd(cwd)
+        void refreshProjectBranch(cwd)
       }
 
       const reasoning = (config.agent?.reasoning_effort ?? '').trim()


### PR DESCRIPTION
## Summary

Fixes the Desktop working-directory precedence bug where a stale renderer `hermes.desktop.workspace-cwd` localStorage value could keep overriding the configured `terminal.cwd` after the user changed Settings -> Workspace -> Working Directory.

The change makes `refreshHermesConfig()` apply the configured `terminal.cwd` directly whenever it is set to a real path, and refreshes project branch state for that same path. This keeps startup and settings-save refreshes aligned with the saved config.

Fixes #38855

## Real Behavior Proof

Behavior addressed: Desktop config reload now lets `terminal.cwd` override a stale remembered workspace cwd, so new sessions use the configured working directory instead of the old localStorage value.

Environment tested: local Hermes checkout on macOS, branch `tui-38855-desktop-cwd`, inside `apps/desktop`.

Exact commands run after the patch:

```bash
npx vitest run src/app/session/hooks/use-hermes-config.test.ts
npx vitest run src/store/session.test.ts
npm run type-check -- --pretty false
npx eslint src/app/session/hooks/use-hermes-config.ts src/app/session/hooks/use-hermes-config.test.ts
git diff --check
```

Evidence after fix:

```text
src/app/session/hooks/use-hermes-config.test.ts: 1 passed, 4 passed
src/store/session.test.ts: 1 passed, 10 passed
npm run type-check -- --pretty false: passed
npx eslint src/app/session/hooks/use-hermes-config.ts src/app/session/hooks/use-hermes-config.test.ts: passed
git diff --check: clean
```

Observed result after fix: the regression test seeds a stale remembered workspace cwd, returns a different `terminal.cwd` from the desktop config refresh path, and observes `$currentCwd` updated to the configured value. The related session-store test remains green.

## Changes

- `apps/desktop/src/app/session/hooks/use-hermes-config.ts`: apply configured `terminal.cwd` directly instead of only when current cwd is empty.
- `apps/desktop/src/app/session/hooks/use-hermes-config.test.ts`: add focused coverage for stale remembered cwd override, empty config, `"."` handling, and branch refresh cwd.

## Notes

This does not add config keys or change settings persistence. It only fixes precedence during desktop config refresh.
