### PR TITLE
fix(skills): normalize skill_view linked file paths

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +14,7 @@ from tools.skills_tool import (
     _parse_tags,
     _get_category_from_path,
     _find_all_skills,
+    _skill_relative_file_path,
     skill_matches_platform,
     skills_list,
     skill_view,
@@ -464,6 +465,27 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is False
 
+    def test_view_nonexistent_file_lists_available_assets_with_posix_paths(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_text("API docs", encoding="utf-8")
+            assets_dir = skill_dir / "assets"
+            assets_dir.mkdir()
+            (assets_dir / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+            scripts_dir = skill_dir / "scripts"
+            scripts_dir.mkdir()
+            (scripts_dir / "run.py").write_text("print('ok')\n", encoding="utf-8")
+
+            raw = skill_view("my-skill", file_path="references/nope.md")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert result["available_files"]["references"] == ["references/api.md"]
+        assert result["available_files"]["assets"] == ["assets/logo.png"]
+        assert result["available_files"]["scripts"] == ["scripts/run.py"]
+
     def test_view_shows_linked_files(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "my-skill")
@@ -474,6 +496,12 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["linked_files"] is not None
         assert "references" in result["linked_files"]
+
+    def test_skill_relative_file_path_normalizes_windows_separators(self):
+        skill_dir = PureWindowsPath(r"C:\Users\me\.hermes\skills\my-skill")
+        file_path = skill_dir / "assets" / "logo.png"
+
+        assert _skill_relative_file_path(skill_dir, file_path) == "assets/logo.png"
 
     def test_view_tags_from_metadata(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -94,6 +94,17 @@ SKILLS_DIR = HERMES_HOME / "skills"
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 
+
+def _skill_relative_file_path(skill_dir: Path, file_path: Path) -> str:
+    """Return a skill-internal relative path for tool output.
+
+    ``skill_view`` examples and follow-up ``file_path`` calls use POSIX-style
+    separators. ``Path.__str__`` emits backslashes on Windows, which makes
+    linked file hints platform-dependent.
+    """
+    return file_path.relative_to(skill_dir).as_posix()
+
+
 # Platform identifiers for the 'platforms' frontmatter field.
 # Maps user-friendly names to sys.platform prefixes.
 _PLATFORM_MAP = {
@@ -1137,7 +1148,7 @@ def skill_view(
                 # Scan for all readable files
                 for f in skill_dir.rglob("*"):
                     if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
+                        rel = _skill_relative_file_path(skill_dir, f)
                         if rel.startswith("references/"):
                             available_files["references"].append(rel)
                         elif rel.startswith("templates/"):
@@ -1210,7 +1221,8 @@ def skill_view(
             references_dir = skill_dir / "references"
             if references_dir.exists():
                 reference_files = [
-                    str(f.relative_to(skill_dir)) for f in references_dir.glob("*.md")
+                    _skill_relative_file_path(skill_dir, f)
+                    for f in references_dir.glob("*.md")
                 ]
 
             templates_dir = skill_dir / "templates"
@@ -1226,7 +1238,7 @@ def skill_view(
                 ]:
                     template_files.extend(
                         [
-                            str(f.relative_to(skill_dir))
+                            _skill_relative_file_path(skill_dir, f)
                             for f in templates_dir.rglob(ext)
                         ]
                     )
@@ -1236,13 +1248,16 @@ def skill_view(
             if assets_dir.exists():
                 for f in assets_dir.rglob("*"):
                     if f.is_file():
-                        asset_files.append(str(f.relative_to(skill_dir)))
+                        asset_files.append(_skill_relative_file_path(skill_dir, f))
 
             scripts_dir = skill_dir / "scripts"
             if scripts_dir.exists():
                 for ext in ["*.py", "*.sh", "*.bash", "*.js", "*.ts", "*.rb"]:
                     script_files.extend(
-                        [str(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
+                        [
+                            _skill_relative_file_path(skill_dir, f)
+                            for f in scripts_dir.glob(ext)
+                        ]
                     )
 
         # Read tags/related_skills with backward compat:


### PR DESCRIPTION
## What does this PR do?

Normalizes `skill_view` linked file paths to POSIX-style skill-relative paths.

On Windows, `Path` stringification emits backslashes, while `skill_view` categorizes linked files with prefixes such as `references/`, `templates/`, `assets/`, and `scripts/`. This keeps missing-file suggestions and follow-up `file_path` values consistent across platforms.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [x] Tests

## Testing

- `uv run --no-sync python -m pytest tests/tools/test_skills_tool.py::TestSkillView::test_view_nonexistent_file_lists_available_assets_with_posix_paths tests/tools/test_skills_tool.py::TestSkillView::test_skill_relative_file_path_normalizes_windows_separators tests/tools/test_skills_tool.py::TestSkillView::test_view_shows_linked_files -q --timeout-method=thread`
- `python scripts/check-windows-footguns.py --all`
- `python -m py_compile tools/skills_tool.py tests/tools/test_skills_tool.py`

## Platform tested

Windows