### PR TITLE
feat(kanban): add mobile proof gate

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1479,6 +1479,27 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
+def _load_active_task(cwd_path: Path) -> str:
+    """Load dispatcher-written _ACTIVE_TASK.md from worker workspace.
+
+    This is deliberately independent of the normal project-context priority chain:
+    a worker's current objective must survive even when AGENTS.md/HERMES.md also
+    exists in the repo. The dispatcher owns this file and rewrites it at spawn.
+    """
+    candidate = cwd_path / "_ACTIVE_TASK.md"
+    if not candidate.exists():
+        return ""
+    try:
+        content = candidate.read_text(encoding="utf-8").strip()
+        if not content or "HERMES_ACTIVE_TASK" not in content:
+            return ""
+        content = _scan_context_content(content, "_ACTIVE_TASK.md")
+        return _truncate_content(f"## _ACTIVE_TASK.md\n\n{content}", "_ACTIVE_TASK.md")
+    except Exception as e:
+        logger.debug("Could not read _ACTIVE_TASK.md: %s", e)
+        return ""
+
+
 def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
     """Discover and load context files for the system prompt.
 
@@ -1499,6 +1520,10 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
 
     cwd_path = Path(cwd).resolve()
     sections = []
+
+    active_task = _load_active_task(cwd_path)
+    if active_task:
+        sections.append(active_task)
 
     # Priority-based project context: first match wins
     project_context = (

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -217,6 +217,39 @@ _CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
 _CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
 _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 
+# Worker recitation + completion contract helpers. The prompt builder already
+# reads _ACTIVE_TASK.md when present; dispatcher writes it before spawn.
+ACTIVE_TASK_FILENAME = "_ACTIVE_TASK.md"
+ACTIVE_TASK_MARKER = "<!-- HERMES_ACTIVE_TASK -->"
+_DEFAULT_COMPLETION_GATE = (
+    "default verification gate: completion requires concrete proof metadata "
+    "such as verification, tests_run, checks, evidence, proof, artifacts, "
+    "sources_read, command_tool_evidence, or marker_readback"
+)
+_COMPLETION_GATE_RE = re.compile(
+    r"^\s*(done_if|done if|done_when|done when|acceptance criteria|verification)\s*:\s*(.+)?$",
+    re.IGNORECASE,
+)
+_VERIFICATION_METADATA_KEYS = (
+    "verification",
+    "verified",
+    "tests_run",
+    "checks",
+    "evidence",
+    "proof",
+    "artifacts",
+    # Existing worker handoffs often record proof under domain-specific keys.
+    # Treat these as evidence when a gate exists instead of forcing agents to
+    # duplicate the same facts under a magic field name.
+    "result",
+    "sources_read",
+    "filing_checks",
+    "command_tool_evidence",
+    "marker_readback",
+    "archive_path",
+    "children_completed",
+)
+
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -3559,6 +3592,99 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class CompletionVerificationError(ValueError):
+    """Raised when a task declares a completion gate but lacks proof."""
+
+    def __init__(self, task_id: str, gate: str):
+        self.task_id = task_id
+        self.gate = gate
+        super().__init__(
+            "completion blocked: task declares a done_if / verification gate "
+            f"but completion metadata did not include proof for {task_id}: {gate[:220]}"
+        )
+
+
+def _task_completion_gate(task: Optional[Task]) -> Optional[str]:
+    if task is None:
+        return None
+    for raw in (task.body or "").splitlines():
+        match = _COMPLETION_GATE_RE.match(raw)
+        if match:
+            tail = (match.group(2) or "").strip()
+            return f"{match.group(1)}: {tail}" if tail else match.group(1)
+    # Mobile/chat-created cards are often terse and should not require the
+    # human to type magic words like done_if/verification. Agent-created
+    # cards carry an originating session_id; direct CLI/DB maintenance cards
+    # keep the old explicit-gate behavior so slash maintenance still works.
+    if task.session_id:
+        return _DEFAULT_COMPLETION_GATE
+    return None
+
+
+def _metadata_has_verification_proof(metadata: Optional[dict]) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    verification = metadata.get("verification")
+    if isinstance(verification, dict):
+        if verification.get("ok") is False or verification.get("passed") is False:
+            return False
+        if verification.get("status") in {"failed", "failure", "error"}:
+            return False
+        exit_code = verification.get("exit_code")
+        if isinstance(exit_code, int) and exit_code != 0:
+            return False
+        if verification.get("ok") is True or verification.get("passed") is True:
+            return True
+        if exit_code == 0:
+            return True
+        if verification.get("status") in {"ok", "passed", "success"}:
+            return True
+        if verification.get("command") and any(
+            verification.get(k) not in (None, "", [], {})
+            for k in ("output", "artifact", "source", "checked_at")
+        ):
+            return True
+        if any(value not in (None, "", [], {}, False) for value in verification.values()):
+            return True
+    elif verification not in (None, "", [], {}, False):
+        return True
+    if metadata.get("verified") is True:
+        return True
+    for key in _VERIFICATION_METADATA_KEYS:
+        if key == "verification":
+            continue
+        if metadata.get(key) not in (None, "", [], {}, False):
+            return True
+    return False
+
+
+def _enforce_completion_gate(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+    summary: Optional[str],
+    result: Optional[str],
+) -> None:
+    gate = _task_completion_gate(get_task(conn, task_id))
+    if not gate or _metadata_has_verification_proof(metadata):
+        return
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "completion_blocked_missing_verification",
+            {
+                "gate": gate,
+                "summary_preview": (
+                    (summary or result or "").strip().splitlines()[0][:200]
+                    if (summary or result)
+                    else None
+                ),
+            },
+        )
+    raise CompletionVerificationError(task_id, gate)
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3599,11 +3725,9 @@ def complete_task(
     """
     now = int(time.time())
 
-    # Gate: verify created_cards BEFORE the main write txn. A rejected
-    # completion still needs an auditable event, so we emit it in a
-    # tiny dedicated txn, then raise. The caller is responsible for
-    # surfacing HallucinatedCardsError to the worker; this function
-    # never mutates task state on a phantom-card rejection.
+    # Gate: verify created_cards BEFORE the main write txn and before the
+    # generic proof gate. A phantom-card rejection is more specific than
+    # "missing proof" and tells the worker exactly what to retry.
     if created_cards:
         verified_cards, phantom_cards = _verify_created_cards(
             conn, task_id, created_cards
@@ -3625,6 +3749,8 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    _enforce_completion_gate(conn, task_id, metadata, summary, result)
 
     with write_txn(conn):
         if expected_run_id is None:
@@ -6610,6 +6736,38 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
+def _write_active_task_file(task: Task, workspace: str) -> Optional[Path]:
+    """Write a compact, dispatcher-owned task recitation into the workspace."""
+    try:
+        workspace_path = Path(workspace)
+        workspace_path.mkdir(parents=True, exist_ok=True)
+        active_path = workspace_path / ACTIVE_TASK_FILENAME
+        body = (task.body or "").strip()
+        lines = [
+            ACTIVE_TASK_MARKER,
+            "# Active Kanban Task",
+            "",
+            f"task_id: `{task.id}`",
+            f"title: {task.title}",
+            f"assignee: {task.assignee or '(unassigned)'}",
+            f"status_at_spawn: {task.status}",
+            "",
+            "## Objective / acceptance gate",
+            body or "(No task body supplied.)",
+            "",
+            "## Completion proof expected",
+            f"Default verification gate: { _task_completion_gate(task) or _DEFAULT_COMPLETION_GATE }.",
+            "Complete only with metadata containing concrete proof such as `verification`, `tests_run`, `checks`, `evidence`, `proof`, `artifacts`, `sources_read`, `command_tool_evidence`, or `marker_readback`. If a check failed, block instead of completing.",
+        ]
+        tmp = active_path.with_suffix(active_path.suffix + ".tmp")
+        tmp.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        tmp.replace(active_path)
+        return active_path
+    except Exception as exc:
+        _log.warning("Could not write %s for %s: %s", ACTIVE_TASK_FILENAME, task.id, exc)
+        return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -6751,6 +6909,7 @@ def _default_spawn(
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and
     # logs don't collide across boards that happen to share task ids.
+    _write_active_task_file(task, workspace)
     log_dir = worker_logs_dir(board=board)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -508,6 +508,17 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_active_task_recitation_loads_alongside_project_context(self, tmp_path):
+        (tmp_path / "_ACTIVE_TASK.md").write_text(
+            "<!-- HERMES_ACTIVE_TASK -->\n# Active Kanban Task\ntask_id: `t_123`\ndone_if: pytest passes\n"
+        )
+        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        assert "_ACTIVE_TASK.md" in result
+        assert "t_123" in result
+        assert "done_if: pytest passes" in result
+        assert "Ruff for linting" in result
+
     def test_loads_cursorrules(self, tmp_path):
         (tmp_path / ".cursorrules").write_text("Always use type hints.")
         result = build_context_files_prompt(cwd=str(tmp_path))

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -171,6 +171,69 @@ def worker_env(monkeypatch, tmp_path):
     return tid
 
 
+def test_default_spawn_writes_active_task_recitation_file(monkeypatch, tmp_path, worker_env):
+    """Dispatch should seed the workspace with a concise objective/proof file."""
+    import subprocess
+    from hermes_cli import kanban_db as kb
+
+    class FakeProc:
+        pid = 4242
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "worker-space"
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", ("done_if: smoke test passes", worker_env))
+        conn.commit()
+        task = kb.get_task(conn, worker_env)
+    finally:
+        conn.close()
+
+    assert task is not None
+    pid = kb._default_spawn(task, str(workspace))
+    assert pid == 4242
+    active = workspace / "_ACTIVE_TASK.md"
+    assert active.exists()
+    text = active.read_text(encoding="utf-8")
+    assert "<!-- HERMES_ACTIVE_TASK -->" in text
+    assert f"task_id: `{worker_env}`" in text
+    assert "done_if: smoke test passes" in text
+    assert "metadata" in text
+    assert captured["kwargs"]["cwd"] == str(workspace)
+
+
+def test_default_spawn_writes_default_completion_gate_for_mobile_tasks(monkeypatch, tmp_path, worker_env):
+    """Workers should see a proof requirement even when the user gave only a mobile-short task."""
+    import subprocess
+    from hermes_cli import kanban_db as kb
+
+    class FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: FakeProc())
+    workspace = tmp_path / "mobile-worker-space"
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET session_id = ? WHERE id = ?", ("discord-session", worker_env))
+        conn.commit()
+        task = kb.get_task(conn, worker_env)
+    finally:
+        conn.close()
+
+    assert task is not None
+    kb._default_spawn(task, str(workspace))
+    text = (workspace / "_ACTIVE_TASK.md").read_text(encoding="utf-8")
+    assert "Default verification gate" in text
+    assert "concrete proof" in text
+
+
 def test_show_defaults_to_env_task_id(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_show({})
@@ -294,7 +357,7 @@ def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({
         "summary": "got the thing done",
-        "metadata": {"files": 2},
+        "metadata": {"files": 2, "verification": {"status": "ok"}},
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -306,7 +369,7 @@ def test_complete_happy_path(worker_env):
         run = kb.latest_run(conn, worker_env)
         assert run.outcome == "completed"
         assert run.summary == "got the thing done"
-        assert run.metadata == {"files": 2}
+        assert run.metadata == {"files": 2, "verification": {"status": "ok"}}
     finally:
         conn.close()
 
@@ -337,11 +400,135 @@ def test_complete_metadata_round_trips_through_show(worker_env):
     assert shown["runs"][-1]["metadata"] == handoff
 
 
+def test_complete_task_blocks_ungated_mobile_task_without_verification(worker_env):
+    """Mobile-created tasks without magic words still require proof metadata."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET session_id = ? WHERE id = ?", ("discord-session", worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({"summary": "claiming done without evidence"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "completion blocked" in d["error"]
+    assert "default verification" in d["error"]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "running"
+        events = kb.list_events(conn, worker_env)
+        assert any(e.kind == "completion_blocked_missing_verification" for e in events)
+    finally:
+        conn.close()
+
+    ok_out = kt._handle_complete({
+        "summary": "done with proof",
+        "metadata": {"verification": {"command": "pytest tests/tools/test_kanban_tools.py", "exit_code": 0}},
+    })
+    assert json.loads(ok_out)["ok"] is True
+
+
+def test_complete_task_blocks_done_if_without_verification(worker_env):
+    """A declared completion gate must require concrete proof metadata."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", ("done_if: pytest passes", worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({"summary": "claiming done without evidence"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "completion blocked" in d["error"]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "running"
+        events = kb.list_events(conn, worker_env)
+        assert any(e.kind == "completion_blocked_missing_verification" for e in events)
+    finally:
+        conn.close()
+
+    ok_out = kt._handle_complete({
+        "summary": "done with proof",
+        "metadata": {"verification": {"command": "pytest tests/tools/test_kanban_tools.py", "exit_code": 0}},
+    })
+    assert json.loads(ok_out)["ok"] is True
+
+
+def test_complete_task_accepts_structured_verification_without_exit_code(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", ("verification: lint and graph recompute", worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({
+        "summary": "done with structured proof",
+        "metadata": {"verification": {"lint_counts": {"error": 0}, "graph_recompute": {"components": 1}}},
+    })
+    assert json.loads(out)["ok"] is True
+
+
+def test_complete_task_rejects_failed_verification_metadata(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", ("verification: failing command must block", worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({
+        "summary": "failed command should not satisfy gate",
+        "metadata": {"verification": {"exit_code": 1, "output": "failed"}},
+    })
+    assert "completion blocked" in json.loads(out).get("error", "")
+
+
+def test_complete_task_accepts_existing_evidence_metadata_keys(worker_env):
+    """Gated completions can use real handoff keys, not only a magic `verification` field."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", ("done_if: source review is archived", worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_complete({
+        "summary": "done with source evidence",
+        "metadata": {"sources_read": ["/tmp/source.md"], "result": "reviewed source file"},
+    })
+    assert json.loads(out)["ok"] is True
+
+
 def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
     from tools import kanban_tools as kt
 
     monkeypatch.setenv("HERMES_SESSION_ID", "session-trusted")
-    metadata = {"files": 2, "worker_session_id": "user-spoof"}
+    metadata = {"files": 2, "verification": {"status": "ok"}, "worker_session_id": "user-spoof"}
 
     out = kt._handle_complete({
         "summary": "done by scoped worker",
@@ -356,6 +543,7 @@ def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
         run = kb.latest_run(conn, worker_env)
         assert run.metadata == {
             "files": 2,
+            "verification": {"status": "ok"},
             "worker_session_id": "session-trusted",
         }
     finally:


### PR DESCRIPTION
## Summary
- enforce proof metadata for session-backed Kanban tasks, so terse Discord/mobile-created cards get a default verification gate without requiring `done_if:` or `verification:` text
- write dispatcher-owned `_ACTIVE_TASK.md` recitation files before worker spawn with objective and proof expectations
- load marked `_ACTIVE_TASK.md` files into prompt context alongside project instructions

## Verification
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_cli.py tests/gateway/test_kanban_notifier.py` → 486 passed, 0 failed
- independent reviewer subagent reviewed actual git diff and passed with no security concerns or logic errors
- live Discord/Kanban smoke: Discord message `1512156250983633026`, task `t_aa3ecba1`; no-proof completion blocked, structured proof completion accepted, task archived for cleanup
- Mission Control `/api/validate` returned `ok: true`, 0 issues

## Notes
- Direct CLI/DB maintenance tasks without `session_id` keep the prior explicit-gate behavior
- Failed verification metadata (`exit_code != 0`, `ok: false`, failed/error status) does not satisfy the gate