### PR TITLE
fix(display): correct spelling of overridable and interruptible

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -137,8 +137,8 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
-# Canonical set of per-platform overrideable keys (for validation).
-OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+# Canonical set of per-platform overridable keys (for validation).
+OVERRIDABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
 def resolve_display_setting(

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1011,7 +1011,7 @@ def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[s
 
 
 # ============================================================================
-# Audio playback (interruptable)
+# Audio playback (interruptible)
 # ============================================================================
 
 # Global reference to the active playback process so it can be interrupted.
@@ -1081,7 +1081,7 @@ def play_audio_file(file_path: str) -> bool:
         except Exception as e:
             logger.debug("sounddevice playback failed: %s", e)
 
-    # Fall back to system audio players (using Popen for interruptability)
+    # Fall back to system audio players (using Popen for interruptibility)
     system = platform.system()
     players = []
 


### PR DESCRIPTION
Closes #9335

## Changes
- `OVERRIDEABLE_KEYS` → `OVERRIDABLE_KEYS` in `gateway/display_config.py`
- `interruptable` → `interruptible` in `tools/voice_mode.py` comments
- `interruptability` → `interruptibility` in `tools/voice_mode.py` comments

## Verification
- [x] Only spelling changes — no logic modified
- [x] Tests pass