### PR TITLE
fix(desktop): macOS update quarantine clear uses xattr -cr

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1533,7 +1533,7 @@ if [ "$SRC" != "$DST" ]; then
     rm -rf "$DST.hermes-update-old" 2>/dev/null || true
   fi
 fi
-/usr/bin/xattr -dr com.apple.quarantine "$DST" 2>/dev/null || true
+/usr/bin/xattr -cr "$DST" 2>/dev/null || true
 /usr/bin/open "$DST"
 `
   const scriptPath = path.join(app.getPath('temp'), `hermes-desktop-update-${Date.now()}.sh`)


### PR DESCRIPTION
## Summary
Replace invalid `xattr -dr` with `xattr -cr` when installing an updated `.app`, matching `scripts/install.sh`.

## Test plan
- [ ] In-app update on macOS no longer logs xattr usage errors

Fixes #38871

Made with [Cursor](https://cursor.com)