### PR TITLE
Keep Desktop sessions attached behind overlays

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -68,7 +68,7 @@ import { ModelVisibilityOverlay } from './model-visibility-overlay'
 import { RightSidebarPane } from './right-sidebar'
 import { $terminalTakeover } from './right-sidebar/store'
 import { PersistentTerminal, TerminalSlot } from './right-sidebar/terminal/persistent'
-import { NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from './routes'
 import { useContextSuggestions } from './session/hooks/use-context-suggestions'
 import { useCwdActions } from './session/hooks/use-cwd-actions'
 import { useHermesConfig } from './session/hooks/use-hermes-config'
@@ -133,6 +133,8 @@ export function DesktopController() {
     currentView,
     openAgents,
     openCommandCenterSection,
+    openSettings,
+    openSettingsTab,
     profilesOpen,
     settingsOpen,
     toggleCommandCenter
@@ -315,9 +317,7 @@ export function DesktopController() {
     requestGateway
   })
 
-  const openProviderSettings = useCallback(() => {
-    navigate(`${SETTINGS_ROUTE}?tab=providers`)
-  }, [navigate])
+  const openProviderSettings = useCallback(() => openSettingsTab('providers'), [openSettingsTab])
 
   const modelMenuContent = useMemo(
     () =>
@@ -397,7 +397,6 @@ export function DesktopController() {
     archiveSession,
     branchCurrentSession,
     createBackendSessionForSend,
-    openSettings,
     removeSession,
     resumeSession,
     selectSidebarItem,
@@ -778,9 +777,9 @@ export function DesktopController() {
           />
           <Route element={null} path="cron" />
           <Route element={null} path="profiles" />
-          <Route element={null} path="settings" />
-          <Route element={null} path="command-center" />
-          <Route element={null} path="agents" />
+          <Route element={chatView} path="settings" />
+          <Route element={chatView} path="command-center" />
+          <Route element={chatView} path="agents" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
@@ -2,7 +2,14 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { type CommandCenterSection } from '@/app/command-center'
-import { AGENTS_ROUTE, appViewForPath, COMMAND_CENTER_ROUTE, isOverlayView, NEW_CHAT_ROUTE } from '@/app/routes'
+import {
+  AGENTS_ROUTE,
+  appViewForPath,
+  COMMAND_CENTER_ROUTE,
+  isOverlayView,
+  NEW_CHAT_ROUTE,
+  SETTINGS_ROUTE
+} from '@/app/routes'
 
 const SECTIONS = ['sessions', 'system', 'usage'] as const
 
@@ -34,9 +41,20 @@ export function useOverlayRouting() {
     [location.search]
   )
 
+  const openOverlayRoute = useCallback(
+    (path: string) => {
+      if (!overlayOpen) {
+        returnPathRef.current = `${location.pathname}${location.search}${location.hash}`
+      }
+
+      navigate(path)
+    },
+    [location.hash, location.pathname, location.search, navigate, overlayOpen]
+  )
+
   const openCommandCenterSection = useCallback(
-    (section: CommandCenterSection) => navigate(`${COMMAND_CENTER_ROUTE}?section=${section}`),
-    [navigate]
+    (section: CommandCenterSection) => openOverlayRoute(`${COMMAND_CENTER_ROUTE}?section=${section}`),
+    [openOverlayRoute]
   )
 
   const closeOverlayToPreviousRoute = useCallback(
@@ -48,11 +66,17 @@ export function useOverlayRouting() {
     if (commandCenterOpen) {
       closeOverlayToPreviousRoute()
     } else {
-      navigate(COMMAND_CENTER_ROUTE)
+      openOverlayRoute(COMMAND_CENTER_ROUTE)
     }
-  }, [closeOverlayToPreviousRoute, commandCenterOpen, navigate])
+  }, [closeOverlayToPreviousRoute, commandCenterOpen, openOverlayRoute])
 
-  const openAgents = useCallback(() => navigate(AGENTS_ROUTE), [navigate])
+  const openAgents = useCallback(() => openOverlayRoute(AGENTS_ROUTE), [openOverlayRoute])
+  const openSettings = useCallback(() => openOverlayRoute(SETTINGS_ROUTE), [openOverlayRoute])
+
+  const openSettingsTab = useCallback(
+    (tab: string) => openOverlayRoute(`${SETTINGS_ROUTE}?tab=${tab}`),
+    [openOverlayRoute]
+  )
 
   return {
     agentsOpen,
@@ -64,6 +88,8 @@ export function useOverlayRouting() {
     currentView,
     openAgents,
     openCommandCenterSection,
+    openSettings,
+    openSettingsTab,
     profilesOpen,
     settingsOpen,
     toggleCommandCenter


### PR DESCRIPTION
## Summary
- keep ChatView mounted when opening Desktop overlay routes for Agents, Settings, and Command Center
- capture the return route synchronously before overlay navigation
- route provider settings through the same overlay-safe path

## Why
Opening Agents, Settings, or Command Center during an active Desktop turn could visually drop the user back to a new or empty chat route. The backend turn may still be running, but the UI loses the active session context because the overlay route unmounted the chat surface and could close back to the root route.

## Test Plan
- git diff --check
- local Hermes source: npm run type-check
- local Hermes source: targeted eslint for changed files
- local Hermes source: npm run build

## Known gaps
- full upstream Desktop test suite was not run successfully in the fresh VPS clone because the clone lacks the full dependency/config setup used by the packaged local source
- packaged Windows app was not overwritten while active Desktop work may be running
