### PR TITLE
fix(desktop): preserve previous unpacked dir on failed pack (rename instead of delete)

### DIFF
--- a/apps/desktop/scripts/after-pack.cjs
+++ b/apps/desktop/scripts/after-pack.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * after-pack.cjs — electron-builder afterPack hook.
  *
@@ -8,10 +10,15 @@
  * to the stock "Electron" icon/name (the bug when the stamp lived only in
  * install.ps1, which the update path doesn't use).
  *
- * Windows-only: rcedit edits PE resources, irrelevant on macOS/Linux where the
- * app identity comes from the bundle Info.plist / desktop entry. Best-effort:
- * a stamp failure must never fail an otherwise-good build (worst case is the
- * stock icon, not a broken app), so we log and resolve rather than throw.
+ * Also cleans up the backup unpacked directory stashed by before-pack.cjs.
+ * Because afterPack only runs on a successful pack, the backup is safely
+ * removed here — if we reach this hook, the new build is complete.
+ *
+ * Windows-only stamp: rcedit edits PE resources, irrelevant on macOS/Linux
+ * where the app identity comes from the bundle Info.plist / desktop entry.
+ * Best-effort: a stamp failure must never fail an otherwise-good build (worst
+ * case is the stock icon, not a broken app), so we log and resolve rather
+ * than throw.
  *
  * electron-builder passes a context with:
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
@@ -19,11 +26,32 @@
  *   - packager.appInfo.productFilename: the exe basename (e.g. 'Hermes')
  */
 
+const fs = require('node:fs')
 const path = require('node:path')
 
 const { stampExeIdentity } = require('./set-exe-identity.cjs')
 
+/** Remove the backup dir stashed by before-pack.cjs, if present. */
+function removeBackupDir(appOutDir) {
+  const backupDir = appOutDir + '.backup'
+  if (fs.existsSync(backupDir)) {
+    fs.rmSync(backupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    console.log(`[after-pack] removed backup unpacked dir: ${backupDir}`)
+  }
+}
+
+exports.removeBackupDir = removeBackupDir
+
 exports.default = async function afterPack(context) {
+  // Always clean up the backup first — this only runs on successful pack.
+  try {
+    if (context && context.appOutDir) {
+      removeBackupDir(context.appOutDir)
+    }
+  } catch (err) {
+    console.warn(`[after-pack] could not remove backup dir (${err.message}); continuing`)
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }

--- a/apps/desktop/scripts/before-pack.cjs
+++ b/apps/desktop/scripts/before-pack.cjs
@@ -3,8 +3,10 @@
 /**
  * before-pack.cjs — electron-builder beforePack hook.
  *
- * Removes any stale unpacked app directory (`appOutDir`) before
- * electron-builder stages the Electron binaries into it.
+ * Renames any existing unpacked app directory (`appOutDir`) to a backup
+ * before electron-builder stages the Electron binaries. On success the
+ * after-pack hook removes the backup; on failure the backup remains so the
+ * previously working app is not lost.
  *
  * WHY THIS EXISTS
  * ---------------
@@ -23,23 +25,22 @@
  *   ENOENT: no such file or directory, rename
  *   '.../release/linux-unpacked/electron' -> '.../release/linux-unpacked/Hermes'
  *
- * This is a hard failure with no obvious cause for the user — `hermes desktop`
- * just prints "Desktop GUI build failed" and the only fix is to manually
- * `rm -rf` the release directory, which a normal user has no way to know.
+ * WHY RENAME INSTEAD OF DELETE
+ * ----------------------------
+ * If the build/compile step fails after beforePack has removed the old
+ * unpacked dir, the user is left with NO working app (the prior version
+ * is gone and the new one never materialized). By renaming to a backup,
+ * we preserve the previous build — the backup is only cleaned up AFTER
+ * a successful pack completes (via after-pack.cjs). If the process is
+ * interrupted or fails, the next run's beforePack will remove any stale
+ * backup before proceeding again.
  *
- * The packaging step is not idempotent across an interrupted run, so we make
- * it idempotent ourselves: wipe the target unpacked directory up front so
- * electron-builder always stages into a clean tree. This is safe — the
- * directory is a pure build artifact that electron-builder fully recreates
- * on every pack; nothing else depends on its prior contents.
+ * Cross-platform: the same problem exists on macOS (mac-unpacked Hermes.app)
+ * and Windows (win-unpacked), so we handle whatever `appOutDir` electron-builder
+ * hands us regardless of platform.
  *
- * Cross-platform: the same partial-state trap exists on macOS
- * (the mac-unpacked Hermes.app bundle) and Windows (win-unpacked), so we
- * clean whatever `appOutDir` electron-builder hands us regardless of platform.
- *
- * Best-effort: a cleanup failure must never mask the real build. We log and
- * resolve rather than throw — worst case electron-builder hits the original
- * ENOENT, which is no worse than not having this hook at all.
+ * Best-effort: a rename/cleanup failure must never mask the real build.
+ * We log and resolve rather than throw.
  *
  * electron-builder passes a context with:
  *   - appOutDir:            the unpacked app directory about to be staged
@@ -47,32 +48,47 @@
  */
 
 const fs = require('node:fs')
+const path = require('node:path')
 
-function cleanStaleAppOutDir(appOutDir) {
+/**
+ * Rename an existing appOutDir to a backup so electron-builder gets a clean
+ * staging target, but the previous build is preserved in case this pack fails.
+ *
+ * Returns the backup path if a rename occurred, false otherwise.
+ */
+function stashAppOutDir(appOutDir) {
   if (!appOutDir || typeof appOutDir !== 'string') {
     return false
   }
   if (!fs.existsSync(appOutDir)) {
     return false
   }
-  // Recursive + force so a half-written tree (read-only bits, partial files)
-  // can't block the wipe. retry/maxRetries rides out transient EBUSY on
-  // Windows where an AV/indexer may briefly hold a handle.
-  fs.rmSync(appOutDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-  return true
+
+  const backupDir = appOutDir + '.backup'
+
+  // Remove any leftover backup from a prior interrupted run before we rename.
+  if (fs.existsSync(backupDir)) {
+    fs.rmSync(backupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+
+  // Rename is near-atomic on the same filesystem — much safer than a
+  // delete-then-rebuild pattern.
+  fs.renameSync(appOutDir, backupDir)
+  return backupDir
 }
 
-exports.cleanStaleAppOutDir = cleanStaleAppOutDir
+exports.stashAppOutDir = stashAppOutDir
 
 exports.default = async function beforePack(context) {
   const appOutDir = context && context.appOutDir
   try {
-    if (cleanStaleAppOutDir(appOutDir)) {
-      console.log(`[before-pack] removed stale unpacked dir before staging: ${appOutDir}`)
+    const backupDir = stashAppOutDir(appOutDir)
+    if (backupDir) {
+      console.log(`[before-pack] stashed previous unpacked dir as backup: ${backupDir}`)
     }
   } catch (err) {
     // Never fail the build over cleanup; surface why so a genuinely stuck
     // directory (permissions, mount) is still diagnosable.
-    console.warn(`[before-pack] could not clean ${appOutDir} (${err.message}); continuing`)
+    console.warn(`[before-pack] could not stash ${appOutDir} (${err.message}); continuing`)
   }
 }

--- a/apps/desktop/scripts/before-pack.cjs
+++ b/apps/desktop/scripts/before-pack.cjs
@@ -48,7 +48,6 @@
  */
 
 const fs = require('node:fs')
-const path = require('node:path')
 
 /**
  * Rename an existing appOutDir to a backup so electron-builder gets a clean

--- a/apps/desktop/scripts/before-pack.test.cjs
+++ b/apps/desktop/scripts/before-pack.test.cjs
@@ -1,12 +1,14 @@
+'use strict'
+
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 const test = require('node:test')
 
-const { cleanStaleAppOutDir } = require('../scripts/before-pack.cjs')
+const { stashAppOutDir } = require('../scripts/before-pack.cjs')
 
-test('cleanStaleAppOutDir removes a populated unpacked directory', () => {
+test('stashAppOutDir renames a populated unpacked directory to .backup', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
   try {
     const appOutDir = path.join(tempRoot, 'linux-unpacked')
@@ -18,36 +20,66 @@ test('cleanStaleAppOutDir removes a populated unpacked directory', () => {
     fs.mkdirSync(path.join(appOutDir, 'resources'), { recursive: true })
     fs.writeFileSync(path.join(appOutDir, 'resources', 'app.asar'), 'x', 'utf8')
 
-    const removed = cleanStaleAppOutDir(appOutDir)
+    const backupPath = stashAppOutDir(appOutDir)
 
-    assert.equal(removed, true)
+    // The original dir should be gone (renamed to backup)
+    assert.equal(fs.existsSync(appOutDir), false)
+    // The backup should exist at the expected location
+    assert.equal(fs.existsSync(backupPath), true)
+    assert.ok(backupPath.endsWith('.backup'))
+    // Contents should be preserved
+    assert.equal(fs.existsSync(path.join(backupPath, 'LICENSE.electron.txt')), true)
+    assert.equal(fs.existsSync(path.join(backupPath, 'resources', 'app.asar')), true)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('stashAppOutDir is a no-op when the directory is absent', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const missing = path.join(tempRoot, 'does-not-exist')
+    assert.equal(stashAppOutDir(missing), false)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('stashAppOutDir ignores empty or invalid input', () => {
+  assert.equal(stashAppOutDir(''), false)
+  assert.equal(stashAppOutDir(undefined), false)
+  assert.equal(stashAppOutDir(null), false)
+  assert.equal(stashAppOutDir(42), false)
+})
+
+test('stashAppOutDir removes a stale backup before renaming', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    const backupDir = appOutDir + '.backup'
+
+    // Create both a current dir and a stale backup from a prior interrupted run
+    fs.mkdirSync(appOutDir, { recursive: true })
+    fs.writeFileSync(path.join(appOutDir, 'Hermes.exe'), 'x', 'utf8')
+
+    fs.mkdirSync(backupDir, { recursive: true })
+    fs.writeFileSync(path.join(backupDir, 'old.exe'), 'x', 'utf8')
+
+    const backupPath = stashAppOutDir(appOutDir)
+
+    // Stale backup should have been removed before rename
+    assert.equal(fs.existsSync(backupDir), true)  // recreated by the rename
+    assert.equal(fs.existsSync(path.join(backupPath, 'Hermes.exe')), true)
+    assert.equal(fs.existsSync(path.join(backupPath, 'old.exe')), false)  // stale content gone
     assert.equal(fs.existsSync(appOutDir), false)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })
 
-test('cleanStaleAppOutDir is a no-op when the directory is absent', () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
-  try {
-    const missing = path.join(tempRoot, 'does-not-exist')
-    assert.equal(cleanStaleAppOutDir(missing), false)
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true })
-  }
-})
-
-test('cleanStaleAppOutDir ignores empty or invalid input', () => {
-  assert.equal(cleanStaleAppOutDir(''), false)
-  assert.equal(cleanStaleAppOutDir(undefined), false)
-  assert.equal(cleanStaleAppOutDir(null), false)
-  assert.equal(cleanStaleAppOutDir(42), false)
-})
-
-test('beforePack default export resolves even when cleanup throws', async () => {
+test('beforePack default export resolves even when stash fails', async () => {
   const { default: beforePack } = require('../scripts/before-pack.cjs')
-  // A directory path that rmSync can't remove is simulated by passing a
-  // context whose appOutDir is a file the hook will try (and be allowed) to
-  // remove; the contract under test is that the hook never rejects.
+  // Passing an empty string for appOutDir should be handled gracefully
+  // (no-op, no error)
   await assert.doesNotReject(beforePack({ appOutDir: '', electronPlatformName: 'linux' }))
 })


### PR DESCRIPTION
## What this fixes

Part 2 of issue #39404 (the TS2411 type error was already fixed by d29caf382).

## Problem

The before-pack.cjs hook deleted the old win-unpacked/linux-unpacked/mac-unpacked directory before electron-builder staged a fresh one. If the build step failed after the deletion (type error, OOM, Ctrl-C), the user was left with no working app at all.

## Fix

- **before-pack.cjs**: Instead of deleting the old unpacked dir, rename it to `.backup` via `fs.renameSync`. Rename is near-atomic on the same filesystem.
- **after-pack.cjs**: On successful pack, remove the `.backup` dir.
- **Stale backups**: Next beforePack removes any leftover .backup before renaming again.
- **Tests**: All 5 tests pass, including new test for stale backup cleanup.

## Testing

```
node --test scripts/before-pack.test.cjs
✓ stashAppOutDir renames a populated unpacked directory to .backup
✓ stashAppOutDir is a no-op when the directory is absent
✓ stashAppOutDir ignores empty or invalid input
✓ stashAppOutDir removes a stale backup before renaming
✓ beforePack default export resolves even when stash fails
```

## Notes

Draft PR — logic is platform-agnostic (fs.renameSync works cross-platform). A maintainer should verify on Windows/macOS before merging.