### PR TITLE
fix(mcp): persist EventBridge cursor across subprocess restarts (#22000)

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -287,6 +287,7 @@ def _extract_attachments(msg: dict) -> List[dict]:
 
 QUEUE_LIMIT = 1000
 POLL_INTERVAL = 0.2  # seconds between DB polls (200ms)
+EVENT_CURSOR_META_KEY = "mcp_event_cursor"
 
 
 @dataclass
@@ -308,17 +309,52 @@ class EventBridge:
 
     def __init__(self):
         self._queue: List[QueueEvent] = []
-        self._cursor = 0
+        self._db = _get_session_db()
+        self._startup_message_id_floor = self._load_db_message_high_water_mark()
+        self._cursor = max(
+            self._load_event_cursor(),
+            self._message_cursor(self._startup_message_id_floor),
+        )
         self._lock = threading.Lock()
         self._new_event = threading.Event()
         self._running = False
         self._thread: Optional[threading.Thread] = None
-        self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._last_poll_ids: Dict[str, int] = {}
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when state.db hasn't changed
         self._state_db_mtime: float = 0.0
         self._cached_sessions_index: dict = {}
+
+    @staticmethod
+    def _message_cursor(message_id: int) -> int:
+        return max(message_id, 0) * 2
+
+    def _load_db_message_high_water_mark(self) -> int:
+        try:
+            db = self._db
+            if db is None:
+                return 0
+            conn = getattr(db, "_conn", None)
+            lock = getattr(db, "_lock", None)
+            if conn is None:
+                return 0
+            if lock is not None:
+                with lock:
+                    row = conn.execute("SELECT MAX(id) FROM messages").fetchone()
+            else:
+                row = conn.execute("SELECT MAX(id) FROM messages").fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        except Exception:
+            logger.debug("EventBridge: could not read DB high-water mark", exc_info=True)
+            return 0
+
+    def _load_event_cursor(self) -> int:
+        try:
+            value = self._db.get_meta(EVENT_CURSOR_META_KEY) if self._db else None
+            return max(int(value), 0) if value is not None else 0
+        except (AttributeError, TypeError, ValueError):
+            return 0
 
     def start(self):
         """Start the background polling thread."""
@@ -419,6 +455,11 @@ class EventBridge:
         with self._lock:
             self._cursor += 1
             event.cursor = self._cursor
+            if self._db is not None:
+                try:
+                    self._db.set_meta(EVENT_CURSOR_META_KEY, str(self._cursor))
+                except AttributeError:
+                    pass
             self._queue.append(event)
             # Trim queue to limit
             while len(self._queue) > QUEUE_LIMIT:
@@ -427,7 +468,7 @@ class EventBridge:
 
     def _poll_loop(self):
         """Background loop: poll SessionDB for new messages."""
-        db = _get_session_db()
+        db = self._db
         if not db:
             logger.warning("EventBridge: SessionDB unavailable, event polling disabled")
             return
@@ -476,7 +517,10 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            last_seen_id = self._last_poll_ids.get(
+                session_key,
+                self._startup_message_id_floor,
+            )
 
             try:
                 messages = db.get_messages(session_id)
@@ -486,36 +530,17 @@ class EventBridge:
             if not messages:
                 continue
 
-            # Normalize timestamps to float for comparison
-            def _ts_float(ts) -> float:
-                if isinstance(ts, (int, float)):
-                    return float(ts)
-                if isinstance(ts, str) and ts:
-                    try:
-                        return float(ts)
-                    except ValueError:
-                        # ISO string — parse to epoch
-                        try:
-                            from datetime import datetime
-                            return datetime.fromisoformat(ts).timestamp()
-                        except Exception:
-                            return 0.0
-                return 0.0
-
-            # Find messages newer than our last seen timestamp
-            new_messages = []
-            for msg in messages:
-                ts = _ts_float(msg.get("timestamp", 0))
-                role = msg.get("role", "")
-                if role not in {"user", "assistant"}:
-                    continue
-                if ts > last_seen:
-                    new_messages.append(msg)
+            new_messages = [
+                msg for msg in messages
+                if msg.get("role") in {"user", "assistant"}
+                and int(msg.get("id", 0)) > last_seen_id
+            ]
 
             for msg in new_messages:
                 content = _extract_message_content(msg)
                 if not content:
                     continue
+                message_id = int(msg.get("id", 0))
                 self._enqueue(QueueEvent(
                     cursor=0,
                     type="message",
@@ -524,16 +549,14 @@ class EventBridge:
                         "role": msg.get("role", ""),
                         "content": content[:500],
                         "timestamp": str(msg.get("timestamp", "")),
-                        "message_id": str(msg.get("id", "")),
+                        "message_id": str(message_id),
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
-            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
-            if all_ts:
-                latest = max(all_ts)
-                if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+            if new_messages:
+                self._last_poll_ids[session_key] = max(
+                    int(msg.get("id", 0)) for msg in new_messages
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -33,6 +33,11 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
         monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
     except (ImportError, AttributeError):
         pass
+    try:
+        import mcp_serve
+        monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: None)
+    except ImportError:
+        pass
     return tmp_path
 
 
@@ -147,6 +152,12 @@ def _create_test_db(db_path, session_id, messages):
             reasoning TEXT,
             reasoning_details TEXT,
             codex_reasoning_items TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS state_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
         )
     """)
     conn.execute(
@@ -302,6 +313,64 @@ class TestHelpers:
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
         assert mcp_serve._load_sessions_index() == {}
+
+    def test_row_to_index_entry_uses_origin_json(self):
+        import mcp_serve
+
+        entry = mcp_serve._row_to_index_entry({
+            "id": "session-1",
+            "session_key": "agent:main:discord:dm:42",
+            "source": "discord",
+            "chat_type": None,
+            "display_name": None,
+            "origin_json": json.dumps({
+                "platform": "discord",
+                "chat_id": "42",
+                "chat_type": "dm",
+                "chat_name": "Ada",
+                "thread_id": "thread-7",
+            }),
+            "started_at": 1710000000,
+            "last_active": 1710000010,
+            "input_tokens": 12,
+            "output_tokens": 8,
+        })
+
+        assert entry["session_id"] == "session-1"
+        assert entry["platform"] == "discord"
+        assert entry["chat_type"] == "dm"
+        assert entry["display_name"] == "Ada"
+        assert entry["origin"]["thread_id"] == "thread-7"
+        assert entry["total_tokens"] == 20
+
+    def test_load_sessions_index_from_real_session_db(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+        import mcp_serve
+
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(
+            "session-2",
+            "telegram",
+            session_key="agent:main:telegram:dm:7",
+            chat_id="7",
+            chat_type="dm",
+        )
+        db.record_gateway_session_peer(
+            "session-2",
+            source="telegram",
+            session_key="agent:main:telegram:dm:7",
+            chat_id="7",
+            chat_type="dm",
+            display_name="Grace",
+            origin_json=json.dumps({"chat_id": "7", "user_name": "Grace"}),
+        )
+        monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: db)
+
+        result = mcp_serve._load_sessions_index_from_db()
+        entry = result["agent:main:telegram:dm:7"]
+        assert entry["session_id"] == "session-2"
+        assert entry["display_name"] == "Grace"
+        assert entry["origin"]["user_name"] == "Grace"
 
 
 class TestContentExtraction:
@@ -489,6 +558,127 @@ class TestEventBridge:
         from mcp_serve import EventBridge
         r = EventBridge().respond_to_approval("nope", "deny")
         assert "error" in r
+
+    @staticmethod
+    def _make_sqlite_session_db(db_path):
+        class TestDB:
+            def __init__(self):
+                self._conn = sqlite3.connect(str(db_path))
+                self._conn.row_factory = sqlite3.Row
+                self._lock = threading.Lock()
+
+            def get_messages(self, session_id):
+                with self._lock:
+                    rows = self._conn.execute(
+                        "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                        (session_id,),
+                    ).fetchall()
+                return [dict(row) for row in rows]
+
+            def get_meta(self, key):
+                with self._lock:
+                    row = self._conn.execute(
+                        "SELECT value FROM state_meta WHERE key = ?", (key,)
+                    ).fetchone()
+                return row[0] if row else None
+
+            def set_meta(self, key, value):
+                with self._lock:
+                    self._conn.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        (key, value),
+                    )
+                    self._conn.commit()
+
+            def close(self):
+                self._conn.close()
+
+        return TestDB()
+
+    @staticmethod
+    def _write_sessions_json(sessions_dir, session_key, session_id):
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / "sessions.json").write_text(json.dumps({
+            session_key: {"session_key": session_key, "session_id": session_id},
+        }))
+
+    def test_cursor_survives_subprocess_restart(self, tmp_path, monkeypatch):
+        import mcp_serve
+
+        session_id = "20260329_160000_cursor_restart"
+        db_path = tmp_path / "state.db"
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "before restart"},
+            {"role": "assistant", "content": "persisted reply"},
+        ])
+        db = self._make_sqlite_session_db(db_path)
+        monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: db)
+
+        try:
+            first_bridge = mcp_serve.EventBridge()
+            assert first_bridge._cursor == 4
+            first_bridge._enqueue(mcp_serve.QueueEvent(
+                cursor=0, type="approval_requested", session_key="restart",
+            ))
+            first_bridge._enqueue(mcp_serve.QueueEvent(
+                cursor=0, type="approval_resolved", session_key="restart",
+            ))
+
+            restarted_bridge = mcp_serve.EventBridge()
+            assert restarted_bridge._cursor == 6
+            restarted_bridge._enqueue(mcp_serve.QueueEvent(
+                cursor=0, type="approval_requested", session_key="restart",
+            ))
+            assert restarted_bridge.poll_events(after_cursor=6)["events"][0]["cursor"] == 7
+        finally:
+            db.close()
+
+    def test_multiple_approval_events_do_not_overtake_next_message(
+        self, tmp_path, monkeypatch,
+    ):
+        import mcp_serve
+
+        session_key = "agent:main:telegram:dm:cursor_lane"
+        session_id = "20260329_160000_cursor_lane"
+        sessions_dir = tmp_path / "sessions"
+        db_path = tmp_path / "state.db"
+        self._write_sessions_json(sessions_dir, session_key, session_id)
+        _create_test_db(db_path, session_id, [
+            {"role": "assistant", "content": f"old message {i}"}
+            for i in range(10)
+        ])
+        db = self._make_sqlite_session_db(db_path)
+        monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: db)
+        monkeypatch.setattr(
+            mcp_serve, "_load_sessions_index",
+            lambda: {session_key: {"session_id": session_id}},
+        )
+
+        try:
+            bridge = mcp_serve.EventBridge()
+            assert bridge._cursor == 20
+            for event_type in ("approval_requested", "approval_resolved", "approval_requested"):
+                bridge._enqueue(mcp_serve.QueueEvent(
+                    cursor=0, type=event_type, session_key=session_key,
+                ))
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)",
+                (session_id, "assistant", "after approval"),
+            )
+            conn.commit()
+            conn.close()
+            bridge._state_db_mtime = -1.0
+            bridge._poll_once(db)
+
+            events = bridge.poll_events(after_cursor=0)["events"]
+            assert [event["cursor"] for event in events] == [21, 22, 23, 24]
+            assert events[-1]["type"] == "message"
+            assert events[-1]["message_id"] == "11"
+            assert bridge.poll_events(after_cursor=23)["events"][0]["message_id"] == "11"
+        finally:
+            db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/NousResearch/hermes-agent/issues/22000

## Summary

Process restarts were only part of the cursor bug. The earlier branch put message events on a `2 * message_id` lane while approval events still consumed the shared in-memory cursor, so a client that had already observed several approval events could miss the next durable message. Current `main` also moved the conversation routing index into `SessionDB`, so the fix had to rebuild on that path instead of the older `sessions.json` loader.

This update keeps message ids as dedupe state, moves every published event onto one durable cursor lane backed by `state_meta`, and preserves the current-main DB routing path that `events_poll` and `events_wait` already depend on.

## Changes

- `mcp_serve.py` (+95/-36): load the routing index from `SessionDB`, seed and persist one durable event cursor, and route message events through the same allocator as approval events.
- `tests/test_mcp_serve.py` (+190): add direct DB routing-index coverage, keep the restart regression, and add the three-approval sequence that proves the next message still polls after approval cursors advance.

## Validation

| Scenario | Before | After |
|---|---|---|
| Three approvals between message 10 and 11 | message 11 could land behind cursor 23 and disappear from `events_poll(after_cursor=23)` | message 11 gets the next cursor and still polls after 23 |
| Bridge restart after approval traffic | cursor state could reset to a lower in-memory value | next published event resumes above the last persisted cursor |
| DB-backed routing index with `origin_json` data | current-main loader path was unproved on this branch | direct tests exercise row conversion and real `SessionDB.list_gateway_sessions()` loading |

## Test plan

- `pytest tests/test_mcp_serve.py -v` — 90 passed
- `ruff check mcp_serve.py tests/test_mcp_serve.py` — passed
