### PR TITLE
perf(codex): dedupe cached model slugs with a set

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -168,9 +168,12 @@ def _read_cache_models(codex_home: Path) -> List[str]:
 
     sortable.sort(key=lambda item: (item[0], item[1]))
     deduped: List[str] = []
+    seen: set[str] = set()
     for _, slug in sortable:
-        if slug not in deduped:
-            deduped.append(slug)
+        if slug in seen:
+            continue
+        seen.add(slug)
+        deduped.append(slug)
     return deduped
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -37,6 +37,30 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
     assert "gpt-5-hidden-codex" not in models
 
 
+def test_get_codex_model_ids_dedupes_duplicate_cache_slugs(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-5.3-codex", "priority": 20},
+                    {"slug": "gpt-5.4", "priority": 1},
+                    {"slug": "gpt-5.4", "priority": 2},
+                    {"slug": "gpt-5.3-codex", "priority": 30},
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    models = get_codex_model_ids()
+
+    assert models.count("gpt-5.4") == 1
+    assert models.count("gpt-5.3-codex") == 1
+    assert models.index("gpt-5.4") < models.index("gpt-5.3-codex")
+
+
 def test_setup_wizard_codex_import_resolves():
     """Regression test for #712: setup.py must import the correct function name."""
     # This mirrors the exact import used in hermes_cli/setup.py line 873.


### PR DESCRIPTION
## Summary
- replace repeated list membership checks while deduping Codex model cache slugs with a `seen` set
- preserve priority-sorted first occurrence behavior for duplicate cache entries
- add a regression test for duplicate cached slugs

## Tests
- `python -m pytest tests/hermes_cli/test_codex_models.py -q --timeout-method=thread` (20 passed)
- `python -m pytest tests/hermes_cli/test_codex_models.py::test_get_codex_model_ids_prioritizes_default_and_cache tests/hermes_cli/test_codex_models.py::test_get_codex_model_ids_dedupes_duplicate_cache_slugs tests/hermes_cli/test_codex_models.py::test_get_codex_model_ids_falls_back_to_curated_defaults tests/hermes_cli/test_codex_models.py::test_fetch_from_api_keeps_supported_in_api_false_models -q --timeout-method=thread` (4 passed)
- `git diff --check`
- `codex review --uncommitted` (no actionable bugs)
- `git fetch origin main; codex review --base origin/main` (focused tests passed; no actionable issues)

Note: on native Windows, the repo pytest addopts default to `--timeout-method=signal`, which trips pytest-timeout on missing SIGALRM. The focused pytest runs above use `--timeout-method=thread`.