### PR TITLE
Feat/cron session titles

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1894,23 +1894,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
-        # Auto-title the cron session so it's identifiable in session listings
-        if _session_db:
-            try:
-                _session_db.set_session_title(_cron_session_id, job_name)
-            except Exception:
-                pass
         return True, output, final_response, None
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        # Auto-title the cron session even on failure
-        if _session_db:
-            try:
-                _session_db.set_session_title(_cron_session_id, job_name)
-            except Exception:
-                pass
         
         output = f"""# Cron Job: {job_name} (FAILED)
 
@@ -1943,6 +1931,15 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        # Auto-title the cron session so it's identifiable in session listings
+        if _session_db:
+            try:
+                _session_db.set_session_title(_cron_session_id, job_name)
+            except ValueError:
+                logger.warning(
+                    "Job '%s': could not set session title (already in use)",
+                    job_name,
+                )
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1894,11 +1894,23 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
+        # Auto-title the cron session so it's identifiable in session listings
+        if _session_db:
+            try:
+                _session_db.set_session_title(_cron_session_id, job_name)
+            except Exception:
+                pass
         return True, output, final_response, None
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        # Auto-title the cron session even on failure
+        if _session_db:
+            try:
+                _session_db.set_session_title(_cron_session_id, job_name)
+            except Exception:
+                pass
         
         output = f"""# Cron Job: {job_name} (FAILED)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -950,7 +950,106 @@ class TestRunJobSessionPersistence:
         assert success is False
         assert final_response == ""
         assert "RuntimeError: boom" in error
+        fake_db.set_session_title.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_sets_session_title_on_failure(self, tmp_path):
+        """set_session_title is called even when run_agent raises."""
+        job = {
+            "id": "title-fail-job",
+            "name": "title-fail",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.side_effect = RuntimeError("boom")
+            mock_agent_cls.return_value = mock_agent
+
+            run_job(job)
+
+        fake_db.set_session_title.assert_called_once()
+        title_call_args = fake_db.set_session_title.call_args
+        assert title_call_args[0][0].startswith("cron_title-fail-job_")
+        assert title_call_args[0][1] == "title-fail"
+
+    def test_run_job_handles_session_title_valueerror(self, tmp_path):
+        """set_session_title ValueError does not crash the job."""
+        job = {
+            "id": "title-collision-job",
+            "name": "title-collision",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        fake_db.set_session_title.side_effect = ValueError("title in use")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _resp, _error = run_job(job)
+
+        # Job still succeeds despite title collision
+        assert success is True
+        fake_db.set_session_title.assert_called_once()
+
+    def test_run_job_skips_title_when_session_db_is_none(self, tmp_path):
+        """No crash when SessionDB returns None (no session persistence)."""
+        job = {
+            "id": "no-db-job",
+            "name": "no-db",
+            "prompt": "hello",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=None), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _resp, _error = run_job(job)
+
+        assert success is True
 
     def test_run_job_reaps_stale_auxiliary_clients_per_tick(self, tmp_path):
         # Regression: auxiliary clients bound to the cron worker's dead

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -909,6 +909,10 @@ class TestRunJobSessionPersistence:
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")
         assert call_args[0][1] == "cron_complete"
+        fake_db.set_session_title.assert_called_once()
+        title_call_args = fake_db.set_session_title.call_args
+        assert title_call_args[0][0].startswith("cron_test-job_")
+        assert title_call_args[0][1] == "test"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 


### PR DESCRIPTION
## What does this PR do?

Cron sessions currently appear as `cron_<id>_<timestamp>` with no title in
`hermes sessions list`, making them indistinguishable from each other. When
you have 10+ cron jobs, there's no way to tell which session was which
without cross-referencing job IDs.

This sets the session title to the cron job's name after each run via
`set_session_title()`, so sessions are immediately identifiable.

### Why `finally` block?

The call fires on both success and failure without
code duplication. It sits right before `end_session()` — same guard
(`if _session_db:`), same lifetime.

### Why catch only `ValueError`?

`set_session_title()` raises `ValueError`
on title collision or invalid length. We log a warning and let the job
complete — a title collision shouldn't block cron execution. All other
exceptions propagate (the `finally` block's existing `end_session` /
`close` calls also catch broadly, so this is consistent).

### Why no new schema field?

Job names already serve as descriptive
identifiers (they cap at 50 chars, well under the 100-char title limit).
No new config, no migration, no API changes.

### Note on existing PRs

PRs [#14813](https://github.com/NousResearch/hermes-agent/pull/14813) and [#23121](https://github.com/NousResearch/hermes-agent/pull/23121) propose similar features with different approaches. This PR is the minimal implementation:

- **vs #14813:** That PR modifies `hermes_state.py` and `run_agent.py` to pass
  the title at session *creation* time, which required a follow-up fix for
  uniqueness collisions on repeated runs (lineage titles: `#2`, `#3`). This PR
  avoids that entirely by using the existing `set_session_title()` API in the
  `finally` block — the session already has a unique ID, so collisions are
  handled gracefully via `ValueError`.
- **vs #23121:** That PR bundles cron titles with a `title_generator.py` rewrite
  (two features, one PR), adds opinionated date suffixes (`· 2026-05-10`), and
  injects token-tracking imports. This PR is a single focused change — 9 lines
  in the scheduler, cron-only, no opinionated formatting.

## Related Issue

N/A — small self-contained improvement.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — added `set_session_title()` call in `finally` block (line ~1940), after TERMINAL_CWD/ContextVar cleanup and before `end_session()`. Catches `ValueError` with `logger.warning()`.
  
- `tests/cron/test_scheduler.py`
  - Added `set_session_title` assertions to existing success-path test
  - Added `test_run_job_sets_session_title_on_failure` — agent raises →
    title still set
  - Added `test_run_job_handles_session_title_valueerror` — collision
    doesn't crash the job
  - Added `test_run_job_skips_title_when_session_db_is_none` — no
    SessionDB → no crash

## How to Test

1. Trigger any cron job:
   ```
   hermes cron run <job_id>
   ```
2. Wait for it to complete, then check sessions:
   ```
   hermes sessions list
   ```
3. Verify: the session shows the job name as its title instead of `—`
4. Edge case — job that fails:
   - Can simulate by creating a job whose prompt triggers an error
   - Session should still have the title set
5. Edge case — `_session_db` is `None`:
   - Covered by unit test, not manual

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicates
- [x] My PR contains **only** changes related to this feature
- [x] I've run tests: `pytest tests/cron/` — **495 passed**
- [x] I've added tests for: success path, failure path, ValueError handling, None SessionDB
- [x] I've tested on: macOS 26.4.1

### Documentation & Housekeeping

- [x] Documentation — N/A (no public API or config surface changed)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture changes)
- [x] Cross-platform — N/A (pure Python + SQLite; no OS-specific code, no paths, no shell)
- [x] Tool descriptions/schemas — N/A (no tool behavior changed)

## Screenshots / Logs

Before — all cron sessions show `—` with no title:

```
Title    Preview                                  Last Active   ID
─        [cron job output...]                     7h ago        cron_acc2c0a0020d_20260604_070018
─        [cron job output...]                     6h ago        cron_a42178af4483_20260604_083028
```

After — the session title is the job's name:

```
Title                   Preview                                  Last Active   ID
Quick Weather Check     [cron job output...]                     1m ago        cron_a5cb6df35aaa_20260604_144633
─                       [cron job output...]                     6h ago        cron_a42178af4483_20260604_083028
```

The still-untitled session (`cron_a421*`) ran before the gateway was
restarted with the new code — all subsequent runs get titled automatically.
