### PR TITLE
fix(cli): widen shutown guards to BaseException so 2nd Ctrl+C does not leak traceback (fixes #39367)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -974,7 +974,7 @@ def _run_cleanup():
     try:
         from tools.mcp_tool import shutdown_mcp_servers
         shutdown_mcp_servers()
-    except Exception:
+    except BaseException:
         pass
     # Close cached auxiliary LLM clients (sync + async) so that
     # AsyncHttpxClientWrapper.__del__ doesn't fire on a closed event loop

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3800,7 +3800,7 @@ def shutdown_mcp_servers():
         if future is not None:
             try:
                 future.result(timeout=15)
-            except Exception as exc:
+            except BaseException as exc:
                 logger.debug("Error during MCP shutdown: %s", exc)
 
     _stop_mcp_loop()


### PR DESCRIPTION
Widen two shutdown guards from `except Exception` to `except BaseException` so a second Ctrl+C during MCP teardown does not leak a KeyboardInterrupt traceback. KeyboardInterrupt inherits from BaseException, not Exception, so the existing guards let it escape.

Closes #39367