### PR TITLE
fix(gateway): stop macOS gateway EMFILE — raise launchd fd limit + fix Telegram pool leak

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import os
 import socket
 from typing import Iterable, Optional
 
@@ -20,6 +21,51 @@ import httpx
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_API_HOST = "api.telegram.org"
+
+# Default connection-pool sizing for the fallback transport's inner
+# AsyncHTTPTransport instances.  httpx's built-in defaults (max_connections=100,
+# max_keepalive_connections=20, keepalive_expiry=5s) are far too small/short for
+# a long-lived gateway: the getUpdates long-poll plus bursty send traffic churn
+# through the pool, leaving server-closed sockets in CLOSE_WAIT and eventually
+# raising "Pool timeout: All connections in the connection pool are occupied."
+# These are overridable via the same env vars the PTB request layer reads.
+_DEFAULT_POOL_SIZE = 512
+_DEFAULT_KEEPALIVE_EXPIRY = 20.0  # seconds
+
+
+def _default_transport_limits() -> "httpx.Limits":
+    """Build sane pool limits for the inner fallback transports.
+
+    PTB applies ``connection_pool_size`` to the *outer* ``httpx.AsyncClient``,
+    but httpx ignores those limits when a custom ``transport`` is supplied — all
+    pool management happens inside this transport's own AsyncHTTPTransport
+    instances.  Without this, the inner pool silently falls back to httpx's
+    default of 100 connections regardless of the configured pool size.
+    """
+
+    def _env_int(name: str, default: int) -> int:
+        try:
+            value = int(os.environ.get(name, str(default)))
+            return value if value > 0 else default
+        except (TypeError, ValueError):
+            return default
+
+    def _env_float(name: str, default: float) -> float:
+        try:
+            value = float(os.environ.get(name, str(default)))
+            return value if value > 0 else default
+        except (TypeError, ValueError):
+            return default
+
+    pool_size = _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", _DEFAULT_POOL_SIZE)
+    keepalive = _env_float(
+        "HERMES_TELEGRAM_HTTP_KEEPALIVE_EXPIRY", _DEFAULT_KEEPALIVE_EXPIRY
+    )
+    return httpx.Limits(
+        max_connections=pool_size,
+        max_keepalive_connections=pool_size,
+        keepalive_expiry=keepalive,
+    )
 
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
@@ -63,6 +109,15 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
+        # PTB sizes the OUTER httpx.AsyncClient pool via connection_pool_size,
+        # but httpx ignores those limits once a custom transport is supplied —
+        # the real pool lives in the inner AsyncHTTPTransport instances below.
+        # Without explicit limits they silently use httpx's tiny defaults
+        # (100 conns / 20 keepalive / 5s expiry), which a long-lived gateway
+        # exhausts ("Pool timeout: All connections ... occupied") and leaks as
+        # CLOSE_WAIT sockets. Inject sane limits unless the caller set them.
+        if "limits" not in transport_kwargs:
+            transport_kwargs["limits"] = _default_transport_limits()
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._fallbacks = {
             ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3053,6 +3053,19 @@ def generate_launchd_plist() -> str:
     )
     prog_args_xml = "\n        ".join(prog_args)
 
+    # Raise the open-file-descriptor limit. launchd agents inherit macOS's
+    # default soft RLIMIT_NOFILE of 256, which a long-lived gateway exhausts:
+    # a large ~/.hermes/sessions/ directory plus accumulated async httpx
+    # transports hit EMFILE ("[Errno 24] Too many open files") on session
+    # writes. The kernel ceiling (kern.maxfilesperproc) is far higher, so 256
+    # is the only real constraint. See #14210.
+    try:
+        max_files = int(os.environ.get("HERMES_GATEWAY_MAX_FILES", "65536"))
+        if max_files <= 0:
+            max_files = 65536
+    except (TypeError, ValueError):
+        max_files = 65536
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -3083,6 +3096,18 @@ def generate_launchd_plist() -> str:
     
     <key>KeepAlive</key>
     <true/>
+    
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{max_files}</integer>
+    </dict>
+    
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{max_files}</integer>
+    </dict>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -355,6 +355,77 @@ class TestFallbackTransportInit:
         assert all("proxy" not in kwargs for kwargs in seen_kwargs)
 
 
+class TestFallbackTransportPoolLimits:
+    """Regression tests for the CLOSE_WAIT / pool-exhaustion leak.
+
+    PTB applies connection_pool_size to the OUTER httpx.AsyncClient, but httpx
+    ignores those limits when a custom transport is supplied. The inner
+    AsyncHTTPTransport instances must therefore set their own limits, or they
+    silently fall back to httpx defaults (100 conns / 20 keepalive / 5s expiry)
+    and exhaust under a long-lived gateway's traffic.
+    """
+
+    def _pool_limits(self, real_transport):
+        pool = real_transport._pool
+        return (
+            pool._max_connections,
+            pool._max_keepalive_connections,
+            pool._keepalive_expiry,
+        )
+
+    def test_inner_transports_get_large_pool_by_default(self, monkeypatch):
+        for key in ("HERMES_TELEGRAM_HTTP_POOL_SIZE", "HERMES_TELEGRAM_HTTP_KEEPALIVE_EXPIRY",
+                    "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                    "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220", "149.154.167.221"])
+
+        for tr in (transport._primary, *transport._fallbacks.values()):
+            max_conn, max_keepalive, expiry = self._pool_limits(tr)
+            assert max_conn == tnet._DEFAULT_POOL_SIZE
+            assert max_keepalive == tnet._DEFAULT_POOL_SIZE
+            assert expiry == tnet._DEFAULT_KEEPALIVE_EXPIRY
+            # Guard against silently reverting to httpx's tiny defaults.
+            assert max_conn > 100
+
+    def test_pool_size_env_override(self, monkeypatch):
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                    "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "1024")
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_KEEPALIVE_EXPIRY", "45")
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        max_conn, max_keepalive, expiry = self._pool_limits(transport._primary)
+        assert max_conn == 1024
+        assert max_keepalive == 1024
+        assert expiry == 45.0
+
+    def test_invalid_env_falls_back_to_defaults(self, monkeypatch):
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                    "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "not-a-number")
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_KEEPALIVE_EXPIRY", "-5")
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        max_conn, _, expiry = self._pool_limits(transport._primary)
+        assert max_conn == tnet._DEFAULT_POOL_SIZE
+        assert expiry == tnet._DEFAULT_KEEPALIVE_EXPIRY
+
+    def test_explicit_limits_kwarg_is_respected(self, monkeypatch):
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+                    "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        caller_limits = tnet.httpx.Limits(max_connections=7, max_keepalive_connections=3)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"], limits=caller_limits)
+        max_conn, max_keepalive, _ = self._pool_limits(transport._primary)
+        assert max_conn == 7
+        assert max_keepalive == 3
+
+
 class TestFallbackTransportClose:
     @pytest.mark.asyncio
     async def test_aclose_closes_all_transports(self, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1629,6 +1629,41 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
+    def test_launchd_plist_sets_open_file_limit(self, tmp_path, monkeypatch):
+        """generate_launchd_plist must raise RLIMIT_NOFILE above the macOS default of 256.
+
+        launchd agents inherit a soft limit of 256 open files; a long-lived
+        gateway exhausts that and hits EMFILE on session writes. See #14210.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.delenv("HERMES_GATEWAY_MAX_FILES", raising=False)
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>HardResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>65536</integer>" in plist
+
+    def test_launchd_plist_open_file_limit_env_override(self, tmp_path, monkeypatch):
+        """HERMES_GATEWAY_MAX_FILES overrides the default fd limit; bad values fall back to 65536."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        monkeypatch.setenv("HERMES_GATEWAY_MAX_FILES", "20000")
+        assert "<integer>20000</integer>" in gateway_cli.generate_launchd_plist()
+
+        # Invalid / non-positive values fall back to the safe default.
+        monkeypatch.setenv("HERMES_GATEWAY_MAX_FILES", "not-a-number")
+        assert "<integer>65536</integer>" in gateway_cli.generate_launchd_plist()
+        monkeypatch.setenv("HERMES_GATEWAY_MAX_FILES", "0")
+        assert "<integer>65536</integer>" in gateway_cli.generate_launchd_plist()
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## What does this PR do?

Fixes `[Errno 24] Too many open files` (EMFILE) on the macOS launchd gateway, which breaks session writes (`.tmp` files in `~/.hermes/sessions/`) and forces a `/reset`.

Two compounding root causes:

1. **launchd fd cap.** Gateway launchd agents inherit macOS's default soft `RLIMIT_NOFILE` of 256. A long-lived gateway with a large `~/.hermes/sessions/` dir plus accumulated `httpx` transports exhausts it. The generated plist set no resource limit, and the plist is reconciled against the template on every start/restart/setup — so any manual edit was silently reverted to 256.
2. **Telegram fallback-transport pool leak.** `TelegramFallbackTransport` builds its inner `httpx.AsyncHTTPTransport` instances with no limits, so they fall back to httpx defaults (`max_connections=100`, `max_keepalive=20`, `keepalive_expiry=5s`). PTB's `connection_pool_size=512`/`pool_timeout` only configure the *outer* `httpx.AsyncClient`, and httpx ignores the outer client's limits once a custom transport is supplied. On the fallback-IP path the effective pool was 100, producing `Pool timeout: All connections in the connection pool are occupied` send failures and hundreds of `CLOSE_WAIT` sockets that combine with the 256 cap to trigger EMFILE.

## Related Issue

Refs #14210

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **launchd plist** — Emit `SoftResourceLimits`/`HardResourceLimits` → `NumberOfFiles` (default `65536`, overridable via `HERMES_GATEWAY_MAX_FILES`) in the generated plist, so the limit persists across template reconciliation.
- **`TelegramFallbackTransport`** — Inject explicit `httpx.Limits` into every inner fallback transport (primary + each fallback): 512 conns / 512 keepalive / 20s expiry, overridable via `HERMES_TELEGRAM_HTTP_POOL_SIZE` and `HERMES_TELEGRAM_HTTP_KEEPALIVE_EXPIRY`. Caller-supplied limits are respected. The non-fallback path already honored `connection_pool_size` and is unaffected.

## How to Test

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/gateway/test_telegram_network.py
```

- `tests/hermes_cli/test_gateway_service.py` — launchd plist sets the fd limit, honors the `HERMES_GATEWAY_MAX_FILES` env override, and falls back to the default on invalid input.
- `tests/gateway/test_telegram_network.py` — inner fallback transports get the large pool, the env override applies, an invalid env value falls back, and explicitly-supplied limits are respected.

Manual (reproduces the original EMFILE):

1. On macOS, install/start the gateway as a launchd agent (`hermes gateway install`). The inherited soft cap is 256 (`launchctl limit maxfiles`), and under sustained session writes + Telegram fallback traffic the gateway logs `[Errno 24] Too many open files`.
2. Apply this change and regenerate the plist (restart/setup).
3. Verify `SoftResourceLimits NumberOfFiles` is `65536` in the generated plist; `CLOSE_WAIT` sockets stay flat (`lsof -p <gateway_pid> | grep -c CLOSE_WAIT`) and the EMFILE no longer occurs.

Result: targeted tests pass; `ruff` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (launchd fd limit + Telegram fallback pool)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var overrides only)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS-specific launchd fix; Telegram pool fix is platform-agnostic; pre-existing systemd/Linux gateway tests fail on macOS regardless of this change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Failing path (before):

`OSError: [Errno 24] Too many open files` writing session `.tmp` under `~/.hermes/sessions/`, alongside `Pool timeout: All connections in the connection pool are occupied` on the Telegram fallback path.

Validation run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/gateway/test_telegram_network.py
```

Passed.
