### PR TITLE
feat(skills): collapse skill categories to one line in the system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -833,7 +833,10 @@ CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+# v2 added ``collapsed_categories`` to the payload. Older snapshots (v1) are
+# treated as a cache miss by the version guard in _load_skills_snapshot, so the
+# field is filled in on the next cold rebuild — no migration needed.
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -887,6 +890,7 @@ def _write_skills_snapshot(
     manifest: dict[str, list[int]],
     skill_entries: list[dict],
     category_descriptions: dict[str, str],
+    collapsed_categories: list[str],
 ) -> None:
     """Persist skill metadata to disk for fast cold-start reuse."""
     payload = {
@@ -894,6 +898,7 @@ def _write_skills_snapshot(
         "manifest": manifest,
         "skills": skill_entries,
         "category_descriptions": category_descriptions,
+        "collapsed_categories": sorted(set(collapsed_categories)),
     }
     try:
         atomic_json_write(_skills_prompt_snapshot_path(), payload)
@@ -929,6 +934,45 @@ def _build_snapshot_entry(
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
+
+
+# Frontmatter field on a category's DESCRIPTION.md. When truthy, the category
+# is folded to a single summary line in the system prompt and its individual
+# skills are omitted from the index — the model expands it on demand with
+# skills_list(category=...). skill_view / skills_list are unaffected.
+_COLLAPSE_FIELD = "collapsed"
+_COLLAPSE_TRUTHY = frozenset({"true", "yes", "1", "on"})
+
+
+def _coerce_collapsed_flag(value) -> bool:
+    """Interpret a DESCRIPTION.md ``collapsed`` value as a boolean.
+
+    Accepts native YAML booleans as well as the string forms produced by the
+    fallback frontmatter parser (``"true"``, ``"yes"``, ``"1"``, ``"on"``).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().strip("'\"").lower() in _COLLAPSE_TRUTHY
+    return False
+
+
+def _parse_category_description(desc_file: Path, base_dir: Path) -> tuple[str, str, bool]:
+    """Parse a category ``DESCRIPTION.md`` into ``(category, description, collapsed)``.
+
+    ``description`` is an empty string when the file declares none. ``collapsed``
+    reflects the ``collapsed`` frontmatter flag (default ``False``).
+    """
+    content = desc_file.read_text(encoding="utf-8")
+    fm, _ = parse_frontmatter(content)
+    rel = desc_file.relative_to(base_dir)
+    category = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
+    raw_desc = fm.get("description")
+    description = str(raw_desc).strip().strip("'\"") if raw_desc else ""
+    collapsed = _coerce_collapsed_flag(fm.get(_COLLAPSE_FIELD))
+    return category, description, collapsed
 
 
 # =========================================================================
@@ -1038,6 +1082,9 @@ def build_skills_system_prompt(
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
+    # Categories whose DESCRIPTION.md sets ``collapsed: true`` — folded to a
+    # single summary line in the index (skills still load normally).
+    collapsed_categories: set[str] = set()
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
@@ -1065,6 +1112,9 @@ def build_skills_system_prompt(
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
         }
+        collapsed_categories = {
+            str(c) for c in (snapshot.get("collapsed_categories") or [])
+        }
     else:
         # Cold path: full filesystem scan + write snapshot for next time
         skill_entries: list[dict] = []
@@ -1090,22 +1140,23 @@ def build_skills_system_prompt(
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
             try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(skills_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
+                cat, cat_desc, collapsed = _parse_category_description(
+                    desc_file, skills_dir
+                )
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
+                continue
+            if cat_desc:
+                category_descriptions[cat] = cat_desc
+            if collapsed:
+                collapsed_categories.add(cat)
 
         _write_skills_snapshot(
             skills_dir,
             _build_skills_manifest(skills_dir),
             skill_entries,
             category_descriptions,
+            sorted(collapsed_categories),
         )
 
     # ── External skill directories ─────────────────────────────────────
@@ -1116,6 +1167,11 @@ def build_skills_system_prompt(
     for cat_skills in skills_by_category.values():
         for name, _desc in cat_skills:
             seen_skill_names.add(name)
+
+    # Categories established by the local dir (snapshot or cold scan). Local
+    # wins: an external DESCRIPTION.md cannot flip the collapse state of a
+    # category the local dir already owns.
+    local_categories = set(skills_by_category.keys()) | set(category_descriptions.keys())
 
     for ext_dir in external_dirs:
         if not ext_dir.exists():
@@ -1148,16 +1204,18 @@ def build_skills_system_prompt(
         # External category descriptions
         for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):
             try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(ext_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
+                cat, cat_desc, collapsed = _parse_category_description(
+                    desc_file, ext_dir
+                )
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
+                continue
+            # Local dirs win: only fill description/collapse the local scan
+            # didn't already establish for this category.
+            if cat_desc:
+                category_descriptions.setdefault(cat, cat_desc)
+            if collapsed and cat not in local_categories:
+                collapsed_categories.add(cat)
 
     if not skills_by_category:
         result = ""
@@ -1165,16 +1223,34 @@ def build_skills_system_prompt(
         index_lines = []
         for category in sorted(skills_by_category.keys()):
             cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
+            # Deduplicate skills within the category up front so the collapsed
+            # count matches what an expanded listing would show.
+            unique_skills = []
             seen = set()
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
+                unique_skills.append((name, desc))
+
+            if category in collapsed_categories:
+                # Fold the whole category to one line; the model expands it on
+                # demand with skills_list(category=...). Skills still load
+                # normally via skill_view — only the index hides them.
+                n = len(unique_skills)
+                summary = f"{cat_desc} " if cat_desc else ""
+                index_lines.append(
+                    f"  {category}: {summary}"
+                    f"({n} skill{'s' if n != 1 else ''} hidden — "
+                    f"use skills_list(category={category}) to list them)"
+                )
+                continue
+
+            if cat_desc:
+                index_lines.append(f"  {category}: {cat_desc}")
+            else:
+                index_lines.append(f"  {category}:")
+            for name, desc in unique_skills:
                 if desc:
                     index_lines.append(f"    - {name}: {desc}")
                 else:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -12,6 +13,7 @@ from agent.prompt_builder import (
     _truncate_content,
     _parse_skill_file,
     _skill_should_show,
+    _coerce_collapsed_flag,
     _find_hermes_md,
     _find_git_root,
     _strip_yaml_frontmatter,
@@ -427,6 +429,243 @@ class TestBuildSkillsSystemPrompt:
 
         result = build_skills_system_prompt()
         assert "backend-skill" in result
+
+
+class TestCoerceCollapsedFlag:
+    @pytest.mark.parametrize("value", [True, "true", "True", "yes", "on", "1", 1])
+    def test_truthy_values(self, value):
+        assert _coerce_collapsed_flag(value) is True
+
+    @pytest.mark.parametrize(
+        "value", [False, "false", "no", "off", "0", 0, None, "", "maybe"]
+    )
+    def test_falsy_values(self, value):
+        assert _coerce_collapsed_flag(value) is False
+
+    def test_quoted_string_true(self):
+        assert _coerce_collapsed_flag('"yes"') is True
+
+
+class TestCollapsedCategories:
+    """Category collapse: a DESCRIPTION.md with ``collapsed: true`` folds the
+    whole category to one summary line in the system prompt, while skill_view /
+    skills_list stay completely unaffected.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_skills_cache(self):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def _make_category(self, tmp_path, category, skill_names, *, collapsed, cat_desc="Cat desc"):
+        cat_dir = tmp_path / "skills" / category
+        for sname in skill_names:
+            d = cat_dir / sname
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {sname}\ndescription: Does {sname}\n---\n"
+            )
+        flag = "\ncollapsed: true" if collapsed else ""
+        (cat_dir / "DESCRIPTION.md").write_text(
+            f"---\ndescription: {cat_desc}{flag}\n---\n"
+        )
+        return cat_dir
+
+    def test_collapsed_category_folds_to_one_line(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_category(
+            tmp_path, "lark", ["lark-im", "lark-base", "lark-calendar"],
+            collapsed=True, cat_desc="Feishu/Lark tools",
+        )
+        result = build_skills_system_prompt()
+
+        # Category summary line is present with the expand hint and count.
+        assert "lark: Feishu/Lark tools (3 skills hidden" in result
+        assert "use skills_list(category=lark) to list them" in result
+        # Individual skills are NOT listed in the prompt index.
+        assert "lark-im" not in result
+        assert "lark-base" not in result
+        assert "- lark-calendar" not in result
+
+    def test_singular_count_phrasing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_category(
+            tmp_path, "solo", ["only-one"], collapsed=True,
+        )
+        result = build_skills_system_prompt()
+        assert "1 skill hidden" in result
+        assert "1 skills hidden" not in result
+
+    def test_non_collapsed_category_unchanged(self, monkeypatch, tmp_path):
+        """Default behavior: a DESCRIPTION.md without the flag lists every skill."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_category(
+            tmp_path, "coding", ["py-debug", "go-build"], collapsed=False,
+            cat_desc="Coding tools",
+        )
+        result = build_skills_system_prompt()
+        assert "coding: Coding tools" in result
+        assert "- py-debug: Does py-debug" in result
+        assert "- go-build: Does go-build" in result
+        assert "hidden" not in result
+
+    def test_no_description_md_does_not_collapse(self, monkeypatch, tmp_path):
+        """A category with no DESCRIPTION.md keeps the existing expanded form."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "skills" / "misc" / "thing"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("---\nname: thing\ndescription: A thing\n---\n")
+        result = build_skills_system_prompt()
+        assert "- thing: A thing" in result
+        assert "hidden" not in result
+
+    def test_collapse_mixes_with_expanded_categories(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_category(
+            tmp_path, "lark", ["lark-im", "lark-base"], collapsed=True,
+            cat_desc="Lark",
+        )
+        self._make_category(
+            tmp_path, "coding", ["py-debug"], collapsed=False, cat_desc="Coding",
+        )
+        result = build_skills_system_prompt()
+        # Collapsed category hidden, expanded category still listed.
+        assert "lark: Lark (2 skills hidden" in result
+        assert "lark-im" not in result
+        assert "- py-debug: Does py-debug" in result
+
+    def test_toggling_collapse_rebuilds_prompt(self, monkeypatch, tmp_path):
+        """Editing DESCRIPTION.md to add the flag invalidates the snapshot
+        (manifest mtime/size mismatch) so the next build reflects the change."""
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cat_dir = self._make_category(
+            tmp_path, "lark", ["lark-im"], collapsed=False, cat_desc="Lark",
+        )
+
+        first = build_skills_system_prompt()
+        assert "- lark-im: Does lark-im" in first
+        assert "hidden" not in first
+
+        # Flip collapse on. Snapshot manifest no longer matches -> cold rebuild.
+        (cat_dir / "DESCRIPTION.md").write_text(
+            "---\ndescription: Lark\ncollapsed: true\n---\n"
+        )
+        # Drop only the in-process LRU (skill-mutation callers do this); the
+        # disk snapshot is intentionally left in place to prove the manifest
+        # check, not snapshot deletion, drives invalidation.
+        clear_skills_system_prompt_cache(clear_snapshot=False)
+
+        second = build_skills_system_prompt()
+        assert "lark-im" not in second
+        assert "use skills_list(category=lark) to list them" in second
+
+    def test_string_true_value_collapses(self, monkeypatch, tmp_path):
+        """Quoted/string boolean forms from the fallback parser still collapse."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cat_dir = tmp_path / "skills" / "lark"
+        d = cat_dir / "lark-im"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("---\nname: lark-im\ndescription: im\n---\n")
+        (cat_dir / "DESCRIPTION.md").write_text(
+            "---\ndescription: Lark\ncollapsed: \"yes\"\n---\n"
+        )
+        result = build_skills_system_prompt()
+        assert "1 skill hidden" in result
+
+    def test_collapsed_flag_false_is_expanded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._make_category(
+            tmp_path, "lark", ["lark-im"], collapsed=False, cat_desc="Lark",
+        )
+        # Explicit collapsed: false
+        (tmp_path / "skills" / "lark" / "DESCRIPTION.md").write_text(
+            "---\ndescription: Lark\ncollapsed: false\n---\n"
+        )
+        result = build_skills_system_prompt()
+        assert "- lark-im: Does lark-im" in result
+        assert "hidden" not in result
+
+    def test_collapsed_skill_still_loads_via_skill_view(self, monkeypatch, tmp_path):
+        """Boundary: collapse hides a skill from the prompt index ONLY. Unlike a
+        disabled skill (which skill_view rejects), a collapsed skill loads
+        byte-identically to an uncollapsed one."""
+        from unittest.mock import patch
+        import tools.skills_tool as skills_tool_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills"
+        self._make_category(
+            tmp_path, "lark", ["lark-im", "lark-base"], collapsed=True,
+        )
+
+        prompt = build_skills_system_prompt()
+        assert "lark-im" not in prompt  # hidden from index
+
+        with patch.object(skills_tool_module, "SKILLS_DIR", skills_dir):
+            payload = json.loads(skills_tool_module.skill_view("lark-im"))
+        assert payload["success"] is True
+        assert payload["name"] == "lark-im"
+        assert "Does lark-im" in payload["content"]
+
+    def test_collapsed_category_fully_listed_by_skills_list(self, monkeypatch, tmp_path):
+        """skills_list returns the full skill set for a collapsed category."""
+        from unittest.mock import patch
+        import tools.skills_tool as skills_tool_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills"
+        self._make_category(
+            tmp_path, "lark", ["lark-im", "lark-base", "lark-calendar"],
+            collapsed=True,
+        )
+
+        with patch.object(skills_tool_module, "SKILLS_DIR", skills_dir):
+            listing = json.loads(skills_tool_module.skills_list(category="lark"))
+        names = sorted(s["name"] for s in listing["skills"])
+        assert names == ["lark-base", "lark-calendar", "lark-im"]
+
+    def test_disabled_vs_collapsed_are_distinct(self, monkeypatch, tmp_path):
+        """A disabled skill is rejected by skill_view; a collapsed skill is not.
+        Both are absent from the prompt index, but for different reasons."""
+        from unittest.mock import patch
+        import tools.skills_tool as skills_tool_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills"
+        # collapsed category
+        self._make_category(tmp_path, "lark", ["lark-im"], collapsed=True)
+        # a separate, disabled skill
+        dis = skills_dir / "tools" / "old-tool"
+        dis.mkdir(parents=True)
+        (dis / "SKILL.md").write_text(
+            "---\nname: old-tool\ndescription: Deprecated\n---\n"
+        )
+
+        with patch(
+            "agent.prompt_builder.get_disabled_skill_names",
+            return_value={"old-tool"},
+        ):
+            prompt = build_skills_system_prompt()
+        # Both absent from the prompt index.
+        assert "old-tool" not in prompt
+        assert "lark-im" not in prompt
+
+        with patch.object(skills_tool_module, "SKILLS_DIR", skills_dir):
+            with patch(
+                "tools.skills_tool._is_skill_disabled",
+                side_effect=lambda name, *a, **k: name == "old-tool",
+            ):
+                collapsed_payload = json.loads(skills_tool_module.skill_view("lark-im"))
+                disabled_payload = json.loads(skills_tool_module.skill_view("old-tool"))
+
+        # Collapsed loads; disabled is refused.
+        assert collapsed_payload["success"] is True
+        assert disabled_payload["success"] is False
+        assert "disabled" in disabled_payload["error"].lower()
 
 
 class TestBuildNousSubscriptionPrompt:


### PR DESCRIPTION
## Summary

Users with large skill collections pay a per-turn token tax: every skill is
flattened into the system prompt on every request, even ones they rarely use.
A user with 26 `lark-*` skills loads all of them on every turn, crowding out
room for skills they actually need.

This PR adds **category collapse**. A category whose `DESCRIPTION.md`
frontmatter sets `collapsed: true` is folded to a single summary line in the
system-prompt skill index:

```
lark: Feishu/Lark tools (26 skills hidden — use skills_list(category=lark) to list them)
```

The model expands the category on demand with `skills_list(category=lark)`,
then loads a specific skill with `skill_view`. Both tools are completely
unaffected by collapse — a collapsed skill loads byte-for-byte identically to
an uncollapsed one. Collapse only changes what the system-prompt index shows.

Opt-in and backward compatible: a `DESCRIPTION.md` without the flag behaves
exactly as before (every skill listed).

## Behavior boundary: collapsed vs disabled

These are deliberately different mechanisms:

| | In prompt index | `skill_view` | `skills_list` |
|---|---|---|---|
| **disabled** skill | hidden | **rejected** (`is disabled`) | hidden |
| **collapsed** category | folded to 1 line | **served normally** | fully listed |

Collapse is a *presentation* change in the system prompt only. Disable is a
*functional* block enforced in the skills tool. A unit test asserts both lines
explicitly so they can't silently converge.

## Caller impact analysis

- **Runtime caller** — `build_skills_system_prompt` has a single runtime
  caller (`run_agent.py`, the system-prompt assembly path). The function
  signature is unchanged; the change is internal to its body.
- **In-process LRU cache key** — unchanged. The collapse flag is *not* added to
  the cache key, matching how category descriptions already work: both are
  derived from `DESCRIPTION.md`, which is tracked by the disk-snapshot manifest,
  not the cache key. Adding it to the key would be redundant and would not
  change correctness.
- **Disk snapshot** (`.skills_prompt_snapshot.json`) — schema bumped
  `version 1 → 2`, adding a `collapsed_categories` list. The existing version
  guard treats a v1 snapshot as a cache miss, so stale snapshots are silently
  rebuilt on first run after upgrade — no migration, no crash. Editing a
  `DESCRIPTION.md` to toggle the flag changes its file size, which invalidates
  the manifest and forces a cold rebuild, so the toggle takes effect on the
  next prompt build.
- **`_write_skills_snapshot`** gained one parameter (`collapsed_categories`).
  It has exactly one call site (the cold-scan path); no stale callers.
- **External skill dirs** — collapse is honored for external-dir categories
  too, with local-dir precedence: an external `DESCRIPTION.md` cannot flip the
  collapse state of a category the local dir already owns.
- **`tools/skills_tool.py` (`skill_view` / `skills_list`)** — zero edits. The
  passthrough guarantee is structural, not just tested.

## Prompt-cache integrity

The rendered prompt is a deterministic function of the same snapshot/manifest
inputs as before, so identical inputs still produce byte-identical prompt text
and prefix caching is preserved. No new per-build `stat` work was added.

## Tests

- New `TestCollapsedCategories` and `TestCoerceCollapsedFlag` covering: the
  collapsed branch (one-line summary, skills hidden), the non-collapsed default
  branch, singular/plural count phrasing, mixed collapsed+expanded categories,
  cache invalidation on toggle (via the snapshot manifest, snapshot left on
  disk to prove the manifest check drives it), string/boolean flag coercion,
  `skill_view` passthrough on a collapsed skill, `skills_list` returning the
  full category list, and the collapsed-vs-disabled boundary.
- `tests/agent/test_prompt_builder.py`, the `tests/tools/` skill suites, and the
  skill-command/reload suites are green.
- Full `python -m pytest` introduces no new failures: the only failures present
  reproduce on a clean baseline with this change stashed (setup-wizard / IRC
  migration tests) or are xdist cross-worker pollution that passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)