### PR TITLE
fix: add channel_prompts support to WhatsApp adapter

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1373,6 +1373,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Resolve per-channel prompt
+            from gateway.platforms.base import resolve_channel_prompt
+
+            chat_id = data.get("chatId", "")
+            _channel_prompt: Optional[str] = resolve_channel_prompt(
+                self.config.extra,
+                chat_id,
+                None,
+            )
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1381,6 +1391,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                channel_prompt=_channel_prompt,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")


### PR DESCRIPTION
## What does this PR do?

The WhatsApp adapter never called `resolve_channel_prompt`, so per-channelsystem prompts configured under `whatsapp.channel_prompts` in config.yamlwere silently ignored. This meant users couldn't set group-specific promptsfor WhatsApp group chats.

Telegram and Slack adapters already call `resolve_channel_prompt` — WhatsApp was simply missing the wiring. This adds it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp.py`: Added `resolve_channel_prompt` call in `_build_message_event`, resolving the bridge's `chatId` against `config.extra.channel_prompts`. Result is passed as `channel_prompt` on the `MessageEvent`.

## How to Test

1. Add a `channel_prompts` entry for a WhatsApp group in config.yaml:

    whatsapp:
      channel_prompts:
        "123456789@g.us": "You are an expert in X."

2. Restart the gateway
3. Send a message in that WhatsApp group
4. Verify the agent responds with the per-channel prompt applied

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu/Debian server)

### Documentation & Housekeeping
- [x] N/A — no config keys changed (only implemented existing schema)
- [x] N/A — no architecture changes
- [x] N/A — no tool behavior changes