### PR TITLE
fix(desktop): slash commands queued when busy and chip |0 suffix leak

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -16,6 +16,7 @@ interface SlashItemMetadata extends Record<string, string> {
   command: string
   display: string
   meta: string
+  rawText?: string
 }
 
 function textValue(value: unknown, fallback = ''): string {
@@ -91,7 +92,13 @@ export function useSlashCompletions(options: { gateway: HermesGateway | null }):
     const metadata: SlashItemMetadata = {
       command,
       display,
-      meta
+      meta,
+      // Provide rawText so hermesDirectiveFormatter.serialize uses the
+      // direct-insertion path instead of the legacy @type:id fallback.
+      // Without this, the item.id (which includes a "|index" suffix for
+      // trigger-adapter uniqueness) leaks into the serialized chip text
+      // and the submitted command.
+      rawText: command
     }
 
     return {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { chatMessageText } from '@/lib/chat-messages'
+import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
@@ -1037,7 +1038,19 @@ export function ChatBar({
     if (queueEdit) {
       exitQueuedEdit('save')
     } else if (busy) {
-      if (hasComposerPayload) {
+      // Slash commands should execute immediately even while the agent is
+      // busy — they're client-side operations (/yolo, /skin, /new, /help,
+      // etc.) or self-contained gateway RPCs (/status, /compress).  onSubmit
+      // routes them to executeSlashCommand, which has its own per-command
+      // busy guard for commands that genuinely need an idle session (skill
+      // /send directives).  Queuing them would make every slash command wait
+      // for the current turn to finish, which is how the TUI never behaves.
+      if (!attachments.length && SLASH_COMMAND_RE.test(draft.trim())) {
+        const submitted = draft
+        triggerHaptic('submit')
+        clearDraft()
+        void onSubmit(submitted)
+      } else if (hasComposerPayload) {
         queueCurrentDraft()
       } else {
         // Stop button: an explicit interrupt must actually halt the running


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in the desktop app's slash command handling compared to the TUI:

1. **Slash commands get queued instead of running immediately when the agent is busy.** In the TUI, `/yolo`, `/skin`, `/status`, etc. execute instantly regardless of busy state. In the desktop composer, `submitDraft()` unconditionally queued any draft when `busy && hasComposerPayload`, forcing all slash commands to wait for the current turn to finish. This is wrong — most slash commands are client-side operations or self-contained gateway RPCs that don't need an idle session.

2. **Slash command chips show a `|0` suffix.** When selecting a slash command from the autocomplete popover, the trigger item's `id` includes a `|index` suffix for adapter uniqueness (e.g. `/status|0`). Because slash item metadata didn't include `rawText`/`insertId`, `hermesDirectiveFormatter.serialize` fell through to the legacy `@${item.type}:${item.id}` path, producing `@slash:/status|0` — the `|0` leaked into both the chip label and the submitted text.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx` — Added `SLASH_COMMAND_RE` check in `submitDraft()` before the queue branch. Slash commands (no attachments) bypass the queue and go straight to `onSubmit()` → `executeSlashCommand()`, which has its own per-command busy guard.
- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts` — Added `rawText: command` to slash item metadata so `hermesDirectiveFormatter.serialize` returns plain command text (e.g. `/status`) instead of `@slash:/status|0`. Slash commands now enter the composer as plain text, matching `selectSkinSlashCommand` and TUI behavior.

## How to Test

1. Start the desktop app with a provider configured
2. Send a message that triggers a long-running tool call (e.g. a web search or code execution)
3. While the agent is busy, type `/status` or `/yolo` and press Enter
4. **Before fix:** the command is queued and waits for the turn to finish
5. **After fix:** the command executes immediately (same as TUI)
6. Clear the input, type `/` and select a slash command from the popover
7. **Before fix:** the chip in the composer shows `/status|0` (or the plain text contains `|0`)
8. **After fix:** the composer shows `/status` as plain text, no `|0` suffix

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, `docs/`, docstrings)
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] N/A — I've considered cross-platform impact (Windows, macOS)
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior