### PR TITLE
test(toolsets): cover uncovered branches to reach >=70% (#36608)

### DIFF
--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -1,11 +1,13 @@
 """Tests for toolset_distributions.py — distribution CRUD, sampling, validation."""
 
 import pytest
+from unittest.mock import patch
 
 from toolset_distributions import (
     DISTRIBUTIONS,
     get_distribution,
     list_distributions,
+    print_distribution_info,
     sample_toolsets_from_distribution,
     validate_distribution,
 )
@@ -54,6 +56,25 @@ class TestValidateDistribution:
         assert validate_distribution("") is False
 
 
+class TestPrintDistributionInfo:
+    def test_known_distribution_prints_info(self, capsys):
+        print_distribution_info("default")
+
+        captured = capsys.readouterr()
+        assert "default" in captured.out
+        assert DISTRIBUTIONS["default"]["description"] in captured.out
+        assert "Description:" in captured.out
+        assert "Toolsets:" in captured.out
+        assert "% chance" in captured.out
+
+    def test_unknown_distribution_prints_error(self, capsys):
+        print_distribution_info("nonexistent_distribution_xyz")
+
+        captured = capsys.readouterr()
+        assert "Unknown distribution" in captured.out
+        assert "nonexistent_distribution_xyz" in captured.out
+
+
 class TestSampleToolsetsFromDistribution:
     def test_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown distribution"):
@@ -83,6 +104,51 @@ class TestSampleToolsetsFromDistribution:
         for _ in range(20):
             result = sample_toolsets_from_distribution("reasoning")
             assert len(result) >= 1
+
+
+class TestSampleInvalidToolset:
+    @patch("toolset_distributions.validate_toolset")
+    @patch("toolset_distributions.random.random", return_value=0.0)
+    def test_invalid_toolset_skipped_with_warning(self, mock_random, mock_validate, capsys):
+        mock_validate.side_effect = lambda toolset_name: toolset_name != "terminal"
+
+        result = sample_toolsets_from_distribution("terminal_only")
+
+        captured = capsys.readouterr()
+        assert "terminal" not in result
+        assert "file" in result
+        assert "Warning" in captured.out
+        assert "terminal" in captured.out
+        assert "terminal_only" in captured.out
+
+    @patch("toolset_distributions.validate_toolset", return_value=False)
+    def test_all_toolsets_invalid_fallback_also_invalid(self, mock_validate):
+        dist = get_distribution("terminal_only")
+        toolset_count = len(dist["toolsets"])
+
+        result = sample_toolsets_from_distribution("terminal_only")
+
+        assert result == []
+        # validate_toolset called once per toolset in the loop + once for the fallback
+        assert mock_validate.call_count == toolset_count + 1
+
+
+class TestSampleFallback:
+    @patch("toolset_distributions.validate_toolset", return_value=True)
+    @patch("toolset_distributions.random.random", return_value=1.0)
+    def test_fallback_picks_highest_probability(self, mock_random, mock_validate):
+        result = sample_toolsets_from_distribution("safe")
+        dist = get_distribution("safe")
+        expected = max(dist["toolsets"], key=dist["toolsets"].get)
+
+        assert result == [expected]
+
+    @patch("toolset_distributions.validate_toolset", return_value=True)
+    @patch("toolset_distributions.random.random", return_value=0.0)
+    def test_deterministic_all_included(self, mock_random, mock_validate):
+        result = sample_toolsets_from_distribution("terminal_only")
+
+        assert set(result) == set(get_distribution("terminal_only")["toolsets"])
 
 
 class TestDistributionStructure:


### PR DESCRIPTION
## Summary

`toolset_distributions.py` still needed focused coverage on the warning, fallback, and print branches from #36608, but the published PR head had drifted in two ways. The fallback test in `tests/test_toolset_distributions.py` froze the current `"safe"` winner as `"web"` instead of asserting the selection rule in `sample_toolsets_from_distribution()`, and the branch also carried an unrelated `scripts/ci/timings_report.py` hunk that current `main` already superseded. This update keeps the PR on the coverage work only: the fallback expectation is now derived from the distribution data, the added tests stay focused on the uncovered branches, and the timing-report change is gone from the final diff.

## Changes

- `tests/test_toolset_distributions.py`: +66 lines
  - `TestPrintDistributionInfo` (2 tests): covers the known-distribution info output and the unknown-distribution error message via stdout capture
  - `TestSampleInvalidToolset` (2 tests): covers the invalid-toolset warning path and the all-invalid fallback edge case
  - `TestSampleFallback` (2 tests): covers the max-probability fallback with a data-relative expected value and the deterministic full-inclusion path

## Validation

| Scenario | Before | After |
|---|---|---|
| Unknown distribution for `print_distribution_info()` | Untested | Covered |
| Invalid toolset inside a distribution | Untested | Covered |
| All toolsets invalid, including fallback | Untested | Covered |
| Fallback path after all random rolls fail | Assertion froze the current winner as `"web"` | Assertion derives the expected winner from the distribution data |
| Deterministic inclusion when `random.random()` returns `0.0` | Untested | Covered |
| Timing report behavior | Unrelated hunk in this PR | Out of scope, owned by current `main` |

## Test plan

- `pytest tests/test_toolset_distributions.py -v --timeout=0` — 21 passed

Fixes #36608
