### PR TITLE
fix(gateway): drop duplicate active inbound messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2374,6 +2374,12 @@ class BasePlatformAdapter(ABC):
         # construction (gateway/run.py). Default to "interrupt" so a stray
         # pre-sync read matches the single-knob default rather than silently
         # queueing.
+        # Track the platform message currently being processed for each
+        # session. Webhook transports (notably BlueBubbles/iMessage) can
+        # redeliver the same inbound message while the first copy is still
+        # active; without this guard the duplicate is queued as a follow-up and
+        # causes the response to be sent twice.
+        self._active_session_message_ids: Dict[str, str] = {}
         self._busy_text_mode: str = (
             os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "interrupt").strip().lower()
             or "interrupt"
@@ -4382,6 +4388,7 @@ class BasePlatformAdapter(ABC):
         if guard is not None and current_guard is not guard:
             return
         del self._active_sessions[session_key]
+        self._active_session_message_ids.pop(session_key, None)
 
     def _session_task_is_stale(self, session_key: str) -> bool:
         """Return True if the owner task for ``session_key`` is done/cancelled.
@@ -4424,6 +4431,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions.pop(session_key, None)
         self._pending_messages.pop(session_key, None)
         self._session_tasks.pop(session_key, None)
+        self._active_session_message_ids.pop(session_key, None)
         self._discard_text_debounce(session_key)
         return True
 
@@ -4443,6 +4451,8 @@ class BasePlatformAdapter(ABC):
         """
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
+        if event.message_id:
+            self._active_session_message_ids[session_key] = str(event.message_id)
 
         task = asyncio.create_task(self._process_message_background(event, session_key))
         self._session_tasks[session_key] = task
@@ -4640,6 +4650,16 @@ class BasePlatformAdapter(ABC):
 
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            active_message_id = self._active_session_message_ids.get(session_key)
+            if active_message_id and event.message_id and str(event.message_id) == active_message_id:
+                logger.info(
+                    "[%s] Dropping duplicate inbound message for active session %s (message_id=%s)",
+                    self.name,
+                    session_key,
+                    active_message_id,
+                )
+                return
+
             # Certain commands must bypass the active-session guard and be
             # dispatched directly to the gateway runner.  Without this, they
             # are queued as pending messages and either:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4435,6 +4435,17 @@ class BasePlatformAdapter(ABC):
         self._discard_text_debounce(session_key)
         return True
 
+    def _set_active_session_message_id(
+        self,
+        session_key: str,
+        event: MessageEvent,
+    ) -> None:
+        """Record the inbound event identity for the task owning a session."""
+        if event.message_id:
+            self._active_session_message_ids[session_key] = str(event.message_id)
+        else:
+            self._active_session_message_ids.pop(session_key, None)
+
     def _start_session_processing(
         self,
         event: MessageEvent,
@@ -4451,8 +4462,7 @@ class BasePlatformAdapter(ABC):
         """
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
-        if event.message_id:
-            self._active_session_message_ids[session_key] = str(event.message_id)
+        self._set_active_session_message_id(session_key, event)
 
         task = asyncio.create_task(self._process_message_background(event, session_key))
         self._session_tasks[session_key] = task
@@ -5229,6 +5239,7 @@ class BasePlatformAdapter(ABC):
                 # exhaust at ~2000 frames and SIGSEGV the process.
                 # Mirror the late-arrival drain pattern below: hand off
                 # to a new task and return so this frame can unwind.
+                self._set_active_session_message_id(session_key, pending_event)
                 drain_task = asyncio.create_task(
                     self._process_message_background(pending_event, session_key)
                 )
@@ -5353,6 +5364,7 @@ class BasePlatformAdapter(ABC):
                     _active = self._active_sessions.get(session_key)
                     if _active is not None:
                         _active.clear()
+                    self._set_active_session_message_id(session_key, late_pending)
                     drain_task = asyncio.create_task(
                         self._process_message_background(late_pending, session_key)
                     )
@@ -5459,6 +5471,7 @@ class BasePlatformAdapter(ABC):
         self._session_tasks.clear()
         self._pending_messages.clear()
         self._active_sessions.clear()
+        self._active_session_message_ids.clear()
         for state in list(self._text_debounce_store().values()):
             if state.task is not None and not state.task.done():
                 state.task.cancel()

--- a/tests/gateway/test_active_message_dedupe.py
+++ b/tests/gateway/test_active_message_dedupe.py
@@ -1,0 +1,102 @@
+"""Regression tests for duplicate inbound delivery while a session is active."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter():
+    adapter = _StubAdapter(PlatformConfig(enabled=True, token="t"), Platform.BLUEBUBBLES)
+    adapter._send_with_retry = AsyncMock(return_value=None)
+    return adapter
+
+
+def _make_event(text="hi", message_id="msg-1"):
+    source = SessionSource(
+        platform=Platform.BLUEBUBBLES,
+        chat_id="any;-;+15550000000",
+        chat_type="dm",
+        user_id="+15550000000",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=message_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_active_message_id_is_dropped_not_queued():
+    """A repeated webhook delivery of the active message must not become a follow-up.
+
+    BlueBubbles can redeliver the same inbound iMessage while the first copy is
+    still being processed. If the duplicate is queued as a pending follow-up, the
+    gateway can send the first response via the queued-follow-up fallback and
+    then send the final response again.
+    """
+    adapter = _make_adapter()
+    first = _make_event(text="first", message_id="same-message")
+    duplicate = _make_event(text="first", message_id="same-message")
+    session_key = build_session_key(first.source)
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    processed = []
+
+    async def handler(event):
+        processed.append(event.text)
+        started.set()
+        await release.wait()
+        return "ok"
+
+    adapter._message_handler = handler
+
+    await adapter.handle_message(first)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await adapter.handle_message(duplicate)
+
+    assert session_key not in adapter._pending_messages
+    assert processed == ["first"]
+
+    release.set()
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_active_message_id_is_cleared_after_completion():
+    adapter = _make_adapter()
+    event = _make_event(text="single", message_id="clear-me")
+    session_key = build_session_key(event.source)
+
+    async def handler(_event):
+        return "ok"
+
+    adapter._message_handler = handler
+
+    await adapter.handle_message(event)
+    await asyncio.sleep(0)
+    await adapter.cancel_background_tasks()
+
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._active_session_message_ids

--- a/tests/gateway/test_active_message_dedupe.py
+++ b/tests/gateway/test_active_message_dedupe.py
@@ -84,6 +84,98 @@ async def test_duplicate_active_message_id_is_dropped_not_queued():
 
 
 @pytest.mark.asyncio
+async def test_duplicate_queued_message_id_is_dropped_while_drain_is_active():
+    """The active ID must follow a queued event into its drain task.
+
+    A transport can redeliver the queued follow-up after the first turn hands
+    it to a drain task. It must be dropped rather than re-queued as another
+    follow-up.
+    """
+    adapter = _make_adapter()
+    # Bypass text debouncing so the test controls the queued-turn handoff.
+    adapter._busy_text_mode = "interrupt"
+    first = _make_event(text="first", message_id="first-message")
+    second = _make_event(text="second", message_id="queued-message")
+    duplicate_second = _make_event(text="second", message_id="queued-message")
+    session_key = build_session_key(first.source)
+
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    release_first = asyncio.Event()
+    release_second = asyncio.Event()
+    processed = []
+
+    async def handler(event):
+        processed.append(event.text)
+        if event.message_id == "first-message":
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+            await release_second.wait()
+        return "ok"
+
+    adapter._message_handler = handler
+
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await adapter.handle_message(second)
+    assert adapter._pending_messages[session_key] is second
+
+    release_first.set()
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
+    await adapter.handle_message(duplicate_second)
+
+    assert session_key not in adapter._pending_messages
+    assert processed == ["first", "second"]
+
+    release_second.set()
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_late_arrival_message_id_is_dropped_while_drain_is_active():
+    """The late-arrival cleanup drain must also take ownership of the ID."""
+    adapter = _make_adapter()
+    adapter._busy_text_mode = "interrupt"
+    first = _make_event(text="first", message_id="first-message")
+    late = _make_event(text="late", message_id="late-message")
+    duplicate_late = _make_event(text="late", message_id="late-message")
+    session_key = build_session_key(first.source)
+
+    late_started = asyncio.Event()
+    release_late = asyncio.Event()
+    injected = False
+    processed = []
+
+    async def handler(event):
+        processed.append(event.text)
+        if event.message_id == "late-message":
+            late_started.set()
+            await release_late.wait()
+        return "ok"
+
+    async def stop_typing_injects_late(*_args, **_kwargs):
+        nonlocal injected
+        if not injected:
+            adapter._pending_messages[session_key] = late
+            injected = True
+
+    adapter._message_handler = handler
+    adapter.stop_typing = stop_typing_injects_late
+
+    await adapter.handle_message(first)
+    await asyncio.wait_for(late_started.wait(), timeout=1.0)
+    await adapter.handle_message(duplicate_late)
+
+    assert session_key not in adapter._pending_messages
+    assert processed == ["first", "late"]
+
+    release_late.set()
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
 async def test_active_message_id_is_cleared_after_completion():
     adapter = _make_adapter()
     event = _make_event(text="single", message_id="clear-me")
@@ -100,3 +192,13 @@ async def test_active_message_id_is_cleared_after_completion():
 
     assert session_key not in adapter._active_sessions
     assert session_key not in adapter._active_session_message_ids
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_tasks_clears_active_message_ids():
+    adapter = _make_adapter()
+    adapter._active_session_message_ids["stale-session"] = "stale-message"
+
+    await adapter.cancel_background_tasks()
+
+    assert not adapter._active_session_message_ids


### PR DESCRIPTION
## Summary
- Drop duplicate inbound platform events when the same message_id is already being processed for a session.
- Prevent duplicate webhook delivery from being treated as a queued follow-up turn.
- Add a BlueBubbles-flavored regression test for duplicate active message delivery and cleanup.

## Context
Webhook transports can redeliver the same inbound message while the first delivery is still active. Before this change, the active-session guard treated that duplicate as a new follow-up message. In queued follow-up flows, that can cause the first response to be sent via the pending-turn safety path and then sent again as the normal final response.

This patch tracks the active inbound message_id per session and drops matching duplicate deliveries while that session is still active.

## Test Plan
- [x] `python -m pytest tests/gateway/test_active_message_dedupe.py tests/gateway/test_session_race_guard.py tests/gateway/test_pending_drain_race.py tests/gateway/test_text_batching.py -q -o 'addopts='`
  - Result: `47 passed`

## Privacy
This report intentionally omits user identifiers, hostnames, local paths from runtime logs, phone numbers, and raw gateway log contents.
