### PR TITLE
fix: resolve TS2411 in use-slash-completions

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -12,11 +12,11 @@ import {
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
 import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
-interface SlashItemMetadata extends Record<string, string> {
+type SlashItemMetadata = {
   command: string
   display: string
   meta: string
-  rawText?: string
+  rawText: string
 }
 
 function textValue(value: unknown, fallback = ''): string {


### PR DESCRIPTION
## Summary
Fixes a TypeScript build error (TS2411) in the desktop app's slash completions hook.

### Problem
The `SlashItemMetadata` interface extends `Record<string, string>` but declares `rawText?: string`. Since `string | undefined` is not assignable to the string index type, builds fail with:

```
src/app/chat/composer/hooks/use-slash-completions.ts:19:3 - error TS2411: Property 'rawText' of type 'string | undefined' is not assignable to 'string' index type 'string'.
```

### Fix
Changed the interface to a typed object with explicit required fields, making `rawText` required (which it already is in practice):

```typescript
// Before
interface SlashItemMetadata extends Record<string, string> {
  command: string
  display: string
  meta: string
  rawText?: string  // conflicts with Record<string, string>
}

// After
type SlashItemMetadata = {
  command: string
  display: string
  meta: string
  rawText: string
}
```

### Testing
- `tsc -b` in `apps/desktop` compiles cleanly with no errors