### PR TITLE
fix: simplify dashboard theme and resume flow

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
 graft skills
 graft optional-skills
+# Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
+# PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs
+# built from the sdist (e.g. Homebrew, downstream packagers). package-data
+# below covers the wheel; this covers the sdist. See #34034 / #28149.
+recursive-include plugins plugin.yaml plugin.yml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,16 +1,20 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
-  "authors": ["Nous Research"],
+  "authors": [
+    "Nous Research"
+  ],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
-      "args": ["hermes-acp"]
+      "package": "hermes-agent[acp]==0.15.2",
+      "args": [
+        "hermes-acp"
+      ]
     }
   }
 }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3934,8 +3934,8 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+    {"name": "default",       "label": "Simple",              "description": "Plain light dashboard with Arial and dark text"},
+    {"name": "default-large", "label": "Simple (Large)",      "description": "Simple light dashboard with bigger fonts and roomier spacing"},
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
@@ -3969,7 +3969,7 @@ def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0)
 
 
 _THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
-    "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    "fontSans": 'Arial, "Helvetica Neue", Helvetica, sans-serif',
     "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace',
     "baseSize": "15px",
     "lineHeight": "1.55",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2431,10 +2431,17 @@ async def cancel_oauth_session(session_id: str, request: Request):
 
 
 def _session_latest_descendant(session_id: str):
-    """Resolve a session id to the newest child leaf session.
+    """Resolve a dashboard resume target to the live chat continuation.
 
-    /model may create child sessions. Dashboard refresh should continue the
-    newest child instead of reopening the old parent.
+    Historically this walked to the newest child leaf, but not every child is a
+    continuation of the visible conversation: delegate/subagent runs, branch
+    rows, and partial empty children also carry ``parent_session_id``. Resuming
+    those children makes embedded chat render the new-chat empty state. Reuse
+    the canonical compression-chain rule from ``SessionDB.get_compression_tip``
+    instead: only follow children created after a parent ended with
+    ``end_reason='compression'``.
+
+    The endpoint name is kept for frontend/backward compatibility.
     """
     from hermes_state import SessionDB
 
@@ -2449,60 +2456,57 @@ def _session_latest_descendant(session_id: str):
             except Exception:
                 return None
 
+    def compression_path(db: SessionDB, start: str, tip: str) -> list[str]:
+        path = [start]
+        if start == tip:
+            return path
+
+        current = start
+        seen = {start}
+        for _ in range(100):
+            try:
+                with db._lock:
+                    row = db._conn.execute(
+                        "SELECT id FROM sessions "
+                        "WHERE parent_session_id = ? "
+                        "  AND started_at >= ("
+                        "      SELECT ended_at FROM sessions "
+                        "      WHERE id = ? AND end_reason = 'compression'"
+                        "  ) "
+                        "ORDER BY started_at DESC LIMIT 1",
+                        (current, current),
+                    ).fetchone()
+            except Exception:
+                break
+            if row is None:
+                break
+            child = row_get(row, "id", 0)
+            if not child or child in seen:
+                break
+            path.append(child)
+            if child == tip:
+                return path
+            seen.add(child)
+            current = child
+
+        # Defensive fallback: preserve the requested→resolved relationship even
+        # if the chain was modified concurrently while we were building path.
+        if path[-1] != tip:
+            path.append(tip)
+        return path
+
     db = SessionDB()
     try:
         sid = db.resolve_session_id(session_id)
         if not sid or not db.get_session(sid):
             return None, []
 
-        conn = (
-            getattr(db, "conn", None)
-            or getattr(db, "_conn", None)
-            or getattr(db, "connection", None)
-            or getattr(db, "_connection", None)
-        )
+        try:
+            tip = db.get_compression_tip(sid) or sid
+        except Exception:
+            tip = sid
 
-        rows = []
-        if conn is not None:
-            raw_rows = conn.execute(
-                "SELECT id, parent_session_id, started_at FROM sessions"
-            ).fetchall()
-            for row in raw_rows:
-                rows.append({
-                    "id": row_get(row, "id", 0),
-                    "parent_session_id": row_get(row, "parent_session_id", 1),
-                    "started_at": row_get(row, "started_at", 2),
-                })
-        else:
-            rows = db.list_sessions_rich(limit=10000, offset=0)
-
-        children = {}
-        for row in rows:
-            rid = row.get("id")
-            parent = row.get("parent_session_id")
-            if rid and parent:
-                children.setdefault(parent, []).append(row)
-
-        def started(row):
-            try:
-                return float(row.get("started_at") or 0)
-            except Exception:
-                return 0.0
-
-        current = sid
-        path = [sid]
-        seen = {sid}
-
-        while children.get(current):
-            candidates = [r for r in children[current] if r.get("id") not in seen]
-            if not candidates:
-                break
-            candidates.sort(key=started, reverse=True)
-            current = candidates[0]["id"]
-            path.append(current)
-            seen.add(current)
-
-        return current, path
+        return tip, compression_path(db, sid, tip)
     finally:
         db.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,14 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  # Plugin discovery (hermes_cli/plugins.py) reads a plugin.yaml/plugin.yml
+  # manifest from each bundled plugin directory to register it. Wheels only
+  # carry files declared here, so without this glob the wheel ships every
+  # plugin's Python code but none of its manifests — the scan finds zero
+  # plugins and all gateway platforms fail with "No adapter available for
+  # <platform>" (#34034), web-search providers go missing (#28149), etc.
+  "**/plugin.yaml",
+  "**/plugin.yml",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/hermes_cli/test_web_server_session_resume.py
+++ b/tests/hermes_cli/test_web_server_session_resume.py
@@ -1,0 +1,84 @@
+"""Regression tests for dashboard session resume targeting."""
+
+from __future__ import annotations
+
+import hermes_state
+
+
+def _use_temp_state_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+def _set_session_times(
+    db,
+    session_id: str,
+    *,
+    started_at: float,
+    ended_at: float | None = None,
+    end_reason: str | None = None,
+) -> None:
+    db._conn.execute(
+        "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+        (started_at, ended_at, end_reason, session_id),
+    )
+    db._conn.commit()
+
+
+def test_dashboard_resume_does_not_follow_empty_non_compression_child(monkeypatch, tmp_path):
+    """Embedded chat resume must not switch to an unrelated/empty child row.
+
+    Branches, delegate/subagent sessions, and partial child rows can share
+    parent_session_id with the visible conversation, but they are not the live
+    continuation of that chat. Resuming the empty child makes the TUI render the
+    new-chat empty state even though the user selected an existing thread.
+    """
+    _use_temp_state_db(monkeypatch, tmp_path)
+
+    from hermes_cli.web_server import _session_latest_descendant
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session("root", source="tui", model="test")
+        _set_session_times(db, "root", started_at=1_000.0)
+        db.append_message("root", role="user", content="resume this existing conversation")
+
+        # A newer child exists, but the parent never ended by compression and
+        # the child has no messages. The old newest-leaf resolver followed this
+        # row and reopened an empty TUI transcript.
+        db.create_session("empty-child", source="tui", model="test", parent_session_id="root")
+        _set_session_times(db, "empty-child", started_at=1_100.0)
+    finally:
+        db.close()
+
+    latest, path = _session_latest_descendant("root")
+
+    assert latest == "root"
+    assert path == ["root"]
+
+
+def test_dashboard_resume_follows_real_compression_tip(monkeypatch, tmp_path):
+    """Dashboard resume should still follow true compression continuations."""
+    _use_temp_state_db(monkeypatch, tmp_path)
+
+    from hermes_cli.web_server import _session_latest_descendant
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session("root", source="tui", model="test")
+        _set_session_times(db, "root", started_at=2_000.0, ended_at=2_100.0, end_reason="compression")
+        db.append_message("root", role="user", content="before compression")
+
+        db.create_session("tip", source="tui", model="test", parent_session_id="root")
+        _set_session_times(db, "tip", started_at=2_101.0)
+        db.append_message("tip", role="user", content="after compression")
+    finally:
+        db.close()
+
+    latest, path = _session_latest_descendant("root")
+
+    assert latest == "tip"
+    assert path == ["root", "tip"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,42 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
+    """Regression test for #34034 / #28149.
+
+    Plugin discovery (hermes_cli/plugins.py) registers each bundled plugin by
+    reading its ``plugin.yaml`` / ``plugin.yml`` manifest. Those manifests are
+    data files, not Python modules, so they only reach installed packages when
+    declared explicitly:
+
+    - wheel  -> ``[tool.setuptools.package-data]`` ``plugins`` glob
+    - sdist  -> ``MANIFEST.in`` (Homebrew and other downstream packagers build
+                from the sdist)
+
+    v0.15.0 declared neither, so the wheel shipped every adapter's Python code
+    but none of its manifests, and *every* gateway platform failed with
+    "No adapter available for <platform>". Both channels must cover manifests.
+    """
+    # There must actually be manifests on disk for the globs to match.
+    on_disk = list((REPO_ROOT / "plugins").rglob("plugin.yaml")) + list(
+        (REPO_ROOT / "plugins").rglob("plugin.yml")
+    )
+    assert on_disk, "expected bundled plugin manifests under plugins/"
+
+    # Wheel channel: package-data must declare a glob that matches plugin
+    # manifests anywhere under the plugins package.
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    plugins_pkg_data = data["tool"]["setuptools"]["package-data"].get("plugins", [])
+    assert any(
+        g.endswith("plugin.yaml") or g.endswith("plugin.yml")
+        for g in plugins_pkg_data
+    ), "pyproject package-data 'plugins' must ship plugin.yaml/plugin.yml (wheel)"
+
+    # Sdist channel: MANIFEST.in must recursively include the manifests so
+    # downstream packagers building from the sdist also get them.
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "recursive-include plugins" in manifest and "plugin.yaml" in manifest, (
+        "MANIFEST.in must recursive-include plugins plugin.yaml/plugin.yml (sdist)"
+    )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -450,7 +450,7 @@ export default function App() {
   return (
     <div
       data-layout-variant={layoutVariant}
-      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-text-primary antialiased"
+      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
     >
       <SelectionSwitcher />
       <Backdrop />
@@ -483,7 +483,6 @@ export default function App() {
 
         <Typography
           className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground"
-          style={{ mixBlendMode: "plus-lighter" }}
         >
           {t.app.brand}
         </Typography>
@@ -541,7 +540,6 @@ export default function App() {
 
                 <Typography
                   className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase"
-                  style={{ mixBlendMode: "plus-lighter" }}
                 >
                   Hermes
                   <br />
@@ -818,7 +816,6 @@ function SidebarNavLink({
               <span
                 aria-hidden
                 className="absolute left-0 top-0 bottom-0 w-px bg-midground"
-                style={{ mixBlendMode: "plus-lighter" }}
               />
             )}
           </>
@@ -979,7 +976,6 @@ function SystemActionButton({
           <span
             aria-hidden
             className="absolute left-0 top-0 bottom-0 w-px bg-midground"
-            style={{ mixBlendMode: "plus-lighter" }}
           />
         )}
       </button>

--- a/web/src/components/Backdrop.tsx
+++ b/web/src/components/Backdrop.tsx
@@ -1,93 +1,16 @@
-import { useGpuTier } from "@nous-research/ui/hooks/use-gpu-tier";
-
-import fillerBgUrl from "@nous-research/ui/assets/filler-bg0.webp";
-
 /**
- * Replicates the visual layer stack of `<Overlays dark />` from
- * `@nous-research/ui` without pulling in its leva / gsap / three peer deps.
+ * Minimal dashboard backdrop.
  *
- * See `design-language/src/ui/components/overlays/index.tsx` for the source of
- * truth. Defaults match LENS_0 (the Hermes teal dark preset); the deep canvas
- * and the warm vignette both read theme-switchable CSS custom properties so
- * `ThemeProvider` can repaint the stack without remounting.
- *
- *   z-1   bg = `var(--background-base)`, mix-blend-mode: difference
- *   z-2   bundled filler-bg WebP, inverted, opacity 0.033, difference
- *   z-99  warm top-left vignette (`var(--warm-glow)`), opacity 0.22, lighten
- *   z-101 noise grain (SVG, ~55% opacity × `--noise-opacity-mul`,
- *         color-dodge) — gated on GPU tier
- *
- * `useGpuTier` returns 0 when WebGL is unavailable, the renderer is a
- * software rasterizer (SwiftShader/llvmpipe), or the user has
- * `prefers-reduced-motion: reduce` set. We skip the animated noise layer
- * in that case so low-power / accessibility-conscious sessions stay crisp,
- * mirroring the DS `<Noise />` component's own opt-out.
+ * Keep the visual foundation intentionally plain: a single solid canvas from
+ * the active theme. This avoids image backgrounds, glow layers, and grain so
+ * dashboard content stays readable with the simple Arial/dark-text theme.
  */
 export function Backdrop() {
-  const gpuTier = useGpuTier();
-
   return (
-    <>
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[1]"
-        style={{
-          backgroundColor: "var(--background-base)",
-          mixBlendMode: "difference",
-        }}
-      />
-
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[2]"
-        style={
-          {
-            // Themes can override the filler background by setting
-            // `assets.bg` — the <img> hides itself when a CSS bg is set
-            // so the two don't double-darken. CSS var fallbacks keep the
-            // default behaviour unchanged when no theme customises these.
-            mixBlendMode:
-              "var(--component-backdrop-filler-blend-mode, difference)",
-            opacity: "var(--component-backdrop-filler-opacity, 0.033)",
-            backgroundImage: "var(--theme-asset-bg)",
-            backgroundSize: "var(--component-backdrop-background-size, cover)",
-            backgroundPosition:
-              "var(--component-backdrop-background-position, center)",
-          } as unknown as React.CSSProperties
-        }
-      >
-        <img
-          alt=""
-          className="h-[150dvh] w-auto min-w-[100dvw] object-cover object-top-left invert theme-default-filler"
-          fetchPriority="low"
-          src={fillerBgUrl}
-        />
-      </div>
-
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[99]"
-        style={{
-          background:
-            "radial-gradient(ellipse at 0% 0%, transparent 60%, var(--warm-glow) 100%)",
-          mixBlendMode: "lighten",
-          opacity: 0.22,
-        }}
-      />
-
-      {gpuTier > 0 && (
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 z-[101]"
-          style={{
-            backgroundImage:
-              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E\")",
-            backgroundSize: "512px 512px",
-            mixBlendMode: "color-dodge",
-            opacity: "calc(0.55 * var(--noise-opacity-mul, 1))",
-          }}
-        />
-      )}
-    </>
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[1]"
+      style={{ backgroundColor: "var(--background-base)" }}
+    />
   );
 }

--- a/web/src/components/SidebarFooter.tsx
+++ b/web/src/components/SidebarFooter.tsx
@@ -29,7 +29,6 @@ export function SidebarFooter({ status }: SidebarFooterProps) {
           "transition-opacity hover:opacity-90",
           "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
         )}
-        style={{ mixBlendMode: "plus-lighter" }}
       >
         {t.app.footer.org}
       </a>

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -88,7 +88,6 @@ export function PageHeaderProvider({
                       ? "shrink truncate"
                       : "truncate",
                 )}
-                style={{ mixBlendMode: "plus-lighter" }}
               >
                 {displayTitle}
               </h1>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -43,34 +43,31 @@
 }
 
 /* ------------------------------------------------------------------ */
-/* Hermes Agent — Nous DS with the LENS_0 (Hermes teal) lens applied   */
-/* statically. Mirrors nousnet-web/(hermes-agent)/layout.tsx so the    */
-/* canonical Hermes palette is the default — teal canvas + cream      */
-/* accent — without relying on leva/gsap at runtime.                  */
+/* Hermes Agent — simple light dashboard defaults. The ThemeProvider   */
+/* can still repaint these values, but a first load should be plain:   */
+/* no image backdrop, Arial, and dark text on a light canvas.          */
 /* ------------------------------------------------------------------ */
 
 :root {
-  /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
-     These are the defaults for the `default` (Hermes Teal) dashboard theme;
+  /* Defaults for the built-in `default` (Simple) dashboard theme;
      ThemeProvider rewrites them as inline styles when a user switches themes. */
   --foreground: color-mix(in srgb, #ffffff 0%, transparent);
   --foreground-base: #ffffff;
   --foreground-alpha: 0;
-  --midground: color-mix(in srgb, #ffe6cb 100%, transparent);
-  --midground-base: #ffe6cb;
+  --midground: color-mix(in srgb, #1f2937 100%, transparent);
+  --midground-base: #1f2937;
   --midground-alpha: 1;
-  --background: color-mix(in srgb, #041c1c 100%, transparent);
-  --background-base: #041c1c;
+  --background: color-mix(in srgb, #f7f7f7 100%, transparent);
+  --background-base: #f7f7f7;
   --background-alpha: 1;
 
   /* Consumed by <Backdrop />; also theme-switchable. */
-  --warm-glow: rgba(255, 189, 56, 0.35);
-  --noise-opacity-mul: 1;
+  --warm-glow: transparent;
+  --noise-opacity-mul: 0;
 
   /* Typography tokens — rewritten by ThemeProvider. Defaults match the
      system stack so themes that don't override look native. */
-  --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  --theme-font-sans: Arial, "Helvetica Neue", Helvetica, sans-serif;
   --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
     Consolas, monospace;
   --theme-font-display: var(--theme-font-sans);
@@ -88,7 +85,7 @@
 /* Theme tokens cascade into the document root so every descendant inherits
    the font stack, base size, and letter spacing without explicit calls. */
 html {
-  font-family: var(--theme-font-sans);
+  font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
   font-size: var(--theme-base-size);
   line-height: var(--theme-line-height);
   letter-spacing: var(--theme-letter-spacing);
@@ -98,7 +95,7 @@ html {
 }
 
 body {
-  font-family: var(--theme-font-sans);
+  font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
   min-height: 0;
   height: 100%;
   margin: 0;
@@ -151,34 +148,50 @@ code { font-size: 0.875rem; }
      stay visible — in LENS_0, `--foreground` itself has alpha 0. */
   --color-foreground: var(--midground);
 
-  --color-card: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  /* Simple readable text scale: dark primary copy with softer secondary
+     states. These names are used by existing `text-text-*` utility classes. */
+  --color-text-primary: var(--midground);
+  --color-text-secondary: color-mix(in srgb, var(--midground-base) 82%, transparent);
+  --color-text-tertiary: color-mix(in srgb, var(--midground-base) 64%, transparent);
+  --color-text-disabled: color-mix(in srgb, var(--midground-base) 42%, transparent);
+
+  --color-card: color-mix(in srgb, var(--midground-base) 3%, var(--background-base));
   --color-card-foreground: var(--midground);
   --color-primary: var(--midground);
   --color-primary-foreground: var(--background-base);
-  --color-secondary: color-mix(in srgb, var(--midground-base) 6%, var(--background-base));
+  --color-secondary: color-mix(in srgb, var(--midground-base) 5%, var(--background-base));
   --color-secondary-foreground: var(--midground);
-  --color-muted: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
+  --color-muted: color-mix(in srgb, var(--midground-base) 7%, var(--background-base));
   /* Routes the shadcn `muted-foreground` slot through the DS semantic
      text-secondary token (defaults to midground 80%) so legacy call
      sites that use `text-muted-foreground` get a readable color
      instead of the old 55%-transparent default. */
   --color-muted-foreground: var(--color-text-secondary);
-  --color-accent: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
+  --color-accent: color-mix(in srgb, var(--midground-base) 9%, var(--background-base));
   --color-accent-foreground: var(--midground);
   --color-destructive: #fb2c36;
   --color-destructive-foreground: #ffffff;
   --color-success: #4ade80;
   --color-warning: #ffbd38;
-  --color-border: color-mix(in srgb, var(--midground-base) 15%, transparent);
-  --color-input: color-mix(in srgb, var(--midground-base) 15%, transparent);
+  --color-border: color-mix(in srgb, var(--midground-base) 18%, transparent);
+  --color-input: color-mix(in srgb, var(--midground-base) 18%, transparent);
   --color-ring: var(--midground);
-  --color-popover: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-popover: color-mix(in srgb, var(--midground-base) 3%, var(--background-base));
   --color-popover-foreground: var(--midground);
 
   --radius-sm: calc(var(--theme-radius) - 4px);
   --radius-md: calc(var(--theme-radius) - 2px);
   --radius-lg: var(--theme-radius);
   --radius-xl: calc(var(--theme-radius) + 4px);
+}
+
+
+/* Force the dashboard chrome onto the simple sans stack. The Nous design
+   system provides stylized display utility classes; for this installation the
+   user wants plain Arial-style typography throughout the web UI. */
+.font-mondwest,
+.text-display {
+  font-family: Arial, "Helvetica Neue", Helvetica, sans-serif !important;
 }
 
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -15,9 +15,8 @@ import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
 // Shared typography / layout presets
 // ---------------------------------------------------------------------------
 
-/** Default system stack — neutral, safe fallback for every platform. */
-const SYSTEM_SANS =
-  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+/** Simple, broadly available stack for the default dashboard theme. */
+const SYSTEM_SANS = 'Arial, "Helvetica Neue", Helvetica, sans-serif';
 const SYSTEM_MONO =
   'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
 
@@ -40,14 +39,14 @@ const DEFAULT_LAYOUT: ThemeLayout = {
 
 export const defaultTheme: DashboardTheme = {
   name: "default",
-  label: "Hermes Teal",
-  description: "Classic dark teal — the canonical Hermes look",
+  label: "Simple",
+  description: "Plain light dashboard with Arial and dark text",
   palette: {
-    background: { hex: "#041c1c", alpha: 1 },
-    midground: { hex: "#ffe6cb", alpha: 1 },
+    background: { hex: "#f7f7f7", alpha: 1 },
+    midground: { hex: "#1f2937", alpha: 1 },
     foreground: { hex: "#ffffff", alpha: 0 },
-    warmGlow: "rgba(255, 189, 56, 0.35)",
-    noiseOpacity: 1,
+    warmGlow: "transparent",
+    noiseOpacity: 0,
   },
   typography: DEFAULT_TYPOGRAPHY,
   layout: DEFAULT_LAYOUT,
@@ -190,8 +189,8 @@ export const roseTheme: DashboardTheme = {
  */
 export const defaultLargeTheme: DashboardTheme = {
   name: "default-large",
-  label: "Hermes Teal (Large)",
-  description: "Hermes Teal with bigger fonts and roomier spacing",
+  label: "Simple (Large)",
+  description: "Simple light dashboard with bigger fonts and roomier spacing",
   palette: defaultTheme.palette,
   typography: {
     ...DEFAULT_TYPOGRAPHY,


### PR DESCRIPTION
## Summary
- replaces the default Hermes dashboard theme with a plain light “Simple” theme
- removes the image/grain/glow backdrop layers so the dashboard uses a solid canvas
- forces dashboard chrome onto Arial/Helvetica-style sans typography and dark text tokens
- updates backend theme labels/descriptions to match the new Simple defaults
- fixes embedded dashboard chat resume so it only follows real compression continuations instead of unrelated empty child sessions
- adds regression coverage for resumed sessions reopening as an empty chat screen

## Verification
- `npm run build` from `web/`
- restarted the live local dashboard on `127.0.0.1:9119`
- loaded `/sessions` in a real browser
- verified computed styles: Arial stack, `#f7f7f7` background, `#1f2937` text, zero background images
- verified browser console has no JS errors
- verified ngrok authenticated dashboard endpoint returns HTTP 200
- `venv/bin/python -m pytest -q -o addopts='' tests/hermes_cli/test_web_server_session_resume.py tests/hermes_state/test_resolve_resume_session_id.py tests/test_hermes_state.py::TestCompressionChainProjection`
- `venv/bin/python -m compileall -q hermes_cli/web_server.py tests/hermes_cli/test_web_server_session_resume.py && git diff --check`

## Notes
- The local venv does not have the configured `pytest-timeout` plugin, so the targeted pytest command was run with `-o addopts=''` to bypass the repository-level timeout addopts for local validation.
