### PR TITLE
fix(desktop): clarify bootstrap kill diagnostics (#39333)

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -21,6 +21,26 @@ function mkTmpHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-bootstrap-test-'))
 }
 
+function makeInstallerScript(body: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-bootstrap-runner-'))
+  const scriptsDir = path.join(root, 'scripts')
+  fs.mkdirSync(scriptsDir, { recursive: true })
+  fs.writeFileSync(path.join(scriptsDir, 'install.sh'), body, { mode: 0o755 })
+
+  return root
+}
+
+function makeRunnerDirs() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-bootstrap-home-'))
+
+  return {
+    root,
+    activeRoot: path.join(root, 'agent'),
+    hermesHome: path.join(root, 'home'),
+    logRoot: path.join(root, 'logs')
+  }
+}
+
 test('runBootstrap bails immediately when the signal is already aborted', async () => {
   const controller = new AbortController()
   controller.abort()
@@ -43,6 +63,85 @@ test('runBootstrap bails immediately when the signal is already aborted', async 
     events.some(ev => ev.type === 'failed' && /cancelled/i.test(ev.error)),
     'should emit a cancelled failure event'
   )
+})
+
+test('killed bootstrap stage reports captured stderr context', async () => {
+  const sourceRepoRoot = makeInstallerScript(`#!/usr/bin/env bash
+if [[ "$*" == *"--manifest"* ]]; then
+  echo '{"protocol_version":1,"stages":[{"name":"repository","title":"Repository"}]}'
+  exit 0
+fi
+if [[ "$*" == *"--stage repository"* ]]; then
+  echo 'Repository ready'
+  echo 'fatal: detached HEAD state' >&2
+  exec sleep 2
+fi
+`)
+
+  const dirs = makeRunnerDirs()
+  const controller = new AbortController()
+  const events = []
+
+  try {
+    const result = await runBootstrap({
+      installStamp: null,
+      sourceRepoRoot,
+      ...dirs,
+      onEvent: ev => {
+        events.push(ev)
+
+        if (ev.type === 'log' && ev.stage === 'repository' && ev.line.includes('fatal: detached HEAD')) {
+          controller.abort()
+        }
+      },
+      abortSignal: controller.signal
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.failedStage, 'repository')
+    assert.match(result.error, /process killed — last output:/)
+    assert.match(result.error, /fatal: detached HEAD state/)
+    assert.doesNotMatch(result.error, /^cancelled by user$/)
+  } finally {
+    fs.rmSync(sourceRepoRoot, { recursive: true, force: true })
+    fs.rmSync(dirs.root, { recursive: true, force: true })
+  }
+})
+
+test('killed bootstrap stage without captured output still reports user cancellation', async () => {
+  const sourceRepoRoot = makeInstallerScript(`#!/usr/bin/env bash
+if [[ "$*" == *"--manifest"* ]]; then
+  echo '{"protocol_version":1,"stages":[{"name":"repository","title":"Repository"}]}'
+  exit 0
+fi
+if [[ "$*" == *"--stage repository"* ]]; then
+  exec sleep 2
+fi
+`)
+
+  const dirs = makeRunnerDirs()
+  const controller = new AbortController()
+
+  try {
+    const result = await runBootstrap({
+      installStamp: null,
+      sourceRepoRoot,
+      ...dirs,
+      onEvent: ev => {
+        if (ev.type === 'stage' && ev.name === 'repository' && ev.state === 'running') {
+          controller.abort()
+        }
+      },
+      abortSignal: controller.signal
+    })
+
+    assert.equal(result.ok, false)
+    assert.equal(result.failedStage, 'repository')
+    assert.equal(result.error, 'cancelled by user')
+  } finally {
+    fs.rmSync(sourceRepoRoot, { recursive: true, force: true })
+    fs.rmSync(dirs.root, { recursive: true, force: true })
+  }
 })
 
 test('installedAgentInstallScript resolves the installer in the agent checkout', () => {

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -671,7 +671,12 @@ async function runStage({
   const durationMs = Date.now() - startedAt
 
   if (result.killed) {
-    const ev = { type: 'stage', name: stage.name, state: 'failed', durationMs, error: 'cancelled by user' }
+    // An abort can come from an internal error cascade as well as an explicit
+    // user cancellation. Preserve captured output so the bootstrap failure
+    // reports the real cause when one exists.
+    const captured = (result.stderr || '').trim() || (result.stdout || '').trim()
+    const reason = captured ? `process killed — last output: ${captured.slice(-300)}` : 'cancelled by user'
+    const ev = { type: 'stage', name: stage.name, state: 'failed', durationMs, error: reason }
     emit(ev)
 
     return ev

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1221,7 +1221,13 @@ clone_repo() {
             # into a multi-minute download that can stall the installer.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
             git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
+            # A previous pinned-commit install may have left HEAD detached
+            # without a local branch ref. Recreate the managed branch from the
+            # fetched remote instead of aborting the entire bootstrap.
+            if ! git checkout "$BRANCH" 2>/dev/null; then
+                log_info "Local branch '$BRANCH' not found — creating from origin/$BRANCH..."
+                git checkout -B "$BRANCH" "origin/$BRANCH"
+            fi
             # Managed installs should follow origin/$BRANCH exactly. If the
             # checkout has diverged (or has local-only commits), ff-only pull
             # cannot succeed — mirror ``hermes update`` and reset to the

--- a/tests/test_install_sh_detached_head.py
+++ b/tests/test_install_sh_detached_head.py
@@ -1,0 +1,75 @@
+"""Regression tests for recovering install.sh from a detached checkout."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _extract_branch_recovery_block() -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?P<block>git remote set-branches origin \"\$BRANCH\".*?"
+        r"git checkout -B \"\$BRANCH\" \"origin/\$BRANCH\"\n\s*fi)",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "could not find install.sh detached-branch recovery block"
+    return match["block"]
+
+
+def test_install_sh_recreates_missing_local_branch_from_origin(tmp_path: Path) -> None:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    checkout = tmp_path / "checkout"
+
+    remote.mkdir()
+    _run_git("init", "--bare", cwd=remote)
+
+    seed.mkdir()
+    _run_git("init", "-b", "main", cwd=seed)
+    _run_git("config", "user.email", "test@example.com", cwd=seed)
+    _run_git("config", "user.name", "Test User", cwd=seed)
+    (seed / "README.md").write_text("current\n", encoding="utf-8")
+    _run_git("add", "README.md", cwd=seed)
+    _run_git("commit", "-m", "seed", cwd=seed)
+    _run_git("remote", "add", "origin", str(remote), cwd=seed)
+    _run_git("push", "-u", "origin", "main", cwd=seed)
+
+    _run_git("clone", "--branch", "main", str(remote), str(checkout), cwd=tmp_path)
+    _run_git("checkout", "--detach", cwd=checkout)
+    _run_git("branch", "-D", "main", cwd=checkout)
+    assert _run_git("branch", "--show-current", cwd=checkout) == ""
+
+    script = f"set -e\ncd {checkout!s}\nBRANCH=main\n{_extract_branch_recovery_block()}\n"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        "branch recovery failed:\n"
+        f"stdout={result.stdout}\n"
+        f"stderr={result.stderr}"
+    )
+    assert _run_git("branch", "--show-current", cwd=checkout) == "main"
+    assert _run_git("rev-parse", "HEAD", cwd=checkout) == _run_git(
+        "rev-parse", "origin/main", cwd=checkout
+    )


### PR DESCRIPTION
## Summary

Fixes #39333.

This PR improves Hermes Desktop bootstrap recovery/diagnostics when the managed checkout drifts into a detached-HEAD state and a repository-stage process is killed after producing useful output.

## What changed

- Preserve captured stderr/stdout when a killed bootstrap stage fails, instead of always surfacing the misleading exact error `cancelled by user`.
- Keep the existing true user-cancel fallback when there is no captured child-process output.
- Make `scripts/install.sh` recover a missing local branch by creating/resetting it from `origin/<branch>` before the managed-clone hard reset.
- Strengthen `bootstrap-runner` tests to exercise the real `runBootstrap` production path with a fake `install.sh` manifest/stage script.

## Verification

- Red proof on upstream/main: the new production-path stderr-context regression test fails because upstream reports `cancelled by user`.
- Green on this branch: `node --test apps/desktop/electron/bootstrap-runner.test.cjs apps/desktop/electron/bootstrap-platform.test.cjs`
  - 17 tests passed, 0 failed.
- Branch is exactly one focused commit ahead of `upstream/main` (`0 1`).

## Duplicate / competitor check

No focused open PRs were found for issue `#39333` or the distinctive topic keywords (`bootstrap detached HEAD Desktop cancelled user`) before publication.

Auto-published by Moonsong via Path B automated pipeline.
