### PR TITLE
fix(gateway): distinguish gateway auth 401 from provider API key errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -336,6 +336,7 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
 _AUTH_PATTERNS = [
     "invalid api key",
     "invalid_api_key",
+    "gateway_auth_failed",
     "authentication",
     "unauthorized",
     "forbidden",

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -48,7 +48,11 @@ function cleanErrorText(value: string) {
 
 const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string) => string }[] = [
   {
-    test: msg => /incorrect api key provided/i.test(msg) || /['"]code['"]\s*:\s*['"]invalid_api_key['"]/i.test(msg),
+    test: msg => /['"']code['"']\s*:\s*['"']gateway_auth_failed['"']/i.test(msg),
+    summarize: () => 'Gateway authentication failed — check your API_SERVER_KEY.'
+  },
+  {
+    test: msg => /incorrect api key provided/i.test(msg) || /['"']code['"']\s*:\s*['"']invalid_api_key['"']/i.test(msg),
     summarize: msg => {
       const status = msg.match(/(?:error code|status(?:Code)?)[^\d]*(\d{3})/i)?.[1]
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -874,7 +874,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._request_audit_log_suffix(request),
         )
         return web.json_response(
-            {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+            {"error": {"message": "Invalid gateway API key (API_SERVER_KEY)", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
             status=401,
         )
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -344,7 +344,7 @@ async def test_session_endpoints_require_auth_when_key_configured(auth_adapter):
         resp = await cli.get("/api/sessions")
         assert resp.status == 401
         body = await resp.json()
-        assert body["error"]["code"] == "invalid_api_key"
+        assert body["error"]["code"] == "gateway_auth_failed"
 
         ok = await cli.get("/api/sessions", headers={"Authorization": "Bearer sk-test"})
         assert ok.status == 200


### PR DESCRIPTION
## Summary

Fixes the misleading "OpenRouter API key missing" error shown by Hermes Desktop when the real failure is a **401 from API_SERVER_KEY** (gateway authentication).

Fixes #39365

## Root Cause

The `api_server.py` adapter's `_check_auth()` returned error code `"invalid_api_key"` for API_SERVER_KEY authentication failures. The Desktop's error classifier (`notifications.ts`) matched this code and displayed "OpenAI rejected the API key" (or triggered the provider onboarding overlay showing OpenRouter) — even though the issue was gateway auth, not a provider key.

## Changes

| File | Change |
|------|--------|
| `gateway/platforms/api_server.py` | Return `"gateway_auth_failed"` code with message `"Invalid gateway API key (API_SERVER_KEY)"` instead of generic `"invalid_api_key"` |
| `apps/desktop/src/store/notifications.ts` | Add `"gateway_auth_failed"` handler **before** `"invalid_api_key"` — shows `"Gateway authentication failed — check your API_SERVER_KEY."` |
| `agent/error_classifier.py` | Add `"gateway_auth_failed"` to `_AUTH_PATTERNS` list |
| `tests/gateway/test_session_api.py` | Update test assertion to expect `"gateway_auth_failed"` |

## Why This Works

- Gateway auth failures now carry a **distinct error code** (`gateway_auth_failed`) that the Desktop can distinguish from provider key errors (`invalid_api_key`)
- The `notifications.ts` handler for `gateway_auth_failed` is **listed first**, so it matches before the generic `invalid_api_key` handler
- The `error_classifier.py` still classifies gateway auth failures as auth errors (for retry logic), but the code is distinct

## Testing

1. Set `API_SERVER_KEY` in gateway config
2. Make a request with wrong/missing key → should show "Gateway authentication failed — check your API_SERVER_KEY" (not "OpenRouter API key missing")
3. Make a request with correct key → should work normally
4. Existing test `test_session_endpoints_require_auth_when_key_configured` updated to match new code