### PR TITLE
fix: prevent TUI stdin EOF crash when SSH backend is slow

### DIFF
--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -101,7 +101,7 @@ class SSHEnvironment(BaseEnvironment):
         cmd = self._build_ssh_command()
         cmd.append("echo 'SSH connection established'")
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL)
             if result.returncode != 0:
                 error_msg = result.stderr.strip() or result.stdout.strip()
                 raise RuntimeError(f"SSH connection failed: {error_msg}")
@@ -151,7 +151,7 @@ class SSHEnvironment(BaseEnvironment):
         if self.key_path:
             scp_cmd.extend(["-i", self.key_path])
         scp_cmd.extend([host_path, f"{self.user}@{self.host}:{remote_path}"])
-        result = subprocess.run(scp_cmd, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(scp_cmd, capture_output=True, text=True, timeout=30, stdin=subprocess.DEVNULL)
         if result.returncode != 0:
             raise RuntimeError(f"scp failed: {result.stderr.strip()}")
 
@@ -174,7 +174,7 @@ class SSHEnvironment(BaseEnvironment):
         if parents:
             cmd = self._build_ssh_command()
             cmd.append(quoted_mkdir_command(parents))
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, stdin=subprocess.DEVNULL)
             if result.returncode != 0:
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
 
@@ -206,7 +206,7 @@ class SSHEnvironment(BaseEnvironment):
             ssh_cmd.append(f"tar xf - --no-overwrite-dir -C {shlex.quote(base)}")
 
             tar_proc = subprocess.Popen(
-                tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL
             )
             try:
                 ssh_proc = subprocess.Popen(
@@ -258,7 +258,7 @@ class SSHEnvironment(BaseEnvironment):
         ssh_cmd = self._build_ssh_command()
         ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
         with open(dest, "wb") as f:
-            result = subprocess.run(ssh_cmd, stdout=f, stderr=subprocess.PIPE, timeout=120)
+            result = subprocess.run(ssh_cmd, stdout=f, stderr=subprocess.PIPE, timeout=120, stdin=subprocess.DEVNULL)
         if result.returncode != 0:
             raise RuntimeError(f"SSH bulk download failed: {result.stderr.decode(errors='replace').strip()}")
 

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -192,6 +192,87 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
+def _log_stdin_eof_diagnostic(trigger: str, extra: str = "") -> None:
+    """Capture diagnostic state at the exact moment stdin returns EOF.
+
+    The stdin EOF crash is the hardest to diagnose because the child exits
+    cleanly (exitCode=0) with no traceback — the ``for raw in sys.stdin``
+    loop simply ends.  This function captures everything we can observe at
+    that moment: thread states, open file descriptors, stdin pipe info,
+    active subprocesses, and the main thread's stack trace.
+    """
+    import threading as _diag_threading
+
+    lines: list[str] = []
+    lines.append(f"\n=== stdin EOF diagnostic · {time.strftime('%Y-%m-%d %H:%M:%S')} ===")
+    lines.append(f"trigger: {trigger}")
+    if extra:
+        lines.append(f"extra: {extra}")
+
+    # Thread snapshot
+    threads = _diag_threading.enumerate()
+    lines.append(f"threads ({len(threads)}):")
+    for t in threads:
+        lines.append(f"  {t.name} (id={t.ident}, daemon={t.daemon}, alive={t.is_alive()})")
+
+    # Open fd count
+    try:
+        fds = os.listdir("/proc/self/fd")
+        lines.append(f"open fds: {len(fds)}")
+    except Exception:
+        lines.append("open fds: unavailable")
+
+    # Stdin pipe info
+    try:
+        with open("/proc/self/fdinfo/0") as f:
+            info = f.read().strip()
+        lines.append(f"stdin fdinfo: {info}")
+    except Exception as e:
+        lines.append(f"stdin fdinfo: error ({e})")
+
+    try:
+        link = os.readlink("/proc/self/fd/0")
+        lines.append(f"stdin fd link: {link}")
+    except Exception as e:
+        lines.append(f"stdin fd link: error ({e})")
+
+    # Check if stdin is still readable via select
+    try:
+        import select
+        readable, _, _ = select.select([sys.stdin], [], [], 0)
+        lines.append(f"stdin select(readable): {bool(readable)}")
+    except Exception as e:
+        lines.append(f"stdin select: error ({e})")
+
+    # Check raw fd 0 directly
+    try:
+        raw_fd_status = os.fstat(0)
+        lines.append(f"stdin fstat: mode={oct(raw_fd_status.st_mode)} ino={raw_fd_status.st_ino}")
+    except Exception as e:
+        lines.append(f"stdin fstat: error ({e})")
+
+    # Main thread stack trace
+    import traceback as _diag_traceback
+    lines.append("main thread stack:")
+    for line in _diag_traceback.format_stack():
+        lines.append(f"  {line.rstrip()}")
+
+    # Write to crash log
+    try:
+        os.makedirs(os.path.dirname(_CRASH_LOG), exist_ok=True)
+        with open(_CRASH_LOG, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except Exception:
+        pass
+
+    # Also print to stderr
+    for line in lines:
+        print(line, file=sys.stderr, flush=True)
+
+    # Now log the normal exit
+    _log_exit("stdin EOF (TUI closed the command pipe)")
+
+
 def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
@@ -271,10 +352,27 @@ def main():
         _log_exit("startup write failed (broken stdout pipe before first event)")
         sys.exit(0)
 
-    for raw in sys.stdin:
+    _diag_count = 0
+    while True:
+        try:
+            raw = sys.stdin.readline()
+        except (OSError, ValueError) as _read_err:
+            _log_stdin_eof_diagnostic("readline exception", extra=f"error={_read_err}")
+            break
+
+        if raw == "":
+            _log_stdin_eof_diagnostic("readline returned empty string (EOF)")
+            break
+
+        if raw is None:
+            _log_stdin_eof_diagnostic("readline returned None")
+            break
+
         line = raw.strip()
         if not line:
             continue
+
+        _diag_count += 1
 
         try:
             req = json.loads(line)
@@ -290,8 +388,6 @@ def main():
             if not write_json(resp):
                 _log_exit(f"response write failed for method={method!r} (broken stdout pipe)")
                 sys.exit(0)
-
-    _log_exit("stdin EOF (TUI closed the command pipe)")
 
 
 if __name__ == "__main__":

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -338,6 +338,34 @@ export class GatewayClient extends EventEmitter {
     this.proc = spawn(python, ['-m', 'tui_gateway.entry'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
     this.lifecycle(`[lifecycle] spawned gateway child ${describeChild(this.proc)} python=${python} cwd=${cwd}`)
 
+    // DEBUG: trace pipe lifecycle to diagnose silent stdin EOF
+    const stdinW = this.proc.stdin!
+    const stdoutR = this.proc.stdout!
+    const stderrR = this.proc.stderr!
+    const self = this
+    stdinW.on('close', () => self.lifecycle(`[debug] stdin writable CLOSED ${describeChild(self.proc)} writableLength=${stdinW.writableLength} destroyed=${stdinW.destroyed}`))
+    stdinW.on('error', (e: Error) => self.lifecycle(`[debug] stdin writable ERROR ${describeChild(self.proc)}: ${e.message}`))
+    stdinW.on('finish', () => self.lifecycle(`[debug] stdin writable FINISH (all data flushed) ${describeChild(self.proc)}`))
+    stdinW.on('pipe', () => self.lifecycle(`[debug] stdin writable PIPE event ${describeChild(self.proc)}`))
+    stdinW.on('unpipe', () => self.lifecycle(`[debug] stdin writable UNPIPE event ${describeChild(self.proc)}`))
+    stdoutR.on('close', () => self.lifecycle(`[debug] stdout readable CLOSED ${describeChild(self.proc)} readableLength=${stdoutR.readableLength} destroyed=${stdoutR.destroyed}`))
+    stdoutR.on('error', (e: Error) => self.lifecycle(`[debug] stdout readable ERROR ${describeChild(self.proc)}: ${e.message}`))
+    stdoutR.on('end', () => self.lifecycle(`[debug] stdout readable END (child stopped writing) ${describeChild(self.proc)}`))
+    stderrR.on('close', () => self.lifecycle(`[debug] stderr readable CLOSED ${describeChild(self.proc)}`))
+
+    // Wrap stdin.write to catch write failures before they propagate
+    const origWrite = stdinW.write.bind(stdinW) as (...a: any[]) => any
+    let writeSeq = 0
+    const debugWrite = (...args: any[]) => {
+      const seq = ++writeSeq
+      const result = origWrite(...args)
+      if (!result) {
+        self.lifecycle(`[debug] stdin write#${seq} returned false (backpressure) ${describeChild(self.proc)}`)
+      }
+      return result
+    }
+    stdinW.write = debugWrite as typeof stdinW.write
+
     this.stdoutRl = createInterface({ input: this.proc.stdout! })
     this.stdoutRl.on('line', raw => {
       try {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -712,7 +712,14 @@ export class GatewayClient extends EventEmitter {
       return this.requestOverWebSocket<T>(method, params)
     }
 
-    if (!this.proc?.stdin || this.proc.killed || this.proc.exitCode !== null) {
+    const _hasProc = !!this.proc
+    const _hasStdin = !!this.proc?.stdin
+    const _killed = this.proc?.killed ?? false
+    const _exitCode = this.proc?.exitCode
+    const _guardFires = !_hasStdin || _killed || _exitCode !== null
+
+    if (_guardFires) {
+      this.lifecycle(`[debug] request() guard FIRED method=${method} hasProc=${_hasProc} hasStdin=${_hasStdin} killed=${_killed} exitCode=${_exitCode ?? 'null'}`)
       this.start()
     }
 
@@ -726,7 +733,6 @@ export class GatewayClient extends EventEmitter {
       const timeout = setTimeout(this.onTimeout, REQUEST_TIMEOUT_MS, id)
 
       timeout.unref?.()
-
       this.pending.set(id, {
         id,
         method,
@@ -736,8 +742,12 @@ export class GatewayClient extends EventEmitter {
       })
 
       try {
-        this.proc!.stdin!.write(JSON.stringify({ id, jsonrpc: '2.0', method, params }) + '\n')
+        const _writeResult = this.proc!.stdin!.write(JSON.stringify({ id, jsonrpc: '2.0', method, params }) + '\n')
+        if (!_writeResult) {
+          this.lifecycle(`[debug] request() write returned false (backpressure) method=${method} id=${id}`)
+        }
       } catch (e) {
+        this.lifecycle(`[debug] request() write THREW method=${method} id=${id} error=${e instanceof Error ? e.message : String(e)}`)
         const pending = this.pending.get(id)
 
         if (pending) {


### PR DESCRIPTION
## AI use disclosure

Hermes did most of the heavy lifting here, but it matches a fix posted for a [similar gateway exit involving ByteRover](https://github.com/NousResearch/hermes-agent/issues/14036). Please review appropriately.

## Summary

TUI gateway child exits cleanly (`exitCode=0`) with `stdin EOF (TUI closed the command pipe)` during SSH file sync operations, even though the parent never closes the pipe. This causes a crash-recovery loop: TUI respawns child → child runs SSH op → child exits → repeat (capped at 3 recoveries in 60s).

## Root Cause

All `subprocess.run()` and `subprocess.Popen()` calls in `ssh.py` inherit stdin from the parent process. When the SSH backend is slow (30-60s for environment creation, 2-22s for file sync), the inherited stdin fd creates an interaction surface between the SSH subprocess and the TUI's stdin pipe. Under certain conditions, this causes the gateway child's `for raw in sys.stdin` loop to see EOF and exit cleanly.

## Fix

Add `stdin=subprocess.DEVNULL` to all 5 subprocess calls in `tools/environments/ssh.py`:
- `_establish_connection` (SSH test)
- `_scp_upload` (SCP)
- `_ssh_bulk_upload` (mkdir + tar/SSH pipeline)
- `_ssh_bulk_download` (tar over SSH)

## Diagnostics

Added pipe lifecycle debug logging to `GatewayClient.ts` — traces `close`, `error`, `end`, `finish` events on the spawned child's stdin/stdout/stderr pipes. This was instrumental in identifying that the parent never closes the pipe (the `stdin writable CLOSED` event never fires for the dying child).

## Reproduction

1. Configure Hermes with `terminal.backend: ssh` to a remote host
2. Submit a prompt that triggers tool use (file read/write)
3. SSH environment creation takes 30-60s
4. On file sync back to sandbox, child exits with `stdin EOF`
5. TUI respawns child, cycle repeats up to 3 times

After fix: child survives SSH operations, no stdin EOF.