### PR TITLE
fix(mcp): use server url instead of config key for connectivity check hostname

### DIFF
--- a/tests/tools/test_mcp_connectivity_hostname.py
+++ b/tests/tools/test_mcp_connectivity_hostname.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+
+def test_connectivity_check_uses_url_hostname_not_config_key():
+    from tools.mcp_tool import _run_mcp_connectivity_check
+
+    probed_hosts: list[str] = []
+
+    _run_mcp_connectivity_check(
+        "github",
+        {"url": "https://api.githubcopilot.com/mcp/"},
+        probed_hosts.append,
+    )
+
+    assert probed_hosts == ["api.githubcopilot.com"]
+    assert "github" not in probed_hosts
+
+
+def test_connectivity_check_skips_dns_for_stdio_transport():
+    from tools.mcp_tool import _run_mcp_connectivity_check
+
+    probed_hosts: list[str] = []
+
+    _run_mcp_connectivity_check(
+        "local-tools",
+        {"command": "python", "args": ["-m", "example_mcp_server"]},
+        probed_hosts.append,
+    )
+
+    assert probed_hosts == []
+
+
+def test_connectivity_check_handles_missing_url_gracefully():
+    from tools.mcp_tool import _run_mcp_connectivity_check
+
+    probed_hosts: list[str] = []
+
+    _run_mcp_connectivity_check("broken-server", {}, probed_hosts.append)
+
+    assert probed_hosts == []

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -585,6 +585,30 @@ def _validate_remote_mcp_url(server_name: str, url: Any) -> str:
     return stripped
 
 
+def _mcp_connectivity_hostname(name: str, config: dict) -> Optional[str]:
+    """Return the hostname a network connectivity probe should resolve.
+
+    MCP server names are config keys, not necessarily DNS names. HTTP/SSE
+    transports should probe the host from the configured URL; stdio transports
+    use local subprocess pipes and have no remote host to resolve.
+    """
+    if "url" not in config:
+        return None
+
+    try:
+        return urlparse(str(config.get("url", ""))).hostname or name
+    except Exception:
+        return name
+
+
+def _run_mcp_connectivity_check(name: str, config: dict, probe) -> None:
+    """Run a hostname-based MCP connectivity probe when one is applicable."""
+    hostname = _mcp_connectivity_hostname(name, config)
+    if hostname is None:
+        return
+    probe(hostname)
+
+
 def _resolve_client_cert(server_name: str, config: dict):
     """Resolve the ``client_cert`` / ``client_key`` config for mTLS.
 


### PR DESCRIPTION
## Summary

The MCP connectivity issue report describes a diagnostic path resolving the server's config dictionary key name as a DNS hostname instead of extracting the hostname from the configured `url` field. A server keyed as `github` with url `https://api.githubcopilot.com/mcp/` can produce a misleading "the `github` host is unreachable" diagnostic even though the actual MCP URL is reachable.

During implementation, the original buggy code path described in the issue was not found on `origin/main`. The SDK-backed MCP probe path already uses the configured server URL rather than treating the config key as a network host. This PR therefore adds a focused hostname-selection helper for hostname-based connectivity checks and regression coverage so future diagnostic probes use the URL hostname for HTTP transports and skip DNS entirely for stdio transports.

## Changes

- `tools/mcp_tool.py`: add `_mcp_connectivity_hostname()` to derive a probe hostname from `urlparse(config["url"]).hostname` instead of the config key name.
- `tools/mcp_tool.py`: add `_run_mcp_connectivity_check()` to run hostname probes only when a remote HTTP/SSE URL is present; stdio servers return without probing DNS.
- `tests/tools/test_mcp_connectivity_hostname.py`: cover URL-hostname selection, stdio DNS skipping, and missing-url handling.

## Validation

| Scenario | Before | After |
|---|---|---|
| HTTP server, key `github`, url `https://api.githubcopilot.com/mcp/` | a hostname-based diagnostic could probe `github` | helper probes `api.githubcopilot.com` |
| HTTP server, key matches hostname, e.g. `localhost` | works by coincidence | continues to use parsed URL hostname |
| stdio server, key `searxng` | a generic hostname probe could try DNS on `searxng` | helper skips DNS because stdio has no remote host |
| Missing or malformed URL config | possible crash in ad hoc probe code | helper returns no host or falls back safely |
| SDK-backed MCP connection path on `origin/main` | already uses configured URL | unchanged |

## Test plan

- `pytest tests/tools/test_mcp_connectivity_hostname.py -v --timeout=0`
- `pytest tests/tools/test_mcp_probe.py -v --timeout=0`
- `pytest tests/hermes_cli/test_mcp_config.py -v --timeout=0`
- New: connectivity helper uses URL hostname, not config key; stdio servers skip DNS; missing URL config is handled gracefully.

## Not in scope

Changing `_probe_single_server()` in `hermes_cli/mcp_config.py`, which already uses the full MCP SDK connection path and reads the configured URL. The originally suspected buggy diagnostic path was not present on `origin/main`, so this PR is limited to the reusable helper and regression tests that prevent the reported hostname mix-up from being introduced in hostname-based MCP diagnostics.

Closes #22724

