### PR TITLE
fix(gateway/email): set DOCUMENT type for non-image attachments

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -467,11 +467,25 @@ class EmailAdapter(BasePlatformAdapter):
         media_types = []
         msg_type = MessageType.TEXT
 
+        has_image = False
+        has_document = False
         for att in attachments:
             media_urls.append(att["path"])
             media_types.append(att["media_type"])
             if att["type"] == "image":
-                msg_type = MessageType.PHOTO
+                has_image = True
+            else:
+                has_document = True
+
+        # Image attachments take priority (PHOTO routes to the vision pipeline).
+        # Otherwise, non-image attachments must be flagged as DOCUMENT so the
+        # gateway's document-handling branch surfaces the cached file path to
+        # the agent — without this, the agent never learns the file exists and
+        # replies "I can't see the attachment".
+        if has_image:
+            msg_type = MessageType.PHOTO
+        elif has_document:
+            msg_type = MessageType.DOCUMENT
 
         # Store thread context for reply threading
         self._thread_context[sender_addr] = {

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -393,6 +393,78 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(captured_events[0].message_type, MessageType.PHOTO)
         self.assertEqual(captured_events[0].media_urls, ["/tmp/img.jpg"])
 
+    def test_document_attachment_sets_document_type(self):
+        """Email with a non-image attachment should set message type to
+        DOCUMENT so the gateway's document-handling branch surfaces the cached
+        file path to the agent. Regression test for emailed documents (e.g.
+        PDFs) being silently dropped — the type stayed TEXT, so the agent was
+        never told the file existed and replied "I can't see the attachment".
+        """
+        import asyncio
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"7",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: report",
+            "message_id": "<msg7@test.com>",
+            "in_reply_to": "",
+            "body": "See attached report",
+            "attachments": [{"path": "/tmp/report.pdf", "filename": "report.pdf", "type": "document", "media_type": "application/pdf"}],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        self.assertEqual(len(captured_events), 1)
+        self.assertEqual(captured_events[0].message_type, MessageType.DOCUMENT)
+        self.assertEqual(captured_events[0].media_urls, ["/tmp/report.pdf"])
+        self.assertEqual(captured_events[0].media_types, ["application/pdf"])
+
+    def test_mixed_attachments_prefer_photo(self):
+        """When an email carries both an image and a document, PHOTO wins so
+        the image still routes to the vision pipeline. Both paths are still
+        forwarded in media_urls.
+        """
+        import asyncio
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"8",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Re: both",
+            "message_id": "<msg8@test.com>",
+            "in_reply_to": "",
+            "body": "Photo and a doc",
+            "attachments": [
+                {"path": "/tmp/report.pdf", "filename": "report.pdf", "type": "document", "media_type": "application/pdf"},
+                {"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"},
+            ],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        self.assertEqual(len(captured_events), 1)
+        self.assertEqual(captured_events[0].message_type, MessageType.PHOTO)
+        self.assertEqual(
+            captured_events[0].media_urls, ["/tmp/report.pdf", "/tmp/img.jpg"]
+        )
+
     def test_source_built_correctly(self):
         """Session source should have correct chat_id and user info."""
         import asyncio


### PR DESCRIPTION
## Summary

Emailed **document** attachments (PDF, ZIP, and any non-image file) are silently dropped: the agent replies that it cannot see the attachment, even though the file was received and cached.

### Root cause

`gateway/platforms/email.py` `_dispatch_message()` caches the attachment and populates `media_urls` / `media_types` correctly, but only ever upgrades `message_type` to `PHOTO` (for images). It never sets `MessageType.DOCUMENT`.

The document-handling branch in `gateway/run.py` that injects the cached file path into the agent's context is gated behind:

```python
if event.media_urls and event.message_type == MessageType.DOCUMENT:
```

Since email never set `DOCUMENT`, that branch never ran for emailed documents — the agent was never told the file path existed, so it replied "I can't see the attachment." Images worked because they correctly set `PHOTO` (which routes to the vision pipeline).

### Fix

Set `message_type = MessageType.DOCUMENT` when a non-image attachment is present, while keeping `PHOTO` priority when an image is also attached (so the image still routes to vision and both paths are forwarded in `media_urls`).

## Test Plan

- [x] Adds `test_document_attachment_sets_document_type` — regression test for the dropped-document bug
- [x] Adds `test_mixed_attachments_prefer_photo` — image priority preserved, both paths forwarded
- [x] Existing `test_image_attachment_sets_photo_type` still passes
- [x] `python -m pytest tests/gateway/test_email.py` → 62 passed

## Notes

The existing suite had an image-attachment dispatch test but no document-attachment dispatch test, which is exactly the gap that let this ship. The new tests close it.
