### PR TITLE
docs: clarify current desktop install path

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -10,13 +10,15 @@ Get Hermes Agent up and running in under two minutes with the one-line installer
 
 ## Quick Install
 
-### Desktop App (macOS + Windows)
+### Desktop App
 
-Prefer a native installer?
+For the packaged desktop UI, download the macOS or Windows installer from the [Desktop App page](https://hermes-agent.nousresearch.com/desktop).
 
-- **Desktop downloads:** [GitHub Releases](https://github.com/NousResearch/hermes-agent/releases/latest)
+If you prefer the CLI path, install Hermes with the platform-specific installer below, then run `hermes desktop` to build and launch the desktop app locally. On Linux, macOS, or WSL2, you can also build the desktop app during installation:
 
-Desktop builds ship signed/notarized macOS artifacts and Windows installers with checksum files.
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --include-desktop
+```
 
 ### One-Line CLI Installer (Linux / macOS / WSL2)
 
@@ -42,13 +44,19 @@ The installer handles **everything**: `uv`, Python 3.11, Node.js 22, `ripgrep`, 
 1. If `git` is already on your PATH, the installer uses your existing install.
 2. Otherwise it downloads portable **PortableGit** (~50MB, from the official `git-for-windows` GitHub release) and unpacks it to `%LOCALAPPDATA%\hermes\git`.  No admin rights required.  Completely isolated — it won't interfere with any system Git install, broken or otherwise.  (On 32-bit Windows it falls back to MinGit because PortableGit ships only 64-bit and ARM64 assets; bash-dependent Hermes features won't work on 32-bit hosts.)
 
-**Why not use winget?**  Earlier designs auto-installed Git via `winget install Git.Git`, but winget fails badly when a system Git install is in a partial or broken state (exactly when users need the installer to just work).  The portable Git approach sidesteps winget, the Windows installer registry, and any existing system Git entirely.  If the Hermes Git install itself ever breaks, `Remove-Item %LOCALAPPDATA%\hermes\git` and re-run the installer — no system impact, no uninstall drama.
+**Why not use winget?**  Earlier designs auto-installed Git via `winget install Git.Git`, but winget fails badly when a system Git install is in a partial or broken state (exactly when users need the installer to just work).  The portable Git approach sidesteps winget, the Windows installer registry, and any existing system Git entirely.  If the Hermes Git install itself ever breaks, run `Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes\git"` in PowerShell and re-run the installer — no system impact, no uninstall drama.
 
 The installer also sets `HERMES_GIT_BASH_PATH` to the located `bash.exe` so Hermes resolves it deterministically in fresh shells.
 
 If you prefer WSL2, the Linux installer above works inside it; both native and WSL installs can coexist without conflict (native data lives under `%LOCALAPPDATA%\hermes`, WSL data lives under `~/.hermes`).
 
-**Desktop installer (alternative):** A thin GUI installer is also available — download Hermes Desktop, run the `.exe`, and on first launch it calls `install.ps1` under the hood to provision Python (via `uv`), Node, PortableGit, and the rest of the dependencies. The desktop app and the PowerShell-installed CLI share the same install and data directories, so you can use either or both. See the [Windows (Native) guide](../user-guide/windows-native#desktop-installer-alternative) for details.
+**Desktop app:** Native Windows users can either download the desktop installer from the [Desktop App page](https://hermes-agent.nousresearch.com/desktop) or use the PowerShell installer above. After the PowerShell install, open a new PowerShell window and run `hermes desktop`; it builds the desktop app on demand using the same install and data directories. If you specifically want the PowerShell installer to include the desktop build on first install, use the scriptblock form to pass `-IncludeDesktop`:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1))) -IncludeDesktop
+```
+
+See the [Windows (Native) guide](../user-guide/windows-native#desktop-app) for details.
 
 ### Android / Termux
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -64,19 +64,23 @@ PyPI releases track tagged versions (major/minor releases), not every commit on 
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-Prefer native installers for desktop use?
+**Windows (native, PowerShell):**
 
-- **Desktop downloads:** [GitHub Releases](https://github.com/NousResearch/hermes-agent/releases/latest)
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+For the desktop UI, download the macOS or Windows installer from the [Desktop App page](https://hermes-agent.nousresearch.com/desktop). You can also install Hermes with the CLI path above, then run `hermes desktop` to build and launch the desktop app locally.
 
 :::tip Android / Termux
 If you're installing on a phone, see the dedicated [Termux guide](./termux.md) for the tested manual path, supported extras, and current Android-specific limitations.
 :::
 
 :::tip Windows Users
-Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run the command above inside your WSL2 terminal.
+Use the native PowerShell installer above for the normal Windows path. If you prefer WSL2, install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) first, then run the Linux/macOS command inside your WSL2 terminal.
 :::
 
-After it finishes, reload your shell:
+After it finishes, reload your shell (Linux / macOS / WSL2 / Termux) or open a new PowerShell window (native Windows):
 
 ```bash
 source ~/.bashrc   # or source ~/.zshrc

--- a/website/docs/guides/run-nemotron-3-ultra-free.md
+++ b/website/docs/guides/run-nemotron-3-ultra-free.md
@@ -12,47 +12,29 @@ Nous Research has been inducted into the **Nemotron Coalition** of leading AI la
 The `nvidia/nemotron-3-ultra:free` tier is available from **June 4th to June 18th**. The `:free` tag is what keeps it on the no-cost plan — pick that exact variant.
 :::
 
-Pick whichever install fits you. The **desktop app** is the easiest — no terminal required. If you live in a terminal, the **command-line** install is right below it.
+Pick whichever install fits your OS. If you want the desktop UI, download the macOS or Windows installer from the [Desktop App page](https://hermes-agent.nousresearch.com/desktop). The CLI installer below works on macOS, Linux, WSL2, Termux, and native Windows PowerShell; after setup, you can also run `hermes desktop` to build and launch the desktop UI locally.
 
-## Option A — Desktop app (recommended)
+## Command line installer
 
-The simplest path: a one-click installer with a guided, point-and-click setup. No terminal needed.
-
-### 1. Download and install
-
-[Download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) for macOS or Windows, then open it. On first launch it finishes setting itself up (usually under a minute).
-
-### 2. Connect Nous Portal
-
-When the app opens, you'll see a "Let's get you set up" screen. Click **Nous Portal** (marked **Recommended**). Your browser opens — create a [Nous Portal](https://portal.nousresearch.com) account (or sign in), choose the **Free** plan, and authorize Hermes. The app connects automatically.
-
-### 3. Pick the free Nemotron 3 Ultra model
-
-After connecting, the app shows a **Default model** card. Click **Change**, search for **nemotron 3 ultra**, and select the variant tagged **Free tier**:
-
-```
-nvidia/nemotron-3-ultra:free
-```
-
-The `:free` tag is what keeps it on the no-cost tier — pick that variant.
-
-### 4. Start chatting
-
-Click **Start chatting**. That's it — you're talking to Nemotron 3 Ultra, free.
-
-## Option B — Command line
-
-Prefer the terminal? You'll need macOS, Linux, or Windows via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) with `curl` installed (`curl` is preinstalled on most systems).
+You'll need macOS, Linux, WSL2, Termux, or native Windows PowerShell.
 
 ### 1. Install Hermes Agent
 
+Linux / macOS / WSL2 / Termux:
+
 ```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-Prefer to review first? Download [`install.sh`](https://hermes-agent.nousresearch.com/install.sh), inspect it, then run it.
+Native Windows PowerShell:
 
-After it finishes, reload your shell:
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+Prefer to review first? Download [`install.sh`](https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh) or [`install.ps1`](https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1), inspect it, then run it.
+
+After it finishes, reload your shell (Linux / macOS / WSL2 / Termux) or open a new PowerShell window (native Windows):
 
 ```bash
 source ~/.bashrc   # or source ~/.zshrc
@@ -109,7 +91,7 @@ Already set up with another model?
 
 ## See also
 
-- **[Desktop App](/user-guide/desktop)** — The native one-click app (macOS, Windows, Linux)
+- **[Desktop App](/user-guide/desktop)** — Desktop UI install and local-build options
 - **[Run Hermes Agent with Nous Portal](/guides/run-hermes-with-nous-portal)** — Full Portal walkthrough: models, Tool Gateway, and verification
 - **[Nous Portal integration](/integrations/nous-portal)** — What's in the subscription
 - **[Quickstart](/getting-started/quickstart)** — Install-to-chat in under 5 minutes

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -15,7 +15,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
 
 <div style={{display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap'}}>
   <Link to="/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>Get Started →</Link>
-  <a href="https://github.com/NousResearch/hermes-agent/releases/latest" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>Download Desktop</a>
+  <a href="https://hermes-agent.nousresearch.com/desktop" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>Download Desktop</a>
   <a href="https://github.com/NousResearch/hermes-agent" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>View on GitHub</a>
 </div>
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -22,27 +22,54 @@ Pick whichever fits the moment. They share state, so you can start a session in 
 
 ## Install
 
-### With the Hermes Desktop installer on MacOS or Windows (recommended)
+:::tip Desktop downloads
+Download the macOS or Windows installer from the [Hermes Desktop download page](https://hermes-agent.nousresearch.com/desktop).
+:::
 
-[Download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) from our website and run it.
+### Recommended CLI path: install Hermes, then launch Desktop
 
-### With the CLI installer on Linux, MacOS, or Windows
+Linux / macOS / WSL2:
 
-Add `--include-desktop` to the regular install script.
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+Reload your shell so the `hermes` command is on `PATH`, then launch Desktop:
+
+```bash
+source ~/.bashrc   # or source ~/.zshrc
+hermes desktop
+```
+
+Native Windows (PowerShell):
+
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+Open a new PowerShell window, then launch Desktop:
+
+```powershell
+hermes desktop
+```
+
+`hermes desktop` uses your current config, keys, sessions, and skills. By default it builds the current OS's packaged Electron app if needed, then launches it.
+
+Android/Termux supports the CLI install path, not the Electron desktop app. Linux desktop users should use the CLI/local-build path below.
+
+### Build Desktop during install
+
+On Linux, macOS, or WSL2, add `--include-desktop` to the regular install script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --include-desktop
 ```
 
-### With an existing Hermes installation
+On native Windows, use the scriptblock form to pass `-IncludeDesktop`:
 
-If you already have Hermes installed, simply run
-
-```bash
-hermes desktop
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1))) -IncludeDesktop
 ```
-
-That uses your current config, keys, sessions, and skills.
 
 ## What's in the app
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -38,16 +38,27 @@ No admin rights required. The installer goes to `%LOCALAPPDATA%\hermes\` and add
 | `-Tag` | unset | Pin install to a specific git tag (e.g. `v0.14.0`) |
 | `-NoVenv` | off | Skip venv creation (advanced — you manage Python yourself) |
 | `-SkipSetup` | off | Skip the post-install `hermes setup` wizard |
+| `-IncludeDesktop` | off | Build the desktop app during install instead of waiting for `hermes desktop` to build on demand |
 | `-HermesHome` | `%LOCALAPPDATA%\hermes` | Override data directory |
 | `-InstallDir` | `%LOCALAPPDATA%\hermes\hermes-agent` | Override code location |
 
 The installer auto-retries flaky git fetches and strips BOM from any downloaded `install.ps1` payload, so a UTF-8 BOM picked up during HTTP transit no longer breaks the `[scriptblock]::Create((irm ...))` form.
 
-### Desktop installer (alternative)
+### Desktop app
 
-A thin GUI installer is also available — useful if you'd rather double-click an `.exe` than open PowerShell. Download Hermes Desktop, run the installer, and on first launch the GUI calls `install.ps1` under the hood to provision Python (via `uv`), Node, PortableGit, and the rest of the dependency bootstrap described below. After the first run, the desktop app and the PowerShell-installed `hermes` CLI share the same `%LOCALAPPDATA%\hermes\hermes-agent` install and `%USERPROFILE%\.hermes` data directory — switch between the GUI and the CLI freely.
+For a double-click Windows install, download `Hermes-Setup.exe` from the [Desktop App page](https://hermes-agent.nousresearch.com/desktop).
 
-Use the desktop installer when you want a familiar Windows install experience or you're handing Hermes to a non-developer; use the PowerShell one-liner when you're already in a terminal.
+If you use the PowerShell installer instead, open a new PowerShell window after install and run:
+
+```powershell
+hermes desktop
+```
+
+That builds and launches the desktop app using the same `%LOCALAPPDATA%\hermes\hermes-agent` install and `%LOCALAPPDATA%\hermes` data directory as the CLI. If you want the initial install to build the desktop app immediately, pass `-IncludeDesktop`:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1))) -IncludeDesktop
+```
 
 ### Dependency bootstrap (`dep_ensure`)
 
@@ -75,7 +86,7 @@ Top-to-bottom, in order:
 6. **Tiered `uv pip install`** — tries `.[all]` first, falls back to progressively smaller sets (`[messaging,dashboard,ext]` → `[messaging]` → `.`) if a `git+https` dep flakes on rate-limited GitHub. Prevents "single flake drops you to a bare install" failure mode.
 7. **Auto-installs messaging SDKs** keyed off `.env` — if `TELEGRAM_BOT_TOKEN` / `DISCORD_BOT_TOKEN` / `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` / `WHATSAPP_ENABLED` are present, runs `python -m ensurepip --upgrade` and targeted `pip install` calls so each platform's SDK is actually importable.
 8. **Sets `HERMES_GIT_BASH_PATH`** to the resolved `bash.exe` so Hermes finds it deterministically in fresh shells.
-9. **Adds `%LOCALAPPDATA%\hermes\bin` to User PATH** — exposes the `hermes` command after you open a new terminal.
+9. **Adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to User PATH** — exposes the `hermes` command after you open a new terminal.
 10. **Runs `hermes setup`** — the normal first-run wizard (model, provider, toolsets). Skip with `-SkipSetup`.
 
 :::tip Skip provider hunting on Windows
@@ -205,10 +216,10 @@ Services require admin rights to install and tie the gateway's lifecycle to mach
 | `%LOCALAPPDATA%\hermes\hermes-agent\` | Git checkout + venv. Safe to `Remove-Item -Recurse` and reinstall. |
 | `%LOCALAPPDATA%\hermes\git\` | PortableGit (only if the installer provisioned it). |
 | `%LOCALAPPDATA%\hermes\node\` | Portable Node.js (only if the installer provisioned it). |
-| `%LOCALAPPDATA%\hermes\bin\` | `hermes.cmd` shim, added to User PATH. |
-| `%USERPROFILE%\.hermes\` | Your config, auth, skills, sessions, logs. **Survives reinstalls.** |
+| `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\` | `hermes.exe`, added to User PATH. |
+| `%LOCALAPPDATA%\hermes\` | Your native Windows config, auth, skills, sessions, and logs via `HERMES_HOME`. **Survives Hermes Agent repo reinstalls unless you delete this whole directory.** |
 
-The split is deliberate: `%LOCALAPPDATA%\hermes` is disposable infrastructure (you can blow it away and the one-liner restores it). `%USERPROFILE%\.hermes` is your data — config, memory, skills, session history — and is identical in shape to a Linux install. Mirror it between machines and your Hermes moves with you.
+The split is deliberate: `%LOCALAPPDATA%\hermes\hermes-agent` is disposable infrastructure (you can blow it away and the one-liner restores it). `%LOCALAPPDATA%\hermes` is the native Windows Hermes home — config, memory, skills, session history, and managed dependencies. Mirror or back it up if you want your Hermes state to move with you.
 
 **Override `HERMES_HOME`:** set the environment variable to point at a different data dir. Works the same as on Linux.
 
@@ -224,18 +235,18 @@ The browser tool uses `agent-browser` (a Node helper) to drive Chromium. On Wind
 
 ### PATH after install
 
-The installer adds `%LOCALAPPDATA%\hermes\bin` to your **User PATH** via `[Environment]::SetEnvironmentVariable`. Existing terminals don't pick this up — open a new PowerShell window (or Windows Terminal tab) after installation. Close-and-reopen, don't `$env:PATH += …` by hand unless you know what you're doing.
+The installer adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to your **User PATH** via `[Environment]::SetEnvironmentVariable`. Existing terminals don't pick this up — open a new PowerShell window (or Windows Terminal tab) after installation. Close-and-reopen, don't `$env:PATH += …` by hand unless you know what you're doing.
 
 Verify:
 
 ```powershell
-Get-Command hermes        # should print C:\Users\<you>\AppData\Local\hermes\bin\hermes.cmd
+Get-Command hermes        # should print ...\AppData\Local\hermes\hermes-agent\venv\Scripts\hermes.exe
 hermes --version
 ```
 
 ### Environment variables
 
-Hermes honors both `$env:X` (process-scope) and User environment variables (permanent, set in System Properties → Environment Variables). Setting API keys in `%USERPROFILE%\.hermes\.env` is the normal path — same as Linux:
+Hermes honors both `$env:X` (process-scope) and User environment variables (permanent, set in System Properties → Environment Variables). Setting API keys in `%LOCALAPPDATA%\hermes\.env` is the normal native Windows path:
 
 ```
 OPENROUTER_API_KEY=sk-or-...
@@ -262,13 +273,12 @@ From PowerShell:
 hermes uninstall
 ```
 
-That's the clean path — removes the schtasks entry, Startup folder shortcut, `hermes.cmd` shim, deletes `%LOCALAPPDATA%\hermes\hermes-agent\`, and trims the User PATH. It leaves `%USERPROFILE%\.hermes\` alone (your config, auth, skills, sessions, logs) in case you're reinstalling.
+That's the clean path — removes the schtasks entry, Startup folder shortcut, deletes `%LOCALAPPDATA%\hermes\hermes-agent\`, and trims the User PATH. It leaves `%LOCALAPPDATA%\hermes\` data files such as config, auth, skills, sessions, and logs alone in case you're reinstalling.
 
 To nuke everything:
 
 ```powershell
 hermes uninstall
-Remove-Item -Recurse -Force "$env:USERPROFILE\.hermes"
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes"
 ```
 
@@ -287,7 +297,7 @@ Consequence: any codepath that said "check if this PID is alive" via `os.kill(pi
 ## Common pitfalls
 
 **`hermes: command not found` right after install.**
-Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\bin` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA\hermes\bin\hermes.cmd"`.
+Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\hermes.exe"`.
 
 **`WinError 193: %1 is not a valid Win32 application` when running a tool.**
 You hit a shebang-script invocation that bypassed the `.cmd` shim. Hermes resolves commands through `shutil.which(cmd, path=local_bin)` so PATHEXT picks up `.CMD` — if you're invoking the tool via a hardcoded path instead, switch to the `.cmd` variant (e.g., `npx.cmd`, not `npx`).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -155,7 +155,7 @@ const config: Config = {
           title: 'Community',
           items: [
             { label: 'Discord', href: 'https://discord.gg/NousResearch' },
-            { label: 'GitHub Discussions', href: 'https://github.com/NousResearch/hermes-agent/discussions' },
+            { label: 'GitHub Issues', href: 'https://github.com/NousResearch/hermes-agent/issues' },
             { label: 'Skills Hub', href: 'https://agentskills.io' },
           ],
         },


### PR DESCRIPTION
## Summary
- point desktop users to the official download page: https://hermes-agent.nousresearch.com/desktop
- document CLI/local-build paths: `install.sh`, native Windows `install.ps1`, `hermes desktop`, `--include-desktop`, and `-IncludeDesktop`
- document shell/PATH reload requirements before running `hermes desktop`
- correct native Windows data/PATH docs to match the installer (`%LOCALAPPDATA%\hermes` and `venv\Scripts\hermes.exe`)
- replace the site footer's broken GitHub Discussions link with GitHub Issues

## Evidence
- `https://hermes-agent.nousresearch.com/desktop` returns 200 and links to:
  - `https://hermes-assets.nousresearch.com/Hermes-Setup.dmg` (200, content-length 6753241)
  - `https://hermes-assets.nousresearch.com/Hermes-Setup.exe` (200, content-length 7587128)
- `scripts/install.sh` supports `--include-desktop`
- `scripts/install.ps1` supports `-IncludeDesktop`
- native Windows installer defaults `HERMES_HOME` to `%LOCALAPPDATA%\hermes` and adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to User PATH

## QA / test plan
- `git diff --check`
- `npm run build` in `website/`
  - Build exits 0 and generates both `en` and `zh-Hans`
  - Existing unrelated broken-link/anchor warnings remain in generated docs/i18n content
- Served the built docs locally and verified these routes return 200:
  - `/`
  - `/docs/getting-started/installation`
  - `/docs/getting-started/quickstart`
  - `/docs/guides/run-nemotron-3-ultra-free`
  - `/docs/user-guide/desktop`
  - `/docs/user-guide/windows-native`
- QA script checked 118 article links from the changed pages
- QA script verified the desktop download page + `.dmg` / `.exe` CDN assets return 200
- QA script asserts the changed docs avoid the negative location pattern (`it is here, not here`)
- Browser smoke checked Installation page: no console errors; rendered text links directly to the Desktop App page
