### PR TITLE
feat(skill): add system resource monitoring skill

### DIFF
--- a/skills/devops/system-monitor/SKILL.md
+++ b/skills/devops/system-monitor/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: system-monitor
+description: "Diagnose Linux CPU, memory, disk, process pressure."
+version: 1.1.0
+author: Alex Chen (@l46983284-cpu)
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [monitoring, diagnostics, linux, devops, system]
+    category: devops
+    requires_toolsets: [terminal]
+    related_skills: [docker-management, systematic-debugging]
+---
+
+# System Monitor Skill
+
+Quick Linux host diagnostics for CPU, memory, disk, processes, and basic network pressure.
+This skill does not replace long-running observability stacks; it is for short operator checks via `terminal`.
+
+## When to Use
+
+- Operator asks about host health, load, free RAM, disk pressure, or "what's eating CPU"
+- Writes fail despite free space (inode / overlay / journal bloat suspects)
+- Need top process consumers or socket summary before deeper debugging
+- Docker host resource snapshot is useful alongside container checks
+
+Do not use for:
+
+- Continuous monitoring / alerting product design
+- Non-Linux hosts (this skill is `platforms: [linux]`)
+- Application-level APM or distributed tracing
+
+## Prerequisites
+
+- Linux host with shell access through Hermes `terminal`
+- Common CLI: `top`, `ps`, `df`, `free`, `ss` (iproute2), optional `lsof`, `docker`, `journalctl`
+
+## How to Run
+
+Run the commands below with `terminal`. Prefer read-only probes first; avoid destructive cleanup unless the operator asks.
+
+## Quick Reference
+
+| Goal | Command |
+|------|---------|
+| Load / CPU snapshot | `top -bn1 \| head -5` |
+| Memory available | `free -h` |
+| Disk free | `df -h / /home 2>/dev/null` |
+| Inodes | `df -i / /home 2>/dev/null` |
+| Top CPU | `ps aux --sort=-%cpu \| head -15` |
+| Top memory | `ps aux --sort=-%mem \| head -15` |
+| Socket summary | `ss -s` |
+| Journal size | `journalctl --disk-usage` |
+| Docker stats | `docker stats --no-stream` |
+
+## Procedure
+
+### 1. Quick health check
+
+```bash
+top -bn1 | head -5
+uptime
+free -h
+df -h / /home 2>/dev/null
+```
+
+Read `load average` against CPU count, prefer `free`'s **available** column, and note filesystem free space before digging further.
+
+### 2. Disk pressure
+
+```bash
+df -h -x overlay -x tmpfs -x devtmpfs
+df -i / /home 2>/dev/null
+du -xhd1 / 2>/dev/null | sort -h | tail -20
+find /var /home /tmp -xdev -type f -size +100M 2>/dev/null | head -40
+```
+
+Use `-xdev` / filesystem filters so overlay/container layers do not dominate the picture.
+
+### 3. Process diagnostics
+
+```bash
+ps aux --sort=-%cpu | head -15
+ps aux --sort=-%mem | head -15
+ss -s
+```
+
+If a PID is suspicious and `lsof` is installed:
+
+```bash
+lsof -p <PID> | wc -l
+```
+
+### 4. Logs and containers (optional)
+
+```bash
+journalctl --disk-usage
+docker stats --no-stream
+```
+
+For broader Docker lifecycle work, load `docker-management`. For deeper host failure diagnosis after the snapshot, load `systematic-debugging`.
+
+## Pitfalls
+
+1. **`df -h` on overlay roots is misleading** — exclude overlay/tmpfs or inspect the real backing mount.
+2. **`free` "used" includes cache** — operator-relevant number is **available**.
+3. **Space free but writes fail** — check inodes (`df -i`) and read-only remounts.
+4. **`du /*` without `-x`** walks other mounts and can look like disk explosion.
+5. **Journal bloat is easy to miss** — `journalctl --disk-usage` before deleting app data.
+6. **`docker stats` without Docker** fails noisily — treat as optional.
+
+## Verification
+
+- [ ] Load, memory available, and root disk free reported
+- [ ] Top CPU and memory PIDs identified when load is high
+- [ ] Inodes checked when free space looks fine but writes fail
+- [ ] Overlay/tmpfs excluded when interpreting disk usage
+- [ ] No destructive cleanup run unless operator explicitly asked

--- a/tests/skills/test_system_monitor_skill.py
+++ b/tests/skills/test_system_monitor_skill.py
@@ -1,0 +1,103 @@
+"""Frontmatter/structure smoke tests for the system-monitor skill."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2] / "skills" / "devops" / "system-monitor"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_src() -> str:
+    assert SKILL_MD.is_file(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_src: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    data = yaml.safe_load(m.group(1))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_name_matches_dir(frontmatter: dict) -> None:
+    assert frontmatter["name"] == "system-monitor"
+
+
+def test_description_under_60_chars(frontmatter: dict) -> None:
+    desc = frontmatter["description"]
+    assert isinstance(desc, str)
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+
+
+def test_platforms_linux_only(frontmatter: dict) -> None:
+    assert frontmatter.get("platforms") == ["linux"]
+
+
+def test_license_mit(frontmatter: dict) -> None:
+    assert frontmatter.get("license") == "MIT"
+
+
+def test_author_credits_contributor(frontmatter: dict) -> None:
+    author = str(frontmatter.get("author") or "")
+    assert "Alex Chen" in author
+    assert "l46983284-cpu" in author
+
+
+def test_related_skills_resolve(frontmatter: dict) -> None:
+    related = (
+        (frontmatter.get("metadata") or {})
+        .get("hermes", {})
+        .get("related_skills")
+        or []
+    )
+    assert related, "expected related_skills"
+    root = Path(__file__).resolve().parents[2]
+    for name in related:
+        dirs = [
+            p.parent
+            for p in (root / "skills").rglob("SKILL.md")
+            if p.parent.name == name
+        ] + [
+            p.parent
+            for p in (root / "optional-skills").rglob("SKILL.md")
+            if p.parent.name == name
+        ]
+        assert dirs, f"related skill not found in tree: {name}"
+
+
+def test_no_escaped_markdown_fences(skill_src: str) -> None:
+    # original PR used backslash-escaped fences that render as literal text
+    assert r"\`\`\`" not in skill_src
+    assert "```bash" in skill_src
+
+
+def test_modern_section_headings(skill_src: str) -> None:
+    for heading in [
+        "# System Monitor Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]:
+        assert heading in skill_src, f"missing section: {heading}"
+
+
+def test_points_at_terminal_tool(skill_src: str) -> None:
+    assert "`terminal`" in skill_src


### PR DESCRIPTION
## What does this PR do?

Adds a focused Linux `system-monitor` skill for quick host diagnostics (CPU, memory, disk, process, network, Docker resource pressure) with pitfalls and a short command reference.

## Related Issue

N/A (skill contribution; hermes-sweeper salvage review on this PR)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/devops/system-monitor/SKILL.md` — Linux system diagnostics skill (platforms, description ≤60, related_skills, modern section order)
- `tests/skills/test_system_monitor_skill.py` — skill surface tests

## How to Test

1. Open `skills/devops/system-monitor/SKILL.md` and confirm frontmatter + fences render as real Markdown code blocks.
2. Run: `pytest tests/skills/test_system_monitor_skill.py -q`
3. Optional: `hermes --toolsets skills -q "Use the system-monitor skill to check memory pressure"` on Linux.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04/24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (skill is `platforms: [linux]`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Salvage addressed hermes-sweeper items: real bash fences, `platforms: [linux]`, description ≤60 chars, related_skills resolve (`docker-management`, `systematic-debugging`), modern section order.
