### PR TITLE
fix(desktop): stream live context usage

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -279,6 +279,42 @@ def _ra():
     return run_agent
 
 
+def _emit_preflight_token_usage(agent: Any, request_tokens: int) -> None:
+    """Send the current request-size estimate through the live usage channel."""
+    if request_tokens <= 0:
+        return
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return
+
+    try:
+        previous = getattr(compressor, "last_prompt_tokens", 0) or 0
+        if request_tokens > previous:
+            compressor.last_prompt_tokens = request_tokens
+    except Exception:
+        logger.debug("could not update preflight context estimate", exc_info=True)
+
+    emit = getattr(agent, "_emit_token_usage", None)
+    if not callable(emit):
+        return
+
+    try:
+        emit(
+            input_tokens=getattr(agent, "session_input_tokens", 0)
+            or getattr(agent, "session_prompt_tokens", 0)
+            or 0,
+            output_tokens=getattr(agent, "session_output_tokens", 0)
+            or getattr(agent, "session_completion_tokens", 0)
+            or 0,
+            total_tokens=getattr(agent, "session_total_tokens", 0) or 0,
+            context_tokens=request_tokens,
+            context_length=getattr(compressor, "context_length", 0) or 0,
+        )
+    except Exception:
+        logger.debug("could not emit preflight token usage", exc_info=True)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -1750,6 +1786,7 @@ def run_conversation(
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
         total_chars = approx_tokens * 4
+        _emit_preflight_token_usage(agent, request_pressure_tokens)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens
@@ -3163,6 +3200,22 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+                    agent._emit_token_usage(
+                        input_tokens=agent.session_input_tokens,
+                        output_tokens=agent.session_output_tokens,
+                        total_tokens=agent.session_total_tokens,
+                        context_tokens=getattr(
+                            agent.context_compressor, "last_prompt_tokens", 0
+                        )
+                        if agent.context_compressor
+                        else 0,
+                        context_length=getattr(
+                            agent.context_compressor, "context_length", 0
+                        )
+                        if agent.context_compressor
+                        else 0,
+                    )
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -16,6 +16,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
+import { usageFromTokenUsagePayload } from '@/lib/usage-events'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
@@ -489,6 +490,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             queryKey:
               explicitSid && sessionId ? modelOptionsQueryKey(activeGatewayProfile, sessionId) : ['model-options']
           })
+        }
+      } else if (event.type === 'token.usage') {
+        if (!explicitSid || isActiveEvent) {
+          const usage = usageFromTokenUsagePayload(payload)
+
+          if (usage) {
+            setCurrentUsage(current => ({ ...current, ...usage }))
+          }
         }
       } else if (event.type === 'message.start') {
         if (!sessionId) {

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -11,7 +11,7 @@ import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import { contextBarLabel, contextCapacityClassName, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { resolveVersionStatus } from '@/lib/version-status'
@@ -174,6 +174,11 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+
+  const contextCapacityClass = useMemo(
+    () => contextCapacityClassName(currentUsage.context_percent),
+    [currentUsage.context_percent]
+  )
 
   const publishContextUsage = useCallback(
     (snapshot: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'>) => {
@@ -474,7 +479,7 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
-        detail: contextBar || undefined,
+        detail: contextBar ? <span className={contextCapacityClass}>{contextBar}</span> : undefined,
         hidden: !contextUsage,
         id: 'context-usage',
         label: contextUsage,
@@ -526,6 +531,7 @@ export function useStatusbarItems({
       chatOpen,
       clientVersionItem,
       contextBar,
+      contextCapacityClass,
       contextUsage,
       copy,
       currentUsage,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -48,7 +48,7 @@ import type { StatusResponse, UsageStats } from '@/types/hermes'
 import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
 
-const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const
+const EMPTY_USAGE: UsageStats = { calls: 0, input: 0, output: 0, total: 0 }
 
 function workspaceLabel(cwd: string): string {
   const normalized = cwd.replace(/[\\/]+$/, '')

--- a/apps/desktop/src/lib/statusbar.test.ts
+++ b/apps/desktop/src/lib/statusbar.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { contextCapacityClassName } from './statusbar'
+
+describe('contextCapacityClassName', () => {
+  it('keeps empty context neutral and reserves color for meaningful capacity bands', () => {
+    expect(contextCapacityClassName(0)).toContain('muted')
+    expect(contextCapacityClassName(24)).toContain('--ui-green')
+    expect(contextCapacityClassName(50)).toContain('--ui-yellow')
+    expect(contextCapacityClassName(80)).toContain('--ui-orange')
+    expect(contextCapacityClassName(95)).toContain('--ui-red')
+  })
+})

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -58,6 +58,28 @@ export function contextBarLabel(usage: UsageStats): string {
   return `[${contextBar(usage.context_percent)}] ${pct}%`
 }
 
+export function contextCapacityClassName(percent: number | undefined): string {
+  const pct = Math.max(0, Math.min(100, percent ?? 0))
+
+  if (pct >= 95) {
+    return 'text-[color-mix(in_srgb,var(--ui-red)_86%,var(--ui-text-tertiary))]'
+  }
+
+  if (pct >= 80) {
+    return 'text-[color-mix(in_srgb,var(--ui-orange)_82%,var(--ui-text-tertiary))]'
+  }
+
+  if (pct >= 50) {
+    return 'text-[color-mix(in_srgb,var(--ui-yellow)_74%,var(--ui-text-tertiary))]'
+  }
+
+  if (pct > 0) {
+    return 'text-[color-mix(in_srgb,var(--ui-green)_52%,var(--ui-text-tertiary))]'
+  }
+
+  return 'text-muted-foreground/80'
+}
+
 export function LiveDuration({ since }: { since: number | null | undefined }) {
   const [now, setNow] = useState(() => Date.now())
 

--- a/apps/desktop/src/lib/usage-events.test.ts
+++ b/apps/desktop/src/lib/usage-events.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { usageFromTokenUsagePayload } from './usage-events'
+
+describe('usageFromTokenUsagePayload', () => {
+  it('maps gateway token.usage payloads onto desktop usage stats', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 131_072,
+        context_pct: 9.4,
+        context_tokens: 12_345,
+        input_tokens: 100,
+        output_tokens: 20,
+        total_tokens: 120
+      })
+    ).toEqual({
+      context_max: 131_072,
+      context_percent: 9.4,
+      context_used: 12_345,
+      input: 100,
+      output: 20,
+      total: 120
+    })
+  })
+
+  it('derives context percent when the backend omits it', () => {
+    expect(
+      usageFromTokenUsagePayload({
+        context_length: 200_000,
+        context_tokens: 50_000
+      })
+    ).toMatchObject({
+      context_max: 200_000,
+      context_percent: 25,
+      context_used: 50_000
+    })
+  })
+})

--- a/apps/desktop/src/lib/usage-events.ts
+++ b/apps/desktop/src/lib/usage-events.ts
@@ -1,0 +1,52 @@
+import type { UsageStats } from '@/types/hermes'
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function usageFromTokenUsagePayload(payload: unknown): Partial<UsageStats> | null {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  const p = payload as Record<string, unknown>
+  const input = finiteNumber(p.input_tokens)
+  const output = finiteNumber(p.output_tokens)
+  const total = finiteNumber(p.total_tokens)
+  const contextUsed = finiteNumber(p.context_tokens)
+  const contextMax = finiteNumber(p.context_length)
+
+  const contextPercent =
+    finiteNumber(p.context_pct) ??
+    (contextUsed !== undefined && contextMax && contextMax > 0
+      ? Math.round((contextUsed / contextMax) * 1000) / 10
+      : undefined)
+
+  const usage: Partial<UsageStats> = {}
+
+  if (input !== undefined) {
+    usage.input = input
+  }
+
+  if (output !== undefined) {
+    usage.output = output
+  }
+
+  if (total !== undefined) {
+    usage.total = total
+  }
+
+  if (contextUsed !== undefined) {
+    usage.context_used = contextUsed
+  }
+
+  if (contextMax !== undefined) {
+    usage.context_max = contextMax
+  }
+
+  if (contextPercent !== undefined) {
+    usage.context_percent = contextPercent
+  }
+
+  return Object.keys(usage).length ? usage : null
+}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1049,6 +1049,38 @@ class AIAgent:
                 _thinking_cb(text)
             except Exception:
                 logger.debug("thinking_callback error in _emit_wait_notice", exc_info=True)
+    def _emit_token_usage(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        total_tokens: int,
+        context_tokens: int,
+        context_length: int,
+    ) -> None:
+        """Emit structured usage for live context meters.
+
+        The gateway forwards this as ``token.usage`` so desktop/TUI chrome can
+        update during a turn, before final message completion snapshots arrive.
+        """
+        if not self.status_callback:
+            return
+
+        payload = json.dumps(
+            {
+                "input_tokens": max(0, int(input_tokens or 0)),
+                "output_tokens": max(0, int(output_tokens or 0)),
+                "total_tokens": max(0, int(total_tokens or 0)),
+                "context_tokens": max(0, int(context_tokens or 0)),
+                "context_length": max(0, int(context_length or 0)),
+                "context_pct": round(context_tokens / context_length * 100, 1)
+                if context_length > 0
+                else 0,
+            }
+        )
+        try:
+            self.status_callback("token_usage", payload)
+        except Exception:
+            logger.debug("status_callback error in _emit_token_usage", exc_info=True)
 
     # ── Buffered retry/fallback status ────────────────────────────────────
     # Retry and fallback chains were flooding the CLI/gateway with status

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4585,6 +4585,40 @@ class TestRunConversation:
             (hook_events[0]["api_request_id"], "success")
         ]
 
+    def test_preflight_token_usage_emits_before_api_response(self, agent):
+        self._setup_agent(agent)
+        agent.context_compressor = SimpleNamespace(
+            context_length=131_072,
+            last_prompt_tokens=0,
+        )
+        events = []
+
+        def _status(kind, text=None):
+            if kind == "token_usage":
+                events.append(json.loads(text))
+
+        def _create(*_args, **_kwargs):
+            assert events
+            assert events[-1]["context_tokens"] == 12_345
+            assert events[-1]["context_length"] == 131_072
+            return _mock_response(content="Final answer", finish_reason="stop")
+
+        agent.status_callback = _status
+        agent.client.chat.completions.create.side_effect = _create
+
+        with (
+            patch("agent.conversation_loop.estimate_messages_tokens_rough", return_value=12_345),
+            patch("agent.conversation_loop._estimate_tools_tokens_rough", return_value=0),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Final answer"
+        assert agent.context_compressor.last_prompt_tokens == 12_345
+
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -921,6 +921,41 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
         server._sessions.pop("detached-sid", None)
 
 
+def test_status_update_emits_structured_token_usage(monkeypatch):
+    events = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+
+    server._status_update(
+        "sid-1",
+        "token_usage",
+        json.dumps(
+            {
+                "context_length": 131_072,
+                "context_pct": 9.4,
+                "context_tokens": 12_345,
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            }
+        ),
+    )
+
+    assert events == [
+        (
+            "token.usage",
+            "sid-1",
+            {
+                "context_length": 131_072,
+                "context_pct": 9.4,
+                "context_tokens": 12_345,
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            },
+        )
+    ]
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1603,6 +1603,14 @@ def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
+    if kind == "token_usage":
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, TypeError):
+            return
+        if isinstance(payload, dict):
+            _emit("token.usage", sid, payload)
+        return
     out_kind = kind if text is not None else "status"
     # Auto-compaction reaches us as a generic "lifecycle" status. Re-tag it so
     # drivers (desktop app) can show an explicit "Summarizing…" indicator —

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -66,6 +66,31 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('merges token usage events into live usage state', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: {
+        context_length: 131_072,
+        context_pct: 9.4,
+        context_tokens: 12_345,
+        input_tokens: 100,
+        output_tokens: 20,
+        total_tokens: 120
+      },
+      type: 'token.usage'
+    } as any)
+
+    expect(getUiState().usage).toMatchObject({
+      context_max: 131_072,
+      context_percent: 9.4,
+      context_used: 12_345,
+      input: 100,
+      output: 20,
+      total: 120
+    })
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -23,7 +23,7 @@ import { isPaintableHex, setTerminalBackground, setTerminalForeground } from '..
 import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
 import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/themeBoot.js'
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
-import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
+import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
@@ -37,6 +37,55 @@ import { isWakeUserDisabled } from './wakeState.js'
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
+
+const finiteNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined)
+
+function usageFromTokenUsagePayload(payload: unknown): null | Partial<Usage> {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  const p = payload as Record<string, unknown>
+  const input = finiteNumber(p.input_tokens)
+  const output = finiteNumber(p.output_tokens)
+  const total = finiteNumber(p.total_tokens)
+  const contextUsed = finiteNumber(p.context_tokens)
+  const contextMax = finiteNumber(p.context_length)
+
+  const contextPercent =
+    finiteNumber(p.context_pct) ??
+    (contextUsed !== undefined && contextMax && contextMax > 0
+      ? Math.round((contextUsed / contextMax) * 1000) / 10
+      : undefined)
+
+  const usage: Partial<Usage> = {}
+
+  if (input !== undefined) {
+    usage.input = input
+  }
+
+  if (output !== undefined) {
+    usage.output = output
+  }
+
+  if (total !== undefined) {
+    usage.total = total
+  }
+
+  if (contextUsed !== undefined) {
+    usage.context_used = contextUsed
+  }
+
+  if (contextMax !== undefined) {
+    usage.context_max = contextMax
+  }
+
+  if (contextPercent !== undefined) {
+    usage.context_percent = contextPercent
+  }
+
+  return Object.keys(usage).length ? usage : null
+}
 
 // The last gateway skin, kept so the theme can be re-derived when the OSC-11
 // background answer arrives after (or without) gateway.ready.
@@ -1337,6 +1386,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (typeof text === 'string' && text.trim()) {
           turnController.recordInterimMessage(text)
+        }
+
+        return
+      }
+
+      case 'token.usage': {
+        const usage = usageFromTokenUsagePayload(ev.payload)
+
+        if (usage) {
+          patchUiState(state => ({ ...state, usage: { ...state.usage, ...usage } }))
         }
 
         return

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -596,6 +596,15 @@ export interface SpawnTreeLoadResponse {
   subagents?: unknown[]
 }
 
+export interface TokenUsagePayload {
+  context_length?: number
+  context_pct?: number
+  context_tokens?: number
+  input_tokens?: number
+  output_tokens?: number
+  total_tokens?: number
+}
+
 export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
@@ -716,6 +725,7 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.progress' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
+  | { payload?: TokenUsagePayload; session_id?: string; type: 'token.usage' }
   | {
       payload: { already_streamed?: boolean; text: string }
       session_id?: string


### PR DESCRIPTION
## Summary

This fixes the desktop footer context meter staying at `0/context` while an agent turn is already running. The backend now emits a structured `token_usage` status update immediately after the high-accuracy preflight token estimate, the gateway forwards it as `token.usage`, and the desktop/TUI clients merge it into live usage state before `message.complete`.

The status bar keeps the main text grey and applies semantic capacity color only to the small bracket meter: muted at 0%, green while comfortably under capacity, yellow/orange as it fills, and red near max.

## Verification

- `/Users/obaradei/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_preflight_token_usage_emits_before_api_response tests/test_tui_gateway_server.py::test_status_update_emits_structured_token_usage -q`
- `npm --prefix apps/desktop exec vitest run src/lib/usage-events.test.ts src/lib/statusbar.test.ts -- --environment jsdom`
- `npm --prefix ui-tui exec vitest run src/__tests__/createGatewayEventHandler.test.ts`
- `npm --prefix apps/desktop run type-check`
- `npx prettier --check apps/desktop/src/lib/usage-events.ts apps/desktop/src/lib/usage-events.test.ts apps/desktop/src/lib/statusbar.ts apps/desktop/src/lib/statusbar.test.ts apps/desktop/src/app/session/hooks/use-message-stream.ts apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx ui-tui/src/app/createGatewayEventHandler.ts ui-tui/src/__tests__/createGatewayEventHandler.test.ts ui-tui/src/gatewayTypes.ts`
- `git diff --check HEAD^..HEAD`

Live install checked locally: packaged `/Applications/Hermes.app` was rebuilt and swapped to commit `7ed069c16b9b6c2d6317814658eb920d76896a00`; install stamp reports that commit and the desktop backend is running on `127.0.0.1:9120`.

Note: `npm --prefix ui-tui run type-check` still fails on existing unrelated `packages/hermes-ink/src/utils/execFileNoThrow.ts` readonly stdio / child-process typing debt.