### PR TITLE
fix(agent): recover from local context overflows

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -279,6 +279,41 @@ def _ra():
     return run_agent
 
 
+def _emit_preflight_token_usage(agent: Any, request_tokens: int) -> None:
+    """Send the current request-size estimate through the live usage channel."""
+    if request_tokens <= 0:
+        return
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return
+
+    try:
+        previous = getattr(compressor, "last_prompt_tokens", 0) or 0
+        if request_tokens > previous:
+            compressor.last_prompt_tokens = request_tokens
+    except Exception:
+        logger.debug("could not update preflight context estimate", exc_info=True)
+
+    emit = getattr(agent, "_emit_token_usage", None)
+    if not callable(emit):
+        return
+
+    try:
+        emit(
+            input_tokens=getattr(agent, "session_input_tokens", 0)
+            or getattr(agent, "session_prompt_tokens", 0)
+            or 0,
+            output_tokens=getattr(agent, "session_output_tokens", 0)
+            or getattr(agent, "session_completion_tokens", 0)
+            or 0,
+            total_tokens=getattr(agent, "session_total_tokens", 0) or 0,
+            context_tokens=request_tokens,
+            context_length=getattr(compressor, "context_length", 0) or 0,
+        )
+    except Exception:
+        logger.debug("could not emit preflight token usage", exc_info=True)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -4718,7 +4753,8 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE.format(tokens=approx_tokens, attempt=compression_attempts, cap=max_compression_attempts))
+                    pre_compress_request_tokens = request_pressure_tokens if request_pressure_tokens > 0 else approx_tokens
+                    agent._buffer_status(COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE.format(tokens=pre_compress_request_tokens, attempt=compression_attempts, cap=max_compression_attempts))
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -4755,6 +4791,7 @@ def run_conversation(
                             agent._buffer_status(COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
+                        _emit_preflight_token_usage(agent, new_tokens)
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1207,6 +1207,46 @@ def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
     return None
 
 
+def _provider_confirmed_config_cap(
+    model: str,
+    base_url: str,
+    configured_length: int,
+    provider: str = "",
+) -> Optional[int]:
+    """Return a cached lower cap that should constrain explicit config.
+
+    Explicit config normally wins.  For custom/local OpenAI-compatible servers,
+    though, a cached lower value means the endpoint has already proven that the
+    configured window is too optimistic.  Honor that evidence so a restarted
+    Hermes process does not keep advertising an impossible context size.
+    """
+    if not base_url or not configured_length or provider == "lmstudio":
+        return None
+
+    normalized_provider = (provider or "").lower()
+    if _is_known_provider_base_url(base_url) and normalized_provider not in {"custom", "local"}:
+        return None
+    if normalized_provider not in {"", "custom", "local", "openai-compatible"} and not is_local_endpoint(base_url):
+        return None
+
+    candidates = [model]
+    stripped = _strip_provider_prefix(model)
+    if stripped != model:
+        candidates.append(stripped)
+
+    for candidate in candidates:
+        cached = get_cached_context_length(candidate, base_url)
+        if (
+            isinstance(cached, int)
+            and 1024 <= cached < configured_length
+            and not (cached <= 32768 and _model_name_suggests_kimi(candidate))
+            and not (cached <= 204_800 and _model_name_suggests_minimax_m3(candidate))
+            and not (cached <= 256_000 and _model_name_suggests_grok_4_3(candidate))
+        ):
+            return cached
+    return None
+
+
 def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     """Drop a stale cache entry so it gets re-resolved on the next lookup."""
     key = _context_cache_key(model, base_url)
@@ -1257,6 +1297,8 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     patterns = [
         r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
+        r'available\s+context\s+size\s*\(?\s*(\d{4,})\s*tokens?\s*\)?',
+        r'\bn_ctx[\'"]?\s*[:=]\s*(\d{4,})',
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
@@ -2190,8 +2232,22 @@ def get_model_context_length(
     7. Local server query (before hardcoded defaults for local endpoints)
     8. Hardcoded defaults (broad family patterns, longest-key-first)
     9. Default fallback (256K)"""
-    # 0. Explicit config override — user knows best
+    # 0. Explicit config override — user knows best, unless a custom/local
+    # endpoint has already rejected that larger window and cached a lower cap.
     if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
+        provider_cap = _provider_confirmed_config_cap(
+            model,
+            base_url,
+            config_context_length,
+            provider=provider,
+        )
+        if provider_cap is not None:
+            logger.info(
+                "Using provider-confirmed context cap for %s@%s: %s "
+                "(configured %s)",
+                model, base_url, f"{provider_cap:,}", f"{config_context_length:,}",
+            )
+            return provider_cap
         return config_context_length
 
     # 0a. MoA virtual provider — ``model`` is a preset name, not a real model,
@@ -2243,6 +2299,19 @@ def get_model_context_length(
                 custom_providers=custom_providers,
             )
             if cp_ctx:
+                provider_cap = _provider_confirmed_config_cap(
+                    model,
+                    base_url,
+                    cp_ctx,
+                    provider=provider or "custom",
+                )
+                if provider_cap is not None:
+                    logger.info(
+                        "Using provider-confirmed context cap for custom provider "
+                        "%s@%s: %s (configured %s)",
+                        model, base_url, f"{provider_cap:,}", f"{cp_ctx:,}",
+                    )
+                    return provider_cap
                 return cp_ctx
         except Exception:
             pass  # fall through to probing

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1670,6 +1670,14 @@ class TestParseContextLimitFromError:
         msg = "Maximum context size 65536 exceeded"
         assert parse_context_limit_from_error(msg) == 65536
 
+    def test_available_context_size_format(self):
+        msg = "HTTP 400: request (70838 tokens) exceeds the available context size (65536 tokens), try increasing it"
+        assert parse_context_limit_from_error(msg) == 65536
+
+    def test_structured_n_ctx_format(self):
+        msg = "llama runner rejected request: {'n_prompt_tokens': 70838, 'n_ctx': 65536}"
+        assert parse_context_limit_from_error(msg) == 65536
+
     def test_no_limit_in_message(self):
         assert parse_context_limit_from_error("Something went wrong with the API") is None
 
@@ -1823,6 +1831,18 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length("unknown/model", "http://local", 65536)
             assert get_model_context_length("unknown/model", base_url="http://local") == 65536
+
+    def test_provider_confirmed_cache_caps_over_optimistic_custom_config(self, tmp_path):
+        cache_file = tmp_path / "cache.yaml"
+        base_url = "http://10.10.20.211:8080/v1"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("qwen3.6-27b", base_url, 65536)
+            assert get_model_context_length(
+                "qwen3.6-27b",
+                base_url=base_url,
+                provider="custom",
+                config_context_length=131072,
+            ) == 65536
 
     def test_special_chars_in_model_name(self, tmp_path):
         """Model names with colons, slashes, etc. don't break the cache."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -489,6 +489,57 @@ class TestHTTP413Compression:
             "content": "compressed summary",
         }
 
+    def test_context_overflow_retries_when_compression_reduces_tokens_not_message_count(self, agent):
+        """A summarizer can shrink message content without shrinking message count."""
+        agent.base_url = "http://10.10.20.211:8080/v1"
+        agent.provider = "custom"
+        agent.context_compressor.context_length = 131_072
+
+        err_400 = Exception(
+            "HTTP 400: request (70838 tokens) exceeds the available context size "
+            "(65536 tokens), try increasing it"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question " * 200},
+            {"role": "assistant", "content": "previous answer " * 200},
+        ]
+
+        request_estimate_calls = {"n": 0}
+
+        def _request_estimate(*_args, **_kwargs):
+            request_estimate_calls["n"] += 1
+            return 70_838 if request_estimate_calls["n"] == 1 else 37_142
+
+        def _compress_same_count(messages, *_args, **_kwargs):
+            return (
+                [
+                    {**msg, "content": f"short {idx}"}
+                    for idx, msg in enumerate(messages)
+                ],
+                "compressed prompt",
+            )
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_request_estimate),
+            patch("agent.conversation_loop.save_context_length"),
+            patch.object(agent, "_compress_context", side_effect=_compress_same_count) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.client.chat.completions.create.call_count == 2
+        assert agent.context_compressor.context_length == 65_536
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert result.get("compression_exhausted") is not True
+
     def test_413_cannot_compress_further(self, agent):
         """When compression can't reduce messages, return partial result."""
         err_413 = _make_413_error()


### PR DESCRIPTION
## Summary
- cap custom/local configured context lengths when the provider reports a smaller confirmed runtime limit
- parse local provider overflow messages that mention available context size or n_ctx
- let context-overflow recovery retry when compression lowers the request-token estimate even if the message count stays the same
- emit preflight token usage during retry so the UI reflects the reduced request size

## Tests
- python3 -m py_compile agent/conversation_loop.py agent/model_metadata.py
- scripts/run_tests.sh tests/agent/test_model_metadata.py tests/run_agent/test_413_compression.py

Related fork rollout: https://github.com/OmarB97/hermes-agent/pull/87