### PR TITLE
fix(cli): propagate venv Scripts to session PATH on Windows install (#39185)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2036,7 +2036,26 @@ function Set-PathVariable {
     Write-Info "Setting up hermes command..."
     
     if ($NoVenv) {
-        $hermesBin = "$InstallDir"
+        # When -NoVenv, entry-point shims land in the system Python's Scripts dir.
+        # Skip the Microsoft Store stub (same guard as Test-Python).
+        $sysPython = Get-Command python -ErrorAction SilentlyContinue
+        $isStoreStub = $false
+        if ($sysPython) {
+            try {
+                $pythonSource = $sysPython.Source
+                if ($pythonSource -and $pythonSource -like "*\WindowsApps\*") {
+                    $isStoreStub = $true
+                } else {
+                    $item = Get-Item $pythonSource -ErrorAction SilentlyContinue
+                    if ($item -and $item.Length -eq 0) { $isStoreStub = $true }
+                }
+            } catch { }
+        }
+        if ($sysPython -and -not $isStoreStub) {
+            $hermesBin = Join-Path (Split-Path $sysPython.Source -Parent) "Scripts"
+        } else {
+            $hermesBin = "$InstallDir"
+        }
     } else {
         $hermesBin = "$InstallDir\venv\Scripts"
     }
@@ -2056,6 +2075,11 @@ function Set-PathVariable {
         Write-Info "PATH already configured"
     }
     
+    # Prepend to the current session so hermes is available immediately.
+    # Remove any existing entry first to guarantee correct precedence.
+    $filteredPath = ($env:Path -split ';' | Where-Object { $_ -ne $hermesBin }) -join ';'
+    $env:Path = "$hermesBin;$filteredPath"
+
     # Set HERMES_HOME so the Python code finds config/data in the right place.
     # Only needed on Windows where we install to %LOCALAPPDATA%\hermes instead
     # of the Unix default ~/.hermes
@@ -2065,9 +2089,15 @@ function Set-PathVariable {
         Write-Success "Set HERMES_HOME=$HermesHome"
     }
     $env:HERMES_HOME = $HermesHome
-    
-    # Update current session
-    $env:Path = "$hermesBin;$env:Path"
+
+    # Verify hermes.exe resolves to the expected location
+    $resolvedHermes = Get-Command hermes -ErrorAction SilentlyContinue
+    if (-not $resolvedHermes) {
+        Write-Warn "hermes.exe was not found on PATH after setup. You may need to open a new terminal."
+        Write-Info "  Expected location: $hermesBin\hermes.exe"
+    } elseif ($resolvedHermes.Source -and (Split-Path $resolvedHermes.Source -Parent) -ne $hermesBin) {
+        Write-Warn "hermes resolves to $($resolvedHermes.Source) instead of $hermesBin\hermes.exe"
+    }
     
     Write-Success "hermes command ready"
 }


### PR DESCRIPTION
## Summary

After a fresh Windows install, `hermes` is unreachable in the current terminal session. `Set-PathVariable` in `scripts/install.ps1` writes the venv Scripts directory to the User PATH registry key via `[Environment]::SetEnvironmentVariable("Path", ..., "User")`, but this only propagates to newly spawned shells. The current session's `$env:Path` is not updated, so the post-install setup wizard invocation (`hermes_cli.main setup`) works (it uses `python -m`), but any subsequent `hermes` command in the same terminal fails with "command not found."

The same installer already patches the session PATH for Git directories (in `Install-Git`: `$env:Path = "$gitDir\cmd;$env:Path"`), so the fix follows an established pattern. A secondary issue affects the `-NoVenv` path, which sets `$hermesBin` to the bare repo root where no `hermes.exe` exists on Windows. The `-NoVenv` fix includes the same Microsoft Store Python stub guard used by `Test-Python` to avoid resolving the WindowsApps alias.

## Changes

- `scripts/install.ps1`: in `Set-PathVariable`, remove any existing `$hermesBin` entry and prepend it to `$env:Path` unconditionally after the registry write so `hermes.exe` is immediately available and correctly ordered; fix the `-NoVenv` branch to resolve the system Python's `Scripts` directory with Microsoft Store stub rejection; add a post-setup verification that warns when `hermes.exe` resolves to a different location than expected (+34 lines, -4)

## Validation

| Scenario | Before | After |
|---|---|---|
| Fresh install, same terminal | `hermes --version` fails: "not recognized" | works immediately |
| Fresh install, new terminal | works (User PATH propagated) | works (unchanged) |
| `-NoVenv` install | `$hermesBin` = repo root (no hermes.exe) | `$hermesBin` = system Python Scripts dir |
| `-NoVenv` with WindowsApps stub | resolves to bogus `WindowsApps\Scripts` | falls back to `$InstallDir` |
| Reinstall with stale PATH entry | stale entry wins (wrong precedence) | existing entry removed, fresh prepend |
| `hermes_cli/stdio.py` PATH augmentation | adds venv Scripts at runtime | still works (unchanged, defense-in-depth) |

## Test plan

- Manual: run `scripts/install.ps1` on a clean Windows venv, verify `hermes --version` works in the same terminal session
- Manual: run with `-NoVenv`, verify `hermes` resolves to the system Python entry point
- Manual: open a new terminal after install, verify `hermes` still works (User PATH unchanged)
- Existing: `pytest tests/hermes_cli/ -v --timeout=0` passes (no CLI regressions)

Fixes #39185