### PR TITLE
fix(gateway): bust cache on auxiliary compression changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -23085,9 +23086,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # would otherwise be silently ignored until the user triggers a
     # different cache eviction (model switch, /reset, etc.).
     #
-    # Each entry is a tuple of (section, key) read from the raw config dict.
+    # Each entry is a config path read from the raw config dict.
     # Add more here as new baked-at-construction config settings are added.
-    _CACHE_BUSTING_CONFIG_KEYS: tuple = (
+    _CACHE_BUSTING_CONFIG_KEYS: tuple[tuple[str, ...], ...] = (
         ("model", "context_length"),
         ("model", "max_tokens"),
         ("compression", "enabled"),
@@ -23097,12 +23098,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "threshold_tokens"),
         ("compression", "codex_gpt55_autoraise"),
         ("compression", "codex_app_server_auto"),
+        ("compression", "codex_responses_native"),
+        ("compression", "codex_responses_compact_threshold"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
         ("compression", "proactive_prune_tokens"),
         ("compression", "proactive_prune_min_result_chars"),
         ("compression", "proactive_prune_min_reclaim_tokens"),
         ("compression", "min_tail_user_messages"),
+        ("auxiliary", "compression", "provider"),
+        ("auxiliary", "compression", "model"),
+        ("auxiliary", "compression", "base_url"),
+        ("auxiliary", "compression", "api_mode"),
+        ("auxiliary", "compression", "context_length"),
+        ("auxiliary", "compression", "fallback_chain"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
         ("checkpoints", "enabled"),
@@ -23158,9 +23167,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _extract_cache_busting_config(cls, user_config: dict | None) -> dict:
         """Pull values that must bust the cached agent.
 
-        Returns a flat dict keyed by 'section.key'.  Missing config keys and
-        non-dict sections yield None values, which still contribute to the
-        signature (so 'absent' vs 'present-and-null' differ).
+        Returns a flat dict keyed by dotted config path. Missing config keys
+        and non-dict intermediate sections yield None values, which still
+        contribute to the signature (so 'absent' vs 'present-and-null' differ).
 
         The live tool registry generation is included too.  MCP reloads and
         dynamic MCP tool-list changes mutate the registry without necessarily
@@ -23170,16 +23179,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         out: Dict[str, Any] = {}
         cfg = user_config if isinstance(user_config, dict) else {}
-        for section, key in cls._CACHE_BUSTING_CONFIG_KEYS:
-            section_val = cfg.get(section)
-            if section == "checkpoints" and isinstance(section_val, bool):
+        for path in cls._CACHE_BUSTING_CONFIG_KEYS:
+            section_val = cfg.get(path[0])
+            if path[0] == "checkpoints" and isinstance(section_val, bool):
                 # Preserve legacy ``checkpoints: true`` behavior.  A live
                 # toggle must still rebuild the cached agent.
-                out[f"{section}.{key}"] = section_val if key == "enabled" else None
-            elif isinstance(section_val, dict):
-                out[f"{section}.{key}"] = section_val.get(key)
-            else:
-                out[f"{section}.{key}"] = None
+                out[".".join(path)] = section_val if path[-1] == "enabled" else None
+                continue
+            cur: Any = cfg
+            for part in path:
+                if not isinstance(cur, dict):
+                    cur = None
+                    break
+                cur = cur.get(part)
+            out[".".join(path)] = cur
+
+        # A fallback chain can contain an inline API key. Keep only a stable
+        # digest in the cache signature so edits rebuild the agent without
+        # retaining raw credentials in cache metadata or debug surfaces.
+        fallback_chain_key = "auxiliary.compression.fallback_chain"
+        fallback_chain = out.get(fallback_chain_key)
+        if fallback_chain is not None:
+            try:
+                serialized_chain = json.dumps(
+                    fallback_chain,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                )
+            except (TypeError, ValueError):
+                serialized_chain = repr(fallback_chain)
+            out[fallback_chain_key] = hashlib.sha256(
+                serialized_chain.encode("utf-8")
+            ).hexdigest()
         try:
             from tools.registry import registry
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -9,6 +9,7 @@ Verifies that the agent cache correctly:
 - Preserves frozen system prompt across turns
 """
 
+import os
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -123,6 +124,8 @@ class TestExtractCacheBustingConfig:
                     "target_ratio": 0.3,
                     "protect_last_n": 25,
                     "codex_app_server_auto": "hermes",
+                    "codex_responses_native": True,
+                    "codex_responses_compact_threshold": 200_000,
                     "some_other_key": "ignored",
                 }
             }
@@ -133,7 +136,63 @@ class TestExtractCacheBustingConfig:
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"
+        assert out["compression.codex_responses_native"] is True
+        assert out["compression.codex_responses_compact_threshold"] == 200_000
 
+    def test_reads_auxiliary_compression_subkeys(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "auxiliary": {
+                    "compression": {
+                        "provider": "summary-provider",
+                        "model": "summary-model",
+                        "base_url": "https://summary.example/v1",
+                        "api_mode": "chat_completions",
+                        "context_length": 272_000,
+                        "fallback_chain": [
+                            {
+                                "provider": "fallback-provider",
+                                "model": "fallback-model",
+                                "api_key": "not-retained-in-cache-metadata",
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+        assert out["auxiliary.compression.provider"] == "summary-provider"
+        assert out["auxiliary.compression.model"] == "summary-model"
+        assert out["auxiliary.compression.base_url"] == "https://summary.example/v1"
+        assert out["auxiliary.compression.api_mode"] == "chat_completions"
+        assert out["auxiliary.compression.context_length"] == 272_000
+        fingerprint = out["auxiliary.compression.fallback_chain"]
+        assert isinstance(fingerprint, str)
+        assert "not-retained-in-cache-metadata" not in fingerprint
+        assert len(fingerprint) == 64
+
+    def test_native_compaction_edit_busts_signature(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        before = GatewayRunner._extract_cache_busting_config(
+            {"compression": {"codex_responses_native": False}}
+        )
+        after = GatewayRunner._extract_cache_busting_config(
+            {
+                "compression": {
+                    "codex_responses_native": True,
+                    "codex_responses_compact_threshold": 200_000,
+                }
+            }
+        )
+
+        assert GatewayRunner._agent_config_signature(
+            "gpt-5.6-sol", runtime, [], "", cache_keys=before
+        ) != GatewayRunner._agent_config_signature(
+            "gpt-5.6-sol", runtime, [], "", cache_keys=after
+        )
 
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
@@ -141,27 +200,34 @@ class TestExtractCacheBustingConfig:
 
         out = GatewayRunner._extract_cache_busting_config({})
         # Every documented cache-busting key must be present, even if None
-        for section, key in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
-            assert f"{section}.{key}" in out
-            assert out[f"{section}.{key}"] is None
+        for path in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
+            key = ".".join(path)
+            assert key in out
+            assert out[key] is None
 
     def test_non_dict_section_treated_as_missing(self):
         from gateway.run import GatewayRunner
 
         # compression is a string — should not crash, all compression.* keys None
         out = GatewayRunner._extract_cache_busting_config(
-            {"compression": "broken", "model": {"context_length": 100_000}}
+            {
+                "compression": "broken",
+                "model": {"context_length": 100_000},
+                "auxiliary": {"compression": "broken"},
+            }
         )
         assert out["compression.enabled"] is None
         assert out["compression.threshold"] is None
         assert out["model.context_length"] == 100_000
+        assert out["auxiliary.compression.provider"] is None
+        assert out["auxiliary.compression.model"] is None
 
     def test_none_config_is_safe(self):
         from gateway.run import GatewayRunner
 
         out = GatewayRunner._extract_cache_busting_config(None)
-        for section, key in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
-            assert out[f"{section}.{key}"] is None
+        for path in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
+            assert out[".".join(path)] is None
         assert "tools.registry_generation" in out
 
     def test_extract_includes_live_tool_registry_generation(self, monkeypatch):
@@ -173,6 +239,207 @@ class TestExtractCacheBustingConfig:
         out = GatewayRunner._extract_cache_busting_config({})
 
         assert out["tools.registry_generation"] == 12345
+
+    def test_skips_honcho_config_read_when_provider_is_not_honcho(self, monkeypatch):
+        """Non-Honcho gateways must not read/parse honcho.json on every message."""
+        from gateway.run import GatewayRunner
+
+        called = False
+
+        def _boom():
+            nonlocal called
+            called = True
+            raise AssertionError("should not read Honcho config")
+
+        monkeypatch.setattr(GatewayRunner, "_extract_honcho_cache_busting_config", _boom)
+
+        out = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "mem0"}})
+
+        assert called is False
+        assert out["honcho.peer_name"] is None
+        assert out["honcho.user_peer_aliases"] is None
+
+    def test_reads_honcho_config_only_when_provider_is_honcho(self, monkeypatch):
+        from gateway.run import GatewayRunner
+
+        calls = []
+
+        def _fake():
+            calls.append(True)
+            return {
+                "honcho.peer_name": "eri",
+                "honcho.ai_peer": "hermes",
+                "honcho.pin_peer_name": True,
+                "honcho.runtime_peer_prefix": "tg_",
+                "honcho.user_peer_aliases": [("123", "eri")],
+            }
+
+        monkeypatch.setattr(GatewayRunner, "_extract_honcho_cache_busting_config", _fake)
+
+        out = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
+
+        assert calls == [True]
+        assert out["honcho.peer_name"] == "eri"
+        assert out["honcho.user_peer_aliases"] == [("123", "eri")]
+
+    def test_memory_provider_change_busts_signature(self, monkeypatch):
+        """Switching memory.provider must itself change the cache-busting
+        signature, so the agent is rebuilt when a user swaps providers
+        mid-gateway (independent of the honcho.json identity keys)."""
+        from gateway.run import GatewayRunner
+
+        # Neutralize honcho.json reads so the only varying input is the
+        # provider value itself.
+        monkeypatch.setattr(
+            GatewayRunner,
+            "_extract_honcho_cache_busting_config",
+            classmethod(lambda cls: cls._empty_honcho_cache_busting_config()),
+        )
+
+        sig_honcho = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
+        sig_mem0 = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "mem0"}})
+
+        assert sig_honcho["memory.provider"] == "honcho"
+        assert sig_mem0["memory.provider"] == "mem0"
+        assert sig_honcho != sig_mem0
+
+    def test_honcho_cache_busting_config_memoized_by_mtime(self, monkeypatch, tmp_path):
+        """Repeated Honcho extraction for unchanged honcho.json should reuse parse result."""
+        from types import SimpleNamespace
+        from gateway.run import GatewayRunner
+
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text("{}")
+        parse_calls = []
+
+        class FakeConfig:
+            peer_name = "eri"
+            ai_peer = "hermes"
+            pin_peer_name = False
+            runtime_peer_prefix = "tg_"
+            user_peer_aliases = {"123": "eri"}
+
+            @classmethod
+            def from_global_config(cls, config_path=None):
+                parse_calls.append(config_path)
+                return cls()
+
+        fake_client = SimpleNamespace(
+            HonchoClientConfig=FakeConfig,
+            resolve_config_path=lambda: config_path,
+        )
+        monkeypatch.setitem(__import__("sys").modules, "plugins.memory.honcho.client", fake_client)
+        monkeypatch.setattr(GatewayRunner, "_HONCHO_CACHE_BUSTING_MEMO", {})
+
+        first = GatewayRunner._extract_honcho_cache_busting_config()
+        second = GatewayRunner._extract_honcho_cache_busting_config()
+
+        assert first == second
+        assert first["honcho.user_peer_aliases"] == [("123", "eri")]
+        assert parse_calls == [config_path]
+
+        before_stat = config_path.stat()
+        config_path.write_text("{\n  \"changed\": true\n}")
+        os.utime(
+            config_path,
+            ns=(before_stat.st_atime_ns, before_stat.st_mtime_ns + 1_000_000_000),
+        )
+        third = GatewayRunner._extract_honcho_cache_busting_config()
+
+        assert third == first
+        assert parse_calls == [config_path, config_path]
+
+    def test_full_round_trip_busts_cache_on_real_edit(self):
+        """End-to-end: simulate a config edit on main and verify the
+        extracted cache_keys change produces a new signature."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg_before = {
+            "model": {"context_length": 200_000},
+            "compression": {"threshold": 0.50, "enabled": True},
+        }
+        cfg_after = {
+            "model": {"context_length": 200_000},
+            "compression": {"threshold": 0.75, "enabled": True},  # user raised threshold
+        }
+
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+        assert sig_before != sig_after, (
+            "Editing compression.threshold in config.yaml must bust the "
+            "gateway's cached agent so the new threshold takes effect."
+        )
+
+    def test_full_round_trip_busts_cache_on_auxiliary_compression_edit(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg_before = {
+            "auxiliary": {
+                "compression": {"provider": "provider-a", "model": "summary-model-a"}
+            }
+        }
+        cfg_after = {
+            "auxiliary": {
+                "compression": {"provider": "provider-b", "model": "summary-model-b"}
+            }
+        }
+
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+        assert sig_before != sig_after, (
+            "Editing auxiliary.compression.model/provider must bust the "
+            "gateway's cached agent so the new compression model takes effect."
+        )
+
+    def test_full_round_trip_busts_cache_on_auxiliary_fallback_chain_edit(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        cfg_before = {
+            "auxiliary": {
+                "compression": {
+                    "fallback_chain": [
+                        {"provider": "provider-a", "model": "summary-model-a"}
+                    ]
+                }
+            }
+        }
+        cfg_after = {
+            "auxiliary": {
+                "compression": {
+                    "fallback_chain": [
+                        {"provider": "provider-b", "model": "summary-model-b"}
+                    ]
+                }
+            }
+        }
+
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+        assert sig_before != sig_after, (
+            "Editing auxiliary.compression.fallback_chain must bust the "
+            "gateway's cached agent so compression preflight is rebuilt."
+        )
 
 
 class TestAgentCacheLifecycle:
@@ -1061,4 +1328,3 @@ class TestCrossProcessInvalidationDefersCleanup:
         # Stale entry was popped, hard-teardown path never used.
         assert "telegram:s1" not in runner._agent_cache
         runner._cleanup_agent_resources.assert_not_called()
-


### PR DESCRIPTION
## Summary

- include auxiliary compression settings in the gateway agent cache signature, including a sanitized `fallback_chain` fingerprint
- support nested configuration paths while preserving the existing cache-key behavior
- invalidate a cached gateway agent when construction-time auxiliary compression feasibility can change
- add regression coverage for fallback-chain and nested missing-path invalidation

## Why

Gateway agent construction resolves auxiliary compression feasibility and can cache an unavailable-client warning or a reduced compression threshold. Changing the provider, model, endpoint, context length, API mode, or fallback chain must construct a fresh agent instead of retaining that stale state.

The earlier Honcho memoization change was deliberately removed because it overlaps upstream PR #46385; this contribution is now limited to auxiliary compression cache invalidation.

## Validation

- rebased onto `4281151ae859241351ba14d8c7682dc67ff4c126` on 2026-07-11; current head: `4ce5cd577eac58ce1f5d913b879bc9e2ede57367`
- `.venv/bin/python -m pytest -q tests/gateway/test_agent_cache.py` - 81 passed
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_agent_cache.py` and `git diff --check upstream/main...HEAD` passed