### PR TITLE
fix(desktop): route macOS/Linux updates through in-app path instead of silent Tauri updater

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1333,6 +1333,19 @@ async function applyUpdates(opts = {}) {
       return { ok: true, manual: true, command, hermesRoot: updateRoot }
     }
 
+    // macOS/Linux: prefer in-app update over the Tauri hermes-setup binary.
+    // On Windows, the venv shim file lock prevents `hermes update` from running
+    // while the desktop process holds the lock, so the detached hermes-setup.exe
+    // --update is the only viable path. On macOS/Linux there is no such
+    // constraint, so the in-app path (applyUpdatesPosixInApp) is always better:
+    // it streams progress to the UI via emitUpdateProgress, handles `hermes
+    // update` + `hermes desktop --build-only` + atomic bundle swap + relaunch,
+    // and degrades gracefully with visible error messages instead of silently
+    // closing the app. (#38300)
+    if (!IS_WINDOWS) {
+      return await applyUpdatesPosixInApp(opts)
+    }
+
     emitUpdateProgress({ stage: 'restart', message: 'Handing off to the Hermes updater…', percent: 100 })
 
     const updateRoot = resolveUpdateRoot()


### PR DESCRIPTION
## Problem

When clicking "Update" in Hermes Desktop on macOS (and Linux), the app silently closes with no feedback and does not actually update.

### Root Cause

The `applyUpdates()` function has three branches:

1. **No `hermes-setup` + POSIX** -> `applyUpdatesPosixInApp()` (runs `hermes update` + `hermes desktop --build-only` + atomic bundle swap + relaunch). **Works correctly.**
2. **No `hermes-setup` + Windows** -> shows manual `hermes update` command. **Works correctly.**
3. **Has `hermes-setup` binary** -> spawns Tauri bootstrap installer with `--update`, `stdio:ignore`, quits after 600ms. The user only sees the app close.

On macOS, `~/hermes-setup` (the Tauri bootstrap installer, ~11MB) may exist from a prior install, causing all "Update" clicks to take branch 3. The Tauri binary was designed as a first-launch installer, not an in-app updater. Running it with `stdio:ignore` discards all output. The app never relaunches.

## Fix

Added a POSIX-preferred branch between the `!updater` fallback and the Tauri updater fallthrough. `applyUpdatesPosixInApp()` is now used on macOS/Linux regardless of whether `hermes-setup` exists.

**Why this is safe:**
- **macOS/Linux**: no venv file-lock constraint (unlike Windows where the venv shim is locked while Python runs). The in-app path can safely run `hermes update` + `hermes desktop --build-only` + bundle swap + relaunch.
- **Feedback**: `applyUpdatesPosixInApp()` streams progress via `emitUpdateProgress()` — the user sees progress with percent indicators.
- **Error handling**: failures show visible error messages instead of silently closing.
- **Degradation**: if `hermes` CLI is not found, shows the exact manual command to run.
- **Windows unchanged**: `hermes-setup.exe --update` path preserved for Windows file-lock constraints.
- **Graceful with missing updater**: the original `!updater && !IS_WINDOWS` branch (line 1300) still handles the case where `hermes-setup` doesn't exist on POSIX.

## Testing

Tested on macOS 15.5 arm64 with Hermes Agent v0.15.1:
- Full TypeScript + Vite + electron-builder build pipeline
- Deployed to `/Applications/Hermes.app`
- Verified asar contains patched `main.cjs`
- All four code paths preserved:
  - No updater + POSIX -> `applyUpdatesPosixInApp()`
  - No updater + Windows -> manual command
  - Has updater + POSIX -> `applyUpdatesPosixInApp()` **(NEW)**
  - Has updater + Windows -> Tauri `--update` (unchanged)
- `hermes desktop --build-only` succeeds
- Gateway connects, app launches without console errors

## Files Changed

- `apps/desktop/electron/main.cjs` — 13 lines added

Fixes desktop "Update" button silently closing the app on macOS/Linux when `hermes-setup` is present at `$HERMES_HOME/hermes-setup`.