### PR TITLE
fix(desktop): sync model header when switching cached sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -42,7 +42,13 @@ import {
   setYoloActive
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
-import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, UsageStats } from '@/types/hermes'
+import type {
+  ModelOptionsResponse,
+  SessionCreateResponse,
+  SessionInfo,
+  SessionResumeResponse,
+  UsageStats
+} from '@/types/hermes'
 
 import { NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../types'
@@ -436,6 +442,30 @@ export function useSessionActions({
         setSessionStartedAt(Date.now())
         clearComposerDraft()
         clearComposerAttachments()
+
+        const storedRow = $sessions
+          .get()
+          .find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)
+
+        if (storedRow?.model) {
+          setCurrentModel(storedRow.model)
+        }
+
+        void requestGateway<ModelOptionsResponse>('model.options', { session_id: cachedRuntimeId })
+          .then(opts => {
+            if (!isCurrentResume()) {
+              return
+            }
+
+            if (opts.model) {
+              setCurrentModel(opts.model)
+            }
+
+            if (opts.provider) {
+              setCurrentProvider(opts.provider)
+            }
+          })
+          .catch(() => undefined)
 
         void requestGateway<UsageStats>('session.usage', { session_id: cachedRuntimeId })
           .then(usage => {


### PR DESCRIPTION
## Summary
Fast resume path now applies stored model and refreshes `model.options` so the picker matches the active session.

## Test plan
- [ ] Two sessions with different models; switch between them; header model updates without full reload

Fixes #38901

Made with [Cursor](https://cursor.com)