### PR TITLE
fix(desktop): inline pasted images for remote gateway connections

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -144,6 +144,83 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
     return local_paths, urls
 
 
+# Desktop remote mode embeds pasted/attached images as data URLs inside the
+# prompt text because the gateway cannot read client-local composer-images
+# paths. Match the desktop renderer's embedded-images.ts extraction rules.
+_EMBEDDED_DATA_IMAGE_RE = re.compile(
+    r"data:image/[\w.+-]+;base64,[A-Za-z0-9+/=]{64,}"
+)
+
+
+def extract_embedded_data_image_urls(text: str) -> Tuple[str, List[str]]:
+    """Pull inline ``data:image/...;base64,...`` URLs out of free-form text.
+
+    Returns ``(cleaned_text, urls)``. Order-preserving, deduplicated.
+    """
+    if not isinstance(text, str) or "data:image/" not in text:
+        return text, []
+
+    urls: List[str] = []
+    seen: set[str] = set()
+
+    def _collect(match: re.Match[str]) -> str:
+        url = match.group(0)
+        if url not in seen:
+            seen.add(url)
+            urls.append(url)
+        return ""
+
+    cleaned = _EMBEDDED_DATA_IMAGE_RE.sub(_collect, text)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned, urls
+
+
+def materialize_data_image_urls(
+    urls: List[str],
+    dest_dir: Path,
+    *,
+    prefix: str = "embedded",
+) -> List[str]:
+    """Decode inline data URLs to temp files for text-mode vision preprocessing."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    paths: List[str] = []
+    ext_by_mime = {
+        "image/png": ".png",
+        "image/jpeg": ".jpg",
+        "image/jpg": ".jpg",
+        "image/gif": ".gif",
+        "image/webp": ".webp",
+        "image/bmp": ".bmp",
+        "image/tiff": ".tiff",
+        "image/svg+xml": ".svg",
+    }
+
+    for index, raw_url in enumerate(urls):
+        url = str(raw_url or "").strip()
+        if not url.startswith("data:image/") or "," not in url:
+            continue
+        header, _, payload = url.partition(",")
+        if not payload:
+            continue
+        mime = header[5:].split(";", 1)[0].strip().lower() or "image/png"
+        ext = ext_by_mime.get(mime, ".png")
+        try:
+            data = base64.b64decode(payload, validate=False)
+        except Exception:
+            logger.warning("image_routing: invalid embedded data URL at index %d", index)
+            continue
+        out_path = dest_dir / f"{prefix}_{index + 1}{ext}"
+        try:
+            out_path.write_bytes(data)
+        except OSError as exc:
+            logger.warning("image_routing: failed to write embedded image %s — %s", out_path, exc)
+            continue
+        paths.append(str(out_path))
+
+    return paths
+
+
 # Strict YAML/JSON boolean coercion for capability overrides.
 #
 # ``bool("false")`` is True in Python because non-empty strings are truthy, so
@@ -508,4 +585,6 @@ __all__ = [
     "decide_image_input_mode",
     "build_native_content_parts",
     "extract_image_refs",
+    "extract_embedded_data_image_urls",
+    "materialize_data_image_urls",
 ]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -17,6 +17,7 @@ import {
   filterDesktopCommandsCatalog,
   isDesktopSlashCommand
 } from '@/lib/desktop-slash-commands'
+import { isDesktopComposerImagePath, shouldInlineImageAttachmentsForGateway } from '@/lib/gateway-connection'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
@@ -179,12 +180,51 @@ export function usePromptActions({
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
-    ) => {
+    ): Promise<string[]> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
       const images = attachments.filter(attachment => attachment.kind === 'image' && attachment.path)
+      const dataUrls: string[] = []
+
+      const inlineImagesForGateway = await shouldInlineImageAttachmentsForGateway()
 
       for (const attachment of images) {
         if (attachment.attachedSessionId === sessionId) {
+          continue
+        }
+
+        const path = attachment.path!
+        const mustInlinePath = isDesktopComposerImagePath(path)
+
+        // Remote gateways cannot read desktop-local paths (composer-images cache,
+        // clipboard paste temp files, etc.). Inline the bytes as data URLs instead
+        // of image.attach, which resolves paths on the gateway machine.
+        if (inlineImagesForGateway || mustInlinePath) {
+          let dataUrl = attachment.previewUrl
+
+          if (!dataUrl) {
+            try {
+              dataUrl = await window.hermesDesktop?.readFileDataUrl(path)
+            } catch (err) {
+              console.error('[remote] Failed to read image as data URL:', err)
+            }
+          }
+
+          if (!dataUrl) {
+            const label = attachment.label || pathLabel(path)
+            throw new Error(`Could not upload ${label} to the remote gateway. Try attaching the image again.`)
+          }
+
+          dataUrls.push(dataUrl)
+
+          if (updateComposerAttachments) {
+            addComposerAttachment({
+              ...attachment,
+              id: attachment.id,
+              attachedSessionId: sessionId,
+              previewUrl: dataUrl
+            })
+          }
+
           continue
         }
 
@@ -210,6 +250,8 @@ export function usePromptActions({
           })
         }
       }
+
+      return dataUrls
     },
     [requestGateway]
   )
@@ -327,10 +369,14 @@ export function usePromptActions({
       }
 
       try {
-        await syncImageAttachmentsForSubmit(sessionId, attachments, {
+        const dataUrls = await syncImageAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
-        await requestGateway('prompt.submit', { session_id: sessionId, text })
+
+        // In remote mode, embed data URLs in the prompt text so the Pi backend receives them
+        const finalText = dataUrls.length > 0 ? `${text}\n\n${dataUrls.join('\n\n')}` : text
+
+        await requestGateway('prompt.submit', { session_id: sessionId, text: finalText })
 
         if (usingComposerAttachments) {
           clearComposerAttachments()

--- a/apps/desktop/src/lib/gateway-connection.test.ts
+++ b/apps/desktop/src/lib/gateway-connection.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { isDesktopComposerImagePath, isRemoteGatewayConnection } from './gateway-connection'
+describe('isRemoteGatewayConnection', () => {
+  it('treats explicit remote mode as remote', () => {
+    expect(
+      isRemoteGatewayConnection({
+        baseUrl: 'http://127.0.0.1:8787',
+        mode: 'remote',
+        token: 't',
+        wsUrl: 'ws://127.0.0.1:8787/api/ws?token=t',
+        isFullscreen: false,
+        nativeOverlayWidth: 0,
+        logs: [],
+        windowButtonPosition: null
+      })
+    ).toBe(true)
+  })
+
+  it('detects remote hosts even when mode is unset', () => {
+    expect(
+      isRemoteGatewayConnection({
+        baseUrl: 'https://hermes.example.com',
+        token: 't',
+        wsUrl: 'wss://hermes.example.com/api/ws?token=t',
+        isFullscreen: false,
+        nativeOverlayWidth: 0,
+        logs: [],
+        windowButtonPosition: null
+      })
+    ).toBe(true)
+  })
+
+  it('treats loopback hosts as local', () => {
+    expect(
+      isRemoteGatewayConnection({
+        baseUrl: 'http://127.0.0.1:8787',
+        mode: 'local',
+        token: 't',
+        wsUrl: 'ws://127.0.0.1:8787/api/ws?token=t',
+        isFullscreen: false,
+        nativeOverlayWidth: 0,
+        logs: [],
+        windowButtonPosition: null
+      })
+    ).toBe(false)
+  })
+})
+
+describe('isDesktopComposerImagePath', () => {
+  it('matches desktop composer cache paths', () => {
+    expect(
+      isDesktopComposerImagePath(
+        'C:\\Users\\danny\\AppData\\Roaming\\Hermes\\composer-images\\composer_2026-06-04_16-35-59-305_f434ea.png'
+      )
+    ).toBe(true)
+  })
+
+  it('ignores unrelated image paths', () => {
+    expect(isDesktopComposerImagePath('/tmp/screenshot.png')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/gateway-connection.ts
+++ b/apps/desktop/src/lib/gateway-connection.ts
@@ -1,0 +1,80 @@
+import type { DesktopConnectionConfig, HermesConnection } from '@/global'
+
+const LOCAL_GATEWAY_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]'])
+
+/** True when the desktop shell talks to a gateway that is not on this machine. */
+export function isRemoteGatewayConnection(conn: HermesConnection | null | undefined): boolean {
+  if (!conn) {
+    return false
+  }
+
+  if (conn.mode === 'remote') {
+    return true
+  }
+
+  const candidates = [conn.baseUrl, conn.wsUrl].filter(Boolean)
+
+  for (const raw of candidates) {
+    try {
+      const hostname = new URL(raw).hostname.toLowerCase()
+
+      if (!LOCAL_GATEWAY_HOSTS.has(hostname)) {
+        return true
+      }
+    } catch {
+      // Ignore malformed URLs and fall through to other signals.
+    }
+  }
+
+  return false
+}
+
+export function isRemoteGatewayConfig(config: DesktopConnectionConfig | null | undefined): boolean {
+  return config?.mode === 'remote'
+}
+
+/** Paths written by the desktop composer's local image cache (never on a remote gateway). */
+export function isDesktopComposerImagePath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, '/').toLowerCase()
+
+  return normalized.includes('/composer-images/') && /\/composer_[^/]+\.(png|jpe?g|gif|webp|bmp|tiff?|svg)$/i.test(normalized)
+}
+
+/** Resolve whether pasted/attached images must be inlined instead of image.attach. */
+export async function shouldInlineImageAttachmentsForGateway(): Promise<boolean> {
+  const desktop = window.hermesDesktop
+
+  if (!desktop) {
+    return false
+  }
+
+  // Lazy import avoids a circular dependency through the session store.
+  const { $connection } = await import('@/store/session')
+  const cached = $connection.get()
+
+  if (isRemoteGatewayConnection(cached)) {
+    return true
+  }
+
+  try {
+    const live = await desktop.getConnection()
+
+    if (isRemoteGatewayConnection(live)) {
+      return true
+    }
+  } catch {
+    // Fall through to saved settings.
+  }
+
+  try {
+    const config = await desktop.getConnectionConfig()
+
+    if (isRemoteGatewayConfig(config)) {
+      return true
+    }
+  } catch {
+    // Fall through.
+  }
+
+  return false
+}

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -15,7 +15,9 @@ from agent.image_routing import (
     _supports_vision_override,
     build_native_content_parts,
     decide_image_input_mode,
+    extract_embedded_data_image_urls,
     extract_image_refs,
+    materialize_data_image_urls,
 )
 
 
@@ -571,6 +573,35 @@ class TestExtractImageRefs:
         body = f"see {img}"
         paths, urls = extract_image_refs(body)
         assert paths == [str(img)]
+
+
+# ─── extract_embedded_data_image_urls ────────────────────────────────────────
+
+
+class TestExtractEmbeddedDataImageUrls:
+    SAMPLE = "data:image/png;base64," + ("A" * 120)
+
+    def test_no_data_urls(self):
+        assert extract_embedded_data_image_urls("hello") == ("hello", [])
+
+    def test_extracts_bare_data_url(self):
+        cleaned, urls = extract_embedded_data_image_urls(f"describe this\n\n{self.SAMPLE}")
+        assert urls == [self.SAMPLE]
+        assert cleaned == "describe this"
+
+    def test_deduplicates_repeated_urls(self):
+        body = f"{self.SAMPLE}\n\n{self.SAMPLE}"
+        cleaned, urls = extract_embedded_data_image_urls(body)
+        assert urls == [self.SAMPLE]
+        assert cleaned == ""
+
+
+class TestMaterializeDataImageUrls:
+    def test_writes_decoded_png(self, tmp_path: Path):
+        data_url = "data:image/png;base64," + base64.b64encode(_png_bytes()).decode("ascii")
+        paths = materialize_data_image_urls([data_url], tmp_path)
+        assert len(paths) == 1
+        assert Path(paths[0]).read_bytes() == _png_bytes()
 
 
 # ─── build_native_content_parts with URLs ────────────────────────────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4263,6 +4263,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             streamer = make_stream_renderer(cols)
             prompt = text
 
+            embedded_data_urls: list[str] = []
+            if isinstance(prompt, str) and "data:image/" in prompt:
+                from agent.image_routing import extract_embedded_data_image_urls
+
+                prompt, embedded_data_urls = extract_embedded_data_image_urls(prompt)
+
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references
                 from agent.model_metadata import get_model_context_length
@@ -4300,11 +4306,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # "text"   → pre-analyze with vision_analyze and prepend the text.
             # See agent/image_routing.py for the full decision table.
             run_message: Any = prompt
-            if images:
+            if images or embedded_data_urls:
                 try:
                     from agent.image_routing import (
                         decide_image_input_mode,
                         build_native_content_parts,
+                        materialize_data_image_urls,
                     )
                     from agent.auxiliary_client import (
                         _read_main_model,
@@ -4332,6 +4339,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         _parts, _skipped = build_native_content_parts(
                             prompt,
                             images,
+                            image_urls=embedded_data_urls or None,
                         )
                         if _skipped:
                             print(
@@ -4341,15 +4349,45 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         if any(p.get("type") == "image_url" for p in _parts):
                             run_message = _parts
                         else:
-                            run_message = _enrich_with_attached_images(prompt, images)
+                            _text_images = list(images)
+                            if embedded_data_urls:
+                                img_dir = _hermes_home / "images"
+                                _text_images.extend(
+                                    materialize_data_image_urls(
+                                        embedded_data_urls,
+                                        img_dir,
+                                        prefix="embedded",
+                                    )
+                                )
+                            run_message = _enrich_with_attached_images(prompt, _text_images)
                     except Exception as _img_exc:
                         print(
                             f"[tui_gateway] native attach failed, falling back to text: {_img_exc}",
                             file=sys.stderr,
                         )
-                        run_message = _enrich_with_attached_images(prompt, images)
+                        _text_images = list(images)
+                        if embedded_data_urls:
+                            img_dir = _hermes_home / "images"
+                            _text_images.extend(
+                                materialize_data_image_urls(
+                                    embedded_data_urls,
+                                    img_dir,
+                                    prefix="embedded",
+                                )
+                            )
+                        run_message = _enrich_with_attached_images(prompt, _text_images)
                 else:
-                    run_message = _enrich_with_attached_images(prompt, images)
+                    _text_images = list(images)
+                    if embedded_data_urls:
+                        img_dir = _hermes_home / "images"
+                        _text_images.extend(
+                            materialize_data_image_urls(
+                                embedded_data_urls,
+                                img_dir,
+                                prefix="embedded",
+                            )
+                        )
+                    run_message = _enrich_with_attached_images(prompt, _text_images)
 
             def _stream(delta):
                 with session["history_lock"]:


### PR DESCRIPTION
Fixes #38078

## Summary
- Desktop: when connected to a remote gateway, read pasted/attached images locally and embed them as data URLs instead of calling `image.attach` with client-side paths
- Gateway: extract embedded `data:image/...;base64,...` URLs from prompt text and route them through native/text vision preprocessing

## Problem
Pasting an image in Hermes Desktop while using Settings → Gateway → Remote sends a path like `C:\Users\...\AppData\Roaming\Hermes\composer-images\...` (or `~/.config/Hermes/composer-images/...` on Linux) to the remote gateway. The gateway tries to resolve that path on its own filesystem and returns `image not found`.

## How to test
1. Configure Hermes Desktop with Gateway mode **Remote** pointing at a gateway on another machine
2. Paste an image into the composer and send
3. Confirm the agent receives and analyzes the image (no `image not found` error)

Also verify local gateway mode still attaches images normally via path.

## Platforms tested
- Windows (desktop client + remote gateway on Raspberry Pi)