### PR TITLE
fix(desktop): bootstrap SIGTERM vs cancelled + detached HEAD on install

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -450,14 +450,25 @@ async function runStage({ scriptPath, installerKind, stage, emit, hermesHome, ac
   })
 
   const durationMs = Date.now() - startedAt
+  const json = parseStageResult(result.stdout)
 
   if (result.killed) {
-    const ev = { type: 'stage', name: stage.name, state: 'failed', durationMs, error: 'cancelled by user' }
+    // Quit/repair can SIGTERM the child after install.sh already emitted
+    // { ok: true } for this stage — don't mislabel that as a user cancel.
+    if (json?.ok) {
+      const ev = { type: 'stage', name: stage.name, state: 'succeeded', durationMs, json }
+      emit(ev)
+      return ev
+    }
+
+    const tail = (result.stderr || result.stdout || '').trim().split(/\r?\n/).slice(-4).join('\n')
+    const err = tail
+      ? `bootstrap stage interrupted (${result.signal || 'SIGTERM'}): ${tail}`
+      : 'cancelled by user'
+    const ev = { type: 'stage', name: stage.name, state: 'failed', durationMs, error: err }
     emit(ev)
     return ev
   }
-
-  const json = parseStageResult(result.stdout)
 
   if (!json) {
     const ev = {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1113,7 +1113,9 @@ clone_repo() {
                 git reset --hard HEAD >/dev/null 2>&1 || true
                 git clean -fd >/dev/null 2>&1 || true
             fi
-            git checkout "$BRANCH"
+            if ! git checkout "$BRANCH" 2>/dev/null; then
+                git checkout -B "$BRANCH" "origin/$BRANCH"
+            fi
             git reset --hard "origin/$BRANCH"
         else
             log_error "Directory exists but is not a git repository: $INSTALL_DIR"


### PR DESCRIPTION
## Summary
- Parse install stage JSON before treating a SIGTERM as user cancel; honor `{ ok: true }` when the child was killed during quit/repair.
- Use clearer errors when the stage was interrupted without a success frame.
- `install.sh` clone path checks out the configured branch (with `-B origin/$BRANCH` fallback), matching `hermes update`.

## Test plan
- [ ] Fresh Desktop bootstrap on macOS completes repository stage without false "cancelled by user"
- [ ] Managed install under `~/.hermes/hermes-agent` on detached HEAD ends on `main` after bootstrap

Fixes #39333

Made with [Cursor](https://cursor.com)