### PR TITLE
fix(desktop): extend read aloud timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import {
+  AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
+  AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
+  audioSpeakRequestTimeoutMs,
+  getSessionMessages,
+  listAllProfileSessions,
+  listSessions,
+  speakText
+} from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -9,7 +17,7 @@ const emptySessionsResponse = {
   total: 0
 }
 
-describe('Hermes REST session helpers', () => {
+describe('Hermes REST helpers', () => {
   let api: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -55,6 +63,35 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('bounds blocking TTS synthesis timeouts by text length', () => {
+    expect(audioSpeakRequestTimeoutMs('short message')).toBe(AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS)
+    expect(audioSpeakRequestTimeoutMs('x'.repeat(8_000))).toBe(280_000)
+    expect(audioSpeakRequestTimeoutMs('x'.repeat(100_000))).toBe(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS)
+  })
+
+  it('uses an extended timeout for blocking TTS synthesis', async () => {
+    api.mockResolvedValueOnce({
+      data_url: 'data:audio/mpeg;base64,AA==',
+      mime_type: 'audio/mpeg',
+      ok: true,
+      provider: 'openai'
+    })
+
+    await expect(speakText('Read this aloud')).resolves.toEqual({
+      data_url: 'data:audio/mpeg;base64,AA==',
+      mime_type: 'audio/mpeg',
+      ok: true,
+      provider: 'openai'
+    })
+
+    expect(api).toHaveBeenCalledWith({
+      body: { text: 'Read this aloud' },
+      method: 'POST',
+      path: '/api/audio/speak',
+      timeoutMs: AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -47,6 +47,18 @@ import type {
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+export const AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS = 180_000
+export const AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS = 600_000
+const AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR = 35
+
+export function audioSpeakRequestTimeoutMs(text: string): number {
+  const estimated = Math.max(
+    AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
+    Math.ceil(String(text || '').length * AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR)
+  )
+
+  return Math.min(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS, estimated)
+}
 
 export type {
   ActionResponse,
@@ -803,7 +815,11 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: { text },
+    // TTS blocks until provider synthesis, file read, and base64 encoding
+    // finish. Remote providers and large messages regularly exceed the
+    // default 15s Electron backend timeout.
+    timeoutMs: audioSpeakRequestTimeoutMs(text)
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes #39290.

Hermes Desktop Read Aloud can currently show a false failure after 15 seconds even when backend TTS synthesis succeeds. The failing path is the Desktop renderer bridge request to `/api/audio/speak`: that endpoint blocks until provider synthesis, audio file read, and base64 response encoding finish, so larger messages or slower remote TTS providers can legitimately exceed the default Electron backend timeout.

This PR gives only the blocking Read Aloud request a bounded TTS-specific timeout. Normal Desktop API requests keep the existing short timeout so real backend hangs still fail promptly.

## Changes

- `apps/desktop/src/hermes.ts`: add `audioSpeakRequestTimeoutMs()` with a 180s floor, 600s cap, and text-length scaling for large read-aloud payloads.
- `apps/desktop/src/hermes.ts`: pass the computed timeout only to `/api/audio/speak` via `speakText()`.
- `apps/desktop/src/hermes.test.ts`: add focused Vitest coverage for timeout bounds and the `speakText()` API request shape.

## Validation

Passed:

```text
cd apps/desktop && npm run test:ui -- src/hermes.test.ts
cd apps/desktop && npm run type-check
cd apps/desktop && npx eslint src/hermes.ts src/hermes.test.ts
cd apps/desktop && npx prettier --check src/hermes.ts src/hermes.test.ts
cd apps/desktop && npm run build
```

Manual reproduction evidence before the fix:

```text
Read aloud failed
Time out connecting to Hermes backend after 15000ms
```

Backend synthesis completed after the Electron timeout, confirming this was a bridge timeout rather than a provider failure.

Windows packaged-app validation: Daevalus confirmed that testing `release/win-unpacked/Hermes.exe` requires repacking so `resources/app.asar` contains the updated renderer bundle; after repacking, longer xAI TTS Read Aloud requests that previously exceeded 15s worked correctly. Source: https://github.com/NousResearch/hermes-agent/pull/39286#issuecomment-4626188602

## Notes

- Not run: `pytest tests/ -q`. This PR changes only Desktop TypeScript API-helper code and adds Vitest coverage for that path.
- `cd apps/desktop && npm run test:ui` was attempted, but the full UI suite failed on unrelated existing test discovery/UI issues, including native-deps `node-pty` tests under `build/native-deps` being collected and unrelated failures in `pane-shell`, `skills`, `model-settings`, and `toolset-config-panel` tests.

