### PR TITLE
[codex] Normalize named custom model picker rows

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -221,6 +221,8 @@ def build_models_payload(
 
     if include_unconfigured:
         rows = list(rows) + [r for r in _append_unconfigured_rows(rows, ctx) if str(r.get("slug", "")).lower() != "moa"]
+    effective_current_provider = _normalize_current_provider(ctx, rows)
+    rows = _hide_shadow_bare_custom_row(rows, effective_current_provider)
     if picker_hints:
         _apply_picker_hints(rows)
     if canonical_order:
@@ -233,8 +235,60 @@ def build_models_payload(
     return {
         "providers": rows,
         "model": ctx.current_model,
-        "provider": ctx.current_provider,
+        "provider": effective_current_provider,
     }
+
+
+def _norm_url(url: str) -> str:
+    return str(url or "").strip().rstrip("/").lower()
+
+
+def _single_named_custom_match(rows: list[dict], base_url: str) -> Optional[dict]:
+    url = _norm_url(base_url)
+    if not url:
+        return None
+    matches = [
+        row
+        for row in rows
+        if row.get("is_user_defined")
+        and str(row.get("slug") or "").startswith("custom:")
+        and _norm_url(row.get("api_url") or "") == url
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _normalize_current_provider(ctx: ConfigContext, rows: list[dict]) -> str:
+    """Map legacy bare ``custom`` state back to the named custom row.
+
+    Older sessions can carry ``provider=custom`` plus a base_url even though
+    the configured picker row is ``custom:<name>``. Returning the bare provider
+    makes desktop pickers put the checkmark under a duplicate CUSTOM group.
+    """
+
+    current = ctx.current_provider
+    if current != "custom":
+        return current
+
+    match = _single_named_custom_match(rows, ctx.current_base_url)
+    if not match:
+        return current
+
+    target = str(match.get("slug") or current)
+    for row in rows:
+        row["is_current"] = row.get("slug") == target
+    return target
+
+
+def _hide_shadow_bare_custom_row(rows: list[dict], current_provider: str) -> list[dict]:
+    """Hide the canonical ``custom`` row when a named custom provider is active."""
+
+    if not str(current_provider or "").startswith("custom:"):
+        return rows
+    return [
+        row
+        for row in rows
+        if not (row.get("slug") == "custom" and row.get("source") == "canonical")
+    ]
 
 
 def _apply_capabilities(rows: list[dict]) -> None:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -221,7 +221,10 @@ def test_build_models_payload_maps_legacy_custom_to_named_provider():
     assert payload["provider"] == "custom:taro"
     slugs = [row["slug"] for row in payload["providers"]]
     assert "custom" not in slugs
-    assert payload["providers"][0]["is_current"] is True
+    # The named custom row carries the checkmark. (``providers[0]`` is now the
+    # virtual ``moa`` baseline row, so key on the slug instead of the index.)
+    taro_row = next(r for r in payload["providers"] if r["slug"] == "custom:taro")
+    assert taro_row["is_current"] is True
 
 
 def test_build_models_payload_hides_shadow_custom_for_named_current():
@@ -244,7 +247,9 @@ def test_build_models_payload_hides_shadow_custom_for_named_current():
         payload = build_models_payload(ctx)
 
     assert payload["provider"] == "custom:taro"
-    assert [row["slug"] for row in payload["providers"]] == ["custom:taro"]
+    # The bare ``custom`` shadow row is hidden; the virtual ``moa`` row is the
+    # upstream baseline prepended to every inventory payload.
+    assert [row["slug"] for row in payload["providers"]] == ["moa", "custom:taro"]
 
 
 def test_build_models_payload_does_not_call_provider_model_ids():

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -196,6 +196,57 @@ def test_build_models_payload_returns_expected_shape():
     assert payload["providers"][1:] == rows
 
 
+def test_build_models_payload_maps_legacy_custom_to_named_provider():
+    """Desktop sessions may still report provider='custom' while carrying the
+    base_url for a named custom provider. The payload must return the named
+    slug so the picker checkmark lands under that provider instead of CUSTOM."""
+    rows = [
+        {"slug": "custom", "name": "Custom endpoint",
+         "models": ["qwen3.6-27b"], "total_models": 1,
+         "is_current": True, "is_user_defined": False,
+         "source": "canonical"},
+        {"slug": "custom:taro", "name": "taro",
+         "models": ["qwen3.6-27b"], "total_models": 1,
+         "is_current": True, "is_user_defined": True,
+         "source": "user-config", "api_url": "http://10.10.20.211:8080/v1"},
+    ]
+    ctx = _empty_ctx(
+        provider="custom",
+        model="qwen3.6-27b",
+        base_url="http://10.10.20.211:8080/v1/",
+    )
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    assert payload["provider"] == "custom:taro"
+    slugs = [row["slug"] for row in payload["providers"]]
+    assert "custom" not in slugs
+    assert payload["providers"][0]["is_current"] is True
+
+
+def test_build_models_payload_hides_shadow_custom_for_named_current():
+    rows = [
+        {"slug": "custom", "name": "Custom endpoint",
+         "models": ["qwen3.6-27b"], "total_models": 1,
+         "is_current": False, "is_user_defined": False,
+         "source": "canonical"},
+        {"slug": "custom:taro", "name": "taro",
+         "models": ["qwen3.6-27b"], "total_models": 1,
+         "is_current": True, "is_user_defined": True,
+         "source": "user-config", "api_url": "http://10.10.20.211:8080/v1"},
+    ]
+    ctx = _empty_ctx(
+        provider="custom:taro",
+        model="qwen3.6-27b",
+        base_url="http://10.10.20.211:8080/v1",
+    )
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    assert payload["provider"] == "custom:taro"
+    assert [row["slug"] for row in payload["providers"]] == ["custom:taro"]
+
+
 def test_build_models_payload_does_not_call_provider_model_ids():
     """``build_models_payload`` is a thin shape adapter — it delegates the
     actual curation to ``list_authenticated_providers`` (which DOES call


### PR DESCRIPTION
## Summary

- Normalize legacy bare `custom` model-provider state to the matching named custom provider when the configured base URL matches a provider row.
- Hide the duplicate canonical `CUSTOM` row when a named custom provider is active, so the desktop picker checkmark lands on `TARO`/`AI-ROUTER` instead of the shadow row.
- Raise the desktop model-picker default visible count from 5 to 6 so the current local provider inventories show both `qwen3.6-27b` and `qwen3.6-35b-a3b` without requiring search.

## Root Cause

Hermes can emit both a canonical bare `custom` provider row and named custom-provider rows such as `custom:taro` and `custom:ai-router`. When live session state still reported `provider=custom` for a base URL that actually belongs to `taro`, the desktop status menu used that payload provider for selection and rendered the active model under `CUSTOM`. Separately, the compact picker only showed the first five models per provider, which hid the sixth local model.

## Validation

- `/Users/obaradei/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_bare_custom_slug_recovers -q`
- `git diff --check upstream/main...HEAD`
- `npm run type-check` in `apps/desktop`, using temporary symlinks to the installed checkout's existing node modules