### PR TITLE
feat(desktop): support base64 image upload for remote backends

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -191,10 +191,17 @@ export function usePromptActions({
           continue
         }
 
-        const result = await requestGateway<ImageAttachResponse>('image.attach', {
-          session_id: sessionId,
-          path: attachment.path
-        })
+        // Windows paths (C:\...) can't be read by a remote Linux backend.
+        // The previewUrl is already a base64 data URL � send the bytes instead.
+        const isWindowsPath = /^[a-zA-Z]:[/\\]|\\/.test(attachment.path ?? '')
+        const attachParams: Record<string, unknown> = { session_id: sessionId }
+        if (isWindowsPath && attachment.previewUrl) {
+          attachParams.data = attachment.previewUrl
+        } else {
+          attachParams.path = attachment.path
+        }
+
+        const result = await requestGateway<ImageAttachResponse>('image.attach', attachParams)
 
         if (!result.attached) {
           const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4731,26 +4731,41 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
-    raw = str(params.get("path", "") or "").strip()
-    if not raw:
-        return _err(rid, 4015, "path required")
+    remainder = ""
     try:
-        from cli import (
-            _IMAGE_EXTENSIONS,
-            _detect_file_drop,
-            _resolve_attachment_path,
-            _split_path_input,
-        )
-
-        dropped = _detect_file_drop(raw)
-        if dropped:
-            image_path = dropped["path"]
-            remainder = dropped["remainder"]
+        from cli import _IMAGE_EXTENSIONS
+        b64_data = str(params.get("data", "") or "").strip()
+        if b64_data:
+            import base64, tempfile, time
+            from pathlib import Path
+            if "," in b64_data:
+                header, b64_data = b64_data.split(",", 1)
+                ext = ".jpg" if "jpeg" in header else ".png" if "png" in header else ".webp" if "webp" in header else ".png"
+            else:
+                ext = str(params.get("ext", ".png") or ".png")
+            img_bytes = base64.b64decode(b64_data)
+            upload_dir = Path(tempfile.gettempdir()) / "hermes-uploads"
+            upload_dir.mkdir(exist_ok=True)
+            image_path = upload_dir / f"upload_{int(time.time() * 1000)}{ext}"
+            image_path.write_bytes(img_bytes)
         else:
-            path_token, remainder = _split_path_input(raw)
-            image_path = _resolve_attachment_path(path_token)
-            if image_path is None:
-                return _err(rid, 4016, f"image not found: {path_token}")
+            raw = str(params.get("path", "") or "").strip()
+            if not raw:
+                return _err(rid, 4015, "path or data required")
+            from cli import (
+                _detect_file_drop,
+                _resolve_attachment_path,
+                _split_path_input,
+            )
+            dropped = _detect_file_drop(raw)
+            if dropped:
+                image_path = dropped["path"]
+                remainder = dropped["remainder"]
+            else:
+                path_token, remainder = _split_path_input(raw)
+                image_path = _resolve_attachment_path(path_token)
+                if image_path is None:
+                    return _err(rid, 4016, f"image not found: {path_token}")
         if image_path.suffix.lower() not in _IMAGE_EXTENSIONS:
             return _err(rid, 4016, f"unsupported image: {image_path.name}")
         session.setdefault("attached_images", []).append(str(image_path))


### PR DESCRIPTION
## Problem

When the desktop app connects to a remote Hermes backend (e.g. a Linux server), image attachments fail. The app saves clipboard/dropped images to a Windows-local temp path (e.g. `C:\Users\...\tmp.png`), then calls `image.attach` with that path. The remote Linux backend cannot read Windows filesystem paths and returns `image not found`.

Affects both clipboard paste (Ctrl+V) and file drag-and-drop when using `HERMES_DESKTOP_REMOTE_URL`.

## Solution

### `tui_gateway/server.py`
`image.attach` now accepts an optional `data` parameter (base64 data URL or raw base64 + `ext`). When provided, bytes are decoded and written to a server-side temp file. The existing `path` flow is unchanged — purely additive.

### `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`
`syncImageAttachmentsForSubmit` detects Windows-style paths before calling `image.attach`. When a Windows path is detected and `previewUrl` is available (already fetched as base64 for the thumbnail), it sends `data` instead of `path`. No new IPC or network calls introduced.

## Testing

Tested on Windows 11 desktop app pointing at a remote Linux Hermes instance via `HERMES_DESKTOP_REMOTE_URL`. Clipboard paste and drag-and-drop now successfully deliver images to the agent.