### PR TITLE
fix(auth): set active_provider after hermes auth add anthropic

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2163,7 +2163,13 @@ def _mark_anthropic_oauth_active(creds: Dict[str, Any]) -> None:
     """
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        state: Dict[str, Any] = {}
+        # Start from any existing anthropic provider state so re-running
+        # `hermes auth add anthropic` does not discard previously stored
+        # metadata (e.g. future labels/config/migration artifacts). We only
+        # overwrite the keys this function owns.
+        providers = auth_store.get("providers")
+        existing = providers.get("anthropic") if isinstance(providers, dict) else None
+        state: Dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
         if creds.get("expires_at_ms"):
             state["expires_at_ms"] = int(creds["expires_at_ms"])
         _save_provider_state(auth_store, "anthropic", state)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2151,6 +2151,25 @@ def get_qwen_auth_status() -> Dict[str, Any]:
 # Actual HTTP traffic goes to https://cloudcode-pa.googleapis.com/v1internal:*.
 # =============================================================================
 
+def _mark_anthropic_oauth_active(creds: Dict[str, Any]) -> None:
+    """Set active_provider to anthropic in auth.json after OAuth add.
+
+    The OAuth tokens live in the credential pool (pool.add_entry) and the
+    Hermes-managed OAuth file (~/.hermes/.anthropic_oauth.json). This function
+    only writes a minimal provider-state entry and sets active_provider so that
+    get_active_provider() and _model_section_has_credentials() detect the
+    provider for the setup wizard and status commands — without duplicating the
+    access/refresh tokens into auth.json where they would become stale.
+    """
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state: Dict[str, Any] = {}
+        if creds.get("expires_at_ms"):
+            state["expires_at_ms"] = int(creds["expires_at_ms"])
+        _save_provider_state(auth_store, "anthropic", state)
+        _save_auth_store(auth_store)
+
+
 def _mark_google_gemini_cli_active(creds: Dict[str, Any]) -> None:
     """Set active_provider to google-gemini-cli in auth.json.
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -226,7 +226,6 @@ def auth_add_command(args) -> None:
         creds = anthropic_mod.run_hermes_oauth_login_pure()
         if not creds:
             raise SystemExit("Anthropic OAuth login did not return credentials.")
-        auth_mod._mark_anthropic_oauth_active(creds)
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -244,6 +243,11 @@ def auth_add_command(args) -> None:
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)
+        # Only mark the provider active once the credential has actually been
+        # persisted. Marking it before pool.add_entry() can leave auth.json
+        # reporting anthropic as active with no backing credential if the
+        # persist raises (disk/permission error).
+        auth_mod._mark_anthropic_oauth_active(creds)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -226,6 +226,7 @@ def auth_add_command(args) -> None:
         creds = anthropic_mod.run_hermes_oauth_login_pure()
         if not creds:
             raise SystemExit("Anthropic OAuth login did not return credentials.")
+        auth_mod._mark_anthropic_oauth_active(creds)
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -139,6 +139,97 @@ def test_auth_add_anthropic_oauth_sets_active_provider(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-ant-oauth-test"
 
 
+def test_auth_add_anthropic_oauth_does_not_mark_active_when_persist_fails(
+    tmp_path, monkeypatch
+):
+    """A failing pool.add_entry() must not leave anthropic marked active.
+
+    active_provider is written only after the credential is persisted. If
+    pool.add_entry() raises (e.g. disk/permission error), auth.json must NOT
+    report anthropic as the active provider with no backing credential.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda: {
+            "access_token": "sk-ant-oauth-test",
+            "refresh_token": "ant-refresh",
+            "expires_at_ms": 9999999999000,
+        },
+    )
+
+    from agent.credential_pool import CredentialPool
+
+    def _boom(self, entry):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(CredentialPool, "add_entry", _boom)
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    with pytest.raises(OSError):
+        auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    # regression: persist failed, so anthropic must NOT be marked active
+    assert payload.get("active_provider") != "anthropic"
+    assert "anthropic" not in payload.get("providers", {})
+
+
+def test_auth_add_anthropic_oauth_preserves_existing_provider_metadata(
+    tmp_path, monkeypatch
+):
+    """Re-running auth add must not discard pre-existing anthropic metadata.
+
+    _mark_anthropic_oauth_active() must merge into the existing
+    providers['anthropic'] entry rather than overwriting it wholesale, so
+    unrelated stored fields (labels/config/migration artifacts) survive.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "anthropic": {"label": "work", "custom_field": "keep-me"}
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda: {
+            "access_token": "sk-ant-oauth-test",
+            "refresh_token": "ant-refresh",
+            "expires_at_ms": 9999999999000,
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    state = payload["providers"]["anthropic"]
+    # regression: pre-existing metadata preserved through the merge
+    assert state["label"] == "work"
+    assert state["custom_field"] == "keep-me"
+    # function-owned key still written
+    assert state["expires_at_ms"] == 9999999999000
+
+
 def test_auth_add_google_gemini_cli_sets_active_provider(tmp_path, monkeypatch):
     """hermes auth add google-gemini-cli must set active_provider in auth.json.
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -97,6 +97,48 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["expires_at_ms"] == 1711234567000
 
 
+def test_auth_add_anthropic_oauth_sets_active_provider(tmp_path, monkeypatch):
+    """hermes auth add anthropic must set active_provider in auth.json.
+
+    Tokens live in the credential pool and the Hermes OAuth file managed by
+    agent.anthropic_adapter. The auth.json entry must record active_provider so
+    get_active_provider() / _model_section_has_credentials() detect the provider
+    for the setup wizard — without duplicating tokens that would become stale.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda: {
+            "access_token": "sk-ant-oauth-test",
+            "refresh_token": "ant-refresh",
+            "expires_at_ms": 9999999999000,
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    # core regression: active_provider must be set
+    assert payload["active_provider"] == "anthropic"
+    state = payload["providers"]["anthropic"]
+    # no token duplication into providers state
+    assert "access_token" not in state
+    assert "refresh_token" not in state
+    # pool entry from pool.add_entry() still present for hermes auth list
+    entries = payload["credential_pool"]["anthropic"]
+    entry = next(item for item in entries if item["source"] == "manual:hermes_pkce")
+    assert entry["access_token"] == "sk-ant-oauth-test"
+
+
 def test_auth_add_google_gemini_cli_sets_active_provider(tmp_path, monkeypatch):
     """hermes auth add google-gemini-cli must set active_provider in auth.json.
 


### PR DESCRIPTION
## This is a sibling follow-up to commits cd68b8f0e / 5f62ba8e4 / 34a290352

- **What the parents covered:** the recent (2026-06-02) auth-hardening family made `hermes auth add` set `active_provider` in `auth.json` for `qwen-oauth` (`_mark_qwen_oauth_active`), `google-gemini-cli` (`_mark_google_gemini_cli_active`), and `xai-oauth` (`_save_xai_oauth_tokens`).
- **What the parents did NOT touch:** the `anthropic` branch of `auth_add_command`. Of the seven `_OAUTH_CAPABLE_PROVIDERS`, six set `active_provider` on add (xai-oauth, qwen-oauth, google-gemini-cli, openai-codex, nous, minimax-oauth) — anthropic was the only remaining gap.
- **What this adds:** an `_mark_anthropic_oauth_active()` helper, called from the anthropic block, closing the family so all seven OAuth providers behave identically.

## What does this PR do?

After a successful Claude Pro/Max OAuth login via `hermes auth add anthropic`, the setup wizard still reported "No inference provider configured".

Root cause: the `anthropic` block in `hermes_cli/auth_commands.py` called `run_hermes_oauth_login_pure()` (a pure function with no store side-effect) and then only `pool.add_entry(entry)`. It never wrote `providers["anthropic"]` or set `active_provider`. Because `_model_section_has_credentials()` consults `get_active_provider()` first, and the `oauth_external` anthropic provider has no `api_key_env_vars`, the provider went undetected despite a valid login — the exact symptom the qwen/gemini/xai siblings already fixed.

The fix mirrors `_mark_google_gemini_cli_active`: it writes a minimal provider-state entry (`expires_at_ms`, display/diagnostic only) and sets `active_provider` via `_save_provider_state`. It deliberately does NOT duplicate the access/refresh tokens into `auth.json` — those already live in the credential pool (`pool.add_entry`) and the Hermes-managed OAuth file, where duplicates would become stale.

## Related Issue

No issue — sibling-path widening of the on-main hardening family (commits `cd68b8f0e`, `5f62ba8e4`, `34a290352`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: add `_mark_anthropic_oauth_active()` beside the other `_mark_*_active` helpers — sets `active_provider` to `anthropic` without duplicating tokens.
- `hermes_cli/auth_commands.py`: call `auth_mod._mark_anthropic_oauth_active(creds)` in the `anthropic` block, mirroring the qwen/gemini blocks.
- `tests/hermes_cli/test_auth_commands.py`: add `test_auth_add_anthropic_oauth_sets_active_provider`.

## How to Test

1. With the fix reverted, `test_auth_add_anthropic_oauth_sets_active_provider` fails with `KeyError: 'active_provider'` (verified — old behavior, RED).
2. With the fix applied, the test passes: `active_provider == "anthropic"`, no tokens duplicated into `providers["anthropic"]`, and the `manual:hermes_pkce` pool entry is still present (verified — GREEN).
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_auth_commands.py -v` → 50 passed, including the existing qwen/gemini active_provider tests (no family regression).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_auth_commands.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring added on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure auth.json state write, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A