### PR TITLE
feat(desktop): manual-only session filter in sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -35,9 +35,11 @@ import {
 } from '@/components/ui/sidebar'
 import { Skeleton } from '@/components/ui/skeleton'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
+import { isManualChatSession } from '@/lib/session-sources'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { cn } from '@/lib/utils'
 import {
+  $manualSessionsOnly,
   $panesFlipped,
   $pinnedSessionIds,
   $sidebarAgentsGrouped,
@@ -260,7 +262,12 @@ export function ChatSidebar({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  const sortedSessions = useMemo(() => [...sessions].sort((a, b) => sessionTime(b) - sessionTime(a)), [sessions])
+  const manualSessionsOnly = useStore($manualSessionsOnly)
+  const sortedSessions = useMemo(() => {
+    const sorted = [...sessions].sort((a, b) => sessionTime(b) - sessionTime(a))
+
+    return manualSessionsOnly ? sorted.filter(isManualChatSession) : sorted
+  }, [sessions, manualSessionsOnly])
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 
@@ -559,28 +566,43 @@ export function ChatSidebar({
             forceEmptyState={showSessionSkeletons}
             groups={agentsGrouped ? agentGroups : undefined}
             headerAction={
-              // Grouping operates on unpinned recents; if everything is
-              // pinned the toggle does nothing visible, so hide it to avoid
-              // a phantom click target.
-              agentSessions.length > 0 ? (
+              <div className="flex items-center gap-px">
                 <Button
-                  aria-label={agentsGrouped ? 'Show sessions as a single list' : 'Group sessions by workspace'}
+                  aria-label={manualSessionsOnly ? 'Show all sessions' : 'Hide automated sessions'}
                   className={cn(
                     'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
-                    agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                    manualSessionsOnly && 'bg-(--ui-control-active-background) text-foreground opacity-100'
                   )}
                   onClick={event => {
                     event.stopPropagation()
-                    setSidebarRecentsOpen(true)
-                    setSidebarAgentsGrouped(!agentsGrouped)
+                    $manualSessionsOnly.set(!manualSessionsOnly)
                   }}
                   size="icon-xs"
-                  title={agentsGrouped ? 'Ungroup sessions' : 'Group by workspace'}
+                  title={manualSessionsOnly ? 'Show cron and gateway sessions' : 'Manual chats only'}
                   variant="ghost"
                 >
-                  <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
+                  <Codicon name={manualSessionsOnly ? 'person' : 'history'} size="0.75rem" />
                 </Button>
-              ) : null
+                {agentSessions.length > 0 ? (
+                  <Button
+                    aria-label={agentsGrouped ? 'Show sessions as a single list' : 'Group sessions by workspace'}
+                    className={cn(
+                      'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+                      agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                    )}
+                    onClick={event => {
+                      event.stopPropagation()
+                      setSidebarRecentsOpen(true)
+                      setSidebarAgentsGrouped(!agentsGrouped)
+                    }}
+                    size="icon-xs"
+                    title={agentsGrouped ? 'Ungroup sessions' : 'Group by workspace'}
+                    variant="ghost"
+                  >
+                    <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
+                  </Button>
+                ) : null}
+              </div>
             }
             label="Sessions"
             labelMeta={countLabel(agentSessions.length, knownSessionTotal)}

--- a/apps/desktop/src/lib/session-sources.ts
+++ b/apps/desktop/src/lib/session-sources.ts
@@ -1,0 +1,10 @@
+import type { SessionInfo } from '@/types/hermes'
+
+/** Session sources that represent scheduled/automated runs, not manual desktop chat. */
+const AUTOMATED_SOURCES = new Set(['cron', 'gateway', 'api_server', 'api-server', 'scheduled', 'autonomous'])
+
+export function isManualChatSession(session: Pick<SessionInfo, 'source'>): boolean {
+  const src = (session.source || 'cli').trim().toLowerCase()
+
+  return !AUTOMATED_SOURCES.has(src)
+}

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -21,6 +21,7 @@ export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
+const SIDEBAR_MANUAL_ONLY_STORAGE_KEY = 'hermes.desktop.manualSessionsOnly'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
 
 export const CHAT_SIDEBAR_PANE_ID = 'chat-sidebar'
@@ -54,6 +55,7 @@ export const $pinnedSessionIds = atom(storedStringArray(SIDEBAR_PINNED_STORAGE_K
 export const $sidebarPinsOpen = atom(true)
 export const $sidebarRecentsOpen = atom(true)
 export const $sidebarAgentsGrouped = atom(storedBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false))
+export const $manualSessionsOnly = atom(storedBoolean(SIDEBAR_MANUAL_ONLY_STORAGE_KEY, true))
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = atom(storedBoolean(PANES_FLIPPED_STORAGE_KEY, false))
@@ -62,6 +64,7 @@ export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
 $pinnedSessionIds.subscribe(ids => persistStringArray(SIDEBAR_PINNED_STORAGE_KEY, [...ids]))
 $sidebarAgentsGrouped.subscribe(grouped => persistBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, grouped))
+$manualSessionsOnly.subscribe(manualOnly => persistBoolean(SIDEBAR_MANUAL_ONLY_STORAGE_KEY, manualOnly))
 $panesFlipped.subscribe(flipped => persistBoolean(PANES_FLIPPED_STORAGE_KEY, flipped))
 
 export function setSidebarWidth(width: number) {


### PR DESCRIPTION
## Summary
- Default sidebar hides automated sessions (`cron`, `gateway`, `api_server`, etc.).
- Toggle in Sessions header (person/history icon) to show all sessions; preference persisted.

## Test plan
- [ ] Cron/gateway sessions hidden by default
- [ ] Toggle shows automated sessions again

Fixes #38894

Made with [Cursor](https://cursor.com)