### PR TITLE
fix(desktop): restore pinned sessions after restart

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -34,8 +34,8 @@ import {
   SidebarMenuItem
 } from '@/components/ui/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
-import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
-import { sessionMatchesSearch } from '@/lib/session-search'
+import { searchSessions, type SessionInfo } from '@/hermes'
+import { searchResultToSession, sessionMatchesSearch } from '@/lib/session-search'
 import { cn } from '@/lib/utils'
 import {
   $panesFlipped,
@@ -134,32 +134,6 @@ const baseName = (path: string) =>
     .split(/[/\\]/)
     .filter(Boolean)
     .pop()
-
-// FTS results cover sessions that aren't in the loaded page; synthesize a
-// minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
-  const ts = result.session_started ?? Date.now() / 1000
-
-  return {
-    archived: false,
-    cwd: null,
-    ended_at: null,
-    id: result.session_id,
-    _lineage_root_id: result.lineage_root ?? null,
-    input_tokens: 0,
-    is_active: false,
-    last_active: ts,
-    message_count: 0,
-    model: result.model ?? null,
-    output_tokens: 0,
-    preview: result.snippet?.trim() || null,
-    source: result.source ?? null,
-    started_at: ts,
-    title: null,
-    tool_call_count: 0
-  }
-}
 
 function workspaceGroupsFor(sessions: SessionInfo[]): SidebarSessionGroup[] {
   const groups = new Map<string, SidebarSessionGroup>()

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -36,6 +36,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,
+  hydratePinnedSessions,
   mergeSessionPage,
   sessionPinId,
   setAwaitingResponse,
@@ -245,7 +246,9 @@ export function DesktopController() {
         // pinned sessions that have aged off the most-recent page — otherwise
         // the pin "disappears until you refresh". mergeSessionPage keeps both.
         const keepIds = new Set<string>([...$workingSessionIds.get(), ...$pinnedSessionIds.get()])
-        setSessions(prev => mergeSessionPage(prev, result.sessions, keepIds))
+        const merged = mergeSessionPage($sessions.get(), result.sessions, keepIds)
+        const withPins = await hydratePinnedSessions(merged, $pinnedSessionIds.get())
+        setSessions(withPins)
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
       }
     } finally {

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo } from '@/types/hermes'
+import type { SessionInfo, SessionSearchResult } from '@/types/hermes'
 
 import { sessionTitle } from './chat-runtime'
 
@@ -16,4 +16,28 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
     session.preview ?? '',
     session.cwd ?? ''
   ].some(value => value.toLowerCase().includes(needle))
+}
+
+/** FTS hit → minimal SessionInfo for sidebar rows (resume by id). */
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
+  const ts = result.session_started ?? Date.now() / 1000
+
+  return {
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: result.session_id,
+    _lineage_root_id: result.lineage_root ?? null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: ts,
+    message_count: 0,
+    model: result.model ?? null,
+    output_tokens: 0,
+    preview: result.snippet?.trim() || null,
+    source: result.source ?? null,
+    started_at: ts,
+    title: null,
+    tool_call_count: 0
+  }
 }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -4,6 +4,8 @@ import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { persistString, storedString } from '@/lib/storage'
+import { searchSessions } from '@/hermes'
+import { searchResultToSession } from '@/lib/session-search'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
@@ -70,6 +72,55 @@ export function mergeSessionPage(
   )
 
   return survivors.length ? [...survivors, ...incoming] : incoming
+}
+
+/** After cold boot `previous` is empty, so pinned ids in keepIds do not survive
+ *  mergeSessionPage. Re-fetch missing pin rows by id before building the sidebar. */
+export async function hydratePinnedSessions(
+  merged: SessionInfo[],
+  pinIds: Iterable<string>
+): Promise<SessionInfo[]> {
+  const pins = [...pinIds]
+
+  if (!pins.length) {
+    return merged
+  }
+
+  const index = new Map<string, SessionInfo>()
+
+  for (const session of merged) {
+    index.set(session.id, session)
+
+    if (session._lineage_root_id) {
+      index.set(session._lineage_root_id, session)
+    }
+  }
+
+  const missing = pins.filter(id => !index.has(id))
+
+  if (!missing.length) {
+    return merged
+  }
+
+  const hydrated: SessionInfo[] = []
+
+  await Promise.all(
+    missing.map(async pinId => {
+      try {
+        const res = await searchSessions(pinId)
+        const hit =
+          res.results.find(r => r.session_id === pinId || r.lineage_root === pinId) ?? res.results[0]
+
+        if (hit) {
+          hydrated.push(searchResultToSession(hit))
+        }
+      } catch {
+        // Session deleted — pin id will be ignored by the sidebar.
+      }
+    })
+  )
+
+  return hydrated.length ? mergeSessionPage(merged, hydrated, pins) : merged
 }
 
 export const $connection = atom<HermesConnection | null>(null)


### PR DESCRIPTION
## Summary
- After cold boot, `mergeSessionPage` drops pin ids not in the first page; fetch missing pins via `searchSessions` and merge.
- Share `searchResultToSession` helper for FTS hits.

## Test plan
- [ ] Pin a session, restart Hermes Desktop, pinned row still appears and resumes

Fixes #38858

Made with [Cursor](https://cursor.com)