### PR TITLE
Fail closed when TUI shell safety checks are unavailable

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2689,6 +2689,35 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     assert "failed" in resp["error"]["message"]
 
 
+def test_shell_exec_fails_closed_when_approval_import_fails(monkeypatch):
+    real_import = __import__
+    calls = []
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tools.approval":
+            raise ImportError("approval unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "shell.exec",
+            "params": {"command": "echo should-not-run"},
+        }
+    )
+
+    assert resp["error"]["code"] == 5004
+    assert "safety checks unavailable" in resp["error"]["message"]
+    assert calls == []
+
+
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
         resp = server.handle_request(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7985,7 +7985,11 @@ def _(rid, params: dict) -> dict:
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        return _err(
+            rid,
+            5004,
+            "command safety checks unavailable; refusing shell.exec",
+        )
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## Summary

This changes the TUI gateway `shell.exec` handler to refuse command execution when the dangerous-command detector cannot be imported. Previously, an `ImportError` from `tools.approval` was silently ignored and the handler continued to `subprocess.run(..., shell=True)`.

## Why

`shell.exec` is a raw command execution surface. If the safety checker is unavailable because of a packaging, import-path, or runtime dependency issue, the safe behavior is to deny the request instead of executing the command without classification.

## Changes

- Return a JSON-RPC error from `shell.exec` when `tools.approval` cannot be imported.
- Add a regression test that simulates the import failure and verifies `subprocess.run` is not called.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k shell_exec_fails_closed_when_approval_import_fails -q --timeout-method=thread
1 passed, 199 deselected

python -m pytest tests/test_tui_gateway_server.py -k "shell_exec or command_dispatch_exec_nonzero_surfaces_error" -q --timeout-method=thread
2 passed, 198 deselected
```