### PR TITLE
fix: decrement api_call_count when refunding execute_code iteration budget

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4003,8 +4003,15 @@ def run_conversation(
                 # Refund the iteration if the ONLY tool(s) called were
                 # execute_code (programmatic tool calling).  These are
                 # cheap RPC-style calls that shouldn't eat the budget.
+                # Both counters must be decremented to stay in sync with
+                # the while-loop condition at line 801 which requires
+                # api_call_count < agent.max_iterations AND
+                # agent.iteration_budget.remaining > 0. The compression-
+                # restart path (line 3505) follows the same pattern.
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
                     agent.iteration_budget.refund()
                 
                 # Use real token counts from the API response to decide


### PR DESCRIPTION
## Description

`execute_code` iterations refund the `iteration_budget` so they don't consume the agent's tool-call budget (they're cheap RPC-style calls). However, the `api_call_count` counter was NOT decremented alongside the budget refund, causing the while-loop condition to exit prematurely.

### The Bug

The main conversation loop at `agent/conversation_loop.py:801` has this condition:

```python
while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
```

Both conditions must be true for the loop to continue. The problem is that `api_call_count` is monotonically incremented on EVERY iteration (line 813) while the budget refund for `execute_code` (lines 4007-4008) only refunds the budget but does NOT decrement `api_call_count`. Compare with the compression-restart path at line 3505 which correctly does BOTH:

```python
# Line 3505 (compression restart - correct):
api_call_count -= 1
agent.iteration_budget.refund()

# Line 4007-4008 (execute_code refund - buggy):
agent.iteration_budget.refund()  # api_call_count NOT decremented!
```

### Impact

With `max_iterations=90` (the default), after 90 total API calls -- any mix of `execute_code` and regular tool calls -- the loop exits because `api_call_count >= agent.max_iterations`, even if the `iteration_budget` shows, say, 45/90 used with 45 remaining slots wasted.

### Walkthrough

1. Agent calls `execute_code` 90 times in a row
2. Each iteration: `api_call_count += 1` (line 813), budget consumed (line 822), then refunded (line 4008)
3. After iteration 90: `api_call_count = 90`, but `budget.used = 0` (all refunded back)
4. Loop condition at line 801: `api_call_count(90) < max_iterations(90)` is False -> loop exits
5. Budget had plenty remaining but the loop can never resume because the grace call flag only fires once

### The Fix

In `agent/conversation_loop.py`, lines 4007-4008, added `api_call_count -= 1` and `agent._api_call_count = api_call_count` alongside the existing budget refund. This mirrors the pattern already proven correct at line 3505.

```python
# After fix:
if _tc_names == {"execute_code"}:
    api_call_count -= 1
    agent._api_call_count = api_call_count
    agent.iteration_budget.refund()
```

### Files Changed

- `agent/conversation_loop.py`: 2 lines added, 0 lines removed

### Checklist

- [x] Bug is a logical defect, not an exception-handling or error-message issue
- [x] Full call chain traced to confirm the bug is reachable
- [x] Fix mirrors the existing compression-restart pattern at line 3505
- [x] `api_call_count` and `agent._api_call_count` both updated to stay in sync
- [x] No new imports or dependencies added
- [x] Existing tests for iteration budget thread safety cover related code
