### PR TITLE
perf(agent): preserve skills snapshot on managed mutations to avoid cold rebuild (#36031)

### DIFF
--- a/tests/tools/test_skill_manager_snapshot.py
+++ b/tests/tools/test_skill_manager_snapshot.py
@@ -1,0 +1,105 @@
+"""Tests for skill manager snapshot preservation and validation."""
+
+import json
+import os
+from unittest.mock import patch
+
+
+VALID_SKILL_CONTENT = """\
+---
+name: snapshot-skill
+description: A test skill for snapshot cache behavior.
+---
+
+# Snapshot Skill
+
+Use this skill to test cache invalidation.
+"""
+
+
+def test_skill_manage_preserves_snapshot(tmp_path):
+    from tools.skill_manager_tool import skill_manage
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+         patch("tools.skill_manager_tool._security_scan_skill", return_value=None), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]), \
+         patch("agent.prompt_builder.clear_skills_system_prompt_cache") as clear_cache:
+        result = json.loads(
+            skill_manage(
+                action="create",
+                name="snapshot-skill",
+                content=VALID_SKILL_CONTENT,
+            )
+        )
+
+    assert result["success"] is True
+    clear_cache.assert_called_once_with(clear_snapshot=False)
+
+
+def test_snapshot_manifest_detects_mtime_change(tmp_path):
+    from agent import prompt_builder
+
+    hermes_home = tmp_path / "hermes-home"
+    skills_dir, skill_md = _create_skill_file(tmp_path)
+    snapshot = _snapshot_for(skills_dir, skill_md)
+
+    with patch.object(prompt_builder, "get_hermes_home", return_value=hermes_home):
+        _write_snapshot(prompt_builder, snapshot)
+
+        stat = skill_md.stat()
+        os.utime(
+            skill_md,
+            ns=(stat.st_atime_ns, stat.st_mtime_ns + 10_000_000_000),
+        )
+        assert skill_md.stat().st_mtime_ns != snapshot["manifest"][str(skill_md.relative_to(skills_dir))][0]
+
+        assert prompt_builder._load_skills_snapshot(skills_dir) is None
+
+
+def test_snapshot_manifest_valid_when_unchanged(tmp_path):
+    from agent import prompt_builder
+
+    hermes_home = tmp_path / "hermes-home"
+    skills_dir, skill_md = _create_skill_file(tmp_path)
+    snapshot = _snapshot_for(skills_dir, skill_md)
+
+    with patch.object(prompt_builder, "get_hermes_home", return_value=hermes_home):
+        _write_snapshot(prompt_builder, snapshot)
+
+        assert prompt_builder._load_skills_snapshot(skills_dir) == snapshot
+
+
+def _create_skill_file(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "snapshot-skill"
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(VALID_SKILL_CONTENT, encoding="utf-8")
+    return skills_dir, skill_md
+
+
+def _snapshot_for(skills_dir, skill_md):
+    stat = skill_md.stat()
+    return {
+        "version": 1,
+        "manifest": {
+            str(skill_md.relative_to(skills_dir)): [stat.st_mtime_ns, stat.st_size],
+        },
+        "skills": [
+            {
+                "name": "snapshot-skill",
+                "description": "A test skill for snapshot cache behavior.",
+                "path": str(skill_md),
+            }
+        ],
+        "category_descriptions": {},
+    }
+
+
+def _write_snapshot(prompt_builder, snapshot):
+    snapshot_path = prompt_builder._skills_prompt_snapshot_path()
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1269,7 +1269,7 @@ def skill_manage(
     if result.get("success"):
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
-            clear_skills_system_prompt_cache(clear_snapshot=True)
+            clear_skills_system_prompt_cache(clear_snapshot=False)
         except Exception:
             pass
         # Curator telemetry: bump patch_count on edit/patch/write_file (the actions


### PR DESCRIPTION
## Summary

With 300+ installed skills, every `skill_manage()` action forces a 30+ second cold rebuild. The call at `skill_manager_tool.py:871` passes `clear_snapshot=True` to `clear_skills_system_prompt_cache()`, which deletes the disk snapshot (`.skills_prompt_snapshot.json`). Without it, `build_skills_system_prompt()` must walk and parse every SKILL.md file from scratch.

The snapshot already carries an mtime+size manifest that `_load_skills_snapshot()` validates on load. When `skill_manage` modifies a SKILL.md, the file's mtime changes, the manifest mismatches, and the cold rebuild fires automatically. Keeping the snapshot on disk means that mutations to non-SKILL.md files (via `write_file`/`remove_file`) correctly hit the fast path instead of forcing a full rescan. The in-memory LRU cache is still cleared regardless of the `clear_snapshot` flag.

The fix is a single parameter change: `clear_snapshot=True` to `clear_snapshot=False`.

## Changes

- `tools/skill_manager_tool.py`: change `clear_skills_system_prompt_cache(clear_snapshot=True)` to `clear_snapshot=False` at the post-action cache invalidation site (+0/-0, 1 word changed)
- `tests/tools/test_skill_manager_snapshot.py`: add 3 tests verifying the snapshot is preserved after skill mutations and that manifest validation still triggers cold rebuild on actual SKILL.md changes (~+105 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| `skill_manage("edit", skill)` with 300 skills | 30s cold rebuild (snapshot deleted) | <1s manifest check + targeted cold rebuild |
| `skill_manage("write_file", non_skill_path)` | 30s cold rebuild (snapshot deleted) | <1s manifest check, snapshot valid, fast path |
| `skill_manage("create", new_skill)` | 30s cold rebuild | <1s manifest check + cold rebuild (mtime changed) |
| In-memory LRU cache | cleared | cleared (unchanged) |

## Test plan

- `pytest tests/tools/test_skill_manager_snapshot.py -v --timeout=0` — 3 passed
- `pytest tests/ -v --timeout=60` — full suite, no regressions

## Upstream

Closes #36031.
Reported by @heidis168.
