### PR TITLE
test(openrouter): cover get_async_client singleton and check_api_key (#36575)

### DIFF
--- a/tests/tools/test_openrouter_client.py
+++ b/tests/tools/test_openrouter_client.py
@@ -1,0 +1,57 @@
+"""Tests for tools/openrouter_client.py - lazy singleton client + API key check."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import tools.openrouter_client as mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    mod._client = None
+    yield
+    mod._client = None
+
+
+class TestGetAsyncClient:
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_happy_path(self, mock_resolve):
+        mock_client = MagicMock()
+        mock_resolve.return_value = (mock_client, {"provider": "openrouter"})
+
+        result = mod.get_async_client()
+
+        assert result is mock_client
+        mock_resolve.assert_called_once_with("openrouter", async_mode=True)
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_singleton_caching(self, mock_resolve):
+        mock_client = MagicMock()
+        mock_resolve.return_value = (mock_client, {"provider": "openrouter"})
+
+        first = mod.get_async_client()
+        second = mod.get_async_client()
+
+        assert first is second
+        mock_resolve.assert_called_once()
+
+    @patch("agent.auxiliary_client.resolve_provider_client")
+    def test_raises_on_none_client(self, mock_resolve):
+        mock_resolve.return_value = (None, None)
+
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            mod.get_async_client()
+
+
+class TestCheckApiKey:
+    def test_returns_true_when_set(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        assert mod.check_api_key() is True
+
+    def test_returns_false_when_missing(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        assert mod.check_api_key() is False
+
+    def test_returns_false_when_empty(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "")
+        assert mod.check_api_key() is False


### PR DESCRIPTION
## Summary

`tools/openrouter_client.py` had 41.67% statement coverage (7 of 12 statements uncovered). The module provides a lazy-initialized singleton `AsyncOpenAI` client for OpenRouter via `get_async_client()` and a simple env-var check via `check_api_key()`. The existing test suite exercised `check_api_key` incidentally but never called `get_async_client()`, leaving its entire body (the `if _client is None` branch, lazy import, provider resolution, error path, and caching) untested.

This PR adds 6 tests in a new file covering both functions completely: the happy path (provider resolution returns a valid client), the singleton caching behavior (second call skips `resolve_provider_client`), the `ValueError` path when the provider returns `None`, and the three `check_api_key` scenarios (key set, missing, empty). Coverage reaches 100% for this module.

## Changes

- `tests/tools/test_openrouter_client.py` (new, +57 lines): 6 tests in 2 classes
  - `TestGetAsyncClient` (3 tests): happy path, singleton caching, ValueError on None
  - `TestCheckApiKey` (3 tests): key present, missing, empty string

## Validation

| Scenario | Before | After |
|---|---|---|
| `get_async_client()` happy path | Untested | Covered (mock `resolve_provider_client`) |
| `get_async_client()` called twice | Untested | Covered (assert single `resolve_provider_client` call) |
| `get_async_client()` with None client | Untested | Covered (ValueError raised) |
| `check_api_key()` with key set | Partially covered | Explicitly tested |
| `check_api_key()` with key missing | Partially covered | Explicitly tested |
| `check_api_key()` with empty key | Untested | Covered |

## Test plan

- `pytest tests/tools/test_openrouter_client.py -v` — 6 passed

Fixes #36575

Model Used: Claude Opus 4.8 via Claude Code CLI