### PR TITLE
Add desktop-only install mode (salvage #36674)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -30,6 +30,17 @@ Add `--include-desktop` to the [one-line installer](../../README.md#quick-instal
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --include-desktop
 ```
 
+If this machine should only run the Desktop shell and connect to a Hermes
+backend running somewhere else, use desktop-only mode instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --desktop-only
+```
+
+Desktop-only mode builds the app but skips the local setup wizard and gateway
+setup. This is useful for a laptop that should control a server, VM, WSL
+instance, or Tailscale-accessible Hermes runtime.
+
 Already have the Hermes CLI? Just run:
 
 ```bash
@@ -37,6 +48,35 @@ hermes desktop
 ```
 
 It builds and launches the GUI against your existing install — same config, keys, sessions, and skills. On first launch Hermes walks you through picking a provider and model; nothing else to configure.
+
+On macOS, source-built desktop installs also create a user app shortcut at:
+
+```text
+~/Applications/Hermes.app
+```
+
+### Remote gateway
+
+Hermes Desktop can connect to a remote dashboard backend instead of starting a
+local runtime. On the backend machine, run:
+
+```bash
+hermes dashboard --tui --no-open --host 127.0.0.1 --port 9120 --insecure
+```
+
+Expose that port through your preferred private network or reverse proxy, then
+configure the Desktop app from **Settings → Gateway → Remote gateway**. Provide
+the base URL and the dashboard session token. Path prefixes are supported, so a
+URL such as `https://server.example.com/hermes` maps Desktop REST calls to
+`/hermes/api/...` and WebSocket calls to `/hermes/api/ws`.
+
+For scripted launches, set both environment variables before starting Desktop:
+
+```bash
+export HERMES_DESKTOP_REMOTE_URL="https://server.example.com/hermes"
+export HERMES_DESKTOP_REMOTE_TOKEN="<dashboard-session-token>"
+hermes desktop --skip-build
+```
 
 ### Prebuilt installers
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,6 +80,7 @@ STAGE_NAME=""
 JSON_OUTPUT=false
 NON_INTERACTIVE=false
 INCLUDE_DESKTOP=false
+DESKTOP_ONLY=false
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -137,6 +138,12 @@ while [[ $# -gt 0 ]]; do
             INCLUDE_DESKTOP=true
             shift
             ;;
+        --desktop-only|-DesktopOnly)
+            DESKTOP_ONLY=true
+            INCLUDE_DESKTOP=true
+            RUN_SETUP=false
+            shift
+            ;;
         --dir)
             INSTALL_DIR="$2"
             INSTALL_DIR_EXPLICIT=true
@@ -173,6 +180,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --json         Print a JSON result frame for --stage"
             echo "  --non-interactive  Skip stages that require user input"
             echo "  --include-desktop  Also build the desktop app (apps/desktop -> Hermes.app)"
+            echo "  --desktop-only  Build only the desktop app and skip local agent setup"
             echo "  --dir PATH     Installation directory"
             echo "                   default (non-root):  ~/.hermes/hermes-agent"
             echo "                   default (root, Linux): /usr/local/lib/hermes-agent"
@@ -1933,6 +1941,11 @@ run_setup_wizard() {
 }
 
 maybe_start_gateway() {
+    if [ "$DESKTOP_ONLY" = true ]; then
+        log_info "Skipping gateway setup (--desktop-only)"
+        return 0
+    fi
+
     # Check if any messaging platform tokens were configured
     ENV_FILE="$HERMES_HOME/.env"
     if [ ! -f "$ENV_FILE" ]; then
@@ -2356,6 +2369,20 @@ install_desktop() {
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
         xattr -cr "$app" 2>/dev/null || true
         codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+    fi
+
+    # Surface the built app where users expect it. macOS: symlink into
+    # ~/Applications so it shows up in Spotlight/Launchpad; the link points at
+    # the (now ad-hoc-signed) bundle above. Other platforms: print the launch
+    # command since there's no equivalent shortcut location.
+    if [ "$OS" = "macos" ]; then
+        local user_apps="$HOME/Applications"
+        mkdir -p "$user_apps"
+        ln -sfn "$app" "$user_apps/Hermes.app"
+        log_success "Desktop app shortcut created: $user_apps/Hermes.app"
+        log_info "Launch with: open \"$user_apps/Hermes.app\""
+    else
+        log_info "Launch with: hermes desktop --skip-build"
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the


### PR DESCRIPTION
## Summary

Salvages #36674 by @el-analista onto current `main`.

Adds `scripts/install.sh --desktop-only` for using Hermes Desktop as a thin shell against a Hermes backend running elsewhere (server, VM, WSL, Tailscale host). It performs the full CLI install (clone / venv / deps / node) but **skips the local setup wizard and gateway setup**, creates a `~/Applications/Hermes.app` symlink on macOS, and documents the remote-gateway flow (`HERMES_DESKTOP_REMOTE_URL` / `HERMES_DESKTOP_REMOTE_TOKEN`, path-prefixed URLs) in the Desktop README.

## Why a salvage rather than a direct merge

#36674 was a draft, 439 commits behind `main`, and CONFLICTING — `main` has since added a **Linux chrome-sandbox security block** and a **macOS ad-hoc codesign block** to `install_desktop`, exactly where the PR adds its macOS app symlink. The cherry-pick conflicted there.

**Resolution:** kept all of `main`'s blocks intact (Linux sandbox chown/chmod + macOS codesign) and placed @el-analista's `~/Applications/Hermes.app` symlink **after** the codesign step, so the link points at the freshly ad-hoc-signed bundle. No deletions — final diff is purely additive (+67/-0).

## Verification

- `bash -n scripts/install.sh` — clean.
- Full install.sh test suite (`test_install_sh_*`, 6 files) — **19/19 pass**.
- Empirical scenario probe (strip `main()`, source the function block, exercise arg parsing + both guards):

| scenario | DESKTOP_ONLY | INCLUDE_DESKTOP | RUN_SETUP | wizard | gateway |
|---|---|---|---|---|---|
| `--desktop-only` | true | true | false | **skipped** | **skipped** |
| `--include-desktop` (sibling) | false | true | true | runs | runs |
| plain install (negative) | false | false | true | runs | runs |
| `-DesktopOnly` alias | true | true | false | skipped | skipped |

`--desktop-only` correctly skips both the wizard (via the existing `RUN_SETUP=false` early-return) and the gateway (via the new `DESKTOP_ONLY` guard), while sibling and negative paths are unaffected. The full CLI install still runs — only config wizard + gateway are skipped, so the desktop build has everything it needs.

## Credit

Feature by @el-analista (#36674). Commit cherry-picked with authorship preserved; conflict resolution against current `main` is the only maintainer change.
