### PR TITLE
fix(desktop): preserve spawn-injected dashboard session token over ~/.hermes/.env

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -209,6 +209,14 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         pass  # best-effort — don't block gateway startup
 
 
+# Ephemeral per-process tokens the desktop shell injects on spawn.  These must
+# not be replaced by a stale value persisted in ~/.hermes/.env — doing so
+# breaks /api/ws (token_mismatch → "Could not connect to Hermes gateway").
+_DOTENV_PRESERVE_IF_SET: frozenset[str] = frozenset({
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+})
+
+
 def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
@@ -221,8 +229,15 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - :data:`_DOTENV_PRESERVE_IF_SET` is restored after each load when already
+      set in the process environment (desktop-spawned ephemeral tokens).
     """
     loaded: list[Path] = []
+    preserved = {
+        key: os.environ[key]
+        for key in _DOTENV_PRESERVE_IF_SET
+        if key in os.environ
+    }
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
@@ -243,6 +258,9 @@ def load_hermes_dotenv(
         loaded.append(project_env_path)
 
     _apply_external_secret_sources(home_path)
+
+    for key, value in preserved.items():
+        os.environ[key] = value
 
     return loaded
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8841,6 +8841,14 @@ def start_server(
     app.state.bound_host = host
     app.state.bound_port = port
 
+    # Adopt a desktop-minted session token after dotenv load.  main.py calls
+    # load_hermes_dotenv() before this module is imported; preserving the spawn
+    # env var there keeps _SESSION_TOKEN aligned with the renderer's wsUrl.
+    global _SESSION_TOKEN
+    injected = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN")
+    if injected:
+        _SESSION_TOKEN = injected
+
     if open_browser:
         import webbrowser
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,26 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
 
 
+def test_dashboard_session_token_not_overwritten_by_user_env(tmp_path, monkeypatch):
+    """Desktop spawns the dashboard with a fresh per-boot token in the environment.
+
+    ~/.hermes/.env must not replace it with a stale persisted value — that
+    breaks /api/ws with token_mismatch (Hermes.app shows gateway offline).
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=stale-from-dotenv\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "desktop-fresh-token")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") == "desktop-fresh-token"
+
+
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()


### PR DESCRIPTION
## Summary

Fixes Hermes.app showing **"Could not connect to Hermes gateway"** when `HERMES_DASHBOARD_SESSION_TOKEN` is persisted in `~/.hermes/.env`.

Closes #39349.

## Root cause

1. Electron spawns the dashboard with a fresh per-boot `HERMES_DASHBOARD_SESSION_TOKEN`.
2. `hermes_cli/main.py` calls `load_hermes_dotenv()` at import, which loads `~/.hermes/.env` with **`override=True`**.
3. A stale token in `.env` replaces the spawn-injected value before `web_server._SESSION_TOKEN` is read.
4. The desktop renderer connects with the fresh token → `/api/ws` gets `token_mismatch` → gateway boot fails.
5. `/api/status` stays public/healthy, so the failure looks like a mysterious gateway outage.

## Fix

- **`env_loader`**: preserve `HERMES_DASHBOARD_SESSION_TOKEN` when already set in the process environment before dotenv override, restore after load.
- **`web_server.start_server()`**: re-sync `_SESSION_TOKEN` from `HERMES_DASHBOARD_SESSION_TOKEN` when present (after dotenv runs).
- **Test**: `test_dashboard_session_token_not_overwritten_by_user_env`.

## Verification

- Reproduced on macOS with Hermes.app 0.15.1: WS upgrade 403/`token_mismatch` with stale `.env` token; works after fix or after removing the line from `.env`.
- Manual WS to `/api/ws` with spawn token succeeds when tokens align.

## User workaround (until merged)

Remove `HERMES_DASHBOARD_SESSION_TOKEN` from `~/.hermes/.env` and relaunch Hermes.app. Do not document pinning this token in `.env` for desktop or mobile-remote setups.


Made with [Cursor](https://cursor.com)