### PR TITLE
Port fork runtime fixes onto upstream main

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1833,6 +1833,7 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _MEMORY_PROVIDER_SHUTDOWN_JOIN_TIMEOUT_SECS: float = 2.0
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -3830,10 +3831,7 @@ class GatewayRunner:
                 # call signature-compatible with the pre-fix behaviour
                 # (``shutdown_memory_provider(messages=None)``).
                 session_messages = getattr(agent, "_session_messages", None)
-                if isinstance(session_messages, list):
-                    agent.shutdown_memory_provider(session_messages)
-                else:
-                    agent.shutdown_memory_provider()
+                self._shutdown_memory_provider_bounded(agent, session_messages)
         except Exception:
             pass
         # Close tool resources (terminal sandboxes, browser daemons,
@@ -3853,6 +3851,43 @@ class GatewayRunner:
             cleanup_stale_async_clients()
         except Exception:
             pass
+
+    def _shutdown_memory_provider_bounded(
+        self,
+        agent: Any,
+        session_messages: Any,
+    ) -> None:
+        """Best-effort memory-provider cleanup without pinning gateway teardown."""
+        errors: list[BaseException] = []
+
+        def _run_shutdown() -> None:
+            try:
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
+            except BaseException as exc:
+                errors.append(exc)
+
+        session_id = getattr(agent, "session_id", None) or "<unknown>"
+        thread = threading.Thread(
+            target=_run_shutdown,
+            name=f"hermes-memory-shutdown-{session_id}",
+            daemon=True,
+        )
+        thread.start()
+        timeout = max(0.0, float(self._MEMORY_PROVIDER_SHUTDOWN_JOIN_TIMEOUT_SECS))
+        thread.join(timeout)
+        if thread.is_alive():
+            logger.warning(
+                "Memory provider shutdown exceeded %.1fs for session %s; "
+                "continuing gateway cleanup",
+                timeout,
+                session_id,
+            )
+            return
+        if errors:
+            raise errors[0]
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,7 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
+    ("wiki",            "📖 Local Wiki Retrieval",      "wiki_search, wiki_read"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -52,6 +52,8 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.4.22"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+_DEFAULT_RETAIN_MAX_CONTENT_CHARS = 200_000
+_DEFAULT_RETAIN_MAX_QUEUE_SIZE = 25
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
 # Without it, reusing a stable session-scoped document_id silently
@@ -573,6 +575,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_every_n_turns = 1
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
+        self._retain_max_content_chars = _DEFAULT_RETAIN_MAX_CONTENT_CHARS
+        self._retain_max_queue_size = _DEFAULT_RETAIN_MAX_QUEUE_SIZE
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
 
@@ -1193,6 +1197,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._auto_retain = self._config.get("auto_retain", True)
         self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
+        self._retain_max_content_chars = max(0, int(self._config.get("retain_max_content_chars", _DEFAULT_RETAIN_MAX_CONTENT_CHARS)))
+        self._retain_max_queue_size = max(0, int(self._config.get("retain_max_queue_size", _DEFAULT_RETAIN_MAX_QUEUE_SIZE)))
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
@@ -1361,6 +1367,20 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
+    def _retain_payload_too_large(self, content: str, *, source: str) -> bool:
+        if self._retain_max_content_chars and len(content) > self._retain_max_content_chars:
+            logger.warning(
+                "Hindsight %s retain skipped: payload %d chars exceeds cap %d",
+                source,
+                len(content),
+                self._retain_max_content_chars,
+            )
+            return True
+        return False
+
+    def _retain_queue_full(self) -> bool:
+        return bool(self._retain_max_queue_size and self._retain_queue.qsize() >= self._retain_max_queue_size)
+
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
@@ -1464,6 +1484,18 @@ class HindsightMemoryProvider(MemoryProvider):
         logger.debug("sync_turn: retaining %d turns, total session content %d chars",
                      len(self._session_turns), sum(len(t) for t in self._session_turns))
         content = "[" + ",".join(self._session_turns) + "]"
+        if self._retain_payload_too_large(content, source="auto-turn"):
+            # Drop the accumulated batch rather than enqueueing a giant stale
+            # retain that can wedge Hindsight for minutes during shutdown.
+            self._session_turns = []
+            return
+        if self._retain_queue_full():
+            logger.warning(
+                "Hindsight auto-turn retain skipped: queue size %d reached cap %d",
+                self._retain_queue.qsize(),
+                self._retain_max_queue_size,
+            )
+            return
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1527,6 +1559,11 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
+                if self._retain_payload_too_large(content, source="tool"):
+                    return tool_error(
+                        f"Memory content is too large ({len(content)} chars; cap {self._retain_max_content_chars}). "
+                        "Summarize or split it before retaining."
+                    )
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
                 self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
@@ -1644,6 +1681,7 @@ class HindsightMemoryProvider(MemoryProvider):
             if old_parent_session_id:
                 old_lineage_tags.append(f"parent:{old_parent_session_id}")
             old_content = "[" + ",".join(old_turns) + "]"
+            flush_old_session = not self._retain_payload_too_large(old_content, source="flush-on-switch")
             # Resolve doc_id + update_mode against the OLD session BEFORE
             # we rotate _session_id, so the flush lands in the old
             # session's document either way (legacy: per-process unique;
@@ -1685,7 +1723,7 @@ class HindsightMemoryProvider(MemoryProvider):
             # two threads on aretain_batch against the same document, and
             # keeps shutdown's drain semantics intact. Skip enqueue if
             # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
+            if flush_old_session and not self._shutting_down.is_set() and not self._retain_queue_full():
                 self._ensure_writer()
                 self._register_atexit()
                 self._retain_queue.put(_flush)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1420,7 +1420,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if bot_id is None:
             return False
 
-        async def _scan_history(channel: Any) -> bool:
+        async def _scan_history(channel: Any, *, allow_unreferenced_bot_response: bool) -> bool:
             history = getattr(channel, "history", None)
             if not callable(history):
                 return False
@@ -1433,17 +1433,28 @@ class DiscordAdapter(BasePlatformAdapter):
                         continue
                     reference = getattr(candidate, "reference", None)
                     ref_id = str(getattr(reference, "message_id", "") or "")
-                    if not ref_id or ref_id == str(getattr(message, "id", "")):
+                    if ref_id == str(getattr(message, "id", "")):
+                        return True
+                    if allow_unreferenced_bot_response and not ref_id:
                         return True
             except Exception:
                 return False
             return False
 
-        if await _scan_history(getattr(message, "channel", None)):
+        message_channel = getattr(message, "channel", None)
+        # In a thread, bot responses are usually ordinary unreferenced messages
+        # after the user's post.  In a parent channel, however, an unreferenced
+        # bot post after a user message is not evidence that it answered this
+        # specific message; otherwise one successful reply can mask multiple
+        # missed parent-channel posts after a rate-limit/outage burst.
+        if await _scan_history(
+            message_channel,
+            allow_unreferenced_bot_response=bool(getattr(message_channel, "parent_id", None)),
+        ):
             return True
 
         thread = getattr(message, "thread", None)
-        if thread is not None and await _scan_history(thread):
+        if thread is not None and await _scan_history(thread, allow_unreferenced_bot_response=True):
             return True
         return False
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import os
+import sqlite3
 import struct
 import subprocess
 import tempfile
@@ -28,6 +29,7 @@ VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
+_DISCORD_RECOVERY_DB_FILENAME = "discord_message_recovery.db"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 
@@ -609,6 +611,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        self._missed_message_backfill_task: Optional[asyncio.Task] = None
+        self._discord_recovery_db_lock = threading.Lock()
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -749,6 +753,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 adapter_self._post_connect_task = asyncio.create_task(
                     adapter_self._run_post_connect_initialization()
                 )
+                if adapter_self._missed_message_backfill_enabled():
+                    if (
+                        adapter_self._missed_message_backfill_task
+                        and not adapter_self._missed_message_backfill_task.done()
+                    ):
+                        adapter_self._missed_message_backfill_task.cancel()
+                    adapter_self._missed_message_backfill_task = asyncio.create_task(
+                        adapter_self._run_missed_message_backfill()
+                    )
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -923,11 +936,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._post_connect_task
             except asyncio.CancelledError:
                 pass
+        if self._missed_message_backfill_task and not self._missed_message_backfill_task.done():
+            self._missed_message_backfill_task.cancel()
+            try:
+                await self._missed_message_backfill_task
+            except asyncio.CancelledError:
+                pass
 
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._missed_message_backfill_task = None
 
         self._release_platform_lock()
 
@@ -1170,6 +1190,474 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
 
+    def _missed_message_backfill_enabled(self) -> bool:
+        """Whether to reconcile Discord messages missed while the gateway was down."""
+        raw = os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL", "false")
+        return str(raw).strip().lower() in ("true", "1", "yes", "on")
+
+    def _missed_message_backfill_channels(self) -> set[str]:
+        """Channels to scan for missed messages after Discord reconnects.
+
+        Defaults to free-response channels because those are the places where
+        mention-free posts are expected to start work. Operators can set
+        DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS="*" to scan every reachable
+        text channel, but the safe default is scoped.
+        """
+        raw = os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS", "")
+        if not raw.strip():
+            return self._discord_free_response_channels()
+        return {item.strip() for item in raw.split(",") if item.strip()}
+
+    def _missed_message_backfill_window_seconds(self) -> float:
+        raw = os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL_WINDOW_SECONDS", "21600")
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = 21600.0
+        return max(60.0, value)
+
+    def _missed_message_backfill_limit(self) -> int:
+        raw = os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL_LIMIT", "100")
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            value = 100
+        return max(1, min(value, 500))
+
+    def _missed_message_backfill_max_dispatches(self) -> int:
+        raw = os.getenv("DISCORD_MISSED_MESSAGE_BACKFILL_MAX_DISPATCHES", "10")
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            value = 10
+        return max(1, min(value, 100))
+
+    async def _run_missed_message_backfill(self) -> None:
+        """Find and enqueue recent Discord messages missed while the bot was down.
+
+        Discord gateway events are not replayed for messages sent while the bot
+        is offline. Normal startup resume only handles sessions already marked
+        resume_pending; this pass scans recent channel/thread history, records
+        what it saw durably, and reuses the normal message handler for messages
+        that lack a substantive non-outage Hermes response. Emoji-only acks are
+        deliberately not sufficient completion evidence.
+        """
+        if not self._client:
+            return
+        channels = self._missed_message_backfill_channels()
+        scan_id = self._record_recovery_scan_start(channels)
+        if not channels:
+            logger.info("[%s] Missed-message backfill enabled but no channels configured", self.name)
+            self._record_recovery_scan_complete(scan_id, status="skipped", scanned=0, missed=0, dispatched=0)
+            return
+
+        max_dispatches = self._missed_message_backfill_max_dispatches()
+        dispatched = 0
+        scanned = 0
+        missed = 0
+        try:
+            async for message in self._iter_missed_message_backfill_candidates(channels):
+                scanned += 1
+                message_id = str(getattr(message, "id", ""))
+                self._record_discord_message_seen(message, status="discovered")
+                if self._dedup.is_duplicate(message_id):
+                    continue
+                if not await self._should_backfill_discord_message(message):
+                    continue
+                missed += 1
+                logger.info(
+                    "[%s] Backfilling missed Discord message %s in channel %s",
+                    self.name,
+                    getattr(message, "id", "unknown"),
+                    getattr(getattr(message, "channel", None), "id", "unknown"),
+                )
+                self._record_recovery_attempt(message, status="queued")
+                try:
+                    await self._handle_message(message)
+                    dispatched += 1
+                except Exception as exc:
+                    self._record_recovery_attempt(message, status="failed", error=str(exc))
+                    raise
+                if dispatched >= max_dispatches:
+                    break
+            self._record_recovery_scan_complete(scan_id, status="success", scanned=scanned, missed=missed, dispatched=dispatched)
+            logger.info(
+                "[%s] Missed-message backfill complete: scanned=%d missed=%d dispatched=%d",
+                self.name,
+                scanned,
+                missed,
+                dispatched,
+            )
+        except asyncio.CancelledError:
+            self._record_recovery_scan_complete(scan_id, status="cancelled", scanned=scanned, missed=missed, dispatched=dispatched)
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._record_recovery_scan_complete(scan_id, status="failed", scanned=scanned, missed=missed, dispatched=dispatched, error=str(exc))
+            logger.warning("[%s] Missed-message backfill failed: %s", self.name, exc, exc_info=True)
+
+    async def _iter_missed_message_backfill_candidates(self, channel_ids: set[str]):
+        if not self._client:
+            return
+        import datetime as _dt
+
+        after = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
+            seconds=self._missed_message_backfill_window_seconds()
+        )
+        limit = self._missed_message_backfill_limit()
+        seen: set[str] = set()
+
+        candidate_channels = []
+        if "*" in channel_ids:
+            for guild in getattr(self._client, "guilds", []) or []:
+                candidate_channels.extend(getattr(guild, "text_channels", []) or [])
+        else:
+            for channel_id in sorted(channel_ids):
+                channel = None
+                try:
+                    channel = self._client.get_channel(int(channel_id))
+                except Exception:
+                    channel = None
+                if channel is None:
+                    try:
+                        channel = await self._client.fetch_channel(int(channel_id))
+                    except Exception as exc:
+                        logger.debug("[%s] Cannot fetch backfill channel %s: %s", self.name, channel_id, exc)
+                        continue
+                candidate_channels.append(channel)
+
+        for channel in candidate_channels:
+            async for item in self._iter_channel_and_thread_messages(channel, limit=limit, after=after, seen_channels=seen):
+                yield item
+
+    async def _iter_channel_and_thread_messages(self, channel: Any, *, limit: int, after: Any, seen_channels: set[str]):
+        """Yield history from a channel plus active/recent archived child threads."""
+        channel_key = str(getattr(channel, "id", ""))
+        if not channel_key or channel_key in seen_channels:
+            return
+        seen_channels.add(channel_key)
+
+        history = getattr(channel, "history", None)
+        if callable(history):
+            try:
+                messages = []
+                async for message in history(limit=limit, after=after, oldest_first=True):
+                    messages.append(message)
+                for message in messages:
+                    yield message
+            except Exception as exc:
+                logger.debug("[%s] Cannot read history for %s: %s", self.name, channel_key, exc)
+
+        child_threads = list(getattr(channel, "threads", []) or [])
+        archived_threads = getattr(channel, "archived_threads", None)
+        if callable(archived_threads):
+            try:
+                async for thread in archived_threads(limit=limit):
+                    child_threads.append(thread)
+            except Exception as exc:
+                logger.debug("[%s] Cannot list archived threads for %s: %s", self.name, channel_key, exc)
+
+        for thread in child_threads:
+            thread_key = str(getattr(thread, "id", ""))
+            if not thread_key or thread_key in seen_channels:
+                continue
+            async for message in self._iter_channel_and_thread_messages(thread, limit=limit, after=after, seen_channels=seen_channels):
+                yield message
+
+    async def _should_backfill_discord_message(self, message: Any) -> bool:
+        """Return True when a recent Discord message still needs Hermes work."""
+        if not self._client or not getattr(self._client, "user", None):
+            return False
+        if getattr(getattr(message, "author", None), "id", None) == getattr(self._client.user, "id", None):
+            return False
+        if getattr(getattr(message, "author", None), "bot", False):
+            return False
+        if self._discord_message_is_persistently_complete(str(getattr(message, "id", ""))):
+            return False
+        # A success reaction alone is only an acknowledgement.  It is not
+        # enough evidence that the substantive response/action completed.
+        if await self._message_has_non_down_bot_response(message):
+            return False
+        return True
+
+    async def _message_has_own_reaction(self, message: Any, emojis: set[str]) -> bool:
+        bot_user = getattr(self._client, "user", None) if self._client else None
+        bot_id = getattr(bot_user, "id", None)
+        for reaction in getattr(message, "reactions", []) or []:
+            if str(getattr(reaction, "emoji", "")) not in emojis:
+                continue
+            if getattr(reaction, "me", False):
+                return True
+            users = getattr(reaction, "users", None)
+            if not callable(users) or bot_id is None:
+                continue
+            try:
+                async for user in users():
+                    if getattr(user, "id", None) == bot_id:
+                        return True
+            except Exception:
+                continue
+        return False
+
+    def _is_down_notice_content(self, content: str) -> bool:
+        text = (content or "").lower()
+        down_markers = (
+            "agent is down",
+            "agent was down",
+            "gateway is down",
+            "gateway was down",
+            "bmo is down",
+            "currently down",
+            "offline",
+            "unavailable",
+            "not running",
+        )
+        return any(marker in text for marker in down_markers)
+
+    async def _message_has_non_down_bot_response(self, message: Any) -> bool:
+        """Detect an already-addressed message without trusting down notices."""
+        bot_user = getattr(self._client, "user", None) if self._client else None
+        bot_id = getattr(bot_user, "id", None)
+        if bot_id is None:
+            return False
+
+        async def _scan_history(channel: Any) -> bool:
+            history = getattr(channel, "history", None)
+            if not callable(history):
+                return False
+            try:
+                async for candidate in history(limit=25, after=getattr(message, "created_at", None), oldest_first=True):
+                    author = getattr(candidate, "author", None)
+                    if getattr(author, "id", None) != bot_id:
+                        continue
+                    if self._is_down_notice_content(getattr(candidate, "content", "")):
+                        continue
+                    reference = getattr(candidate, "reference", None)
+                    ref_id = str(getattr(reference, "message_id", "") or "")
+                    if not ref_id or ref_id == str(getattr(message, "id", "")):
+                        return True
+            except Exception:
+                return False
+            return False
+
+        if await _scan_history(getattr(message, "channel", None)):
+            return True
+
+        thread = getattr(message, "thread", None)
+        if thread is not None and await _scan_history(thread):
+            return True
+        return False
+
+    def _discord_recovery_db_path(self) -> _Path:
+        from hermes_constants import get_hermes_home
+
+        directory = get_hermes_home() / "gateway"
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory / _DISCORD_RECOVERY_DB_FILENAME
+
+    def _with_discord_recovery_db(self, fn, default=None):
+        try:
+            with self._discord_recovery_db_lock:
+                conn = sqlite3.connect(self._discord_recovery_db_path())
+                try:
+                    conn.execute("PRAGMA journal_mode=WAL")
+                    conn.execute("""
+                        CREATE TABLE IF NOT EXISTS discord_messages (
+                            message_id TEXT PRIMARY KEY,
+                            channel_id TEXT,
+                            thread_id TEXT,
+                            parent_channel_id TEXT,
+                            author_id TEXT,
+                            created_at TEXT,
+                            status TEXT NOT NULL,
+                            replied INTEGER NOT NULL DEFAULT 0,
+                            emoji_ack INTEGER NOT NULL DEFAULT 0,
+                            outage_response INTEGER NOT NULL DEFAULT 0,
+                            response_message_id TEXT,
+                            action_id TEXT,
+                            attempts INTEGER NOT NULL DEFAULT 0,
+                            last_attempt_at TEXT,
+                            last_error TEXT,
+                            updated_at TEXT NOT NULL
+                        )
+                    """)
+                    conn.execute("""
+                        CREATE TABLE IF NOT EXISTS discord_recovery_scans (
+                            scan_id TEXT PRIMARY KEY,
+                            started_at TEXT NOT NULL,
+                            completed_at TEXT,
+                            status TEXT NOT NULL,
+                            channels TEXT NOT NULL,
+                            window_seconds REAL NOT NULL,
+                            limit_count INTEGER NOT NULL,
+                            scanned INTEGER NOT NULL DEFAULT 0,
+                            missed INTEGER NOT NULL DEFAULT 0,
+                            dispatched INTEGER NOT NULL DEFAULT 0,
+                            error TEXT
+                        )
+                    """)
+                    result = fn(conn)
+                    conn.commit()
+                    return result
+                finally:
+                    conn.close()
+        except Exception as exc:
+            logger.debug("[%s] Discord recovery DB operation failed: %s", self.name, exc, exc_info=True)
+            return default
+
+    @staticmethod
+    def _utc_now_iso() -> str:
+        import datetime as _dt
+        return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    def _message_channel_ids(self, message: Any) -> tuple[str, Optional[str], Optional[str]]:
+        channel = getattr(message, "channel", None)
+        channel_id = str(getattr(channel, "id", "") or "")
+        parent_id = str(getattr(channel, "parent_id", "") or "") or None
+        thread_id = channel_id if parent_id else None
+        return channel_id, thread_id, parent_id
+
+    def _record_discord_message_seen(self, message: Any, *, status: str) -> None:
+        message_id = str(getattr(message, "id", "") or "")
+        if not message_id:
+            return
+        channel_id, thread_id, parent_id = self._message_channel_ids(message)
+        author_id = str(getattr(getattr(message, "author", None), "id", "") or "")
+        created_at = getattr(message, "created_at", None)
+        created_text = created_at.isoformat() if hasattr(created_at, "isoformat") else None
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            existing = conn.execute("SELECT status FROM discord_messages WHERE message_id=?", (message_id,)).fetchone()
+            final_status = existing[0] if existing and existing[0] == "responded" else status
+            conn.execute(
+                """
+                INSERT INTO discord_messages (message_id, channel_id, thread_id, parent_channel_id, author_id, created_at, status, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(message_id) DO UPDATE SET
+                    channel_id=excluded.channel_id,
+                    thread_id=excluded.thread_id,
+                    parent_channel_id=excluded.parent_channel_id,
+                    author_id=excluded.author_id,
+                    created_at=COALESCE(discord_messages.created_at, excluded.created_at),
+                    status=?,
+                    updated_at=excluded.updated_at
+                """,
+                (message_id, channel_id, thread_id, parent_id, author_id, created_text, final_status, now, final_status),
+            )
+
+        self._with_discord_recovery_db(_op)
+
+    def _record_recovery_attempt(self, message: Any, *, status: str, error: Optional[str] = None) -> None:
+        self._record_discord_message_seen(message, status=status)
+        message_id = str(getattr(message, "id", "") or "")
+        if not message_id:
+            return
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            conn.execute(
+                """
+                UPDATE discord_messages
+                   SET status=?, attempts=attempts+1, last_attempt_at=?, last_error=?, updated_at=?
+                 WHERE message_id=?
+                """,
+                (status, now, error, now, message_id),
+            )
+
+        self._with_discord_recovery_db(_op)
+
+    def _record_discord_processing_start(self, event: MessageEvent, *, emoji_ack: bool) -> None:
+        message = event.raw_message
+        self._record_discord_message_seen(message, status="processing")
+        message_id = str(getattr(message, "id", "") or getattr(event, "message_id", "") or "")
+        if not message_id:
+            return
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            conn.execute(
+                "UPDATE discord_messages SET status='processing', emoji_ack=?, updated_at=? WHERE message_id=?",
+                (1 if emoji_ack else 0, now, message_id),
+            )
+
+        self._with_discord_recovery_db(_op)
+
+    def _record_discord_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        message_id = str(getattr(getattr(event, "raw_message", None), "id", "") or getattr(event, "message_id", "") or "")
+        if not message_id:
+            return
+        status = "responded" if outcome == ProcessingOutcome.SUCCESS else ("cancelled" if outcome == ProcessingOutcome.CANCELLED else "failed")
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            conn.execute(
+                "UPDATE discord_messages SET status=?, replied=CASE WHEN ? THEN 1 ELSE replied END, updated_at=? WHERE message_id=?",
+                (status, 1 if outcome == ProcessingOutcome.SUCCESS else 0, now, message_id),
+            )
+
+        self._with_discord_recovery_db(_op)
+
+    def _record_discord_response(self, *, reply_to: Optional[str], result: SendResult, content: str) -> None:
+        if not reply_to:
+            return
+        now = self._utc_now_iso()
+        outage = self._is_down_notice_content(content)
+        status = "missed" if outage else ("responded" if result.success else "failed")
+
+        def _op(conn):
+            conn.execute(
+                """
+                INSERT INTO discord_messages (message_id, status, replied, outage_response, response_message_id, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(message_id) DO UPDATE SET
+                    status=?,
+                    replied=CASE WHEN ? THEN 1 ELSE replied END,
+                    outage_response=CASE WHEN ? THEN 1 ELSE outage_response END,
+                    response_message_id=COALESCE(?, response_message_id),
+                    updated_at=?
+                """,
+                (reply_to, status, 1 if result.success and not outage else 0, 1 if outage else 0, result.message_id, now, status, 1 if result.success and not outage else 0, 1 if outage else 0, result.message_id, now),
+            )
+
+        self._with_discord_recovery_db(_op)
+
+    def _discord_message_is_persistently_complete(self, message_id: str) -> bool:
+        if not message_id:
+            return False
+
+        def _op(conn):
+            row = conn.execute("SELECT status, replied, outage_response FROM discord_messages WHERE message_id=?", (message_id,)).fetchone()
+            if not row:
+                return False
+            status, replied, outage = row
+            return status == "responded" and bool(replied) and not bool(outage)
+
+        return bool(self._with_discord_recovery_db(_op, default=False))
+
+    def _record_recovery_scan_start(self, channels: set[str]) -> str:
+        scan_id = f"{int(time.time() * 1000)}-{os.getpid()}"
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            conn.execute(
+                "INSERT OR REPLACE INTO discord_recovery_scans (scan_id, started_at, status, channels, window_seconds, limit_count) VALUES (?, ?, ?, ?, ?, ?)",
+                (scan_id, now, "running", json.dumps(sorted(channels)), self._missed_message_backfill_window_seconds(), self._missed_message_backfill_limit()),
+            )
+
+        self._with_discord_recovery_db(_op)
+        return scan_id
+
+    def _record_recovery_scan_complete(self, scan_id: str, *, status: str, scanned: int, missed: int, dispatched: int, error: Optional[str] = None) -> None:
+        now = self._utc_now_iso()
+
+        def _op(conn):
+            conn.execute(
+                "UPDATE discord_recovery_scans SET completed_at=?, status=?, scanned=?, missed=?, dispatched=?, error=? WHERE scan_id=?",
+                (now, status, scanned, missed, dispatched, error, scan_id),
+            )
+
+        self._with_discord_recovery_db(_op)
+
     def _get_discord_command_sync_policy(self) -> str:
         raw = str(os.getenv("DISCORD_COMMAND_SYNC_POLICY", "safe") or "").strip().lower()
         if raw in _DISCORD_COMMAND_SYNC_POLICIES:
@@ -1383,15 +1871,16 @@ class DiscordAdapter(BasePlatformAdapter):
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction for normal Discord message events."""
-        if not self._reactions_enabled():
-            return
+        """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
-        if hasattr(message, "add_reaction"):
-            await self._add_reaction(message, "👀")
+        acked = False
+        if self._reactions_enabled() and hasattr(message, "add_reaction"):
+            acked = await self._add_reaction(message, "👀")
+        self._record_discord_processing_start(event, emoji_ack=acked)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction."""
+        """Swap the in-progress reaction for final reaction and durable state."""
+        self._record_discord_processing_complete(event, outcome)
         if not self._reactions_enabled():
             return
         message = event.raw_message
@@ -1504,15 +1993,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 _target_id = thread_id or chat_id
                 self._last_self_message_id[_target_id] = message_ids[-1]
 
-            return SendResult(
+            result = SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
                 raw_response={"message_ids": message_ids}
             )
+            self._record_discord_response(reply_to=reply_to, result=result, content=content)
+            return result
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+            result = SendResult(success=False, error=str(e))
+            self._record_discord_response(reply_to=reply_to, result=result, content=content)
+            return result
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
@@ -6201,6 +6694,22 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+    backfill_cfg = discord_cfg.get("missed_message_backfill")
+    if isinstance(backfill_cfg, dict):
+        _backfill_env = {
+            "enabled": "DISCORD_MISSED_MESSAGE_BACKFILL",
+            "channels": "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
+            "window_seconds": "DISCORD_MISSED_MESSAGE_BACKFILL_WINDOW_SECONDS",
+            "limit": "DISCORD_MISSED_MESSAGE_BACKFILL_LIMIT",
+            "max_dispatches": "DISCORD_MISSED_MESSAGE_BACKFILL_MAX_DISPATCHES",
+        }
+        for _key, _env in _backfill_env.items():
+            if _key not in backfill_cfg or os.getenv(_env):
+                continue
+            _value = backfill_cfg[_key]
+            if isinstance(_value, list):
+                _value = ",".join(str(v) for v in _value)
+            os.environ[_env] = str(_value).lower() if isinstance(_value, bool) else str(_value)
     # ignored_channels: channels where bot never responds (even when mentioned)
     ic = discord_cfg.get("ignored_channels")
     if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -45,7 +45,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 
 
 class FakeReaction:

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -1,0 +1,241 @@
+"""Tests for Discord missed-message startup backfill."""
+
+import os
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class FakeReaction:
+    def __init__(self, emoji, *, me=False, users=None):
+        self.emoji = emoji
+        self.me = me
+        self._users = list(users or [])
+
+    async def users(self):
+        for user in self._users:
+            yield user
+
+
+class FakeChannel:
+    def __init__(self, channel_id=123, history_messages=None):
+        self.id = channel_id
+        self.name = "wiki-inbox"
+        self.guild = SimpleNamespace(name="emo")
+        self.topic = None
+        self._history_messages = list(history_messages or [])
+
+    def history(self, **kwargs):
+        async def _gen():
+            for message in self._history_messages:
+                yield message
+
+        return _gen()
+
+
+@pytest.fixture
+def adapter(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999), get_channel=lambda _id: None)
+    adapter._handle_message = AsyncMock()
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL", "true")
+    return adapter
+
+
+def make_message(*, message_id=1, author_id=42, content="please ingest", reactions=None, channel=None):
+    channel = channel or FakeChannel()
+    return SimpleNamespace(
+        id=message_id,
+        content=content,
+        reactions=list(reactions or []),
+        author=SimpleNamespace(id=author_id, bot=False, display_name="Emo", name="emo"),
+        channel=channel,
+        created_at=datetime.now(timezone.utc),
+        attachments=[],
+        mentions=[],
+        reference=None,
+        type=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfills_message_with_only_own_success_reaction(adapter):
+    message = make_message(reactions=[FakeReaction("✅", me=True)])
+
+    assert await adapter._should_backfill_discord_message(message) is True
+
+
+@pytest.mark.asyncio
+async def test_should_not_backfill_message_with_non_down_bot_response(adapter):
+    bot_reply = SimpleNamespace(
+        id=2,
+        content="Done — captured it.",
+        author=SimpleNamespace(id=999, bot=True),
+        reference=SimpleNamespace(message_id=1),
+        created_at=datetime.now(timezone.utc),
+    )
+    channel = FakeChannel(history_messages=[bot_reply])
+    message = make_message(message_id=1, channel=channel)
+
+    assert await adapter._should_backfill_discord_message(message) is False
+
+
+@pytest.mark.asyncio
+async def test_backfills_when_only_down_notice_exists(adapter):
+    down_notice = SimpleNamespace(
+        id=2,
+        content="The agent is down right now.",
+        author=SimpleNamespace(id=999, bot=True),
+        reference=SimpleNamespace(message_id=1),
+        created_at=datetime.now(timezone.utc),
+    )
+    channel = FakeChannel(history_messages=[down_notice])
+    message = make_message(message_id=1, channel=channel)
+
+    assert await adapter._should_backfill_discord_message(message) is True
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_dispatches_unaddressed_messages(adapter, monkeypatch):
+    message = make_message(message_id=1)
+
+    async def fake_candidates(_channels):
+        yield message
+
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS", "123")
+    monkeypatch.setattr(adapter, "_iter_missed_message_backfill_candidates", fake_candidates)
+    monkeypatch.setattr(adapter, "_should_backfill_discord_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(adapter, "_missed_message_backfill_max_dispatches", lambda: 10)
+    monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    await adapter._run_missed_message_backfill()
+
+    adapter._handle_message.assert_awaited_once_with(message)
+
+
+def test_missed_message_backfill_config_bridge(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for key in (
+        "DISCORD_MISSED_MESSAGE_BACKFILL",
+        "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
+        "DISCORD_MISSED_MESSAGE_BACKFILL_WINDOW_SECONDS",
+        "DISCORD_MISSED_MESSAGE_BACKFILL_LIMIT",
+        "DISCORD_MISSED_MESSAGE_BACKFILL_MAX_DISPATCHES",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    (tmp_path / "config.yaml").write_text(
+        "platforms:\n"
+        "  discord:\n"
+        "    enabled: true\n"
+        "discord:\n"
+        "  missed_message_backfill:\n"
+        "    enabled: true\n"
+        "    channels: ['1501971993405292796']\n"
+        "    window_seconds: 3600\n"
+        "    limit: 25\n"
+        "    max_dispatches: 3\n"
+    )
+
+    load_gateway_config()
+
+    assert os.environ["DISCORD_MISSED_MESSAGE_BACKFILL"] == "true"
+    assert os.environ["DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS"] == "1501971993405292796"
+    assert os.environ["DISCORD_MISSED_MESSAGE_BACKFILL_WINDOW_SECONDS"] == "3600"
+    assert os.environ["DISCORD_MISSED_MESSAGE_BACKFILL_LIMIT"] == "25"
+    assert os.environ["DISCORD_MISSED_MESSAGE_BACKFILL_MAX_DISPATCHES"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_persistent_responded_record_suppresses_backfill(adapter):
+    message = make_message(message_id=77)
+    adapter._record_discord_message_seen(message, status="responded")
+    adapter._record_discord_response(
+        reply_to="77",
+        result=SimpleNamespace(success=True, message_id="9001"),
+        content="Done — captured it.",
+    )
+
+    assert await adapter._should_backfill_discord_message(message) is False
+
+
+def test_down_notice_response_does_not_mark_message_complete(adapter):
+    adapter._record_discord_response(
+        reply_to="88",
+        result=SimpleNamespace(success=True, message_id="9002"),
+        content="The agent is down right now.",
+    )
+
+    assert adapter._discord_message_is_persistently_complete("88") is False
+
+
+@pytest.mark.asyncio
+async def test_iter_candidates_includes_active_and_archived_threads(adapter):
+    active_msg = make_message(message_id=201, channel=FakeChannel(channel_id=2010))
+    archived_msg = make_message(message_id=202, channel=FakeChannel(channel_id=2020))
+    active_thread = FakeChannel(channel_id=2010, history_messages=[active_msg])
+    archived_thread = FakeChannel(channel_id=2020, history_messages=[archived_msg])
+
+    class ParentChannel(FakeChannel):
+        threads = [active_thread]
+
+        def archived_threads(self, **kwargs):
+            async def _gen():
+                yield archived_thread
+            return _gen()
+
+    parent = ParentChannel(channel_id=123, history_messages=[])
+    adapter._client.get_channel = lambda _id: parent
+
+    got = []
+    async for msg in adapter._iter_missed_message_backfill_candidates({"123"}):
+        got.append(msg.id)
+
+    assert got == [201, 202]

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -60,8 +60,9 @@ class FakeReaction:
 
 
 class FakeChannel:
-    def __init__(self, channel_id=123, history_messages=None):
+    def __init__(self, channel_id=123, history_messages=None, parent_id=None):
         self.id = channel_id
+        self.parent_id = parent_id
         self.name = "wiki-inbox"
         self.guild = SimpleNamespace(name="emo")
         self.topic = None
@@ -120,6 +121,36 @@ async def test_should_not_backfill_message_with_non_down_bot_response(adapter):
     )
     channel = FakeChannel(history_messages=[bot_reply])
     message = make_message(message_id=1, channel=channel)
+
+    assert await adapter._should_backfill_discord_message(message) is False
+
+
+@pytest.mark.asyncio
+async def test_parent_channel_unreferenced_bot_message_does_not_suppress_backfill(adapter):
+    unrelated_bot_post = SimpleNamespace(
+        id=2,
+        content="Done — captured a different item.",
+        author=SimpleNamespace(id=999, bot=True),
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    channel = FakeChannel(history_messages=[unrelated_bot_post])
+    message = make_message(message_id=1, channel=channel)
+
+    assert await adapter._should_backfill_discord_message(message) is True
+
+
+@pytest.mark.asyncio
+async def test_thread_unreferenced_bot_message_suppresses_backfill(adapter):
+    bot_post = SimpleNamespace(
+        id=2,
+        content="Done — captured it.",
+        author=SimpleNamespace(id=999, bot=True),
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    thread = FakeChannel(channel_id=456, parent_id=123, history_messages=[bot_post])
+    message = make_message(message_id=1, channel=thread)
 
     assert await adapter._should_backfill_discord_message(message) is False
 

--- a/tests/gateway/test_hindsight_retain_guardrails.py
+++ b/tests/gateway/test_hindsight_retain_guardrails.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _provider(monkeypatch):
+    from plugins.memory.hindsight import HindsightMemoryProvider
+
+    p = HindsightMemoryProvider()
+    p._auto_retain = True
+    p._session_id = "s1"
+    p._document_id = "doc1"
+    p._bank_id = "hermes"
+    p._retain_max_content_chars = 50
+    p._retain_max_queue_size = 1
+    monkeypatch.setattr(p, "_resolve_retain_target", lambda doc: (doc, None))
+    return p
+
+
+def test_auto_retain_drops_oversized_session_batch(monkeypatch):
+    p = _provider(monkeypatch)
+    p.sync_turn("u" * 100, "a")
+
+    assert p._retain_queue.qsize() == 0
+    assert p._session_turns == []
+
+
+def test_auto_retain_respects_queue_cap(monkeypatch):
+    p = _provider(monkeypatch)
+    p._retain_max_content_chars = 10_000
+    p._retain_queue.put(lambda: None)
+    p.sync_turn("u", "a")
+
+    assert p._retain_queue.qsize() == 1
+
+
+def test_tool_retain_rejects_oversized_payload(monkeypatch):
+    p = _provider(monkeypatch)
+    result = json.loads(p.handle_tool_call("hindsight_retain", {"content": "x" * 100}))
+
+    assert "error" in result
+    assert "too large" in result["error"]

--- a/tests/gateway/test_shutdown_memory_provider_messages.py
+++ b/tests/gateway/test_shutdown_memory_provider_messages.py
@@ -20,6 +20,8 @@ change is backward-compatible with existing suites.
 from __future__ import annotations
 
 import sys
+import threading
+import time
 import types
 from unittest.mock import MagicMock
 
@@ -127,6 +129,33 @@ class TestCleanupAgentResourcesPassesMessages:
         runner._cleanup_agent_resources(agent)
 
         # close() still invoked after the swallowed exception.
+        agent.close.assert_called_once()
+
+    def test_blocking_provider_shutdown_does_not_block_cleanup(self):
+        """A stuck memory provider must not pin gateway teardown."""
+        runner = _make_runner()
+        runner._MEMORY_PROVIDER_SHUTDOWN_JOIN_TIMEOUT_SECS = 0.01
+        started = threading.Event()
+        release = threading.Event()
+        transcript = [{"role": "user", "content": "x"}]
+        agent = _FakeAgent(session_messages=transcript)
+
+        def _blocked_shutdown(messages):
+            assert messages is transcript
+            started.set()
+            release.wait(timeout=1.0)
+
+        agent.shutdown_memory_provider = _blocked_shutdown
+
+        before = time.monotonic()
+        try:
+            runner._cleanup_agent_resources(agent)
+            elapsed = time.monotonic() - before
+        finally:
+            release.set()
+
+        assert started.wait(timeout=0.2)
+        assert elapsed < 0.2
         agent.close.assert_called_once()
 
     def test_none_agent_is_noop(self):

--- a/tests/tools/test_wiki_tool.py
+++ b/tests/tools/test_wiki_tool.py
@@ -1,0 +1,165 @@
+"""Tests for local wiki retrieval tools."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestWikiConfig:
+    def test_wiki_root_uses_configured_path(self, tmp_path):
+        from tools.wiki_tool import _get_wiki_root
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            assert _get_wiki_root() == wiki.resolve()
+
+    def test_wiki_root_supports_legacy_wiki_path_key(self, tmp_path):
+        from tools.wiki_tool import _get_wiki_root
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        with patch("hermes_cli.config.load_config", return_value={"wiki_path": str(wiki)}):
+            assert _get_wiki_root() == wiki.resolve()
+
+
+class TestWikiSearch:
+    def test_search_returns_ranked_markdown_matches_with_citations(self, tmp_path):
+        from tools.wiki_tool import wiki_search
+
+        wiki = tmp_path / "wiki"
+        _write(
+            wiki / "AI" / "Hindsight.md",
+            "# Hindsight\n\nHindsight is the local embedded memory provider for Hermes.",
+        )
+        _write(
+            wiki / "AI" / "Unrelated.md",
+            "# Bananas\n\nThis page is about fruit.",
+        )
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_search("embedded memory provider", limit=5)
+
+        assert result["query"] == "embedded memory provider"
+        assert result["wiki_root"] == str(wiki.resolve())
+        assert len(result["results"]) == 1
+        match = result["results"][0]
+        assert match["path"] == "AI/Hindsight.md"
+        assert match["title"] == "Hindsight"
+        assert "local embedded memory provider" in match["snippet"]
+        assert match["citation"] == f"{wiki.resolve()}/AI/Hindsight.md"
+
+    def test_search_ignores_dotdirs_and_non_markdown_files(self, tmp_path):
+        from tools.wiki_tool import wiki_search
+
+        wiki = tmp_path / "wiki"
+        _write(wiki / ".trash" / "Secret.md", "# Secret\n\nneedle")
+        _write(wiki / "notes.txt", "needle")
+        _write(wiki / "Visible.md", "# Visible\n\nneedle")
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_search("needle", limit=10)
+
+        assert [r["path"] for r in result["results"]] == ["Visible.md"]
+
+    def test_search_skips_symlinks_that_escape_wiki_root(self, tmp_path):
+        from tools.wiki_tool import wiki_search
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        outside = tmp_path / "secret.md"
+        outside.write_text("# Secret\n\nneedle outside secret", encoding="utf-8")
+        (wiki / "Visible.md").write_text("# Visible\n\nneedle public", encoding="utf-8")
+        (wiki / "Linked.md").symlink_to(outside)
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_search("needle", limit=10)
+
+        assert [r["path"] for r in result["results"]] == ["Visible.md"]
+        assert "outside secret" not in str(result)
+
+    def test_search_skips_symlinked_directories_that_escape_wiki_root(self, tmp_path):
+        from tools.wiki_tool import wiki_search
+
+        wiki = tmp_path / "wiki"
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir(parents=True)
+        wiki.mkdir()
+        (outside_dir / "Secret.md").write_text("# Secret\n\nneedle outside dir", encoding="utf-8")
+        (wiki / "Visible.md").write_text("# Visible\n\nneedle public", encoding="utf-8")
+        (wiki / "linked-dir").symlink_to(outside_dir, target_is_directory=True)
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_search("needle", limit=10)
+
+        assert [r["path"] for r in result["results"]] == ["Visible.md"]
+        assert "outside dir" not in str(result)
+
+    def test_search_requires_non_empty_query(self, tmp_path):
+        from tools.wiki_tool import wiki_search
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            with pytest.raises(ValueError, match="query"):
+                wiki_search("   ")
+
+
+class TestWikiRead:
+    def test_read_returns_page_content_and_metadata(self, tmp_path):
+        from tools.wiki_tool import wiki_read
+
+        wiki = tmp_path / "wiki"
+        _write(wiki / "AI" / "Hindsight.md", "# Hindsight\n\nBody text")
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_read("AI/Hindsight.md")
+
+        assert result["path"] == "AI/Hindsight.md"
+        assert result["title"] == "Hindsight"
+        assert result["citation"] == f"{wiki.resolve()}/AI/Hindsight.md"
+        assert result["content"] == "# Hindsight\n\nBody text"
+        assert result["truncated"] is False
+
+    def test_read_enforces_wiki_root_scope(self, tmp_path):
+        from tools.wiki_tool import wiki_read
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("nope", encoding="utf-8")
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            with pytest.raises(ValueError, match="outside the configured wiki root"):
+                wiki_read("../outside.md")
+
+    def test_read_truncates_with_flag(self, tmp_path):
+        from tools.wiki_tool import wiki_read
+
+        wiki = tmp_path / "wiki"
+        _write(wiki / "Long.md", "# Long\n\n" + "x" * 100)
+
+        with patch("hermes_cli.config.load_config", return_value={"wiki": {"path": str(wiki)}}):
+            result = wiki_read("Long.md", max_chars=20)
+
+        assert result["truncated"] is True
+        assert len(result["content"]) <= 20
+
+
+class TestToolRegistration:
+    def test_wiki_toolset_is_registered_and_in_core_tools(self):
+        import toolsets
+        from tools.registry import registry
+        import tools.wiki_tool  # noqa: F401 - import triggers registration
+
+        assert set(toolsets.TOOLSETS["wiki"]["tools"]) == {"wiki_search", "wiki_read"}
+        assert "wiki_search" in toolsets._HERMES_CORE_TOOLS
+        assert "wiki_read" in toolsets._HERMES_CORE_TOOLS
+        assert registry.get_entry("wiki_search") is not None
+        assert registry.get_entry("wiki_read") is not None

--- a/tools/wiki_tool.py
+++ b/tools/wiki_tool.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Local wiki retrieval tools.
+
+The wiki is a compiled knowledge base, not personal memory. These tools expose
+explicit search/read access to the configured wiki root and always return source
+paths so answers can cite the canonical page.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+DEFAULT_MAX_CHARS = 20_000
+DEFAULT_SNIPPET_CHARS = 320
+SUPPORTED_SUFFIXES = {".md", ".markdown"}
+
+
+def _get_wiki_root() -> Path:
+    """Return the configured wiki root.
+
+    Preferred config shape is ``wiki.path``. ``wiki_path`` is accepted for older
+    local configs because several Hermes profiles already carried that key.
+    """
+
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        config = {}
+
+    raw_path = None
+    if isinstance(config, dict):
+        wiki_cfg = config.get("wiki")
+        if isinstance(wiki_cfg, dict):
+            raw_path = wiki_cfg.get("path") or wiki_cfg.get("root")
+        raw_path = raw_path or config.get("wiki_path")
+
+    if not raw_path:
+        raw_path = "~/Documents/Sync/wiki"
+
+    root = Path(str(raw_path)).expanduser().resolve()
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(f"Configured wiki root does not exist: {root}")
+    return root
+
+
+def _is_indexable(path: Path, root: Path) -> bool:
+    if path.is_symlink():
+        return False
+    if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+        return False
+    try:
+        path.resolve().relative_to(root)
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        return False
+    return not any(part.startswith(".") for part in rel_parts)
+
+
+def _iter_pages(root: Path) -> Iterable[Path]:
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and _is_indexable(path, root):
+            yield path
+
+
+def _title_for(path: Path, content: str) -> str:
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip() or path.stem
+    return path.stem
+
+
+def _snippet_for(content: str, query: str, max_chars: int = DEFAULT_SNIPPET_CHARS) -> str:
+    terms = [t for t in re.findall(r"[\w-]+", query, flags=re.UNICODE) if t]
+    lowered = content.lower()
+    positions = [lowered.find(term.lower()) for term in terms]
+    positions = [pos for pos in positions if pos >= 0]
+    center = min(positions) if positions else 0
+    start = max(0, center - max_chars // 3)
+    end = min(len(content), start + max_chars)
+    snippet = content[start:end].strip()
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(content):
+        snippet += "…"
+    return " ".join(snippet.split())
+
+
+def _safe_fts_query(query: str) -> str:
+    terms = re.findall(r"[\w-]+", query, flags=re.UNICODE)
+    if not terms:
+        raise ValueError("query must contain at least one searchable term")
+    # Prefix matching improves recall for page titles and project terminology.
+    return " OR ".join(f'"{term}"*' for term in terms[:12])
+
+
+def _build_memory_index(root: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE VIRTUAL TABLE pages USING fts5(path UNINDEXED, title, content, tokenize='unicode61')"
+    )
+    rows = []
+    for path in _iter_pages(root):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        rel = path.relative_to(root).as_posix()
+        rows.append((rel, _title_for(path, content), content))
+    conn.executemany("INSERT INTO pages(path, title, content) VALUES (?, ?, ?)", rows)
+    return conn
+
+
+def wiki_search(query: str, limit: int = 5, snippet_chars: int = DEFAULT_SNIPPET_CHARS) -> Dict[str, Any]:
+    """Search the configured local wiki and return path-cited results."""
+
+    query = str(query or "").strip()
+    if not query:
+        raise ValueError("query must be non-empty")
+    limit = max(1, min(int(limit or 5), 20))
+    snippet_chars = max(120, min(int(snippet_chars or DEFAULT_SNIPPET_CHARS), 2_000))
+
+    root = _get_wiki_root()
+    fts_query = _safe_fts_query(query)
+    conn = _build_memory_index(root)
+    try:
+        rows = conn.execute(
+            """
+            SELECT path, title, content, bm25(pages) AS score
+            FROM pages
+            WHERE pages MATCH ?
+            ORDER BY score
+            LIMIT ?
+            """,
+            (fts_query, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    results = []
+    for rel_path, title, content, score in rows:
+        citation = str((root / rel_path).resolve())
+        results.append(
+            {
+                "path": rel_path,
+                "title": title,
+                "snippet": _snippet_for(content, query, snippet_chars),
+                "citation": citation,
+                "score": score,
+            }
+        )
+
+    return {
+        "query": query,
+        "wiki_root": str(root),
+        "results": results,
+    }
+
+
+def _resolve_page_path(page_path: str, root: Path) -> Path:
+    raw = str(page_path or "").strip()
+    if not raw:
+        raise ValueError("path must be non-empty")
+    candidate = (root / raw).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("path is outside the configured wiki root") from exc
+    if not candidate.exists() or not candidate.is_file():
+        raise FileNotFoundError(f"Wiki page not found: {raw}")
+    if not _is_indexable(candidate, root):
+        raise ValueError("path is not a readable wiki text page")
+    return candidate
+
+
+def wiki_read(path: str, max_chars: int = DEFAULT_MAX_CHARS) -> Dict[str, Any]:
+    """Read one wiki page by relative path and return content plus citation."""
+
+    root = _get_wiki_root()
+    page = _resolve_page_path(path, root)
+    content = page.read_text(encoding="utf-8", errors="replace")
+    max_chars = max(1, min(int(max_chars or DEFAULT_MAX_CHARS), 100_000))
+    truncated = len(content) > max_chars
+    if truncated:
+        content = content[:max_chars]
+
+    return {
+        "path": page.relative_to(root).as_posix(),
+        "title": _title_for(page, content),
+        "citation": str(page.resolve()),
+        "content": content,
+        "truncated": truncated,
+        "wiki_root": str(root),
+    }
+
+
+def _handler(fn, args: Dict[str, Any]) -> str:
+    from tools.registry import tool_error, tool_result
+
+    try:
+        return tool_result(fn(**args))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+WIKI_SEARCH_SCHEMA = {
+    "name": "wiki_search",
+    "description": (
+        "Search the configured local wiki/knowledge base. Use this when a user asks about "
+        "project knowledge, internal terminology, prior research, AI/tooling concepts, or "
+        "anything likely to live in the wiki rather than personal memory. Returns snippets "
+        "with canonical file-path citations."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Maximum results, 1-20.", "default": 5},
+            "snippet_chars": {
+                "type": "integer",
+                "description": "Approximate maximum snippet length per result.",
+                "default": DEFAULT_SNIPPET_CHARS,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+WIKI_READ_SCHEMA = {
+    "name": "wiki_read",
+    "description": (
+        "Read a specific page from the configured local wiki by relative path. Use after "
+        "wiki_search when the snippet is not enough. The path is sandboxed to the wiki root."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Wiki-relative page path, e.g. AI/Hindsight.md."},
+            "max_chars": {
+                "type": "integer",
+                "description": "Maximum characters to return, capped at 100000.",
+                "default": DEFAULT_MAX_CHARS,
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+
+def check_wiki_requirements() -> bool:
+    try:
+        _get_wiki_root()
+        return True
+    except Exception:
+        return False
+
+
+from tools.registry import registry
+
+registry.register(
+    name="wiki_search",
+    toolset="wiki",
+    schema=WIKI_SEARCH_SCHEMA,
+    handler=lambda args, **kw: _handler(wiki_search, args),
+    check_fn=check_wiki_requirements,
+    emoji="📖",
+)
+
+registry.register(
+    name="wiki_read",
+    toolset="wiki",
+    schema=WIKI_READ_SCHEMA,
+    handler=lambda args, **kw: _handler(wiki_read, args),
+    check_fn=check_wiki_requirements,
+    emoji="📖",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -31,6 +31,8 @@ from typing import List, Dict, Any, Set, Optional
 _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
+    # Local wiki / knowledge base retrieval
+    "wiki_search", "wiki_read",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -91,6 +93,12 @@ TOOLSETS = {
         "description": "Web research and content extraction tools",
         "tools": ["web_search", "web_extract"],
         "includes": []  # No other toolsets included
+    },
+
+    "wiki": {
+        "description": "Local wiki/knowledge-base retrieval with path-cited search and page reads",
+        "tools": ["wiki_search", "wiki_read"],
+        "includes": []
     },
     
     "search": {


### PR DESCRIPTION
## Summary
- port Discord missed-message backfill to the plugin Discord adapter
- preserve Hindsight retain behavior across shutdown/session-boundary cases
- add local wiki retrieval tools and focused tests

## Verification
- `UV_PROJECT_ENVIRONMENT=/private/tmp/hermes-port.vVXFb5/.venv uv run --frozen --python 3.11 --extra dev pytest tests/gateway/test_discord_missed_message_backfill.py tests/gateway/test_hindsight_retain_guardrails.py tests/tools/test_wiki_tool.py -q`

Draft while we finish the restore/backup PR and decide whether these fork-specific local wiki tools belong upstream or should stay fork-only.