### PR TITLE
fix(tools): check is_approved() before prompting in execute_code guard

### DIFF
--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -119,6 +119,10 @@ def gw_session(monkeypatch):
     with A._lock:
         A._gateway_queues.pop(session_key, None)
         A._gateway_notify_cbs.pop(session_key, None)
+        previous_session_approvals = set(A._session_approved.get(session_key, set()))
+        had_permanent_execute_code = "execute_code" in A._permanent_approved
+        A._session_approved.pop(session_key, None)
+        A._permanent_approved.discard("execute_code")
     try:
         yield session_key
     finally:
@@ -126,6 +130,14 @@ def gw_session(monkeypatch):
         with A._lock:
             A._gateway_queues.pop(session_key, None)
             A._gateway_notify_cbs.pop(session_key, None)
+            if previous_session_approvals:
+                A._session_approved[session_key] = previous_session_approvals
+            else:
+                A._session_approved.pop(session_key, None)
+            if had_permanent_execute_code:
+                A._permanent_approved.add("execute_code")
+            else:
+                A._permanent_approved.discard("execute_code")
 
 
 def _register_resolver(session_key: str, result):
@@ -174,6 +186,43 @@ def test_guard_gateway_user_approves_is_one_shot(gw_session):
     assert res.get("user_approved") is True
     # One-shot: approval must NOT persist to future scripts.
     assert A.is_approved(gw_session, "execute_code") is False
+
+
+def test_guard_gateway_session_approval_persists(gw_session):
+    try:
+        _register_resolver(gw_session, "session")
+        result = A.check_execute_code_guard("import os", "local")
+        assert result["approved"] is True
+        assert A.is_approved(gw_session, "execute_code") is True
+        # Second call must short-circuit without registering a new resolver
+        result2 = A.check_execute_code_guard("print(2)", "local")
+        assert result2["approved"] is True
+    finally:
+        with A._lock:
+            approvals = A._session_approved.get(gw_session)
+            if approvals is not None:
+                approvals.discard("execute_code")
+
+
+def test_guard_gateway_always_approval_persists_permanently(gw_session, monkeypatch):
+    saved_allowlists = []
+    monkeypatch.setattr(
+        A, "save_permanent_allowlist",
+        lambda patterns: saved_allowlists.append(set(patterns)),
+    )
+    try:
+        _register_resolver(gw_session, "always")
+        result = A.check_execute_code_guard("import os", "local")
+        assert result["approved"] is True
+        assert A.is_approved(gw_session, "execute_code") is True
+        assert "execute_code" in A._permanent_approved
+        assert saved_allowlists and "execute_code" in saved_allowlists[-1]
+    finally:
+        with A._lock:
+            approvals = A._session_approved.get(gw_session)
+            if approvals is not None:
+                approvals.discard("execute_code")
+            A._permanent_approved.discard("execute_code")  # cleanup
 
 
 def test_guard_gateway_user_denies_blocks(gw_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1534,8 +1534,7 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     pattern_key = "execute_code"
     description = (
         "execute_code script execution. The script can spawn subprocesses or "
-        "mutate files without passing through terminal command approval; "
-        "approval is one-shot for this run."
+        "mutate files without passing through terminal command approval."
     )
 
     # Isolated backends already sandbox the child — matches the container skip
@@ -1580,6 +1579,9 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
+    if is_approved(session_key, pattern_key):
+        return {"approved": True, "message": None}
+
     # Built only now (past the early-return gates) so the common non-approval
     # paths don't pay to copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"
@@ -1674,9 +1676,13 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
             "user_consent": False,
         }
 
-    # Approved — one-shot only. Deliberately NO approve_session/approve_permanent:
-    # each execute_code script is distinct arbitrary code, so approval never
-    # persists to future scripts.
+    if choice == "session":
+        approve_session(session_key, pattern_key)
+    elif choice == "always":
+        approve_session(session_key, pattern_key)
+        approve_permanent(pattern_key)
+        save_permanent_allowlist(_permanent_approved)
+
     return {"approved": True, "message": None,
             "user_approved": True, "description": description}
 


### PR DESCRIPTION
## Summary

`check_execute_code_guard()` offered session and always approval choices for `execute_code`, but the guard never checked the existing approval state before prompting and the approved return path ignored the selected choice. As a result, choosing "Approve session" or "Always" behaved like a one-shot approval and the next `execute_code` call prompted again.

The fix checks `is_approved(session_key, "execute_code")` before constructing the synthetic command prompt, preserving the existing lazy-build optimization. It also persists approvals according to the selected choice: session approvals call `approve_session`, always approvals call both `approve_session` and `approve_permanent` and save the permanent allowlist, while once remains one-shot.

## Changes

- `tools/approval.py`: remove stale one-shot wording from the `execute_code` description.
- `tools/approval.py`: short-circuit approved `execute_code` calls with `is_approved()` before building the prompt command string.
- `tools/approval.py`: persist `session` and `always` choices through the same approval helpers used by command guards.
- `tests/tools/test_execute_code_approval_cluster.py`: isolate session and permanent approval state in the `gw_session` fixture.
- `tests/tools/test_execute_code_approval_cluster.py`: add regressions for session persistence, permanent persistence, and permanent allowlist saving.

## Validation

| Scenario | Before | After |
|---|---|---|
| User chooses `once` | current script allowed, next call prompts | unchanged |
| User chooses `session` | current script allowed, next call prompts again | session approval is remembered and next call short-circuits |
| User chooses `always` | current script allowed, no permanent allowlist update | session and permanent approvals are recorded and saved |
| Deny, timeout, YOLO, smart mode guards | unchanged | unchanged |

## Test plan

- `pytest tests/tools/test_execute_code_approval_cluster.py -v --timeout=0`
- Existing regression guards: `test_guard_gateway_user_approves_is_one_shot`, `test_guard_gateway_user_denies_blocks`, `test_guard_gateway_timeout_blocks`, `test_guard_session_yolo_bypasses`, `test_guard_smart_mode`.
- New: session approval persists and short-circuits without registering a second resolver.
- New: always approval persists in `_permanent_approved` and calls `save_permanent_allowlist`.

## Not in scope

Changing `check_all_command_guards`, `_await_gateway_decision`, `code_execution_tool.py`, or the one-shot behavior for the explicit `once` choice.

Closes #39275

