### PR TITLE
fix: add lmstudio model discovery to provider_model_ids

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1390,6 +1390,13 @@ def list_authenticated_providers(
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
                         has_creds = True
                         break
+            # Providers that use a base_url alone (no api key required)
+            # should be detected when their base_url_env_var is set.
+            if not has_creds:
+                pcfg = _auth_registry.get(hermes_slug) or _auth_registry.get(pid)
+                if pcfg and pcfg.base_url_env_var:
+                    if os.environ.get(pcfg.base_url_env_var):
+                        has_creds = True
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2156,6 +2156,23 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
+    if normalized == "lmstudio":
+        base_url = (
+            os.getenv("LM_BASE_URL", "")
+            or _get_custom_base_url()
+            or "http://127.0.0.1:1234/v1"
+        )
+        api_key = os.getenv("LM_API_KEY", "") or ""
+        try:
+            live = fetch_lmstudio_models(api_key=api_key, base_url=base_url)
+            if live:
+                return live
+        except Exception:
+            pass
+        # Fallback: try OpenAI-compatible /v1/models endpoint
+        fallback = fetch_api_models(api_key, base_url)
+        if fallback:
+            return fallback
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2162,7 +2162,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             or _get_custom_base_url()
             or "http://127.0.0.1:1234/v1"
         )
-        api_key = os.getenv("LM_API_KEY", "") or ""
+        api_key = os.getenv("LM_API_KEY", "")
         try:
             live = fetch_lmstudio_models(api_key=api_key, base_url=base_url)
             if live:


### PR DESCRIPTION
## Problem

LM Studio users with only `LM_BASE_URL` set (no `LM_API_KEY`) couldn't see their models in Hermes. Two issues:

1. **`provider_model_ids()` had no code path for `lmstudio`** — returned 0 models for the `/model` picker, gateway model listing, and cached provider display.

2. **Credential detection required `LM_API_KEY`** — `list_authenticated_providers` only checked `extra_env_vars` and `api_key_env_vars` for credential detection, but LM Studio typically doesn't require an API key (only a base URL). So the provider was hidden from the provider list entirely.

## Fix

**models.py**: Add a dedicated `lmstudio` case to `provider_model_ids()` that:
- Reads `LM_BASE_URL` (falls back to config `model.base_url`, then default `127.0.0.1:1234`)
- Calls `fetch_lmstudio_models()` via LM Studio's native `/api/v1/models` endpoint
- Falls back to OpenAI-compatible `/v1/models` as safety net

**model_switch.py**: Add `base_url_env_var` check to the Section 2 credential detection so providers configured via a base URL env var (not an API key) are recognized as configured.

## Testing

Tested against a live LM Studio instance on a custom port (11435):
- `provider_model_ids("lmstudio")`: 0 → 133 models
- `list_authenticated_providers()`: LM Studio now appears with 133 models
- Config with `model.provider: lmstudio` and `LM_BASE_URL` env var works end-to-end