### PR TITLE
fix: clear all error fields when syncing Anthropic credential from credentials file

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -566,6 +566,9 @@ class CredentialPool:
                     last_status=None,
                     last_status_at=None,
                     last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
                 )
                 self._replace_entry(entry, updated)
                 self._persist()
@@ -959,6 +962,9 @@ class CredentialPool:
                             last_status=STATUS_OK,
                             last_status_at=None,
                             last_error_code=None,
+                            last_error_reason=None,
+                            last_error_message=None,
+                            last_error_reset_at=None,
                         )
                         self._replace_entry(synced, updated)
                         self._persist()


### PR DESCRIPTION
## Bug

Two places in `_sync_anthropic_entry_from_credentials_file` and the Anthropic credential retry-success path did not clear `last_error_reason`, `last_error_message`, and `last_error_reset_at` when syncing fresh tokens.

Every other provider sync method (`_sync_codex_entry_from_auth_store`, `_sync_xai_oauth_entry_from_auth_store`, `_sync_nous_entry_from_auth_store`) and the main refresh success path (lines 1182-1190) consistently clear all six error fields. The Anthropic paths only cleared three of them.

## Impact

After another process refreshes an Anthropic OAuth token and writes it to `~/.claude/.credentials.json`, the pool entry is synced with fresh tokens but retains stale `last_error_reason`, `last_error_message`, and `last_error_reset_at` from a previous failure. These stale values:

- Persist to `auth.json` via `to_dict()` / `_persist()`, making them appear on every future `load_pool()`  
- Mislead `/usage` display and internal logs (old error message shown alongside a healthy credential)
- Leave a stale `last_error_reset_at` timestamp on disk that could produce incorrect cooldown expiry if the entry is ever re-exhausted and the field is read before `_mark_exhausted` overwrites it

## Fix

Add the three missing fields to both affected `replace()` calls, matching the pattern used by every other sync and refresh-success path.