### PR TITLE
fix: preserve embedded Hindsight database URL

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -424,6 +424,12 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         "HINDSIGHT_API_LLM_MODEL": str(current_model),
         "HINDSIGHT_API_LOG_LEVEL": "info",
     }
+    database_url = config.get("database_url") or os.environ.get("HINDSIGHT_EMBED_API_DATABASE_URL", "")
+    if database_url:
+        # hindsight-embed's daemon manager only treats HINDSIGHT_EMBED_API_DATABASE_URL
+        # as an explicit profile DB override; it maps that into HINDSIGHT_API_DATABASE_URL
+        # for the actual hindsight-api child process.
+        env_values["HINDSIGHT_EMBED_API_DATABASE_URL"] = str(database_url)
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -278,6 +278,25 @@ class TestConfig:
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
 
+    def test_embedded_profile_env_includes_database_url_from_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "ollama",
+            "llm_model": "qwen2.5:7b",
+            "database_url": "pg0://hindsight-embed-infra:55449",
+        })
+
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "pg0://hindsight-embed-infra:55449"
+
+    def test_embedded_profile_env_includes_database_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_EMBED_API_DATABASE_URL", "pg0://hindsight-embed-test:55450")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "ollama",
+            "llm_model": "qwen2.5:7b",
+        })
+
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "pg0://hindsight-embed-test:55450"
+
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
             "llm_provider": "openai",


### PR DESCRIPTION
## Summary
- Include configured embedded Hindsight database_url in the profile env as HINDSIGHT_EMBED_API_DATABASE_URL
- Preserve existing environment override behavior for HINDSIGHT_EMBED_API_DATABASE_URL
- Add regression coverage for config and env fallback sources

## Test Plan
- ./venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='

## Context
Local embedded Hindsight profiles can use explicit pg0 database URLs. Without materializing HINDSIGHT_EMBED_API_DATABASE_URL into the standalone hindsight-embed profile env, daemon starts can drift back to default pg0 behavior.