### PR TITLE
fix(desktop): prevent statusbar timer jitter with tabular-nums

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -87,7 +87,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     <>
       {item.icon}
       {item.label && <span className="truncate">{item.label}</span>}
-      {item.detail && <span className="truncate text-muted-foreground/80">{item.detail}</span>}
+      {item.detail && <span className="truncate tabular-nums px-0.5 text-muted-foreground/80">{item.detail}</span>}
     </>
   )
 


### PR DESCRIPTION
## Summary
Session timer in the desktop app's statusbar causes layout shift as digits change width each second (e.g. `0:05` → `0:10`). This makes the bottom bar visibly jump while counting.

## Fix
Added `tabular-nums` CSS property to force fixed-width digits so the timer never causes layout reflow. Also added `px-0.5` for a small breathing room.

## Testing
`tsc -b` in apps/desktop compiles cleanly.
