### PR TITLE
fix(skills): stop blocked updates from force installing

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -958,7 +958,7 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
         installed = lock.get_installed(entry["name"])
         category = _derive_category_from_install_path(installed.get("install_path", "")) if installed else ""
         c.print(f"[bold]Updating:[/] {entry['name']}")
-        do_install(entry["identifier"], category=category, force=True, console=c)
+        do_install(entry["identifier"], category=category, console=c)
 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2201,3 +2201,46 @@ class TestInstallPathSafety:
 
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
+
+
+# ---------------------------------------------------------------------------
+# do_update — must not bypass blocked scan verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestDoUpdateRespectsBlockedVerdict:
+    """Regression test for #38041: do_update() must not pass force=True to
+    do_install(), otherwise blocked scan verdicts are silently overridden."""
+
+    def test_do_update_does_not_force_install(self):
+        """do_update must call do_install without force=True."""
+        from hermes_cli.skills_hub import do_update
+
+        fake_updates = [
+            {
+                "name": "test-skill",
+                "identifier": "owner/repo/test-skill",
+                "status": "update_available",
+            }
+        ]
+
+        calls = []
+
+        def mock_do_install(identifier, **kwargs):
+            calls.append(kwargs)
+
+        mock_lock = MagicMock()
+        mock_lock.get_installed.return_value = {
+            "install_path": "~/.hermes/skills/test-skill",
+        }
+
+        with patch("hermes_cli.skills_hub.do_install", mock_do_install), \
+             patch("tools.skills_hub.check_for_skill_updates", return_value=fake_updates), \
+             patch("tools.skills_hub.HubLockFile", return_value=mock_lock):
+            do_update()
+
+        assert len(calls) == 1
+        assert calls[0].get("force") is not True, (
+            "do_update() must not pass force=True to do_install(); "
+            "this bypasses blocked scan verdicts (#38041)"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes `do_update()` in `hermes_cli/skills_hub.py` to respect the Skills Guard scan verdict. Previously, `do_update()` called `do_install()` with `force=True`, which caused `should_allow_install()` to return `True` for non-dangerous BLOCKED verdicts — silently overriding the security scan and installing skill updates that should have been blocked.

## Related Issue

Fixes #38041

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py`: Removed `force=True` from `do_update()`'s call to `do_install()`. The normal install policy now applies: safe verdicts install automatically, caution/community verdicts are blocked, and dangerous verdicts are always blocked.
- `tests/tools/test_skills_hub.py`: Added `TestDoUpdateRespectsBlockedVerdict` with `test_do_update_does_not_force_install` — verifies that `do_update()` never passes `force=True` to `do_install()`.

## How to Test

1. Run `pytest tests/tools/test_skills_hub.py::TestDoUpdateRespectsBlockedVerdict -v` — the regression test should pass
2. Run `pytest tests/tools/test_skills_guard.py -v` — all 80 existing guard tests should pass
3. Run `pytest tests/tools/test_skills_hub.py -v` — all 142 hub tests should pass
4. Manual verification: install a community skill, then modify its SKILL.md to trigger a "caution" verdict on scan. Run `hermes skills update` — the update should be blocked instead of silently installed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/skills_hub.py:do_update()` (callers: CLI `skills update` subcommand, TUI gateway `skills.manage` update action)
- Analyzed: `tools/skills_guard.py:should_allow_install()` (callers: `hermes_cli/skills_hub.py:do_install()`, `tui_gateway/server.py`)
- Blast radius: LOW — single line change, only affects the update path, install path unchanged
- Related patterns: `should_allow_install()` already has a `force` parameter with correct semantics (dangerous verdicts cannot be overridden); the bug was that `do_update()` unconditionally opted into the force override
