### PR TITLE
fix(agent): classify quota-exhaustion 429s as billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -830,7 +830,8 @@ def _classify_by_status(
         # disambiguation used by 402 and message-only classification.
         has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
         has_billing_pattern = any(p in error_msg for p in _BILLING_PATTERNS)
-        if has_usage_limit or has_billing_pattern:
+        has_rate_limit_pattern = any(p in error_msg for p in _RATE_LIMIT_PATTERNS)
+        if has_billing_pattern or (has_usage_limit and not has_rate_limit_pattern):
             has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
             if not has_transient_signal:
                 return result_fn(

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -825,7 +825,20 @@ def _classify_by_status(
         )
 
     if status_code == 429:
-        # Already checked long_context_tier above; this is a normal rate limit
+        # Already checked long_context_tier above. Some providers still use 429
+        # for terminal quota/billing exhaustion, so keep the same message-aware
+        # disambiguation used by 402 and message-only classification.
+        has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        has_billing_pattern = any(p in error_msg for p in _BILLING_PATTERNS)
+        if has_usage_limit or has_billing_pattern:
+            has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+            if not has_transient_signal:
+                return result_fn(
+                    FailoverReason.billing,
+                    retryable=False,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
         return result_fn(
             FailoverReason.rate_limit,
             retryable=True,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -328,6 +328,12 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    def test_429_rate_limit_exceeded_stays_rate_limit(self):
+        e = MockAPIError("Rate limit exceeded.", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_429_billing_phrase_without_usage_limit_is_billing(self):
         e = MockAPIError("insufficient credits remaining", status_code=429)
         result = classify_api_error(e)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -308,6 +308,32 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_fallback is True
 
+    def test_429_usage_limit_without_retry_signal_is_billing(self):
+        e = MockAPIError(
+            "You've reached monthly usage limit for this billing cycle",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_429_usage_limit_with_retry_signal_stays_rate_limit(self):
+        e = MockAPIError(
+            "usage limit exceeded, try again in 5 minutes",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_billing_phrase_without_usage_limit_is_billing(self):
+        e = MockAPIError("insufficient credits remaining", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     def test_alibaba_rate_increased_too_quickly(self):
         """Alibaba/DashScope returns a unique throttling message.
 


### PR DESCRIPTION
## What does this PR do?

Fixes the 429 classification gap in `agent/error_classifier.py` for providers that return permanent quota or billing exhaustion as HTTP 429 instead of 402.

Before this change, the 429 branch always classified as `rate_limit`, which burned through retries and delayed fallback even when the response body clearly indicated a terminal usage-limit or billing-cycle exhaustion error.

This patch keeps transient 429s with retry-window language on the existing `rate_limit` path, but classifies terminal usage-limit or billing-pattern 429s as `billing` so Hermes fails fast or falls back immediately.

## Related Issue

Fixes #36276

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update the HTTP 429 branch in `agent/error_classifier.py` to inspect usage-limit and billing phrases before defaulting to `rate_limit`
- Preserve retryable behavior for transient 429s that include retry-window signals like `try again`
- Add regression coverage in `tests/agent/test_error_classifier.py` for terminal and transient 429 variants

## How to Test

1. Run `.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q`
2. Run `.venv/bin/ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`
3. Run `.venv/bin/python -m py_compile agent/error_classifier.py tests/agent/test_error_classifier.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ .venv/bin/python -m pytest tests/agent/test_error_classifier.py -q
158 passed in 2.33s

$ .venv/bin/ruff check agent/error_classifier.py tests/agent/test_error_classifier.py
All checks passed!

$ .venv/bin/python -m py_compile agent/error_classifier.py tests/agent/test_error_classifier.py
# exit 0
```
