### PR TITLE
fix(install): expand 8.3 short %TEMP% so Windows Node/Electron stages don't abort

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -122,6 +122,16 @@ function ConvertTo-LongPath {
     return $Path
 }
 
+foreach ($tmpVar in @('TEMP', 'TMP')) {
+    $current = [Environment]::GetEnvironmentVariable($tmpVar)
+    if ($current) {
+        $expanded = ConvertTo-LongPath $current
+        if ($expanded -and $expanded -ne $current) {
+            Set-Item -Path "Env:$tmpVar" -Value $expanded
+        }
+    }
+}
+
 # ============================================================================
 # Configuration
 # ============================================================================

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -89,6 +89,40 @@ try {
 }
 
 # ============================================================================
+# 8.3 short-path normalization
+# ============================================================================
+# When the Windows user-profile folder name contains a space (e.g.
+# "First Last"), Windows generates an 8.3 short alias for it (e.g. FIRST~1.LAS)
+# and may expose %TEMP%/%TMP% in that short form:
+#   C:\Users\FIRST~1.LAS\AppData\Local\Temp
+# PowerShell's FileSystem provider mishandles the "~1.ext" component when such a
+# path is handed to a provider cmdlet like `Tee-Object -FilePath` /
+# `Out-File -FilePath`, throwing:
+#   "An object at the specified path C:\Users\FIRST~1.LAS does not exist."
+# Every Node/Electron build+install stage streams its log to %TEMP% via
+# Tee-Object, so they all abort with that error, while the Python/uv stages --
+# which never write a side log to %TEMP% through a provider cmdlet -- complete
+# fine. Expanding %TEMP%/%TMP% back to their long form once, up front, lets
+# every downstream cmdlet (and child process) see a path the provider can
+# resolve. (GH: Windows desktop installer fails at Node/Electron stages.)
+
+function ConvertTo-LongPath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
+    # Only 8.3 short names carry a tilde+digit ("~1"); skip the COM round-trip
+    # for ordinary long paths.
+    if ($Path -notmatch '~\d') { return $Path }
+    try {
+        $fso = New-Object -ComObject Scripting.FileSystemObject
+        if ($fso.FolderExists($Path)) { return $fso.GetFolder($Path).Path }
+        if ($fso.FileExists($Path))   { return $fso.GetFile($Path).Path }
+    } catch {
+        # COM unavailable / locked-down host: fall back to the original path.
+    }
+    return $Path
+}
+
+# ============================================================================
 # Configuration
 # ============================================================================
 

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -1,0 +1,86 @@
+# Unit tests for install.ps1's ConvertTo-LongPath helper.
+#
+# Run from a PowerShell prompt:
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+#
+# Background: on a Windows profile whose folder name contains a space (e.g.
+# "First Last"), %TEMP%/%TMP% can be exposed as an 8.3 short path
+# (C:\Users\FIRST~1.LAS\...). PowerShell's FileSystem provider chokes on the
+# "~1.ext" component when it reaches a provider cmdlet (Tee-Object -FilePath),
+# aborting the Node/Electron install+build stages. install.ps1 expands such
+# paths to their long form up front; this verifies the helper's contract.
+#
+# We extract just the function from install.ps1 via the AST so the installer's
+# top-level body never runs (dot-sourcing would execute the whole script).
+# The COM-backed expansion only fires for inputs containing "~<digit>"; the
+# pass-through and graceful-fallback paths are assertable on any host (incl.
+# non-Windows pwsh, where the COM object is simply unavailable).
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot "scripts/install.ps1"
+
+if (-not (Test-Path $installScript)) {
+    throw "Could not locate install.ps1 at $installScript"
+}
+
+$failures = 0
+function Assert-Equal {
+    param([Parameter(Mandatory = $true)] $Expected,
+          [Parameter(Mandatory = $true)] $Actual,
+          [Parameter(Mandatory = $true)] [string]$Label)
+    if ($Expected -ne $Actual) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        Write-Host "  expected: $Expected"
+        Write-Host "  actual:   $Actual"
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+
+# --- Load ConvertTo-LongPath from install.ps1 without executing the script ---
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($installScript, [ref]$tokens, [ref]$errors)
+$fnAst = $ast.FindAll(
+    {
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq 'ConvertTo-LongPath'
+    }, $true) | Select-Object -First 1
+
+if (-not $fnAst) {
+    throw "ConvertTo-LongPath not found in install.ps1 -- did the helper get renamed/removed?"
+}
+. ([scriptblock]::Create($fnAst.Extent.Text))
+
+# --- Tests ---
+Write-Host ""
+Write-Host "-- ConvertTo-LongPath --"
+
+Assert-Equal -Expected "" -Actual (ConvertTo-LongPath "") -Label "empty string returns empty"
+Assert-Equal -Expected $null -Actual (ConvertTo-LongPath $null) -Label "null returns null"
+
+# No 8.3 component -> returned verbatim (even with spaces).
+$longish = "C:\Users\First Last\AppData\Local\Temp"
+Assert-Equal -Expected $longish -Actual (ConvertTo-LongPath $longish) -Label "long path with spaces is unchanged"
+
+$noTilde = "/tmp/some/long/path"
+Assert-Equal -Expected $noTilde -Actual (ConvertTo-LongPath $noTilde) -Label "tilde-free path is unchanged"
+
+# Looks like an 8.3 name but does not exist -> graceful fallback to the input
+# (FolderExists/FileExists both false, or COM unavailable on this host).
+$fakeShort = "C:\Users\FIRST~1.LAS\does\not\exist"
+Assert-Equal -Expected $fakeShort -Actual (ConvertTo-LongPath $fakeShort) -Label "nonexistent 8.3 path falls back to input"
+
+# --- Summary ---
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "All ConvertTo-LongPath tests passed." -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
Fixes #39308

## Symptom

On Windows, the Python/uv stages complete ("All dependencies installed") but **every Node-side stage fails** with:

```
An object at the specified path C:\Users\FIRST~1.LAS does not exist.
```

— at the browser-tools npm install, Playwright Chromium install, TUI deps install, and finally the desktop build, which hard-fails the installer:

```
bootstrap FAILED stage=desktop
    error=An object at the specified path C:\Users\FIRST~1.LAS does not exist.
```

Repro: a Windows account whose profile folder contains a space (e.g. `C:\Users\First Last`), which forces Windows to generate an 8.3 short name (`dir /x C:\Users` → `FIRST~1.LAS`).

## Root cause

When the user-profile folder name contains a space, Windows can expose `%TEMP%`/`%TMP%` in **8.3 short form**:

```
C:\Users\FIRST~1.LAS\AppData\Local\Temp
```

PowerShell's FileSystem provider mishandles the `~1.ext` component when such a path reaches a **provider cmdlet** — here `Tee-Object -FilePath` — and throws `An object at the specified path … does not exist` (a `System.Management.Automation.PSArgumentException`). This is a known PowerShell-provider behavior with tilde 8.3 paths, e.g. [SO #41572933](https://stackoverflow.com/questions/41572933/an-object-at-the-specified-path-c-users-user1-name-does-not-exist) and [jabbera/my-vsts-tasks#6](https://github.com/jabbera/my-vsts-tasks/issues/6).

Why only the Node stages break: every Node/Electron install+build stage streams its log to `%TEMP%` via `Tee-Object -FilePath "$env:TEMP\…log"` (`install.ps1` lines ~1828, ~1855, ~1932, ~2057). The Python/uv stages stream output directly and never write a side log to `%TEMP%` through a provider cmdlet, so they're unaffected.

## Fix

Expand `%TEMP%`/`%TMP%` to their long form **once, up front**, via a new `ConvertTo-LongPath` helper (uses `Scripting.FileSystemObject`, which resolves 8.3 aliases). Every downstream cmdlet and child process then sees a path the provider can resolve. The helper:

- returns the input unchanged when it has no `~<digit>` component (no COM round-trip for normal long paths),
- falls back to the input on any COM error (locked-down host).

This matches the reporter's suggested fix (expand short paths to long form before use).

## Tests

`scripts/tests/test-install-ps1-longpath.ps1` loads `ConvertTo-LongPath` from `install.ps1` via the AST (so the installer body never runs) and asserts pass-through, null/empty, and graceful-fallback behavior.

```
powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
```

## Test plan

- [ ] On a Windows profile with a space in the name (`C:\Users\First Last`), the installer completes all Node stages and the desktop build instead of failing with the 8.3 path error
- [ ] Normal (space-free) profiles unaffected — `%TEMP%` has no `~1` component, so the helper is a no-op