### PR TITLE
perf(providers): cache provider list snapshots

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
+_PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
@@ -57,9 +58,11 @@ def register_provider(profile: ProviderProfile) -> None:
     plugins under ``$HERMES_HOME/plugins/model-providers/`` can override
     bundled profiles without editing repo code.
     """
+    global _PROVIDER_LIST_CACHE
     _REGISTRY[profile.name] = profile
     for alias in profile.aliases:
         _ALIASES[alias] = profile.name
+    _PROVIDER_LIST_CACHE = None
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:
@@ -75,8 +78,11 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
 
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
+    global _PROVIDER_LIST_CACHE
     if not _discovered:
         _discover_providers()
+    if _PROVIDER_LIST_CACHE is not None:
+        return list(_PROVIDER_LIST_CACHE)
     # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
     seen: set[int] = set()
     result: list[ProviderProfile] = []
@@ -85,7 +91,8 @@ def list_providers() -> list[ProviderProfile]:
         if pid not in seen:
             seen.add(pid)
             result.append(profile)
-    return result
+    _PROVIDER_LIST_CACHE = result
+    return list(result)
 
 
 def _user_plugins_dir() -> Path | None:

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -21,6 +21,7 @@ def _clear_provider_caches():
     import providers as _pkg
     _pkg._REGISTRY.clear()
     _pkg._ALIASES.clear()
+    _pkg._PROVIDER_LIST_CACHE = None
     _pkg._discovered = False
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):

--- a/tests/providers/test_provider_registry.py
+++ b/tests/providers/test_provider_registry.py
@@ -1,0 +1,61 @@
+import pytest
+
+from providers import ProviderProfile
+import providers
+
+
+@pytest.fixture(autouse=True)
+def isolate_provider_registry():
+    registry = providers._REGISTRY.copy()
+    aliases = providers._ALIASES.copy()
+    provider_list_cache = (
+        None
+        if providers._PROVIDER_LIST_CACHE is None
+        else list(providers._PROVIDER_LIST_CACHE)
+    )
+    discovered = providers._discovered
+
+    yield
+
+    providers._REGISTRY.clear()
+    providers._REGISTRY.update(registry)
+    providers._ALIASES.clear()
+    providers._ALIASES.update(aliases)
+    providers._PROVIDER_LIST_CACHE = provider_list_cache
+    providers._discovered = discovered
+
+
+def _profile(name: str, *aliases: str) -> ProviderProfile:
+    return ProviderProfile(name=name, aliases=aliases)
+
+
+def _reset_registry() -> None:
+    providers._REGISTRY.clear()
+    providers._ALIASES.clear()
+    providers._PROVIDER_LIST_CACHE = None
+    providers._discovered = True
+
+
+def test_list_providers_reuses_cached_snapshot_until_registration_changes():
+    _reset_registry()
+    first = _profile("alpha")
+    providers.register_provider(first)
+
+    listed = providers.list_providers()
+    listed.clear()
+
+    assert providers.list_providers() == [first]
+
+    second = _profile("beta")
+    providers.register_provider(second)
+
+    assert providers.list_providers() == [first, second]
+
+
+def test_list_providers_dedupes_aliases_in_cached_snapshot():
+    _reset_registry()
+    profile = _profile("kimi", "moonshot", "kimi-k2")
+    providers.register_provider(profile)
+
+    assert providers.get_provider_profile("moonshot") is profile
+    assert providers.list_providers() == [profile]


### PR DESCRIPTION
## Summary
- cache provider list snapshots after discovery instead of rebuilding the deduped list on every call
- invalidate the cached snapshot whenever a provider registers
- keep list returns defensive so callers cannot mutate the cached snapshot

## Tests
- `python -m pytest tests/providers/test_provider_registry.py tests/providers/test_transport_parity.py -q --timeout-method=thread` (21 passed)
- `python -m pytest tests/providers/test_plugin_discovery.py -q --timeout-method=thread` (4 passed)
- `python -m pytest tests/providers/test_plugin_discovery.py tests/providers/test_provider_registry.py -q --timeout-method=thread` (6 passed)
- `git diff --check`
- `codex review --uncommitted` (accepted the test isolation fix; rerun found no actionable issues)
- `git fetch origin main; codex review --base origin/main` (no actionable correctness issues)

Note: on native Windows, the repo pytest addopts default to `--timeout-method=signal`, which trips pytest-timeout on missing SIGALRM. The focused pytest runs above use `--timeout-method=thread`.