### PR TITLE
feat: add deepseek-v4 models to opencode-go provider catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -399,6 +399,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "big-pickle",
     ],
     "opencode-go": [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
         "kimi-k2.6",
         "kimi-k2.5",
         "glm-5.1",


### PR DESCRIPTION
## What does this PR do?

Adds `deepseek-v4-pro` and `deepseek-v4-flash` to the opencode-go provider
model catalog in `hermes_cli/models.py`. These models are already supported
by the opencode-go provider at the API level — they just weren't listed in
the catalog, so they wouldn't appear in model selection/picker and couldn't
be auto-completed.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/models.py`: Added `deepseek-v4-pro` and `deepseek-v4-flash`
  to the `opencode-go` model list, placed at the top as the most capable
  models on that provider.

## How to Test

1. Run `hermes model` (interactive) and verify DeepSeek models appear under
   opencode-go
2. Or run `hermes --model deepseek-v4-pro --provider opencode-go -q "hello"`
   and confirm the model connects and responds

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu/Debian server)

### Documentation & Housekeeping
- [x] N/A — no new config keys
- [x] N/A
- [x] N/A