### PR TITLE
feat(tts): expose ElevenLabs generation options

### DIFF
--- a/tests/tools/test_tts_elevenlabs_options.py
+++ b/tests/tools/test_tts_elevenlabs_options.py
@@ -1,0 +1,489 @@
+"""ElevenLabs TTS configuration passthrough tests.
+
+Covers both request-building surfaces that must accept the same
+``tts.elevenlabs`` option shape:
+
+* the synchronous file-generation path (``tools.tts_tool._generate_elevenlabs``)
+* the live-streaming path (``tools.tts_streaming.ElevenLabsStreamer.stream``)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _voice_settings_value(voice_settings, key):
+    if isinstance(voice_settings, dict):
+        return voice_settings[key]
+    return getattr(voice_settings, key)
+
+
+# ── Synchronous file-generation path ─────────────────────────────────────
+
+
+class TestElevenLabsOptionsSync:
+    def test_default_config_keeps_request_shape_unchanged(self, tmp_path):
+        """No options set anywhere -> only the four managed kwargs are sent."""
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs("Hello", str(tmp_path / "out.mp3"), {})
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert set(kwargs) == {"text", "voice_id", "model_id", "output_format"}
+
+    def test_passes_language_voice_settings_and_convert_options(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "Hello",
+                str(tmp_path / "out.mp3"),
+                {
+                    "elevenlabs": {
+                        "voice_id": "voice-123",
+                        "model_id": "eleven_v3",
+                        "language_code": "en",
+                        "voice_settings": {
+                            "stability": 0.55,
+                            "similarity_boost": 0.8,
+                            "style": 0.25,
+                            "use_speaker_boost": False,
+                            "speed": 1.1,
+                        },
+                        "convert_options": {
+                            "seed": 1234,
+                            "previous_text": "Previous sentence.",
+                            "apply_text_normalization": "on",
+                        },
+                    }
+                },
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["text"] == "Hello"
+        assert kwargs["voice_id"] == "voice-123"
+        assert kwargs["model_id"] == "eleven_v3"
+        assert kwargs["language_code"] == "en"
+        assert kwargs["seed"] == 1234
+        assert kwargs["previous_text"] == "Previous sentence."
+        assert kwargs["apply_text_normalization"] == "on"
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.55
+        assert _voice_settings_value(kwargs["voice_settings"], "similarity_boost") == 0.8
+        assert _voice_settings_value(kwargs["voice_settings"], "style") == 0.25
+        assert _voice_settings_value(kwargs["voice_settings"], "use_speaker_boost") is False
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 1.1
+
+    def test_base_url_environment_coexists_with_convert_options(self, tmp_path):
+        from tools import tts_tool
+
+        environment = object()
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+        factory = MagicMock(return_value=mock_client)
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=factory), \
+             patch.object(
+                 tts_tool,
+                 "_elevenlabs_environment_kwargs",
+                 return_value={"environment": environment},
+             ) as environment_kwargs:
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {
+                    "elevenlabs": {
+                        "base_url": "https://el-proxy.example",
+                        "language_code": "en",
+                    }
+                },
+            )
+
+        environment_kwargs.assert_called_once_with(
+            {"base_url": "https://el-proxy.example", "language_code": "en"}
+        )
+        factory.assert_called_once_with(api_key="el-key", environment=environment)
+        assert mock_client.text_to_speech.convert.call_args.kwargs["language_code"] == "en"
+
+    def test_accepts_legacy_top_level_voice_settings_keys(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {
+                    "elevenlabs": {
+                        "stability": 0.4,
+                        "similarity_boost": 0.7,
+                        "style": 0.2,
+                        "use_speaker_boost": True,
+                        "speed": 0.95,
+                    }
+                },
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.4
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 0.95
+
+    def test_nested_voice_settings_wins_over_legacy_top_level_keys(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {
+                    "elevenlabs": {
+                        "stability": 0.1,
+                        "voice_settings": {"stability": 0.9},
+                    }
+                },
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.9
+
+    def test_options_alias_forwards_convert_options(self, tmp_path):
+        """``options`` remains a compatibility alias for ``convert_options``."""
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {"elevenlabs": {"options": {"seed": 99}}},
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["seed"] == 99
+
+    def test_uses_global_speed_fallback_when_provider_speed_is_absent(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {
+                    "speed": 1.2,
+                    "elevenlabs": {
+                        "voice_id": "voice-123",
+                        "voice_settings": {"stability": 0.4},
+                    },
+                },
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.4
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 1.2
+
+    def test_provider_speed_overrides_global_speed(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {
+                    "speed": 1.2,
+                    "elevenlabs": {
+                        "voice_id": "voice-123",
+                        "voice_settings": {"speed": 0.9},
+                    },
+                },
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 0.9
+
+    def test_rejects_unknown_convert_options_before_api_call(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            with pytest.raises(ValueError, match="Unknown ElevenLabs convert_options"):
+                tts_tool._generate_elevenlabs(
+                    "hi",
+                    str(tmp_path / "out.mp3"),
+                    {"elevenlabs": {"convert_options": {"not_a_real_option": True}}},
+                )
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_non_mapping_voice_settings_before_api_call(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            with pytest.raises(ValueError, match="voice_settings must be a mapping"):
+                tts_tool._generate_elevenlabs(
+                    "hi",
+                    str(tmp_path / "out.mp3"),
+                    {"elevenlabs": {"voice_settings": "fast"}},
+                )
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_non_mapping_convert_options_before_api_call(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            with pytest.raises(ValueError, match="convert_options must be a mapping"):
+                tts_tool._generate_elevenlabs(
+                    "hi",
+                    str(tmp_path / "out.mp3"),
+                    {"elevenlabs": {"convert_options": "seed=1234"}},
+                )
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_unknown_voice_settings_before_api_call(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            with pytest.raises(ValueError, match="Unknown ElevenLabs voice_settings"):
+                tts_tool._generate_elevenlabs(
+                    "hi",
+                    str(tmp_path / "out.mp3"),
+                    {"elevenlabs": {"voice_settings": {"not_a_real_setting": 1}}},
+                )
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_controlled_keys_in_convert_options_before_api_call(self, tmp_path):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            with pytest.raises(ValueError, match="Hermes-managed option"):
+                tts_tool._generate_elevenlabs(
+                    "hi",
+                    str(tmp_path / "out.mp3"),
+                    {
+                        "elevenlabs": {
+                            "convert_options": {"voice_id": "someone-elses-voice"},
+                        }
+                    },
+                )
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_uses_mapping_voice_settings_when_sdk_type_is_unavailable(self, tmp_path, monkeypatch):
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "elevenlabs":
+                raise ImportError("no VoiceSettings type")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        with patch.object(tts_tool, "get_env_value", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            tts_tool._generate_elevenlabs(
+                "hi",
+                str(tmp_path / "out.mp3"),
+                {"elevenlabs": {"voice_settings": {"stability": 0.5}}},
+            )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["voice_settings"] == {"stability": 0.5}
+
+
+# ── Live-streaming path ──────────────────────────────────────────────────
+
+
+class TestElevenLabsStreamerOptions:
+    """Direct coverage of ``ElevenLabsStreamer.stream`` — the provider-agnostic
+    streaming architecture introduced after the hard-coded ElevenLabs branch
+    was removed from ``stream_tts_to_speaker``.
+    """
+
+    def _stream(self, tts_config, section, text="Hello", mock_client=None):
+        from tools import tts_streaming as ts
+
+        if mock_client is None:
+            mock_client = MagicMock()
+            mock_client.text_to_speech.convert.return_value = iter([b"\x00\x00"])
+
+        with patch.object(ts, "get_env_value", lambda k, *a: "el-key" if k == "ELEVENLABS_API_KEY" else None), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            streamer = ts.ElevenLabsStreamer(tts_config, section)
+            list(streamer.stream(text))
+
+        return mock_client
+
+    def test_default_config_keeps_request_shape_unchanged(self):
+        mock_client = self._stream({}, {})
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert set(kwargs) == {"text", "voice_id", "model_id", "output_format"}
+        assert kwargs["output_format"] == "pcm_24000"
+
+    def test_forwards_language_voice_settings_and_convert_options(self):
+        mock_client = self._stream(
+            {"speed": 1.2},
+            {
+                "voice_id": "voice-123",
+                "streaming_model_id": "eleven_flash_v2_5",
+                "language_code": "en",
+                "voice_settings": {"stability": 0.5},
+                "convert_options": {"seed": 42},
+            },
+            text="Hello there",
+        )
+
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["text"] == "Hello there"
+        assert kwargs["voice_id"] == "voice-123"
+        assert kwargs["model_id"] == "eleven_flash_v2_5"
+        assert kwargs["output_format"] == "pcm_24000"
+        assert kwargs["language_code"] == "en"
+        assert kwargs["seed"] == 42
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.5
+        # No provider-specific speed was set -> global tts.speed fills in.
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 1.2
+
+    def test_base_url_environment_coexists_with_convert_options(self):
+        from tools import tts_streaming as ts
+        from tools import tts_tool
+
+        environment = object()
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"\x00\x00"])
+        factory = MagicMock(return_value=mock_client)
+
+        with patch.object(ts, "_resolve_key", return_value="el-key"), \
+             patch.object(tts_tool, "_import_elevenlabs", return_value=factory), \
+             patch.object(
+                 tts_tool,
+                 "_elevenlabs_environment_kwargs",
+                 return_value={"environment": environment},
+             ) as environment_kwargs:
+            streamer = ts.ElevenLabsStreamer(
+                {}, {"base_url": "https://el-proxy.example", "language_code": "en"}
+            )
+            list(streamer.stream("hi"))
+
+        environment_kwargs.assert_called_once_with(
+            {"base_url": "https://el-proxy.example", "language_code": "en"}
+        )
+        factory.assert_called_once_with(api_key="el-key", environment=environment)
+        assert mock_client.text_to_speech.convert.call_args.kwargs["language_code"] == "en"
+
+    def test_accepts_legacy_top_level_voice_settings_keys(self):
+        mock_client = self._stream({}, {"stability": 0.4, "speed": 0.8})
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "stability") == 0.4
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 0.8
+
+    def test_provider_speed_overrides_global_speed(self):
+        mock_client = self._stream(
+            {"speed": 1.2},
+            {"voice_settings": {"speed": 0.9}},
+        )
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert _voice_settings_value(kwargs["voice_settings"], "speed") == 0.9
+
+    def test_rejects_unknown_convert_options_before_api_call(self):
+        from tools import tts_streaming as ts
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"\x00\x00"])
+
+        with patch.object(ts, "get_env_value", lambda k, *a: "el-key" if k == "ELEVENLABS_API_KEY" else None), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            streamer = ts.ElevenLabsStreamer({}, {"convert_options": {"not_a_real_option": True}})
+            with pytest.raises(ValueError, match="Unknown ElevenLabs convert_options"):
+                list(streamer.stream("hi"))
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_controlled_keys_in_convert_options_before_api_call(self):
+        from tools import tts_streaming as ts
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"\x00\x00"])
+
+        with patch.object(ts, "get_env_value", lambda k, *a: "el-key" if k == "ELEVENLABS_API_KEY" else None), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            streamer = ts.ElevenLabsStreamer({}, {"convert_options": {"model_id": "not-allowed"}})
+            with pytest.raises(ValueError, match="Hermes-managed option"):
+                list(streamer.stream("hi"))
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_rejects_unknown_voice_settings_before_api_call(self):
+        from tools import tts_streaming as ts
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"\x00\x00"])
+
+        with patch.object(ts, "get_env_value", lambda k, *a: "el-key" if k == "ELEVENLABS_API_KEY" else None), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock(return_value=mock_client)):
+            streamer = ts.ElevenLabsStreamer({}, {"voice_settings": {"not_a_real_setting": 1}})
+            with pytest.raises(ValueError, match="Unknown ElevenLabs voice_settings"):
+                list(streamer.stream("hi"))
+
+        mock_client.text_to_speech.convert.assert_not_called()
+
+    def test_streaming_model_resolution_unaffected_by_options(self):
+        """model resolution order (streaming_model_id > model_id > default)
+        must survive the option-forwarding change untouched."""
+        mock_client = self._stream(
+            {},
+            {"model_id": "eleven_v3", "language_code": "de"},
+        )
+        kwargs = mock_client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["model_id"] == "eleven_v3"
+        assert kwargs["language_code"] == "de"

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -231,6 +231,7 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         from tools.tts_tool import (
             DEFAULT_ELEVENLABS_STREAMING_MODEL_ID,
             DEFAULT_ELEVENLABS_VOICE_ID,
+            _build_elevenlabs_convert_kwargs,
             _elevenlabs_environment_kwargs,
             _import_elevenlabs,
         )
@@ -244,12 +245,16 @@ class ElevenLabsStreamer(StreamingTTSProvider):
             "streaming_model_id",
             self.section.get("model_id", DEFAULT_ELEVENLABS_STREAMING_MODEL_ID),
         )
-        yield from client.text_to_speech.convert(
+        convert_kwargs = _build_elevenlabs_convert_kwargs(
             text=text,
             voice_id=voice_id,
             model_id=model_id,
             output_format="pcm_24000",
+            el_config=self.section,
+            tts_config=self.tts_config,
+            convert_method=client.text_to_speech.convert,
         )
+        yield from client.text_to_speech.convert(**convert_kwargs)
 
 
 def _openai_config_api_key() -> str:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -210,6 +210,41 @@ DEFAULT_EDGE_VOICE = "en-US-AriaNeural"
 DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
+
+ELEVENLABS_VOICE_SETTING_KEYS = frozenset({
+    "stability",
+    "similarity_boost",
+    "style",
+    "use_speaker_boost",
+    "speed",
+})
+
+ELEVENLABS_CONTROLLED_CONVERT_KEYS = frozenset({
+    "text",
+    "voice_id",
+    "model_id",
+    "output_format",
+    "language_code",
+    "voice_settings",
+})
+
+# Keyword-only parameters exposed by elevenlabs.client.ElevenLabs.text_to_speech.convert,
+# excluding values Hermes manages directly above.
+ELEVENLABS_KNOWN_CONVERT_OPTION_KEYS = frozenset({
+    "enable_logging",
+    "optimize_streaming_latency",
+    "pronunciation_dictionary_locators",
+    "seed",
+    "previous_text",
+    "next_text",
+    "previous_request_ids",
+    "next_request_ids",
+    "use_pvc_as_ivc",
+    "apply_text_normalization",
+    "apply_language_text_normalization",
+    "request_options",
+})
+
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 # The managed OpenAI audio gateway (Nous portal proxy) only proxies these speech
 # models. A user's tts.openai.model set for *direct* OpenAI (e.g. "tts-1-hd")
@@ -1398,6 +1433,190 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
 # ===========================================================================
 # Provider: ElevenLabs (premium)
 # ===========================================================================
+def _elevenlabs_allowed_voice_setting_keys(voice_settings_cls: Any = None) -> frozenset:
+    allowed = set(ELEVENLABS_VOICE_SETTING_KEYS)
+    if voice_settings_cls is None:
+        try:
+            from elevenlabs import VoiceSettings as voice_settings_cls
+        except Exception:
+            voice_settings_cls = None
+
+    if voice_settings_cls is not None:
+        fields = getattr(voice_settings_cls, "model_fields", None)
+        if isinstance(fields, dict):
+            allowed.update(fields)
+        # Pydantic v1 exposed __fields__; read it from __dict__ so Pydantic v2
+        # does not emit a deprecation warning through its descriptor.
+        legacy_fields = vars(voice_settings_cls).get("__fields__")
+        if isinstance(legacy_fields, dict):
+            allowed.update(legacy_fields)
+        annotations = getattr(voice_settings_cls, "__annotations__", None)
+        if isinstance(annotations, dict):
+            allowed.update(annotations)
+        try:
+            import inspect
+
+            signature = inspect.signature(voice_settings_cls)
+            for name, param in signature.parameters.items():
+                if param.kind in {
+                    inspect.Parameter.KEYWORD_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                }:
+                    allowed.add(name)
+        except Exception:
+            pass
+    allowed.discard("extra_data")
+    return frozenset(allowed)
+
+
+def _make_elevenlabs_voice_settings(
+    el_config: Dict[str, Any],
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Return an ElevenLabs VoiceSettings object/dict from config, if present.
+
+    Preferred shape::
+
+        tts.elevenlabs.voice_settings: {stability: 0.5, speed: 1.05}
+
+    For compatibility with existing user configs, the same keys are also
+    accepted directly under ``tts.elevenlabs`` when the nested block is
+    absent. If neither shape sets ``speed``, the global ``tts.speed`` value
+    is used as the ElevenLabs speed fallback, matching other TTS providers.
+    """
+    raw_settings = el_config.get("voice_settings")
+    if raw_settings is None:
+        raw_settings = {
+            key: el_config[key]
+            for key in ELEVENLABS_VOICE_SETTING_KEYS
+            if key in el_config
+        }
+
+    if (
+        isinstance(raw_settings, dict)
+        and "speed" not in raw_settings
+        and isinstance(tts_config, dict)
+    ):
+        global_speed = tts_config.get("speed")
+        if global_speed not in (None, ""):
+            raw_settings = {**raw_settings, "speed": global_speed}
+
+    if raw_settings in (None, {}):
+        return None
+    if not isinstance(raw_settings, dict):
+        raise ValueError("tts.elevenlabs.voice_settings must be a mapping")
+
+    try:
+        from elevenlabs import VoiceSettings
+    except Exception:
+        VoiceSettings = None
+
+    unknown = sorted(
+        set(raw_settings) - _elevenlabs_allowed_voice_setting_keys(VoiceSettings)
+    )
+    if unknown:
+        raise ValueError(
+            "Unknown ElevenLabs voice_settings option(s): " + ", ".join(unknown)
+        )
+
+    if VoiceSettings is None:
+        # Older SDKs may not expose VoiceSettings. The generated client has
+        # historically accepted plain mapping payloads too, so keep working
+        # rather than dropping the user's explicit settings.
+        return dict(raw_settings)
+    return VoiceSettings(**raw_settings)
+
+
+def _elevenlabs_allowed_convert_options(convert_method: Any = None) -> frozenset:
+    allowed = set(ELEVENLABS_KNOWN_CONVERT_OPTION_KEYS)
+    if convert_method is not None:
+        try:
+            import inspect
+
+            signature = inspect.signature(convert_method)
+            for name, param in signature.parameters.items():
+                if param.kind in {
+                    inspect.Parameter.KEYWORD_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                }:
+                    allowed.add(name)
+        except Exception:
+            pass
+    allowed.difference_update(ELEVENLABS_CONTROLLED_CONVERT_KEYS)
+    return frozenset(allowed)
+
+
+def _elevenlabs_convert_options(
+    el_config: Dict[str, Any],
+    convert_method: Any = None,
+) -> Dict[str, Any]:
+    """Return validated extra kwargs for ElevenLabs ``convert``.
+
+    Users may set ``tts.elevenlabs.convert_options`` (``options`` is accepted
+    as a short alias) for less-common SDK parameters such as ``seed``,
+    context text, text normalization, or pronunciation dictionaries.
+    Hermes-managed fields stay top-level so output routing and voice/model
+    selection remain predictable.
+    """
+    raw_options = el_config.get("convert_options", el_config.get("options", {}))
+    if raw_options in (None, {}):
+        return {}
+    if not isinstance(raw_options, dict):
+        raise ValueError("tts.elevenlabs.convert_options must be a mapping")
+
+    controlled = sorted(set(raw_options) & ELEVENLABS_CONTROLLED_CONVERT_KEYS)
+    if controlled:
+        raise ValueError(
+            "ElevenLabs convert_options cannot override Hermes-managed option(s): "
+            + ", ".join(controlled)
+        )
+
+    allowed = _elevenlabs_allowed_convert_options(convert_method)
+    unknown = sorted(set(raw_options) - allowed)
+    if unknown:
+        raise ValueError(
+            "Unknown ElevenLabs convert_options option(s): " + ", ".join(unknown)
+        )
+
+    return dict(raw_options)
+
+
+def _build_elevenlabs_convert_kwargs(
+    *,
+    text: str,
+    voice_id: str,
+    model_id: str,
+    output_format: str,
+    el_config: Dict[str, Any],
+    tts_config: Optional[Dict[str, Any]] = None,
+    convert_method: Any = None,
+) -> Dict[str, Any]:
+    """Build kwargs for ``client.text_to_speech.convert()``.
+
+    Shared by the synchronous file-generation path (``_generate_elevenlabs``)
+    and the live-streaming path (``tools.tts_streaming.ElevenLabsStreamer``)
+    so both surfaces accept the same ``tts.elevenlabs`` option shape. All
+    validation happens here, before any SDK call is made.
+    """
+    kwargs = _elevenlabs_convert_options(el_config, convert_method)
+    kwargs.update(
+        text=text,
+        voice_id=voice_id,
+        model_id=model_id,
+        output_format=output_format,
+    )
+
+    language_code = el_config.get("language_code")
+    if isinstance(language_code, str) and language_code.strip():
+        kwargs["language_code"] = language_code.strip()
+
+    voice_settings = _make_elevenlabs_voice_settings(el_config, tts_config)
+    if voice_settings is not None:
+        kwargs["voice_settings"] = voice_settings
+
+    return kwargs
+
+
 def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """
     Generate audio using ElevenLabs.
@@ -1426,12 +1645,16 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
 
     ElevenLabs = _import_elevenlabs()
     client = ElevenLabs(api_key=api_key, **_elevenlabs_environment_kwargs(el_config))
-    audio_generator = client.text_to_speech.convert(
+    convert_kwargs = _build_elevenlabs_convert_kwargs(
         text=text,
         voice_id=voice_id,
         model_id=model_id,
         output_format=output_format,
+        el_config=el_config,
+        tts_config=tts_config,
+        convert_method=client.text_to_speech.convert,
     )
+    audio_generator = client.text_to_speech.convert(**convert_kwargs)
 
     # audio_generator yields chunks -- write them all
     with open(output_path, "wb") as f:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1596,6 +1596,18 @@ tts:
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"
     model_id: "eleven_multilingual_v2"
+    language_code: "en"          # Optional; e.g. "pl" with multilingual/v3 models
+    voice_settings:              # Optional ElevenLabs VoiceSettings
+      stability: 0.5
+      similarity_boost: 0.75
+      style: 0.0
+      use_speaker_boost: true
+      speed: 1.0                 # Overrides global tts.speed for ElevenLabs
+    convert_options:             # Optional extra text_to_speech.convert kwargs
+      seed: 1234
+      previous_text: "Optional preceding context."
+      next_text: "Optional following context."
+      apply_text_normalization: "auto"
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
@@ -1624,6 +1636,11 @@ tts:
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
 ```
+
+For ElevenLabs, nested `voice_settings` takes precedence over the legacy
+top-level voice-setting keys. `voice_settings.speed` takes precedence over
+global `tts.speed`, which is used as a fallback. The older `options` key remains
+accepted as an alias for `convert_options`.
 
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -52,6 +52,18 @@ tts:
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"  # Adam
     model_id: "eleven_multilingual_v2"
+    language_code: "en"          # Optional; e.g. "pl" with multilingual/v3 models
+    voice_settings:              # Optional ElevenLabs VoiceSettings
+      stability: 0.5
+      similarity_boost: 0.75
+      style: 0.0
+      use_speaker_boost: true
+      speed: 1.0                 # Overrides global tts.speed for ElevenLabs
+    convert_options:             # Optional extra text_to_speech.convert kwargs
+      seed: 1234
+      previous_text: "Optional preceding context."
+      next_text: "Optional following context."
+      apply_text_normalization: "auto"
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
@@ -111,6 +123,11 @@ MiniMax TTS selects its region, endpoint, and credential together:
 - `region: "cn"` uses `https://api.minimaxi.com/v1/t2a_v2` with `MINIMAX_CN_API_KEY`.
 - If `region` is omitted, `MINIMAX_API_KEY` keeps precedence for backward compatibility. If only `MINIMAX_CN_API_KEY` is configured, Hermes selects `cn`.
 - An explicitly selected region must have its matching credential. Hermes never borrows the other region's key. A `base_url` override does not change the selected credential, and an override pointing at the other region's official endpoint is rejected.
+
+For ElevenLabs, nested `voice_settings` takes precedence over the legacy
+top-level voice-setting keys. `voice_settings.speed` takes precedence over
+global `tts.speed`, which is used as a fallback. The older `options` key remains
+accepted as an alias for `convert_options`.
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -440,6 +440,18 @@ tts:
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"    # Adam
     model_id: "eleven_multilingual_v2"
+    language_code: "en"                 # Optional; e.g. "pl" with multilingual/v3 models
+    voice_settings:                     # Optional ElevenLabs VoiceSettings
+      stability: 0.5
+      similarity_boost: 0.75
+      style: 0.0
+      use_speaker_boost: true
+      speed: 1.0                        # Overrides global tts.speed for ElevenLabs
+    convert_options:                    # Optional extra text_to_speech.convert kwargs
+      seed: 1234
+      previous_text: "Optional preceding context."
+      next_text: "Optional following context."
+      apply_text_normalization: "auto"
   openai:
     model: "gpt-4o-mini-tts"
     voice: "alloy"                 # alloy, echo, fable, onyx, nova, shimmer
@@ -455,6 +467,11 @@ tts:
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
 ```
+
+For ElevenLabs, nested `voice_settings` takes precedence over the legacy
+top-level voice-setting keys. `voice_settings.speed` takes precedence over
+global `tts.speed`, which is used as a fallback. The older `options` key remains
+accepted as an alias for `convert_options`.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary

Expose ElevenLabs generation options through `tts.elevenlabs` config, with identical behavior in synchronous file generation and live streaming:

- Adds `language_code` passthrough.
- Adds nested `voice_settings` support for `stability`, `similarity_boost`, `style`, `use_speaker_boost`, and `speed`.
- Uses global `tts.speed` as the ElevenLabs speed fallback when no provider-specific speed is configured.
- Keeps compatibility with the top-level voice-setting keys proposed in #32571.
- Adds validated `convert_options` passthrough for supported ElevenLabs `text_to_speech.convert()` kwargs such as `seed`, context text, previous/next request IDs, pronunciation dictionaries, and text-normalization controls.
- Prevents `convert_options` from overriding Hermes-controlled request fields.
- Documents the config shape and precedence in the TTS, voice-mode, and configuration docs.

This is intended as a broader, tested version of #32571 and also covers the ElevenLabs `speed` configuration requested in #17789 for the native provider path.

## Related Issue

Fixes #17789

Related implementations: #32571 and #43980.

## Current-main integration

The branch is based on current `main` and follows the provider-agnostic streaming architecture introduced by #69511:

- `_generate_elevenlabs()` uses the shared request-option builder for synchronous output.
- `ElevenLabsStreamer.stream()` uses the same builder while retaining `pcm_24000` and streaming-model resolution.
- Both paths preserve current-main support for configurable ElevenLabs `base_url` / `wss_url` while applying the PR's request options.
- The obsolete hard-coded ElevenLabs branch in `stream_tts_to_speaker()` is not restored.

This resolves the earlier review feedback that live voice streaming must receive the same options as file generation.

## Why

Hermes currently limits native ElevenLabs requests to `text`, `voice_id`, `model_id`, and `output_format`. Users therefore cannot tune voice generation or use newer ElevenLabs model features without modifying the provider implementation locally.

## Config example

```yaml
tts:
  provider: elevenlabs
  speed: 1.05  # optional global fallback
  elevenlabs:
    voice_id: "pNInz6obpgDQGcFmaJgB"
    model_id: "eleven_v3"
    language_code: "pl"
    voice_settings:
      stability: 0.5
      similarity_boost: 0.75
      style: 0.2
      use_speaker_boost: true
      speed: 1.05  # provider-specific override
    convert_options:
      seed: 1234
      previous_text: "Optional preceding context."
      next_text: "Optional following context."
      apply_text_normalization: "auto"
```

Nested `voice_settings` takes precedence over compatibility top-level keys. `voice_settings.speed` takes precedence over global `tts.speed`, which remains the fallback.

## Validation

- [x] `python -m pytest -q tests/tools/test_tts_elevenlabs_options.py tests/tools/test_tts_provider_base_urls.py` — **25 passed**
- [x] `python -m pytest -q tests/tools/test_tts*.py` — **243 passed, 2 skipped**
- [x] `ruff check tools/tts_tool.py tools/tts_streaming.py tests/tools/test_tts_elevenlabs_options.py tests/tools/test_tts_provider_base_urls.py`
- [x] `python -m py_compile tools/tts_tool.py tools/tts_streaming.py tests/tools/test_tts_elevenlabs_options.py tests/tools/test_tts_provider_base_urls.py`
- [x] `git diff --check origin/main...HEAD`

The regression tests cover both request surfaces, coexistence with configurable ElevenLabs `base_url` / `wss_url`, default request-shape preservation, option precedence, compatibility keys, controlled-key rejection, and validation before the SDK call.

