### PR TITLE
feat(cron): add session_retention_days config to auto-prune old cron sessions (#38378)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -478,6 +478,7 @@ def _prune_cron_sessions_from_config() -> None:
             removed = _session_db.prune_sessions(
                 older_than_days=retention_days,
                 source="cron",
+                sessions_dir=_get_hermes_home() / "sessions",
             )
             if removed:
                 logger.info(
@@ -489,6 +490,16 @@ def _prune_cron_sessions_from_config() -> None:
             _session_db.close()
     except Exception as exc:
         logger.warning("Cron session retention cleanup failed: %s", exc)
+
+
+def _run_post_run_maintenance() -> None:
+    """Run best-effort cleanup after a scheduler-owned run boundary."""
+    try:
+        from tools.mcp_tool import _kill_orphaned_mcp_children
+        _kill_orphaned_mcp_children()
+    except Exception as exc:
+        logger.debug("Post-run MCP orphan cleanup failed: %s", exc)
+    _prune_cron_sessions_from_config()
 
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
@@ -3461,6 +3472,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         if verbose and not due_jobs:
             logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            _run_post_run_maintenance()
             return 0
 
         if verbose:
@@ -3599,29 +3611,16 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 if not sync:
                     _results.append(True)  # optimistically counted
 
-        # Best-effort sweep of MCP stdio subprocesses that survived their
-        # session teardown.  Must run AFTER jobs finish so active sessions
-        # (including live user chats) are never touched — only PIDs explicitly
-        # detected as orphans in tools.mcp_tool._run_stdio's finally block are
-        # reaped.
-        def _sweep_mcp_orphans() -> None:
-            try:
-                from tools.mcp_tool import _kill_orphaned_mcp_children
-                _kill_orphaned_mcp_children()
-            except Exception as _e:
-                logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
-
         if sync:
             # Sync mode (tests / manual ticks): wait for all dispatched jobs,
-            # collect results, then sweep once.
+            # collect results, then run maintenance once.
             for f in concurrent.futures.as_completed(_all_futures):
                 try:
                     _results.append(f.result())
                 except Exception as exc:
                     logger.error("Cron job future failed: %s", exc)
                     _results.append(False)
-            _sweep_mcp_orphans()
-            _prune_cron_sessions_from_config()
+            _run_post_run_maintenance()
             return sum(_results)
 
         # Async (gateway ticker) mode: don't block.  Sweep orphans via a
@@ -3639,15 +3638,13 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 except Exception:
                     pass
                 if _remaining[0] <= 0:
-                    _sweep_mcp_orphans()
-                    _prune_cron_sessions_from_config()
+                    _run_post_run_maintenance()
 
             for _f in _all_futures:
                 _f.add_done_callback(_on_done)
         else:
-            # Nothing dispatched (all skipped / no due jobs) — sweep inline.
-            _sweep_mcp_orphans()
-            _prune_cron_sessions_from_config()
+            # Nothing dispatched (all skipped / no due jobs) — maintain inline.
+            _run_post_run_maintenance()
 
         return sum(_results)
     finally:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -462,6 +462,98 @@ def _get_lock_paths() -> tuple[Path, Path]:
     return lock_dir, lock_dir / ".tick.lock"
 
 
+def _prune_cron_sessions_from_config() -> None:
+    """Apply config-driven retention for completed cron sessions."""
+    try:
+        _cfg = load_config() or {}
+        _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
+        retention_days = int(_cron_cfg.get("session_retention_days") or 0)
+        if retention_days <= 0:
+            return
+
+        from hermes_state import SessionDB
+
+        _session_db = SessionDB()
+        try:
+            removed = _session_db.prune_sessions(
+                older_than_days=retention_days,
+                source="cron",
+            )
+            if removed:
+                logger.info(
+                    "Pruned %d cron session(s) older than %d day(s)",
+                    removed,
+                    retention_days,
+                )
+        finally:
+            _session_db.close()
+    except Exception as exc:
+        logger.warning("Cron session retention cleanup failed: %s", exc)
+
+
+@contextmanager
+def _job_profile_context(job_id: str, profile: Optional[str]):
+    """Temporarily run a job under a specific Hermes profile.
+
+    Cron jobs are stored and scheduled by the profile running the scheduler, but
+    an individual job can opt into a different runtime profile. While active,
+    the scheduler's test/override hook and a context-local Hermes home override
+    both point at the resolved profile directory so _get_hermes_home(),
+    .env/config loading, script resolution, AIAgent construction, and downstream
+    get_hermes_home() callers agree on the same home.
+
+    Some existing provider/config paths still load profile .env values through
+    os.environ, so profile jobs also snapshot and restore the process
+    environment on exit. tick() runs profile jobs sequentially to keep that
+    temporary mutation isolated from other scheduled jobs.
+    """
+    raw_profile = str(profile or "").strip()
+    if not raw_profile:
+        yield None
+        return
+
+    global _hermes_home
+    prior_override = _hermes_home
+    env_snapshot = os.environ.copy()
+
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    normalized_profile = normalize_profile_name(raw_profile)
+    try:
+        profile_home = Path(resolve_profile_env(normalized_profile)).resolve()
+    except (FileNotFoundError, ValueError) as exc:
+        logger.warning(
+            "Job '%s': configured profile %r no longer valid (%s) — "
+            "falling back to scheduler default",
+            job_id, raw_profile, exc,
+        )
+        yield None
+        return
+
+    override_token = None
+    try:
+        override_token = set_hermes_home_override(profile_home)
+        _hermes_home = profile_home
+        logger.info(
+            "Job '%s': using Hermes profile '%s' (%s)",
+            job_id,
+            normalized_profile,
+            profile_home,
+        )
+        yield normalized_profile
+    finally:
+        _hermes_home = prior_override
+        if override_token is not None:
+            reset_hermes_home_override(override_token)
+        # Delta-based restore: remove added keys, restore changed keys.
+        # Avoids a brief window where other threads see an empty env.
+        added = set(os.environ.keys()) - set(env_snapshot.keys())
+        for k in added:
+            os.environ.pop(k, None)
+        for k, v in env_snapshot.items():
+            if os.environ.get(k) != v:
+                os.environ[k] = v
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
 
@@ -3593,6 +3685,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     logger.error("Cron job future failed: %s", exc)
                     _results.append(False)
             _sweep_mcp_orphans()
+            _prune_cron_sessions_from_config()
             return sum(_results)
 
         # Async (gateway ticker) mode: don't block.  Sweep orphans via a
@@ -3611,12 +3704,14 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     pass
                 if _remaining[0] <= 0:
                     _sweep_mcp_orphans()
+                    _prune_cron_sessions_from_config()
 
             for _f in _all_futures:
                 _f.add_done_callback(_on_done)
         else:
             # Nothing dispatched (all skipped / no due jobs) — sweep inline.
             _sweep_mcp_orphans()
+            _prune_cron_sessions_from_config()
 
         return sum(_results)
     finally:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,7 +12,6 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
-from contextlib import contextmanager
 import json
 import logging
 import os
@@ -491,70 +490,6 @@ def _prune_cron_sessions_from_config() -> None:
     except Exception as exc:
         logger.warning("Cron session retention cleanup failed: %s", exc)
 
-
-@contextmanager
-def _job_profile_context(job_id: str, profile: Optional[str]):
-    """Temporarily run a job under a specific Hermes profile.
-
-    Cron jobs are stored and scheduled by the profile running the scheduler, but
-    an individual job can opt into a different runtime profile. While active,
-    the scheduler's test/override hook and a context-local Hermes home override
-    both point at the resolved profile directory so _get_hermes_home(),
-    .env/config loading, script resolution, AIAgent construction, and downstream
-    get_hermes_home() callers agree on the same home.
-
-    Some existing provider/config paths still load profile .env values through
-    os.environ, so profile jobs also snapshot and restore the process
-    environment on exit. tick() runs profile jobs sequentially to keep that
-    temporary mutation isolated from other scheduled jobs.
-    """
-    raw_profile = str(profile or "").strip()
-    if not raw_profile:
-        yield None
-        return
-
-    global _hermes_home
-    prior_override = _hermes_home
-    env_snapshot = os.environ.copy()
-
-    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
-    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
-
-    normalized_profile = normalize_profile_name(raw_profile)
-    try:
-        profile_home = Path(resolve_profile_env(normalized_profile)).resolve()
-    except (FileNotFoundError, ValueError) as exc:
-        logger.warning(
-            "Job '%s': configured profile %r no longer valid (%s) — "
-            "falling back to scheduler default",
-            job_id, raw_profile, exc,
-        )
-        yield None
-        return
-
-    override_token = None
-    try:
-        override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
-        logger.info(
-            "Job '%s': using Hermes profile '%s' (%s)",
-            job_id,
-            normalized_profile,
-            profile_home,
-        )
-        yield normalized_profile
-    finally:
-        _hermes_home = prior_override
-        if override_token is not None:
-            reset_hermes_home_override(override_token)
-        # Delta-based restore: remove added keys, restore changed keys.
-        # Avoids a brief window where other threads see an empty env.
-        added = set(os.environ.keys()) - set(env_snapshot.keys())
-        for k in added:
-            os.environ.pop(k, None)
-        for k, v in env_snapshot.items():
-            if os.environ.get(k) != v:
-                os.environ[k] = v
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+from contextlib import contextmanager
 import json
 import logging
 import os

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -95,14 +95,17 @@ class CronScheduler(ABC):
         was lost (another machine/retry won it) or the job no longer exists.
         """
         from cron.jobs import claim_job_for_fire, get_job
-        from cron.scheduler import run_one_job
+        from cron.scheduler import _run_post_run_maintenance, run_one_job
 
         if not claim_job_for_fire(job_id):
             return False  # another machine already claimed this fire
         job = get_job(job_id)
         if job is None:
             return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        return run_one_job(job, adapters=adapters, loop=loop)
+        try:
+            return run_one_job(job, adapters=adapters, loop=loop)
+        finally:
+            _run_post_run_maintenance()
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2602,6 +2602,8 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Delete ended cron sessions older than this many days.  0 disables.
+        "session_retention_days": 0,
         # Per-job output-file retention: save_job_output keeps the N most
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -338,12 +338,15 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
+    maintained = []
     monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
     monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: maintained.append(True))
 
     assert InProcessCronScheduler().fire_due("j1") is True
     assert ran == ["j1"]
+    assert maintained == [True]
 
 
 def test_fire_due_lost_claim_does_not_run(monkeypatch):
@@ -354,11 +357,14 @@ def test_fire_due_lost_claim_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
+    maintained = []
     monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: False, raising=False)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: maintained.append(True))
 
     assert InProcessCronScheduler().fire_due("j1") is False
     assert ran == []
+    assert maintained == []
 
 
 def test_fire_due_missing_job_does_not_run(monkeypatch):
@@ -369,12 +375,15 @@ def test_fire_due_missing_job_does_not_run(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
+    maintained = []
     monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
     monkeypatch.setattr(jobs, "get_job", lambda jid: None)
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: maintained.append(True))
 
     assert InProcessCronScheduler().fire_due("gone") is False
     assert ran == []
+    assert maintained == []
 
 
 # ── F2a: ticker liveness — survival, heartbeat, honest status (#32612, #32895) ──

--- a/tests/cron/test_session_retention.py
+++ b/tests/cron/test_session_retention.py
@@ -1,0 +1,74 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_tick_state(tmp_path, monkeypatch):
+    import cron.scheduler as sched
+
+    sched._shutdown_parallel_pool()
+    sched._running_job_ids.clear()
+
+    lock_dir = tmp_path / "cron"
+    lock_dir.mkdir()
+    lock_file = lock_dir / ".tick.lock"
+    monkeypatch.setattr(sched, "_get_lock_paths", lambda: (lock_dir, lock_file))
+
+    yield sched
+
+    sched._running_job_ids.clear()
+    sched._shutdown_parallel_pool()
+
+
+def _run_tick_with_retention(monkeypatch, retention_days):
+    import cron.scheduler as sched
+
+    job = {"id": "retention-job", "name": "Retention", "deliver": "local"}
+
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "run_job", lambda _job: (True, "output", "response", None))
+    monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        sched,
+        "load_config",
+        lambda: {"cron": {"session_retention_days": retention_days}},
+    )
+
+    fake_db = MagicMock()
+    fake_db.prune_sessions.return_value = 3
+    with patch("hermes_state.SessionDB", return_value=fake_db) as session_db_cls:
+        result = sched.tick(verbose=False)
+
+    return result, session_db_cls, fake_db
+
+
+def test_session_retention_prunes_old_cron_sessions(monkeypatch):
+    result, session_db_cls, fake_db = _run_tick_with_retention(monkeypatch, 7)
+
+    assert result == 1
+    session_db_cls.assert_called_once_with()
+    fake_db.prune_sessions.assert_called_once_with(
+        older_than_days=7,
+        source="cron",
+    )
+    fake_db.close.assert_called_once_with()
+
+
+def test_session_retention_zero_skips_prune(monkeypatch):
+    result, session_db_cls, fake_db = _run_tick_with_retention(monkeypatch, 0)
+
+    assert result == 1
+    session_db_cls.assert_not_called()
+    fake_db.prune_sessions.assert_not_called()
+    fake_db.close.assert_not_called()
+
+
+def test_session_retention_only_affects_cron_sessions(monkeypatch):
+    _result, _session_db_cls, fake_db = _run_tick_with_retention(monkeypatch, 14)
+
+    assert fake_db.prune_sessions.call_args.kwargs["source"] == "cron"
+

--- a/tests/cron/test_session_retention.py
+++ b/tests/cron/test_session_retention.py
@@ -1,3 +1,5 @@
+import concurrent.futures
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -56,6 +58,8 @@ def _run_tick_with_retention(monkeypatch, retention_days):
 
 
 def test_session_retention_prunes_old_cron_sessions(monkeypatch):
+    import cron.scheduler as sched
+
     result, session_db_cls, fake_db = _run_tick_with_retention(monkeypatch, 7)
 
     assert result == 1
@@ -63,6 +67,7 @@ def test_session_retention_prunes_old_cron_sessions(monkeypatch):
     fake_db.prune_sessions.assert_called_once_with(
         older_than_days=7,
         source="cron",
+        sessions_dir=sched._get_hermes_home() / "sessions",
     )
     fake_db.close.assert_called_once_with()
 
@@ -76,8 +81,102 @@ def test_session_retention_zero_skips_prune(monkeypatch):
     fake_db.close.assert_not_called()
 
 
+def test_session_retention_default_is_disabled():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["session_retention_days"] == 0
+
+
 def test_session_retention_only_affects_cron_sessions(monkeypatch):
     _result, _session_db_cls, fake_db = _run_tick_with_retention(monkeypatch, 14)
 
     assert fake_db.prune_sessions.call_args.kwargs["source"] == "cron"
+
+
+def test_session_retention_removes_cron_artifacts_but_preserves_users_and_active(tmp_path, monkeypatch):
+    import hermes_state
+    import cron.scheduler as sched
+
+    home = tmp_path / "profile"
+    sessions_dir = home / "sessions"
+    sessions_dir.mkdir(parents=True)
+    db_path = home / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    old_cron = db.create_session("old-cron", source="cron")
+    old_user = db.create_session("old-user", source="cli")
+    active = db.create_session("active-cron", source="cron")
+    db.end_session(old_cron, "completed")
+    db.end_session(old_user, "completed")
+    with db._lock:
+        old = time.time() - 10 * 86400
+        db._conn.execute("UPDATE sessions SET started_at = ? WHERE id IN (?, ?)", (old, old_cron, old_user))
+        db._conn.commit()
+    db.close()
+
+    for suffix in (".json", ".jsonl"):
+        (sessions_dir / f"{old_cron}{suffix}").write_text("artifact")
+    (sessions_dir / f"request_dump_{old_cron}_1.json").write_text("artifact")
+
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: home)
+    monkeypatch.setattr(sched, "load_config", lambda: {"cron": {"session_retention_days": 7}})
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    sched._prune_cron_sessions_from_config()
+
+    db = hermes_state.SessionDB(db_path=db_path)
+    assert db.get_session(old_cron) is None
+    assert db.get_session(old_user) is not None
+    assert db.get_session(active) is not None
+    db.close()
+    assert not list(sessions_dir.glob(f"{old_cron}*"))
+    assert not list(sessions_dir.glob(f"request_dump_{old_cron}_*.json"))
+
+
+def test_tick_runs_post_run_maintenance_once_for_empty_batch(monkeypatch):
+    import cron.scheduler as sched
+
+    calls = []
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [])
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: calls.append(1))
+
+    assert sched.tick(verbose=True) == 0
+    assert calls == [1]
+
+
+def test_sync_tick_runs_post_run_maintenance_once_for_batch(monkeypatch):
+    import cron.scheduler as sched
+
+    calls = []
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [{"id": "a"}, {"id": "b"}])
+    monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: True)
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: calls.append(1))
+
+    assert sched.tick(verbose=False) == 2
+    assert calls == [1]
+
+
+def test_async_tick_runs_post_run_maintenance_after_last_future(monkeypatch):
+    import cron.scheduler as sched
+
+    futures = []
+    calls = []
+
+    class Pool:
+        def submit(self, fn):
+            future = concurrent.futures.Future()
+            futures.append((future, fn))
+            return future
+
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [{"id": "a"}, {"id": "b"}])
+    monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "_get_parallel_pool", lambda *_a, **_kw: Pool())
+    monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: True)
+    monkeypatch.setattr(sched, "_run_post_run_maintenance", lambda: calls.append(1))
+
+    assert sched.tick(verbose=False, sync=False) == 2
+    assert calls == []
+    futures[0][0].set_result(True)
+    assert calls == []
+    futures[1][0].set_result(True)
+    assert calls == [1]
 

--- a/tests/cron/test_session_retention.py
+++ b/tests/cron/test_session_retention.py
@@ -28,7 +28,16 @@ def _run_tick_with_retention(monkeypatch, retention_days):
 
     monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
     monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
-    monkeypatch.setattr(sched, "run_job", lambda _job: (True, "output", "response", None))
+    monkeypatch.setattr(
+        sched,
+        "run_job",
+        lambda _job, *, defer_agent_teardown=None: (
+            True,
+            "output",
+            "response",
+            None,
+        ),
+    )
     monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
     monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
     monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -225,6 +225,17 @@ On each tick Hermes:
 
 A file lock at `~/.hermes/cron/.tick.lock` prevents overlapping scheduler ticks from double-running the same job batch.
 
+### Session retention
+
+Cron session retention is disabled by default. To delete ended cron sessions older than a configured age, set:
+
+```yaml
+cron:
+  session_retention_days: 30
+```
+
+Set `session_retention_days` to `0` to disable cleanup. Positive values remove matching ended cron sessions from the active profile's database and `sessions` artifact directory. User sessions and active sessions are untouched.
+
 ## Delivery options
 
 When scheduling jobs, you specify where the output goes:


### PR DESCRIPTION
## Summary

Cron jobs can accumulate thousands of old session rows and matching session artifacts over time, especially when jobs deliver output through chat platforms where the historical session list is not useful. The published PR head added retention inside `tick()`, but it missed the external `fire_due()` path, pruned database rows without passing the active profile's `sessions` directory, and never surfaced the setting through `DEFAULT_CONFIG` or the cron user guide. This rework moves retention onto one shared post-run maintenance path for scheduler-owned runs, keeps it best-effort, passes the profile-scoped sessions directory so matching artifacts are deleted with the rows, adds the default-off config entry, and documents the setting.

## Changes

- `cron/scheduler.py`: +45, -17
  - passes the active profile `sessions` directory into `prune_sessions()`
  - extracts shared post-run maintenance so sync ticks, async ticks, and empty batches each sweep once
- `cron/scheduler_provider.py`: +5, -2
  - runs the shared maintenance path after a claimed `fire_due()` run
- `hermes_cli/config.py`: +2
  - adds `cron.session_retention_days: 0` to `DEFAULT_CONFIG`
- `tests/cron/test_session_retention.py`: +182
  - adds real DB and artifact coverage, default-off coverage, sync/async batch coverage, and empty-batch coverage
- `tests/cron/test_scheduler_provider.py`: +9
  - verifies provider `fire_due()` triggers maintenance only after a claimed run
- `website/docs/user-guide/features/cron.md`: +11
  - documents the default-off retention setting and its profile-scoped cleanup behavior

## Validation

| Scenario | Before | After |
|---|---|---|
| `session_retention_days=0` | No pruning | No pruning, unchanged |
| Old ended cron session | DB row could be pruned only from `tick()` | Shared post-run maintenance prunes it after scheduler-owned runs |
| Matching session artifacts | Could survive DB pruning | Deleted with the pruned cron session |
| User sessions | Untouched | Untouched, unchanged |
| Active cron sessions | Untouched | Untouched, unchanged |
| Built-in tick batch | Retention wired only through `tick()` exits | One post-run sweep per completed batch |
| External `fire_due()` path | Bypassed retention | Uses the shared maintenance path |
| Config and docs | Setting absent from `DEFAULT_CONFIG` and cron guide | Default-off config entry and user-guide docs added |

## Test plan

- `pytest tests/cron/test_session_retention.py -v --timeout=0` — 8 passed
- `pytest tests/cron/test_scheduler_provider.py -v --timeout=0` — 37 passed
- `pytest tests/plugins/test_chronos_cron.py -v --timeout=0` — 13 passed

Fixes #38378
