### PR TITLE
[codex] auto-archive old desktop sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react'
 
-import { getCronJobs, listAllProfileSessions, type SessionInfo } from '@/hermes'
+import { autoArchiveOldSessions, getCronJobs, listAllProfileSessions, type SessionInfo } from '@/hermes'
 import {
   isMessagingSource,
   LOCAL_SESSION_SOURCE_IDS,
@@ -11,6 +11,7 @@ import { setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import {
+  $activeSessionId,
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
@@ -159,6 +160,28 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     try {
       const limit = $sessionsLimit.get()
+
+      const preserveIds = new Set<string>([
+        ...$workingSessionIds.get(),
+        ...$pinnedSessionIds.get()
+      ])
+
+      const selectedSessionId = $selectedStoredSessionId.get()
+      const activeSessionId = $activeSessionId.get()
+
+      if (selectedSessionId) {
+        preserveIds.add(selectedSessionId)
+      }
+
+      if (activeSessionId) {
+        preserveIds.add(activeSessionId)
+      }
+
+      try {
+        await autoArchiveOldSessions([...preserveIds])
+      } catch (error) {
+        console.warn('Hermes session auto-archive skipped', error)
+      }
 
       // Require at least one message so abandoned/empty "Untitled" drafts (one
       // was created per TUI/desktop launch before the lazy-create fix) don't

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -215,6 +215,16 @@ export async function listSessions(
   }
 }
 
+export function autoArchiveOldSessions(
+  preserveIds: string[] = []
+): Promise<{ ok: boolean; archived: number; skipped?: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean; archived: number; skipped?: boolean }>({
+    path: '/api/sessions/auto-archive',
+    method: 'POST',
+    body: { preserve_ids: Array.from(new Set(preserveIds.filter(Boolean))).slice(0, 5000) }
+  })
+}
+
 // Unified, read-only session list aggregated across ALL profiles. Served by the
 // primary backend straight off each profile's state.db — no per-profile backend
 // is spawned. Single-profile users get the same rows as listSessions(), tagged

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2993,6 +2993,28 @@ DEFAULT_CONFIG = {
     # reports 384MB+ databases with 68K+ messages, which slows down FTS5
     # inserts, /resume listing, and insights queries.
     "sessions": {
+        # Desktop sidebar hygiene: soft-archive older, inactive chats at
+        # startup so a heavy local state.db does not leave thousands of old
+        # conversations in the default Sessions list. This never deletes data:
+        # archived chats stay recoverable from Settings -> Archived Chats.
+        "auto_archive": True,
+        # Keep at least this many most-recent surfaced conversations
+        # unarchived. Pinned/active ids sent by the desktop are preserved even
+        # when they fall outside this cap.
+        "auto_archive_keep_recent": 100,
+        # Also archive inactive surfaced conversations older than this many
+        # days, even when the recent cap has not been exceeded. 0 disables the
+        # age cutoff while leaving the keep_recent cap active.
+        "auto_archive_after_days": 14,
+        # Avoid sweeping state.db on every renderer refresh.
+        "auto_archive_min_interval_hours": 6,
+        # Match the desktop sidebar's normal min_messages=1 list so empty
+        # abandoned drafts are left to the explicit empty-session cleanup.
+        "auto_archive_min_messages": 1,
+        # Sessions with ended_at=NULL and activity inside this window are
+        # presumed live and never auto-archived. Matches the web API's existing
+        # active-session heuristic.
+        "auto_archive_active_grace_seconds": 300,
         # When true, prune ended sessions older than retention_days once
         # per (roughly) min_interval_hours at CLI/gateway/cron startup.
         # Only touches ended sessions — active sessions are always preserved.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9445,12 +9445,79 @@ def _session_latest_descendant(session_id: str, db):
 # templated ``/api/sessions/{session_id}`` family that follows. FastAPI/
 # Starlette match routes in registration order, and the ``{session_id}``
 # pattern is unconstrained — it would otherwise swallow e.g.
-# ``DELETE /api/sessions/empty``, ``POST /api/sessions/bulk-delete``, or
-# ``GET /api/sessions/stats`` as "operate on the session with id
-# 'empty'" / "'bulk-delete'" / "'stats'", which would 404 (or worse,
-# succeed and delete the wrong row). Same story as the older
-# ``/api/sessions/search`` endpoint up at line ~1191. If you split or
-# reorder this block, move every route in it together.
+# ``DELETE /api/sessions/empty``, ``POST /api/sessions/bulk-delete``,
+# ``POST /api/sessions/auto-archive``, or ``GET /api/sessions/stats`` as
+# "operate on the session with id 'empty'" / "'bulk-delete'" /
+# "'auto-archive'" / "'stats'", which would 404 (or worse, succeed and
+# update the wrong row). Same story as the older ``/api/sessions/search``
+# endpoint up at line ~1191. If you split or reorder this block, move every
+# route in it together.
+class AutoArchiveSessions(BaseModel):
+    preserve_ids: Optional[List[str]] = None
+    keep_recent: Optional[int] = None
+    older_than_days: Optional[int] = None
+    min_interval_hours: Optional[float] = None
+
+
+@app.post("/api/sessions/auto-archive")
+async def auto_archive_sessions_endpoint(body: AutoArchiveSessions):
+    """Soft-archive old sessions so desktop restarts stay uncluttered.
+
+    Desktop owns pinned-session state in localStorage, so it sends the ids to
+    preserve on each startup/refresh. The backend persists the archive flag in
+    state.db; archived sessions disappear from normal `/api/sessions` results
+    but remain recoverable from the Archived Sessions settings panel.
+    """
+    preserve_ids = [
+        str(sid).strip()
+        for sid in (body.preserve_ids or [])
+        if str(sid).strip()
+    ]
+    if len(preserve_ids) > 5000:
+        raise HTTPException(
+            status_code=400,
+            detail="preserve_ids must contain at most 5000 entries",
+        )
+
+    cfg = (load_config().get("sessions") or {})
+    if not cfg.get("auto_archive", True):
+        return {"ok": True, "skipped": True, "archived": 0, "reason": "disabled"}
+
+    keep_recent = (
+        body.keep_recent
+        if body.keep_recent is not None
+        else cfg.get("auto_archive_keep_recent", 100)
+    )
+    older_than_days = (
+        body.older_than_days
+        if body.older_than_days is not None
+        else cfg.get("auto_archive_after_days", 14)
+    )
+    min_interval_hours = (
+        body.min_interval_hours
+        if body.min_interval_hours is not None
+        else cfg.get("auto_archive_min_interval_hours", 6)
+    )
+    min_message_count = int(cfg.get("auto_archive_min_messages", 1))
+    active_grace_seconds = int(cfg.get("auto_archive_active_grace_seconds", 300))
+
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        result = db.maybe_auto_archive_old_sessions(
+            keep_recent=max(0, int(keep_recent or 0)),
+            older_than_days=max(0, int(older_than_days or 0)),
+            min_interval_hours=max(0.0, float(min_interval_hours or 0)),
+            min_message_count=max(0, min_message_count),
+            preserve_ids=preserve_ids,
+            active_grace_seconds=max(0, active_grace_seconds),
+        )
+        return {"ok": True, **result}
+    finally:
+        db.close()
+
+
 class BulkDeleteSessions(BaseModel):
     ids: List[str]
     profile: Optional[str] = None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6341,6 +6341,195 @@ class SessionDB:
 
         return result
 
+    def archive_old_sessions(
+        self,
+        *,
+        keep_recent: int = 100,
+        older_than_days: int = 14,
+        min_message_count: int = 1,
+        preserve_ids: Optional[List[str]] = None,
+        active_grace_seconds: int = 300,
+    ) -> int:
+        """Soft-archive old surfaced sessions while keeping recent work visible.
+
+        This is intentionally a soft hide (``sessions.archived = 1``), not a
+        delete.  It is designed for desktop/sidebar maintenance where a heavy
+        user can have thousands of old chats, but still needs Settings ->
+        Archived Chats to restore them.
+
+        A session is eligible when it is surfaced by ``list_sessions_rich``
+        (root conversations and branch sessions, not hidden subagent children),
+        has at least ``min_message_count`` messages, is not preserved by id, and
+        is either older than ``older_than_days`` or outside the most-recent
+        ``keep_recent`` surfaced conversations.  Recent live sessions
+        (``ended_at IS NULL`` and activity within ``active_grace_seconds``) are
+        kept even when they would otherwise fall outside the cap.
+        """
+        keep_recent = max(0, int(keep_recent or 0))
+        older_than_days = max(0, int(older_than_days or 0))
+        min_message_count = max(0, int(min_message_count or 0))
+        active_grace_seconds = max(0, int(active_grace_seconds or 0))
+        if keep_recent <= 0 and older_than_days <= 0:
+            return 0
+
+        preserved = {
+            str(sid).strip()
+            for sid in (preserve_ids or [])
+            if str(sid).strip()
+        }
+        now = time.time()
+        cutoff = now - older_than_days * 86400 if older_than_days > 0 else None
+        archive_ids: List[str] = []
+        seen_targets = set()
+
+        sessions = self.list_sessions_rich(
+            limit=100000,
+            offset=0,
+            min_message_count=min_message_count,
+            include_archived=False,
+            archived_only=False,
+            order_by_last_active=True,
+        )
+        for index, session in enumerate(sessions):
+            sid = str(session.get("id") or "").strip()
+            if not sid:
+                continue
+            root_id = str(session.get("_lineage_root_id") or sid).strip()
+            target_id = root_id or sid
+            if target_id in seen_targets:
+                continue
+            seen_targets.add(target_id)
+            if sid in preserved or target_id in preserved:
+                continue
+
+            started_at = float(session.get("started_at") or 0)
+            last_active = float(session.get("last_active") or started_at)
+            ended_at = session.get("ended_at")
+            recently_active = (
+                ended_at is None
+                and active_grace_seconds > 0
+                and now - last_active < active_grace_seconds
+            )
+            if recently_active:
+                continue
+
+            beyond_recent_cap = keep_recent > 0 and index >= keep_recent
+            past_age_cutoff = cutoff is not None and last_active < cutoff
+            if beyond_recent_cap or past_age_cutoff:
+                archive_ids.append(target_id)
+
+        if not archive_ids:
+            return self.archive_hidden_descendants_of_archived_sessions()
+
+        def _do(conn):
+            placeholders = ",".join("?" for _ in archive_ids)
+            cursor = conn.execute(
+                f"UPDATE sessions SET archived = 1 "
+                f"WHERE archived = 0 AND id IN ({placeholders})",
+                archive_ids,
+            )
+            return cursor.rowcount
+
+        archived = self._execute_write(_do)
+        return archived + self.archive_hidden_descendants_of_archived_sessions()
+
+    def archive_hidden_descendants_of_archived_sessions(self) -> int:
+        """Archive hidden child rows that belong to archived conversations.
+
+        ``session_count()`` counts raw rows, while ``list_sessions_rich`` hides
+        subagent children and compression continuations. Without this sync, a
+        root conversation can be archived while hidden children still inflate
+        the desktop "Sessions X/Y" total. Branch sessions stay visible and are
+        not swept as descendants; they are archived only when they independently
+        match the normal old-session policy.
+        """
+
+        def _do(conn):
+            rows = conn.execute(
+                """
+                WITH RECURSIVE archive_tree(id) AS (
+                    SELECT id FROM sessions WHERE archived = 1
+                    UNION ALL
+                    SELECT child.id
+                    FROM sessions child
+                    JOIN archive_tree parent_tree ON child.parent_session_id = parent_tree.id
+                    LEFT JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE child.archived = 0
+                      AND json_extract(child.model_config, '$._branched_from') IS NULL
+                      AND NOT (
+                          COALESCE(parent.end_reason, '') = 'branched'
+                          AND child.started_at >= parent.ended_at
+                      )
+                )
+                SELECT s.id
+                FROM sessions s
+                JOIN archive_tree tree ON tree.id = s.id
+                WHERE s.archived = 0
+                """
+            ).fetchall()
+            ids = [row["id"] for row in rows]
+            updated = 0
+            for start in range(0, len(ids), 500):
+                chunk = ids[start:start + 500]
+                placeholders = ",".join("?" for _ in chunk)
+                cursor = conn.execute(
+                    f"UPDATE sessions SET archived = 1 "
+                    f"WHERE archived = 0 AND id IN ({placeholders})",
+                    chunk,
+                )
+                updated += cursor.rowcount
+            return updated
+
+        return self._execute_write(_do)
+
+    def maybe_auto_archive_old_sessions(
+        self,
+        *,
+        keep_recent: int = 100,
+        older_than_days: int = 14,
+        min_interval_hours: float = 6,
+        min_message_count: int = 1,
+        preserve_ids: Optional[List[str]] = None,
+        active_grace_seconds: int = 300,
+    ) -> Dict[str, Any]:
+        """Idempotent auto-maintenance wrapper around old-session archiving."""
+        result: Dict[str, Any] = {"skipped": False, "archived": 0}
+        try:
+            last_raw = self.get_meta("last_auto_archive")
+            now = time.time()
+            interval_seconds = max(0.0, float(min_interval_hours or 0)) * 3600
+            if last_raw and interval_seconds > 0:
+                try:
+                    last_ts = float(last_raw)
+                    if now - last_ts < interval_seconds:
+                        result["skipped"] = True
+                        return result
+                except (TypeError, ValueError):
+                    pass
+
+            archived = self.archive_old_sessions(
+                keep_recent=keep_recent,
+                older_than_days=older_than_days,
+                min_message_count=min_message_count,
+                preserve_ids=preserve_ids,
+                active_grace_seconds=active_grace_seconds,
+            )
+            result["archived"] = archived
+            self.set_meta("last_auto_archive", str(now))
+            if archived > 0:
+                logger.info(
+                    "state.db auto-maintenance: archived %d old session(s) "
+                    "(keep_recent=%d, older_than_days=%d)",
+                    archived,
+                    keep_recent,
+                    older_than_days,
+                )
+        except Exception as exc:
+            logger.warning("state.db auto-archive failed: %s", exc)
+            result["error"] = str(exc)
+
+        return result
+
     # ── Handoff (cross-platform session transfer) ──────────────────────────
     #
     # State machine:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1114,6 +1114,58 @@ class TestWebServerEndpoints:
         restored = self.client.get("/api/sessions").json()
         assert any(s["id"] == "arch-me" for s in restored["sessions"])
 
+    def test_auto_archive_endpoint_preserves_ids_and_hides_old_sessions(self):
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        def _seed(db, sid: str, last_active: float):
+            db.create_session(session_id=sid, source="cli")
+            db.append_message(session_id=sid, role="user", content=f"hello {sid}")
+            db.end_session(sid, end_reason="done")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+                (last_active - 10, last_active, sid),
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+                (last_active, sid),
+            )
+
+        now = _time.time()
+        db = SessionDB()
+        try:
+            _seed(db, "recent", now)
+            _seed(db, "old-preserved", now - 200)
+            _seed(db, "old-archive", now - 300)
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.post(
+            "/api/sessions/auto-archive",
+            json={
+                "preserve_ids": ["old-preserved"],
+                "keep_recent": 1,
+                "older_than_days": 0,
+                "min_interval_hours": 0,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["archived"] == 1
+
+        listed = self.client.get("/api/sessions?limit=10").json()["sessions"]
+        listed_ids = {s["id"] for s in listed}
+        assert "recent" in listed_ids
+        assert "old-preserved" in listed_ids
+        assert "old-archive" not in listed_ids
+
+        archived = self.client.get(
+            "/api/sessions?archived=only&limit=10"
+        ).json()["sessions"]
+        assert any(s["id"] == "old-archive" for s in archived)
+
     def test_patch_session_without_fields_is_400(self):
         """An existing session + empty body is a bad request, not a 404."""
         from hermes_state import SessionDB
@@ -1336,6 +1388,28 @@ class TestWebServerEndpoints:
         # ...carrying the durable lineage root so the desktop can match pins.
         tip = next(r for r in rows if r["id"] == "tip-new")
         assert tip.get("_lineage_root_id") == "root-old"
+
+    def test_get_sessions_total_counts_surfaced_conversations(self):
+        """Hidden child rows must not inflate the desktop session total."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="root-visible", source="cli")
+            db.append_message("root-visible", role="user", content="root")
+            db.create_session(
+                session_id="hidden-child",
+                source="cli",
+                parent_session_id="root-visible",
+            )
+            db.append_message("hidden-child", role="user", content="child")
+        finally:
+            db.close()
+
+        data = self.client.get("/api/sessions?limit=10&min_messages=1").json()
+        ids = [row["id"] for row in data["sessions"]]
+        assert ids == ["root-visible"]
+        assert data["total"] == 1
 
     def test_search_dedupes_compression_lineage_to_tip(self):
         """A conversation that auto-compresses leaves the matched term in both

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4239,6 +4239,150 @@ class TestAutoMaintenance:
         )
         db._conn.commit()
 
+    def _make_archivable_session(
+        self,
+        db,
+        sid: str,
+        *,
+        last_active: float,
+        ended: bool = True,
+    ):
+        db.create_session(session_id=sid, source="cli")
+        db.append_message(session_id=sid, role="user", content=f"hello {sid}")
+        if ended:
+            db.end_session(sid, end_reason="done")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (
+                last_active - 10,
+                last_active if ended else None,
+                sid,
+            ),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (last_active, sid),
+        )
+        db._conn.commit()
+
+    def test_auto_archive_hides_sessions_beyond_recent_cap(self, db):
+        now = time.time()
+        for idx in range(5):
+            self._make_archivable_session(
+                db,
+                f"s{idx}",
+                last_active=now - idx * 60,
+            )
+
+        archived = db.archive_old_sessions(
+            keep_recent=2,
+            older_than_days=0,
+        )
+
+        assert archived == 3
+        assert db.session_count(include_archived=False) == 2
+        assert db.session_count(archived_only=True) == 3
+        assert db.get_session("s0")["archived"] == 0
+        assert db.get_session("s1")["archived"] == 0
+        assert db.get_session("s2")["archived"] == 1
+        assert db.get_session("s4")["archived"] == 1
+
+    def test_auto_archive_preserves_requested_and_recent_live_sessions(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "recent", last_active=now)
+        self._make_archivable_session(db, "old-preserved", last_active=now - 500)
+        self._make_archivable_session(db, "old-archive", last_active=now - 600)
+        self._make_archivable_session(
+            db,
+            "live-recent",
+            last_active=now - 700,
+            ended=False,
+        )
+
+        archived = db.archive_old_sessions(
+            keep_recent=1,
+            older_than_days=0,
+            preserve_ids=["old-preserved"],
+            active_grace_seconds=3600,
+        )
+
+        assert archived == 1
+        assert db.get_session("recent")["archived"] == 0
+        assert db.get_session("old-preserved")["archived"] == 0
+        assert db.get_session("live-recent")["archived"] == 0
+        assert db.get_session("old-archive")["archived"] == 1
+
+    def test_auto_archive_syncs_hidden_descendants_not_visible_branches(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "archived-root", last_active=now - 500)
+        db.set_session_archived("archived-root", True)
+        db.create_session(
+            session_id="hidden-child",
+            source="cli",
+            parent_session_id="archived-root",
+        )
+        db.append_message("hidden-child", role="user", content="child")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 490, "hidden-child"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (now - 490, "hidden-child"),
+        )
+
+        db.create_session(session_id="branch-parent", source="cli")
+        db.append_message("branch-parent", role="user", content="parent")
+        db.end_session("branch-parent", end_reason="branched")
+        db.set_session_archived("branch-parent", True)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (now - 400, now - 390, "branch-parent"),
+        )
+        db.create_session(
+            session_id="visible-branch",
+            source="cli",
+            parent_session_id="branch-parent",
+        )
+        db.append_message("visible-branch", role="user", content="branch")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 380, "visible-branch"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (now - 380, "visible-branch"),
+        )
+        db._conn.commit()
+
+        archived = db.archive_old_sessions(keep_recent=100, older_than_days=14)
+
+        assert archived == 1
+        assert db.get_session("hidden-child")["archived"] == 1
+        assert db.get_session("visible-branch")["archived"] == 0
+
+    def test_maybe_auto_archive_uses_interval_marker(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "old1", last_active=now - 100)
+
+        first = db.maybe_auto_archive_old_sessions(
+            keep_recent=0,
+            older_than_days=1,
+            min_interval_hours=24,
+        )
+        assert first["skipped"] is False
+        assert first["archived"] == 0
+
+        self._make_archivable_session(db, "old2", last_active=now - 200)
+        second = db.maybe_auto_archive_old_sessions(
+            keep_recent=1,
+            older_than_days=0,
+            min_interval_hours=24,
+        )
+        assert second["skipped"] is True
+        assert second["archived"] == 0
+        assert db.get_session("old2")["archived"] == 0
+
     def test_first_run_prunes_and_vacuums(self, db):
         self._make_old_ended(db, "old1", days_old=100)
         self._make_old_ended(db, "old2", days_old=100)


### PR DESCRIPTION
## What changed

- Added a soft auto-archive maintenance path for old surfaced sessions in `state.db`.
- Added a desktop API endpoint that persists archive state while preserving pinned, selected, and working session ids sent by the renderer.
- Wired desktop session refresh to run the archive pass before loading the normal `archived=exclude` sidebar list.
- Added session config defaults so the behavior is durable and tunable: keep the latest 100 surfaced chats, archive inactive chats older than 14 days, and skip repeated sweeps for 6 hours.
- Tightened stale-live handling to the existing 300-second active-session heuristic, archives hidden descendants under archived roots, and makes `/api/sessions` totals count the same surfaced conversations the endpoint returns.

## Why

Heavy desktop installs can accumulate thousands of historical sessions. Hermes already supports soft-archived sessions, but there was no automatic persistent path to move old chats out of the active desktop list across app restarts. The raw session total also counted hidden child rows, so the sidebar could still report hundreds or thousands of sessions even after roots were archived.

## Impact

Old chats are soft-hidden from the default Sessions list instead of deleted. Users can still restore them from the Archived Sessions settings panel. Recent live sessions and locally pinned/selected/working sessions are preserved. Sidebar totals now match surfaced conversations instead of hidden child rows.

## Validation

- `python3 -m pytest tests/test_hermes_state.py::TestAutoMaintenance tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_auto_archive_endpoint_preserves_ids_and_hides_old_sessions tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_archive_session_via_patch tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_total_counts_surfaced_conversations tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_forwards_min_messages`
- `python3 -m py_compile hermes_state.py hermes_cli/web_server.py hermes_cli/config.py`
- `npm run type-check --workspace apps/desktop`
- `npm exec --workspace apps/desktop -- eslint src/hermes.ts src/app/desktop-controller.tsx`

## Fork rollout

- Original fork PR merged: https://github.com/OmarB97/hermes-agent/pull/89
- Fork follow-up PR: https://github.com/OmarB97/hermes-agent/pull/91