### PR TITLE
fix: keep s6 gateway restart desired-up

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -683,6 +683,25 @@ class S6ServiceManager:
 
     # -- lifecycle ---------------------------------------------------------
 
+    def _clear_down_marker(self, service_dir: Path) -> None:
+        """Remove s6's static ``down`` marker before starts/restarts.
+
+        ``s6-svc -u`` flips the live supervise state to "want up", but
+        it does not remove a service directory's persistent ``down`` file.
+        If that marker is left behind, ``s6-svstat`` reports the process as
+        "up ... normally down" and a later restart can terminate the gateway
+        without bringing it back. Clearing the marker keeps CLI start/restart
+        semantics durable across the container lifetime.
+        """
+        try:
+            (service_dir / "down").unlink()
+        except FileNotFoundError:
+            pass
+
+    def is_normally_down(self, name: str) -> bool:
+        """True when the service directory contains s6's ``down`` marker."""
+        return (self.scandir / name / "down").exists()
+
     def _run_svc(self, action_flag: str, action_label: str, name: str) -> None:
         """Shared lifecycle dispatch for start / stop / restart.
 
@@ -715,6 +734,9 @@ class S6ServiceManager:
                 else name
             )
             raise GatewayNotRegisteredError(profile)
+
+        if action_label in {"start", "restart"}:
+            self._clear_down_marker(service_dir)
 
         try:
             subprocess.run(
@@ -749,13 +771,17 @@ class S6ServiceManager:
         self._run_svc("-d", "stop", name)
 
     def restart(self, name: str) -> None:
-        """Restart a registered service (``s6-svc -t`` = SIGTERM).
+        """Restart a registered service (``s6-svc -tu`` = TERM, then want up).
+
+        The explicit ``-u`` matters when the service was previously stopped or
+        still has a stale ``down`` marker: restart should converge to running,
+        not merely signal an already-down supervise slot.
 
         Raises:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason.
         """
-        self._run_svc("-t", "restart", name)
+        self._run_svc("-tu", "restart", name)
 
     def is_running(self, name: str) -> bool:
         """True iff ``s6-svstat`` reports the service as up."""

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -680,7 +680,44 @@ def test_s6_lifecycle_dispatches_to_s6_svc(
     mgr.restart("gateway-coder")
 
     flags = [c[1] for c in fake_subprocess_run if c[0] == "s6-svc"]
-    assert flags == ["-u", "-d", "-t"]
+    assert flags == ["-u", "-d", "-tu"]
+
+
+def test_s6_start_and_restart_clear_stale_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """Regression: `s6-svc -u` does not remove a service dir's static
+    `down` marker, leaving svstat at "up ... normally down" and making
+    later restarts shut the gateway down. CLI start/restart must clear it.
+    """
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    svc_dir = s6_scandir / "gateway-coder"
+    svc_dir.mkdir()
+    down = svc_dir / "down"
+
+    down.write_text("")
+    assert mgr.is_normally_down("gateway-coder") is True
+    mgr.start("gateway-coder")
+    assert not down.exists()
+    assert mgr.is_normally_down("gateway-coder") is False
+
+    down.write_text("")
+    mgr.restart("gateway-coder")
+    assert not down.exists()
+
+
+def test_s6_stop_preserves_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    svc_dir = s6_scandir / "gateway-coder"
+    svc_dir.mkdir()
+    down = svc_dir / "down"
+    down.write_text("")
+
+    mgr.stop("gateway-coder")
+
+    assert down.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clear stale s6 `down` marker before gateway start/restart
- make s6 restart use `-tu` so restart converges to desired-up
- add regression coverage for stale down markers and restart flags

## Test Plan
- `PYTHONPATH=/workspace/projects/hermes-agent-pr /opt/hermes/.venv/bin/python -m pytest tests/hermes_cli/test_service_manager.py tests/hermes_cli/test_gateway_s6_dispatch.py -q`
- `PYTHONPATH=/workspace/projects/hermes-agent-pr /opt/hermes/.venv/bin/python -m py_compile hermes_cli/service_manager.py tests/hermes_cli/test_service_manager.py`
