### PR TITLE
fix EventBridge._poll_once: move early-return guard before mtime cache updates

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -356,10 +356,6 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
-            self._sessions_json_mtime = sj_mtime
-            self._cached_sessions_index = _load_sessions_index()
-
         # Check if state.db has changed
         try:
             from hermes_constants import get_hermes_home
@@ -372,8 +368,18 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
+        # Early-exit check must happen before updating the cached mtimes.
+        # If the sessions.json update block runs first it sets
+        # self._sessions_json_mtime = sj_mtime, making the equality check
+        # trivially True and silently skipping message processing whenever
+        # only sessions.json changed (e.g. a new conversation was opened
+        # but state.db had not yet been written).
         if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
             return  # Nothing changed since last poll — skip entirely
+
+        if sj_mtime != self._sessions_json_mtime:
+            self._sessions_json_mtime = sj_mtime
+            self._cached_sessions_index = _load_sessions_index()
 
         self._state_db_mtime = db_mtime
         entries = self._cached_sessions_index


### PR DESCRIPTION
## Bug

In `EventBridge._poll_once`, the early-return guard ran after the sessions.json mtime cache was already updated. Once `self._sessions_json_mtime = sj_mtime` is assigned, the condition `sj_mtime == self._sessions_json_mtime` is trivially True, making the guard effectively a pure state.db check.

## Impact

When a new conversation is opened (sessions.json updated but state.db not yet written), the EventBridge reloads the sessions index but exits before processing any messages for the new session. The `events_poll` and `events_wait` MCP tools miss all events from that session until state.db is next modified.

## Fix

Moved the early-return check to after both mtimes are read but before either cache is updated, so the guard compares against the previous cached values rather than the just-assigned ones.