### PR TITLE
test: preserve graph metadata dry-run helper

### DIFF
--- a/hermes_cli/kanban_graph_metadata.py
+++ b/hermes_cli/kanban_graph_metadata.py
@@ -1,0 +1,289 @@
+"""Dry-run lean graph_metadata sidecar parser and validator for Kanban.
+
+This module is intentionally helper-only.  Nothing in the dispatcher, gateway,
+or Kanban persistence path imports it automatically; callers must opt in when
+they want to inspect candidate graph-shaped handoff metadata.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "workflow_id",
+    "node_id",
+    "node_type",
+    "owner_profile",
+    "depends_on",
+    "objective",
+    "deliverable",
+    "acceptance_criteria",
+    "validation_required",
+    "mutation_level",
+    "source_of_truth.state",
+)
+_ARTIFACT_FIELDS: tuple[str, ...] = ("artifact_ref", "save_location")
+_MIRROR_CONTENT_FIELDS: tuple[str, ...] = (
+    "kanban_mirror_comment",
+    "mirror_comment",
+    "evidence_comment",
+    "kanban_mirror_content",
+    "mirror_content",
+    "evidence_content",
+    "kanban_mirror_excerpt",
+    "mirror_excerpt",
+    "evidence_excerpt",
+)
+_SOURCE_OF_TRUTH_STATES: frozenset[str] = frozenset(
+    {"candidate", "validation_passed", "promoted", "rejected"}
+)
+_SCRATCH_PATH_RE = re.compile(
+    r"/(?:\.hermes/)?kanban/(?:boards/[^/]+/)?workspaces/[^/]+(?:/|$)"
+)
+_FENCED_YAML_RE = re.compile(
+    r"```(?:ya?ml)?\s*\n(?P<body>.*?)\n```",
+    re.IGNORECASE | re.DOTALL,
+)
+_MARKDOWN_SECTION_RE = re.compile(
+    r"^#{1,6}\s+graph_metadata\s*$\n(?P<body>.*?)(?=^#{1,6}\s+|\Z)",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
+_VALIDATION_READY_MIRROR_RE = re.compile(
+    r"\bvalidation[- ]ready mirror\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class GraphMetadataValidation:
+    """Validation result for an optional Phase 1 graph_metadata sidecar."""
+
+    valid: bool
+    legacy: bool = False
+    missing_fields: list[str] | None = None
+    errors: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "missing_fields", list(self.missing_fields or []))
+        object.__setattr__(self, "errors", list(self.errors or []))
+
+
+@dataclass(frozen=True)
+class DurableEvidence:
+    """Durable-evidence classification for a graph_metadata artifact pointer."""
+
+    state: str
+    reason: str
+
+
+def extract_graph_metadata_from_text(text: str | None) -> dict[str, Any] | None:
+    """Return the first ``graph_metadata`` block found in markdown/YAML text.
+
+    Missing or malformed metadata is treated as legacy/no-op and returns None;
+    this helper is for dry-run inspection, not enforcement of legacy packets.
+    """
+
+    if not text:
+        return None
+
+    for section in _MARKDOWN_SECTION_RE.finditer(text):
+        parsed = _safe_yaml(section.group("body"))
+        if isinstance(parsed, Mapping):
+            return dict(parsed.get("graph_metadata", parsed))
+
+    candidates: list[str] = [match.group("body") for match in _FENCED_YAML_RE.finditer(text)]
+    candidates.append(text)
+    for candidate in candidates:
+        parsed = _safe_yaml(candidate)
+        if isinstance(parsed, Mapping):
+            block = parsed.get("graph_metadata")
+            if isinstance(block, Mapping):
+                return dict(block)
+    return None
+
+
+def extract_graph_metadata_from_completion_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return ``metadata.graph_metadata`` from completion metadata, if present."""
+
+    if not isinstance(metadata, Mapping):
+        return None
+    block = metadata.get("graph_metadata")
+    if isinstance(block, Mapping):
+        return dict(block)
+    return None
+
+
+def validate_graph_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> GraphMetadataValidation:
+    """Validate the lean Phase 1 required field set.
+
+    ``None`` means a legacy task/handoff with no sidecar metadata and is valid
+    no-op. Optional/advisory fields are allowed but never required here.
+    """
+
+    if metadata is None:
+        return GraphMetadataValidation(valid=True, legacy=True)
+    if not isinstance(metadata, Mapping):
+        return GraphMetadataValidation(valid=False, errors=["graph_metadata must be an object"])
+
+    missing = [field for field in _REQUIRED_FIELDS if _missing(metadata, field)]
+    if all(_missing(metadata, field) for field in _ARTIFACT_FIELDS):
+        missing.append("artifact_ref or save_location")
+
+    errors: list[str] = []
+    state = _nested_get(metadata, "source_of_truth.state")
+    if state is not None and state not in _SOURCE_OF_TRUTH_STATES:
+        errors.append("source_of_truth.state must be one of candidate, validation_passed, promoted, rejected")
+
+    return GraphMetadataValidation(
+        valid=not missing and not errors,
+        legacy=False,
+        missing_fields=missing,
+        errors=errors,
+    )
+
+
+def classify_durable_evidence(
+    metadata: Mapping[str, Any] | None,
+    *,
+    comments: Sequence[str] | None = None,
+    workspace_kind: str | None = None,
+) -> DurableEvidence:
+    """Classify artifact evidence for a Phase 1 graph_metadata sidecar.
+
+    States are exactly: ``durable``, ``mirrored``, ``insufficient``, and
+    ``not_applicable``. Scratch workspace paths are never durable unless the
+    caller explicitly identifies a shared ``workspace_kind='dir'`` surface.
+    """
+
+    if metadata is None:
+        return DurableEvidence("not_applicable", "legacy task has no graph_metadata")
+
+    artifact_ref = metadata.get("artifact_ref")
+    save_location = metadata.get("save_location")
+    artifact = _first_nonempty_string(artifact_ref, save_location)
+
+    if not artifact:
+        if _looks_non_artifact_node(metadata):
+            return DurableEvidence("not_applicable", "non-artifact node has no artifact pointer")
+        if _has_validation_ready_mirror(metadata, comments):
+            return DurableEvidence("mirrored", "validation-ready mirror evidence is present")
+        return DurableEvidence("insufficient", "artifact-producing node has no durable artifact pointer or mirror")
+
+    if _is_scratch_path(artifact) and workspace_kind != "dir":
+        if _has_validation_ready_mirror(metadata, comments):
+            return DurableEvidence("mirrored", "scratch artifact path is paired with validation-ready mirror evidence")
+        return DurableEvidence("insufficient", "scratch artifact path has no validation-ready mirror evidence")
+
+    if _is_durable_location(artifact, workspace_kind=workspace_kind):
+        return DurableEvidence("durable", "artifact pointer uses a durable location class")
+
+    if _has_validation_ready_mirror(metadata, comments):
+        return DurableEvidence("mirrored", "artifact pointer is paired with validation-ready mirror evidence")
+    return DurableEvidence("insufficient", "artifact pointer is not a recognized durable location")
+
+
+def _safe_yaml(text: str) -> Any:
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+
+def _missing(data: Mapping[str, Any], dotted_key: str) -> bool:
+    value = _nested_get(data, dotted_key)
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and len(value) == 0:
+        return True
+    return False
+
+
+def _nested_get(data: Mapping[str, Any], dotted_key: str) -> Any:
+    current: Any = data
+    for part in dotted_key.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _first_nonempty_string(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _is_scratch_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return bool(_SCRATCH_PATH_RE.search(normalized))
+
+
+def _is_durable_location(path: str, *, workspace_kind: str | None = None) -> bool:
+    normalized = path.replace("\\", "/")
+    lower = normalized.lower()
+    if workspace_kind == "dir":
+        return True
+    if "/durable-artifacts/" in normalized:
+        return True
+    if lower.startswith(("gdrive://", "docs://")):
+        return True
+    if lower.startswith("http://") or lower.startswith("https://"):
+        return any(host in lower for host in ("drive.google.com", "docs.google.com"))
+    if re.fullmatch(r"[A-Za-z0-9_-]{20,}", path):
+        return True
+    if _is_scratch_path(normalized):
+        return False
+    return normalized.startswith("/") and "/kanban/workspaces/" not in normalized
+
+
+def _has_validation_ready_mirror(
+    metadata: Mapping[str, Any],
+    comments: Sequence[str] | None,
+) -> bool:
+    has_labeled_metadata_content = any(
+        _contains_validation_ready_mirror_label(metadata.get(field)) for field in _MIRROR_CONTENT_FIELDS
+    )
+    has_labeled_comment = any(
+        isinstance(comment, str) and _VALIDATION_READY_MIRROR_RE.search(comment)
+        for comment in comments or ()
+    )
+    return has_labeled_metadata_content or has_labeled_comment
+
+
+def _contains_validation_ready_mirror_label(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(_VALIDATION_READY_MIRROR_RE.search(value))
+    if isinstance(value, Mapping):
+        return any(_contains_validation_ready_mirror_label(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_contains_validation_ready_mirror_label(item) for item in value)
+    return False
+
+
+def _looks_non_artifact_node(metadata: Mapping[str, Any]) -> bool:
+    text = " ".join(
+        str(metadata.get(key, ""))
+        for key in ("node_type", "deliverable", "objective", "mutation_level")
+    ).lower()
+    return any(
+        marker in text
+        for marker in (
+            "validation verdict",
+            "validator",
+            "routing decision",
+            "operational block",
+            "no artifact",
+            "not_applicable",
+        )
+    )

--- a/hermes_cli/kanban_graph_metadata.py
+++ b/hermes_cli/kanban_graph_metadata.py
@@ -177,7 +177,7 @@ def classify_durable_evidence(
             return DurableEvidence("mirrored", "validation-ready mirror evidence is present")
         return DurableEvidence("insufficient", "artifact-producing node has no durable artifact pointer or mirror")
 
-    if _is_scratch_path(artifact) and workspace_kind != "dir":
+    if _is_scratch_workspace_path(artifact, workspace_kind=workspace_kind):
         if _has_validation_ready_mirror(metadata, comments):
             return DurableEvidence("mirrored", "scratch artifact path is paired with validation-ready mirror evidence")
         return DurableEvidence("insufficient", "scratch artifact path has no validation-ready mirror evidence")
@@ -229,6 +229,21 @@ def _is_scratch_path(path: str) -> bool:
     return bool(_SCRATCH_PATH_RE.search(normalized))
 
 
+def _is_scratch_workspace_path(path: str, *, workspace_kind: str | None = None) -> bool:
+    normalized = path.replace("\\", "/")
+    if workspace_kind == "dir":
+        return False
+    if _is_scratch_path(normalized):
+        return True
+    if workspace_kind == "scratch" and _is_local_absolute_path(normalized):
+        return "/durable-artifacts/" not in normalized
+    return False
+
+
+def _is_local_absolute_path(path: str) -> bool:
+    return path.startswith("/") or bool(re.match(r"^[A-Za-z]:/", path))
+
+
 def _is_durable_location(path: str, *, workspace_kind: str | None = None) -> bool:
     normalized = path.replace("\\", "/")
     lower = normalized.lower()
@@ -243,6 +258,8 @@ def _is_durable_location(path: str, *, workspace_kind: str | None = None) -> boo
     if re.fullmatch(r"[A-Za-z0-9_-]{20,}", path):
         return True
     if _is_scratch_path(normalized):
+        return False
+    if workspace_kind == "scratch" and _is_local_absolute_path(normalized):
         return False
     return normalized.startswith("/") and "/kanban/workspaces/" not in normalized
 

--- a/tests/hermes_cli/test_kanban_graph_metadata.py
+++ b/tests/hermes_cli/test_kanban_graph_metadata.py
@@ -1,0 +1,278 @@
+"""Dry-run tests for lean Kanban graph_metadata sidecar helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_graph_metadata import (
+    classify_durable_evidence,
+    extract_graph_metadata_from_completion_metadata,
+    extract_graph_metadata_from_text,
+    validate_graph_metadata,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def lean_metadata(**overrides):
+    data = {
+        "workflow_id": "graph_kanban_metadata_v0_1_1",
+        "node_id": "adapter_spike",
+        "node_type": "implementation_spike",
+        "owner_profile": "ax0s",
+        "depends_on": ["validator_review"],
+        "objective": "Implement dry-run parser only.",
+        "deliverable": "Reviewable helper and tests.",
+        "acceptance_criteria": ["No dispatcher mutation", "Legacy compatible"],
+        "validation_required": True,
+        "mutation_level": "helper_only",
+        "artifact_ref": "/root/.hermes/kanban/boards/demo/durable-artifacts/packet.md",
+        "source_of_truth": {"state": "candidate"},
+    }
+    data.update(overrides)
+    return data
+
+
+def test_extracts_valid_lean_graph_metadata_from_yaml_section():
+    body = """
+# Task body
+
+```yaml
+graph_metadata:
+  workflow_id: graph_kanban_metadata_v0_1_1
+  node_id: adapter_spike
+  node_type: implementation_spike
+  owner_profile: ax0s
+  depends_on:
+    - validator_review
+  objective: Implement dry-run parser only.
+  deliverable: Reviewable helper and tests.
+  acceptance_criteria:
+    - No dispatcher mutation
+    - Legacy compatible
+  validation_required: true
+  mutation_level: helper_only
+  artifact_ref: /root/.hermes/kanban/boards/demo/durable-artifacts/packet.md
+  source_of_truth:
+    state: candidate
+```
+"""
+
+    metadata = extract_graph_metadata_from_text(body)
+    result = validate_graph_metadata(metadata)
+
+    assert metadata is not None
+    assert metadata["workflow_id"] == "graph_kanban_metadata_v0_1_1"
+    assert result.valid is True
+    assert result.legacy is False
+    assert result.missing_fields == []
+
+
+def test_extracts_graph_metadata_from_markdown_section():
+    body = """
+## graph_metadata
+workflow_id: graph_kanban_metadata_v0_1_1
+node_id: adapter_spike
+node_type: implementation_spike
+owner_profile: ax0s
+depends_on:
+  - validator_review
+objective: Implement dry-run parser only.
+deliverable: Reviewable helper and tests.
+acceptance_criteria:
+  - No dispatcher mutation
+validation_required: true
+mutation_level: helper_only
+artifact_ref: /root/.hermes/kanban/boards/demo/durable-artifacts/packet.md
+source_of_truth:
+  state: candidate
+
+## Next section
+Plain markdown resumes.
+"""
+
+    metadata = extract_graph_metadata_from_text(body)
+
+    assert metadata is not None
+    assert metadata["node_id"] == "adapter_spike"
+    assert validate_graph_metadata(metadata).valid is True
+
+
+def test_extracts_graph_metadata_from_completion_metadata_json():
+    metadata = extract_graph_metadata_from_completion_metadata(
+        {"graph_metadata": lean_metadata()}
+    )
+
+    assert metadata is not None
+    assert metadata["node_id"] == "adapter_spike"
+    assert validate_graph_metadata(metadata).valid is True
+
+
+def test_missing_required_fields_are_reported():
+    metadata = lean_metadata()
+    del metadata["owner_profile"]
+    del metadata["source_of_truth"]
+
+    result = validate_graph_metadata(metadata)
+
+    assert result.valid is False
+    assert result.legacy is False
+    assert result.missing_fields == ["owner_profile", "source_of_truth.state"]
+
+
+def test_optional_advisory_fields_are_allowed_but_not_required():
+    metadata = lean_metadata(
+        unlocks=["validator_review"],
+        non_goals=["dispatcher enforcement"],
+        return_schema={"summary": "string"},
+        attempt=1,
+        edge_type="advisory",
+        human_approval_required=True,
+    )
+
+    result = validate_graph_metadata(metadata)
+
+    assert result.valid is True
+    assert result.missing_fields == []
+
+
+def test_legacy_absent_graph_metadata_is_valid_noop():
+    assert extract_graph_metadata_from_text("# Legacy handoff\nNo sidecar here.") is None
+    assert extract_graph_metadata_from_completion_metadata({"summary": "legacy"}) is None
+
+    result = validate_graph_metadata(None)
+
+    assert result.valid is True
+    assert result.legacy is True
+    assert result.missing_fields == []
+
+
+def test_scratch_artifact_alone_is_insufficient():
+    metadata = lean_metadata(
+        artifact_ref="/root/.hermes/kanban/boards/demo/workspaces/t_1234/output.md"
+    )
+
+    evidence = classify_durable_evidence(metadata)
+
+    assert evidence.state == "insufficient"
+    assert "scratch" in evidence.reason
+
+
+def test_scratch_artifact_with_mirror_pointer_only_is_insufficient():
+    metadata = lean_metadata(
+        artifact_ref="/root/.hermes/kanban/boards/demo/workspaces/t_1234/output.md",
+        kanban_mirror_comment_id=19,
+    )
+
+    evidence = classify_durable_evidence(metadata)
+
+    assert evidence.state == "insufficient"
+    assert "mirror evidence" in evidence.reason
+
+
+def test_scratch_artifact_with_validation_ready_mirror_comment_is_mirrored():
+    metadata = lean_metadata(
+        artifact_ref="/root/.hermes/kanban/boards/demo/workspaces/t_1234/output.md",
+        kanban_mirror_comment_id=19,
+    )
+
+    evidence = classify_durable_evidence(
+        metadata,
+        comments=["## Validation-ready mirror\nFull packet excerpt for downstream review."],
+    )
+
+    assert evidence.state == "mirrored"
+
+
+def test_validation_ready_mirror_comment_accepts_missing_artifact_as_mirrored():
+    metadata = lean_metadata(artifact_ref=None, save_location=None)
+
+    evidence = classify_durable_evidence(
+        metadata,
+        comments=["Validation-ready mirror: self-contained validator packet excerpt."],
+    )
+
+    assert evidence.state == "mirrored"
+
+
+def test_durable_artifact_path_is_durable():
+    metadata = lean_metadata(
+        artifact_ref="/root/.hermes/kanban/boards/demo/durable-artifacts/output.md"
+    )
+
+    evidence = classify_durable_evidence(metadata)
+
+    assert evidence.state == "durable"
+
+
+def test_non_artifact_validator_node_is_not_applicable():
+    metadata = lean_metadata(
+        node_type="validator_review",
+        deliverable="Validation verdict only",
+        artifact_ref=None,
+        save_location=None,
+    )
+
+    evidence = classify_durable_evidence(metadata)
+
+    assert evidence.state == "not_applicable"
+
+
+def test_graph_metadata_sidecar_does_not_change_dispatch_or_parent_child_behavior(
+    kanban_home, monkeypatch
+):
+    body = """
+```yaml
+graph_metadata:
+  workflow_id: graph_kanban_metadata_v0_1_1
+  node_id: child
+  node_type: implementation_spike
+  owner_profile: other-profile
+  depends_on: [some_graph_node]
+  objective: This metadata is advisory only.
+  deliverable: Helper tests.
+  acceptance_criteria: [No dispatch mutation]
+  validation_required: true
+  mutation_level: helper_only
+  artifact_ref: /root/.hermes/kanban/boards/demo/durable-artifacts/output.md
+  source_of_truth:
+    state: promoted
+```
+"""
+    spawned = []
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "ax0s")
+
+    def spawn_fn(task, *_args, **_kwargs):
+        spawned.append(task.id)
+        return 12345
+
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(
+            conn,
+            title="child",
+            assignee="ax0s",
+            body=body,
+            parents=[parent],
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.dispatch_once(conn, spawn_fn=spawn_fn).spawned == []
+
+        kb.complete_task(conn, parent, summary="done")
+        assert kb.get_task(conn, child).status == "ready"
+        result = kb.dispatch_once(conn, spawn_fn=spawn_fn)
+
+    assert [item[0] for item in result.spawned] == [child]
+    assert spawned == [child]

--- a/tests/hermes_cli/test_kanban_graph_metadata.py
+++ b/tests/hermes_cli/test_kanban_graph_metadata.py
@@ -170,6 +170,17 @@ def test_scratch_artifact_alone_is_insufficient():
     assert "scratch" in evidence.reason
 
 
+def test_custom_scratch_root_with_scratch_workspace_kind_is_insufficient():
+    metadata = lean_metadata(
+        artifact_ref="/tmp/custom-kanban-workspaces/t_123/output.md"
+    )
+
+    evidence = classify_durable_evidence(metadata, workspace_kind="scratch")
+
+    assert evidence.state == "insufficient"
+    assert "scratch" in evidence.reason
+
+
 def test_scratch_artifact_with_mirror_pointer_only_is_insufficient():
     metadata = lean_metadata(
         artifact_ref="/root/.hermes/kanban/boards/demo/workspaces/t_1234/output.md",


### PR DESCRIPTION
## Summary
Review-only preservation of a dry-run helper for graph metadata handling.

## Scope boundaries
- No dispatcher/runtime/config/profile/gateway/cron/supervisor/credential changes
- No LangGraph
- No source-of-truth promotion
- Visibility/review step only; do not merge from this automation

## Validation
- Focused helper tests pass: `uv run --extra dev pytest tests/hermes_cli/test_kanban_graph_metadata.py -q` -> `13 passed in 0.46s`
- Ruff passes: `uv run --extra dev ruff check hermes_cli/kanban_graph_metadata.py tests/hermes_cli/test_kanban_graph_metadata.py` -> `All checks passed!`
- Branch diff against `origin/main` contains exactly:
  - `hermes_cli/kanban_graph_metadata.py`
  - `tests/hermes_cli/test_kanban_graph_metadata.py`

## Known broader-suite context
Broader Kanban suite has 10 unrelated origin/main/order-dependent failures per validator audit `t_c02fe1e6`; focused helper tests and ruff pass.
