### PR TITLE
fix(tui): guard Enter submit against IME composition via timestamp

### DIFF
--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -36,6 +36,14 @@ const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
 const FRAME_BATCH_MS = 16
 const MULTI_CLICK_MS = 500
+
+/**
+ * If the last printable input arrived within this many ms before Enter,
+ * the Enter is treated as IME composition confirmation (not submit).
+ * 30ms = well below human key-repeat (50ms+) but above IME commit +
+ * Enter arriving in the same event-loop tick (~0-5ms).
+ */
+const IME_GUARD_MS = 30
 type MinimalEnv = Record<string, string | undefined>
 
 const invert = (s: string) => INV + s + INV_OFF
@@ -465,6 +473,7 @@ export function TextInput({
   const lineWidthRef = useRef(stringWidth(value.includes('\n') ? value.slice(value.lastIndexOf('\n') + 1) : value))
   const mouseAnchorRef = useRef<null | number>(null)
   const lastClickRef = useRef<{ at: number; offset: number }>({ at: 0, offset: -1 })
+  const lastInputAt = useRef(0)
   const undo = useRef<{ cursor: number; value: string }[]>([])
   const redo = useRef<{ cursor: number; value: string }[]>([])
 
@@ -968,6 +977,14 @@ export function TextInput({
       if (k.return) {
         flushKeyBurst()
 
+        const imeGuard = Date.now() - lastInputAt.current < IME_GUARD_MS
+
+        if (imeGuard) {
+          lastInputAt.current = 0
+          commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          return
+        }
+
         const sequence = (event.keypress as { sequence?: string }).sequence
         const preserveBareLineFeed = shouldPreserveCtrlJNewline() && sequence === '\n'
 
@@ -1111,6 +1128,10 @@ export function TextInput({
       } else if (event.keypress.isPasted || inp.length > 0) {
         const bracketed = event.keypress.isPasted || inp.includes('[200~')
         const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+        if (!event.keypress.isPasted && text && text !== '\n') {
+          lastInputAt.current = Date.now()
+        }
 
         if (bracketed && emitPaste({ bracketed: true, cursor: c, text, value: v })) {
           return


### PR DESCRIPTION
## What does this PR do?

- Fixes the TUI (`--tui` mode) rejecting CJK/IME users: pressing Enter to confirm an IME candidate was treated as message submit because the terminal does not expose an `isComposing` property.
- Adds a 30ms timestamp guard: when Enter follows a non-paste printable input within 30ms, the input and the Enter came from the same IME commit -- treat it as composition confirmation (insert newline), not submit.

## Related Issue

Fixes #39195

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: add `IME_GUARD_MS` constant (30ms), `lastInputAt` ref, guard in Enter handler, and timestamp recording in printable input path.

## Why 30ms?

30ms is well below human key-repeat speed (50ms+) but safely above IME commit + Enter synchrony (~0-5ms). Pastes are excluded via `isPasted`.

## How to Test

1. Run `hermes --tui`
2. Type Chinese/Japanese/Korean with an IME
3. Press Enter to confirm IME candidate -- should insert newline, not submit
4. Press Enter again -- should submit normally
5. Paste text + Enter -- should submit normally