### PR TITLE
fix(desktop): satisfy slash metadata typecheck

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -16,7 +16,7 @@ interface SlashItemMetadata extends Record<string, string> {
   command: string
   display: string
   meta: string
-  rawText?: string
+  rawText: string
 }
 
 function textValue(value: unknown, fallback = ''): string {


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop TypeScript build failure introduced by the slash command metadata change in #39289. `SlashItemMetadata` extends `Record<string, string>`, but `rawText` was declared optional as `string | undefined`, which makes `tsc -b` fail with TS2411.

The metadata object always sets `rawText: command`, so this makes the interface match the actual runtime shape.

## Related Issue

Fixes #

Support thread evidence: Windows Desktop installer failed at `apps/desktop build failed (exit 1)` on commit `1eeb7da2e6e5` with:

`src/app/chat/composer/hooks/use-slash-completions.ts(19,3): error TS2411: Property rawText of type string | undefined is not assignable to string index type string.`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts` — Changed `SlashItemMetadata.rawText` from optional to required so it satisfies the `Record<string, string>` index signature and matches the object literal that always supplies `rawText: command`.

## How to Test

1. On `origin/main` at `1eeb7da2e6e5`, the Windows Desktop installer log shows `npm run pack` failing during `tsc -b` with TS2411 in `use-slash-completions.ts`.
2. Apply this change.
3. Run `cd apps/desktop && npm run type-check`.

Result: `npm run type-check` passes locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux via Desktop TypeScript build check

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows Desktop installer build failure; TypeScript-only fix
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Failing installer log excerpt from support thread:

`src/app/chat/composer/hooks/use-slash-completions.ts(19,3): error TS2411: Property rawText of type string | undefined is not assignable to string index type string.`

Validation run:

`cd apps/desktop && npm run type-check`

Passed.