### PR TITLE
fix(dashboard): honor gated OAuth sessions in token guard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -198,7 +198,20 @@ def _has_valid_session_token(request: Request) -> bool:
 
 
 def _require_token(request: Request) -> None:
-    """Validate the ephemeral session token.  Raises 401 on mismatch."""
+    """Validate dashboard API authentication.  Raises 401 on mismatch.
+
+    Loopback-mode dashboard API calls use the legacy ephemeral session token.
+    OAuth-gated deployments are authenticated earlier by
+    ``gated_auth_middleware``, which validates the session cookie and attaches
+    the verified session to ``request.state.session``. Route-local guards must
+    accept that middleware-authenticated session instead of requiring the
+    legacy token header that the gated SPA no longer sends.
+    """
+    if getattr(request.app.state, "auth_required", False):
+        if getattr(request.state, "session", None) is not None:
+            return
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
 

--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -170,6 +170,7 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         self._jwks_url = f"{self._portal_url}/.well-known/jwks.json"
         self._authorize_url = f"{self._portal_url}/oauth/authorize"
         self._token_url = f"{self._portal_url}/api/oauth/token"
+        self._missing_contract_version_warned = False
         # PyJWKClient is lazily imported so plugin discovery doesn't pay the
         # crypto-import cost when the provider isn't activated.
         self._jwks_client: Any = None
@@ -496,11 +497,15 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         """Contract C11 — tolerant treatment per OQ-C2."""
         contract_version = claims.get("oauth_contract_version")
         if contract_version is None:
-            logger.warning(
+            message = (
                 "Nous Portal token missing oauth_contract_version claim "
-                "(contract says it should be %d); proceeding anyway.",
-                _EXPECTED_CONTRACT_VERSION,
+                "(contract says it should be %d); proceeding anyway."
             )
+            if not self._missing_contract_version_warned:
+                logger.warning(message, _EXPECTED_CONTRACT_VERSION)
+                self._missing_contract_version_warned = True
+            else:
+                logger.debug(message, _EXPECTED_CONTRACT_VERSION)
             return
         if contract_version != _EXPECTED_CONTRACT_VERSION:
             raise ProviderError(

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -149,10 +149,11 @@ def test_gated_static_asset_path_is_public(gated_app):
 # ---------------------------------------------------------------------------
 
 
-def test_full_login_round_trip_unlocks_gated_api(gated_app):
+def _login_with_stub_provider(client: TestClient) -> list[str]:
+    """Complete the in-process OAuth round trip and return callback cookies."""
     # 1) Click "Sign in with Stub IdP" — /auth/login redirects to the stub
     #    with a PKCE cookie on the response.
-    r1 = gated_app.get("/auth/login?provider=stub", follow_redirects=False)
+    r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
     assert r1.status_code == 302
     pkce = next(
         (c for c in r1.headers.get_list("set-cookie")
@@ -169,7 +170,7 @@ def test_full_login_round_trip_unlocks_gated_api(gated_app):
 
     # 2) The browser would now follow the redirect to /auth/callback.
     #    TestClient automatically carries the PKCE cookie forward.
-    r2 = gated_app.get(
+    r2 = client.get(
         f"/auth/callback?code=stub_code&state={state}",
         follow_redirects=False,
     )
@@ -178,6 +179,11 @@ def test_full_login_round_trip_unlocks_gated_api(gated_app):
     set_cookies = r2.headers.get_list("set-cookie")
     assert any("hermes_session_at" in c for c in set_cookies)
     assert any("hermes_session_rt" in c for c in set_cookies)
+    return set_cookies
+
+
+def test_full_login_round_trip_unlocks_gated_api(gated_app):
+    _login_with_stub_provider(gated_app)
 
     # 3) A gated API route (``/api/sessions``) now succeeds because we
     #    have a valid session cookie. (We deliberately don't probe
@@ -189,6 +195,75 @@ def test_full_login_round_trip_unlocks_gated_api(gated_app):
         f"Expected 200 for /api/sessions post-login, got {r3.status_code}: "
         f"{r3.text}"
     )
+
+
+def test_full_login_round_trip_unlocks_legacy_token_guarded_api(
+    gated_app,
+    monkeypatch,
+):
+    """OAuth-gated requests must satisfy route-local legacy token guards.
+
+    Some dashboard endpoints keep explicit ``_require_token(request)`` calls
+    for loopback-mode API protection. In OAuth-gated mode the middleware has
+    already authenticated the cookie and attached ``request.state.session``;
+    those route-local guards must accept that validated session rather than
+    requiring the legacy ``_SESSION_TOKEN`` header that the gated SPA no
+    longer sends.
+    """
+    _login_with_stub_provider(gated_app)
+    monkeypatch.setattr(
+        web_server,
+        "_merged_plugins_hub",
+        lambda: {"plugins": [], "dashboard_plugins": [], "providers": {}},
+    )
+
+    r = gated_app.get("/api/dashboard/plugins/hub")
+    assert r.status_code == 200, (
+        "Expected a valid OAuth session cookie to unlock a route that also "
+        f"calls _require_token(); got {r.status_code}: {r.text}"
+    )
+    assert r.json() == {"plugins": [], "dashboard_plugins": [], "providers": {}}
+
+
+def test_legacy_token_guarded_api_still_requires_oauth_session(
+    gated_app,
+    monkeypatch,
+):
+    """The gated-mode _require_token path must not become a broad bypass."""
+    called = False
+
+    def fake_hub():
+        nonlocal called
+        called = True
+        return {"plugins": []}
+
+    monkeypatch.setattr(web_server, "_merged_plugins_hub", fake_hub)
+
+    r = gated_app.get("/api/dashboard/plugins/hub")
+    assert r.status_code == 401
+    assert called is False
+
+
+def test_legacy_session_token_does_not_unlock_gated_api_without_oauth_session(
+    gated_app,
+    monkeypatch,
+):
+    """Gated dashboards trust the OAuth cookie session, not legacy headers."""
+    called = False
+
+    def fake_hub():
+        nonlocal called
+        called = True
+        return {"plugins": []}
+
+    monkeypatch.setattr(web_server, "_merged_plugins_hub", fake_hub)
+
+    r = gated_app.get(
+        "/api/dashboard/plugins/hub",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+    assert r.status_code == 401
+    assert called is False
 
 
 def test_login_unknown_provider_returns_404(gated_app):

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -727,17 +727,22 @@ class TestVerifySession:
         session = provider.verify_session(access_token=token)
         assert session is not None
 
-    def test_contract_version_missing_warns_but_succeeds(
+    def test_contract_version_missing_warns_once_but_succeeds(
         self, provider, rsa_keypair, caplog
     ):
         import logging
+
         token = _mint_token(rsa_keypair, oauth_contract_version=None)
-        with caplog.at_level(logging.WARNING, logger="plugins.dashboard_auth.nous"):
-            session = provider.verify_session(access_token=token)
-        assert session is not None
-        assert any(
-            "oauth_contract_version" in r.message for r in caplog.records
-        )
+        with caplog.at_level(logging.DEBUG, logger="plugins.dashboard_auth.nous"):
+            first = provider.verify_session(access_token=token)
+            second = provider.verify_session(access_token=token)
+
+        assert first is not None
+        assert second is not None
+        matching_records = [
+            r for r in caplog.records if "oauth_contract_version" in r.message
+        ]
+        assert [r.levelno for r in matching_records] == [logging.WARNING, logging.DEBUG]
 
     def test_contract_version_mismatch_rejected(self, provider, rsa_keypair):
         token = _mint_token(rsa_keypair, oauth_contract_version=2)


### PR DESCRIPTION
## What does this PR do?

Fixes OAuth-gated dashboard API endpoints that still call the legacy `_require_token(request)` guard. It also reduces repeated `oauth_contract_version` warning spam from manual Nous Portal OAuth clients while preserving the first warning as an operator diagnostic.

In gated mode, `gated_auth_middleware` validates the OAuth session cookie and attaches the verified session to `request.state.session`. Several dashboard routes still have route-local `_require_token(request)` calls for loopback/legacy protection, so an already-authenticated gated browser request could still be rejected for not sending the legacy `X-Hermes-Session-Token` header.

This updates `_require_token()` to use the correct auth source for each dashboard mode:

- OAuth-gated dashboard: accept only a middleware-validated `request.state.session`.
- Loopback / legacy dashboard: keep requiring the ephemeral session token header / legacy bearer token.

This restores authenticated `/api/dashboard/plugins/hub` access in gated mode while keeping the gated path fail-closed.

For Nous Portal tokens missing `oauth_contract_version`, Hermes already intentionally proceeds per the tolerant contract path. This PR keeps that behavior and keeps mismatched versions strict, but changes repeated missing-claim observations from warning-level spam to debug after the first warning per provider instance.

## Related Issue / Prior Art

Fixes #35492

Related prior art:

- #35500 covers the same issue but skips `_require_token()` broadly whenever `auth_required=True`. This PR is stricter: gated mode still requires `request.state.session`, so route-local guards do not become a no-op if middleware/path configuration drifts.
- #35589 has the same safe high-level direction. This PR is a fresh current-`main` alternative with an explicit negative regression test that a legacy `X-Hermes-Session-Token` header alone does not unlock gated APIs without an OAuth session.

## Operational log noise

Local manual-client testing showed `505` repeated `Nous Portal token missing oauth_contract_version claim ... proceeding anyway` warnings in `agent.log`, with up to `39` warnings in one minute. This is not an auth failure: manual Portal clients can receive tokens without the non-standard internal contract-version claim, and the provider already tolerates that case.

The PR therefore does not remove the contract check. It preserves:

- missing claim: proceed, with one warning as operator signal;
- repeated missing claim on the same provider instance: debug only;
- present but unsupported claim value: still rejected.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py`
  - Teach `_require_token(request)` about the two dashboard auth modes.
  - In OAuth-gated mode, accept a verified `request.state.session` and reject otherwise.
  - Preserve existing legacy token behavior when `auth_required` is false.
- `plugins/dashboard_auth/nous/__init__.py`
  - Track whether a missing `oauth_contract_version` warning has already been emitted for this provider instance.
  - Keep the first missing-claim observation at warning level.
  - Downgrade repeat missing-claim observations to debug.
  - Preserve strict rejection for unsupported present contract versions.
- `tests/hermes_cli/test_dashboard_auth_middleware.py`
  - Refactor the stub OAuth login round trip into a helper.
  - Add a regression test showing a successful OAuth login unlocks `/api/dashboard/plugins/hub`, which also calls `_require_token()`.
  - Add a negative test showing unauthenticated gated requests are still rejected and do not call `_merged_plugins_hub()`.
  - Add a negative test showing the legacy `X-Hermes-Session-Token` header alone does not unlock gated APIs without an OAuth session.
- `tests/plugins/dashboard_auth/test_nous_provider.py`
  - Update the missing-contract-version test to verify only the first observation is warning-level and the repeat observation is debug-level.

## How to Test

Reproduction before the fix:

1. Configure dashboard gated mode with a `DashboardAuthProvider`.
2. Complete `/login` successfully.
3. Visit `/plugins`.
4. `/api/dashboard/plugins/hub` returns `401 {"detail":"Unauthorized"}` because `_require_token()` still expects the legacy dashboard token header.

Local verification performed:

- RED test before the fix:
  - `python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py::test_full_login_round_trip_unlocks_legacy_token_guarded_api -q -o addopts=`
  - Result before production change: failed with `401 Unauthorized` from `/api/dashboard/plugins/hub`.
- Focused gated API regression tests:
  - `python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py::test_full_login_round_trip_unlocks_legacy_token_guarded_api tests/hermes_cli/test_dashboard_auth_middleware.py::test_legacy_token_guarded_api_still_requires_oauth_session tests/hermes_cli/test_dashboard_auth_middleware.py::test_legacy_session_token_does_not_unlock_gated_api_without_oauth_session -q -o addopts=`
  - Result: `3 passed`.
- Focused Nous provider contract-warning tests:
  - `python -m pytest tests/plugins/dashboard_auth/test_nous_provider.py::TestVerifySession::test_contract_version_missing_warns_once_but_succeeds tests/plugins/dashboard_auth/test_nous_provider.py::TestVerifySession::test_contract_version_mismatch_rejected -q -o addopts=`
  - Result: `2 passed`.
- Adjacent dashboard auth/web tests:
  - `./scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_status_endpoint.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_dashboard_admin_endpoints.py tests/hermes_cli/test_web_oauth_dispatch.py`
  - Result: `425 tests passed, 0 failed`.
- Broader dashboard/plugin auth suite:
  - `./scripts/run_tests.sh tests/plugins/dashboard_auth tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_status_endpoint.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_dashboard_admin_endpoints.py tests/hermes_cli/test_web_oauth_dispatch.py`
  - Result: `567 tests passed, 0 failed`.
- Lint:
  - `python -m ruff check plugins/dashboard_auth/nous/__init__.py tests/plugins/dashboard_auth/test_nous_provider.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_middleware.py`
  - Result: `All checks passed!`.
- Larger Hermes CLI suite:
  - `./scripts/run_tests.sh tests/hermes_cli`
  - Result: `6318 tests passed, 2 failed`.
  - The 2 failures are unrelated root-environment baseline failures in `tests/hermes_cli/test_gateway_service.py`:
    - `TestGeneratedSystemdUnits::test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout`
    - `TestGeneratedUnitIncludesLocalBin::test_system_unit_includes_local_bin_in_path`
  - Both fail because this local environment runs as `root` and `generate_systemd_unit(system=True)` refuses root unless `--run-as-user root` is explicit.
  - Verified the same two failures reproduce on clean `origin/main` at `acce1a2452f8b85343db1b057c1d98717c421522`.
- Full test suite attempt:
  - `./scripts/run_tests.sh tests`
  - Reached 98.1% with this PR's focused/adjacent tests already passing; showed unrelated failures in `tests/gateway/test_email.py` and `tests/hermes_cli/test_gateway_service.py`, then the runner stopped making progress with no child pytest processes.
  - The email test passed when rerun directly on both clean base and this branch (`1 passed in 30.47s`), indicating a near-timeout/flaky baseline issue rather than this auth change.

CI on this PR is green on GitHub Actions for the latest head SHA.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.17, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal auth guard/logging behavior only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, FastAPI request-state/provider logging logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshots included; this is covered by the in-process gated OAuth regression tests and provider log-level regression tests.
