### PR TITLE
feat(desktop): preview cron message history

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-actions-menu.tsx
+++ b/apps/desktop/src/app/cron/cron-job-actions-menu.tsx
@@ -12,6 +12,7 @@ interface CronJobActions {
   title: string
   onDelete: () => void
   onEdit: () => void
+  onHistory: () => void
   onPauseResume: () => void
   onTrigger: () => void
 }
@@ -28,6 +29,7 @@ export function CronJobActionsMenu({
   isPaused,
   onDelete,
   onEdit,
+  onHistory,
   onPauseResume,
   onTrigger,
   sideOffset = 6,
@@ -39,12 +41,17 @@ export function CronJobActionsMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent
-        align={align}
-        aria-label={c.actionsFor(title)}
-        className="w-44"
-        sideOffset={sideOffset}
-      >
+      <DropdownMenuContent align={align} aria-label={c.actionsFor(title)} className="w-44" sideOffset={sideOffset}>
+        <DropdownMenuItem
+          onSelect={() => {
+            triggerHaptic('selection')
+            onHistory()
+          }}
+        >
+          <Codicon name="history" size="0.875rem" />
+          <span>{c.messageHistory}</span>
+        </DropdownMenuItem>
+
         <DropdownMenuItem
           disabled={busy}
           onSelect={() => {

--- a/apps/desktop/src/app/cron/history-dialog.test.ts
+++ b/apps/desktop/src/app/cron/history-dialog.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CronJobRun } from '@/types/hermes'
+
+import { buildCronHistoryMessages } from './history-dialog'
+
+function run(overrides: Partial<CronJobRun> = {}): CronJobRun {
+  return {
+    ended_at: 1_715_000_065,
+    end_reason: 'cron_complete',
+    message_count: 4,
+    messages: [
+      { content: 'Generate the briefing', role: 'user', timestamp: 1_715_000_000 },
+      {
+        content: '',
+        role: 'assistant',
+        timestamp: 1_715_000_010,
+        tool_calls: [{ function: { arguments: '{}', name: 'text_to_speech' }, id: 'call-1' }]
+      },
+      {
+        content: '{"success":true,"path":"/tmp/briefing.mp3"}',
+        role: 'tool',
+        timestamp: 1_715_000_020,
+        tool_call_id: 'call-1',
+        tool_name: 'text_to_speech'
+      },
+      { content: 'MEDIA: /tmp/briefing.mp3', role: 'assistant', timestamp: 1_715_000_030 }
+    ],
+    session_id: 'cron_job-1_20240504_120000',
+    started_at: 1_715_000_000,
+    ...overrides
+  }
+}
+
+describe('buildCronHistoryMessages', () => {
+  it('adds visible run timing metadata and preserves media messages', () => {
+    const messages = buildCronHistoryMessages([run()])
+
+    expect(messages[0].role).toBe('system')
+    expect(messages[0].parts[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('Duration: 1m 5s')
+    })
+
+    const mediaPart = messages
+      .flatMap(message => message.parts)
+      .find(part => part.type === 'text' && part.text.includes('#media:%2Ftmp%2Fbriefing.mp3'))
+
+    expect(mediaPart).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('#media:%2Ftmp%2Fbriefing.mp3')
+    })
+  })
+
+  it('labels missing media instead of rendering an unusable player', () => {
+    const messages = buildCronHistoryMessages([run({ unavailable_media: ['/tmp/briefing.mp3'] })])
+
+    const text = messages
+      .flatMap(message => message.parts)
+      .filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join('\n')
+
+    expect(text).toContain('Audio: briefing.mp3 unavailable (file was not created or no longer exists)')
+
+    expect(text).not.toContain('#media:%2Ftmp%2Fbriefing.mp3')
+  })
+
+  it('prefixes message and tool-call ids across runs', () => {
+    const first = run()
+    const second = run({ session_id: 'cron_job-1_20240505_120000' })
+    const messages = buildCronHistoryMessages([second, first])
+    const ids = messages.map(message => message.id)
+
+    const toolIds = messages.flatMap(message =>
+      message.parts.flatMap(part => (part.type === 'tool-call' ? [part.toolCallId] : []))
+    )
+
+    expect(ids[0]).toBe(`${first.session_id}:run-header`)
+    expect(ids.at(-1)?.startsWith(second.session_id)).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(new Set(toolIds).size).toBe(toolIds.length)
+    expect(ids.every(id => id.startsWith('cron_job-1_'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/cron/history-dialog.tsx
+++ b/apps/desktop/src/app/cron/history-dialog.tsx
@@ -1,0 +1,205 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { Thread } from '@/components/assistant-ui/thread'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { type CronJob, type CronJobRun, getCronJobRuns } from '@/hermes'
+import { type ChatMessage, type ChatMessagePart, textPart, toChatMessages } from '@/lib/chat-messages'
+import { toRuntimeMessage } from '@/lib/chat-runtime'
+import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
+
+interface CronHistoryDialogProps {
+  job: CronJob | null
+  onClose: () => void
+}
+
+const RUN_TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'medium'
+})
+
+function formatRunTime(value?: null | number): string {
+  if (!value) {
+    return '—'
+  }
+
+  const date = new Date(value * 1000)
+
+  return Number.isNaN(date.valueOf()) ? '—' : RUN_TIME_FORMAT.format(date)
+}
+
+function formatDuration(startedAt: number, endedAt?: null | number): string {
+  if (!startedAt || !endedAt || endedAt < startedAt) {
+    return '—'
+  }
+
+  const seconds = Math.max(0, Math.round(endedAt - startedAt))
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+
+  return minutes ? `${minutes}m ${remainder}s` : `${remainder}s`
+}
+
+function prefixToolCallIds(parts: ChatMessagePart[], sessionId: string): ChatMessagePart[] {
+  return parts.map((part, index) =>
+    part.type === 'tool-call'
+      ? {
+          ...part,
+          toolCallId: `${sessionId}:${part.toolCallId || `${part.toolName}-${index}`}`
+        }
+      : part
+  )
+}
+
+function markUnavailableMedia(parts: ChatMessagePart[], paths: string[]): ChatMessagePart[] {
+  if (paths.length === 0) {
+    return parts
+  }
+
+  return parts.map(part => {
+    if (part.type !== 'text') {
+      return part
+    }
+
+    const text = paths.reduce((current, path) => {
+      const mediaLink = `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
+      const unavailable = `${mediaDisplayLabel(path)} unavailable (file was not created or no longer exists)`
+
+      return current.replaceAll(mediaLink, unavailable)
+    }, part.text)
+
+    return text === part.text ? part : { ...part, text }
+  })
+}
+
+export function buildCronHistoryMessages(runs: CronJobRun[]): ChatMessage[] {
+  return [...runs].reverse().flatMap((run, index) => {
+    const runNumber = index + 1
+
+    const header = [
+      `Run ${runNumber} of ${runs.length}`,
+      `Started: ${formatRunTime(run.started_at)}`,
+      `Ended: ${formatRunTime(run.ended_at)}`,
+      `Duration: ${formatDuration(run.started_at, run.ended_at)}`,
+      `Messages: ${run.message_count}`,
+      run.end_reason ? `Result: ${run.end_reason}` : ''
+    ]
+      .filter(Boolean)
+      .join('\n')
+
+    const messages = toChatMessages(run.messages).map(message => ({
+      ...message,
+      id: `${run.session_id}:${message.id}`,
+      parts: markUnavailableMedia(prefixToolCallIds(message.parts, run.session_id), run.unavailable_media ?? [])
+    }))
+
+    return [
+      {
+        id: `${run.session_id}:run-header`,
+        parts: [textPart(header)],
+        role: 'system' as const,
+        timestamp: run.started_at
+      },
+      ...messages
+    ]
+  })
+}
+
+function CronTranscript({ runs }: { runs: CronJobRun[] }) {
+  const messages = useMemo<ThreadMessage[]>(() => buildCronHistoryMessages(runs).map(toRuntimeMessage), [runs])
+
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    isRunning: false,
+    messages,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread sessionKey={runs.map(run => run.session_id).join(':')} />
+    </AssistantRuntimeProvider>
+  )
+}
+
+export function CronHistoryDialog({ job, onClose }: CronHistoryDialogProps) {
+  const [runs, setRuns] = useState<CronJobRun[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!job) {
+      setRuns([])
+      setLoading(false)
+      setError('')
+
+      return
+    }
+
+    let cancelled = false
+
+    setRuns([])
+    setLoading(true)
+    setError('')
+
+    void getCronJobRuns(job.id, job.profile_name || job.profile)
+      .then(result => {
+        if (!cancelled) {
+          setRuns(result.runs)
+        }
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load cron messages')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [job])
+
+  const messageCount = runs.reduce((total, run) => total + run.message_count, 0)
+
+  return (
+    <Dialog onOpenChange={open => !open && onClose()} open={job !== null}>
+      <DialogContent className="h-[min(88vh,54rem)] max-h-[88vh] max-w-5xl grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b border-border/45 px-5 py-4 pr-12">
+          <DialogTitle>{job ? `${job.name || job.id} messages` : 'Cron messages'}</DialogTitle>
+          <DialogDescription>
+            {loading
+              ? 'Loading complete execution history...'
+              : `${runs.length} run${runs.length === 1 ? '' : 's'} · ${messageCount} persisted message${
+                  messageCount === 1 ? '' : 's'
+                } · includes tool calls and media`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 overflow-hidden bg-(--ui-chat-surface-background)">
+          {loading ? (
+            <div className="grid h-full place-items-center text-xs text-muted-foreground">Loading cron messages...</div>
+          ) : error ? (
+            <div className="grid h-full place-items-center px-6 text-center text-xs text-destructive">{error}</div>
+          ) : runs.length === 0 ? (
+            <div className="grid h-full place-items-center px-6 text-center">
+              <div className="max-w-sm space-y-1.5">
+                <div className="text-sm font-medium">No persisted messages yet</div>
+                <p className="text-xs text-muted-foreground">
+                  Messages appear here after this cron job completes an agent-backed run.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="cron-history-transcript h-full [--composer-width:100%] [--titlebar-height:0px] [&_[data-role=user]]:static">
+              <CronTranscript runs={runs} />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/cron/index.test.tsx
+++ b/apps/desktop/src/app/cron/index.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCronJobs = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  createCronJob: vi.fn(),
+  deleteCronJob: vi.fn(),
+  getCronJobs: () => getCronJobs(),
+  pauseCronJob: vi.fn(),
+  resumeCronJob: vi.fn(),
+  triggerCronJob: vi.fn(),
+  updateCronJob: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('./history-dialog', () => ({
+  CronHistoryDialog: ({ job }: { job: null | { id: string } }) =>
+    job ? <div role="dialog">History for {job.id}</div> : null
+}))
+
+beforeEach(() => {
+  getCronJobs.mockResolvedValue([
+    {
+      enabled: true,
+      id: 'daily-briefing',
+      name: 'Daily briefing',
+      prompt: 'Summarize the day',
+      schedule: { expr: '0 9 * * *' },
+      state: 'scheduled'
+    }
+  ])
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CronView message preview', () => {
+  it('keeps history inside the actions menu', async () => {
+    const { CronView } = await import('./index')
+
+    render(
+      <MemoryRouter>
+        <CronView onClose={() => {}} />
+      </MemoryRouter>
+    )
+
+    const actions = await screen.findByRole('button', { name: 'Actions for Daily briefing' })
+
+    expect(screen.queryByRole('button', { name: 'Preview messages for Daily briefing' })).toBeNull()
+
+    actions.focus()
+    fireEvent.keyDown(actions, { key: 'Enter' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Message history' }))
+
+    await waitFor(() => expect(screen.getByRole('dialog').textContent).toContain('daily-briefing'))
+  })
+})

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -36,6 +36,7 @@ import { PageSearchShell } from '../page-search-shell'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { CronJobActionsMenu, CronJobActionsTrigger } from './cron-job-actions-menu'
+import { CronHistoryDialog } from './history-dialog'
 
 const DEFAULT_DELIVER = 'local'
 
@@ -273,6 +274,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
   const [busyJobId, setBusyJobId] = useState<null | string>(null)
 
   const [editor, setEditor] = useState<EditorState>({ mode: 'closed' })
+  const [historyJob, setHistoryJob] = useState<CronJob | null>(null)
   const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null)
   const [deleting, setDeleting] = useState(false)
 
@@ -443,6 +445,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
                   key={job.id}
                   onDelete={() => setPendingDelete(job)}
                   onEdit={() => setEditor({ mode: 'edit', job })}
+                  onHistory={() => setHistoryJob(job)}
                   onPauseResume={() => void handlePauseResume(job)}
                   onTrigger={() => void handleTrigger(job)}
                 />
@@ -451,6 +454,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
           </div>
         )}
         <CronEditorDialog editor={editor} onClose={() => setEditor({ mode: 'closed' })} onSave={handleEditorSave} />
+        <CronHistoryDialog job={historyJob} onClose={() => setHistoryJob(null)} />
 
         <Dialog onOpenChange={open => !open && !deleting && setPendingDelete(null)} open={pendingDelete !== null}>
           <DialogContent className="max-w-md">
@@ -487,6 +491,7 @@ function CronJobRow({
   job,
   onDelete,
   onEdit,
+  onHistory,
   onPauseResume,
   onTrigger
 }: {
@@ -495,6 +500,7 @@ function CronJobRow({
   job: CronJob
   onDelete: () => void
   onEdit: () => void
+  onHistory: () => void
   onPauseResume: () => void
   onTrigger: () => void
 }) {
@@ -539,12 +545,13 @@ function CronJobRow({
         )}
       </button>
 
-      <div className="flex shrink-0 items-center">
+      <div className="flex shrink-0 items-center gap-0.5">
         <CronJobActionsMenu
           busy={busy}
           isPaused={isPaused}
           onDelete={onDelete}
           onEdit={onEdit}
+          onHistory={onHistory}
           onPauseResume={onPauseResume}
           onTrigger={onTrigger}
           title={jobTitle(job)}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -10,6 +10,7 @@ import type {
   ConfigSchemaResponse,
   CronJob,
   CronJobCreatePayload,
+  CronJobRunsResponse,
   CronJobUpdates,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
@@ -58,6 +59,8 @@ export type {
   ConfigSchemaResponse,
   CronJob,
   CronJobCreatePayload,
+  CronJobRun,
+  CronJobRunsResponse,
   CronJobSchedule,
   CronJobUpdates,
   ElevenLabsVoice,
@@ -475,6 +478,14 @@ export function getCronJobs(): Promise<CronJob[]> {
 export function getCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`
+  })
+}
+
+export function getCronJobRuns(jobId: string, profile?: string): Promise<CronJobRunsResponse> {
+  const profileQuery = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
+  return window.hermesDesktop.api<CronJobRunsResponse>({
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs${profileQuery}`
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -497,6 +497,7 @@ export const en: Translations = {
     next: 'Next:',
     actionsFor: title => `Actions for ${title}`,
     actionsTitle: 'Cron job actions',
+    messageHistory: 'Message history',
     resume: 'Resume cron',
     pause: 'Pause cron',
     resumeTitle: 'Resume',
@@ -521,8 +522,7 @@ export const en: Translations = {
     editTitle: 'Edit cron job',
     createTitle: 'New cron job',
     editDesc: 'Update the schedule, prompt, or delivery target. Changes apply on next run.',
-    createDesc:
-      'Schedule a prompt to run automatically. Use cron syntax or a natural phrase like "every 15 minutes".',
+    createDesc: 'Schedule a prompt to run automatically. Use cron syntax or a natural phrase like "every 15 minutes".',
     nameLabel: 'Name',
     namePlaceholder: 'Morning briefing',
     promptLabel: 'Prompt',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -417,6 +417,7 @@ export interface Translations {
     next: string
     actionsFor: (title: string) => string
     actionsTitle: string
+    messageHistory: string
     resume: string
     pause: string
     resumeTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -478,8 +478,7 @@ export const zh: Translations = {
     platformIntro: {
       telegram:
         '在 Telegram 中,与 @BotFather 对话,运行 /newbot,复制它给你的令牌。然后从 @userinfobot 获取你的数字用户 ID。',
-      discord:
-        '打开 Discord 开发者门户,创建应用,添加 Bot,然后复制其令牌。用正确的权限范围把机器人邀请到你的服务器。',
+      discord: '打开 Discord 开发者门户,创建应用,添加 Bot,然后复制其令牌。用正确的权限范围把机器人邀请到你的服务器。',
       slack: '创建 Slack 应用,启用 Socket Mode,安装到你的工作区,然后复制 bot 令牌和 app 级令牌。',
       mattermost: '在你的 Mattermost 服务器上,创建机器人账户或个人访问令牌,然后在此粘贴服务器 URL 和令牌。',
       matrix: '用机器人账户登录你的 homeserver,然后复制访问令牌、用户 ID 和 homeserver URL。',
@@ -495,7 +494,8 @@ export const zh: Translations = {
       wecom_callback: '设置一个企业微信自建应用,暴露其回调 URL,并提供 corp ID、secret、agent ID 和 AES key。',
       weixin: '登录微信公众平台,复制 AppID 和 Token,并把消息回调 URL 指向 Hermes。',
       qqbot: '在 QQ 开放平台(q.qq.com)注册一个应用,复制 App ID 和 Client Secret。',
-      api_server: '把 Hermes 暴露为兼容 OpenAI 的 API。设置一个鉴权密钥,然后把 Open WebUI / LobeChat 等指向 host:port。',
+      api_server:
+        '把 Hermes 暴露为兼容 OpenAI 的 API。设置一个鉴权密钥,然后把 Open WebUI / LobeChat 等指向 host:port。',
       webhook: '运行一个 HTTP 服务器,供其他工具(GitHub、GitLab、自定义应用)POST。用 secret 验证签名。'
     }
   },
@@ -627,6 +627,7 @@ export const zh: Translations = {
     next: '下次:',
     actionsFor: title => `${title} 的操作`,
     actionsTitle: '定时任务操作',
+    messageHistory: '消息历史',
     resume: '恢复定时任务',
     pause: '暂停定时任务',
     resumeTitle: '恢复',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -840,6 +840,16 @@ canvas {
   mask-image: none;
 }
 
+.cron-history-transcript .sticky-human-clamp,
+.cron-history-transcript .sticky-human-clamp[data-clamped='true'],
+.cron-history-transcript .composer-human-message:hover .sticky-human-clamp,
+.cron-history-transcript .composer-human-message:focus-within .sticky-human-clamp {
+  max-height: none;
+  overflow: visible;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 /* The thread renders items in natural document flow (padding spacers, not
    transforms) and @tanstack/react-virtual already adjusts scrollTop itself
    when an off-screen turn is measured and its real height differs from the

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -415,16 +415,36 @@ export interface AnalyticsTotals {
 export interface CronJob {
   deliver?: null | string
   enabled: boolean
+  hermes_home?: string
   id: string
+  is_default_profile?: boolean
   last_error?: null | string
   last_run_at?: null | string
   name?: null | string
   next_run_at?: null | string
+  profile?: string
+  profile_name?: string
   prompt?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
   state?: null | string
+}
+
+export interface CronJobRun {
+  ended_at?: null | number
+  end_reason?: null | string
+  message_count: number
+  messages: SessionMessage[]
+  session_id: string
+  started_at: number
+  unavailable_media?: string[]
+}
+
+export interface CronJobRunsResponse {
+  job_id: string
+  profile: string
+  runs: CronJobRun[]
 }
 
 export interface CronJobCreatePayload {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5509,6 +5509,41 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
     return None
 
 
+def _is_cron_run_session_id(session_id: str, prefix: str) -> bool:
+    suffix = session_id[len(prefix):]
+    return (
+        session_id.startswith(prefix)
+        and len(suffix) == 15
+        and suffix[8] == "_"
+        and suffix[:8].isdigit()
+        and suffix[9:].isdigit()
+    )
+
+
+def _unavailable_cron_media(messages: List[Dict[str, Any]]) -> List[str]:
+    """Return MEDIA paths that cannot be safely read from local storage."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    unavailable = set()
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+
+        media_files, _ = BasePlatformAdapter.extract_media(content)
+        for media_path, _is_voice in media_files:
+            try:
+                path = Path(media_path).expanduser()
+                available = path.is_file() and os.access(path, os.R_OK)
+            except (OSError, RuntimeError, ValueError):
+                available = False
+
+            if not available:
+                unavailable.add(media_path)
+
+    return sorted(unavailable)
+
+
 @app.get("/api/cron/jobs")
 async def list_cron_jobs(profile: str = "all"):
     requested = (profile or "all").strip()
@@ -5525,6 +5560,55 @@ async def list_cron_jobs(profile: str = "all"):
         except Exception:
             _log.exception("Failed to list cron jobs for profile %s", name)
     return jobs
+
+
+@app.get("/api/cron/jobs/{job_id}/runs")
+async def get_cron_job_runs(job_id: str, profile: Optional[str] = None):
+    selected = profile or _find_cron_job_profile(job_id)
+    if not selected:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = _call_cron_for_profile(selected, "get_job", job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    profile_name, home = _cron_profile_home(selected)
+    canonical_job_id = str(job.get("id") or job_id)
+    db_path = home / "state.db"
+    if not db_path.exists():
+        return {"job_id": canonical_job_id, "profile": profile_name, "runs": []}
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path)
+    try:
+        prefix = f"cron_{canonical_job_id}_"
+        sessions = db.list_root_sessions_by_id_prefix(prefix, source="cron")
+        runs = []
+
+        for session in sessions:
+            session_id = str(session.get("id") or "")
+            if not _is_cron_run_session_id(session_id, prefix):
+                continue
+
+            tip_id = db.get_compression_tip(session_id) or session_id
+            tip = db.get_session(tip_id) or session
+            messages = db.get_messages_in_lineage(session_id)
+            runs.append(
+                {
+                    "session_id": session_id,
+                    "started_at": session.get("started_at") or 0,
+                    "ended_at": tip.get("ended_at"),
+                    "end_reason": tip.get("end_reason"),
+                    "message_count": len(messages),
+                    "messages": messages,
+                    "unavailable_media": _unavailable_cron_media(messages),
+                }
+            )
+
+        return {"job_id": canonical_job_id, "profile": profile_name, "runs": runs}
+    finally:
+        db.close()
 
 
 @app.get("/api/cron/jobs/{job_id}")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1364,6 +1364,30 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def list_root_sessions_by_id_prefix(
+        self, prefix: str, source: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """List root sessions whose IDs begin with a literal prefix."""
+        escaped = (
+            prefix
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+        where = ["id LIKE ? ESCAPE '\\'", "parent_session_id IS NULL"]
+        params: List[Any] = [f"{escaped}%"]
+        if source:
+            where.append("source = ?")
+            params.append(source)
+
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM sessions WHERE {' AND '.join(where)} "
+                "ORDER BY started_at DESC, id DESC",
+                params,
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 
@@ -2143,6 +2167,28 @@ class SessionDB:
                     msg["tool_calls"] = []
             result.append(msg)
         return result
+
+    def get_messages_in_lineage(
+        self, session_id: str, include_inactive: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Load a full compression lineage while preserving message metadata.
+
+        Unlike :meth:`get_messages_as_conversation`, this returns the raw
+        stored-message shape, including timestamps and tool metadata needed by
+        read-only transcript UIs.
+        """
+        tip_id = self.get_compression_tip(session_id) or session_id
+        messages: List[Dict[str, Any]] = []
+
+        for lineage_id in self._session_lineage_root_to_tip(tip_id):
+            for msg in self.get_messages(
+                lineage_id, include_inactive=include_inactive
+            ):
+                if self._is_duplicate_replayed_user_message(messages, msg):
+                    continue
+                messages.append(msg)
+
+        return messages
 
     def get_messages_around(
         self,

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -50,6 +50,26 @@ def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_prof
     assert cron_jobs.OUTPUT_DIR == old_output_dir
 
 
+def test_unavailable_cron_media_keeps_existing_files_playable(tmp_path):
+    from hermes_cli import web_server
+
+    existing = tmp_path / "briefing.mp3"
+    existing.write_bytes(b"audio")
+
+    unavailable = web_server._unavailable_cron_media(
+        [
+            {
+                "content": (
+                    f"MEDIA: {existing}\n"
+                    "MEDIA: /tmp/hermes-cron-history-missing.mp3"
+                )
+            }
+        ]
+    )
+
+    assert unavailable == ["/tmp/hermes-cron-history-missing.mp3"]
+
+
 @pytest.mark.asyncio
 async def test_list_cron_jobs_all_includes_default_and_named_profiles(isolated_profiles):
     from hermes_cli import web_server
@@ -104,6 +124,76 @@ async def test_list_cron_jobs_specific_profile_filters_results(isolated_profiles
 
     assert [job["id"] for job in jobs] == [worker_job["id"]]
     assert jobs[0]["profile"] == "worker_alpha"
+
+
+@pytest.mark.asyncio
+async def test_cron_job_runs_return_full_profile_scoped_lineage(isolated_profiles):
+    from hermes_state import SessionDB
+    from hermes_cli import web_server
+
+    worker_job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="worker history",
+        schedule="every 3h",
+        name="worker-history",
+    )
+    worker_home = isolated_profiles["worker_alpha"]
+    root_id = f"cron_{worker_job['id']}_20260603_120000"
+
+    db = SessionDB(worker_home / "state.db")
+    try:
+        db.create_session(session_id=root_id, source="cron")
+        db.append_message(root_id, role="user", content="Build the report")
+        db.end_session(root_id, "compression")
+
+        db.create_session(session_id="compressed-tip", source="cron", parent_session_id=root_id)
+        db.append_message("compressed-tip", role="user", content="Build the report")
+        db.append_message("compressed-tip", role="assistant", content="MEDIA: /tmp/report.png")
+        db.end_session("compressed-tip", "cron_complete")
+
+        db.create_session(session_id="cron_other-job_20260603_120000", source="cron")
+        db.append_message("cron_other-job_20260603_120000", role="assistant", content="not this job")
+        colliding_id = f"cron_{worker_job['id']}_legacy_20260603_120000"
+        db.create_session(session_id=colliding_id, source="cron")
+        db.append_message(colliding_id, role="assistant", content="prefix collision")
+    finally:
+        db.close()
+
+    result = await web_server.get_cron_job_runs(worker_job["id"], profile="worker_alpha")
+
+    assert result["profile"] == "worker_alpha"
+    assert result["job_id"] == worker_job["id"]
+    assert len(result["runs"]) == 1
+    run = result["runs"][0]
+    assert run["session_id"] == root_id
+    assert run["end_reason"] == "cron_complete"
+    assert run["message_count"] == 2
+    assert [message["content"] for message in run["messages"]] == [
+        "Build the report",
+        "MEDIA: /tmp/report.png",
+    ]
+    assert run["unavailable_media"] == ["/tmp/report.png"]
+    assert all(message["timestamp"] > 0 for message in run["messages"])
+
+
+@pytest.mark.asyncio
+async def test_cron_job_runs_without_state_db_are_empty(isolated_profiles):
+    from hermes_cli import web_server
+
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="worker history",
+        schedule="every 3h",
+        name="worker-history-empty",
+    )
+    state_db = isolated_profiles["worker_alpha"] / "state.db"
+
+    result = await web_server.get_cron_job_runs(job["id"], profile="worker_alpha")
+
+    assert result == {"job_id": job["id"], "profile": "worker_alpha", "runs": []}
+    assert not state_db.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -347,6 +347,45 @@ class TestMessageStorage:
         assert messages[0]["content"] == "Hello"
         assert messages[1]["role"] == "assistant"
 
+    def test_get_messages_in_lineage_preserves_metadata_and_dedupes_replay(self, db):
+        db.create_session(session_id="root", source="cron")
+        db.append_message("root", role="user", content="Run the report")
+        db.end_session("root", "compression")
+
+        db.create_session(session_id="tip", source="cron", parent_session_id="root")
+        db.append_message("tip", role="user", content="Run the report")
+        db.append_message(
+            "tip",
+            role="assistant",
+            content="",
+            tool_calls=[{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+        )
+        db.append_message("tip", role="assistant", content="Complete")
+
+        messages = db.get_messages_in_lineage("root")
+
+        assert [message["role"] for message in messages] == ["user", "assistant", "assistant"]
+        assert messages[0]["timestamp"] > 0
+        assert messages[1]["tool_calls"][0]["id"] == "call-1"
+
+    def test_list_root_sessions_by_id_prefix_is_literal_and_source_scoped(self, db):
+        db.create_session(session_id="cron_job_1_new", source="cron")
+        db.create_session(session_id="cron_job_1_old", source="cron")
+        db.create_session(session_id="cron_jobX1_other", source="cron")
+        db.create_session(session_id="cron_job_1_cli", source="cli")
+        db.create_session(
+            session_id="cron_job_1_child",
+            source="cron",
+            parent_session_id="cron_job_1_new",
+        )
+
+        sessions = db.list_root_sessions_by_id_prefix("cron_job_1_", source="cron")
+
+        assert {session["id"] for session in sessions} == {
+            "cron_job_1_new",
+            "cron_job_1_old",
+        }
+
     def test_message_increments_session_count(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Hello")


### PR DESCRIPTION
## What does this PR do?

Adds a message-history button to every Hermes Desktop Cron row. The new dialog renders every persisted message across all executions of that Cron job, including user/assistant messages, tool calls, media, run timestamps, duration, and completion reason.

Cron runs were already persisted in `state.db`, but the desktop had no profile-aware read path that followed compression lineages. Missing `MEDIA:` files also produced audio/image controls that could not play or open. This PR exposes the persisted run lineage through a read-only endpoint, reuses the existing desktop transcript renderer, and labels unavailable media instead of rendering dead controls.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a browsing-history action beside each Cron row's actions menu and open a full transcript dialog using the existing `Thread` UI.
- Add `GET /api/cron/jobs/{job_id}/runs`, scoped to the Cron job's profile, with complete compression-lineage messages and run timing metadata.
- Add raw lineage helpers to `SessionDB` while preserving message timestamps and tool metadata.
- Detect missing local `MEDIA:` paths so the dialog clearly marks unavailable audio/images instead of showing unusable playback/open controls.
- Add Python endpoint/state coverage and desktop UI/transcript regression tests.

## How to Test

1. Open Hermes Desktop → Cron and click the history icon to the left of a job's actions menu.
2. Verify all persisted runs show timing metadata, complete messages, tool calls, and available media.
3. Verify a missing `MEDIA:` path is shown as unavailable and does not render an unusable player/open link.
4. Run:
   - `pytest -q tests/hermes_cli/test_web_server_cron_profiles.py tests/test_hermes_state.py -q`
   - `ruff check hermes_cli/web_server.py hermes_state.py tests/hermes_cli/test_web_server_cron_profiles.py tests/test_hermes_state.py`
   - `cd apps/desktop && npm run test:ui -- src/app/cron/history-dialog.test.ts src/app/cron/index.test.tsx`
   - `cd apps/desktop && npm run type-check`
   - `cd apps/desktop && npm run build`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted state/Web API suites passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Desktop Vitest: 2 files, 4 tests passed.
- Python targeted state/Web API suites passed.
- Ruff, ESLint, Prettier, TypeScript type-check, and desktop production build passed.
