### PR TITLE
fix(skills): skip .bak-* and .backup-* directories in skill discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -20,6 +20,7 @@ from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     SKILL_SUPPORT_DIRS,
+    _is_backup_dir_name,
     extract_skill_conditions,
     extract_skill_description,
     get_all_skills_dirs,
@@ -1284,6 +1285,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
             d
             for d in dirs
             if d not in EXCLUDED_SKILL_DIRS
+            and not _is_backup_dir_name(d)
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
         ]
         for filename in ("SKILL.md", "DESCRIPTION.md"):

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -50,12 +50,22 @@ EXCLUDED_SKILL_DIRS = frozenset(
 SKILL_SUPPORT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
 
 
+_BACKUP_DIR_PATTERN = re.compile(
+    r"(^\.bak-|^\.backup-|\.bak-|\.backup-)",
+)
+
+
+def _is_backup_dir_name(name: str) -> bool:
+    """Return True when *name* matches a backup directory pattern."""
+    return bool(_BACKUP_DIR_PATTERN.search(name))
+
+
 def is_excluded_skill_path(path) -> bool:
     """True if *path* should be skipped by active skill scanners.
 
     Use this on every ``SKILL.md`` path produced by direct ``rglob`` scans to
-    prune dependency, virtualenv, VCS, cache, and progressive-disclosure
-    support-package paths. Centralising the check here keeps every
+    prune dependency, virtualenv, VCS, cache, backup, and progressive-
+    disclosure support-package paths. Centralising the check here keeps every
     skill-scanning site in sync with the shared exclusion set.
 
     Accepts a Path or string.
@@ -65,8 +75,9 @@ def is_excluded_skill_path(path) -> bool:
     except AttributeError:
         from pathlib import PurePath
         parts = PurePath(str(path)).parts
-    return any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
-        path
+    return (
+        any(part in EXCLUDED_SKILL_DIRS or _is_backup_dir_name(part) for part in parts)
+        or is_skill_support_path(path)
     )
 
 
@@ -799,6 +810,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
             d
             for d in dirs
             if d not in EXCLUDED_SKILL_DIRS
+            and not _is_backup_dir_name(d)
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
         ]
         if filename in files:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1,6 +1,7 @@
 """Tests for agent/prompt_builder.py — context scanning, truncation, skills index."""
 
 import builtins
+import os
 import importlib
 import logging
 import sys
@@ -8,6 +9,7 @@ import sys
 import pytest
 
 from agent.prompt_builder import (
+    _build_skills_manifest,
     _scan_context_content,
     _truncate_content,
     _parse_skill_file,
@@ -414,6 +416,19 @@ class TestBuildSkillsSystemPrompt:
         assert "python-debug" in result
         assert "Debug Python scripts" in result
         assert "available_skills" in result
+
+    def test_manifest_excludes_backup_skill_sibling(self, tmp_path):
+        live = tmp_path / "live-skill"
+        live.mkdir()
+        (live / "SKILL.md").write_text("---\nname: live-skill\n---\n")
+
+        backup = tmp_path / "live-skill.bak-20260510"
+        backup.mkdir()
+        (backup / "SKILL.md").write_text("---\nname: backup-skill\n---\n")
+
+        manifest = _build_skills_manifest(tmp_path)
+
+        assert set(manifest) == {os.path.join("live-skill", "SKILL.md")}
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -37,7 +37,7 @@ def test_metadata_as_dict_with_hermes():
 
 
 def test_metadata_as_string_does_not_crash():
-    """Bug case: metadata is a non-dict truthy value."""
+    """Bug case: metadata is a non-dict truthy value (e.g. a YAML string)."""
     frontmatter = {"metadata": "some text"}
     result = extract_skill_conditions(frontmatter)
     assert result == {
@@ -147,16 +147,15 @@ skills:
 
     assert get_disabled_skill_names() == {"hidden-skill"}
     assert get_external_skills_dirs() == [external.resolve()]
-    assert resolve_skill_config_values(
-        [{"key": "wiki.path", "description": "Wiki path"}]
-    )["wiki.path"].endswith("/wiki")
+    assert resolve_skill_config_values([
+        {"key": "wiki.path", "description": "Wiki path"}
+    ])["wiki.path"].endswith("/wiki")
     assert parse_count == 1
 
 
 def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch):
     """Editing config.yaml should invalidate the shared raw config cache."""
     from agent import skill_utils
-    import os
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -168,6 +167,7 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     assert get_disabled_skill_names() == {"old-skill"}
 
     config_path.write_text("skills:\n  disabled: [new-skill]\n", encoding="utf-8")
+    import os
     os.utime(config_path, None)
 
     assert get_disabled_skill_names() == {"new-skill"}
@@ -308,11 +308,21 @@ def test_is_excluded_skill_path_matches_dot_backup_pattern():
 def test_is_excluded_skill_path_allows_skill_with_bak_in_name():
     assert is_excluded_skill_path(Path("skills/bak-manager/SKILL.md")) is False
 
+# ── skill_matches_platform on Termux ──────────────────────────────────────
+
 
 class TestSkillMatchesPlatformTermux:
-    """Termux is Linux userland on Android."""
+    """Termux is Linux userland on Android. Skills tagged platforms:[linux]
+    must load there regardless of whether Python reports sys.platform as
+    "linux" (pre-3.13) or "android" (3.13+). Reported by user @LikiusInik
+    in May 2026 — only 3 built-in skills appeared on Termux because every
+    github/productivity/mlops skill is tagged platforms:[linux,macos,windows]
+    and sys.platform=="android" did not start with "linux".
+    """
 
     def test_no_platforms_field_matches_everywhere(self):
+        # Backward-compat default — skills without a platforms tag load
+        # on any OS, Termux included.
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
         ):
@@ -320,6 +330,7 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform({"name": "foo"}) is True
 
     def test_linux_skill_loads_on_termux_android_platform(self):
+        # Python 3.13+ on Termux reports sys.platform == "android".
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -328,6 +339,8 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_linux_macos_windows_skill_loads_on_termux(self):
+        # The common "[linux, macos, windows]" tag used by github-*,
+        # productivity, mlops, etc.
         fm = {"platforms": ["linux", "macos", "windows"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -336,6 +349,8 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_linux_skill_loads_on_termux_linux_platform(self):
+        # Pre-3.13 Termux reports sys.platform == "linux" already — this
+        # works without the Termux escape hatch but must still pass.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "linux"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -344,6 +359,8 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_macos_only_skill_still_excluded_on_termux(self):
+        # macOS-only skills (apple-notes, imessage, ...) should NOT load
+        # on Termux. The Termux fallback only widens platforms:[linux,...].
         fm = {"platforms": ["macos"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -360,6 +377,8 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is False
 
     def test_explicit_termux_or_android_tag_matches(self):
+        # Skills can also opt in explicitly via platforms:[termux] or
+        # platforms:[android] — both should match a Termux session.
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
         ):
@@ -369,6 +388,8 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(["android"]) is True
 
     def test_non_termux_android_does_not_widen(self):
+        # If we're somehow on a plain Android Python (not Termux), don't
+        # silently load Linux skills — Termux is the supported environment.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=False
@@ -377,6 +398,7 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is False
 
     def test_linux_skill_on_real_linux_unaffected(self):
+        # The non-Termux Linux path must not change.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "linux"), patch(
             "agent.skill_utils.is_termux", return_value=False

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,6 @@
 """Tests for agent/skill_utils.py."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from agent.skill_utils import (
@@ -36,7 +37,7 @@ def test_metadata_as_dict_with_hermes():
 
 
 def test_metadata_as_string_does_not_crash():
-    """Bug case: metadata is a non-dict truthy value (e.g. a YAML string)."""
+    """Bug case: metadata is a non-dict truthy value."""
     frontmatter = {"metadata": "some text"}
     result = extract_skill_conditions(frontmatter)
     assert result == {
@@ -146,15 +147,16 @@ skills:
 
     assert get_disabled_skill_names() == {"hidden-skill"}
     assert get_external_skills_dirs() == [external.resolve()]
-    assert resolve_skill_config_values([
-        {"key": "wiki.path", "description": "Wiki path"}
-    ])["wiki.path"].endswith("/wiki")
+    assert resolve_skill_config_values(
+        [{"key": "wiki.path", "description": "Wiki path"}]
+    )["wiki.path"].endswith("/wiki")
     assert parse_count == 1
 
 
 def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch):
     """Editing config.yaml should invalidate the shared raw config cache."""
     from agent import skill_utils
+    import os
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -166,7 +168,6 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     assert get_disabled_skill_names() == {"old-skill"}
 
     config_path.write_text("skills:\n  disabled: [new-skill]\n", encoding="utf-8")
-    import os
     os.utime(config_path, None)
 
     assert get_disabled_skill_names() == {"new-skill"}
@@ -239,21 +240,79 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
 
 
-# ── skill_matches_platform on Termux ──────────────────────────────────────
+def test_iter_skill_index_files_prunes_bak_dirs(tmp_path):
+    live = tmp_path / "hermes-profile"
+    live.mkdir()
+    (live / "SKILL.md").write_text("---\nname: hermes-profile\n---\n", encoding="utf-8")
+
+    backup = tmp_path / "hermes-profile.bak-20260510_233500"
+    backup.mkdir()
+    (backup / "SKILL.md").write_text(
+        "---\nname: hermes-profile-backup\n---\n", encoding="utf-8"
+    )
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [live / "SKILL.md"]
+
+
+def test_iter_skill_index_files_prunes_dot_bak_dirs(tmp_path):
+    backup = tmp_path / ".bak-20260510_233500"
+    backup.mkdir()
+    (backup / "SKILL.md").write_text("---\nname: backup\n---\n", encoding="utf-8")
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == []
+
+
+def test_iter_skill_index_files_prunes_backup_dirs(tmp_path):
+    dot_backup = tmp_path / ".backup-old"
+    dot_backup.mkdir()
+    (dot_backup / "SKILL.md").write_text(
+        "---\nname: dot-backup\n---\n", encoding="utf-8"
+    )
+
+    named_backup = tmp_path / "my-skill.backup-20260510"
+    named_backup.mkdir()
+    (named_backup / "SKILL.md").write_text(
+        "---\nname: named-backup\n---\n", encoding="utf-8"
+    )
+
+    live = tmp_path / "live-skill"
+    live.mkdir()
+    (live / "SKILL.md").write_text("---\nname: live-skill\n---\n", encoding="utf-8")
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [live / "SKILL.md"]
+
+
+def test_is_excluded_skill_path_matches_bak_pattern():
+    assert (
+        is_excluded_skill_path(
+            Path("skills/hermes-profile.bak-20260510_233500/SKILL.md")
+        )
+        is True
+    )
+
+
+def test_is_excluded_skill_path_does_not_exclude_live_skill():
+    assert is_excluded_skill_path(Path("skills/hermes-profile/SKILL.md")) is False
+
+
+def test_is_excluded_skill_path_matches_dot_backup_pattern():
+    assert is_excluded_skill_path(Path("skills/.backup-old/nested/SKILL.md")) is True
+
+
+def test_is_excluded_skill_path_allows_skill_with_bak_in_name():
+    assert is_excluded_skill_path(Path("skills/bak-manager/SKILL.md")) is False
 
 
 class TestSkillMatchesPlatformTermux:
-    """Termux is Linux userland on Android. Skills tagged platforms:[linux]
-    must load there regardless of whether Python reports sys.platform as
-    "linux" (pre-3.13) or "android" (3.13+). Reported by user @LikiusInik
-    in May 2026 — only 3 built-in skills appeared on Termux because every
-    github/productivity/mlops skill is tagged platforms:[linux,macos,windows]
-    and sys.platform=="android" did not start with "linux".
-    """
+    """Termux is Linux userland on Android."""
 
     def test_no_platforms_field_matches_everywhere(self):
-        # Backward-compat default — skills without a platforms tag load
-        # on any OS, Termux included.
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
         ):
@@ -261,7 +320,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform({"name": "foo"}) is True
 
     def test_linux_skill_loads_on_termux_android_platform(self):
-        # Python 3.13+ on Termux reports sys.platform == "android".
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -270,8 +328,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_linux_macos_windows_skill_loads_on_termux(self):
-        # The common "[linux, macos, windows]" tag used by github-*,
-        # productivity, mlops, etc.
         fm = {"platforms": ["linux", "macos", "windows"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -280,8 +336,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_linux_skill_loads_on_termux_linux_platform(self):
-        # Pre-3.13 Termux reports sys.platform == "linux" already — this
-        # works without the Termux escape hatch but must still pass.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "linux"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -290,8 +344,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is True
 
     def test_macos_only_skill_still_excluded_on_termux(self):
-        # macOS-only skills (apple-notes, imessage, ...) should NOT load
-        # on Termux. The Termux fallback only widens platforms:[linux,...].
         fm = {"platforms": ["macos"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
@@ -308,8 +360,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is False
 
     def test_explicit_termux_or_android_tag_matches(self):
-        # Skills can also opt in explicitly via platforms:[termux] or
-        # platforms:[android] — both should match a Termux session.
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=True
         ):
@@ -319,8 +369,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(["android"]) is True
 
     def test_non_termux_android_does_not_widen(self):
-        # If we're somehow on a plain Android Python (not Termux), don't
-        # silently load Linux skills — Termux is the supported environment.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "android"), patch(
             "agent.skill_utils.is_termux", return_value=False
@@ -329,7 +377,6 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform_list(fm["platforms"]) is False
 
     def test_linux_skill_on_real_linux_unaffected(self):
-        # The non-Termux Linux path must not change.
         fm = {"platforms": ["linux"]}
         with patch("agent.skill_utils.sys.platform", "linux"), patch(
             "agent.skill_utils.is_termux", return_value=False


### PR DESCRIPTION
## Summary

Backup skill directories such as `.bak-*` and `.backup-*` can still leak into skill discovery and the snapshot manifest when they sit beside live skills. That lets stale backups win over live content and leaves the prompt snapshot walker inconsistent with the active skill index.

This PR now applies one shared backup-directory rule everywhere skills are discovered:
- `agent/skill_utils.py:is_excluded_skill_path()`
- `agent/skill_utils.py:iter_skill_index_files()`
- `agent/prompt_builder.py:_build_skills_manifest()`

The rule still excludes only dotted backup forms, so valid names such as `bak-manager` keep working.

## Changes

- `agent/skill_utils.py`: add `_is_backup_dir_name()` and use it in path exclusion plus active skill walking
- `agent/prompt_builder.py`: prune backup directories in `_build_skills_manifest()`
- `tests/agent/test_skill_utils.py`: cover `.bak-*`, `.backup-*`, live siblings, and `bak-manager`
- `tests/agent/test_prompt_builder.py`: add a direct manifest regression for a live skill beside a backup sibling

## Validation

- `pytest tests/agent/test_skill_utils.py tests/agent/test_prompt_builder.py -v --timeout=0`
- the new manifest regression passes locally
- the same run still has two unrelated pre-existing Windows failures in `tests/agent/test_skill_utils.py`:
  - `test_skill_config_raw_cache_invalidates_on_config_edit`
  - `TestNormalizeSkillLookupName::test_absolute_under_skills_dir_becomes_relative`

Closes https://github.com/NousResearch/hermes-agent/issues/25113