### PR TITLE
fix(gateway): harden Discord startup and Telegram fallback discovery

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -205,7 +205,9 @@ async def discover_fallback_ips() -> list[str]:
     """
     async with httpx.AsyncClient(timeout=httpx.Timeout(_DOH_TIMEOUT)) as client:
         doh_tasks = [_query_doh_provider(client, p) for p in _DOH_PROVIDERS]
-        system_dns_task = asyncio.to_thread(_resolve_system_dns)
+        system_dns_task = asyncio.wait_for(
+            asyncio.to_thread(_resolve_system_dns), timeout=_DOH_TIMEOUT
+        )
         results = await asyncio.gather(system_dns_task, *doh_tasks, return_exceptions=True)
 
     # results[0] = system DNS IPs (set), results[1:] = DoH IP lists

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -621,6 +621,143 @@ class DiscordAdapter(BasePlatformAdapter):
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
 
+    async def _await_bot_task_cleanup(self) -> None:
+        """Cancel/await the background discord.py start task.
+
+        ``commands.Bot.start()`` runs in ``self._bot_task`` for the lifetime of
+        the connection. Closing the client makes that task exit, often by
+        raising a Discord transport/auth exception. If we neither await nor
+        cancel it, asyncio logs ``Task exception was never retrieved`` during
+        reconnects and shutdown.
+        """
+
+        task = self._bot_task
+        self._bot_task = None
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("[%s] Suppressed Discord bot task exception during cleanup", self.name, exc_info=True)
+
+    async def _cleanup_client_runtime(self) -> None:
+        """Close the Discord client and await all background connection tasks."""
+
+        client = self._client
+        if client is not None:
+            try:
+                is_closed = False
+                is_closed_fn = getattr(client, "is_closed", None)
+                if callable(is_closed_fn):
+                    try:
+                        is_closed = bool(is_closed_fn())
+                    except Exception:
+                        is_closed = False
+                if not is_closed:
+                    await client.close()
+            except Exception:
+                logger.debug("[%s] Failed to close Discord client during cleanup", self.name, exc_info=True)
+
+        await self._await_bot_task_cleanup()
+
+        if self._post_connect_task and not self._post_connect_task.done():
+            self._post_connect_task.cancel()
+            try:
+                await self._post_connect_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug("[%s] Suppressed Discord post-connect task exception during cleanup", self.name, exc_info=True)
+
+        self._client = None
+        self._ready_event.clear()
+        self._post_connect_task = None
+
+    def _ready_timeout_seconds(self) -> float:
+        return 30.0
+
+    def _classify_bot_start_exception(self, exc: BaseException) -> tuple[str, str, bool]:
+        """Map early discord.py startup failures to gateway fatal-error semantics."""
+
+        login_failure_cls = getattr(discord, "LoginFailure", None) if DISCORD_AVAILABLE and discord is not None else None
+        http_exception_cls = getattr(discord, "HTTPException", None) if DISCORD_AVAILABLE and discord is not None else None
+
+        if isinstance(login_failure_cls, type) and isinstance(exc, login_failure_cls):
+            return (
+                "discord_auth_failed",
+                f"Discord authentication failed: {exc}",
+                False,
+            )
+
+        if isinstance(http_exception_cls, type) and isinstance(exc, http_exception_cls):
+            status = getattr(exc, "status", None)
+            if status == 401:
+                return (
+                    "discord_auth_failed",
+                    f"Discord authentication failed: {exc}",
+                    False,
+                )
+
+        text = str(exc).lower()
+        if "improper token" in text or "401 unauthorized" in text:
+            return (
+                "discord_auth_failed",
+                f"Discord authentication failed: {exc}",
+                False,
+            )
+
+        return (
+            "discord_connect_failed",
+            f"Discord startup failed before on_ready: {exc}",
+            True,
+        )
+
+    async def _wait_for_ready_or_start_failure(self) -> None:
+        """Wait until Discord is ready, or surface the real startup failure."""
+
+        task = self._bot_task
+        if task is None:
+            raise RuntimeError("Discord bot task was not started")
+
+        ready_waiter = asyncio.create_task(self._ready_event.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {task, ready_waiter},
+                timeout=self._ready_timeout_seconds(),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not ready_waiter.done():
+                ready_waiter.cancel()
+                try:
+                    await ready_waiter
+                except asyncio.CancelledError:
+                    pass
+
+        if not done:
+            raise asyncio.TimeoutError()
+        if self._ready_event.is_set():
+            return
+
+        if task.cancelled():
+            message = "Discord bot task was cancelled before on_ready was fired"
+            self._set_fatal_error("discord_connect_cancelled", message, retryable=True)
+            raise RuntimeError(message)
+
+        exc = task.exception()
+        if exc is None:
+            message = "Discord bot task exited before on_ready was fired"
+            self._set_fatal_error("discord_connect_failed", message, retryable=True)
+            raise RuntimeError(message)
+
+        code, message, retryable = self._classify_bot_start_exception(exc)
+        self._set_fatal_error(code, message, retryable=retryable)
+        raise exc
+
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
         if not DISCORD_AVAILABLE:
@@ -718,14 +855,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # connected to Discord gateway and both fire on_message, causing
             # double responses.
             if self._client is not None:
-                try:
-                    if not self._client.is_closed():
-                        await self._client.close()
-                except Exception:
-                    logger.debug("[%s] Failed to close previous Discord client", self.name)
-                finally:
-                    self._client = None
-                    self._ready_event.clear()
+                await self._cleanup_client_runtime()
 
             self._client = commands.Bot(
                 command_prefix="!",  # Not really used, we handle raw messages
@@ -887,17 +1017,23 @@ class DiscordAdapter(BasePlatformAdapter):
             # Start the bot in background
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
 
-            # Wait for ready
-            await asyncio.wait_for(self._ready_event.wait(), timeout=30)
+            # Wait for ready, but fail fast if the background start task dies first.
+            await self._wait_for_ready_or_start_failure()
 
             self._running = True
             return True
 
+        except asyncio.CancelledError:
+            await self._cleanup_client_runtime()
+            self._release_platform_lock()
+            raise
         except asyncio.TimeoutError:
+            await self._cleanup_client_runtime()
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
+            await self._cleanup_client_runtime()
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
             self._release_platform_lock()
             return False
@@ -911,23 +1047,8 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
 
-        if self._client:
-            try:
-                await self._client.close()
-            except Exception as e:  # pragma: no cover - defensive logging
-                logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
-
-        if self._post_connect_task and not self._post_connect_task.done():
-            self._post_connect_task.cancel()
-            try:
-                await self._post_connect_task
-            except asyncio.CancelledError:
-                pass
-
+        await self._cleanup_client_runtime()
         self._running = False
-        self._client = None
-        self._ready_event.clear()
-        self._post_connect_task = None
 
         self._release_platform_lock()
 

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -119,6 +119,58 @@ class FakeBot:
         return None
 
 
+class HangingBot(FakeBot):
+    def __init__(self, *, intents, proxy=None, allowed_mentions=None, **_):
+        super().__init__(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+        self._closed = False
+        self.start_cancelled = asyncio.Event()
+        self._blocker = asyncio.Event()
+
+    def is_closed(self):
+        return self._closed
+
+    async def start(self, token):
+        try:
+            await self._blocker.wait()
+        except asyncio.CancelledError:
+            self.start_cancelled.set()
+            raise
+
+    async def close(self):
+        self._closed = True
+
+
+class CrashingBot(FakeBot):
+    def __init__(self, *, exc: Exception, intents, proxy=None, allowed_mentions=None, **_):
+        super().__init__(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+        self._exc = exc
+        self._closed = False
+
+    def is_closed(self):
+        return self._closed
+
+    async def start(self, token):
+        raise self._exc
+
+    async def close(self):
+        self._closed = True
+
+
+class SilentBot(FakeBot):
+    def __init__(self, *, intents, proxy=None, allowed_mentions=None, **_):
+        super().__init__(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+        self._closed = False
+
+    def is_closed(self):
+        return self._closed
+
+    async def start(self, token):
+        return None
+
+    async def close(self):
+        self._closed = True
+
+
 class SlowSyncTree(FakeTree):
     def __init__(self):
         super().__init__()
@@ -256,27 +308,127 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
     monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
 
+    created = {}
+
     monkeypatch.setattr(
         discord_platform.commands,
         "Bot",
-        lambda **kwargs: FakeBot(
+        lambda **kwargs: created.setdefault(
+            "bot",
+            HangingBot(
+                intents=kwargs["intents"],
+                proxy=kwargs.get("proxy"),
+                allowed_mentions=kwargs.get("allowed_mentions"),
+            ),
+        ),
+    )
+
+    monkeypatch.setattr(adapter, "_ready_timeout_seconds", lambda: 0.01)
+
+    ok = await asyncio.wait_for(adapter.connect(), timeout=5.0)
+
+    assert ok is False
+    assert released == [("discord-bot-token", "test-token")]
+    assert adapter._platform_lock_identity is None
+    assert created["bot"]._closed is True
+    assert adapter._bot_task is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_awaits_bot_task_exception_cleanup(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    closed = []
+
+    class _ClosableClient:
+        def is_closed(self):
+            return False
+
+        async def close(self):
+            closed.append(True)
+
+    adapter._client = _ClosableClient()
+    adapter._platform_lock_identity = "test-token"
+    adapter._platform_lock_scope = "discord-bot-token"
+    adapter._voice_clients = {}
+
+    loop = asyncio.get_running_loop()
+    task = loop.create_future()
+    task.set_exception(RuntimeError("discord boom"))
+    adapter._bot_task = task
+
+    await adapter.disconnect()
+
+    assert closed == [True]
+    assert adapter._bot_task is None
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_fast_on_login_failure_and_marks_auth_nonretryable(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="bad-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    released = []
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: released.append((scope, identity)))
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    class _LoginFailure(Exception):
+        pass
+
+    monkeypatch.setattr(discord_platform.discord, "LoginFailure", _LoginFailure, raising=False)
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: CrashingBot(
+            exc=_LoginFailure("Improper token has been passed."),
             intents=kwargs["intents"],
             proxy=kwargs.get("proxy"),
             allowed_mentions=kwargs.get("allowed_mentions"),
         ),
     )
 
-    async def fake_wait_for(awaitable, timeout):
-        awaitable.close()
-        raise asyncio.TimeoutError()
+    ok = await asyncio.wait_for(adapter.connect(), timeout=5.0)
 
-    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+    assert ok is False
+    assert released == [("discord-bot-token", "bad-token")]
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "discord_auth_failed"
+    assert adapter.fatal_error_retryable is False
+    assert adapter._bot_task is None
 
-    ok = await adapter.connect()
+
+@pytest.mark.asyncio
+async def test_connect_fails_fast_when_bot_exits_without_ready(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    released = []
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: released.append((scope, identity)))
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: SilentBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    ok = await asyncio.wait_for(adapter.connect(), timeout=5.0)
 
     assert ok is False
     assert released == [("discord-bot-token", "test-token")]
-    assert adapter._platform_lock_identity is None
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "discord_connect_failed"
+    assert adapter.fatal_error_retryable is True
+    assert adapter._bot_task is None
 
 
 @pytest.mark.asyncio
@@ -300,7 +452,7 @@ async def test_connect_does_not_wait_for_slash_sync(monkeypatch):
     monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
     monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
 
-    ok = await asyncio.wait_for(adapter.connect(), timeout=1.0)
+    ok = await asyncio.wait_for(adapter.connect(), timeout=5.0)
 
     assert ok is True
     assert adapter._ready_event.is_set()

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -602,6 +602,25 @@ class TestDiscoverFallbackIps:
         assert ips == ["149.154.167.220"]
 
     @pytest.mark.asyncio
+    async def test_stalled_system_dns_does_not_block_doh_results(self, monkeypatch):
+        client = FakeDoHClient({
+            "https://dns.google": (200, _doh_answer("149.154.167.220")),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+        })
+        monkeypatch.setattr(tnet.httpx, "AsyncClient", lambda **kw: client)
+        monkeypatch.setattr(tnet, "_DOH_TIMEOUT", 0.01)
+
+        def slow_system_dns():
+            import time
+            time.sleep(0.05)
+            return {"149.154.166.110"}
+
+        monkeypatch.setattr(tnet, "_resolve_system_dns", slow_system_dns)
+
+        ips = await tnet.discover_fallback_ips()
+        assert ips == ["149.154.167.220", "149.154.167.221"]
+
+    @pytest.mark.asyncio
     async def test_system_dns_failure_keeps_all_doh_ips(self, monkeypatch):
         """If system DNS fails, nothing gets excluded — all DoH IPs kept."""
         self._patch_doh(monkeypatch, {


### PR DESCRIPTION
What

This fixes two Windows-specific gateway issues:
- Discord startup now fails fast if the bot task exits before on_ready fires, and cleans up client runtime reliably.
- Telegram DNS discovery no longer blocks the entire connect timeout when system DNS stalls, so DoH fallbacks can still succeed.

Why

These changes address the crash/stall path observed on Windows and make gateway startup more deterministic.

How

- Added Discord startup race handling and cleanup helpers.
- Wrapped system DNS resolution in a timeout so fallback resolvers can be used if local DNS hangs.
- Added regression tests and adjusted Windows test timeouts for stability.

Testing

- pytest: 107/107 passing

Notes

- Pushed from fork branch HConr:main.