### PR TITLE
fix(agent): preserve final_response on failure returns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -691,11 +691,18 @@ def run_conversation(
             # context windows (each pass summarises the middle N turns).
             for _pass in range(3):
                 _orig_len = len(messages)
+                _orig_tokens = _preflight_tokens
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
-                if len(messages) >= _orig_len:
+                _post_preflight_tokens = estimate_request_tokens_rough(
+                    messages,
+                    system_prompt=active_system_prompt or "",
+                    tools=agent.tools or None,
+                )
+                if len(messages) >= _orig_len and _post_preflight_tokens >= _orig_tokens:
+                    _preflight_tokens = _post_preflight_tokens
                     break  # Cannot compress further
                 # Compression created a new session — clear the history
                 # reference so _flush_messages_to_session_db writes ALL
@@ -713,12 +720,10 @@ def run_conversation(
                 agent._last_content_with_tools = None
                 agent._last_content_tools_all_housekeeping = False
                 agent._mute_post_response = False
-                # Re-estimate after compression
-                _preflight_tokens = estimate_request_tokens_rough(
-                    messages,
-                    system_prompt=active_system_prompt or "",
-                    tools=agent.tools or None,
-                )
+                # Re-use the post-compression estimate above.  A compressor may
+                # keep the same number of messages while replacing large
+                # contents with summaries; that is still useful progress.
+                _preflight_tokens = _post_preflight_tokens
                 if not _compressor.should_compress(_preflight_tokens):
                     break  # Under threshold or anti-thrash guard stopped it
 
@@ -3134,7 +3139,11 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
+                    pre_compress_request_tokens = approx_request_tokens if approx_request_tokens > 0 else approx_tokens
+                    agent._buffer_status(
+                        f"🗜️ Context too large (~{pre_compress_request_tokens:,} request tokens) "
+                        f"— compressing ({compression_attempts}/{max_compression_attempts})..."
+                    )
 
                     original_len = len(messages)
                     messages, active_system_prompt = agent._compress_context(
@@ -3145,10 +3154,22 @@ def run_conversation(
                     # so _flush_messages_to_session_db writes compressed
                     # messages to the new session, not skipping them.
                     conversation_history = None
+                    post_compress_request_tokens = estimate_request_tokens_rough(
+                        messages,
+                        system_prompt=active_system_prompt or "",
+                        tools=agent.tools or None,
+                    )
+                    token_reduced = post_compress_request_tokens < pre_compress_request_tokens
 
-                    if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
+                    if len(messages) < original_len or token_reduced or new_ctx and new_ctx < old_ctx:
                         if len(messages) < original_len:
                             agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                        elif token_reduced:
+                            agent._buffer_status(
+                                f"🗜️ Compressed request estimate "
+                                f"~{pre_compress_request_tokens:,} → ~{post_compress_request_tokens:,} tokens, retrying..."
+                            )
+                        _emit_preflight_token_usage(agent, post_compress_request_tokens)
                         time.sleep(2)  # Brief pause between compression retries
                         restart_with_compressed_messages = True
                         break
@@ -3157,13 +3178,16 @@ def run_conversation(
                         agent._flush_status_buffer()
                         agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
-                        logger.error(f"{agent.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                        logger.error(
+                            f"{agent.log_prefix}Context length exceeded: "
+                            f"{post_compress_request_tokens:,} request tokens. Cannot compress further."
+                        )
                         agent._persist_session(messages, conversation_history)
                         return {
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
+                            "error": f"Context length exceeded ({post_compress_request_tokens:,} request tokens). Cannot compress further.",
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -117,6 +117,41 @@ def _ra():
     return run_agent
 
 
+def _emit_preflight_token_usage(agent: Any, request_tokens: int) -> None:
+    """Send the current request-size estimate through the live usage channel."""
+    if request_tokens <= 0:
+        return
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return
+
+    try:
+        previous = getattr(compressor, "last_prompt_tokens", 0) or 0
+        if request_tokens > previous:
+            compressor.last_prompt_tokens = request_tokens
+    except Exception:
+        logger.debug("could not update preflight context estimate", exc_info=True)
+
+    emit = getattr(agent, "_emit_token_usage", None)
+    if not callable(emit):
+        return
+
+    try:
+        emit(
+            input_tokens=getattr(agent, "session_input_tokens", 0)
+            or getattr(agent, "session_prompt_tokens", 0)
+            or 0,
+            output_tokens=getattr(agent, "session_output_tokens", 0)
+            or getattr(agent, "session_completion_tokens", 0)
+            or 0,
+            total_tokens=getattr(agent, "session_total_tokens", 0) or 0,
+            context_tokens=request_tokens,
+            context_length=getattr(compressor, "context_length", 0) or 0,
+        )
+    except Exception:
+        logger.debug("could not emit preflight token usage", exc_info=True)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -1089,6 +1124,7 @@ def run_conversation(
         approx_request_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        _emit_preflight_token_usage(agent, approx_request_tokens)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1841,6 +1841,19 @@ def run_conversation(
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
 
+                    # Emit structured token usage for real-time context bar updates.
+                    # Fire-and-forget: the target may not have a status_callback wired,
+                    # and we never want to block the conversation loop.
+                    agent._emit_token_usage(
+                        input_tokens=agent.session_input_tokens,
+                        output_tokens=agent.session_output_tokens,
+                        total_tokens=agent.session_total_tokens,
+                        context_tokens=agent.context_compressor.last_prompt_tokens
+                        if agent.context_compressor else 0,
+                        context_length=agent.context_compressor.context_length
+                        if agent.context_compressor else 0,
+                    )
+
                     # Log API call details for debugging/observability
                     _cache_pct = ""
                     if canonical_usage.cache_read_tokens and prompt_tokens:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1590,11 +1590,13 @@ def run_conversation(
                         agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                         logger.error(f"{agent.log_prefix}Invalid API response after {max_retries} retries.")
                         agent._persist_session(messages, conversation_history)
+                        _final_response = f"Invalid API response after {max_retries} retries: {_failure_hint}"
                         return {
+                            "final_response": _final_response,
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
+                            "error": _final_response,
                             "failed": True  # Mark as failure for filtering
                         }
                     
@@ -2974,11 +2976,13 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
                         agent._persist_session(messages, conversation_history)
+                        _final_response = f"Request payload too large: max compression attempts ({max_compression_attempts}) reached."
                         return {
+                            "final_response": _final_response,
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
+                            "error": _final_response,
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,
@@ -3008,11 +3012,13 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}413 payload too large. Cannot compress further.")
                         agent._persist_session(messages, conversation_history)
+                        _final_response = "Request payload too large (413). Cannot compress further."
                         return {
+                            "final_response": _final_response,
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": "Request payload too large (413). Cannot compress further.",
+                            "error": _final_response,
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,
@@ -3061,11 +3067,13 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                             agent._persist_session(messages, conversation_history)
+                            _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
                             return {
+                                "final_response": _final_response,
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
-                                "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
+                                "error": _final_response,
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
@@ -3130,11 +3138,13 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                         agent._persist_session(messages, conversation_history)
+                        _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
                         return {
+                            "final_response": _final_response,
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
+                            "error": _final_response,
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,
@@ -3183,11 +3193,13 @@ def run_conversation(
                             f"{post_compress_request_tokens:,} request tokens. Cannot compress further."
                         )
                         agent._persist_session(messages, conversation_history)
+                        _final_response = f"Context length exceeded ({post_compress_request_tokens:,} request tokens). Cannot compress further."
                         return {
+                            "final_response": _final_response,
                             "messages": messages,
                             "completed": False,
                             "api_calls": api_call_count,
-                            "error": f"Context length exceeded ({post_compress_request_tokens:,} request tokens). Cannot compress further.",
+                            "error": _final_response,
                             "partial": True,
                             "failed": True,
                             "compression_exhausted": True,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -865,6 +865,46 @@ def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
     return cache.get(key)
 
 
+def _provider_confirmed_config_cap(
+    model: str,
+    base_url: str,
+    configured_length: int,
+    provider: str = "",
+) -> Optional[int]:
+    """Return a cached lower cap that should constrain explicit config.
+
+    Explicit config normally wins.  For custom/local OpenAI-compatible servers,
+    though, a cached lower value means the endpoint has already proven that the
+    configured window is too optimistic.  Honor that evidence so a restarted
+    Hermes process does not keep advertising an impossible context size.
+    """
+    if not base_url or not configured_length or provider == "lmstudio":
+        return None
+
+    normalized_provider = (provider or "").lower()
+    if _is_known_provider_base_url(base_url) and normalized_provider not in {"custom", "local"}:
+        return None
+    if normalized_provider not in {"", "custom", "local", "openai-compatible"} and not is_local_endpoint(base_url):
+        return None
+
+    candidates = [model]
+    stripped = _strip_provider_prefix(model)
+    if stripped != model:
+        candidates.append(stripped)
+
+    for candidate in candidates:
+        cached = get_cached_context_length(candidate, base_url)
+        if (
+            isinstance(cached, int)
+            and 1024 <= cached < configured_length
+            and not (cached <= 32768 and _model_name_suggests_kimi(candidate))
+            and not (cached <= 204_800 and _model_name_suggests_minimax_m3(candidate))
+            and not (cached <= 256_000 and _model_name_suggests_grok_4_3(candidate))
+        ):
+            return cached
+    return None
+
+
 def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     """Drop a stale cache entry so it gets re-resolved on the next lookup."""
     key = f"{model}@{base_url}"
@@ -901,6 +941,8 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords
     patterns = [
+        r'available\s+context\s+size\s*\(?\s*(\d{4,})\s*tokens?\s*\)?',
+        r'\bn_ctx[\'"]?\s*[:=]\s*(\d{4,})',
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
@@ -1509,8 +1551,22 @@ def get_model_context_length(
     7. Hardcoded defaults (broad family patterns, longest-key-first)
     8. Local server query (last resort)
     9. Default fallback (256K)"""
-    # 0. Explicit config override — user knows best
+    # 0. Explicit config override — user knows best, unless a custom/local
+    # endpoint has already rejected that larger window and cached a lower cap.
     if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
+        provider_cap = _provider_confirmed_config_cap(
+            model,
+            base_url,
+            config_context_length,
+            provider=provider,
+        )
+        if provider_cap is not None:
+            logger.info(
+                "Using provider-confirmed context cap for %s@%s: %s "
+                "(configured %s)",
+                model, base_url, f"{provider_cap:,}", f"{config_context_length:,}",
+            )
+            return provider_cap
         return config_context_length
 
     # 0b. custom_providers per-model override — check before any probe.
@@ -1526,6 +1582,19 @@ def get_model_context_length(
                 custom_providers=custom_providers,
             )
             if cp_ctx:
+                provider_cap = _provider_confirmed_config_cap(
+                    model,
+                    base_url,
+                    cp_ctx,
+                    provider=provider or "custom",
+                )
+                if provider_cap is not None:
+                    logger.info(
+                        "Using provider-confirmed context cap for custom provider "
+                        "%s@%s: %s (configured %s)",
+                        model, base_url, f"{provider_cap:,}", f"{cp_ctx:,}",
+                    )
+                    return provider_cap
                 return cp_ctx
         except Exception:
             pass  # fall through to probing

--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -103,6 +103,14 @@ pub fn copy_self_to_hermes_home() -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::copy(&src, &dest)?;
+    let _ = std::process::Command::new("codesign")
+        .args(["--sign", "-", "--force", "--preserve-metadata=identifier,entitlements,flags", dest.to_string_lossy().as_ref()])
+        .status();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755));
+    }
     tracing::info!(?src, ?dest, "copied installer to HERMES_HOME");
     Ok(())
 }

--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -41,6 +41,8 @@ const https = require('node:https')
 const { spawn } = require('node:child_process')
 
 const STAMP_COMMIT_RE = /^[0-9a-f]{7,40}$/i
+const STAMP_REF_RE = /^[0-9A-Za-z._/-]{1,200}$/
+const DEFAULT_GITHUB_REPOSITORY = 'NousResearch/hermes-agent'
 
 // Stages flagged needs_user_input=true in the manifest are skipped by the
 // runner (passed -NonInteractive to install.ps1, which the install script
@@ -77,31 +79,80 @@ function bootstrapCacheDir(hermesHome) {
 }
 
 function cachedScriptPath(hermesHome, commit) {
-  return path.join(bootstrapCacheDir(hermesHome), `install-${commit}.${process.platform === 'win32' ? 'ps1' : 'sh'}`)
+  return path.join(
+    bootstrapCacheDir(hermesHome),
+    `install-${sanitizeRefForCache(commit)}.${process.platform === 'win32' ? 'ps1' : 'sh'}`
+  )
 }
 
-function downloadInstallScript(commit, destPath) {
-  // Fetch from GitHub raw at the pinned commit. The raw URL with a SHA
-  // is immutable (unlike a branch ref), so we don't need integrity
-  // verification beyond "did the file we wrote pass a syntax probe."
-  const scriptName = installScriptName()
-  const url = `https://raw.githubusercontent.com/NousResearch/hermes-agent/${commit}/scripts/${scriptName}`
+function sanitizeRefForCache(ref) {
+  return String(ref || '').replace(/[^0-9A-Za-z._-]/g, '_')
+}
+
+function normalizeGitHubRepository(value) {
+  if (!value || typeof value !== 'string') return null
+  const trimmed = value.trim()
+  const sshMatch = trimmed.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i)
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\/)?$/i)
+  if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`
+  const slugMatch = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/)
+  if (slugMatch) return `${slugMatch[1]}/${slugMatch[2].replace(/\.git$/i, '')}`
+  return null
+}
+
+function installerRepository(installStamp) {
+  return normalizeGitHubRepository(installStamp && installStamp.repository) || DEFAULT_GITHUB_REPOSITORY
+}
+
+function installScriptRef(installStamp) {
+  if (installStamp && typeof installStamp.bootstrapRef === 'string' && STAMP_REF_RE.test(installStamp.bootstrapRef)) {
+    return installStamp.bootstrapRef
+  }
+  return installStamp && installStamp.commit
+}
+
+function installScriptRepositories(installStamp) {
+  const repos = [installerRepository(installStamp), DEFAULT_GITHUB_REPOSITORY]
+  return [...new Set(repos.filter(Boolean))]
+}
+
+function installerRepoEnv(installStamp) {
+  const repo = installerRepository(installStamp)
+  const env = {}
+  if (repo) {
+    env.HERMES_INSTALL_REPO_URL_HTTPS =
+      (installStamp && typeof installStamp.repoUrlHttps === 'string' && installStamp.repoUrlHttps) ||
+      `https://github.com/${repo}.git`
+    env.HERMES_INSTALL_REPO_URL_SSH =
+      (installStamp && typeof installStamp.repoUrlSsh === 'string' && installStamp.repoUrlSsh) ||
+      `git@github.com:${repo}.git`
+  }
+  return env
+}
+
+function shouldPinCommit(installStamp) {
+  return Boolean(installStamp && installStamp.commit && installStamp.commitPinned !== false)
+}
+
+function rawInstallScriptUrl(repository, ref, scriptName) {
+  return `https://raw.githubusercontent.com/${repository}/${ref}/scripts/${scriptName}`
+}
+
+function downloadFromUrl(url, scriptName, destPath) {
   return new Promise((resolve, reject) => {
-    fs.mkdirSync(path.dirname(destPath), { recursive: true })
     const tmpPath = destPath + '.tmp'
     const out = fs.createWriteStream(tmpPath)
     https
       .get(url, res => {
         if (res.statusCode === 301 || res.statusCode === 302) {
-          // GitHub raw shouldn't redirect for a SHA URL, but follow once
-          // defensively.
           out.close()
           fs.unlinkSync(tmpPath)
           https
             .get(res.headers.location, res2 => {
               if (res2.statusCode !== 200) {
                 reject(
-                  new Error(`Failed to download ${scriptName}: HTTP ${res2.statusCode} from redirect ${res.headers.location}`)
+                  new Error(`HTTP ${res2.statusCode} from redirect ${res.headers.location}`)
                 )
                 return
               }
@@ -122,7 +173,7 @@ function downloadInstallScript(commit, destPath) {
           try {
             fs.unlinkSync(tmpPath)
           } catch {}
-          reject(new Error(`Failed to download ${scriptName}: HTTP ${res.statusCode} from ${url}`))
+          reject(new Error(`HTTP ${res.statusCode} from ${url}`))
           return
         }
         res.pipe(out)
@@ -147,6 +198,27 @@ function downloadInstallScript(commit, destPath) {
   })
 }
 
+async function downloadInstallScript(installStamp, destPath) {
+  // Fetch from GitHub raw at the build stamp's bootstrap ref. Official/CI
+  // stamps use an immutable SHA; local unpublished builds may fall back to a
+  // reachable branch ref so the packaged app does not brick itself.
+  const scriptName = installScriptName()
+  const ref = installScriptRef(installStamp)
+  const errors = []
+
+  fs.mkdirSync(path.dirname(destPath), { recursive: true })
+  for (const repository of installScriptRepositories(installStamp)) {
+    const url = rawInstallScriptUrl(repository, ref, scriptName)
+    try {
+      return await downloadFromUrl(url, scriptName, destPath)
+    } catch (error) {
+      errors.push(error.message || String(error))
+    }
+  }
+
+  throw new Error(`Failed to download ${scriptName}: ${errors.join('; ')}`)
+}
+
 async function resolveInstallScript({ installStamp, sourceRepoRoot, hermesHome, emit }) {
   // 1. Dev shortcut: prefer a local checkout's installer so we can iterate
   //    without pushing. SOURCE_REPO_ROOT comes from main.cjs (path.resolve
@@ -158,33 +230,37 @@ async function resolveInstallScript({ installStamp, sourceRepoRoot, hermesHome, 
   }
 
   // 2. Packaged path: download from GitHub at the pinned commit (1B's stamp).
-  if (!installStamp || !installStamp.commit || !STAMP_COMMIT_RE.test(installStamp.commit)) {
+  const scriptRef = installScriptRef(installStamp)
+  if (!installStamp || !installStamp.commit || !STAMP_COMMIT_RE.test(installStamp.commit) || !STAMP_REF_RE.test(scriptRef)) {
     throw new Error(
       `Cannot resolve ${installScriptName()}: no SOURCE_REPO_ROOT and no install stamp. ` +
         'This packaged build was produced without a valid build-time stamp.'
     )
   }
 
-  const cached = cachedScriptPath(hermesHome, installStamp.commit)
+  const cached = cachedScriptPath(hermesHome, scriptRef)
   try {
     await fsp.access(cached, fs.constants.R_OK)
-    emit({ type: 'log', line: `[bootstrap] using cached ${installScriptName()} for ${installStamp.commit.slice(0, 12)}` })
-    return { path: cached, source: 'cache', commit: installStamp.commit, kind: installScriptKind() }
+    emit({ type: 'log', line: `[bootstrap] using cached ${installScriptName()} for ${scriptRef.slice(0, 12)}` })
+    return { path: cached, source: 'cache', ref: scriptRef, kind: installScriptKind() }
   } catch {
     // not cached; download
   }
 
-  emit({ type: 'log', line: `[bootstrap] fetching ${installScriptName()} for ${installStamp.commit.slice(0, 12)} from GitHub` })
-  await downloadInstallScript(installStamp.commit, cached)
+  emit({
+    type: 'log',
+    line: `[bootstrap] fetching ${installScriptName()} for ${scriptRef.slice(0, 12)} from ${installerRepository(installStamp)}`
+  })
+  await downloadInstallScript(installStamp, cached)
   emit({ type: 'log', line: `[bootstrap] saved to ${cached}` })
-  return { path: cached, source: 'download', commit: installStamp.commit, kind: installScriptKind() }
+  return { path: cached, source: 'download', ref: scriptRef, kind: installScriptKind() }
 }
 
 // ---------------------------------------------------------------------------
 // powershell wrapper
 // ---------------------------------------------------------------------------
 
-function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, hermesHome } = {}) {
+function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, hermesHome, installerEnv } = {}) {
   return new Promise((resolve, reject) => {
     const ps = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
     const fullArgs = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath, ...args]
@@ -193,6 +269,7 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...(installerEnv || {}),
         // Pass HERMES_HOME through so install.ps1 respects the caller's
         // choice rather than re-computing the default.
         HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
@@ -260,12 +337,13 @@ function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, herme
   })
 }
 
-function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome } = {}) {
+function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome, installerEnv } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn('bash', [scriptPath, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...(installerEnv || {}),
         HERMES_HOME: hermesHome || process.env.HERMES_HOME || ''
       }
     })
@@ -333,12 +411,12 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // Manifest + stage dispatch
 // ---------------------------------------------------------------------------
 
-// Build the install.ps1 pin args (-Commit / -Branch) from the install-stamp
-// so the repository stage clones the exact SHA the .exe was tested with
-// instead of falling back to install.ps1's default ($Branch = "main").
+// Build installer pin args from the install-stamp. CI/reachable commits get
+// exact SHA pins; local unpublished builds intentionally omit -Commit so the
+// installer can use a reachable branch instead of failing on a private SHA.
 function buildPinArgs(installStamp) {
   const args = []
-  if (installStamp && installStamp.commit) {
+  if (shouldPinCommit(installStamp)) {
     args.push('-Commit', installStamp.commit)
   }
   if (installStamp && installStamp.branch) {
@@ -352,7 +430,7 @@ function buildPosixPinArgs({ installStamp, activeRoot, hermesHome }) {
   if (installStamp && installStamp.branch) {
     args.push('--branch', installStamp.branch)
   }
-  if (installStamp && installStamp.commit) {
+  if (shouldPinCommit(installStamp)) {
     args.push('--commit', installStamp.commit)
   }
   return args
@@ -360,13 +438,15 @@ function buildPosixPinArgs({ installStamp, activeRoot, hermesHome }) {
 
 async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp }) {
   const isPosix = installerKind === 'posix'
+  const installerEnv = installerRepoEnv(installStamp)
   const args = isPosix
     ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })]
     : ['-Manifest', ...buildPinArgs(installStamp)]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: '__manifest__',
-    hermesHome
+    hermesHome,
+    installerEnv
   })
   if (result.code !== 0) {
     throw new Error(`${isPosix ? 'install.sh --manifest' : 'install.ps1 -Manifest'} failed: exit ${result.code}\n${result.stderr || result.stdout}`)
@@ -407,13 +487,14 @@ async function runStage({ scriptPath, installerKind, stage, emit, hermesHome, ac
   emit({ type: 'stage', name: stage.name, state: 'running' })
 
   const isPosix = installerKind === 'posix'
+  const installerEnv = installerRepoEnv(installStamp)
   const args = isPosix
     ? ['--stage', stage.name, '--non-interactive', '--json', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })]
     : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp)]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(
     scriptPath,
     args,
-    { emit, stageName: stage.name, abortSignal, hermesHome }
+    { emit, stageName: stage.name, abortSignal, hermesHome, installerEnv }
   )
 
   const durationMs = Date.now() - startedAt
@@ -587,5 +668,10 @@ module.exports = {
   // Exposed for testability
   parseStageResult,
   resolveLocalInstallScript,
-  cachedScriptPath
+  cachedScriptPath,
+  installScriptRef,
+  installScriptRepositories,
+  installerRepoEnv,
+  normalizeGitHubRepository,
+  shouldPinCommit
 }

--- a/apps/desktop/electron/bootstrap-runner.test.cjs
+++ b/apps/desktop/electron/bootstrap-runner.test.cjs
@@ -1,7 +1,15 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
 
-const { runBootstrap } = require('./bootstrap-runner.cjs')
+const {
+  cachedScriptPath,
+  installScriptRef,
+  installScriptRepositories,
+  installerRepoEnv,
+  normalizeGitHubRepository,
+  runBootstrap,
+  shouldPinCommit
+} = require('./bootstrap-runner.cjs')
 
 test('runBootstrap bails immediately when the signal is already aborted', async () => {
   const controller = new AbortController()
@@ -24,4 +32,39 @@ test('runBootstrap bails immediately when the signal is already aborted', async 
     events.some(ev => ev.type === 'failed' && /cancelled/i.test(ev.error)),
     'should emit a cancelled failure event'
   )
+})
+
+test('install script resolution honors stamped fork repository metadata', () => {
+  const stamp = {
+    commit: 'abcdef1234567890',
+    repository: 'OmarB97/hermes-agent',
+    repoUrlHttps: 'https://github.com/OmarB97/hermes-agent.git',
+    repoUrlSsh: 'git@github.com:OmarB97/hermes-agent.git'
+  }
+
+  assert.deepEqual(installScriptRepositories(stamp), ['OmarB97/hermes-agent', 'NousResearch/hermes-agent'])
+  assert.deepEqual(installerRepoEnv(stamp), {
+    HERMES_INSTALL_REPO_URL_HTTPS: 'https://github.com/OmarB97/hermes-agent.git',
+    HERMES_INSTALL_REPO_URL_SSH: 'git@github.com:OmarB97/hermes-agent.git'
+  })
+})
+
+test('install script resolution falls back to bootstrapRef for unpinned local builds', () => {
+  const stamp = {
+    commit: 'abcdef1234567890',
+    bootstrapRef: 'main',
+    commitPinned: false,
+    repository: 'OmarB97/hermes-agent'
+  }
+
+  assert.equal(installScriptRef(stamp), 'main')
+  assert.equal(shouldPinCommit(stamp), false)
+  assert.match(cachedScriptPath('/tmp/hermes-home', 'fix/some-branch'), /install-fix_some-branch\.(sh|ps1)$/)
+})
+
+test('normalizes GitHub repository values from common remote forms', () => {
+  assert.equal(normalizeGitHubRepository('git@github.com:OmarB97/hermes-agent.git'), 'OmarB97/hermes-agent')
+  assert.equal(normalizeGitHubRepository('https://github.com/NousResearch/hermes-agent.git'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('NousResearch/hermes-agent'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('not github'), null)
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1162,6 +1162,30 @@ function runGit(args, options = {}) {
 
 const firstLine = text => (text || '').split('\n').find(Boolean) || ''
 
+function splitTrackingRef(ref) {
+  const value = String(ref || '').trim()
+  const slash = value.indexOf('/')
+  if (slash <= 0 || slash === value.length - 1) {
+    return null
+  }
+
+  return {
+    branch: value.slice(slash + 1),
+    ref: value,
+    remote: value.slice(0, slash)
+  }
+}
+
+async function resolveCurrentTrackingRef(updateRoot) {
+  const result = await runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
+    cwd: updateRoot
+  })
+  if (result.code !== 0) {
+    return null
+  }
+  return splitTrackingRef(firstLine(result.stdout))
+}
+
 function emitUpdateProgress(payload) {
   const merged = { stage: 'idle', message: '', percent: null, error: null, ...payload, at: Date.now() }
   rememberLog(`[updates] ${merged.stage}: ${merged.message || merged.error || ''}`)
@@ -1176,22 +1200,51 @@ function emitUpdateProgress(payload) {
 // installed clients. Read-only ls-remote probe; only flips on a definitive
 // "ref absent" (exit 2), never on a transient network error, so a flaky
 // connection can't strand a user on the wrong branch.
-async function resolveHealedBranch(updateRoot, branch) {
+async function resolveHealedBranch(updateRoot, branch, remote = 'origin') {
   if (!branch || branch === 'main') {
     return branch || 'main'
   }
 
-  const probe = await runGit(['ls-remote', '--exit-code', '--heads', 'origin', branch], { cwd: updateRoot })
+  const probe = await runGit(['ls-remote', '--exit-code', '--heads', remote, branch], { cwd: updateRoot })
   if (probe.code !== 2) {
     return branch
   }
 
-  rememberLog(`[updates] origin/${branch} is gone (merged?); falling back to main`)
+  rememberLog(`[updates] ${remote}/${branch} is gone (merged?); falling back to main`)
   const config = readDesktopUpdateConfig()
   if (config.branch !== 'main') {
     writeDesktopUpdateConfig({ ...config, branch: 'main' })
   }
   return 'main'
+}
+
+async function resolveUpdateTarget(updateRoot, configuredBranch) {
+  const branch = configuredBranch || DEFAULT_UPDATE_BRANCH
+  const head = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: updateRoot })
+  const currentBranch = firstLine(head.stdout).trim()
+  const tracking = await resolveCurrentTrackingRef(updateRoot)
+
+  if (
+    tracking &&
+    (!branch || branch === DEFAULT_UPDATE_BRANCH || currentBranch === branch || tracking.branch === branch)
+  ) {
+    return {
+      branch: tracking.branch,
+      currentBranch,
+      label: tracking.ref,
+      ref: tracking.ref,
+      remote: tracking.remote
+    }
+  }
+
+  const healedBranch = await resolveHealedBranch(updateRoot, branch)
+  return {
+    branch: healedBranch,
+    currentBranch,
+    label: healedBranch,
+    ref: `origin/${healedBranch}`,
+    remote: 'origin'
+  }
 }
 
 async function checkUpdates() {
@@ -1208,8 +1261,9 @@ async function checkUpdates() {
     }
   }
 
-  branch = await resolveHealedBranch(updateRoot, branch)
-  const fetched = await runGit(['fetch', '--quiet', 'origin', branch], { cwd: updateRoot })
+  const target = await resolveUpdateTarget(updateRoot, branch)
+  branch = target.label
+  const fetched = await runGit(['fetch', '--quiet', target.remote, target.branch], { cwd: updateRoot })
   if (fetched.code !== 0) {
     return {
       supported: true,
@@ -1222,21 +1276,20 @@ async function checkUpdates() {
   }
 
   const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
-  const [currentSha, targetSha, countStr, dirtyStr, currentBranch] = await Promise.all([
+  const [currentSha, targetSha, countStr, dirtyStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),
-    git(['rev-parse', `origin/${branch}`]),
-    git(['rev-list', `HEAD..origin/${branch}`, '--count']),
-    git(['status', '--porcelain']),
-    git(['rev-parse', '--abbrev-ref', 'HEAD'])
+    git(['rev-parse', target.ref]),
+    git(['rev-list', `HEAD..${target.ref}`, '--count']),
+    git(['status', '--porcelain'])
   ])
 
   const behind = Number.parseInt(countStr, 10) || 0
-  const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []
+  const commits = behind > 0 ? await readCommitLog(updateRoot, target.ref) : []
 
   return {
     supported: true,
     branch,
-    currentBranch,
+    currentBranch: target.currentBranch,
     behind,
     currentSha,
     targetSha,
@@ -1247,11 +1300,11 @@ async function checkUpdates() {
   }
 }
 
-async function readCommitLog(cwd, branch) {
+async function readCommitLog(cwd, targetRef) {
   const SEP = '\x1f'
   const REC = '\x1e'
   const { stdout } = await runGit(
-    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
+    ['log', `HEAD..${targetRef}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
     { cwd }
   )
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -117,7 +117,8 @@ const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')
 // build hasn't been invoked, or schema mismatch). Callers must handle null.
 //
 // Schema:
-//   { schemaVersion: 1, commit, branch, builtAt, dirty, source }
+//   { schemaVersion: 1, commit, branch, repository, bootstrapRef, commitPinned,
+//     repoUrlHttps, repoUrlSsh, builtAt, dirty, source }
 const INSTALL_STAMP_SCHEMA_VERSION = 1
 function loadInstallStamp() {
   // Try packaged location first (resources/install-stamp.json), then the
@@ -1600,6 +1601,11 @@ function isBootstrapComplete() {
   return isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(getVenvPython(VENV_ROOT))
 }
 
+function hasRunnableActiveInstall() {
+  const venvPython = getVenvPython(VENV_ROOT)
+  return isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(venvPython) && canImportHermesCli(venvPython)
+}
+
 function writeBootstrapMarker(payload) {
   fs.mkdirSync(path.dirname(BOOTSTRAP_COMPLETE_MARKER), { recursive: true })
   const merged = {
@@ -1760,6 +1766,13 @@ function resolveHermesBackend(dashboardArgs) {
   //    to spawning hermes. Updates flow through the in-app update path
   //    (applyUpdates -> git pull) or `hermes update` from the CLI.
   if (isBootstrapComplete()) {
+    return createActiveBackend(dashboardArgs)
+  }
+
+  if (hasRunnableActiveInstall()) {
+    rememberLog(
+      `Using existing Hermes install at ${ACTIVE_HERMES_ROOT}: venv imports hermes_cli even though bootstrap marker is missing.`
+    )
     return createActiveBackend(dashboardArgs)
   }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs scripts/write-build-stamp.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/scripts/write-build-stamp.cjs
+++ b/apps/desktop/scripts/write-build-stamp.cjs
@@ -11,6 +11,9 @@
  *     "schemaVersion": 1,
  *     "commit":        "<40-char SHA>",
  *     "branch":        "<branch name>",
+ *     "repository":    "<github owner/repo>",
+ *     "bootstrapRef":  "<remote ref used to fetch installer scripts>",
+ *     "commitPinned":  true|false,
  *     "builtAt":       "<ISO 8601 UTC timestamp>",
  *     "dirty":         true|false,
  *     "source":        "ci" | "local"
@@ -28,7 +31,7 @@
 
 const fs = require("fs")
 const path = require("path")
-const { execSync } = require("child_process")
+const { execFileSync, execSync } = require("child_process")
 
 const STAMP_SCHEMA_VERSION = 1
 
@@ -45,13 +48,87 @@ function tryExec(cmd, opts) {
   }
 }
 
+function tryGit(args) {
+  try {
+    return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()
+  } catch {
+    return null
+  }
+}
+
+function normalizeGitHubRepository(value) {
+  if (!value || typeof value !== "string") return null
+  const trimmed = value.trim()
+  const sshMatch = trimmed.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i)
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\/)?$/i)
+  if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`
+  const slugMatch = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/)
+  if (slugMatch) return `${slugMatch[1]}/${slugMatch[2].replace(/\.git$/i, "")}`
+  return null
+}
+
+function repoUrls(repository) {
+  if (!repository) return { repoUrlHttps: null, repoUrlSsh: null }
+  return {
+    repoUrlHttps: `https://github.com/${repository}.git`,
+    repoUrlSsh: `git@github.com:${repository}.git`
+  }
+}
+
+function remoteNameFromRef(ref) {
+  if (!ref || typeof ref !== "string" || !ref.includes("/")) return null
+  return ref.split("/")[0]
+}
+
+function remoteBranchName(ref) {
+  if (!ref || typeof ref !== "string" || !ref.includes("/")) return null
+  return ref.split("/").slice(1).join("/")
+}
+
+function remoteBranchesContaining(commit) {
+  const output = tryGit(["branch", "-r", "--contains", commit])
+  if (!output) return []
+  return output
+    .split(/\r?\n/)
+    .map(line => line.replace(/^\*\s*/, "").trim())
+    .filter(line => line && !line.endsWith("/HEAD") && !line.includes(" -> "))
+}
+
+function remoteBranchExists(remoteName, branch) {
+  if (!remoteName || !branch) return false
+  return Boolean(tryGit(["show-ref", "--verify", `refs/remotes/${remoteName}/${branch}`]))
+}
+
+function localRemoteMetadata(commit, branch) {
+  const upstream = tryGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+  const containingBranches = remoteBranchesContaining(commit)
+  const remoteRef = containingBranches[0] || (upstream && remoteBranchExists(remoteNameFromRef(upstream), remoteBranchName(upstream)) ? upstream : null)
+  const remoteName = remoteNameFromRef(remoteRef) || remoteNameFromRef(upstream) || "origin"
+  const remoteUrl = tryGit(["remote", "get-url", remoteName]) || tryGit(["remote", "get-url", "origin"])
+  const repository = normalizeGitHubRepository(remoteUrl) || "NousResearch/hermes-agent"
+  const remoteBranch = remoteBranchName(remoteRef) || (remoteBranchExists(remoteName, branch) ? branch : "main")
+  const commitPinned = containingBranches.length > 0
+  return {
+    repository,
+    bootstrapRef: commitPinned ? commit : remoteBranch,
+    commitPinned,
+    ...repoUrls(repository)
+  }
+}
+
 function fromCI() {
   const sha = process.env.GITHUB_SHA
   if (!sha) return null
   const branch = process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || null
+  const repository = normalizeGitHubRepository(process.env.GITHUB_REPOSITORY) || "NousResearch/hermes-agent"
   return {
     commit: sha,
     branch: branch,
+    repository,
+    bootstrapRef: sha,
+    commitPinned: true,
+    ...repoUrls(repository),
     dirty: false, // CI builds from a checkout-of-ref by definition
     source: "ci"
   }
@@ -69,9 +146,11 @@ function fromLocalGit() {
   // differs from the commit being pinned.
   const status = tryExec("git status --porcelain -uno", { cwd: REPO_ROOT })
   const dirty = status !== null && status.length > 0
+  const normalizedBranch = branch === "HEAD" ? null : branch
   return {
     commit: sha,
-    branch: branch === "HEAD" ? null : branch, // detached HEAD -> null
+    branch: normalizedBranch, // detached HEAD -> null
+    ...localRemoteMetadata(sha, normalizedBranch),
     dirty: dirty,
     source: "local"
   }
@@ -102,10 +181,29 @@ function main() {
     )
   }
 
+  if (stamp.source === "local" && stamp.commitPinned === false) {
+    console.warn(
+      "[write-build-stamp] WARNING: local HEAD is not contained in a fetched remote branch.\n" +
+        "  The packaged app will bootstrap Hermes from " +
+        stamp.repository +
+        "@" +
+        stamp.bootstrapRef +
+        " instead of pinning unreachable commit " +
+        stamp.commit.slice(0, 12) +
+        ".\n" +
+        "  Push the branch before publishing a release build."
+    )
+  }
+
   const payload = {
     schemaVersion: STAMP_SCHEMA_VERSION,
     commit: stamp.commit,
     branch: stamp.branch,
+    repository: stamp.repository,
+    bootstrapRef: stamp.bootstrapRef,
+    commitPinned: stamp.commitPinned,
+    repoUrlHttps: stamp.repoUrlHttps,
+    repoUrlSsh: stamp.repoUrlSsh,
     builtAt: new Date().toISOString(),
     dirty: stamp.dirty,
     source: stamp.source
@@ -119,8 +217,20 @@ function main() {
       " -> " +
       stamp.commit.slice(0, 12) +
       (stamp.branch ? " (" + stamp.branch + ")" : "") +
+      (stamp.repository ? " [" + stamp.repository + "@" + stamp.bootstrapRef + "]" : "") +
+      (stamp.commitPinned === false ? " [UNPINNED]" : "") +
       (stamp.dirty ? " [DIRTY]" : "")
   )
 }
 
-main()
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  localRemoteMetadata,
+  normalizeGitHubRepository,
+  remoteBranchName,
+  remoteNameFromRef,
+  repoUrls
+}

--- a/apps/desktop/scripts/write-build-stamp.test.cjs
+++ b/apps/desktop/scripts/write-build-stamp.test.cjs
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  normalizeGitHubRepository,
+  remoteBranchName,
+  remoteNameFromRef,
+  repoUrls
+} = require('./write-build-stamp.cjs')
+
+test('normalizes GitHub repository values for stamp metadata', () => {
+  assert.equal(normalizeGitHubRepository('git@github.com:OmarB97/hermes-agent.git'), 'OmarB97/hermes-agent')
+  assert.equal(normalizeGitHubRepository('https://github.com/NousResearch/hermes-agent.git'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('NousResearch/hermes-agent'), 'NousResearch/hermes-agent')
+  assert.equal(normalizeGitHubRepository('not github'), null)
+})
+
+test('splits remote tracking refs without losing slashy branch names', () => {
+  assert.equal(remoteNameFromRef('origin/fix/desktop-bootstrap'), 'origin')
+  assert.equal(remoteBranchName('origin/fix/desktop-bootstrap'), 'fix/desktop-bootstrap')
+  assert.equal(remoteNameFromRef('main'), null)
+  assert.equal(remoteBranchName('main'), null)
+})
+
+test('derives clone URLs from repository slug', () => {
+  assert.deepEqual(repoUrls('OmarB97/hermes-agent'), {
+    repoUrlHttps: 'https://github.com/OmarB97/hermes-agent.git',
+    repoUrlSsh: 'git@github.com:OmarB97/hermes-agent.git'
+  })
+})

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -11,7 +11,7 @@ import { Pane, PaneMain } from '@/components/pane-shell'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
-import { getSessionMessages, listSessions } from '../hermes'
+import { autoArchiveOldSessions, getSessionMessages, listSessions } from '../hermes'
 import { preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import { toggleCommandPalette } from '../store/command-palette'
 import {
@@ -233,6 +233,29 @@ export function DesktopController() {
 
     try {
       const limit = $sessionsLimit.get()
+
+      const preserveIds = new Set<string>([
+        ...$workingSessionIds.get(),
+        ...$pinnedSessionIds.get()
+      ])
+
+      const selectedSessionId = $selectedStoredSessionId.get()
+      const activeSessionId = $activeSessionId.get()
+
+      if (selectedSessionId) {
+        preserveIds.add(selectedSessionId)
+      }
+
+      if (activeSessionId) {
+        preserveIds.add(activeSessionId)
+      }
+
+      try {
+        await autoArchiveOldSessions([...preserveIds])
+      } catch (error) {
+        console.warn('Hermes session auto-archive skipped', error)
+      }
+
       // Require at least one message so abandoned/empty "Untitled" drafts (one
       // was created per TUI/desktop launch before the lazy-create fix) don't
       // clutter the sidebar.

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $currentUsage } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './use-message-stream'
+
+let handleEvent: (event: RpcEvent) => void = () => undefined
+
+function MessageStreamHarness({ activeSessionId = 'session-1' }: { activeSessionId?: string }) {
+  const activeSessionIdRef = useRef<string | null>(activeSessionId)
+  const queryClientRef = useRef(new QueryClient())
+  const statesRef = useRef(new Map<string, ClientSessionState>())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    updateSessionState: (sessionId, updater) => {
+      const previous = statesRef.current.get(sessionId) ?? createClientSessionState(null)
+      const next = updater(previous)
+      statesRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream token usage events', () => {
+  beforeEach(() => {
+    handleEvent = () => undefined
+    $currentUsage.set({ calls: 0, input: 0, output: 0, total: 0 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    $currentUsage.set({ calls: 0, input: 0, output: 0, total: 0 })
+    vi.restoreAllMocks()
+  })
+
+  it('updates current usage from token.usage before message.complete', () => {
+    render(<MessageStreamHarness />)
+
+    act(() =>
+      handleEvent({
+        payload: {},
+        session_id: 'session-1',
+        type: 'message.start'
+      } as RpcEvent)
+    )
+
+    act(() =>
+      handleEvent({
+        payload: {
+          context_length: 131_072,
+          context_pct: 49.9,
+          context_tokens: 65_432,
+          input_tokens: 1_200,
+          output_tokens: 34,
+          total_tokens: 1_234
+        },
+        session_id: 'session-1',
+        type: 'token.usage'
+      } as RpcEvent)
+    )
+
+    expect($currentUsage.get()).toMatchObject({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
+  it('ignores token.usage events for inactive sessions', () => {
+    $currentUsage.set({ calls: 1, input: 10, output: 5, total: 15 })
+    render(<MessageStreamHarness />)
+
+    act(() =>
+      handleEvent({
+        payload: {
+          context_length: 131_072,
+          context_tokens: 70_000,
+          input_tokens: 70_000,
+          total_tokens: 70_000
+        },
+        session_id: 'session-2',
+        type: 'token.usage'
+      } as RpcEvent)
+    )
+
+    expect($currentUsage.get()).toEqual({ calls: 1, input: 10, output: 5, total: 15 })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -16,6 +16,7 @@ import {
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { mergeTokenUsagePayload, type TokenUsagePayload } from '@/lib/token-usage'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -708,6 +709,10 @@ export function useMessageStream({
           void queryClient.invalidateQueries({
             queryKey: explicitSid && sessionId ? ['model-options', sessionId] : ['model-options']
           })
+        }
+      } else if (event.type === 'token.usage') {
+        if (!explicitSid || isActiveEvent) {
+          setCurrentUsage(current => mergeTokenUsagePayload(current, event.payload as TokenUsagePayload | undefined))
         }
       } else if (event.type === 'message.start') {
         if (!sessionId) {

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.ts
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { isThinkingEnabled, normalizeEffort } from './model-edit-submenu'
+
+describe('model-edit-submenu reasoning defaults', () => {
+  it('treats empty startup state as thinking off', () => {
+    expect(isThinkingEnabled('')).toBe(false)
+    expect(normalizeEffort('')).toBe('')
+  })
+
+  it('keeps explicit off and effort levels distinct', () => {
+    expect(isThinkingEnabled('none')).toBe(false)
+    expect(normalizeEffort('none')).toBe('')
+    expect(isThinkingEnabled('low')).toBe(true)
+    expect(normalizeEffort('low')).toBe('low')
+  })
+
+  it('falls back unknown enabled efforts to medium', () => {
+    expect(isThinkingEnabled('mystery')).toBe(true)
+    expect(normalizeEffort('mystery')).toBe('medium')
+  })
+})

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -231,13 +231,12 @@ export function ModelEditSubmenu({
   )
 }
 
-function isThinkingEnabled(effort: string): boolean {
-  // Empty = Hermes default (medium) = on; only an explicit "none" is off.
-  return (effort || 'medium').trim().toLowerCase() !== 'none'
+export function isThinkingEnabled(effort: string): boolean {
+  return normalizeReasoningEffort(effort) !== 'none'
 }
 
-function normalizeEffort(effort: string): string {
-  const value = (effort || 'medium').trim().toLowerCase()
+export function normalizeEffort(effort: string): string {
+  const value = normalizeReasoningEffort(effort)
 
   // Thinking off → no effort selected in the radio group.
   if (value === 'none') {
@@ -245,4 +244,8 @@ function normalizeEffort(effort: string): string {
   }
 
   return EFFORT_OPTIONS.some(option => option.value === value) ? value : 'medium'
+}
+
+function normalizeReasoningEffort(effort: string): string {
+  return effort.trim().toLowerCase() || 'none'
 }

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -17,7 +17,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { getGlobalModelOptions } from '@/hermes'
-import { displayModelName, modelDisplayParts, reasoningEffortLabel } from '@/lib/model-status-label'
+import { defaultReasoningEffortLabel, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
 import {
   $visibleModels,
@@ -157,7 +157,10 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                 // Grayed text: active row shows live state (Fast + effort);
                 // others show a fast-capability hint.
                 const meta = isCurrent
-                  ? [fastControl.kind !== 'none' && fastControl.on ? 'Fast' : null, reasoningEffortLabel(currentReasoningEffort) || 'Med']
+                  ? [
+                      fastControl.kind !== 'none' && fastControl.on ? 'Fast' : null,
+                      defaultReasoningEffortLabel(currentReasoningEffort)
+                    ]
                       .filter(Boolean)
                       .join(' ')
                   : caps?.fast || family.fastId

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -128,6 +128,16 @@ export async function listSessions(
   }
 }
 
+export function autoArchiveOldSessions(
+  preserveIds: string[] = []
+): Promise<{ ok: boolean; archived: number; skipped?: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean; archived: number; skipped?: boolean }>({
+    path: '/api/sessions/auto-archive',
+    method: 'POST',
+    body: { preserve_ids: Array.from(new Set(preserveIds.filter(Boolean))).slice(0, 5000) }
+  })
+}
+
 export function setSessionArchived(id: string, archived: boolean): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     path: `/api/sessions/${encodeURIComponent(id)}`,

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { displayModelName, formatModelStatusLabel, reasoningEffortLabel } from './model-status-label'
+import {
+  defaultReasoningEffortLabel,
+  displayModelName,
+  formatModelStatusLabel,
+  reasoningEffortLabel
+} from './model-status-label'
 
 describe('model-status-label', () => {
   it('formats display names consistently', () => {
@@ -12,6 +17,8 @@ describe('model-status-label', () => {
     expect(reasoningEffortLabel('high')).toBe('High')
     expect(reasoningEffortLabel('xhigh')).toBe('Max')
     expect(reasoningEffortLabel('')).toBe('')
+    expect(defaultReasoningEffortLabel('')).toBe('Off')
+    expect(defaultReasoningEffortLabel('none')).toBe('Off')
   })
 
   it('appends fast + effort session state to the status label', () => {
@@ -20,9 +27,10 @@ describe('model-status-label', () => {
     )
   })
 
-  it('always surfaces the effort (default medium) so the level is visible', () => {
+  it('always surfaces the effective effort so the level is visible', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'medium' })).toBe('GPT-5.5 · Med')
-    expect(formatModelStatusLabel('openai/gpt-5.5')).toBe('GPT-5.5 · Med')
+    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'none' })).toBe('GPT-5.5 · Off')
+    expect(formatModelStatusLabel('openai/gpt-5.5')).toBe('GPT-5.5 · Off')
   })
 
   it('returns just the placeholder name when there is no model', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -17,6 +17,10 @@ export function reasoningEffortLabel(effort: string): string {
   return REASONING_LABELS[key] ?? effort
 }
 
+export function defaultReasoningEffortLabel(effort: string): string {
+  return reasoningEffortLabel(effort || 'none') || 'Off'
+}
+
 /** Strip provider prefix and normalize for display. */
 export function modelBaseId(model: string): string {
   const trimmed = model.trim()
@@ -95,9 +99,9 @@ export function formatModelStatusLabel(
     parts.push('Fast')
   }
 
-  // Always surface the effort (empty = Hermes default of medium) so the
-  // current reasoning level is visible at a glance, not just when non-default.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '') || 'Med')
+  // Always surface the effective effort so the status bar makes Thinking-off
+  // visible at a glance, including when startup state arrives empty.
+  parts.push(defaultReasoningEffortLabel(options?.reasoningEffort ?? ''))
 
   return `${name} · ${parts.join(' ')}`
 }

--- a/apps/desktop/src/lib/token-usage.test.ts
+++ b/apps/desktop/src/lib/token-usage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeTokenUsagePayload, usageFromTokenUsagePayload } from './token-usage'
+
+describe('usageFromTokenUsagePayload', () => {
+  it('maps gateway token.usage payload fields into statusbar usage stats', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 131_072,
+        context_pct: 49.9,
+        context_tokens: 65_432,
+        input_tokens: 1_200,
+        output_tokens: 34,
+        total_tokens: 1_234
+      })
+    ).toEqual({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
+  it('derives context percent when the backend omits context_pct', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 200_000,
+        context_tokens: 50_000,
+        input_tokens: 50_000,
+        total_tokens: 50_000
+      })
+    ).toMatchObject({
+      context_max: 200_000,
+      context_percent: 25,
+      context_used: 50_000
+    })
+  })
+
+  it('preserves existing usage when a malformed payload arrives', () => {
+    const current = { calls: 2, input: 10, output: 20, total: 30 }
+
+    expect(mergeTokenUsagePayload(current, { input_tokens: Number.NaN })).toBe(current)
+  })
+})

--- a/apps/desktop/src/lib/token-usage.ts
+++ b/apps/desktop/src/lib/token-usage.ts
@@ -1,6 +1,13 @@
-import type { TokenUsagePayload, Usage } from '../types.js'
+import type { UsageStats } from '@/types/hermes'
 
-export const ZERO: Usage = { calls: 0, input: 0, output: 0, total: 0 }
+export interface TokenUsagePayload {
+  context_length?: unknown
+  context_pct?: unknown
+  context_tokens?: unknown
+  input_tokens?: unknown
+  output_tokens?: unknown
+  total_tokens?: unknown
+}
 
 function finiteNumber(value: unknown): number | undefined {
   if (typeof value === 'number') {
@@ -41,12 +48,12 @@ function percentFrom(payload: TokenUsagePayload): number | undefined {
   return used !== undefined && max !== undefined ? Math.min(100, (used / max) * 100) : undefined
 }
 
-export function usageFromTokenUsagePayload(payload: null | TokenUsagePayload | undefined): Partial<Usage> | null {
+export function usageFromTokenUsagePayload(payload: TokenUsagePayload | null | undefined): Partial<UsageStats> | null {
   if (!payload) {
     return null
   }
 
-  const usage: Partial<Usage> = {}
+  const usage: Partial<UsageStats> = {}
   const input = nonNegativeNumber(payload.input_tokens)
   const output = nonNegativeNumber(payload.output_tokens)
   const total = nonNegativeNumber(payload.total_tokens)
@@ -81,7 +88,10 @@ export function usageFromTokenUsagePayload(payload: null | TokenUsagePayload | u
   return Object.keys(usage).length ? usage : null
 }
 
-export function mergeTokenUsagePayload(current: Usage, payload: null | TokenUsagePayload | undefined): Usage {
+export function mergeTokenUsagePayload(
+  current: UsageStats,
+  payload: TokenUsagePayload | null | undefined
+): UsageStats {
   const usage = usageFromTokenUsagePayload(payload)
 
   return usage ? { ...current, ...usage } : current

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -144,20 +144,46 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
-def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
+def _git_tracking_ref(repo_dir: Path) -> str:
+    """Return the current branch's tracking ref, falling back to origin/main."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            ref = (result.stdout or "").strip()
+            if "/" in ref:
+                return ref
+    except Exception:
+        pass
+    return "origin/main"
+
+
+def _fetch_tracking_ref(repo_dir: Path, tracking_ref: str) -> None:
+    """Best-effort fetch for the remote that owns ``tracking_ref``."""
+    remote = tracking_ref.split("/", 1)[0] if "/" in tracking_ref else "origin"
     try:
         subprocess.run(
-            ["git", "fetch", "origin", "--quiet"],
+            ["git", "fetch", remote, "--quiet"],
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
     except Exception:
         pass  # Offline or timeout — use stale refs, that's fine
 
+
+def _check_via_local_git(repo_dir: Path) -> Optional[int]:
+    """Count commits behind the current branch's tracking ref."""
+    tracking_ref = _git_tracking_ref(repo_dir)
+    _fetch_tracking_ref(repo_dir, tracking_ref)
+
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            ["git", "rev-list", "--count", f"HEAD..{tracking_ref}"],
             capture_output=True, text=True, timeout=5,
             cwd=str(repo_dir),
         )
@@ -215,7 +241,7 @@ def check_for_updates() -> Optional[int]:
 
     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
     it to upstream main via ``git ls-remote``. Otherwise look for a local
-    git checkout and count commits behind ``origin/main``.
+    git checkout and count commits behind the current branch's tracking ref.
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
@@ -324,10 +350,11 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
             pass
         return None
 
-    upstream = _git_short_hash(repo_dir, "origin/main")
+    upstream_ref = _git_tracking_ref(repo_dir)
+    upstream = _git_short_hash(repo_dir, upstream_ref)
     local = _git_short_hash(repo_dir, "HEAD")
     if not upstream or not local:
-        # Live-git lookup failed (e.g. shallow clone without origin/main).
+        # Live-git lookup failed (e.g. shallow clone without the tracking ref).
         # Fall back to the baked build SHA if available.
         try:
             from hermes_cli.build_info import get_build_sha
@@ -341,7 +368,7 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
     ahead = 0
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "origin/main..HEAD"],
+            ["git", "rev-list", "--count", f"{upstream_ref}..HEAD"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2218,9 +2218,10 @@ DEFAULT_CONFIG = {
         # Match the desktop sidebar's normal min_messages=1 list so empty
         # abandoned drafts are left to the explicit empty-session cleanup.
         "auto_archive_min_messages": 1,
-        # Sessions with ended_at=NULL and recent activity are presumed live and
-        # never auto-archived during this grace window.
-        "auto_archive_active_grace_hours": 24,
+        # Sessions with ended_at=NULL and activity inside this window are
+        # presumed live and never auto-archived. Matches the web API's existing
+        # active-session heuristic.
+        "auto_archive_active_grace_seconds": 300,
         # When true, prune ended sessions older than retention_days once
         # per (roughly) min_interval_hours at CLI/gateway/cron startup.
         # Only touches ended sessions — active sessions are always preserved.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2200,6 +2200,27 @@ DEFAULT_CONFIG = {
     # reports 384MB+ databases with 68K+ messages, which slows down FTS5
     # inserts, /resume listing, and insights queries.
     "sessions": {
+        # Desktop sidebar hygiene: soft-archive older, inactive chats at
+        # startup so a heavy local state.db does not leave thousands of old
+        # conversations in the default Sessions list. This never deletes data:
+        # archived chats stay recoverable from Settings -> Archived Chats.
+        "auto_archive": True,
+        # Keep at least this many most-recent surfaced conversations
+        # unarchived. Pinned/active ids sent by the desktop are preserved even
+        # when they fall outside this cap.
+        "auto_archive_keep_recent": 100,
+        # Also archive inactive surfaced conversations older than this many
+        # days, even when the recent cap has not been exceeded. 0 disables the
+        # age cutoff while leaving the keep_recent cap active.
+        "auto_archive_after_days": 14,
+        # Avoid sweeping state.db on every renderer refresh.
+        "auto_archive_min_interval_hours": 6,
+        # Match the desktop sidebar's normal min_messages=1 list so empty
+        # abandoned drafts are left to the explicit empty-session cleanup.
+        "auto_archive_min_messages": 1,
+        # Sessions with ended_at=NULL and recent activity are presumed live and
+        # never auto-archived during this grace window.
+        "auto_archive_active_grace_hours": 24,
         # When true, prune ended sessions older than retention_days once
         # per (roughly) min_interval_hours at CLI/gateway/cron startup.
         # Only touches ended sessions — active sessions are always preserved.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12530,6 +12530,7 @@ _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS = frozenset(
 def _hoist_post_subcommand_global_flags(
     argv: list[str],
     known_cmds: set[str] | frozenset[str],
+    subcommand_option_strings: dict[str, set[str]] | None = None,
 ) -> list[str]:
     """Move known top-level launcher flags before the subcommand.
 
@@ -12574,13 +12575,15 @@ def _hoist_post_subcommand_global_flags(
 
     prefix = head[:command_index]
     command_and_args = head[command_index:]
+    command_name = command_and_args[0]
+    native_options = (subcommand_option_strings or {}).get(command_name, set())
     hoisted: list[str] = []
     remainder: list[str] = []
     i = 0
     while i < len(command_and_args):
         token = command_and_args[i]
         if i > 0 and token in _POST_SUBCOMMAND_TOP_LEVEL_BOOL_FLAGS:
-            hoisted.append(token)
+            (remainder if token in native_options else hoisted).append(token)
             i += 1
             continue
 
@@ -12594,12 +12597,14 @@ def _hoist_post_subcommand_global_flags(
                 None,
             )
             if inline_value_match:
-                hoisted.append(token)
+                (remainder if inline_value_match in native_options else hoisted).append(token)
                 i += 1
                 continue
 
             if token in _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS and i + 1 < len(command_and_args):
-                hoisted.extend([token, command_and_args[i + 1]])
+                (remainder if token in native_options else hoisted).extend(
+                    [token, command_and_args[i + 1]]
+                )
                 i += 2
                 continue
 
@@ -12610,6 +12615,18 @@ def _hoist_post_subcommand_global_flags(
         return argv
 
     return [*prefix, *hoisted, *remainder, *tail]
+
+
+def _subcommand_option_strings(subparsers) -> dict[str, set[str]]:  # noqa: ANN001
+    choices = getattr(subparsers, "choices", {}) or {}
+    return {
+        name: {
+            option
+            for action in getattr(parser, "_actions", [])
+            for option in getattr(action, "option_strings", [])
+        }
+        for name, parser in choices.items()
+    }
 
 
 def _first_positional_argv() -> str | None:
@@ -16051,6 +16068,7 @@ Examples:
     _processed_argv = _hoist_post_subcommand_global_flags(
         _coalesce_session_name_args(sys.argv[1:]),
         _known_cmds,
+        _subcommand_option_strings(subparsers),
     )
     _has_cmd_token = any(
         t in _known_cmds for t in _processed_argv if not t.startswith("-")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9688,6 +9688,44 @@ def _resolve_update_branch(args) -> str:
     return (getattr(args, "branch", None) or "main").strip() or "main"
 
 
+def _resolve_update_target(
+    git_cmd: list[str], cwd: Path, branch: str
+) -> tuple[str, str, str]:
+    """Return the remote, remote branch, and compare ref for ``branch``.
+
+    ``hermes update`` historically hard-coded ``origin/<branch>``. That works
+    for normal installs, but managed desktop installs can have ``origin`` point
+    at upstream while their local ``main`` tracks a fork remote. Honor the
+    branch's configured upstream when it exists so update checks and pulls the
+    ref Git would use for that branch.
+    """
+    fallback_remote = "origin"
+    fallback_ref = f"{fallback_remote}/{branch}"
+    try:
+        result = subprocess.run(
+            git_cmd
+            + [
+                "for-each-ref",
+                "--format=%(upstream:short)",
+                f"refs/heads/{branch}",
+            ],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return fallback_remote, branch, fallback_ref
+
+    upstream_ref = result.stdout.strip() if result.returncode == 0 else ""
+    if "/" not in upstream_ref:
+        return fallback_remote, branch, fallback_ref
+
+    remote, remote_branch = upstream_ref.split("/", 1)
+    if not remote or not remote_branch:
+        return fallback_remote, branch, fallback_ref
+    return remote, remote_branch, upstream_ref
+
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -10373,9 +10411,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
             and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
         )
 
+        update_remote, update_remote_branch, update_ref = _resolve_update_target(
+            git_cmd, PROJECT_ROOT, branch
+        )
+        if update_remote != "origin":
+            fetch_target_result = subprocess.run(
+                git_cmd + ["fetch", update_remote],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            if fetch_target_result.returncode != 0:
+                stderr = fetch_target_result.stderr.strip()
+                print(f"✗ Failed to fetch updates from {update_remote}.")
+                if stderr:
+                    print(f"  {stderr.splitlines()[0]}")
+                sys.exit(1)
+
         # Check if there are updates
         result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+            git_cmd + ["rev-list", f"HEAD..{update_ref}", "--count"],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -10439,7 +10494,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
         try:
             pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
+                git_cmd + ["pull", "--ff-only", update_remote, update_remote_branch],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True,
@@ -10452,17 +10507,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
                 reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                    git_cmd + ["reset", "--hard", update_ref],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
                 )
                 if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
+                    print(f"✗ Failed to reset to {update_ref}.")
                     if reset_result.stderr.strip():
                         print(f"  {reset_result.stderr.strip()}")
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        f"  Try manually: git fetch {update_remote} && git reset --hard {update_ref}"
                     )
                     sys.exit(1)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7156,6 +7156,82 @@ def _desktop_stamp_path() -> Path:
     return get_hermes_home() / "desktop-build-stamp.json"
 
 
+def _run_git_text(project_root: Path, args: list[str]) -> str | None:
+    try:
+        proc = subprocess.Popen(
+            ["git", *args],
+            cwd=project_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        output, _ = proc.communicate(timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return output.strip() or None
+
+
+def _normalize_github_repository(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip()
+    if value.startswith("git@github.com:"):
+        value = value.removeprefix("git@github.com:")
+    elif value.startswith("https://github.com/"):
+        value = value.removeprefix("https://github.com/")
+    else:
+        return None
+    value = value.removesuffix(".git").rstrip("/")
+    parts = [part for part in value.split("/") if part]
+    if len(parts) < 2:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _current_desktop_install_identity(project_root: Path) -> dict[str, str | None] | None:
+    commit = _run_git_text(project_root, ["rev-parse", "HEAD"])
+    if not commit:
+        return None
+    branch = _run_git_text(project_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch == "HEAD":
+        branch = None
+    remote_name = None
+    if branch:
+        remote_name = _run_git_text(project_root, ["config", "--get", f"branch.{branch}.remote"])
+    remote_url = _run_git_text(project_root, ["remote", "get-url", remote_name or "origin"])
+    repository = _normalize_github_repository(remote_url)
+    return {
+        "commit": commit,
+        "branch": branch,
+        "repository": repository,
+    }
+
+
+def _desktop_packaged_install_stamp_path(packaged_executable: Path) -> Path | None:
+    if sys.platform == "darwin":
+        # .../Hermes.app/Contents/MacOS/Hermes -> .../Hermes.app/Contents/Resources/install-stamp.json
+        return packaged_executable.parent.parent / "Resources" / "install-stamp.json"
+    if sys.platform == "win32":
+        return packaged_executable.parent / "resources" / "install-stamp.json"
+    return packaged_executable.parent / "resources" / "install-stamp.json"
+
+
+def _read_desktop_install_identity(stamp_path: Path) -> dict[str, str | None] | None:
+    try:
+        payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or not payload.get("commit"):
+        return None
+    return {
+        "commit": payload.get("commit"),
+        "branch": payload.get("branch"),
+        "repository": payload.get("repository"),
+    }
+
+
 def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode: bool) -> bool:
     """Return True when the desktop build output is stale or missing.
 
@@ -7164,12 +7240,24 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
     ``hermes update`` that pulled new source but hasn't built yet).
     """
     # If there's no build output at all, we definitely need to build
+    packaged_executable = None
     if source_mode:
         if not _desktop_dist_exists(desktop_dir):
             return True
     else:
-        if _desktop_packaged_executable(desktop_dir) is None:
+        packaged_executable = _desktop_packaged_executable(desktop_dir)
+        if packaged_executable is None:
             return True
+        current_identity = _current_desktop_install_identity(project_root)
+        if current_identity:
+            embedded_stamp_path = _desktop_packaged_install_stamp_path(packaged_executable)
+            embedded_identity = (
+                _read_desktop_install_identity(embedded_stamp_path)
+                if embedded_stamp_path is not None and embedded_stamp_path.is_file()
+                else None
+            )
+            if embedded_identity != current_identity:
+                return True
 
     stamp_file = _desktop_stamp_path()
     if not stamp_file.is_file():
@@ -7183,6 +7271,12 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
     # If the mode changed (source vs packaged), force a rebuild
     if stamp_data.get("sourceMode") != source_mode:
         return True
+
+    if not source_mode:
+        current_identity = _current_desktop_install_identity(project_root)
+        saved_identity = stamp_data.get("installIdentity")
+        if current_identity and saved_identity and saved_identity != current_identity:
+            return True
 
     saved_hash = stamp_data.get("contentHash")
     if not saved_hash:
@@ -7204,6 +7298,10 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
             "sourceMode": source_mode,
             "builtAt": datetime.now(timezone.utc).isoformat(),
         }
+        if not source_mode:
+            identity = _current_desktop_install_identity(project_root)
+            if identity:
+                stamp_data["installIdentity"] = identity
         stamp_file.write_text(json.dumps(stamp_data, indent=2) + "\n", encoding="utf-8")
     except Exception as exc:
         # Never let stamp-writing block or fail a build

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12350,6 +12350,114 @@ _TOP_LEVEL_VALUE_FLAGS = frozenset(
     }
 )
 
+_POST_SUBCOMMAND_TOP_LEVEL_BOOL_FLAGS = frozenset(
+    {
+        "-w", "--worktree",
+        "--accept-hooks",
+        "--yolo",
+        "--pass-session-id",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--tui",
+        "--cli",
+        "--dev",
+    }
+)
+
+_POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS = frozenset(
+    {
+        "-m", "--model",
+        "--provider",
+        "-t", "--toolsets",
+        "-s", "--skills",
+    }
+)
+
+
+def _hoist_post_subcommand_global_flags(
+    argv: list[str],
+    known_cmds: set[str] | frozenset[str],
+) -> list[str]:
+    """Move known top-level launcher flags before the subcommand.
+
+    ``argparse`` only accepts parent-parser options before a subcommand unless
+    each child parser repeats them. That is easy to forget in launchers and
+    relaunch paths: ``hermes dashboard --no-open --tui`` should not die just
+    because ``--tui`` trails the dashboard command. Keep this deliberately
+    conservative: hoist only top-level flags whose values remain meaningful at
+    the parent level, and leave command-specific flags untouched.
+    """
+    if not argv:
+        return argv
+
+    try:
+        separator_index = argv.index("--")
+    except ValueError:
+        separator_index = len(argv)
+
+    head = argv[:separator_index]
+    tail = argv[separator_index:]
+
+    command_index = None
+    i = 0
+    while i < len(head):
+        token = head[i]
+        if token.startswith("-"):
+            if "=" in token:
+                i += 1
+                continue
+            if token in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(head):
+                i += 2
+                continue
+            i += 1
+            continue
+        if token in known_cmds:
+            command_index = i
+            break
+        return argv
+
+    if command_index is None:
+        return argv
+
+    prefix = head[:command_index]
+    command_and_args = head[command_index:]
+    hoisted: list[str] = []
+    remainder: list[str] = []
+    i = 0
+    while i < len(command_and_args):
+        token = command_and_args[i]
+        if i > 0 and token in _POST_SUBCOMMAND_TOP_LEVEL_BOOL_FLAGS:
+            hoisted.append(token)
+            i += 1
+            continue
+
+        if i > 0:
+            inline_value_match = next(
+                (
+                    flag
+                    for flag in _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS
+                    if token.startswith(f"{flag}=")
+                ),
+                None,
+            )
+            if inline_value_match:
+                hoisted.append(token)
+                i += 1
+                continue
+
+            if token in _POST_SUBCOMMAND_TOP_LEVEL_VALUE_FLAGS and i + 1 < len(command_and_args):
+                hoisted.extend([token, command_and_args[i + 1]])
+                i += 2
+                continue
+
+        remainder.append(token)
+        i += 1
+
+    if not hoisted:
+        return argv
+
+    return [*prefix, *hoisted, *remainder, *tail]
+
 
 def _first_positional_argv() -> str | None:
     """Return the first non-flag, non-flag-value token in ``sys.argv[1:]``.
@@ -15772,8 +15880,6 @@ Examples:
         # and raises OSError on failure (which propagates as a traceback).
         sys.exit(1)
 
-    _processed_argv = _coalesce_session_name_args(sys.argv[1:])
-
     # ── Defensive subparser routing (bpo-9338 workaround) ───────────
     # On some Python versions (notably <3.11), argparse fails to route
     # subcommand tokens when the parent parser has nargs='?' optional
@@ -15788,6 +15894,10 @@ Examples:
 
     _known_cmds = (
         set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
+    )
+    _processed_argv = _hoist_post_subcommand_global_flags(
+        _coalesce_session_name_args(sys.argv[1:]),
+        _known_cmds,
     )
     _has_cmd_token = any(
         t in _known_cmds for t in _processed_argv if not t.startswith("-")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1588,7 +1588,7 @@ async def get_sessions(
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
             )
-            total = db.session_count(
+            total = db.surfaced_session_count(
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
@@ -4577,7 +4577,7 @@ async def auto_archive_sessions_endpoint(body: AutoArchiveSessions):
         else cfg.get("auto_archive_min_interval_hours", 6)
     )
     min_message_count = int(cfg.get("auto_archive_min_messages", 1))
-    active_grace_hours = float(cfg.get("auto_archive_active_grace_hours", 24))
+    active_grace_seconds = int(cfg.get("auto_archive_active_grace_seconds", 300))
 
     from hermes_state import SessionDB
 
@@ -4589,7 +4589,7 @@ async def auto_archive_sessions_endpoint(body: AutoArchiveSessions):
             min_interval_hours=max(0.0, float(min_interval_hours or 0)),
             min_message_count=max(0, min_message_count),
             preserve_ids=preserve_ids,
-            active_grace_seconds=max(0, int(active_grace_hours * 3600)),
+            active_grace_seconds=max(0, active_grace_seconds),
         )
         return {"ok": True, **result}
     finally:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4530,6 +4530,72 @@ def _session_latest_descendant(session_id: str):
 # succeed and delete the wrong row). Same story as the older
 # ``/api/sessions/search`` endpoint up at line ~1191. If you split or
 # reorder this block, move every route in it together.
+class AutoArchiveSessions(BaseModel):
+    preserve_ids: Optional[List[str]] = None
+    keep_recent: Optional[int] = None
+    older_than_days: Optional[int] = None
+    min_interval_hours: Optional[float] = None
+
+
+@app.post("/api/sessions/auto-archive")
+async def auto_archive_sessions_endpoint(body: AutoArchiveSessions):
+    """Soft-archive old sessions so desktop restarts stay uncluttered.
+
+    Desktop owns pinned-session state in localStorage, so it sends the ids to
+    preserve on each startup/refresh. The backend persists the archive flag in
+    state.db; archived sessions disappear from normal `/api/sessions` results
+    but remain recoverable from the Archived Sessions settings panel.
+    """
+    preserve_ids = [
+        str(sid).strip()
+        for sid in (body.preserve_ids or [])
+        if str(sid).strip()
+    ]
+    if len(preserve_ids) > 5000:
+        raise HTTPException(
+            status_code=400,
+            detail="preserve_ids must contain at most 5000 entries",
+        )
+
+    cfg = (load_config().get("sessions") or {})
+    if not cfg.get("auto_archive", True):
+        return {"ok": True, "skipped": True, "archived": 0, "reason": "disabled"}
+
+    keep_recent = (
+        body.keep_recent
+        if body.keep_recent is not None
+        else cfg.get("auto_archive_keep_recent", 100)
+    )
+    older_than_days = (
+        body.older_than_days
+        if body.older_than_days is not None
+        else cfg.get("auto_archive_after_days", 14)
+    )
+    min_interval_hours = (
+        body.min_interval_hours
+        if body.min_interval_hours is not None
+        else cfg.get("auto_archive_min_interval_hours", 6)
+    )
+    min_message_count = int(cfg.get("auto_archive_min_messages", 1))
+    active_grace_hours = float(cfg.get("auto_archive_active_grace_hours", 24))
+
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        result = db.maybe_auto_archive_old_sessions(
+            keep_recent=max(0, int(keep_recent or 0)),
+            older_than_days=max(0, int(older_than_days or 0)),
+            min_interval_hours=max(0.0, float(min_interval_hours or 0)),
+            min_message_count=max(0, min_message_count),
+            preserve_ids=preserve_ids,
+            active_grace_seconds=max(0, int(active_grace_hours * 3600)),
+        )
+        return {"ok": True, **result}
+    finally:
+        db.close()
+
+
 class BulkDeleteSessions(BaseModel):
     ids: List[str]
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3075,6 +3075,44 @@ class SessionDB:
             cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions{where_sql}", params)
             return cursor.fetchone()[0]
 
+    def surfaced_session_count(
+        self,
+        source: str = None,
+        min_message_count: int = 0,
+        include_archived: bool = False,
+        archived_only: bool = False,
+    ) -> int:
+        """Count the root/branch conversations surfaced by list_sessions_rich."""
+        where_clauses = [
+            "(s.parent_session_id IS NULL"
+            " OR json_extract(s.model_config, '$._branched_from') IS NOT NULL"
+            " OR EXISTS (SELECT 1 FROM sessions p"
+            "            WHERE p.id = s.parent_session_id"
+            "            AND p.end_reason = 'branched'"
+            "            AND s.started_at >= p.ended_at))"
+        ]
+        params = []
+
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if min_message_count > 0:
+            where_clauses.append("s.message_count >= ?")
+            params.append(min_message_count)
+        if archived_only:
+            where_clauses.append("s.archived = 1")
+        elif not include_archived:
+            where_clauses.append("s.archived = 0")
+
+        where_sql = f"WHERE {' AND '.join(where_clauses)}"
+
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT COUNT(*) FROM sessions s {where_sql}",
+                params,
+            )
+            return cursor.fetchone()[0]
+
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
         with self._lock:
@@ -4031,7 +4069,7 @@ class SessionDB:
         older_than_days: int = 14,
         min_message_count: int = 1,
         preserve_ids: Optional[List[str]] = None,
-        active_grace_seconds: int = 86400,
+        active_grace_seconds: int = 300,
     ) -> int:
         """Soft-archive old surfaced sessions while keeping recent work visible.
 
@@ -4102,7 +4140,7 @@ class SessionDB:
                 archive_ids.append(target_id)
 
         if not archive_ids:
-            return 0
+            return self.archive_hidden_descendants_of_archived_sessions()
 
         def _do(conn):
             placeholders = ",".join("?" for _ in archive_ids)
@@ -4112,6 +4150,56 @@ class SessionDB:
                 archive_ids,
             )
             return cursor.rowcount
+
+        archived = self._execute_write(_do)
+        return archived + self.archive_hidden_descendants_of_archived_sessions()
+
+    def archive_hidden_descendants_of_archived_sessions(self) -> int:
+        """Archive hidden child rows that belong to archived conversations.
+
+        ``session_count()`` counts raw rows, while ``list_sessions_rich`` hides
+        subagent children and compression continuations. Without this sync, a
+        root conversation can be archived while hidden children still inflate
+        the desktop "Sessions X/Y" total. Branch sessions stay visible and are
+        not swept as descendants; they are archived only when they independently
+        match the normal old-session policy.
+        """
+
+        def _do(conn):
+            rows = conn.execute(
+                """
+                WITH RECURSIVE archive_tree(id) AS (
+                    SELECT id FROM sessions WHERE archived = 1
+                    UNION ALL
+                    SELECT child.id
+                    FROM sessions child
+                    JOIN archive_tree parent_tree ON child.parent_session_id = parent_tree.id
+                    LEFT JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE child.archived = 0
+                      AND json_extract(child.model_config, '$._branched_from') IS NULL
+                      AND NOT (
+                          COALESCE(parent.end_reason, '') = 'branched'
+                          AND child.started_at >= parent.ended_at
+                      )
+                )
+                SELECT s.id
+                FROM sessions s
+                JOIN archive_tree tree ON tree.id = s.id
+                WHERE s.archived = 0
+                """
+            ).fetchall()
+            ids = [row["id"] for row in rows]
+            updated = 0
+            for start in range(0, len(ids), 500):
+                chunk = ids[start:start + 500]
+                placeholders = ",".join("?" for _ in chunk)
+                cursor = conn.execute(
+                    f"UPDATE sessions SET archived = 1 "
+                    f"WHERE archived = 0 AND id IN ({placeholders})",
+                    chunk,
+                )
+                updated += cursor.rowcount
+            return updated
 
         return self._execute_write(_do)
 
@@ -4123,7 +4211,7 @@ class SessionDB:
         min_interval_hours: float = 6,
         min_message_count: int = 1,
         preserve_ids: Optional[List[str]] = None,
-        active_grace_seconds: int = 86400,
+        active_grace_seconds: int = 300,
     ) -> Dict[str, Any]:
         """Idempotent auto-maintenance wrapper around old-session archiving."""
         result: Dict[str, Any] = {"skipped": False, "archived": 0}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4024,6 +4024,145 @@ class SessionDB:
 
         return result
 
+    def archive_old_sessions(
+        self,
+        *,
+        keep_recent: int = 100,
+        older_than_days: int = 14,
+        min_message_count: int = 1,
+        preserve_ids: Optional[List[str]] = None,
+        active_grace_seconds: int = 86400,
+    ) -> int:
+        """Soft-archive old surfaced sessions while keeping recent work visible.
+
+        This is intentionally a soft hide (``sessions.archived = 1``), not a
+        delete.  It is designed for desktop/sidebar maintenance where a heavy
+        user can have thousands of old chats, but still needs Settings ->
+        Archived Chats to restore them.
+
+        A session is eligible when it is surfaced by ``list_sessions_rich``
+        (root conversations and branch sessions, not hidden subagent children),
+        has at least ``min_message_count`` messages, is not preserved by id, and
+        is either older than ``older_than_days`` or outside the most-recent
+        ``keep_recent`` surfaced conversations.  Recent live sessions
+        (``ended_at IS NULL`` and activity within ``active_grace_seconds``) are
+        kept even when they would otherwise fall outside the cap.
+        """
+        keep_recent = max(0, int(keep_recent or 0))
+        older_than_days = max(0, int(older_than_days or 0))
+        min_message_count = max(0, int(min_message_count or 0))
+        active_grace_seconds = max(0, int(active_grace_seconds or 0))
+        if keep_recent <= 0 and older_than_days <= 0:
+            return 0
+
+        preserved = {
+            str(sid).strip()
+            for sid in (preserve_ids or [])
+            if str(sid).strip()
+        }
+        now = time.time()
+        cutoff = now - older_than_days * 86400 if older_than_days > 0 else None
+        archive_ids: List[str] = []
+        seen_targets = set()
+
+        sessions = self.list_sessions_rich(
+            limit=100000,
+            offset=0,
+            min_message_count=min_message_count,
+            include_archived=False,
+            archived_only=False,
+            order_by_last_active=True,
+        )
+        for index, session in enumerate(sessions):
+            sid = str(session.get("id") or "").strip()
+            if not sid:
+                continue
+            root_id = str(session.get("_lineage_root_id") or sid).strip()
+            target_id = root_id or sid
+            if target_id in seen_targets:
+                continue
+            seen_targets.add(target_id)
+            if sid in preserved or target_id in preserved:
+                continue
+
+            started_at = float(session.get("started_at") or 0)
+            last_active = float(session.get("last_active") or started_at)
+            ended_at = session.get("ended_at")
+            recently_active = (
+                ended_at is None
+                and active_grace_seconds > 0
+                and now - last_active < active_grace_seconds
+            )
+            if recently_active:
+                continue
+
+            beyond_recent_cap = keep_recent > 0 and index >= keep_recent
+            past_age_cutoff = cutoff is not None and last_active < cutoff
+            if beyond_recent_cap or past_age_cutoff:
+                archive_ids.append(target_id)
+
+        if not archive_ids:
+            return 0
+
+        def _do(conn):
+            placeholders = ",".join("?" for _ in archive_ids)
+            cursor = conn.execute(
+                f"UPDATE sessions SET archived = 1 "
+                f"WHERE archived = 0 AND id IN ({placeholders})",
+                archive_ids,
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do)
+
+    def maybe_auto_archive_old_sessions(
+        self,
+        *,
+        keep_recent: int = 100,
+        older_than_days: int = 14,
+        min_interval_hours: float = 6,
+        min_message_count: int = 1,
+        preserve_ids: Optional[List[str]] = None,
+        active_grace_seconds: int = 86400,
+    ) -> Dict[str, Any]:
+        """Idempotent auto-maintenance wrapper around old-session archiving."""
+        result: Dict[str, Any] = {"skipped": False, "archived": 0}
+        try:
+            last_raw = self.get_meta("last_auto_archive")
+            now = time.time()
+            interval_seconds = max(0.0, float(min_interval_hours or 0)) * 3600
+            if last_raw and interval_seconds > 0:
+                try:
+                    last_ts = float(last_raw)
+                    if now - last_ts < interval_seconds:
+                        result["skipped"] = True
+                        return result
+                except (TypeError, ValueError):
+                    pass
+
+            archived = self.archive_old_sessions(
+                keep_recent=keep_recent,
+                older_than_days=older_than_days,
+                min_message_count=min_message_count,
+                preserve_ids=preserve_ids,
+                active_grace_seconds=active_grace_seconds,
+            )
+            result["archived"] = archived
+            self.set_meta("last_auto_archive", str(now))
+            if archived > 0:
+                logger.info(
+                    "state.db auto-maintenance: archived %d old session(s) "
+                    "(keep_recent=%d, older_than_days=%d)",
+                    archived,
+                    keep_recent,
+                    older_than_days,
+                )
+        except Exception as exc:
+            logger.warning("state.db auto-archive failed: %s", exc)
+            result["error"] = str(exc)
+
+        return result
+
     # ── Handoff (cross-platform session transfer) ──────────────────────────
     #
     # State machine:

--- a/run_agent.py
+++ b/run_agent.py
@@ -768,6 +768,31 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    def _emit_token_usage(self, input_tokens: int, output_tokens: int,
+                          total_tokens: int, context_tokens: int,
+                          context_length: int) -> None:
+        """Emit structured token usage data to the gateway for real-time UI updates.
+
+        The gateway forwards this as a structured ``token.usage`` event so the
+        desktop app's context bar can update smoothly during a turn rather than
+        jumping to the final value at end-of-turn.
+        """
+        if not self.status_callback:
+            return
+        import json
+        payload = json.dumps({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "context_tokens": context_tokens,
+            "context_length": context_length,
+            "context_pct": round(context_tokens / context_length * 100, 1) if context_length > 0 else 0,
+        })
+        try:
+            self.status_callback("token_usage", payload)
+        except Exception:
+            logger.debug("status_callback error in _emit_token_usage", exc_info=True)
+
     # ── Buffered retry/fallback status ────────────────────────────────────
     # Retry and fallback chains were flooding the CLI/gateway with status
     # noise that users found confusing: a single transient 429 could produce

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -92,8 +92,8 @@ try {
 # Configuration
 # ============================================================================
 
-$RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
-$RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
+$RepoUrlSsh = if ($env:HERMES_INSTALL_REPO_URL_SSH) { $env:HERMES_INSTALL_REPO_URL_SSH } else { "git@github.com:NousResearch/hermes-agent.git" }
+$RepoUrlHttps = if ($env:HERMES_INSTALL_REPO_URL_HTTPS) { $env:HERMES_INSTALL_REPO_URL_HTTPS } else { "https://github.com/NousResearch/hermes-agent.git" }
 $PythonVersion = "3.11"
 $NodeVersion = "22"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,8 +43,8 @@ NC='\033[0m' # No Color
 BOLD='\033[1m'
 
 # Configuration
-REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
-REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+REPO_URL_SSH="${HERMES_INSTALL_REPO_URL_SSH:-git@github.com:NousResearch/hermes-agent.git}"
+REPO_URL_HTTPS="${HERMES_INSTALL_REPO_URL_HTTPS:-https://github.com/NousResearch/hermes-agent.git}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -130,6 +130,7 @@ AUTHOR_MAP = {
     "saeed919@pm.me": "falasi",
     "chrisdlc119@outlook.com": "chdlc",
     "omar@techdeveloper.site": "nycomar",
+    "omar@kostudios.io": "OmarB97",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "adityargadgil@gmail.com": "AdityaRajeshGadgil",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1133,6 +1133,14 @@ class TestParseContextLimitFromError:
         msg = "Maximum context size 65536 exceeded"
         assert parse_context_limit_from_error(msg) == 65536
 
+    def test_available_context_size_format(self):
+        msg = "HTTP 400: request (70838 tokens) exceeds the available context size (65536 tokens), try increasing it"
+        assert parse_context_limit_from_error(msg) == 65536
+
+    def test_structured_n_ctx_format(self):
+        msg = "llama runner rejected request: {'n_prompt_tokens': 70838, 'n_ctx': 65536}"
+        assert parse_context_limit_from_error(msg) == 65536
+
     def test_no_limit_in_message(self):
         assert parse_context_limit_from_error("Something went wrong with the API") is None
 
@@ -1238,6 +1246,18 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length("unknown/model", "http://local", 65536)
             assert get_model_context_length("unknown/model", base_url="http://local") == 65536
+
+    def test_provider_confirmed_cache_caps_over_optimistic_custom_config(self, tmp_path):
+        cache_file = tmp_path / "cache.yaml"
+        base_url = "http://10.10.20.211:8080/v1"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("qwen3.6-27b", base_url, 65536)
+            assert get_model_context_length(
+                "qwen3.6-27b",
+                base_url=base_url,
+                provider="custom",
+                config_context_length=131072,
+            ) == 65536
 
     def test_special_chars_in_model_name(self, tmp_path):
         """Model names with colons, slashes, etc. don't break the cache."""

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -39,13 +39,16 @@ def test_format_banner_version_label_with_carried_commits():
     assert "+3 carried commits" in value
 
 
-def test_get_git_banner_state_reads_origin_and_head(tmp_path):
+def test_get_git_banner_state_reads_tracking_ref_and_head(tmp_path):
     from hermes_cli import banner
 
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
     results = {
+        ("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): MagicMock(
+            returncode=0, stdout="origin/main\n"
+        ),
         ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
         ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
         ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="3\n"),
@@ -61,6 +64,33 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
         state = banner.get_git_banner_state(repo_dir)
 
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
+
+
+def test_get_git_banner_state_uses_fork_tracking_ref(tmp_path):
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): MagicMock(
+            returncode=0, stdout="fork/main\n"
+        ),
+        ("git", "rev-parse", "--short=8", "fork/main"): MagicMock(returncode=0, stdout="11d19735\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="11d19735\n"),
+        ("git", "rev-list", "--count", "fork/main..HEAD"): MagicMock(returncode=0, stdout="0\n"),
+    }
+
+    def fake_run(cmd, **kwargs):
+        key = tuple(cmd)
+        if key not in results:
+            raise AssertionError(f"unexpected command: {cmd}")
+        return results[key]
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state == {"upstream": "11d19735", "local": "11d19735", "ahead": 0}
 
 
 def test_get_git_banner_state_falls_back_to_build_sha_when_no_repo():
@@ -96,11 +126,12 @@ def test_get_git_banner_state_returns_none_when_no_repo_and_no_build_sha():
 
 
 def test_get_git_banner_state_falls_back_when_live_git_returns_nothing(tmp_path):
-    """Shallow clone without origin/main → still surface build SHA if baked.
+    """Shallow clone without a tracking ref → still surface build SHA if baked.
 
     Some install paths (e.g. ``git clone --depth 1`` without a remote) have
-    a ``.git`` directory but ``git rev-parse origin/main`` fails.  When that
-    happens AND a baked SHA exists, return the baked one instead of None.
+    a ``.git`` directory but ``git rev-parse`` against the tracking ref fails.
+    When that happens AND a baked SHA exists, return the baked one instead of
+    None.
     """
     from hermes_cli import banner
 

--- a/tests/hermes_cli/test_default_interface_resolution.py
+++ b/tests/hermes_cli/test_default_interface_resolution.py
@@ -191,13 +191,14 @@ class TestPostSubcommandGlobalFlagHoisting:
         dashboard.add_argument("--port", type=int, default=9119)
         dashboard.add_argument("--host", default="127.0.0.1")
         dashboard.add_argument("--no-open", action="store_true")
-        return parser, set(subparsers.choices.keys())
+        return parser, subparsers
 
     def test_dashboard_accepts_trailing_tui_flag(self):
-        parser, known_cmds = self._dashboard_parser()
+        parser, subparsers = self._dashboard_parser()
         argv = m._hoist_post_subcommand_global_flags(
             ["dashboard", "--no-open", "--host", "127.0.0.1", "--port", "65535", "--tui"],
-            known_cmds,
+            set(subparsers.choices.keys()),
+            m._subcommand_option_strings(subparsers),
         )
 
         args = parser.parse_args(argv)
@@ -209,10 +210,11 @@ class TestPostSubcommandGlobalFlagHoisting:
         assert args.port == 65535
 
     def test_dashboard_accepts_trailing_skills_and_tui_flags(self):
-        parser, known_cmds = self._dashboard_parser()
+        parser, subparsers = self._dashboard_parser()
         argv = m._hoist_post_subcommand_global_flags(
             ["dashboard", "--no-open", "--skills", "desktop-backend", "--tui"],
-            known_cmds,
+            set(subparsers.choices.keys()),
+            m._subcommand_option_strings(subparsers),
         )
 
         args = parser.parse_args(argv)
@@ -222,11 +224,32 @@ class TestPostSubcommandGlobalFlagHoisting:
         assert args.tui is True
         assert args.no_open is True
 
+    def test_chat_keeps_native_provider_flag_after_subcommand(self):
+        parser, subparsers = self._dashboard_parser()
+        argv = m._hoist_post_subcommand_global_flags(
+            ["chat", "--provider", "gmi"],
+            set(subparsers.choices.keys()),
+            m._subcommand_option_strings(subparsers),
+        )
+
+        args = parser.parse_args(argv)
+
+        assert argv == ["chat", "--provider", "gmi"]
+        assert args.command == "chat"
+        assert args.provider == "gmi"
+
     def test_double_dash_stops_global_flag_hoisting(self):
-        _parser, known_cmds = self._dashboard_parser()
+        _parser, subparsers = self._dashboard_parser()
         argv = ["dashboard", "--", "--tui"]
 
-        assert m._hoist_post_subcommand_global_flags(argv, known_cmds) == argv
+        assert (
+            m._hoist_post_subcommand_global_flags(
+                argv,
+                set(subparsers.choices.keys()),
+                m._subcommand_option_strings(subparsers),
+            )
+            == argv
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_default_interface_resolution.py
+++ b/tests/hermes_cli/test_default_interface_resolution.py
@@ -182,6 +182,53 @@ class TestParserFlags:
         assert "--tui" in inherited
 
 
+class TestPostSubcommandGlobalFlagHoisting:
+    def _dashboard_parser(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, subparsers, _chat = build_top_level_parser()
+        dashboard = subparsers.add_parser("dashboard")
+        dashboard.add_argument("--port", type=int, default=9119)
+        dashboard.add_argument("--host", default="127.0.0.1")
+        dashboard.add_argument("--no-open", action="store_true")
+        return parser, set(subparsers.choices.keys())
+
+    def test_dashboard_accepts_trailing_tui_flag(self):
+        parser, known_cmds = self._dashboard_parser()
+        argv = m._hoist_post_subcommand_global_flags(
+            ["dashboard", "--no-open", "--host", "127.0.0.1", "--port", "65535", "--tui"],
+            known_cmds,
+        )
+
+        args = parser.parse_args(argv)
+
+        assert args.command == "dashboard"
+        assert args.tui is True
+        assert args.no_open is True
+        assert args.host == "127.0.0.1"
+        assert args.port == 65535
+
+    def test_dashboard_accepts_trailing_skills_and_tui_flags(self):
+        parser, known_cmds = self._dashboard_parser()
+        argv = m._hoist_post_subcommand_global_flags(
+            ["dashboard", "--no-open", "--skills", "desktop-backend", "--tui"],
+            known_cmds,
+        )
+
+        args = parser.parse_args(argv)
+
+        assert args.command == "dashboard"
+        assert args.skills == ["desktop-backend"]
+        assert args.tui is True
+        assert args.no_open is True
+
+    def test_double_dash_stops_global_flag_hoisting(self):
+        _parser, known_cmds = self._dashboard_parser()
+        argv = ["dashboard", "--", "--tui"]
+
+        assert m._hoist_post_subcommand_global_flags(argv, known_cmds) == argv
+
+
 # ---------------------------------------------------------------------------
 # config default — shipped default preserves classic behavior
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -48,6 +49,13 @@ def _make_packaged_executable(root: Path, monkeypatch, platform: str = "darwin")
     exe.parent.mkdir(parents=True)
     exe.write_text("", encoding="utf-8")
     return exe
+
+
+def _write_packaged_install_stamp(exe: Path, payload: dict[str, object]) -> None:
+    stamp_path = cli_main._desktop_packaged_install_stamp_path(exe)
+    assert stamp_path is not None
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
@@ -365,6 +373,55 @@ def test_desktop_build_stamp_round_trip(tmp_path, monkeypatch):
     assert cli_main._desktop_build_needed(
         root / "apps" / "desktop", root, source_mode=False
     ) is False
+
+
+def test_desktop_build_needed_skips_when_packaged_install_identity_matches(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    (root / "package-lock.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    identity = {
+        "commit": "a" * 40,
+        "branch": "main",
+        "repository": "NousResearch/hermes-agent",
+    }
+    monkeypatch.setattr(cli_main, "_current_desktop_install_identity", lambda _root: identity)
+    exe = _make_packaged_executable(root, monkeypatch)
+    _write_packaged_install_stamp(exe, identity)
+
+    cli_main._write_desktop_build_stamp(root, source_mode=False)
+
+    assert cli_main._desktop_build_needed(
+        root / "apps" / "desktop", root, source_mode=False
+    ) is False
+
+
+def test_desktop_build_needed_detects_stale_packaged_install_identity(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    (root / "package-lock.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    current_identity = {
+        "commit": "b" * 40,
+        "branch": "main",
+        "repository": "NousResearch/hermes-agent",
+    }
+    monkeypatch.setattr(cli_main, "_current_desktop_install_identity", lambda _root: current_identity)
+    exe = _make_packaged_executable(root, monkeypatch)
+    _write_packaged_install_stamp(
+        exe,
+        {
+            "commit": "a" * 40,
+            "branch": "live/local-feature",
+            "repository": "OmarB97/hermes-agent",
+        },
+    )
+
+    cli_main._write_desktop_build_stamp(root, source_mode=False)
+
+    assert cli_main._desktop_build_needed(
+        root / "apps" / "desktop", root, source_mode=False
+    ) is True
 
 
 def test_compute_desktop_content_hash_works_without_gitignore(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -482,6 +482,7 @@ def _make_update_side_effect(
     reset_fails=False,
     fetch_fails=False,
     fetch_stderr="",
+    upstream_ref="",
 ):
     """Build a subprocess.run side_effect for cmd_update tests."""
     recorded = []
@@ -489,12 +490,14 @@ def _make_update_side_effect(
     def side_effect(cmd, **kwargs):
         recorded.append(cmd)
         joined = " ".join(str(c) for c in cmd)
-        if "fetch" in joined and "origin" in joined:
+        if "fetch" in joined:
             if fetch_fails:
                 return SimpleNamespace(stdout="", stderr=fetch_stderr, returncode=128)
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if "for-each-ref" in joined:
+            return SimpleNamespace(stdout=f"{upstream_ref}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -546,6 +549,34 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 0
+
+
+def test_cmd_update_uses_target_branch_tracking_remote(monkeypatch, tmp_path):
+    """A live install updating to main should honor main's configured upstream.
+
+    The macOS desktop update path can run from a temporary live branch while the
+    local ``main`` branch tracks a fork remote. In that shape, hard-coding
+    ``origin/main`` makes the updater report "Already up to date" against the
+    wrong remote and leaves the app on stale code.
+    """
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+
+    side_effect, recorded = _make_update_side_effect(
+        current_branch="live/hermes-desktop-thinking-off-20260604",
+        commit_count="2",
+        upstream_ref="fork/main",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace(branch="main"))
+
+    assert ["git", "fetch", "fork"] in recorded
+    assert ["git", "rev-list", "HEAD..fork/main", "--count"] in recorded
+    assert ["git", "pull", "--ff-only", "fork", "main"] in recorded
+    assert ["git", "pull", "--ff-only", "origin", "main"] not in recorded
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -93,7 +93,40 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git upstream ref + git fetch + git rev-list
+
+
+def test_check_for_updates_uses_current_tracking_ref(tmp_path, monkeypatch):
+    """Fork installs should compare to their tracking remote, not origin/main."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 22}))
+
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(tuple(cmd))
+        if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name"]:
+            return MagicMock(returncode=0, stdout="fork/main\n")
+        if cmd[:3] == ["git", "fetch", "fork"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = check_for_updates()
+
+    assert result == 0
+    assert ("git", "fetch", "fork", "--quiet") in calls
+    assert ("git", "rev-list", "--count", "HEAD..fork/main") in calls
+    assert ("git", "rev-list", "--count", "HEAD..origin/main") not in calls
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -287,6 +287,10 @@ class TestWebServerEndpoints:
                 captured["count"] = min_message_count
                 return 0
 
+            def surfaced_session_count(self, min_message_count=0, **kwargs):
+                captured["count"] = min_message_count
+                return 0
+
             def close(self):
                 pass
 
@@ -479,6 +483,28 @@ class TestWebServerEndpoints:
         # ...carrying the durable lineage root so the desktop can match pins.
         tip = next(r for r in rows if r["id"] == "tip-new")
         assert tip.get("_lineage_root_id") == "root-old"
+
+    def test_get_sessions_total_counts_surfaced_conversations(self):
+        """Hidden child rows must not inflate the desktop session total."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="root-visible", source="cli")
+            db.append_message("root-visible", role="user", content="root")
+            db.create_session(
+                session_id="hidden-child",
+                source="cli",
+                parent_session_id="root-visible",
+            )
+            db.append_message("hidden-child", role="user", content="child")
+        finally:
+            db.close()
+
+        data = self.client.get("/api/sessions?limit=10&min_messages=1").json()
+        ids = [row["id"] for row in data["sessions"]]
+        assert ids == ["root-visible"]
+        assert data["total"] == 1
 
     def test_search_dedupes_compression_lineage_to_tip(self):
         """A conversation that auto-compresses leaves the matched term in both

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -368,6 +368,58 @@ class TestWebServerEndpoints:
         restored = self.client.get("/api/sessions").json()
         assert any(s["id"] == "arch-me" for s in restored["sessions"])
 
+    def test_auto_archive_endpoint_preserves_ids_and_hides_old_sessions(self):
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        def _seed(db, sid: str, last_active: float):
+            db.create_session(session_id=sid, source="cli")
+            db.append_message(session_id=sid, role="user", content=f"hello {sid}")
+            db.end_session(sid, end_reason="done")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+                (last_active - 10, last_active, sid),
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+                (last_active, sid),
+            )
+
+        now = _time.time()
+        db = SessionDB()
+        try:
+            _seed(db, "recent", now)
+            _seed(db, "old-preserved", now - 200)
+            _seed(db, "old-archive", now - 300)
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.post(
+            "/api/sessions/auto-archive",
+            json={
+                "preserve_ids": ["old-preserved"],
+                "keep_recent": 1,
+                "older_than_days": 0,
+                "min_interval_hours": 0,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["archived"] == 1
+
+        listed = self.client.get("/api/sessions?limit=10").json()["sessions"]
+        listed_ids = {s["id"] for s in listed}
+        assert "recent" in listed_ids
+        assert "old-preserved" in listed_ids
+        assert "old-archive" not in listed_ids
+
+        archived = self.client.get(
+            "/api/sessions?archived=only&limit=10"
+        ).json()["sessions"]
+        assert any(s["id"] == "old-archive" for s in archived)
+
     def test_patch_session_without_fields_is_400(self):
         """An existing session + empty body is a bad request, not a 404."""
         from hermes_state import SessionDB
@@ -3967,4 +4019,3 @@ class TestValidateProviderCredential:
     def test_empty_value_rejected(self):
         data = self._post("OPENAI_API_KEY", "   ").json()
         assert data["ok"] is False
-

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -387,6 +387,57 @@ class TestHTTP413Compression:
             "content": "compressed summary",
         }
 
+    def test_context_overflow_retries_when_compression_reduces_tokens_not_message_count(self, agent):
+        """A summarizer can shrink message content without shrinking message count."""
+        agent.base_url = "http://10.10.20.211:8080/v1"
+        agent.provider = "custom"
+        agent.context_compressor.context_length = 131_072
+
+        err_400 = Exception(
+            "HTTP 400: request (70838 tokens) exceeds the available context size "
+            "(65536 tokens), try increasing it"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question " * 200},
+            {"role": "assistant", "content": "previous answer " * 200},
+        ]
+
+        request_estimate_calls = {"n": 0}
+
+        def _request_estimate(*_args, **_kwargs):
+            request_estimate_calls["n"] += 1
+            return 70_838 if request_estimate_calls["n"] == 1 else 37_142
+
+        def _compress_same_count(messages, *_args, **_kwargs):
+            return (
+                [
+                    {**msg, "content": f"short {idx}"}
+                    for idx, msg in enumerate(messages)
+                ],
+                "compressed prompt",
+            )
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_request_estimate),
+            patch("agent.conversation_loop.save_context_length"),
+            patch.object(agent, "_compress_context", side_effect=_compress_same_count) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.client.chat.completions.create.call_count == 2
+        assert agent.context_compressor.context_length == 65_536
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert result.get("compression_exhausted") is not True
+
     def test_413_cannot_compress_further(self, agent):
         """When compression can't reduce messages, return partial result."""
         err_413 = _make_413_error()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3292,6 +3292,38 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_preflight_token_usage_emits_before_api_response(self, agent):
+        self._setup_agent(agent)
+        agent.context_compressor = SimpleNamespace(
+            context_length=131072,
+            last_prompt_tokens=0,
+        )
+        events = []
+
+        def _status(kind, text=None):
+            if kind == "token_usage":
+                events.append(json.loads(text))
+
+        def _create(*_args, **_kwargs):
+            assert events
+            assert events[-1]["context_tokens"] == 12345
+            assert events[-1]["context_length"] == 131072
+            return _mock_response(content="Final answer", finish_reason="stop")
+
+        agent.status_callback = _status
+        agent.client.chat.completions.create.side_effect = _create
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=12345),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Final answer"
+        assert agent.context_compressor.last_prompt_tokens == 12345
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -54,6 +54,28 @@ def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
 
 
+def test_run_conversation_dict_returns_include_final_response():
+    from agent import conversation_loop
+
+    source = inspect.getsource(conversation_loop.run_conversation)
+    tree = ast.parse(source)
+    missing = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Dict):
+            continue
+        keys = [
+            key.value if isinstance(key, ast.Constant) else None
+            for key in node.value.keys
+        ]
+        if "final_response" not in keys:
+            missing.append(node.lineno)
+
+    assert missing == [], (
+        "run_conversation() dict returns must preserve the final_response "
+        f"contract; missing at source-local lines {missing}"
+    )
+
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
@@ -4548,6 +4570,7 @@ class TestRetryExhaustion:
         assert result.get("failed") is True
         assert "error" in result
         assert "Invalid API response" in result["error"]
+        assert result.get("final_response") == result["error"]
 
     def test_api_error_returns_gracefully_after_retries(self, agent):
         """Exhausted retries on API errors must return error result, not crash."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3268,6 +3268,55 @@ class TestAutoMaintenance:
         assert db.get_session("live-recent")["archived"] == 0
         assert db.get_session("old-archive")["archived"] == 1
 
+    def test_auto_archive_syncs_hidden_descendants_not_visible_branches(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "archived-root", last_active=now - 500)
+        db.set_session_archived("archived-root", True)
+        db.create_session(
+            session_id="hidden-child",
+            source="cli",
+            parent_session_id="archived-root",
+        )
+        db.append_message("hidden-child", role="user", content="child")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 490, "hidden-child"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (now - 490, "hidden-child"),
+        )
+
+        db.create_session(session_id="branch-parent", source="cli")
+        db.append_message("branch-parent", role="user", content="parent")
+        db.end_session("branch-parent", end_reason="branched")
+        db.set_session_archived("branch-parent", True)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (now - 400, now - 390, "branch-parent"),
+        )
+        db.create_session(
+            session_id="visible-branch",
+            source="cli",
+            parent_session_id="branch-parent",
+        )
+        db.append_message("visible-branch", role="user", content="branch")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 380, "visible-branch"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (now - 380, "visible-branch"),
+        )
+        db._conn.commit()
+
+        archived = db.archive_old_sessions(keep_recent=100, older_than_days=14)
+
+        assert archived == 1
+        assert db.get_session("hidden-child")["archived"] == 1
+        assert db.get_session("visible-branch")["archived"] == 0
+
     def test_maybe_auto_archive_uses_interval_marker(self, db):
         now = time.time()
         self._make_archivable_session(db, "old1", last_active=now - 100)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3195,6 +3195,101 @@ class TestAutoMaintenance:
         )
         db._conn.commit()
 
+    def _make_archivable_session(
+        self,
+        db,
+        sid: str,
+        *,
+        last_active: float,
+        ended: bool = True,
+    ):
+        db.create_session(session_id=sid, source="cli")
+        db.append_message(session_id=sid, role="user", content=f"hello {sid}")
+        if ended:
+            db.end_session(sid, end_reason="done")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (
+                last_active - 10,
+                last_active if ended else None,
+                sid,
+            ),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (last_active, sid),
+        )
+        db._conn.commit()
+
+    def test_auto_archive_hides_sessions_beyond_recent_cap(self, db):
+        now = time.time()
+        for idx in range(5):
+            self._make_archivable_session(
+                db,
+                f"s{idx}",
+                last_active=now - idx * 60,
+            )
+
+        archived = db.archive_old_sessions(
+            keep_recent=2,
+            older_than_days=0,
+        )
+
+        assert archived == 3
+        assert db.session_count(include_archived=False) == 2
+        assert db.session_count(archived_only=True) == 3
+        assert db.get_session("s0")["archived"] == 0
+        assert db.get_session("s1")["archived"] == 0
+        assert db.get_session("s2")["archived"] == 1
+        assert db.get_session("s4")["archived"] == 1
+
+    def test_auto_archive_preserves_requested_and_recent_live_sessions(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "recent", last_active=now)
+        self._make_archivable_session(db, "old-preserved", last_active=now - 500)
+        self._make_archivable_session(db, "old-archive", last_active=now - 600)
+        self._make_archivable_session(
+            db,
+            "live-recent",
+            last_active=now - 700,
+            ended=False,
+        )
+
+        archived = db.archive_old_sessions(
+            keep_recent=1,
+            older_than_days=0,
+            preserve_ids=["old-preserved"],
+            active_grace_seconds=3600,
+        )
+
+        assert archived == 1
+        assert db.get_session("recent")["archived"] == 0
+        assert db.get_session("old-preserved")["archived"] == 0
+        assert db.get_session("live-recent")["archived"] == 0
+        assert db.get_session("old-archive")["archived"] == 1
+
+    def test_maybe_auto_archive_uses_interval_marker(self, db):
+        now = time.time()
+        self._make_archivable_session(db, "old1", last_active=now - 100)
+
+        first = db.maybe_auto_archive_old_sessions(
+            keep_recent=0,
+            older_than_days=1,
+            min_interval_hours=24,
+        )
+        assert first["skipped"] is False
+        assert first["archived"] == 0
+
+        self._make_archivable_session(db, "old2", last_active=now - 200)
+        second = db.maybe_auto_archive_old_sessions(
+            keep_recent=1,
+            older_than_days=0,
+            min_interval_hours=24,
+        )
+        assert second["skipped"] is True
+        assert second["archived"] == 0
+        assert db.get_session("old2")["archived"] == 0
+
     def test_first_run_prunes_and_vacuums(self, db):
         self._make_old_ended(db, "old1", days_old=100)
         self._make_old_ended(db, "old2", days_old=100)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -109,6 +109,24 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_status_update_token_usage_emits_structured_event(monkeypatch):
+    events: list[tuple[str, str, dict | None]] = []
+    payload = {
+        "context_length": 131072,
+        "context_pct": 49.9,
+        "context_tokens": 65432,
+        "input_tokens": 1200,
+        "output_tokens": 34,
+        "total_tokens": 1234,
+    }
+
+    monkeypatch.setattr(server, "_emit", lambda event, sid, body=None: events.append((event, sid, body)))
+
+    server._status_update("sid", "token_usage", json.dumps(payload))
+
+    assert events == [("token.usage", "sid", payload)]
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4761,8 +4761,8 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False
             ),
             patch(
-                "hermes_cli.browser_connect.get_chrome_debug_candidates",
-                return_value=[],
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value="",
             ),
         ):
             resp = server.handle_request(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1910,6 +1910,12 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+    )
 
     resp_effort = server.handle_request(
         {
@@ -1920,10 +1926,25 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     )
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+    assert emitted[-1][0] == "session.info"
+    assert emitted[-1][1] == "sid"
+    assert emitted[-1][2]["reasoning_effort"] == "low"
+
+    resp_none = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "none"},
+        }
+    )
+    assert resp_none["result"]["value"] == "none"
+    assert agent.reasoning_config == {"enabled": False}
+    assert emitted[-1][0] == "session.info"
+    assert emitted[-1][2]["reasoning_effort"] == "none"
 
     resp_show = server.handle_request(
         {
-            "id": "2",
+            "id": "3",
             "method": "config.set",
             "params": {"session_id": "sid", "key": "reasoning", "value": "show"},
         }
@@ -1934,7 +1955,7 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
 
     resp_hide = server.handle_request(
         {
-            "id": "3",
+            "id": "4",
             "method": "config.set",
             "params": {"session_id": "sid", "key": "reasoning", "value": "hide"},
         }
@@ -2917,6 +2938,19 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     info = server._session_info(types.SimpleNamespace(tools=[], model=""))
 
     assert info["mcp_servers"] == fake_status
+
+
+def test_session_info_reports_reasoning_none_when_disabled(monkeypatch):
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "")
+    agent = types.SimpleNamespace(
+        model="qwen3-coder",
+        reasoning_config={"enabled": False},
+        tools=[],
+    )
+
+    info = server._session_info(agent)
+
+    assert info["reasoning_effort"] == "none"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4929,6 +4929,28 @@ def test_make_agent_handles_null_agent_config(monkeypatch):
     assert mock_agent.call_args.kwargs["max_iterations"] == 80
 
 
+def test_make_agent_passes_fallback_chain_from_config(monkeypatch):
+    fallback_chain = [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "taro", "model": "qwen3.6-27b-256k"},
+    ]
+    _setup_make_agent_mocks(
+        monkeypatch,
+        {
+            "fallback_providers": fallback_chain,
+            "fallback_model": {
+                "provider": "opencode-zen",
+                "model": "deepseek-v4-flash-free",
+            },
+        },
+    )
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["fallback_model"] == fallback_chain
+
+
 class _FakeAgentForBackground:
     base_url = None
     api_key = None
@@ -4981,6 +5003,20 @@ def test_background_agent_kwargs_handles_null_agent_config(monkeypatch):
     kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
 
     assert kwargs["max_iterations"] == 40
+
+
+def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    agent = _FakeAgentForBackground()
+    agent._fallback_chain = [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "taro", "model": "qwen3.6-27b-256k"},
+    ]
+    agent._fallback_model = {"provider": "opencode-zen", "model": "legacy-only"}
+
+    kwargs = server._background_agent_kwargs(agent, "task_1")
+
+    assert kwargs["fallback_model"] == agent._fallback_chain
 
 
 def test_config_show_displays_nested_max_turns(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2953,6 +2953,96 @@ def test_session_info_reports_reasoning_none_when_disabled(monkeypatch):
     assert info["reasoning_effort"] == "none"
 
 
+def test_session_info_reports_reasoning_none_when_agent_uses_default(monkeypatch):
+    """Desktop must not display AIAgent's implicit provider default as Medium.
+
+    In the TUI gateway, a missing reasoning_config is still effective Thinking
+    Off for status purposes; otherwise the desktop can flip from Off to Med as
+    soon as a lazy session starts.
+    """
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "")
+    agent = types.SimpleNamespace(
+        model="qwen3-coder",
+        reasoning_config=None,
+        tools=[],
+    )
+
+    info = server._session_info(agent)
+
+    assert info["reasoning_effort"] == "none"
+
+
+def test_load_reasoning_config_defaults_blank_to_disabled(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {}})
+
+    assert server._load_reasoning_config() == {"enabled": False}
+
+
+def test_make_agent_defaults_blank_reasoning_to_disabled(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {}})
+    monkeypatch.setattr(
+        server,
+        "_resolve_startup_runtime",
+        lambda: ("qwen3-coder", None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_agent_cbs", lambda sid: {})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["reasoning_config"] == {"enabled": False}
+
+
+def test_session_create_lazy_info_reports_reasoning_none(monkeypatch, tmp_path):
+    class NoopTimer:
+        daemon = False
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    previous_sessions = dict(server._sessions)
+    server._sessions.clear()
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "qwen3-coder")
+    monkeypatch.setattr(server.threading, "Timer", NoopTimer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {}})
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "session-create",
+                "method": "session.create",
+                "params": {"cols": 96},
+            }
+        )
+
+        assert resp["result"]["info"]["reasoning_effort"] == "none"
+    finally:
+        server._sessions.clear()
+        server._sessions.update(previous_sessions)
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1569,6 +1569,15 @@ def _current_profile_name() -> str:
         return "default"
 
 
+def _reasoning_effort_for_session_info(agent) -> str:
+    reasoning_config = getattr(agent, "reasoning_config", None)
+    if not isinstance(reasoning_config, dict):
+        return ""
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    return str(reasoning_config.get("effort", "") or "")
+
+
 # Monotonic GUI<->backend contract version. The desktop app refuses to drive a
 # backend reporting less than its required value (or none at all — a pre-GUI
 # checkout), surfacing a one-click "update to align" prompt instead of failing
@@ -1585,13 +1594,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     cwd = _session_cwd(session)
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
-    reasoning_config = getattr(agent, "reasoning_config", None)
-    reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    reasoning_effort = _reasoning_effort_for_session_info(agent)
     service_tier = getattr(agent, "service_tier", None) or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
@@ -5158,6 +5161,11 @@ def _(rid, params: dict) -> dict:
             _write_config_key("agent.reasoning_effort", arg)
             if session and session.get("agent") is not None:
                 session["agent"].reasoning_config = parsed
+                _emit(
+                    "session.info",
+                    params.get("session_id", ""),
+                    _session_info(session["agent"], session),
+                )
             return _ok(rid, {"key": key, "value": arg})
         except Exception as e:
             return _err(rid, 5001, str(e))
@@ -5401,7 +5409,7 @@ def _(rid, params: dict) -> dict:
     if key == "reasoning":
         cfg = _load_cfg()
         effort = str(
-            (cfg.get("agent") or {}).get("reasoning_effort", "medium") or "medium"
+            (cfg.get("agent") or {}).get("reasoning_effort", "") or ""
         )
         display = (
             "show"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -395,6 +395,16 @@ def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
+    # Structured token_usage events are JSON-encoded; unpack and re-emit
+    # as a typed event so the desktop app can consume them directly.
+    if kind == "token_usage":
+        import json
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, TypeError):
+            return
+        _emit("token.usage", sid, payload)
+        return
     _emit(
         "status.update",
         sid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.fallback_config import get_fallback_chain
 from utils import is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
@@ -1972,7 +1973,10 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
         "session_db": _get_db(),
-        "fallback_model": getattr(agent, "_fallback_model", None),
+        "fallback_model": (
+            list(getattr(agent, "_fallback_chain", None) or [])
+            or getattr(agent, "_fallback_model", None)
+        ),
     }
 
 
@@ -2019,6 +2023,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         pass
 
     cfg = _load_cfg()
+    fallback_chain = get_fallback_chain(cfg)
     agent_cfg = cfg.get("agent") or {}
     system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     startup_skills = _parse_tui_skills_env()
@@ -2050,6 +2055,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        fallback_model=fallback_chain or None,
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1047,7 +1047,10 @@ def _load_reasoning_config() -> dict | None:
     effort = str(
         (_load_cfg().get("agent") or {}).get("reasoning_effort", "") or ""
     ).strip()
-    return parse_reasoning_effort(effort)
+    # Desktop/TUI sessions default to Thinking Off.  AIAgent treats
+    # ``reasoning_config=None`` as provider default, which can become Medium on
+    # the first real turn even though the desktop startup UI showed Off.
+    return parse_reasoning_effort(effort) or {"enabled": False}
 
 
 def _load_service_tier() -> str | None:
@@ -1572,7 +1575,7 @@ def _current_profile_name() -> str:
 def _reasoning_effort_for_session_info(agent) -> str:
     reasoning_config = getattr(agent, "reasoning_config", None)
     if not isinstance(reasoning_config, dict):
-        return ""
+        return "none"
     if reasoning_config.get("enabled") is False:
         return "none"
     return str(reasoning_config.get("effort", "") or "")
@@ -2891,6 +2894,7 @@ def _(rid, params: dict) -> dict:
             "messages": _history_to_messages(history),
             "info": {
                 "model": _resolve_model(),
+                "reasoning_effort": _reasoning_effort_for_session_info(None),
                 "tools": {},
                 "skills": {},
                 "cwd": _sessions[sid]["cwd"],

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -105,6 +105,33 @@ describe('createGatewayEventHandler', () => {
     })
   })
 
+  it('updates usage from token.usage before message.complete', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    patchUiState({ sid: 'session-1' })
+    onEvent({
+      payload: {
+        context_length: 131_072,
+        context_pct: 49.9,
+        context_tokens: 65_432,
+        input_tokens: 1_200,
+        output_tokens: 34,
+        total_tokens: 1_234
+      },
+      session_id: 'session-1',
+      type: 'token.usage'
+    })
+
+    expect(getUiState().usage).toMatchObject({
+      context_max: 131_072,
+      context_percent: 49.9,
+      context_used: 65_432,
+      input: 1_200,
+      output: 34,
+      total: 1_234
+    })
+  })
+
   it('keeps the current todo list visible when the next message starts', () => {
     const appended: Msg[] = []
     const todos = [{ content: 'Boil water', id: 'boil', status: 'in_progress' }]

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,7 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
+import { mergeTokenUsagePayload } from '../domain/usage.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -397,6 +398,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }))
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
+
+        return
+      }
+
+      case 'token.usage': {
+        patchUiState(state => {
+          const usage = mergeTokenUsagePayload(state.usage, ev.payload)
+
+          return usage === state.usage ? state : { ...state, usage }
+        })
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
+import type { SessionInfo, SlashCategory, SubagentStatus, TokenUsagePayload, Usage } from './types.js'
 
 export interface GatewaySkin {
   banner_hero?: string
@@ -505,6 +505,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
+  | { payload?: TokenUsagePayload; session_id?: string; type: 'token.usage' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -176,6 +176,15 @@ export interface Usage {
   total: number
 }
 
+export interface TokenUsagePayload {
+  context_length?: unknown
+  context_pct?: unknown
+  context_tokens?: unknown
+  input_tokens?: unknown
+  output_tokens?: unknown
+  total_tokens?: unknown
+}
+
 export interface SudoReq {
   requestId: string
 }


### PR DESCRIPTION
## Why

A MeshBoard Hermes worker streamed real activity, then exited through `hermes -z` with:

`hermes -z: agent failed: 'final_response'`

The linked stream tap showed the upstream path before that crash: successful streaming/tool-call activity, two `ClientConnectionResetError` stream drops, large fallback requests returning 400, small recovery/finalization requests returning 502 then 200, and finally the oneshot wrapper crashed because the agent result did not contain `final_response`.

Root cause: `AIAgent.run_conversation()` promises a dict with `final_response`, but several terminal failure branches returned dicts with only `error`. `hermes_cli.oneshot._run_agent()` indexes `result['final_response']`, so those branches turn a real provider/context failure into an opaque wrapper `KeyError`.

## What changed

- Adds `final_response` to the invalid-response retry-exhaustion return.
- Adds `final_response` to payload/context compression-exhaustion returns.
- Keeps `error` identical to `final_response` for these terminal failures so callers can both display and classify the same actionable message.
- Adds a source-level regression test that fails if any `run_conversation()` dict return omits `final_response`.
- Tightens the existing invalid-response regression to assert `final_response == error`.

## Evidence

Live failing sequence from MeshBoard dispatch `autopilot-handoff-launch-quota-backlog-triage-20260604-implementer-attempt-1`:

- stream request with prompt ~52k chars produced deltas and tool-call chunks
- later stream requests reset with `ClientConnectionResetError: Cannot write to closing transport`
- fallback non-streaming requests returned 400 for ~96k/~98k char prompts
- smaller recovery/finalization calls returned 502 then 200
- Hermes oneshot emitted `agent failed: 'final_response'`

That matches the contract hole: the real upstream/provider failure should be returned as a failed agent result, not converted into a missing-key crash.

## Verification

- `python -m py_compile agent/conversation_loop.py hermes_cli/oneshot.py`
- `python -m pytest tests/run_agent/test_run_agent.py::TestRetryExhaustion -q` -> 3 passed
- `python -m pytest tests/run_agent/test_run_agent.py::test_run_conversation_dict_returns_include_final_response tests/run_agent/test_run_agent.py::TestRetryExhaustion -q` -> 4 passed
- `python -m pytest tests/run_agent/test_413_compression.py -q` -> 21 passed
- `python -m pytest tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_fails_closed_on_empty_final_response tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_fails_closed_on_agent_exception tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_prints_nonempty_final_response -q` -> 3 passed
- `git diff --check`

## Risks / gaps

This does not hide the underlying provider/context failure; it preserves it in the promised `final_response` field so wrappers, cron, gateway, and external launchers can surface the actionable error instead of crashing on a missing key. The broader stream reset/400/502 behavior can still be investigated separately, but this removes the opaque `final_response` loss that made the worker task look like a Hermes wrapper failure.
