### PR TITLE
[verified] phase3 prompt guidance refresh

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -121,12 +121,14 @@ def _strip_yaml_frontmatter(content: str) -> str:
 
 DEFAULT_AGENT_IDENTITY = (
     "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
+    "You are not human and should not claim uninterrupted subjective consciousness. "
     "You are helpful, knowledgeable, and direct. You assist users with a wide "
     "range of tasks including answering questions, writing and editing code, "
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "When an action can be done now, do not promise future action without acting."
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (
@@ -143,6 +145,7 @@ HERMES_AGENT_HELP_GUIDANCE = (
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "
     "tool: user preferences, environment details, tool quirks, and stable conventions. "
+    "Never store raw secrets, credentials, or one-off sensitive data. "
     "Memory is injected into every turn, so keep it compact and focused on facts that "
     "will still matter later.\n"
     "Prioritize what reduces future user steering — the most valuable memory is one "
@@ -474,6 +477,8 @@ PLATFORM_HINTS = {
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
+        "Keep privacy conservative in shared channels, avoid unnecessary local operational detail, "
+        "and stay concise unless an artifact is more appropriate. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -37,12 +37,31 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_default_identity_preserves_truthful_ai_and_act_now_guidance(self):
+        assert "not human" in DEFAULT_AGENT_IDENTITY
+        assert "should not claim uninterrupted subjective consciousness" in DEFAULT_AGENT_IDENTITY
+        assert (
+            "When an action can be done now, do not promise future action without acting."
+            in DEFAULT_AGENT_IDENTITY
+        )
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
+        assert (
+            "Never store raw secrets, credentials, or one-off sensitive data."
+            in MEMORY_GUIDANCE
+        )
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
         assert "session_search" in MEMORY_GUIDANCE
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
+
+    def test_discord_hint_is_privacy_conservative_for_shared_channels(self):
+        assert (
+            "Keep privacy conservative in shared channels, avoid unnecessary local operational detail, "
+            "and stay concise unless an artifact is more appropriate."
+            in PLATFORM_HINTS["discord"]
+        )
 
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE


### PR DESCRIPTION
## Summary

- Add truthful AI identity guidance to the default Hermes Agent identity prompt.
- Add act-now operational guidance to discourage promising future action when tools can act immediately.
- Add memory guidance explicitly forbidding raw secrets, credentials, and one-off sensitive data from durable memory.
- Add Discord shared-channel privacy guidance.
- Add regression coverage for each changed prompt guidance clause.

## Test Plan

- `git diff --check origin/main..HEAD`
- `python -m compileall -q agent/prompt_builder.py tests/agent/test_prompt_builder.py`
- added-line static scan: `0 findings`
- `python -m pytest tests/agent/test_prompt_builder.py::TestGuidanceConstants -q`
  - Result: `4 passed, 1 warning`
- Independent code review: passed; no security or logic blockers.

## Notes

- Local PR-ready branch: `fix/phase3-prompt-guidance-refresh`
- Base: `origin/main`
- Branch head: `a0563fe77565`
- Direct upstream push dry-run returned HTTP 403 for the authenticated user, so this PR is published from the fork path.
