### PR TITLE
fix: render generic self/lineage status lines

### DIFF
--- a/docs/hermes-maintenance-lineage.json
+++ b/docs/hermes-maintenance-lineage.json
@@ -1,0 +1,50 @@
+{
+  "project": "hermes-maintenance",
+  "updated_at": "2026-06-01T00:00:00Z",
+  "profiles": {
+    "pa_yunuen": {
+      "role": "pa",
+      "parent": null,
+      "children": ["coordinator_hermes_maintenance"]
+    },
+    "coordinator_hermes_maintenance": {
+      "role": "coordinator",
+      "parent": "pa_yunuen",
+      "children": [
+        "responsible_board_safety",
+        "responsible_kanban_semantics",
+        "responsible_matrix_hardening",
+        "responsible_memory_rollout",
+        "responsible_project_autonomy"
+      ]
+    },
+    "responsible_board_safety": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_kanban_semantics": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_matrix_hardening": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_memory_rollout": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_project_autonomy": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    }
+  },
+  "dependencies": {
+    "tasks": {}
+  }
+}

--- a/docs/hermes-maintenance-self-lineage-status.md
+++ b/docs/hermes-maintenance-self-lineage-status.md
@@ -1,0 +1,47 @@
+# Hermes Maintenance Self/Lineage status notifications
+
+Hermes Maintenance profile/project notifications must use generic two-line status output instead of role-specific labels.
+
+Canonical Matrix/profile notification shape:
+
+```text
+Self status: WORKING|WAITING|BLOCKED|DORMANT — <short status for the speaking profile itself>
+Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <short aggregate status for structural descendants>
+```
+
+Do not use role-specific coordinator/PA/responsible status labels for these notifications. Do not use legacy blocker-only or negated-blocker wording. `BLOCKED` remains reserved for a concrete human-action dependency; non-human pauses render as `WAITING`, and taskless/no-active-assignment profiles render as `DORMANT`.
+
+Lineage is structural responsibility (for example `pa_yunuen -> coordinator_hermes_maintenance -> responsible_*`), not Kanban task dependency. The machine-readable lineage registry lives at `docs/hermes-maintenance-lineage.json`; its `dependencies` key is intentionally separate.
+
+Deterministic renderer:
+
+```bash
+python scripts/hermes-maintenance-status.py --profile coordinator_hermes_maintenance --board hermes-maintenance
+```
+
+For tests, dry-runs, or sample notifications, pass fixture task rows instead of reading the live Kanban DB:
+
+```bash
+python scripts/hermes-maintenance-status.py \
+  --profile coordinator_hermes_maintenance \
+  --tasks-json /path/to/tasks.json
+```
+
+Machine-readable output is available with `--json`.
+
+Kanban compatibility mapping used by the renderer:
+
+- `ready`, `queue`, `running`, `in_progress`, `review` -> `WORKING`
+- `todo`, `scheduled` -> `WAITING`
+- `blocked` -> `BLOCKED`
+- `triage` -> `DORMANT`
+- `done`, `archived` -> completion/history only, not live status
+
+Aggregation default for lineage descendants:
+
+1. `WORKING` if any descendant is working or immediately spawnable.
+2. `BLOCKED` if none are working and at least one descendant is human-blocked.
+3. `WAITING` if none are working/blocked and at least one descendant is waiting on non-human/system continuation.
+4. `DORMANT` if no descendant has active/queued/waiting/blocked work.
+
+The text includes concise counts/evidence so a `WORKING` aggregate does not hide branch-local blockers.

--- a/hermes_cli/kanban_status_lines.py
+++ b/hermes_cli/kanban_status_lines.py
@@ -1,0 +1,242 @@
+"""Deterministic Self/Lineage status rendering for project profile notifications.
+
+This module is intentionally small and dependency-light: it turns Kanban task
+state plus an explicit profile lineage registry into the two generic lines that
+project/profile notifications can paste without LLM reasoning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from hermes_cli import kanban_db
+
+LIVE_STATES = ("working", "waiting", "blocked", "dormant")
+LIVE_STATE_SET = set(LIVE_STATES)
+
+_WORKING_STATUSES = {"queue", "ready", "running", "in_progress", "review"}
+_WAITING_STATUSES = {"todo", "scheduled"}
+_BLOCKED_STATUSES = {"blocked"}
+_DORMANT_STATUSES = {"triage"}
+_INACTIVE_STATUSES = {"done", "archived"}
+
+# Prefer active/spawnable work over hidden blockers in the aggregate, but include
+# counts/evidence in text so a branch-local blocker is not lost.
+_PRECEDENCE = ("working", "blocked", "waiting", "dormant")
+
+
+@dataclass(frozen=True)
+class TaskStatusInput:
+    """Minimal task shape needed to compute notification status."""
+
+    id: str
+    assignee: str | None
+    status: str
+    title: str | None = None
+
+
+@dataclass(frozen=True)
+class ProfileStatus:
+    state: str
+    text: str
+    counts: dict[str, int] = field(default_factory=dict)
+    evidence: list[str] = field(default_factory=list)
+
+    def line(self, label: str) -> str:
+        return f"{label}: {self.state.upper()} — {self.text}"
+
+
+def kanban_status_to_live(status: str) -> str | None:
+    """Map internal/legacy Kanban statuses to four live notification states.
+
+    ``None`` means the task is completion history, not live availability.
+    """
+
+    normalized = str(status or "").strip().lower()
+    if normalized in _WORKING_STATUSES:
+        return "working"
+    if normalized in _WAITING_STATUSES:
+        return "waiting"
+    if normalized in _BLOCKED_STATUSES:
+        return "blocked"
+    if normalized in _DORMANT_STATUSES:
+        return "dormant"
+    if normalized in _INACTIVE_STATUSES:
+        return None
+    # Unknown legacy statuses are safest as waiting: there is some active row, but
+    # this renderer cannot prove it is spawnable, blocked on a human, or dormant.
+    return "waiting"
+
+
+def load_lineage_registry(path: str | Path) -> dict[str, Any]:
+    with Path(path).expanduser().open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict):
+        raise ValueError("lineage registry must contain a 'profiles' object")
+    return data
+
+
+def descendants_for(profile: str, registry: Mapping[str, Any]) -> list[str]:
+    profiles = registry.get("profiles", {})
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    def visit(name: str) -> None:
+        node = profiles.get(name, {})
+        children = node.get("children", []) if isinstance(node, Mapping) else []
+        if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+            return
+        for child in children:
+            child_name = str(child)
+            if child_name in seen:
+                continue
+            seen.add(child_name)
+            ordered.append(child_name)
+            visit(child_name)
+
+    visit(profile)
+    return ordered
+
+
+def _choose_state(counts: Mapping[str, int]) -> str:
+    for state in _PRECEDENCE:
+        if counts.get(state, 0) > 0:
+            return state
+    return "dormant"
+
+
+def _group_tasks(tasks: Iterable[TaskStatusInput], profile: str) -> tuple[dict[str, int], dict[str, list[str]]]:
+    counts = {state: 0 for state in LIVE_STATES}
+    evidence = {state: [] for state in LIVE_STATES}
+    for task in tasks:
+        if task.assignee != profile:
+            continue
+        live = kanban_status_to_live(task.status)
+        if live is None:
+            continue
+        counts[live] += 1
+        evidence[live].append(task.id)
+    return counts, evidence
+
+
+def compute_self_status(profile: str, tasks: Iterable[TaskStatusInput]) -> ProfileStatus:
+    counts, evidence_by_state = _group_tasks(tasks, profile)
+    state = _choose_state(counts)
+    evidence = evidence_by_state.get(state, [])[:5]
+    active_total = sum(counts.values())
+
+    if active_total == 0 or state == "dormant":
+        return ProfileStatus(
+            state="dormant",
+            text=f"no active direct Kanban task for {profile}.",
+            counts=counts,
+            evidence=[],
+        )
+
+    pieces = [f"{counts[s]} direct {s}" for s in LIVE_STATES if counts[s]]
+    if evidence:
+        pieces.append("evidence: " + ", ".join(evidence))
+    return ProfileStatus(state=state, text="; ".join(pieces) + ".", counts=counts, evidence=evidence)
+
+
+def compute_lineage_status(profile: str, registry: Mapping[str, Any], tasks: Iterable[TaskStatusInput]) -> ProfileStatus:
+    task_list = list(tasks)
+    descendants = descendants_for(profile, registry)
+    if not descendants:
+        return ProfileStatus(
+            state="dormant",
+            text=f"no registered descendants for {profile}.",
+            counts={state: 0 for state in LIVE_STATES},
+            evidence=[],
+        )
+
+    counts = {state: 0 for state in LIVE_STATES}
+    evidence_by_state = {state: [] for state in LIVE_STATES}
+    for descendant in descendants:
+        child_status = compute_self_status(descendant, task_list)
+        counts[child_status.state] += 1
+        evidence_by_state[child_status.state].extend(child_status.evidence)
+
+    state = _choose_state(counts)
+    evidence = evidence_by_state.get(state, [])[:5]
+    pieces = [f"{counts[s]} descendant {s}" for s in LIVE_STATES if counts[s]]
+    if evidence:
+        pieces.append("evidence: " + ", ".join(evidence))
+    return ProfileStatus(state=state, text="; ".join(pieces) + ".", counts=counts, evidence=evidence)
+
+
+def render_status_lines(profile: str, registry: Mapping[str, Any], tasks: Iterable[TaskStatusInput]) -> tuple[str, str, dict[str, Any]]:
+    task_list = list(tasks)
+    self_status = compute_self_status(profile, task_list)
+    lineage_status = compute_lineage_status(profile, registry, task_list)
+    payload = {
+        "project": registry.get("project"),
+        "profile": profile,
+        "self_status": self_status.state,
+        "self_text": self_status.text,
+        "self_counts": self_status.counts,
+        "self_evidence": self_status.evidence,
+        "lineage_status": lineage_status.state,
+        "lineage_text": lineage_status.text,
+        "lineage_counts": lineage_status.counts,
+        "lineage_evidence": lineage_status.evidence,
+    }
+    return self_status.line("Self status"), lineage_status.line("Lineage status"), payload
+
+
+def tasks_from_kanban(board: str | None = None, tenant: str | None = None) -> list[TaskStatusInput]:
+    conn = kanban_db.connect(board=board)
+    try:
+        rows = kanban_db.list_tasks(conn, tenant=tenant, include_archived=False)
+    finally:
+        conn.close()
+    return [TaskStatusInput(id=t.id, assignee=t.assignee, status=t.status, title=t.title) for t in rows]
+
+
+def tasks_from_json(path: str | Path) -> list[TaskStatusInput]:
+    with Path(path).expanduser().open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+    if isinstance(raw, Mapping):
+        raw = raw.get("tasks", [])
+    if not isinstance(raw, list):
+        raise ValueError("tasks JSON must be a list or an object with a 'tasks' list")
+    return [
+        TaskStatusInput(
+            id=str(item["id"]),
+            assignee=item.get("assignee"),
+            status=str(item.get("status", "")),
+            title=item.get("title"),
+        )
+        for item in raw
+        if isinstance(item, Mapping)
+    ]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render generic Self/Lineage status lines from Kanban state.")
+    parser.add_argument("--profile", required=True, help="Profile to report, e.g. coordinator_hermes_maintenance")
+    parser.add_argument("--registry", required=True, help="Path to project lineage registry JSON")
+    parser.add_argument("--board", default=None, help="Kanban board slug; defaults to normal Hermes board resolution")
+    parser.add_argument("--tenant", default=None, help="Optional tenant filter")
+    parser.add_argument("--tasks-json", default=None, help="Fixture/input tasks JSON instead of reading the live Kanban DB")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of two text lines")
+    args = parser.parse_args(argv)
+
+    registry = load_lineage_registry(args.registry)
+    tasks = tasks_from_json(args.tasks_json) if args.tasks_json else tasks_from_kanban(board=args.board, tenant=args.tenant)
+    self_line, lineage_line, payload = render_status_lines(args.profile, registry, tasks)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(self_line)
+        print(lineage_line)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/hermes-maintenance-status.py
+++ b/scripts/hermes-maintenance-status.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Render Hermes Maintenance Self/Lineage status notification lines.
+
+Default registry: docs/hermes-maintenance-lineage.json
+Example:
+  python scripts/hermes-maintenance-status.py --profile coordinator_hermes_maintenance --board hermes-maintenance
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hermes_cli.kanban_status_lines import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    argv = list(sys.argv[1:])
+    if "--registry" not in argv:
+        argv.extend(["--registry", str(REPO_ROOT / "docs" / "hermes-maintenance-lineage.json")])
+    raise SystemExit(main(argv))

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -139,7 +139,14 @@ kanban_complete(
 
 ### Step 5 — Report back to the user
 
-Tell them what you created in plain prose, naming the actual profiles you used:
+Tell them what you created in plain prose, naming the actual profiles you used.
+
+**Self/Lineage status requirement for project notifications to Yunuen:** project-structured profile responses should include both generic status lines:
+
+- `Self status: WORKING|WAITING|BLOCKED|DORMANT — <status of the speaking profile itself>`
+- `Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <aggregate status of structural descendants>`
+
+Use `BLOCKED` only for a concrete human-action blocker. Non-human waits are `WAITING`; no active task/no instruction is `DORMANT`. Do not use role-specific status labels for coordinator, PA, or responsible profiles, and do not use blocker-only/negated-blocker wording. Prefer deterministic output from `scripts/hermes-maintenance-status.py` (or the installed equivalent) instead of recomputing status by LLM reasoning.
 
 > I've queued 4 tasks:
 > - **T1** (`<profile-A>`): cost comparison

--- a/tests/hermes_cli/test_kanban_status_lines.py
+++ b/tests/hermes_cli/test_kanban_status_lines.py
@@ -1,0 +1,117 @@
+from hermes_cli.kanban_status_lines import (
+    TaskStatusInput,
+    descendants_for,
+    kanban_status_to_live,
+    render_status_lines,
+)
+
+
+REGISTRY = {
+    "project": "hermes-maintenance",
+    "profiles": {
+        "pa_yunuen": {"children": ["coordinator_hermes_maintenance"]},
+        "coordinator_hermes_maintenance": {
+            "children": ["responsible_kanban_semantics", "responsible_matrix_hardening"]
+        },
+        "responsible_kanban_semantics": {"children": []},
+        "responsible_matrix_hardening": {"children": []},
+    },
+    "dependencies": {"tasks": {}},
+}
+
+
+def test_kanban_status_to_live_uses_four_notification_states():
+    assert kanban_status_to_live("ready") == "working"
+    assert kanban_status_to_live("queue") == "working"
+    assert kanban_status_to_live("running") == "working"
+    assert kanban_status_to_live("in_progress") == "working"
+    assert kanban_status_to_live("review") == "working"
+    assert kanban_status_to_live("todo") == "waiting"
+    assert kanban_status_to_live("scheduled") == "waiting"
+    assert kanban_status_to_live("blocked") == "blocked"
+    assert kanban_status_to_live("triage") == "dormant"
+    assert kanban_status_to_live("done") is None
+    assert kanban_status_to_live("archived") is None
+
+
+def test_descendants_are_structural_not_dependencies():
+    assert descendants_for("coordinator_hermes_maintenance", REGISTRY) == [
+        "responsible_kanban_semantics",
+        "responsible_matrix_hardening",
+    ]
+
+
+def test_render_status_lines_uses_generic_self_and_lineage_labels_only():
+    tasks = [
+        TaskStatusInput(
+            id="t_self",
+            assignee="coordinator_hermes_maintenance",
+            status="running",
+            title="coordinate",
+        ),
+        TaskStatusInput(
+            id="t_child_wait",
+            assignee="responsible_kanban_semantics",
+            status="scheduled",
+            title="non-human wait",
+        ),
+        TaskStatusInput(
+            id="t_child_block",
+            assignee="responsible_matrix_hardening",
+            status="blocked",
+            title="human action required",
+        ),
+    ]
+
+    self_line, lineage_line, payload = render_status_lines(
+        "coordinator_hermes_maintenance", REGISTRY, tasks
+    )
+
+    assert self_line.startswith("Self status: WORKING — ")
+    assert lineage_line.startswith("Lineage status: BLOCKED — ")
+    rendered = "\n".join([self_line, lineage_line])
+    forbidden = [
+        "Coordinator" + " status",
+        "PA" + " status",
+        "Responsible" + " status",
+        "Blocker" + " status",
+        "NOT" + " BLOCKED",
+    ]
+    for label in forbidden:
+        assert label not in rendered
+    assert payload["self_status"] == "working"
+    assert payload["lineage_status"] == "blocked"
+    assert payload["lineage_counts"] == {
+        "working": 0,
+        "waiting": 1,
+        "blocked": 1,
+        "dormant": 0,
+    }
+    assert payload["lineage_evidence"] == ["t_child_block"]
+
+
+def test_lineage_working_precedence_keeps_blocked_count_visible():
+    tasks = [
+        TaskStatusInput("t_work", "responsible_kanban_semantics", "ready"),
+        TaskStatusInput("t_block", "responsible_matrix_hardening", "blocked"),
+    ]
+
+    _self_line, lineage_line, payload = render_status_lines(
+        "coordinator_hermes_maintenance", REGISTRY, tasks
+    )
+
+    assert lineage_line.startswith("Lineage status: WORKING — ")
+    assert "1 descendant blocked" in lineage_line
+    assert payload["lineage_counts"]["blocked"] == 1
+
+
+def test_taskless_profile_renders_dormant_not_not_blocked():
+    self_line, lineage_line, payload = render_status_lines(
+        "responsible_kanban_semantics", REGISTRY, []
+    )
+
+    assert self_line.startswith("Self status: DORMANT — ")
+    assert lineage_line.startswith("Lineage status: DORMANT — ")
+    assert "NOT" + " BLOCKED" not in self_line + lineage_line
+    assert payload["self_status"] == "dormant"
+    assert payload["lineage_status"] == "dormant"


### PR DESCRIPTION
Supersedes #37006 with the same Self status + Lineage status notification-label fix rebased onto current origin/main.

Evidence:
- python -m pytest -o addopts='' tests/hermes_cli/test_kanban_status_lines.py -q (5 passed)
- python scripts/hermes-maintenance-status.py --profile responsible_kanban_semantics --registry docs/hermes-maintenance-lineage.json --board hermes-maintenance emits both Self status and Lineage status
- git diff --check origin/main...HEAD clean

Kanban: t_80da4a7e.
