### PR TITLE
fix: add lmstudio case to provider_model_ids for model discovery

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2168,6 +2168,23 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             live = fetch_api_models(api_key, base_url)
             if live:
                 return live
+    if normalized == "lmstudio":
+        base_url = (
+            os.getenv("LM_BASE_URL", "")
+            or _get_custom_base_url()
+            or "http://127.0.0.1:1234/v1"
+        )
+        api_key = os.getenv("LM_API_KEY", "")
+        try:
+            live = fetch_lmstudio_models(api_key=api_key, base_url=base_url)
+            if live:
+                return live
+        except Exception:
+            pass
+        # Fallback: try OpenAI-compatible /v1/models endpoint
+        fallback = fetch_api_models(api_key, base_url)
+        if fallback:
+            return fallback
     # Bedrock uses live discovery keyed by the resolved AWS region so that
     # EU/AP users see eu.*/ap.* model IDs instead of the static us.* list.
     # Note: early return intentionally skips _MODELS_DEV_PREFERRED merge


### PR DESCRIPTION
## Problem

`provider_model_ids()` had no code path for the `lmstudio` provider, so it returned 0 models for any secondary model listing (in-session `/model` picker, gateway model picker, cached provider display) even though the interactive `hermes model` setup flow correctly called `fetch_lmstudio_models()`.

When users select LM Studio in the interactive picker, models are discovered. But when the session picker, gateway, or any downstream consumer calls `provider_model_ids("lmstudio")`, it falls through all special cases, finds no ProviderProfile (LM Studio is registered in auth.py, not the newer providers/ plugin system), finds no `_PROVIDER_MODELS` entry, and returns an empty list.

## Fix

Add a dedicated `lmstudio` case to `provider_model_ids()` that:
- Reads `LM_BASE_URL` env var (fallback: config `model.base_url`, then the lmstudio default `127.0.0.1:1234`)
- Calls `fetch_lmstudio_models()` via the LM Studio native API at `{base_root}/api/v1/models`
- Falls back to the OpenAI-compatible `/v1/models` endpoint as a safety net

## Testing

Tested against a live LM Studio instance on a custom port:
- Before fix: `provider_model_ids("lmstudio")` → 0 models
- After fix: `provider_model_ids("lmstudio")` → 133 models
- `provider_model_ids("custom")` still works (138 models, same endpoint)\n