### PR TITLE
fix(desktop): skip no-op session message flushes

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -3,7 +3,13 @@ import { useCallback, useRef } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import {
+  type ChatMessage,
+  chatMessageArraysEquivalent,
+  chatMessageText,
+  preserveLocalAssistantErrors,
+  toChatMessages
+} from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { setSessionYolo } from '@/lib/yolo-session'
@@ -92,29 +98,6 @@ function preserveReasoningParts(message: ChatMessage, previous: ChatMessage): Ch
   const reasoningParts = previous.parts.filter(part => part.type === 'reasoning')
 
   return reasoningParts.length ? { ...message, parts: [...reasoningParts, ...message.parts] } : message
-}
-
-function chatMessagesEquivalent(a: ChatMessage, b: ChatMessage): boolean {
-  if (
-    a.id !== b.id ||
-    a.role !== b.role ||
-    a.pending !== b.pending ||
-    a.error !== b.error ||
-    a.hidden !== b.hidden ||
-    a.branchGroupId !== b.branchGroupId
-  ) {
-    return false
-  }
-
-  if (a.parts.length !== b.parts.length) {
-    return false
-  }
-
-  return a.parts.every((part, index) => JSON.stringify(part) === JSON.stringify(b.parts[index]))
-}
-
-function chatMessageArraysEquivalent(a: ChatMessage[], b: ChatMessage[]): boolean {
-  return a.length === b.length && a.every((message, index) => chatMessagesEquivalent(message, b[index]))
 }
 
 function reconcileResumeMessages(nextMessages: ChatMessage[], previousMessages: ChatMessage[]): ChatMessage[] {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -1,0 +1,113 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $busy, $messages } from '@/store/session'
+
+import { useSessionStateCache } from './use-session-state-cache'
+
+type SessionStateCacheApi = ReturnType<typeof useSessionStateCache>
+
+function assistantMessage(id: string, text: string): ChatMessage {
+  return {
+    id,
+    parts: [assistantTextPart(text)],
+    role: 'assistant'
+  }
+}
+
+function SessionStateCacheHarness({
+  onReady,
+  setAwaitingResponse,
+  setBusy,
+  setMessages
+}: {
+  onReady: (api: SessionStateCacheApi) => void
+  setAwaitingResponse: (awaiting: boolean) => void
+  setBusy: (busy: boolean) => void
+  setMessages: (messages: ChatMessage[]) => void
+}) {
+  const busyRef = useRef(false)
+
+  const api = useSessionStateCache({
+    activeSessionId: 'session-1',
+    busyRef,
+    selectedStoredSessionId: null,
+    setAwaitingResponse,
+    setBusy,
+    setMessages
+  })
+
+  useEffect(() => {
+    onReady(api)
+  }, [api, onReady])
+
+  return null
+}
+
+async function waitForRaf() {
+  await act(async () => {
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+  })
+}
+
+describe('useSessionStateCache', () => {
+  beforeEach(() => {
+    $busy.set(false)
+    $messages.set([])
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+  })
+
+  afterEach(() => {
+    cleanup()
+    $busy.set(false)
+    $messages.set([])
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('does not publish messages when an active-session flush is equivalent to the current view', async () => {
+    const messages = [assistantMessage('assistant-1', 'Already rendered response')]
+    const setAwaitingResponse = vi.fn()
+    const setBusy = vi.fn()
+    const setMessages = vi.fn()
+    let api: SessionStateCacheApi | undefined
+
+    $messages.set(messages)
+
+    render(
+      <SessionStateCacheHarness
+        onReady={nextApi => {
+          api = nextApi
+        }}
+        setAwaitingResponse={setAwaitingResponse}
+        setBusy={setBusy}
+        setMessages={setMessages}
+      />
+    )
+
+    if (!api) {
+      throw new Error('Session state cache harness did not initialize')
+    }
+
+    const sessionCacheApi = api as SessionStateCacheApi
+
+    act(() => {
+      sessionCacheApi.syncSessionStateToView('session-1', {
+        ...createClientSessionState(null, messages),
+        awaitingResponse: true,
+        busy: true
+      })
+    })
+    await waitForRaf()
+
+    expect(setBusy).toHaveBeenCalledWith(true)
+    expect(setAwaitingResponse).toHaveBeenCalledWith(true)
+    expect(setMessages).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
-import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
+import { chatMessageArraysEquivalent, preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { $busy, $messages, noteSessionActivity, setSessionAttention, setSessionWorking } from '@/store/session'
@@ -88,7 +88,13 @@ export function useSessionStateCache({
       return
     }
 
-    setMessages(preserveLocalAssistantErrors(pending.state.messages, $messages.get()))
+    const currentMessages = $messages.get()
+    const nextMessages = preserveLocalAssistantErrors(pending.state.messages, currentMessages)
+
+    if (!chatMessageArraysEquivalent(currentMessages, nextMessages)) {
+      setMessages(nextMessages)
+    }
+
     setBusy(pending.state.busy)
     setMutableRef(busyRef, pending.state.busy)
     setAwaitingResponse(pending.state.awaitingResponse)

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -110,6 +110,31 @@ export function chatMessageText(message: ChatMessage): string {
     .join('')
 }
 
+export function chatMessagesEquivalent(a: ChatMessage, b: ChatMessage): boolean {
+  if (
+    a.id !== b.id ||
+    a.role !== b.role ||
+    a.pending !== b.pending ||
+    a.error !== b.error ||
+    a.hidden !== b.hidden ||
+    a.branchGroupId !== b.branchGroupId ||
+    a.timestamp !== b.timestamp ||
+    (a.attachmentRefs ?? []).join('\n') !== (b.attachmentRefs ?? []).join('\n')
+  ) {
+    return false
+  }
+
+  if (a.parts.length !== b.parts.length) {
+    return false
+  }
+
+  return a.parts.every((part, index) => JSON.stringify(part) === JSON.stringify(b.parts[index]))
+}
+
+export function chatMessageArraysEquivalent(a: ChatMessage[], b: ChatMessage[]): boolean {
+  return a.length === b.length && a.every((message, index) => chatMessagesEquivalent(message, b[index]))
+}
+
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/
 const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g


### PR DESCRIPTION
## Summary

- Prevent active-session cache flushes from republishing equivalent chat message arrays.
- Share the existing chat-message equivalence helper so resume and active-view flush paths use the same comparison.
- Add hook-level regression coverage proving the RAF flush still runs while `setMessages` is skipped for equivalent messages.

## Related Issue

No GitHub issue is linked; this PR comes from the Hermes Desktop flicker / scroll-jump investigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## User Impact

This targets the severe Hermes Desktop flicker / scroll-jump pattern seen while reading long assistant responses on macOS. In practice, the app can feel like it is fighting the user: the transcript re-renders, the viewport shifts, and code blocks or tables appear to jump even when the user is just trying to read.

This fix removes one noisy no-op update path that can rebuild an unchanged transcript. That makes the desktop chat view behave more like a stable document: if the content did not actually change, the app should not republish it and risk moving the reader around.

## Problem

The desktop thread virtualizer already has scroll-jump fixes around native scroll anchoring, content-growth interim scrolls, stale programmatic scroll events, and post-run code-highlight growth. The remaining suspicious idle-reading path was above the virtualizer: `flushPendingViewState` always called `setMessages(preserveLocalAssistantErrors(...))` for the active session.

`preserveLocalAssistantErrors` maps into a fresh array even when the transcript is unchanged. That means a no-op active-session state update can still publish a new `$messages` reference, forcing assistant-ui and the virtualizer to reprocess an already-rendered transcript while the user is reading or scrolling.

## Fix

- Move `chatMessageArraysEquivalent` / `chatMessagesEquivalent` into `lib/chat-messages.ts`.
- In `use-session-state-cache.ts`, compare the merged messages against the current `$messages` before calling `setMessages`.
- Continue updating busy and awaiting-response state even when the message array is equivalent.

## Regression Coverage

- New `use-session-state-cache.test.tsx` seeds `$messages` with the same array as the pending active session.
- The test flushes the pending active view state through RAF.
- It asserts `setBusy(true)` and `setAwaitingResponse(true)` are still called, proving the flush executed.
- It asserts `setMessages` is not called for equivalent messages.

## Validation

- Manual Hermes Desktop dev-window test on macOS: reopened the flicker investigation chat, scrolled around the numbered-list/code-block section, and observed stable idle scroll behavior.
- Visual review of the latest 49s Studio recording: no visible spontaneous viewport movement, snap-back, code-card jumping, table reflow instability, or obvious overlap/clipping in sampled frames.
- From `apps/desktop`: `npx eslint src/app/session/hooks/use-session-actions.ts src/app/session/hooks/use-session-state-cache.ts src/app/session/hooks/use-session-state-cache.test.tsx src/lib/chat-messages.ts`
- From `apps/desktop`: `npm run test:ui -- src/app/session/hooks/use-session-state-cache.test.tsx`
- From `apps/desktop`: `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx src/lib/chat-messages.test.ts`
- From `apps/desktop`: `npm run type-check`
- From `apps/desktop`: `npm run test:desktop:platforms`
- From repo root: `git diff --check`

Note: full `npm run lint` currently fails on unrelated baseline files outside this diff:

- `apps/desktop/electron/main.cjs`
- `apps/desktop/src/app/messaging/index.tsx`
- `apps/desktop/src/app/settings/env-var-actions-menu.tsx`

## Contributor Checklist

- [x] Read the Contributing Guide.
- [x] Commit message follows Conventional Commits: `fix(desktop): skip no-op session message flushes`.
- [x] Searched for existing PRs; related open scroll PRs are separate TUI or bottom-follow/virtualizer scopes.
- [x] PR contains only the desktop no-op flush fix commit.
- [x] Added regression coverage for the changed path.
- [x] Tested on macOS; full validation is listed above.
- [ ] Root Python `pytest tests/ -q` not run; this PR changes desktop TypeScript/UI code, and targeted desktop checks are listed above.
- [x] Documentation, config, and tool-schema updates are N/A.
- [x] Cross-platform impact considered: the change is desktop UI state management, with no new OS-specific file, process, terminal, or shell behavior.

## Review Notes

Independent read-only review of `origin/main...HEAD` for commit `5d0b90e37` found no blocking issues.

Residual risk: `chatMessageArraysEquivalent` is now shared hand-rolled API surface. Future `ChatMessage` fields or non-JSON-ish part metadata could be missed unless comparator tests are added when the message shape grows. Current render-relevant fields are compared by the helper: `timestamp`, `attachmentRefs`, `pending`, `error`, `hidden`, `branchGroupId`, role/id, and parts.

## Scope Notes

- This does not remove `virtualizer.scrollToIndex()` from `jumpToBottom`; open PR #38143 targets that separate bottom-follow/reflow behavior.
- This does not claim every movement in the source recording was programmatic. The recording shows some visible user gesture/cursor state during later movement. This fix addresses the no-op state flush path that can cause unnecessary transcript rebuilds while reading.
