### PR TITLE
feat(models): add qwen/qwen3.7-plus to nous + openrouter catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -52,6 +52,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("deepseek/deepseek-v4-flash",             ""),
     # Qwen
     ("qwen/qwen3.7-max",                       ""),
+    ("qwen/qwen3.7-plus",                      ""),
     ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
     ("moonshotai/kimi-k2.6",                   "recommended"),
@@ -169,6 +170,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-v4-flash",
         # Qwen
         "qwen/qwen3.7-max",
+        "qwen/qwen3.7-plus",
         "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
         "moonshotai/kimi-k2.6",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-01T08:20:18Z",
+  "updated_at": "2026-06-04T23:57:51Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -66,6 +66,10 @@
         },
         {
           "id": "qwen/qwen3.7-max",
+          "description": ""
+        },
+        {
+          "id": "qwen/qwen3.7-plus",
           "description": ""
         },
         {
@@ -170,6 +174,9 @@
         },
         {
           "id": "qwen/qwen3.7-max"
+        },
+        {
+          "id": "qwen/qwen3.7-plus"
         },
         {
           "id": "qwen/qwen3.6-35b-a3b"


### PR DESCRIPTION
## Summary
`qwen/qwen3.7-plus` is now offered in both the Nous Portal and OpenRouter curated model catalogs, listed directly under `qwen/qwen3.7-max`.

## Changes
- `hermes_cli/models.py`: add `qwen/qwen3.7-plus` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`, immediately after `qwen/qwen3.7-max`.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (generated mirror, not hand-edited). Slug appears under qwen3.7-max in both the `openrouter` and `nous` sections.

No `DEFAULT_CONTEXT_LENGTHS` entry needed — the existing `qwen` catch-all (131072) covers it, same as qwen3.7-max which has no specific override.

## Validation
| | Before | After |
|---|---|---|
| `tests/hermes_cli/test_model_catalog.py` + `test_models.py` | — | 104/104 pass |
| Manifest drift guard | — | green (regenerated from source lists) |

## Infographic

![model-catalog-add-qwen37plus](https://v3b.fal.media/files/b/0a9d01bb/N9L0UCIDmsCXelJP5CPJ__IEeruj6U.png)
