### PR TITLE
feat(caching): add prompt_caching.enabled config override + force_enabled kwarg

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1157,6 +1157,7 @@ def anthropic_prompt_cache_policy(
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
     model: Optional[str] = None,
+    force_enabled: Optional[bool] = None,
 ) -> tuple[bool, bool]:
     """Decide whether to apply Anthropic prompt caching and which layout to use.
 
@@ -1191,6 +1192,29 @@ def anthropic_prompt_cache_policy(
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower
+
+    # Config-level force-enable: ``prompt_caching.enabled: true`` in
+    # config.yaml overrides URL-based detection.  Useful when routing
+    # through a local proxy (localhost) that forwards to a caching-capable
+    # gateway, or for any custom provider known to honour cache_control.
+    # Uses OpenAI-wire envelope layout (native_anthropic=False) since
+    # the target is a LiteLLM-style proxy, not the native Anthropic API.
+    if force_enabled is None:
+        try:
+            from hermes_cli.config import load_config as _load_pc_cfg
+            _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+            _cfg_enabled = _pc_cfg.get("enabled")
+            if _cfg_enabled is True and is_claude:
+                return True, False
+            if _cfg_enabled is False:
+                return False, False
+        except Exception:
+            pass
+    elif force_enabled is True and is_claude:
+        return True, False
+    elif force_enabled is False:
+        return False, False
+
     is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
     # Nous Portal proxies to OpenRouter behind the scenes — identical
     # OpenAI-wire envelope cache_control semantics. Treat it as an

--- a/run_agent.py
+++ b/run_agent.py
@@ -1178,10 +1178,11 @@ class AIAgent:
         base_url: Optional[str] = None,
         api_mode: Optional[str] = None,
         model: Optional[str] = None,
+        force_enabled: Optional[bool] = None,
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.anthropic_prompt_cache_policy``."""
         from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
-        return anthropic_prompt_cache_policy(self, provider=provider, base_url=base_url, api_mode=api_mode, model=model)
+        return anthropic_prompt_cache_policy(self, provider=provider, base_url=base_url, api_mode=api_mode, model=model, force_enabled=force_enabled)
 
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -326,6 +326,97 @@ class TestExplicitOverrides:
         assert (should, native) == (True, False)
 
 
+class TestForceEnabled:
+    """``force_enabled`` kwarg bypasses URL detection for proxy/localhost scenarios."""
+
+    def test_force_enabled_true_enables_caching_on_localhost(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="http://localhost:8765",
+            api_mode="chat_completions",
+            model="anthropic.claude-sonnet-4-6",
+        )
+        # Without override, localhost URL → no caching
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+        # With force_enabled=True, caching is on with envelope layout
+        assert agent._anthropic_prompt_cache_policy(force_enabled=True) == (True, False)
+
+    def test_force_enabled_false_disables_caching_on_openrouter(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        # Default: caching on
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        # force_enabled=False overrides it off
+        assert agent._anthropic_prompt_cache_policy(force_enabled=False) == (False, False)
+
+    def test_force_enabled_true_non_claude_no_cache(self):
+        # force_enabled=True only activates for Claude models
+        agent = _make_agent(
+            provider="custom",
+            base_url="http://localhost:8765",
+            api_mode="chat_completions",
+            model="moonshotai.kimi-k2.5",
+        )
+        assert agent._anthropic_prompt_cache_policy(force_enabled=True) == (False, False)
+
+
+class TestConfigEnabled:
+    """``prompt_caching.enabled`` in config.yaml overrides URL-based detection."""
+
+    def test_config_enabled_true_activates_on_localhost(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="http://localhost:8765",
+            api_mode="chat_completions",
+            model="anthropic.claude-sonnet-4-6",
+        )
+        import hermes_cli.config as _cfg_mod
+        original_load = _cfg_mod.load_config
+        try:
+            _cfg_mod.load_config = lambda: {"prompt_caching": {"enabled": True, "cache_ttl": "5m"}}
+            result = agent._anthropic_prompt_cache_policy()
+            assert result == (True, False), f"Expected (True, False), got {result}"
+        finally:
+            _cfg_mod.load_config = original_load
+
+    def test_config_enabled_false_suppresses_openrouter(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        import hermes_cli.config as _cfg_mod
+        original_load = _cfg_mod.load_config
+        try:
+            _cfg_mod.load_config = lambda: {"prompt_caching": {"enabled": False}}
+            result = agent._anthropic_prompt_cache_policy()
+            assert result == (False, False), f"Expected (False, False), got {result}"
+        finally:
+            _cfg_mod.load_config = original_load
+
+    def test_config_enabled_missing_falls_through_to_url_detection(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        import hermes_cli.config as _cfg_mod
+        original_load = _cfg_mod.load_config
+        try:
+            # No "enabled" key — should fall through to URL detection (True, False for OpenRouter)
+            _cfg_mod.load_config = lambda: {"prompt_caching": {"cache_ttl": "5m"}}
+            result = agent._anthropic_prompt_cache_policy()
+            assert result == (True, False), f"Expected (True, False), got {result}"
+        finally:
+            _cfg_mod.load_config = original_load
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Long-lived prefix cache policy (cross-session 1h tier)
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a config-level `prompt_caching.enabled` override and a `force_enabled` kwarg to `anthropic_prompt_cache_policy()` so users routing through a local proxy or any non-whitelisted gateway URL can still get `cache_control` markers injected.

## Problem

`anthropic_prompt_cache_policy()` uses URL-based detection to decide whether to inject `cache_control` markers. When routing through a local proxy (`localhost`) that forwards to a caching-capable LiteLLM gateway, the URL check returns `False` and `_use_prompt_caching` is set to `False` at agent init — **zero `cache_control` markers are ever sent on the wire**, even though the upstream gateway supports prompt caching.

Confirmed via logging proxy: every request had `cache_marker_count=0` with `base_url=localhost`, despite the upstream gateway correctly translating `cache_control` markers to Bedrock cachePoint format.

## Changes

- `agent/agent_runtime_helpers.py`: `force_enabled` kwarg + `prompt_caching.enabled` config override
- `run_agent.py`: forward `force_enabled` through the forwarder method
- Tests: `TestForceEnabled` and `TestConfigEnabled` (6 new tests)

## Usage

```yaml
prompt_caching:
  enabled: true   # force on for any Claude model, any endpoint
  cache_ttl: 5m
```

## Tests

`30 passed`