### PR TITLE
fix(gateway): always prefix group/channel messages with sender name

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8488,7 +8488,12 @@ class GatewayRunner:
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
+        # Always preserve explicit sender attribution for group/channel messages
+        # before they reach the agent. Shared multi-user sessions need this so
+        # participants are distinguishable inside one history; per-user-isolated
+        # Telegram groups need it because the session context only describes the
+        # session owner, not necessarily the current message author.
+        if source.chat_type != "dm" and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
         # Prepend channel context from history backfill (if any).  This

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -44,7 +44,7 @@ async def test_preprocess_prefixes_sender_for_shared_non_thread_group_session():
 
 
 @pytest.mark.asyncio
-async def test_preprocess_keeps_plain_text_for_default_group_sessions():
+async def test_preprocess_prefixes_sender_for_default_per_user_group_sessions():
     runner = _make_runner(
         GatewayConfig(
             platforms={
@@ -57,6 +57,33 @@ async def test_preprocess_keeps_plain_text_for_default_group_sessions():
         chat_id="-1002285219667",
         chat_name="Test Group",
         chat_type="group",
+        user_name="Alice",
+    )
+    event = MessageEvent(text="hello", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "[Alice] hello"
+
+
+@pytest.mark.asyncio
+async def test_preprocess_keeps_plain_text_for_dm_sessions():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_name="Alice",
+        chat_type="dm",
         user_name="Alice",
     )
     event = MessageEvent(text="hello", source=source)


### PR DESCRIPTION
## Problem

In per-user-isolated Telegram group sessions (the default with `group_sessions_per_user: True`), the agent receives bare message text with no sender attribution. The Session Context block only displays the session "owner" user — not the actual author of each message. This makes it impossible to distinguish who is writing in a group chat without asking every time.

Previously, sender prefixing (`[Alice] hello`) was only applied when `group_sessions_per_user=False` (shared multi-user sessions).

## Change

Made the sender-prefix logic conditional on `source.chat_type != "dm"` instead of `_is_shared_multi_user`:

```python
# Before: only shared multi-user sessions
if _is_shared_multi_user and source.user_name:
    message_text = f"[{source.user_name}] {message_text}"

# After: all non-DM group/channel messages with a known sender
if source.chat_type != "dm" and source.user_name:
    message_text = f"[{source.user_name}] {message_text}"
```

DMs remain untouched — no prefix changes for private chats.

## Tests

- **Updated** `test_preprocess_keeps_plain_text_for_default_group_sessions` → now expects `"[Alice] hello"` (renamed to clarify the new behavior)
- **Added** `test_preprocess_keeps_plain_text_for_dm_sessions` — verifies DMs remain bare text
- **Shared multi-user test** unchanged — still expects `"[Alice] hello"`
- **88 Telegram gateway tests** (group gating + topic mode) — all green, no regressions

## Side effects

Low risk. The condition is broader only for Telegram/channel group messages with a known sender. Slash commands and internal events flow through different code paths. DMs are gated by `chat_type != "dm"` and stay clean.