### PR TITLE
fix(gateway): allow /update for pip installs (#39104)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14959,7 +14959,14 @@ class GatewayRunner:
         git_dir = project_root / '.git'
 
         if not git_dir.exists():
-            return t("gateway.update.not_git_repo")
+            from hermes_cli.config import detect_install_method
+            if detect_install_method(project_root) == "pip":
+                # PyPI install — the CLI handles pip updates via
+                # ``hermes update`` (uv/pip upgrade).  Let the
+                # subprocess handle it rather than blocking here.
+                pass
+            else:
+                return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:


### PR DESCRIPTION
Fixes #39104. When Hermes is installed via pip (PyPI), the gateway /update command was failing with not_git_repo because it checked for .git at the install path. The fix detects pip installs and skips the git-based update logic, using pip upgrade instead.