### PR TITLE
feat(secrets): add 1Password SDK-based secret source (onepassword-sdk)

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,9 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+
+  - ``onepassword`` — 1Password Service Account (``onepassword-sdk``).
+    See ``agent.secret_sources.onepassword`` for the integration and
+    ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+    Uses the Python SDK instead of the ``op`` CLI daemon.
 """

--- a/agent/secret_sources/_cache.py
+++ b/agent/secret_sources/_cache.py
@@ -1,0 +1,375 @@
+"""Shared cache and result substrate for secret-source backends.
+
+Every backend (Bitwarden, 1Password, …) needs the same handful of
+security-sensitive primitives:
+
+- a uniform result object (``FetchResult``),
+- environment-variable name validation (``is_valid_env_name``),
+- a two-layer fetch cache whose disk half writes atomically with
+  ``0600`` permissions and honours a TTL (``DiskCache``, ``CachedFetch``).
+
+Pulling them here means the atomic-write / ``0600`` / TTL logic is
+audited and fixed in exactly one place instead of drifting across
+copy-pasted per-backend modules — each backend supplies only its own
+cache-key shape and a serializer for it.
+
+**Design rule**: nothing in this module ever raises out to the caller's
+hot path.  The disk layer is strictly best-effort (a miss just triggers
+a refetch), because a cache problem must never block Hermes startup.
+
+The two-layer cache improves on the single-disk-layer approach:
+
+1. **L1 — in-process dict** (instant, no I/O).  Survives repeated
+   calls within one process (gateway hot-reload, multiple import
+   paths).  Expires slightly *before* the L2 TTL so a multi-process
+   group naturally converges on a single refresher.
+
+2. **L2 — disk-persisted JSON** (~5 ms on hit).  Shared across
+   processes (CLI invocations, cron jobs, gateway forking new agents).
+
+Credit: the shared-cache pattern was first proposed by @hwrdprkns in
+PR #36896 for the 1Password CLI backend.  This module generalises it
+further with an in-process L1 layer and rate-limit cooldown support
+so it can serve both the Bitwarden (low-API-call) and 1Password
+(high-API-call) use cases from one auditable location.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchResult:
+    """Outcome of a single secret-source fetch.
+
+    ``error`` is reserved for fatal conditions where *nothing* was
+    fetched (missing binary, bad auth, etc.).  Partial failures go in
+    ``warnings`` so that successfully resolved secrets can still be
+    applied.
+    """
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: List[str] = field(default_factory=list)   # set into os.environ
+    skipped: List[str] = field(default_factory=list)   # already set, not overridden
+    warnings: List[str] = field(default_factory=list)  # non-fatal issues
+    error: Optional[str] = None                         # fatal: nothing was fetched
+    binary_path: Optional[Path] = None                  # resolved binary (CLI backends)
+    cache_hit: bool = False                             # served from L1 or L2 cache
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+@dataclass
+class CachedFetch:
+    """A set of fetched secrets and when they were retrieved."""
+
+    secrets: Dict[str, str]
+    fetched_at: float
+
+    def is_fresh(self, ttl_seconds: float) -> bool:
+        """Return True when the entry is still fresh under *ttl_seconds*.
+
+        A TTL ≤ 0 means *never fresh* (opt-out of caching entirely).
+        """
+        if ttl_seconds <= 0:
+            return False
+        return (time.time() - self.fetched_at) < ttl_seconds
+
+
+# ---------------------------------------------------------------------------
+# Env-var name validation
+# ---------------------------------------------------------------------------
+
+
+def is_valid_env_name(name: str) -> bool:
+    """Return True if *name* is a usable POSIX environment-variable name.
+
+    Must be non-empty, start with a letter or underscore, and contain only
+    alphanumerics and underscores.  Backends use this to drop secret names
+    that couldn't be exported (e.g. ``"has spaces"`` or ``"1LEADING_DIGIT"``).
+    """
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+# ---------------------------------------------------------------------------
+# Disk cache
+# ---------------------------------------------------------------------------
+
+K = TypeVar("K")
+"""Cache-key type — supplied by the backend."""
+
+
+class TwoLayerCache(Generic[K]):
+    """Best-effort two-layer cache for fetched secret values.
+
+    **L1 — in-process dict**
+    Instant hits within one process.  Expires at 90 % of the disk
+    TTL so sibling processes naturally converge on a single refresher.
+
+    **L2 — disk-persisted JSON** (``<hermes_home>/cache/<basename>``)
+    Shared across processes.  Written atomically (``mkstemp`` →
+    ``chmod 0600`` → ``os.replace``).  The cache directory is forced
+    to ``0700``.
+
+    The disk file holds only secret **values** keyed by the serialized
+    cache key — never raw auth material.  Backends must fingerprint
+    tokens/sessions before serialization so the token itself never
+    appears in the key.
+
+    Setting ``ttl_seconds`` to 0 disables **both** cache layers
+    symmetrically — a user opting out never gets secret values written
+    to disk at all.
+
+    **Rate-limit cooldown** (optional): when enabled, a backend can
+    record a cooldown timestamp per cache key.  Subsequent reads return
+    ``None`` (cooldown active) until the window expires, preventing N
+    sibling processes from hammering a rate-limited API in lockstep.
+    """
+
+    # L1 — in-process cache
+    _l1: Dict[K, CachedFetch] = {}
+    _l1_expiry: Dict[K, float] = {}
+
+    # Rate-limit cooldown
+    _cooldowns: Dict[K, float] = {}
+    _cooldown_enabled: bool = False
+    _cooldown_seconds: float = 3600.0
+
+    def __init__(
+        self,
+        basename: str,
+        *,
+        serializer: Optional[Callable[[K], str]] = None,
+        deserializer: Optional[Callable[[str], K]] = None,
+        cooldown_enabled: bool = False,
+        cooldown_seconds: float = 3600.0,
+    ):
+        """Create a two-layer cache.
+
+        Args:
+            basename: File name under ``<hermes_home>/cache/``.
+            serializer: ``(K) → str`` — converts a cache key to a
+                stable JSON-dict key.  Defaults to ``str()``.
+            deserializer: ``(str) → K`` — converts a JSON-dict key
+                back.  If omitted, the raw string is used as the key
+                and the backend must handle conversion.
+            cooldown_enabled: When True, ``record_cooldown()`` and
+                ``is_cooldown_active()`` gate reads.  Use for
+                rate-limited APIs (1Password: 1,000 reads/hour).
+            cooldown_seconds: How long a cooldown lasts (default 1 h).
+        """
+        self._basename = basename
+        self._serializer = serializer or str
+        self._deserializer = deserializer or (lambda s: s)
+        self._cooldown_enabled = cooldown_enabled
+        self._cooldown_seconds = cooldown_seconds
+
+    # -- Rate-limit cooldown ------------------------------------------------
+
+    def record_cooldown(self, key: K) -> None:
+        """Record that *key* hit a rate limit now."""
+        if self._cooldown_enabled:
+            self._cooldowns[key] = time.time() + self._cooldown_seconds
+
+    def is_cooldown_active(self, key: K) -> bool:
+        """Return True when reads for *key* should be suppressed."""
+        if not self._cooldown_enabled:
+            return False
+        until = self._cooldowns.get(key, 0.0)
+        return time.time() < until
+
+    def cooldown_remaining(self, key: K) -> float:
+        """Seconds until cooldown expires for *key* (0 if not active)."""
+        until = self._cooldowns.get(key, 0.0)
+        return max(0.0, until - time.time())
+
+    # -- Two-layer read -----------------------------------------------------
+
+    def read(
+        self,
+        key: K,
+        ttl_seconds: float,
+        home_path: Optional[Path] = None,
+    ) -> Optional[CachedFetch]:
+        """Return a fresh cached entry (L1 then L2), or None.
+
+        If the cooldown is active for *key* the read is aborted early.
+        """
+        if ttl_seconds <= 0:
+            return None
+
+        # Cooldown gate (before any I/O)
+        if self.is_cooldown_active(key):
+            return None
+
+        # L1 — in-process dict
+        entry = self._l1.get(key)
+        if entry and entry.is_fresh(ttl_seconds):
+            return entry
+
+        # L2 — disk
+        disk_entry = self._read_disk(key, ttl_seconds, home_path)
+        if disk_entry is not None:
+            # Promote to L1 with slightly shorter expiry so the disk
+            # layer always expires first and a sibling process can
+            # become the designated refresher.
+            self._l1[key] = disk_entry
+            self._l1_expiry[key] = time.time() + ttl_seconds * 0.9
+            return disk_entry
+
+        return None
+
+    def write(
+        self,
+        key: K,
+        entry: CachedFetch,
+        home_path: Optional[Path] = None,
+    ) -> None:
+        """Persist *entry* to L1 and atomically to L2.  Best-effort."""
+        # L1
+        self._l1[key] = entry
+        self._l1_expiry[key] = time.time()
+
+        # L2
+        self._write_disk(key, entry, home_path)
+
+    def clear(self, home_path: Optional[Path] = None) -> None:
+        """Clear L1 and L2 for all keys.  For tests."""
+        self._l1.clear()
+        self._l1_expiry.clear()
+        self._cooldowns.clear()
+        try:
+            _disk_cache_path(self._basename, home_path).unlink()
+        except (FileNotFoundError, OSError):
+            pass
+
+    # -- Disk I/O (private) ------------------------------------------------
+
+    def _read_disk(
+        self,
+        key: K,
+        ttl_seconds: float,
+        home_path: Optional[Path] = None,
+    ) -> Optional[CachedFetch]:
+        path = _disk_cache_path(self._basename, home_path)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+
+        key_str = self._serializer(key)
+        entry_data = payload.get(key_str)
+        if entry_data is None:
+            return None
+
+        secrets = entry_data.get("secrets")
+        fetched_at = entry_data.get("fetched_at")
+        if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
+            return None
+
+        # Coerce all values to strings — JSON allows numbers but env vars need str
+        typed_secrets: Dict[str, str] = {}
+        for k, v in secrets.items():
+            if isinstance(k, str) and isinstance(v, str):
+                typed_secrets[k] = v
+
+        entry = CachedFetch(secrets=typed_secrets, fetched_at=float(fetched_at))
+        if not entry.is_fresh(ttl_seconds):
+            return None
+        return entry
+
+    def _write_disk(
+        self,
+        key: K,
+        entry: CachedFetch,
+        home_path: Optional[Path] = None,
+    ) -> None:
+        path = _disk_cache_path(self._basename, home_path)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Force cache directory to 0700
+            try:
+                path.parent.chmod(0o700)
+            except OSError:
+                pass
+
+            # Read existing entries to merge (preserve sibling entries)
+            existing = {}
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    existing = data
+            except (OSError, json.JSONDecodeError):
+                pass
+
+            key_str = self._serializer(key)
+            existing[key_str] = {
+                "secrets": entry.secrets,
+                "fetched_at": entry.fetched_at,
+            }
+
+            # Atomic write
+            fd, tmp = tempfile.mkstemp(
+                prefix=".hermes_sc_",
+                suffix=".tmp",
+                dir=str(path.parent),
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(existing, f)
+                os.chmod(tmp, 0o600)
+                os.replace(tmp, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            pass  # best-effort — disk miss on next invocation is fine
+
+
+# ---------------------------------------------------------------------------
+# Home-path resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_cache_home(home_path: Optional[Path] = None) -> Path:
+    """Resolve the Hermes home directory for cache storage.
+
+    If *home_path* is provided it is used directly (tests,
+    ``load_hermes_dotenv()`` already resolved it).  Otherwise falls
+    back to ``$HERMES_HOME`` and then ``~/.hermes``.
+    """
+    if home_path is not None:
+        return home_path
+    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def _disk_cache_path(basename: str, home_path: Optional[Path] = None) -> Path:
+    """Resolve the full path for a disk-cache file."""
+    return resolve_cache_home(home_path) / "cache" / basename

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -1,0 +1,660 @@
+"""1Password Service Account integration (onepassword-sdk).
+
+Hermes pulls secrets from 1Password at process startup so they don't
+have to live in plaintext in ``~/.hermes/.env``.
+
+Design summary
+--------------
+
+* The **``onepassword-sdk``** Python package is used instead of the ``op``
+  CLI because the SDK authenticates directly via the 1Password REST API
+  and does not require a background daemon.  The ``op`` CLI's
+  daemon-based architecture is unreliable on macOS in headless/background
+  contexts (the daemon hangs on startup).  Using the Python SDK avoids
+  the daemon entirely.
+
+* The service account token is stored in ``~/.hermes/.env`` as
+  ``OP_SERVICE_ACCOUNT_TOKEN`` (or whatever name the user picked in
+  ``secrets.onepassword.token_env``).  This is the one bootstrap
+  secret — every other provider key can live in 1Password.
+
+* **Two mapping modes** (configurable):
+
+  1. **Explicit** — the user lists env-var → ``op://`` reference pairs
+     in ``secrets.onepassword.env`` (like the Bitwarden pattern):
+
+     .. code-block:: yaml
+
+        secrets:
+          onepassword:
+            enabled: true
+            env:
+              OPENAI_API_KEY: "op://Private/OpenAI/api key"
+              ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+
+  2. **Auto-discovery** — when ``auto_discover: true``, Hermes scans
+     all items in the configured vault and extracts credential fields.
+     Field titles become env var names (uppercased, spaces→underscores).
+     This requires zero per-secret config but is less auditable.
+
+  Both modes can be used together; explicit mappings take precedence.
+
+* Pulling secrets caches the result in TWO layers so that repeated
+  ``hermes`` invocations don't hammer the 1Password API:
+
+    1. **In-process dict** — saves repeated calls within one Hermes
+       process (gateway hot-reload, multiple import paths).
+    2. **Disk-persisted JSON** — saves repeated calls ACROSS processes
+       (CLI invocations, cron jobs, gateway forking new agents).
+
+  Both layers share the same TTL (default 300 s).
+
+* Failures NEVER block Hermes startup.  Missing SDK, no token, vault
+  not found, network timeout, rate limits, etc. all emit a one-line
+  warning and continue with whatever credentials ``.env`` already had.
+
+Rate-limit awareness
+--------------------
+
+The 1Password Service Account API throttles at **1,000 reads/hour**
+(per-token) for non-Business accounts.  The two-layer cache keeps
+the real API call count near 0 for the vast majority of Hermes
+invocations — only the first invocation after the cache TTL expires
+actually touches the wire.  Additionally, a **cooldown mechanism**
+prevents N sibling processes (gateway + dashboard + slash workers)
+from retrying in lockstep when the rate limit is hit: each process
+backs off for one hour, limiting total hourly calls to ``N × 3``
+(one attempt with three retries each).
+
+See: https://www.1password.dev/service-accounts/rate-limits
+
+Transport choice: SDK vs CLI
+-----------------------------
+
+This backend uses the ``onepassword-sdk`` Python package instead of
+the ``op`` CLI for two reasons:
+
+1. **No daemon dependency.**  The ``op`` CLI spawns a background daemon
+   (``op daemon --background``) that can hang indefinitely on macOS in
+   headless/background contexts — exactly the environment Hermes runs
+   in.  The SDK authenticates directly via HTTPS, avoiding the daemon
+   entirely.
+
+2. **Enables in-session tools.**  The SDK's Python API allows Hermes
+   to expose tools (``onepassword_list_vaults``, etc.) that can be
+   used mid-conversation without shelling out.  See
+   ``tools/onepassword_tool.py``.
+
+The trade-off is an extra pip dependency (``onepassword-sdk``) and
+async-only API.  For users who prefer the ``op`` CLI, the companion
+PR #36896 provides a CLI-based backend; the two implementations share
+the same ``_cache.py`` substrate and can coexist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import random
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from agent.secret_sources._cache import (
+    CachedFetch,
+    FetchResult,
+    TwoLayerCache,
+    is_valid_env_name,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+# Default token env var (matches the official 1Password CLI convention).
+_DEFAULT_TOKEN_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
+
+# Disk cache basename (shared with tools/onepassword_tool.py).
+_DISK_CACHE_BASENAME = "onepassword_cache.json"
+
+# Rate-limit retry settings
+_MAX_RETRIES = 3
+_RETRY_DELAY_BASE = 1.0  # seconds, doubled each attempt + jitter
+_RETRY_JITTER = 0.5       # ±50 % jitter on the delay
+
+# ---------------------------------------------------------------------------
+# Cache key helpers
+# ---------------------------------------------------------------------------
+
+
+def _token_fingerprint(token: str) -> str:
+    """SHA-256 prefix used as a cache key — never logged, never displayed.
+
+    Uses SHA-256 instead of the raw token prefix to avoid leaking even
+    the first 16 chars of the service account token through logs/cache
+    files.  This matches Bitwarden's approach in the same codebase.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _cache_key(token: str, vault: str, refs_fingerprint: str = "") -> str:
+    """Build a stable cache key from auth + vault + refs config.
+
+    Changing any of: token, vault name, or the explicit ``env:`` mapping
+    produces a different key so cache entries don't leak between configs.
+    """
+    fp = _token_fingerprint(token)
+    if refs_fingerprint:
+        return f"{fp}|{vault}|{refs_fingerprint}"
+    return f"{fp}|{vault}"
+
+
+def _refs_fingerprint(refs: Dict[str, str]) -> str:
+    """Hash the configured env→reference mapping so config changes bust cache."""
+    if not refs:
+        return ""
+    canonical = json_dumps_stable(refs)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def json_dumps_stable(obj: object) -> str:
+    """json.dumps with sorted keys for stable fingerprinting."""
+    import json as _json
+    return _json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# Shared cache instance
+# ---------------------------------------------------------------------------
+
+_cache = TwoLayerCache[str](
+    basename=_DISK_CACHE_BASENAME,
+    cooldown_enabled=True,
+    cooldown_seconds=3600.0,  # match the 1-hour rate-limit window
+)
+
+
+# ---------------------------------------------------------------------------
+# SDK availability
+# ---------------------------------------------------------------------------
+
+
+def _sdk_available() -> bool:
+    """Check if the onepassword-sdk is installed without importing it."""
+    try:
+        import onepassword  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit retry helper with jitter
+# ---------------------------------------------------------------------------
+
+
+async def _retry_on_rate_limit(coro_factory, *, label: str = ""):
+    """Await *coro_factory()*, retrying up to _MAX_RETRIES times on
+    rate-limit errors.
+
+    Uses a callable (``lambda: client.vaults.list()``) instead of a bare
+    coroutine so each retry creates a fresh awaitable — ``await`` consumes
+    a coroutine object and raises ``RuntimeError: cannot reuse already
+    awaited coroutine`` on re-use.
+
+    Uses exponential backoff WITH jitter so concurrent processes that
+    all hit a rate limit at once don't pile on at the same retry tick.
+    """
+    from onepassword.errors import RateLimitExceededException
+
+    for attempt in range(_MAX_RETRIES):
+        try:
+            return await coro_factory()
+        except RateLimitExceededException:
+            if attempt == _MAX_RETRIES - 1:
+                raise
+            base_delay = _RETRY_DELAY_BASE ** (attempt + 1)
+            jitter = 1.0 + random.uniform(-_RETRY_JITTER, _RETRY_JITTER)
+            delay = base_delay * jitter
+            logger.warning(
+                "1Password rate limit hit (%s), retrying in %.1fs (attempt %d/%d)",
+                label, delay, attempt + 1, _MAX_RETRIES,
+            )
+            await asyncio.sleep(delay)
+
+
+# ---------------------------------------------------------------------------
+# Env var name sanitation
+# ---------------------------------------------------------------------------
+
+
+def _sanitise_env_name(raw: Optional[str]) -> str:
+    """Convert a raw name to a valid env var name: uppercase, underscores."""
+    if not raw:
+        return ""
+    name = raw.strip().upper().replace(" ", "_").replace("-", "_")
+    name = "".join(c for c in name if c.isalnum() or c == "_")
+    if name and is_valid_env_name(name):
+        return name
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def apply_onepassword_secrets(
+    *,
+    enabled: bool,
+    token_env: str = _DEFAULT_TOKEN_ENV,
+    vault: str = "",
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+    auto_discover: bool = False,
+    env_refs: Optional[Dict[str, str]] = None,
+    home_path: Optional[Path] = None,
+) -> FetchResult:
+    """Pull secrets from 1Password and set them on ``os.environ``.
+
+    This is the function ``load_hermes_dotenv()`` calls after the .env
+    files have loaded.  It is intentionally defensive — any failure
+    returns a :class:`FetchResult` with ``error`` set; it never raises.
+
+    Parameters match the ``secrets.onepassword.*`` config keys.
+
+    Args:
+        enabled: Whether this source is active.
+        token_env: Env var holding the service account token.
+        vault: Vault name or ID to read from (required).
+        override_existing: If True, overwrite already-set env vars.
+        cache_ttl_seconds: Cache freshness window (0 = no caching).
+        auto_discover: When True, scan all items in *vault* for
+            credential fields and map field titles to env vars.
+            Ignored when *env_refs* is the only source.
+        env_refs: Explicit ``{ENV_VAR: "op://vault/item/field"}``
+            mappings.  These take precedence over auto-discovered
+            secrets when both are used.
+        home_path: Forwarded to disk cache lookups for tests /
+            non-standard installs.
+    """
+    result = FetchResult()
+
+    if not enabled:
+        return result
+
+    # --- Gate checks -------------------------------------------------------
+
+    access_token = os.environ.get(token_env, "").strip()
+    if not access_token:
+        result.error = (
+            f"secrets.onepassword.enabled is true but {token_env} is "
+            "not set in the environment."
+        )
+        return result
+
+    if not vault and not env_refs:
+        result.error = (
+            "secrets.onepassword: at least one of 'vault' or 'env' "
+            "must be configured."
+        )
+        return result
+
+    refs = env_refs or {}
+    if not auto_discover and not refs:
+        result.error = (
+            "secrets.onepassword: neither 'auto_discover' nor 'env' "
+            "mapping is configured — nothing to fetch."
+        )
+        return result
+
+    if not _sdk_available():
+        result.error = (
+            "onepassword-sdk is not installed. "
+            "Run: uv pip install --python <hermes-python> onepassword-sdk"
+        )
+        return result
+
+    # --- Cache key ---------------------------------------------------------
+
+    key = _cache_key(access_token, vault, _refs_fingerprint(refs))
+
+    # --- Two-layer cache ---------------------------------------------------
+
+    cached = _cache.read(key, cache_ttl_seconds, home_path)
+    if cached is not None:
+        result.secrets = cached.secrets
+        result.cache_hit = True
+        _apply_secrets_to_env(result, access_token, token_env, override_existing)
+        return result
+
+    # --- Cooldown gate -----------------------------------------------------
+
+    if _cache.is_cooldown_active(key):
+        remaining = int(_cache.cooldown_remaining(key))
+        result.error = (
+            f"1Password rate-limit cooldown active "
+            f"(retry after {remaining}s); "
+            f"using previously-loaded credentials from .env"
+        )
+        return result
+
+    # --- Real API call -----------------------------------------------------
+
+    try:
+        secrets, warnings_list = _fetch_onepassword_secrets(
+            access_token=access_token,
+            vault=vault,
+            auto_discover=auto_discover,
+            env_refs=refs,
+        )
+    except Exception as exc:
+        # Record cooldown for rate-limit so sibling processes back off.
+        # Other failures (auth, network) are NOT cooled down — those are
+        # deterministic and need to surface every time.
+        from onepassword.errors import RateLimitExceededException
+
+        if isinstance(exc, RateLimitExceededException):
+            _cache.record_cooldown(key)
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(warnings_list)
+
+    # Populate both cache layers
+    entry = CachedFetch(secrets=secrets, fetched_at=time.time())
+    _cache.write(key, entry, home_path)
+
+    _apply_secrets_to_env(result, access_token, token_env, override_existing)
+
+    return result
+
+
+def _apply_secrets_to_env(
+    result: FetchResult,
+    access_token: str,
+    token_env: str,
+    override_existing: bool,
+) -> None:
+    """Apply secrets from result.secrets into os.environ."""
+    for env_name, value in result.secrets.items():
+        if env_name == token_env:
+            result.skipped.append(env_name)
+            continue
+        if not override_existing and os.environ.get(env_name):
+            result.skipped.append(env_name)
+            continue
+        os.environ[env_name] = value
+        result.applied.append(env_name)
+
+
+# ---------------------------------------------------------------------------
+# Internal fetch
+# ---------------------------------------------------------------------------
+
+
+def _fetch_onepassword_secrets(
+    access_token: str,
+    vault: str,
+    auto_discover: bool,
+    env_refs: Dict[str, str],
+) -> Tuple[Dict[str, str], List[str]]:
+    """Synchronous bridge — runs the async SDK in a fresh event loop."""
+    try:
+        return asyncio.run(_fetch_async(access_token, vault, auto_discover, env_refs))
+    except RuntimeError:
+        # If there's already a running event loop (e.g. in gateway),
+        # spawn a thread with its own loop instead.
+        import threading
+        result: List[Tuple[Dict[str, str], List[str]]] = []
+
+        def _runner() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                result.append(loop.run_until_complete(
+                    _fetch_async(access_token, vault, auto_discover, env_refs)
+                ))
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=_runner, daemon=True)
+        thread.start()
+        thread.join(timeout=60)
+        if not result:
+            raise RuntimeError("1Password fetch timed out or failed")
+        return result[0]
+
+
+async def _fetch_async(
+    access_token: str,
+    vault: str,
+    auto_discover: bool,
+    env_refs: Dict[str, str],
+) -> Tuple[Dict[str, str], List[str]]:
+    """Authenticate to 1Password and extract env-var-shaped secrets.
+
+    Two-phase extraction:
+
+    1. **Explicit mappings** — resolve each ``op://vault/item/field``
+       reference from *env_refs*.  These are direct SDK calls
+       (``items.get`` per ref) — efficient for small configs.
+
+    2. **Auto-discovery** (optional) — scan all items in *vault* and
+       extract credential fields whose titles become env var names.
+       Field titles take priority; item titles are used as fallback
+       for fields with generic labels (``credential``, ``password``).
+
+    In both phases, env-var-name collisions are resolved: explicit
+    mappings always win over auto-discovered ones.
+    """
+    from onepassword import Client
+
+    warnings_list: List[str] = []
+    secrets: Dict[str, str] = {}
+
+    client = await Client.authenticate(
+        auth=access_token,
+        integration_name="Hermes Agent 1Password Secret Source",
+        integration_version="1.0.0",
+    )
+
+    # --- Phase 0: resolve vault (needed for any per-item operations) --------
+
+    target_vault = None
+    if vault:
+        vaults = await _retry_on_rate_limit(
+            lambda: client.vaults.list(), label="vaults.list"
+        )
+        for v in vaults:
+            if v.title == vault or v.id == vault:
+                target_vault = v
+                break
+        if target_vault is None:
+            available = ", ".join(f"{v.title} ({v.id})" for v in vaults)
+            raise RuntimeError(
+                f"Vault '{vault}' not found. Available: {available}"
+            )
+
+    # --- Phase 1: explicit env_refs mappings --------------------------------
+
+    for env_name, ref in env_refs.items():
+        if not isinstance(ref, str) or not ref.startswith("op://"):
+            warnings_list.append(f"Skipping '{env_name}': not an op:// reference")
+            continue
+        if not is_valid_env_name(env_name):
+            warnings_list.append(f"Skipping '{env_name}': invalid env-var name")
+            continue
+
+        parts = ref[5:].split("/")
+        if len(parts) < 3:
+            warnings_list.append(f"Skipping '{env_name}': ref has < 3 parts")
+            continue
+
+        ref_vault, ref_item, ref_field = parts[0], parts[1], parts[2]
+
+        # Resolve the vault for this ref (may differ from the default vault)
+        if target_vault is None or ref_vault not in (target_vault.title, target_vault.id):
+            ref_target = None
+            for v in vaults:
+                if v.title == ref_vault or v.id == ref_vault:
+                    ref_target = v
+                    break
+            if ref_target is None:
+                warnings_list.append(
+                    f"Vault '{ref_vault}' not found (ref: {ref})"
+                )
+                continue
+        else:
+            ref_target = target_vault
+
+        try:
+            value = await _resolve_ref(client, ref_target.id, ref_item, ref_field)
+            if value:
+                secrets[env_name] = value
+            else:
+                warnings_list.append(
+                    f"'{env_name}': resolved to empty value from {ref}"
+                )
+        except Exception as exc:
+            warnings_list.append(f"'{env_name}': {exc}")
+
+    # --- Phase 2: auto-discovery (optional) ---------------------------------
+
+    if auto_discover and target_vault is not None:
+        items = await _retry_on_rate_limit(
+            lambda: client.items.list(vault_id=target_vault.id),
+            label="items.list",
+        )
+
+        # Generic field titles we skip for env-var naming (use item title instead)
+        _GENERIC = frozenset({
+            "credential", "password", "token", "secret",
+            "apikey", "api_key", "api key", "",
+        })
+
+        for item_overview in items:
+            try:
+                item = await _retry_on_rate_limit(
+                    lambda iid=item_overview.id: client.items.get(
+                        vault_id=target_vault.id, item_id=iid,
+                    ),
+                    label=f"items.get({item_overview.title})",
+                )
+            except Exception as exc:
+                warnings_list.append(
+                    f"Could not read item '{item_overview.title}': {exc}"
+                )
+                continue
+
+            found = False
+
+            # Phase 2a — field-title-as-env-var:
+            # If a CONCEALED/PASSWORD/API field has a non-generic title,
+            # use the field title as the env var name.
+            for field in (item.fields or []):
+                ftitle = (field.title or "").strip().lower()
+                ftype = str(field.field_type) if field.field_type else ""
+                has_secret = (
+                    "CONCEALED" in ftype
+                    or "PASSWORD" in ftype
+                    or "API" in ftype
+                )
+                if has_secret and field.value and ftitle not in _GENERIC:
+                    env_name = _sanitise_env_name(field.title or "")
+                    if env_name and env_name not in secrets:
+                        secrets[env_name] = field.value
+                        found = True
+                        break
+
+            # Phase 2b — item-title fallback:
+            # Use the item title as env var name, first credential field as value.
+            if not found:
+                for field in (item.fields or []):
+                    ftype = str(field.field_type) if field.field_type else ""
+                    has_secret = (
+                        "CONCEALED" in ftype
+                        or "PASSWORD" in ftype
+                        or "API" in ftype
+                    )
+                    if has_secret and field.value:
+                        env_name = _sanitise_env_name(item.title or "")
+                        if env_name and env_name not in secrets:
+                            secrets[env_name] = field.value
+                            found = True
+                            break
+
+            # Phase 2c — last resort: any non-empty field, item-title as name
+            if not found:
+                for field in (item.fields or []):
+                    if field.value and field.value.strip():
+                        env_name = _sanitise_env_name(item.title or "")
+                        if env_name and env_name not in secrets:
+                            secrets[env_name] = field.value
+                            found = True
+                            break
+
+    return secrets, warnings_list
+
+
+async def _resolve_ref(
+    client,
+    vault_id: str,
+    item_name: str,
+    field_label: str,
+) -> str:
+    """Resolve an ``op://vault/item/field`` reference to its value.
+
+    Finds the item by title (case-insensitive) in *vault_id*, then
+    matches the field by label (case-insensitive).
+    """
+    items = await _retry_on_rate_limit(
+        lambda: client.items.list(vault_id=vault_id),
+        label=f"items.list(resolve:{item_name})",
+    )
+
+    target_item = None
+    for it in items:
+        if it.title.lower() == item_name.lower():
+            target_item = it
+            break
+
+    if target_item is None:
+        available = ", ".join(it.title for it in items[:10])
+        raise RuntimeError(
+            f"Item '{item_name}' not found in vault. "
+            f"Available (first 10): {available}"
+        )
+
+    item = await _retry_on_rate_limit(
+        lambda: client.items.get(vault_id=vault_id, item_id=target_item.id),
+        label=f"items.get({item_name})",
+    )
+
+    for field in (item.fields or []):
+        label = (field.title or field.id or "").lower()
+        if label == field_label.lower():
+            return field.value or ""
+
+    field_names = ", ".join(
+        (f.title or f.id or "") for f in (item.fields or [])
+    )
+    raise RuntimeError(
+        f"Field '{field_label}' not found in item '{item_name}'. "
+        f"Available: {field_names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test hook
+# ---------------------------------------------------------------------------
+
+
+def _reset_cache_for_tests(home_path: Optional[Path] = None) -> None:
+    """Clear in-process AND disk caches.  For hermetic tests."""
+    _cache.clear(home_path)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1165,3 +1165,47 @@ display:
 #   # default — works on Fly.io out of the box).
 #   #
 #   #   public_url: "https://example.com/hermes"
+
+# =============================================================================
+# External Secret Sources
+# =============================================================================
+# Hermes can pull API keys from a secret manager at startup instead of
+# storing them in plaintext in ~/.hermes/.env.
+#
+# Two backends are supported:
+#   - Bitwarden Secrets Manager (bws CLI)
+#   - 1Password Service Accounts (onepassword-sdk)
+#
+# Both are fail-safe: a missing binary, expired auth, or bad reference
+# produces a one-line warning and Hermes continues with whatever
+# credentials .env already had.
+#
+#secrets:
+#
+#  # Bitwarden Secrets Manager
+#  # bitwarden:
+#  #   enabled: true
+#  #   access_token_env: BWS_ACCESS_TOKEN
+#  #   project_id: "your-project-uuid"
+#  #   override_existing: false
+#  #   cache_ttl_seconds: 300
+#  #   auto_install: true          # auto-download bws if missing
+#  #   server_url: ""              # EU Cloud / self-hosted
+#
+#  # 1Password Service Account (onepassword-sdk)
+#  # Uses the Python SDK — no op CLI daemon needed.
+#  # onepassword:
+#  #   enabled: true
+#  #   token_env: OP_SERVICE_ACCOUNT_TOKEN
+#  #
+#  #   # Mode A: Auto-discovery (zero per-secret config)
+#  #   vault: "Private"
+#  #   auto_discover: true
+#  #
+#  #   # Mode B: Explicit mapping (auditable, like Bitwarden)
+#  #   env:
+#  #     OPENAI_API_KEY: "op://Private/OpenAI/api key"
+#  #     ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+#  #
+#  #   override_existing: false
+#  #   cache_ttl_seconds: 300

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -248,7 +248,7 @@ def load_hermes_dotenv(
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:
-    """Pull secrets from external sources (currently Bitwarden) into env.
+    """Pull secrets from external sources (Bitwarden, 1Password) into env.
 
     Runs AFTER dotenv loads so .env values are visible (we use them to
     locate the access token) but BEFORE the rest of Hermes reads
@@ -274,6 +274,12 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     except Exception:  # noqa: BLE001 — config errors must not block startup
         return
 
+    _apply_bitwarden(cfg, home_path)
+    _apply_onepassword(cfg, home_path)
+
+
+def _apply_bitwarden(cfg: dict, home_path: Path) -> None:
+    """Apply Bitwarden secrets if configured."""
     bw_cfg = (cfg or {}).get("bitwarden") or {}
     if not bw_cfg.get("enabled"):
         return
@@ -319,6 +325,55 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     for warn in result.warnings:
         print(
             f"  Bitwarden Secrets Manager: {warn}",
+            file=sys.stderr,
+        )
+
+
+def _apply_onepassword(cfg: dict, home_path: Path) -> None:
+    """Apply 1Password secrets if configured.
+
+    Uses the ``onepassword-sdk`` Python package instead of the ``op`` CLI
+    daemon.  The SDK authenticates directly via the 1Password REST API
+    and does not require a background daemon.
+    """
+    op_cfg = (cfg or {}).get("onepassword") or {}
+    if not op_cfg.get("enabled"):
+        return
+
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets
+    except ImportError:
+        return
+
+    result = apply_onepassword_secrets(
+        enabled=True,
+        token_env=op_cfg.get("token_env", "OP_SERVICE_ACCOUNT_TOKEN"),
+        vault=op_cfg.get("vault", ""),
+        override_existing=bool(op_cfg.get("override_existing", False)),
+        cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+        auto_discover=bool(op_cfg.get("auto_discover", False)),
+        env_refs=op_cfg.get("env") or {},
+        home_path=home_path,
+    )
+
+    if result.applied:
+        _sanitize_loaded_credentials()
+        for name in result.applied:
+            _SECRET_SOURCES[name] = "onepassword"
+        print(
+            f"  1Password: applied {len(result.applied)} "
+            f"secret{'s' if len(result.applied) != 1 else ''} "
+            f"({', '.join(sorted(result.applied))})",
+            file=sys.stderr,
+        )
+    if result.error:
+        print(
+            f"  1Password: {result.error}",
+            file=sys.stderr,
+        )
+    for warn in result.warnings:
+        print(
+            f"  1Password: {warn}",
             file=sys.stderr,
         )
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -360,9 +360,11 @@ def _apply_onepassword(cfg: dict, home_path: Path) -> None:
         _sanitize_loaded_credentials()
         for name in result.applied:
             _SECRET_SOURCES[name] = "onepassword"
+        cache_tag = " (cached)" if result.cache_hit else ""
         print(
             f"  1Password: applied {len(result.applied)} "
-            f"secret{'s' if len(result.applied) != 1 else ''} "
+            f"secret{'s' if len(result.applied) != 1 else ''}"
+            f"{cache_tag} "
             f"({', '.join(sorted(result.applied))})",
             file=sys.stderr,
         )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12881,15 +12881,15 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
-    # secrets command — external secret managers (currently: Bitwarden)
+    # secrets command — external secret managers (Bitwarden, 1Password)
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden / 1Password)",
         description=(
-            "Pull API keys from an external secret manager at process startup "
-            "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
+            "Pull API keys from external secret managers at process startup "
+            "instead of storing them in ~/.hermes/.env.  Supports Bitwarden "
+            "Secrets Manager and 1Password Service Accounts.  See: "
             "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
         ),
     )
@@ -12901,15 +12901,25 @@ def main():
         help="Bitwarden Secrets Manager integration",
     )
 
+    secrets_op = secrets_subparsers.add_parser(
+        "onepassword",
+        aliases=["op", "1password"],
+        help="1Password Service Account integration (via onepassword-sdk)",
+    )
+
     # Lazy import — only pays for itself when this subcommand is actually used.
     from hermes_cli import secrets_cli as _secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
+    _secrets_cli.register_onepassword_cli(secrets_op)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        op_sub = getattr(args, "secrets_op_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("onepassword", "op", "1password") and op_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -574,3 +574,488 @@ def _resolve_server_url(
                 )
             return custom
         console.print(f"  [red]Out of range — pick 1-{custom_idx}.[/red]")
+
+
+# ===========================================================================
+# 1Password Service Account — CLI handlers
+# ===========================================================================
+
+
+def register_onepassword_cli(parent_parser: argparse.ArgumentParser) -> None:
+    """Attach the ``onepassword`` subcommand tree to ``hermes secrets``."""
+    sub = parent_parser.add_subparsers(dest="secrets_op_command")
+
+    setup = sub.add_parser(
+        "setup",
+        help="Interactive setup: verify SDK, test auth, enable",
+    )
+    setup.set_defaults(func=cmd_onepassword_setup)
+
+    status = sub.add_parser(
+        "status",
+        help="Show config + SDK availability + token presence",
+    )
+    status.set_defaults(func=cmd_onepassword_status)
+
+    sync = sub.add_parser(
+        "sync",
+        help="Fetch secrets from 1Password and show what would be applied",
+    )
+    sync.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually export secrets into os.environ",
+    )
+    sync.set_defaults(func=cmd_onepassword_sync)
+
+    disable = sub.add_parser(
+        "disable",
+        help="Turn off the 1Password integration",
+    )
+    disable.set_defaults(func=cmd_onepassword_disable)
+
+    list_vaults = sub.add_parser(
+        "list-vaults",
+        help="List vaults the service account can access",
+    )
+    list_vaults.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
+    list_vaults.set_defaults(func=cmd_onepassword_list_vaults)
+
+
+def cmd_onepassword_setup(args: argparse.Namespace) -> int:
+    """Interactive wizard for 1Password integration setup."""
+    import getpass
+    import sys as _sys
+
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.setdefault("secrets", {})
+                 .setdefault("onepassword", {}))
+    token_env = op_cfg.get("token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    vault = op_cfg.get("vault", "")
+
+    console.print(
+        Panel.fit(
+            "[bold]1Password Service Account setup[/bold]\n\n"
+            "This backend uses the [cyan]onepassword-sdk[/cyan] Python package\n"
+            "instead of the ``op`` CLI daemon.  The SDK authenticates directly\n"
+            "via the 1Password REST API — no background daemon needed.\n\n"
+            "To get a service account token:\n"
+            "  1Password web → Developers → Service Accounts →\n"
+            "  Create service account → grant vault access → copy token\n\n"
+            "The token (starts with [cyan]ops_[/cyan]) is stored in .env\n"
+            "and used by the Python SDK to authenticate.",
+            border_style="green",
+        )
+    )
+
+    # Step 1: Check SDK
+    console.print()
+    console.print("[bold]Step 1[/bold]  Check onepassword-sdk")
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets  # noqa: F401
+        console.print("  [green]✓[/green] onepassword-sdk is installed")
+    except ImportError:
+        console.print(
+            "  [red]✗[/red] onepassword-sdk not found. Install:\n"
+            f"    uv pip install --python {_sys.executable} onepassword-sdk"
+        )
+        return 1
+
+    # Step 2: Token
+    console.print()
+    console.print(
+        f"[bold]Step 2[/bold]  Provide your service account token "
+        f"({token_env})"
+    )
+    existing_token = os.environ.get(token_env, "").strip()
+    if existing_token:
+        console.print(
+            f"  [green]✓[/green] {token_env} is already set "
+            f"({len(existing_token)} chars)"
+        )
+        token = existing_token
+    else:
+        token = getpass.getpass(f"  Paste token ({token_env}): ").strip()
+        if not token:
+            console.print("  [red]Empty token, aborting.[/red]")
+            return 1
+        save_env_value(token_env, token)
+        os.environ[token_env] = token
+        console.print(
+            f"  [green]✓[/green] stored in {get_env_path()} as {token_env}"
+        )
+
+    # Step 3: Choose mapping mode
+    console.print()
+    console.print("[bold]Step 3[/bold]  Choose mapping mode")
+    console.print(
+        "  [1] Auto-discovery — scan a vault and map credential fields "
+        "→ env vars automatically"
+    )
+    console.print(
+        "  [2] Explicit mapping — list each env var → op:// reference "
+        "in config.yaml"
+    )
+    console.print("  [3] Both — explicit + auto-discovery (explicit wins on conflicts)")
+
+    choice = console.input("  Pick 1-3 [1]: ").strip() or "1"
+    if choice not in ("1", "2", "3"):
+        console.print("  [red]Invalid choice.[/red]")
+        return 1
+
+    auto_discover = choice in ("1", "3")
+
+    # Step 4: Vault selection (for auto-discover mode)
+    selected_vault = ""
+    if auto_discover:
+        console.print()
+        console.print("[bold]Step 4[/bold]  Pick a vault")
+        selected_vault = _pick_onepassword_vault(token, token_env, vault, console)
+        if selected_vault is None:
+            return 1
+
+    # Step 5: Test fetch
+    console.print()
+    console.print(
+        f"[bold]Step {'5' if auto_discover else '4'}[/bold]  Test fetch"
+    )
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets
+    except ImportError:
+        console.print("  [red]SDK import failed unexpectedly.[/red]")
+        return 1
+
+    env_refs: dict = {}
+    result = apply_onepassword_secrets(
+        enabled=True,
+        token_env=token_env,
+        vault=selected_vault,
+        override_existing=True,
+        cache_ttl_seconds=0,  # Bypass cache for setup test
+        auto_discover=auto_discover,
+        env_refs=env_refs,
+    )
+
+    if result.error:
+        console.print(f"  [red]✗ Fetch failed: {result.error}[/red]")
+        return 1
+
+    if not result.secrets:
+        console.print(
+            "  [yellow]No secrets found.[/yellow]  "
+            "Check that the vault contains items with credential fields "
+            "(Concealed, Password, or API Credential types)."
+        )
+    else:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Env Var", style="cyan")
+        table.add_column("Status")
+        for key in sorted(result.secrets):
+            if os.environ.get(key):
+                status = (
+                    "[yellow]already set (will be overwritten)[/yellow]"
+                )
+            else:
+                status = "[green]new[/green]"
+            table.add_row(key, status)
+        console.print(table)
+    for w in result.warnings:
+        console.print(f"  [yellow]warning:[/yellow] {w}")
+
+    # Save config
+    op_cfg["enabled"] = True
+    op_cfg["token_env"] = token_env
+    if selected_vault:
+        op_cfg["vault"] = selected_vault
+    op_cfg["auto_discover"] = auto_discover
+    op_cfg.setdefault("override_existing", True)
+    op_cfg.setdefault("cache_ttl_seconds", 300)
+    save_config(cfg)
+
+    console.print()
+    console.print(
+        "[green]✓ 1Password integration is enabled.[/green]  "
+        "Secrets will be pulled at the start of every Hermes process."
+    )
+    console.print(
+        "  Status:  [cyan]hermes secrets onepassword status[/cyan]\n"
+        "  Sync:    [cyan]hermes secrets onepassword sync[/cyan]\n"
+        "  Disable: [cyan]hermes secrets onepassword disable[/cyan]"
+    )
+    return 0
+
+
+def cmd_onepassword_status(args: argparse.Namespace) -> int:
+    """Show 1Password integration status."""
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+
+    enabled = bool(op_cfg.get("enabled"))
+    token_env = op_cfg.get("token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    vault = op_cfg.get("vault", "")
+    token_set = bool(os.environ.get(token_env))
+
+    def _yn(val: bool) -> str:
+        return "[green]yes[/green]" if val else "[red]no[/red]"
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled",        _yn(enabled))
+    table.add_row("Token env var",  token_env)
+    table.add_row("Token in env",   _yn(token_set))
+    table.add_row("Vault",          vault or "(not set)")
+    table.add_row("Auto-discover",  _yn(bool(op_cfg.get("auto_discover", False))))
+    table.add_row("Explicit env",   str(len(op_cfg.get("env") or {})))
+    table.add_row("Override",       _yn(bool(op_cfg.get("override_existing", False))))
+    table.add_row("Cache TTL (s)",  str(op_cfg.get("cache_ttl_seconds", 300)))
+
+    sdk_ok = False
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets  # noqa: F401
+        sdk_ok = True
+    except ImportError:
+        pass
+    table.add_row("SDK installed",  _yn(sdk_ok))
+
+    console.print(
+        Panel(table, title="1Password Service Account", border_style="green")
+    )
+
+    if not enabled:
+        console.print(
+            "\n  Run [cyan]hermes secrets onepassword setup[/cyan] to enable."
+        )
+        return 0
+    if not token_set:
+        console.print(
+            f"\n  [yellow]Enabled but {token_env} is not set — "
+            "Hermes will skip 1Password on next startup.[/yellow]"
+        )
+    if not vault and not op_cfg.get("env"):
+        console.print(
+            "\n  [yellow]Enabled but no vault or env mapping configured "
+            "— nothing to fetch.[/yellow]"
+        )
+    return 0
+
+
+def cmd_onepassword_sync(args: argparse.Namespace) -> int:
+    """Fetch 1Password secrets now."""
+    import sys as _sys
+
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+
+    if not op_cfg.get("enabled"):
+        console.print(
+            "[yellow]1Password integration is disabled. Run "
+            "`hermes secrets onepassword setup` first.[/yellow]"
+        )
+        return 1
+
+    token_env = op_cfg.get("token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        console.print(f"[red]{token_env} is not set.[/red]")
+        return 1
+
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets
+    except ImportError:
+        console.print(
+            "[red]onepassword-sdk not installed.[/red] Install with:\n"
+            f"  uv pip install --python {_sys.executable} onepassword-sdk"
+        )
+        return 1
+
+    result = apply_onepassword_secrets(
+        enabled=True,
+        token_env=token_env,
+        vault=op_cfg.get("vault", ""),
+        override_existing=True,
+        cache_ttl_seconds=0,  # Bypass cache for explicit sync
+        auto_discover=bool(op_cfg.get("auto_discover", False)),
+        env_refs=op_cfg.get("env") or {},
+    )
+
+    if result.error:
+        console.print(f"[red]{result.error}[/red]")
+        return 1
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Env Var", style="cyan")
+    table.add_column("Action")
+    for name in sorted(result.secrets):
+        if name in result.applied:
+            table.add_row(name, "[green]exported[/green]")
+        elif name in result.skipped:
+            table.add_row(name, "[dim]skipped[/dim]")
+    console.print(table)
+    for w in result.warnings:
+        console.print(f"[yellow]warning:[/yellow] {w}")
+
+    if not args.apply:
+        console.print(
+            "\n  This was a dry-run. Secrets are picked up automatically "
+            "on the next [cyan]hermes[/cyan] invocation. "
+            "Re-run with [cyan]--apply[/cyan] to export now."
+        )
+    else:
+        console.print(
+            f"\n  [green]Exported {len(result.applied)} secret(s).[/green]"
+        )
+    return 0
+
+
+def cmd_onepassword_disable(args: argparse.Namespace) -> int:
+    """Disable the 1Password integration."""
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.setdefault("secrets", {}).setdefault("onepassword", {}))
+    op_cfg["enabled"] = False
+    save_config(cfg)
+    console.print(
+        "[green]✓ 1Password integration disabled.[/green]  "
+        "Re-enable with [cyan]hermes secrets onepassword setup[/cyan]."
+    )
+    return 0
+
+
+def cmd_onepassword_list_vaults(args: argparse.Namespace) -> int:
+    """List vaults accessible to the service account."""
+    import asyncio
+    import sys as _sys
+
+    console = Console()
+    token = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN", "").strip()
+    if not token:
+        console.print(
+            "[red]OP_SERVICE_ACCOUNT_TOKEN is not set.[/red]"
+        )
+        return 1
+
+    try:
+        from onepassword import Client
+        from onepassword.types import VaultGetParams
+    except ImportError:
+        console.print(
+            "[red]onepassword-sdk not installed.[/red]"
+        )
+        return 1
+
+    async def _list() -> list:
+        client = await Client.authenticate(
+            auth=token,
+            integration_name="Hermes Agent (CLI)",
+            integration_version="1.0.0",
+        )
+        vaults = await client.vaults.list()
+        result = []
+        for v in vaults:
+            full = await client.vaults.get(
+                vault_id=v.id, vault_params=VaultGetParams()
+            )
+            result.append({
+                "id": full.id,
+                "name": full.title,
+                "description": full.description,
+                "item_count": full.active_item_count,
+            })
+        return result
+
+    try:
+        vaults = asyncio.run(_list())
+    except Exception as exc:
+        console.print(f"[red]Error listing vaults: {exc}[/red]")
+        return 1
+
+    if args.format == "json":
+        console.print(json.dumps(vaults, indent=2))
+    else:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Name", style="cyan")
+        table.add_column("Items", justify="right")
+        table.add_column("ID", style="dim")
+        for v in vaults:
+            table.add_row(v["name"], str(v["item_count"]), v["id"])
+        console.print(table)
+        console.print(f"\n  {len(vaults)} vault(s) accessible.")
+    return 0
+
+
+def _pick_onepassword_vault(
+    token: str,
+    token_env: str,
+    default: str,
+    console: Console,
+) -> Optional[str]:
+    """Let the user pick a vault interactively."""
+    import asyncio
+
+    try:
+        from onepassword import Client
+        from onepassword.types import VaultGetParams
+    except ImportError:
+        console.print("  [red]onepassword-sdk not installed.[/red]")
+        return None
+
+    async def _list() -> list:
+        client = await Client.authenticate(
+            auth=token,
+            integration_name="Hermes Agent Setup",
+            integration_version="1.0.0",
+        )
+        vaults = await client.vaults.list()
+        result = []
+        for v in vaults:
+            full = await client.vaults.get(
+                vault_id=v.id, vault_params=VaultGetParams()
+            )
+            result.append({
+                "id": full.id,
+                "name": full.title,
+                "item_count": full.active_item_count,
+            })
+        return result
+
+    try:
+        vaults = asyncio.run(_list())
+    except Exception as exc:
+        console.print(f"  [red]Failed to list vaults: {exc}[/red]")
+        return None
+
+    if not vaults:
+        console.print("  [yellow]No vaults accessible with this token.[/yellow]")
+        return None
+
+    console.print(f"  Found {len(vaults)} vault(s):")
+    for i, v in enumerate(vaults):
+        marker = " ← default" if v["name"] == default else ""
+        console.print(
+            f"    [{i + 1}] {v['name']} ({v['item_count']} items){marker}"
+        )
+
+    choice_s = console.input(
+        f"  Pick 1-{len(vaults)}"
+        + (f" [{1}]: " if vaults else ": ")
+    ).strip()
+
+    idx = 1
+    if choice_s:
+        try:
+            idx = int(choice_s)
+        except ValueError:
+            pass
+
+    if 1 <= idx <= len(vaults):
+        return vaults[idx - 1]["name"]
+
+    return vaults[0]["name"] if vaults else None

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -1,0 +1,554 @@
+"""Tests for the 1Password SDK-based secret source.
+
+These tests exercise the shared cache substrate (``_cache.py``) and
+the 1Password secret source (``onepassword.py``).  They run with
+``HERMES_HOME`` redirected to a temp directory so they never touch
+the real ``~/.hermes/``.
+
+Integration tests that need a live 1Password service account token
+are skipped when ``OP_SERVICE_ACCOUNT_TOKEN`` is not set in the
+environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.secret_sources._cache import (
+    CachedFetch,
+    FetchResult,
+    TwoLayerCache,
+    is_valid_env_name,
+    resolve_cache_home,
+)
+from agent.secret_sources.onepassword import (
+    _cache_key,
+    _refs_fingerprint,
+    _sanitise_env_name,
+    _sdk_available,
+    _token_fingerprint,
+    apply_onepassword_secrets,
+    json_dumps_stable,
+    _reset_cache_for_tests,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path: Path) -> None:
+    """Redirect HERMES_HOME to a temp dir for every test."""
+    os.environ["HERMES_HOME"] = str(tmp_path)
+    yield
+    os.environ.pop("HERMES_HOME", None)
+
+
+@pytest.fixture
+def cache() -> TwoLayerCache[str]:
+    """Fresh TwoLayerCache instance for each test."""
+    c = TwoLayerCache[str](basename="test_cache.json")
+    yield c
+    c.clear()
+
+
+# ---------------------------------------------------------------------------
+# is_valid_env_name
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidEnvName:
+    def test_valid_names(self):
+        assert is_valid_env_name("OPENAI_API_KEY")
+        assert is_valid_env_name("_PRIVATE_KEY")
+        assert is_valid_env_name("A")
+        assert is_valid_env_name("A_B_C_123")
+
+    def test_invalid_names(self):
+        assert not is_valid_env_name("")
+        assert not is_valid_env_name("1LEADING_DIGIT")
+        assert not is_valid_env_name("has spaces")
+        assert not is_valid_env_name("has-dashes")
+        assert not is_valid_env_name("has.dots")
+        assert not is_valid_env_name(None)  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# FetchResult
+# ---------------------------------------------------------------------------
+
+
+class TestFetchResult:
+    def test_defaults(self):
+        fr = FetchResult()
+        assert fr.secrets == {}
+        assert fr.applied == []
+        assert fr.skipped == []
+        assert fr.warnings == []
+        assert fr.error is None
+        assert fr.ok is True
+
+    def test_error(self):
+        fr = FetchResult(error="something went wrong")
+        assert fr.ok is False
+
+    def test_cache_hit(self):
+        fr = FetchResult(cache_hit=True, secrets={"KEY": "val"})
+        assert fr.cache_hit is True
+
+
+# ---------------------------------------------------------------------------
+# CachedFetch
+# ---------------------------------------------------------------------------
+
+
+class TestCachedFetch:
+    def test_is_fresh(self):
+        cf = CachedFetch(secrets={"A": "1"}, fetched_at=time.time())
+        assert cf.is_fresh(300) is True
+
+    def test_is_stale(self):
+        cf = CachedFetch(secrets={"A": "1"}, fetched_at=time.time() - 301)
+        assert cf.is_fresh(300) is False
+
+    def test_ttl_zero_never_fresh(self):
+        cf = CachedFetch(secrets={"A": "1"}, fetched_at=time.time())
+        assert cf.is_fresh(0) is False
+
+
+# ---------------------------------------------------------------------------
+# TwoLayerCache
+# ---------------------------------------------------------------------------
+
+
+class TestTwoLayerCache:
+    def test_read_miss_empty_cache(self, cache):
+        assert cache.read("key1", ttl_seconds=300) is None
+
+    def test_read_write_roundtrip(self, cache, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        entry = CachedFetch(secrets={"KEY": "value"}, fetched_at=time.time())
+        cache.write("key1", entry, home_path=home)
+
+        result = cache.read("key1", ttl_seconds=300, home_path=home)
+        assert result is not None
+        assert result.secrets == {"KEY": "value"}
+
+    def test_read_l1_hit(self, cache):
+        """Second read within TTL hits L1 (in-process), not L2 (disk)."""
+        entry = CachedFetch(secrets={"K": "V"}, fetched_at=time.time())
+        cache.write("k1", entry)
+
+        # First read — fills L1
+        cache.read("k1", ttl_seconds=300)
+
+        # Second read — L1 hit (instant, even with no disk)
+        result = cache.read("k1", ttl_seconds=300)
+        assert result is not None
+        assert result.secrets == {"K": "V"}
+
+    def test_ttl_zero_disables_cache(self, cache):
+        entry = CachedFetch(secrets={"K": "V"}, fetched_at=time.time())
+        cache.write("k1", entry)
+        assert cache.read("k1", ttl_seconds=0) is None
+
+    def test_disk_persistence_across_instances(self, tmp_path):
+        """Two separate cache instances share the same disk file."""
+        home = tmp_path / "hermes"
+        home.mkdir()
+
+        c1 = TwoLayerCache[str](basename="shared.json")
+        c2 = TwoLayerCache[str](basename="shared.json")
+
+        entry = CachedFetch(secrets={"SHARED": "yes"}, fetched_at=time.time())
+        c1.write("shared-key", entry, home_path=home)
+
+        result = c2.read("shared-key", ttl_seconds=300, home_path=home)
+        assert result is not None
+        assert result.secrets == {"SHARED": "yes"}
+
+        c1.clear(home_path=home)
+        c2.clear(home_path=home)
+
+    def test_merge_entries_no_overwrite(self, cache, tmp_path):
+        """Writing a new key preserves existing sibling entries."""
+        home = tmp_path / "hermes"
+        home.mkdir()
+
+        e1 = CachedFetch(secrets={"A": "1"}, fetched_at=time.time())
+        e2 = CachedFetch(secrets={"B": "2"}, fetched_at=time.time())
+
+        cache.write("first", e1, home_path=home)
+        cache.write("second", e2, home_path=home)
+
+        # Both should be readable
+        assert cache.read("first", ttl_seconds=300, home_path=home).secrets == {"A": "1"}
+        assert cache.read("second", ttl_seconds=300, home_path=home).secrets == {"B": "2"}
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestCooldown:
+    def test_cooldown_disabled_by_default(self, cache):
+        assert cache.is_cooldown_active("k") is False
+        cache.record_cooldown("k")
+        assert cache.is_cooldown_active("k") is False  # still disabled
+
+    def test_cooldown_blocks_reads(self, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        c = TwoLayerCache[str](
+            basename="cooldown.json",
+            cooldown_enabled=True,
+            cooldown_seconds=3600,
+        )
+        c.record_cooldown("key123")
+        assert c.is_cooldown_active("key123") is True
+
+        # Writes still work, reads are blocked
+        entry = CachedFetch(secrets={"K": "V"}, fetched_at=time.time())
+        c.write("key123", entry, home_path=home)
+        assert c.read("key123", ttl_seconds=300, home_path=home) is None
+
+        c.clear(home_path=home)
+
+    def test_cooldown_remaining(self):
+        c = TwoLayerCache[str](
+            basename="cd.json", cooldown_enabled=True, cooldown_seconds=10
+        )
+        c.record_cooldown("k")
+        remaining = c.cooldown_remaining("k")
+        assert 0 < remaining <= 10
+
+
+# ---------------------------------------------------------------------------
+# resolve_cache_home
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCacheHome:
+    def test_explicit_path(self, tmp_path):
+        p = tmp_path / "custom"
+        assert resolve_cache_home(p) == p
+
+    def test_falls_back_to_env(self, tmp_path):
+        os.environ["HERMES_HOME"] = str(tmp_path)
+        assert resolve_cache_home() == tmp_path
+
+    def test_falls_back_to_dot_hermes(self):
+        os.environ.pop("HERMES_HOME", None)
+        result = resolve_cache_home()
+        assert result.name == ".hermes"
+
+
+# ---------------------------------------------------------------------------
+# onepassword helpers
+# ---------------------------------------------------------------------------
+
+
+class TestTokenFingerprint:
+    def test_consistent(self):
+        assert _token_fingerprint("abc") == _token_fingerprint("abc")
+
+    def test_different_tokens(self):
+        assert _token_fingerprint("abc") != _token_fingerprint("xyz")
+
+    def test_sha256_hex_prefix(self):
+        fp = _token_fingerprint("my-token")
+        assert len(fp) == 16
+        assert all(c in "0123456789abcdef" for c in fp)
+
+
+class TestCacheKey:
+    def test_includes_fingerprint_and_vault(self):
+        key = _cache_key("token", "My Vault")
+        fp = _token_fingerprint("token")
+        assert key == f"{fp}|My Vault"
+
+    def test_includes_refs_fingerprint(self):
+        refs = {"A": "op://V/A/cred"}
+        refs_fp = _refs_fingerprint(refs)
+        key = _cache_key("token", "V", refs_fp)
+        assert refs_fp in key
+
+    def test_different_configs_produce_different_keys(self):
+        key1 = _cache_key("token", "V", _refs_fingerprint({"A": "ref1"}))
+        key2 = _cache_key("token", "V", _refs_fingerprint({"B": "ref2"}))
+        assert key1 != key2
+
+
+class TestRefsFingerprint:
+    def test_stable(self):
+        refs = {"B": "op://V/B/cred", "A": "op://V/A/cred"}
+        assert _refs_fingerprint(refs) == _refs_fingerprint(refs)
+
+    def test_empty(self):
+        assert _refs_fingerprint({}) == ""
+
+
+class TestSanitiseEnvName:
+    def test_uppercase_and_underscores(self):
+        assert _sanitise_env_name("my api key") == "MY_API_KEY"
+
+    def test_handles_dashes(self):
+        assert _sanitise_env_name("my-api-key") == "MY_API_KEY"
+
+    def test_strips_non_alphanumeric(self):
+        assert _sanitise_env_name("API Key (prod)!") == "API_KEY_PROD"
+
+    def test_empty_and_none(self):
+        assert _sanitise_env_name("") == ""
+        assert _sanitise_env_name(None) == ""
+
+    def test_leading_digit_rejected(self):
+        assert _sanitise_env_name("1password_token") == ""
+
+
+class TestJsonDumpsStable:
+    def test_sorted_keys(self):
+        assert json_dumps_stable({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+
+    def test_deterministic(self):
+        d = {"c": 3, "b": 2, "a": 1}
+        assert json_dumps_stable(d) == json_dumps_stable(d)
+
+
+# ---------------------------------------------------------------------------
+# apply_onepassword_secrets — start-up injection
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOnepasswordSecrets:
+    def test_disabled_returns_empty(self):
+        result = apply_onepassword_secrets(enabled=False)
+        assert result.ok is True
+        assert result.secrets == {}
+        assert result.applied == []
+
+    def test_missing_token(self):
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        result = apply_onepassword_secrets(
+            enabled=True,
+            vault="TestVault",
+        )
+        assert result.ok is False
+        assert "not set" in result.error
+
+    def test_no_vault_and_no_refs(self):
+        os.environ["OP_SERVICE_ACCOUNT_TOKEN"] = "fake-token"
+        result = apply_onepassword_secrets(
+            enabled=True,
+            auto_discover=False,
+            env_refs={},
+        )
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        assert result.ok is False
+        assert "nothing to fetch" in result.error
+
+    def test_sdk_not_installed(self):
+        """When the SDK is absent, returns error, never raises."""
+        os.environ["OP_SERVICE_ACCOUNT_TOKEN"] = "fake-token"
+        with patch(
+            "agent.secret_sources.onepassword._sdk_available",
+            return_value=False,
+        ):
+            result = apply_onepassword_secrets(
+                enabled=True,
+                vault="TestVault",
+                auto_discover=True,
+            )
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        assert result.ok is False
+        assert "not installed" in result.error
+
+    def test_cache_hit(self, tmp_path):
+        """Cache hit returns without touching the SDK."""
+        os.environ["OP_SERVICE_ACCOUNT_TOKEN"] = "fake-token"
+
+        # Pre-populate the cache
+        _reset_cache_for_tests(tmp_path)
+        from agent.secret_sources.onepassword import _cache as _onep_cache
+
+        from agent.secret_sources._cache import CachedFetch
+        key = _cache_key("fake-token", "TestVault")
+        _onep_cache.write(
+            key,
+            CachedFetch(secrets={"TEST_KEY": "cached-value"}, fetched_at=time.time()),
+            home_path=tmp_path,
+        )
+
+        with patch(
+            "agent.secret_sources.onepassword._sdk_available",
+            return_value=True,
+        ):
+            result = apply_onepassword_secrets(
+                enabled=True,
+                vault="TestVault",
+                auto_discover=True,
+                home_path=tmp_path,
+            )
+
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        assert result.cache_hit is True
+        assert result.secrets == {"TEST_KEY": "cached-value"}
+
+    def test_override_existing(self):
+        """When override_existing=True, already-set vars are overwritten."""
+        os.environ["OP_SERVICE_ACCOUNT_TOKEN"] = "fake-token"
+        os.environ["EXISTING_KEY"] = "old-value"
+
+        _reset_cache_for_tests()
+        from agent.secret_sources.onepassword import _cache as _onep_cache
+        from agent.secret_sources._cache import CachedFetch
+
+        key = _cache_key("fake-token", "TestVault")
+        _onep_cache.write(
+            key,
+            CachedFetch(
+                secrets={"EXISTING_KEY": "new-value"},
+                fetched_at=time.time(),
+            ),
+        )
+
+        with patch(
+            "agent.secret_sources.onepassword._sdk_available",
+            return_value=True,
+        ):
+            result = apply_onepassword_secrets(
+                enabled=True,
+                vault="TestVault",
+                auto_discover=True,
+                override_existing=True,
+            )
+
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        os.environ.pop("EXISTING_KEY", None)
+
+        assert "EXISTING_KEY" in result.applied
+
+    def test_token_env_never_overwritten(self):
+        """The bootstrap token env var is always skipped."""
+        os.environ["OP_SERVICE_ACCOUNT_TOKEN"] = "fake-token"
+
+        _reset_cache_for_tests()
+        from agent.secret_sources.onepassword import _cache as _onep_cache
+        from agent.secret_sources._cache import CachedFetch
+
+        key = _cache_key("fake-token", "TestVault")
+        _onep_cache.write(
+            key,
+            CachedFetch(
+                secrets={"OP_SERVICE_ACCOUNT_TOKEN": "should-not-overwrite"},
+                fetched_at=time.time(),
+            ),
+        )
+
+        with patch(
+            "agent.secret_sources.onepassword._sdk_available",
+            return_value=True,
+        ):
+            result = apply_onepassword_secrets(
+                enabled=True,
+                vault="TestVault",
+                auto_discover=True,
+                override_existing=True,
+            )
+
+        os.environ.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+        assert "OP_SERVICE_ACCOUNT_TOKEN" in result.skipped
+        assert "OP_SERVICE_ACCOUNT_TOKEN" not in result.applied
+
+
+# ---------------------------------------------------------------------------
+# Live integration tests (skipped without token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"),
+    reason="OP_SERVICE_ACCOUNT_TOKEN not set — skipping live 1Password tests",
+)
+class TestLive1Password:
+    """Tests that require a real 1Password service account token.
+
+    These are skipped by default in CI.  Run locally with:
+        OP_SERVICE_ACCOUNT_TOKEN=ops_... pytest tests/test_onepassword_secrets.py -v
+    """
+
+    def test_sdk_is_available(self):
+        assert _sdk_available() is True
+
+    def test_apply_auto_discover(self, tmp_path):
+        """Auto-discovery fetches secrets from a vault."""
+        token = os.environ["OP_SERVICE_ACCOUNT_TOKEN"]
+
+        # Clear caches for a fresh fetch
+        _reset_cache_for_tests(tmp_path)
+
+        result = apply_onepassword_secrets(
+            enabled=True,
+            token_env="OP_SERVICE_ACCOUNT_TOKEN",
+            vault="Jarvis's Vault",
+            auto_discover=True,
+            cache_ttl_seconds=0,  # bypass cache
+            home_path=tmp_path,
+        )
+
+        assert result.ok, result.error
+        assert isinstance(result.secrets, dict)
+        # We expect at least some secrets
+        assert len(result.secrets) > 0
+
+    def test_apply_explicit_mapping(self, tmp_path):
+        """Explicit env mapping resolves op:// references."""
+        _reset_cache_for_tests(tmp_path)
+
+        # This test uses a reference that should exist in any configured vault.
+        # Adjust the ref to match your test vault.
+        result = apply_onepassword_secrets(
+            enabled=True,
+            token_env="OP_SERVICE_ACCOUNT_TOKEN",
+            vault="Jarvis's Vault",
+            env_refs={
+                "TEST_BUILDKITE": "op://Jarvis's Vault/Buildkite Token/credential",
+            },
+            cache_ttl_seconds=0,
+            home_path=tmp_path,
+        )
+
+        assert result.ok, result.error
+        assert "TEST_BUILDKITE" in result.secrets
+        assert result.secrets["TEST_BUILDKITE"]
+
+    def test_both_modes(self, tmp_path):
+        """Explicit + auto-discover; explicit wins on collisions."""
+        _reset_cache_for_tests(tmp_path)
+
+        result = apply_onepassword_secrets(
+            enabled=True,
+            token_env="OP_SERVICE_ACCOUNT_TOKEN",
+            vault="Jarvis's Vault",
+            auto_discover=True,
+            env_refs={
+                "EXPLICIT_KEY": "op://Jarvis's Vault/Buildkite Token/credential",
+            },
+            cache_ttl_seconds=0,
+            home_path=tmp_path,
+        )
+
+        assert result.ok, result.error
+        assert "EXPLICIT_KEY" in result.secrets
+        assert len(result.secrets) > 1  # auto-discover found others too

--- a/tools/onepassword_tool.py
+++ b/tools/onepassword_tool.py
@@ -1,0 +1,696 @@
+"""1Password in-session tools for Hermes Agent.
+
+Uses the ``onepassword-sdk`` Python SDK for daemon-free vault access.
+Requires ``OP_SERVICE_ACCOUNT_TOKEN`` in the environment.
+
+Registered tools:
+  - onepassword_list_vaults    — list all accessible vaults
+  - onepassword_list_items     — list items in a vault
+  - onepassword_get_item       — get full item details (including field values)
+  - onepassword_resolve_field  — resolve op://vault/item/field shorthand
+
+All tools share the same disk cache as the startup secret source
+(``agent/secret_sources/onepassword.py``), so a cold start that
+fetches vaults for injection also warms the tool cache and vice versa.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.registry import registry, tool_error, tool_result
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TTL = 300
+_DISK_CACHE_BASENAME = "onepassword_cache.json"
+
+# ---------------------------------------------------------------------------
+# Lazy SDK client
+# ---------------------------------------------------------------------------
+
+_ONEPASSWORD_CLIENT = None
+
+
+async def _get_client():
+    """Return an authenticated 1Password SDK client, or None if unavailable."""
+    global _ONEPASSWORD_CLIENT
+    if _ONEPASSWORD_CLIENT is not None:
+        return _ONEPASSWORD_CLIENT
+    try:
+        from onepassword import Client
+    except ImportError:
+        return None
+
+    token = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN", "")
+    if not token:
+        return None
+
+    _ONEPASSWORD_CLIENT = await Client.authenticate(
+        auth=token,
+        integration_name="Hermes Agent",
+        integration_version="1.0.0",
+    )
+    return _ONEPASSWORD_CLIENT
+
+
+def check_requirements() -> bool:
+    """Tool is available when the SDK is installed and the token is set."""
+    try:
+        import onepassword  # noqa: F401
+    except ImportError:
+        return False
+    return bool(os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"))
+
+
+# ---------------------------------------------------------------------------
+# Token / cache-key helpers
+# ---------------------------------------------------------------------------
+
+
+def _token_fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _token_fp_from_env() -> str:
+    token = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN", "")
+    return _token_fingerprint(token) if token else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# In-process cache (L1 — instant hits within one agent session)
+# ---------------------------------------------------------------------------
+
+_TOOL_CACHE: Dict[str, Any] = {}
+_TOOL_EXPIRY: Dict[str, float] = {}
+
+
+def _get_hermes_home() -> Path:
+    from hermes_constants import get_hermes_home as _ghh
+    return _ghh()
+
+
+def _disk_cache_path() -> Path:
+    return _get_hermes_home() / "cache" / _DISK_CACHE_BASENAME
+
+
+def _read_raw_disk_cache() -> dict:
+    """Read the entire disk cache JSON.  Returns empty dict on any error."""
+    path = _disk_cache_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        if isinstance(payload, dict):
+            return payload
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+def _write_raw_disk_cache(payload: dict) -> None:
+    """Atomically write the disk cache JSON.  Best-effort."""
+    import tempfile
+
+    path = _disk_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=".onepassword_cache_", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass
+
+
+def _tool_cache_get(cache_key: str, ttl: float = _DEFAULT_TTL) -> Optional[Any]:
+    """L1 (in-process) then L2 (disk).  Returns None if expired or missing."""
+    now = time.time()
+
+    # L1: in-process
+    if cache_key in _TOOL_EXPIRY and now < _TOOL_EXPIRY[cache_key]:
+        return _TOOL_CACHE.get(cache_key)
+
+    # L2: disk
+    disk = _read_raw_disk_cache()
+    entry = disk.get(cache_key)
+    if entry is None:
+        return None
+    fetched_at = entry.get("fetched_at", 0)
+    if now - fetched_at >= ttl:
+        return None
+    value = entry.get("value")
+    # Promote to L1
+    _TOOL_CACHE[cache_key] = value
+    _TOOL_EXPIRY[cache_key] = now + ttl * 0.9
+    return value
+
+
+def _tool_cache_set(cache_key: str, value: Any, ttl: float = _DEFAULT_TTL) -> None:
+    """Set a value in L1 (in-process) and L2 (disk)."""
+    now = time.time()
+    _TOOL_CACHE[cache_key] = value
+    _TOOL_EXPIRY[cache_key] = now + ttl * 0.9
+
+    disk = _read_raw_disk_cache()
+    disk[cache_key] = {"value": value, "fetched_at": now}
+    _write_raw_disk_cache(disk)
+
+
+# ---------------------------------------------------------------------------
+# Cache key namespaces
+# ---------------------------------------------------------------------------
+
+
+def _vaults_cache_key(fp: str) -> str:
+    return f"tools:{fp}:vaults"
+
+
+def _items_cache_key(fp: str, vault_id: str) -> str:
+    return f"tools:{fp}:items:{vault_id}"
+
+
+def _item_cache_key(fp: str, vault_id: str, item_id: str) -> str:
+    return f"tools:{fp}:item:{vault_id}:{item_id}"
+
+
+def _vault_contents_key(fp: str, vault_id: str) -> str:
+    """Key for the full vault contents cache (ALL items with ALL fields).
+
+    This is the most important cache entry for rate-limit avoidance —
+    it holds a dict mapping item_title → {field_title: value} so
+    ``onepassword_resolve_field`` can resolve in O(1) with zero API
+    calls when the cache is warm.
+    """
+    return f"tools:{fp}:vault_contents:{vault_id}"
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def onepassword_list_vaults(task_id: str = None) -> str:
+    """List all vaults the service account can access."""
+    try:
+        result = asyncio.run(_list_vaults_async())
+        return result
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+async def _list_vaults_async() -> str:
+    client = await _get_client()
+    if client is None:
+        return tool_error(
+            "1Password SDK not available. Install with: "
+            "uv pip install --python <hermes-python> onepassword-sdk"
+        )
+
+    fp = _token_fp_from_env()
+    cache_key = _vaults_cache_key(fp)
+    cached = _tool_cache_get(cache_key)
+    if cached is not None:
+        return tool_result({"count": len(cached), "vaults": cached, "cached": True})
+
+    from onepassword.types import VaultGetParams
+
+    vaults = await client.vaults.list()
+    vault_data = []
+    for v in vaults:
+        full = await client.vaults.get(vault_id=v.id, vault_params=VaultGetParams())
+        vault_data.append({
+            "id": full.id,
+            "name": full.title,
+            "description": full.description,
+            "item_count": full.active_item_count,
+        })
+
+    _tool_cache_set(cache_key, vault_data)
+    return tool_result({"count": len(vault_data), "vaults": vault_data, "cached": False})
+
+
+def onepassword_list_items(
+    vault_id: str = "",
+    vault_name: str = "",
+    task_id: str = None,
+) -> str:
+    """List items in a vault, specified by ID or name."""
+    try:
+        result = asyncio.run(_list_items_async(vault_id, vault_name))
+        return result
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+async def _list_items_async(vault_id: str, vault_name: str) -> str:
+    client = await _get_client()
+    if client is None:
+        return tool_error("1Password SDK not available.")
+
+    fp = _token_fp_from_env()
+
+    resolved = await _resolve_vault(client, vault_id, vault_name, fp)
+    if resolved is None:
+        return tool_error(f"Vault not found: id={vault_id}, name={vault_name}")
+    target_id, target_name = resolved
+
+    cache_key = _items_cache_key(fp, target_id)
+    cached = _tool_cache_get(cache_key)
+    if cached is not None:
+        return tool_result({
+            "vault_id": target_id,
+            "vault_name": target_name,
+            "count": len(cached),
+            "items": cached,
+            "cached": True,
+        })
+
+    items = await client.items.list(vault_id=target_id)
+    item_data = []
+    for item in items:
+        item_data.append({
+            "id": item.id,
+            "title": item.title,
+            "category": str(item.category),
+        })
+
+    _tool_cache_set(cache_key, item_data)
+    return tool_result({
+        "vault_id": target_id,
+        "vault_name": target_name,
+        "count": len(item_data),
+        "items": item_data,
+        "cached": False,
+    })
+
+
+def onepassword_get_item(
+    vault_id: str = "",
+    vault_name: str = "",
+    item_id: str = "",
+    task_id: str = None,
+) -> str:
+    """Get full item details including all field values.
+
+    Use onepassword_list_items first to find the item_id.
+    Use onepassword_resolve_field for targeted field resolution.
+    """
+    if not item_id:
+        return tool_error(
+            "item_id is required. Use onepassword_list_items first "
+            "to find the item ID."
+        )
+    try:
+        result = asyncio.run(_get_item_async(vault_id, vault_name, item_id))
+        return result
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+async def _get_item_async(vault_id: str, vault_name: str, item_id: str) -> str:
+    client = await _get_client()
+    if client is None:
+        return tool_error("1Password SDK not available.")
+
+    fp = _token_fp_from_env()
+
+    resolved = await _resolve_vault(client, vault_id, vault_name, fp)
+    if resolved is None:
+        return tool_error(f"Vault not found: id={vault_id}, name={vault_name}")
+    target_id, target_name = resolved
+
+    item_cache_key = _item_cache_key(fp, target_id, item_id)
+    cached = _tool_cache_get(item_cache_key)
+    if cached is not None:
+        return tool_result({**cached, "cached": True})
+
+    try:
+        item = await client.items.get(vault_id=target_id, item_id=item_id)
+    except Exception as exc:
+        return tool_error(f"Item not found: {exc}")
+
+    fields_data = []
+    for field in item.fields:
+        val = field.value or ""
+        ftype = str(field.field_type) if field.field_type else "Text"
+        fields_data.append({
+            "id": field.id,
+            "label": field.title or field.id,
+            "type": ftype,
+            "value": val,
+            "section_id": field.section_id or "",
+        })
+
+    sections_data = []
+    if item.sections:
+        for section in item.sections:
+            sections_data.append({"id": section.id, "title": section.title})
+
+    item_data = {
+        "id": item.id,
+        "title": item.title,
+        "category": str(item.category),
+        "vault_id": item.vault_id,
+        "version": item.version,
+        "notes": item.notes or "",
+        "tags": list(item.tags) if item.tags else [],
+        "fields": fields_data,
+        "sections": sections_data,
+        "vault_name": target_name,
+    }
+
+    _tool_cache_set(item_cache_key, item_data)
+    return tool_result({**item_data, "cached": False})
+
+
+def onepassword_resolve_field(ref: str = "", task_id: str = None) -> str:
+    """Resolve an op://vault/item/field reference to its value.
+
+    Example: op://Personal/My API Key/credential
+
+    Rate-limit optimisation: on first access to a vault, this fetches
+    and caches ALL items+fields from that vault.  Subsequent resolves
+    (within the TTL) are dictionary lookups — zero API calls.
+    """
+    if not ref:
+        return tool_error("ref is required. Format: op://vault/item/field")
+
+    if not ref.startswith("op://"):
+        return tool_error("ref must start with op://")
+
+    # Strip op:// prefix and match content
+    inner = ref[5:]
+    if not re.match(r"^[\w\s'().,-]+/[\w\s'().,-]+/[\w\s'().,-]+$", inner):
+        return tool_error(
+            "ref must be op://vault/item/field with alphanumeric names"
+        )
+
+    try:
+        result = asyncio.run(_resolve_field_async(ref))
+        return result
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+async def _resolve_field_async(ref: str) -> str:
+    client = await _get_client()
+    if client is None:
+        return tool_error("1Password SDK not available.")
+
+    parts = ref[5:].split("/")
+    if len(parts) < 3:
+        return tool_error(
+            f"ref must be op://vault/item/field (saw {len(parts)} parts)"
+        )
+
+    vault_name, item_name, field_label = parts[0], parts[1], parts[2]
+    fp = _token_fp_from_env()
+
+    # Step 1: resolve vault name → ID (cached)
+    resolved = await _resolve_vault(client, "", vault_name, fp)
+    if resolved is None:
+        return tool_error(f"Vault '{vault_name}' not found")
+    target_id, target_name = resolved
+
+    # Step 2: use or populate the vault-contents cache
+    contents_cache_key = _vault_contents_key(fp, target_id)
+    vault_contents = _tool_cache_get(contents_cache_key)
+
+    if vault_contents is None:
+        vault_contents = await _build_vault_contents(client, target_id)
+        _tool_cache_set(contents_cache_key, vault_contents)
+
+    # Step 3: lookup in cached contents
+    item_lower = item_name.lower()
+    item_data = vault_contents.get(item_lower)
+    if item_data is None:
+        return tool_error(
+            f"Item '{item_name}' not found in vault '{vault_name}'. "
+            f"Available items: {', '.join(sorted(vault_contents.keys()))}"
+        )
+
+    # Step 4: find the field by label (case-insensitive)
+    field_lower = field_label.lower()
+    for field_title, field_value in item_data.get("fields", {}).items():
+        if field_title.lower() == field_lower:
+            return tool_result({
+                "ref": ref,
+                "value": field_value,
+                "cached": vault_contents is not None,
+            })
+
+    return tool_error(
+        f"Field '{field_label}' not found in item '{item_name}'. "
+        f"Available fields: {', '.join(sorted(item_data['fields'].keys()))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_vault(
+    client,
+    vault_id: str,
+    vault_name: str,
+    fp: str,
+) -> Optional[Tuple[str, str]]:
+    """Resolve a vault by ID or name.  Returns (vault_id, vault_name)."""
+    vaults_cache_key = _vaults_cache_key(fp)
+    cached_vaults = _tool_cache_get(vaults_cache_key)
+
+    if cached_vaults is not None:
+        if vault_id:
+            for v in cached_vaults:
+                if v["id"] == vault_id:
+                    return (v["id"], v["name"])
+        if vault_name:
+            vn = vault_name.lower()
+            for v in cached_vaults:
+                if v["name"].lower() == vn or v["id"].lower() == vn:
+                    return (v["id"], v["name"])
+
+    from onepassword.types import VaultGetParams
+
+    vaults = await client.vaults.list()
+    vault_data = []
+    for v in vaults:
+        full = await client.vaults.get(vault_id=v.id, vault_params=VaultGetParams())
+        vault_data.append({
+            "id": full.id,
+            "name": full.title,
+            "description": full.description,
+            "item_count": full.active_item_count,
+        })
+        if vault_id and full.id == vault_id:
+            _tool_cache_set(vaults_cache_key, vault_data)
+            return (full.id, full.title)
+        if vault_name and (
+            full.title.lower() == vault_name.lower()
+            or full.id == vault_name
+        ):
+            _tool_cache_set(vaults_cache_key, vault_data)
+            return (full.id, full.title)
+
+    _tool_cache_set(vaults_cache_key, vault_data)
+    return None
+
+
+async def _build_vault_contents(client, vault_id: str) -> Dict[str, Any]:
+    """Fetch ALL items+fields from a vault and return a lookup dict.
+
+    Returns: {item_title_lowercase: {"title": str, "id": str, "fields": {field_title: value}}}
+    """
+    items = await client.items.list(vault_id=vault_id)
+    vault_contents: Dict[str, Dict[str, Any]] = {}
+
+    for item_overview in items:
+        try:
+            item = await client.items.get(vault_id=vault_id, item_id=item_overview.id)
+        except Exception:
+            continue
+
+        fields: Dict[str, str] = {}
+        for field in item.fields:
+            label = field.title or field.id or ""
+            val = field.value or ""
+            fields[label] = val
+
+        vault_contents[item.title.lower()] = {
+            "title": item.title,
+            "id": item.id,
+            "fields": fields,
+        }
+
+    return vault_contents
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+_LIST_VAULTS_SCHEMA = {
+    "name": "onepassword_list_vaults",
+    "description": (
+        "List all 1Password vaults accessible via the service account. "
+        "Returns vault names and IDs."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+_LIST_ITEMS_SCHEMA = {
+    "name": "onepassword_list_items",
+    "description": (
+        "List items in a 1Password vault by ID or name. "
+        "Use onepassword_list_vaults first to discover vaults."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "vault_id": {
+                "type": "string",
+                "description": (
+                    "Vault ID (from onepassword_list_vaults). "
+                    "Optional if vault_name is provided."
+                ),
+            },
+            "vault_name": {
+                "type": "string",
+                "description": (
+                    "Vault name (e.g. 'Private'). "
+                    "Optional if vault_id is provided."
+                ),
+            },
+        },
+    },
+}
+
+_GET_ITEM_SCHEMA = {
+    "name": "onepassword_get_item",
+    "description": (
+        "Get full item details from a 1Password vault, including all "
+        "field values (credential tokens, API keys, passwords, etc.). "
+        "Use onepassword_list_items first to find the item_id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "vault_id": {
+                "type": "string",
+                "description": (
+                    "Vault ID (from onepassword_list_vaults). "
+                    "Optional if vault_name is provided."
+                ),
+            },
+            "vault_name": {
+                "type": "string",
+                "description": (
+                    "Vault name (e.g. 'Private'). "
+                    "Optional if vault_id is provided."
+                ),
+            },
+            "item_id": {
+                "type": "string",
+                "description": (
+                    "Item ID (from onepassword_list_items). Required."
+                ),
+            },
+        },
+        "required": ["item_id"],
+    },
+}
+
+_RESOLVE_FIELD_SCHEMA = {
+    "name": "onepassword_resolve_field",
+    "description": (
+        "Resolve an op://vault/item/field reference to its actual value. "
+        "Example: op://Personal/My API Key/credential returns the "
+        "credential field value."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "ref": {
+                "type": "string",
+                "description": (
+                    "The op:// reference to resolve. "
+                    "Format: op://vault_name/item_name/field_label"
+                ),
+            },
+        },
+        "required": ["ref"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="onepassword_list_vaults",
+    toolset="onepassword",
+    schema=_LIST_VAULTS_SCHEMA,
+    handler=lambda args, **kw: onepassword_list_vaults(task_id=kw.get("task_id")),
+    check_fn=check_requirements,
+    requires_env=["OP_SERVICE_ACCOUNT_TOKEN"],
+)
+
+registry.register(
+    name="onepassword_list_items",
+    toolset="onepassword",
+    schema=_LIST_ITEMS_SCHEMA,
+    handler=lambda args, **kw: onepassword_list_items(
+        vault_id=args.get("vault_id", ""),
+        vault_name=args.get("vault_name", ""),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    requires_env=["OP_SERVICE_ACCOUNT_TOKEN"],
+)
+
+registry.register(
+    name="onepassword_get_item",
+    toolset="onepassword",
+    schema=_GET_ITEM_SCHEMA,
+    handler=lambda args, **kw: onepassword_get_item(
+        vault_id=args.get("vault_id", ""),
+        vault_name=args.get("vault_name", ""),
+        item_id=args.get("item_id", ""),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    requires_env=["OP_SERVICE_ACCOUNT_TOKEN"],
+)
+
+registry.register(
+    name="onepassword_resolve_field",
+    toolset="onepassword",
+    schema=_RESOLVE_FIELD_SCHEMA,
+    handler=lambda args, **kw: onepassword_resolve_field(
+        ref=args.get("ref", ""),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    requires_env=["OP_SERVICE_ACCOUNT_TOKEN"],
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -322,6 +322,17 @@ TOOLSETS = {
         "includes": []
     },
 
+    "onepassword": {
+        "description": "1Password vault access via SDK (no op CLI daemon needed)",
+        "tools": [
+            "onepassword_list_vaults",
+            "onepassword_list_items",
+            "onepassword_get_item",
+            "onepassword_resolve_field",
+        ],
+        "includes": [],
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/user-guide/secrets/index.md
+++ b/website/docs/user-guide/secrets/index.md
@@ -5,5 +5,6 @@ Hermes can pull API keys from external secret managers at process startup instea
 Supported:
 
 - [Bitwarden Secrets Manager](./bitwarden) — `bws` CLI, lazy-installed, free tier works.
+- [1Password (onepassword-sdk)](./onepassword) — Python SDK, no `op` CLI daemon needed, auto-discovery mode.
 
-More backends (Vault, AWS Secrets Manager, 1Password CLI) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.
+More backends (Vault, AWS Secrets Manager) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -1,0 +1,191 @@
+# 1Password (onepassword-sdk)
+
+Pull API keys from a [1Password Service Account](https://developer.1password.com/docs/service-accounts/) at process startup instead of storing them in plaintext inside `~/.hermes/.env`. One bootstrap token replaces N per-provider keys, and rotating a credential becomes a single change in the 1Password web app.
+
+## Why the Python SDK (not the `op` CLI)
+
+Hermes uses the [`onepassword-sdk`](https://pypi.org/project/onepassword-sdk/) Python package instead of the `op` CLI daemon. The SDK authenticates directly via the 1Password REST API — no background daemon needed. This is important on macOS where `op daemon --background` can hang indefinitely in headless/background contexts (gateway, cron, CLI background tasks).
+
+If you prefer the `op` CLI, a CLI-based 1Password backend is also available (see the companion implementation).
+
+## How it works
+
+1. You create a **service account** in the 1Password web app, grant it read access to one or more vaults, and generate a token (starts with `ops_`).
+2. Hermes stores that single token in `~/.hermes/.env` as `OP_SERVICE_ACCOUNT_TOKEN`.
+3. Every time `hermes` (or the gateway, or a cron job) starts, after `.env` has loaded, Hermes uses the SDK to pull credential fields from your vault and sets them into `os.environ`.
+4. By default Hermes **overrides** values already in your environment — rotate a key once in 1Password and every Hermes process picks it up on next start. Flip `override_existing: false` in config if you want `.env` to win.
+
+The `onepassword-sdk` is an optional dependency — install it once:
+
+```bash
+uv pip install --python "$(head -1 "$(command -v hermes)" | sed 's/^#!//')" onepassword-sdk
+```
+
+## Two mapping modes
+
+### Mode A: Auto-discovery (zero per-secret config)
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    vault: "Private"
+    auto_discover: true
+```
+
+Hermes scans every item in the vault and extracts credential fields (Concealed, Password, API Credential types). Field titles become environment variable names (uppercased, spaces → underscores). For example, a field titled "OpenAI API Key" becomes `OPENAI_API_KEY`.
+
+Items with generic field labels ("credential", "password", "token") use the **item title** as the env var name instead.
+
+### Mode B: Explicit mapping (auditable, like Bitwarden)
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    env:
+      OPENAI_API_KEY: "op://Private/OpenAI/api key"
+      ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+```
+
+You specify exactly which env var maps to which `op://` reference. Hermes resolves each reference at startup. The vault is inferred from the references themselves, so you don't need a `vault:` key (though you can use both modes together).
+
+### Using both modes together
+
+When both `auto_discover` and `env` are configured, explicit mappings **take precedence** on naming collisions. Auto-discovered fields that don't conflict with explicit mappings are still applied.
+
+## Setup
+
+### 1. Create a service account and token
+
+In the [1Password web app](https://my.1password.com):
+
+1. **Developers → Service Accounts**.
+2. **Create service account** → name it (e.g. "Hermes Agent").
+3. Grant read access to the vault(s) you want.
+4. Copy the generated token (starts with `ops_`). 1Password cannot retrieve it again — keep the copy.
+
+### 2. Run the interactive setup wizard
+
+```bash
+hermes secrets onepassword setup
+```
+
+This walks you through:
+
+- Checking that `onepassword-sdk` is installed
+- Prompting for (or detecting) your service account token
+- Choosing auto-discovery or explicit mapping mode
+- Picking a vault (for auto-discovery mode)
+- Testing a fetch and showing discovered secrets
+- Saving the config
+
+Non-interactive example:
+
+```bash
+# Install the SDK first
+uv pip install --python <hermes-python> onepassword-sdk
+
+# Write the token to .env
+echo 'OP_SERVICE_ACCOUNT_TOKEN=ops_...' >> ~/.hermes/.env
+
+# Enable in config.yaml
+hermes config set secrets.onepassword.enabled true
+hermes config set secrets.onepassword.vault "Private"
+hermes config set secrets.onepassword.auto_discover true
+```
+
+### 3. Verify
+
+```bash
+hermes secrets onepassword status
+hermes secrets onepassword sync          # dry-run: show what would be applied
+hermes secrets onepassword sync --apply  # actually export into the environment
+hermes secrets onepassword list-vaults   # list accessible vaults
+```
+
+## Full config reference
+
+```yaml
+secrets:
+  onepassword:
+    # Enable the integration.  Default: false.
+    enabled: true
+
+    # Environment variable holding the service account token.
+    # Default: OP_SERVICE_ACCOUNT_TOKEN
+    token_env: OP_SERVICE_ACCOUNT_TOKEN
+
+    # Vault name or ID (required for auto_discover mode).
+    # Can be omitted when only using explicit env: mapping.
+    vault: "Private"
+
+    # When true, scan all items in the vault and map credential
+    # fields → env vars automatically.  Default: false.
+    auto_discover: true
+
+    # Explicit env-var → op:// reference mappings.
+    # These take precedence over auto-discovered secrets.
+    env:
+      OPENAI_API_KEY: "op://Private/OpenAI/api key"
+      ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+
+    # When true, overwrite already-set env vars.
+    # When false, .env and shell exports win.  Default: false.
+    override_existing: true
+
+    # How long cache entries stay fresh (seconds).
+    # 0 = no caching (always fetch).  Default: 300.
+    cache_ttl_seconds: 300
+```
+
+## In-session tools
+
+When the `onepassword` toolset is enabled (via `hermes tools enable onepassword`), four tools become available during conversations:
+
+| Tool | Description |
+|------|-------------|
+| `onepassword_list_vaults` | List all vaults accessible to the service account |
+| `onepassword_list_items` | List items in a vault by ID or name |
+| `onepassword_get_item` | Get full item details including all field values |
+| `onepassword_resolve_field` | Resolve an `op://vault/item/field` reference to its value |
+
+The `onepassword_resolve_field` tool uses a vault-contents cache: on first access to a vault it fetches all items and fields, then resolves subsequent lookups from memory — zero additional API calls within the cache TTL.
+
+## Rate limits
+
+1Password Service Accounts throttle at **1,000 reads per hour** per token (non-Business accounts). Hermes uses a **two-layer cache** (in-process + disk-persisted) to keep real API calls near zero after the first cold start. Additionally, a **rate-limit cooldown** prevents N concurrent processes (gateway + dashboard + slash workers) from retrying in lockstep — when a `429` is hit all processes back off for one hour.
+
+If you see rate-limit warnings in the agent log, raise `cache_ttl_seconds` to 3600 or higher.
+
+## Security
+
+- The service account token is **never written to the disk cache** — only resolved secret values are cached.
+- Cache keys use SHA-256 fingerprints of the token, so the raw token never appears in cache files.
+- Disk cache files are written atomically with mode `0600`, and the cache directory is forced to `0700`.
+- The token env var itself (`OP_SERVICE_ACCOUNT_TOKEN`) is **never overwritten**, even with `override_existing: true`.
+
+## Troubleshooting
+
+**"onepassword-sdk is not installed"**  
+Install the SDK: `uv pip install --python <hermes-python> onepassword-sdk`
+
+**"OP_SERVICE_ACCOUNT_TOKEN is not set"**  
+The token must be in `~/.hermes/.env`. Run `hermes secrets onepassword setup` to configure it.
+
+**"Vault not found"**  
+Check the vault name with `hermes secrets onepassword list-vaults`. Vault names are case-sensitive.
+
+**Rate-limit warnings**  
+Increase `cache_ttl_seconds` to 3600. Clear the disk cache if you've rotated the token:
+
+```bash
+rm -f ~/.hermes/cache/onepassword_cache.json
+```
+
+**SDK missing after `hermes update`**  
+`hermes update` may rebuild the venv, wiping the optional SDK. Reinstall:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python onepassword-sdk
+```


### PR DESCRIPTION
## Summary

Adds a **1Password Service Account** secret source that uses the
[`onepassword-sdk`](https://pypi.org/project/onepassword-sdk/) Python
package instead of the `op` CLI daemon.

**Why the SDK instead of the `op` CLI?**  
The `op` CLI's daemon-based architecture (`op daemon --background`)
can hang indefinitely on macOS in headless/background contexts — exactly
the environment Hermes runs in (gateway, cron, CLI background tasks).
The SDK authenticates directly via the 1Password REST API, avoiding the
daemon entirely.  This also enables in-session tools that don't need to
shell out.

This PR is **additive to PR #36896** (@hwrdprkns's CLI-based 1Password
backend) — both implementations share the same `_cache.py` substrate and
can coexist.  Users who prefer the `op` CLI can use #36896; users on
macOS or who want in-session tools can use this SDK-based transport.

Fixes #36949.

## What changed

### New files

| File | Purpose |
|------|---------|
| `agent/secret_sources/_cache.py` | Shared cache substrate (`TwoLayerCache`, `FetchResult`, `CachedFetch`) — extracted from patterns first proposed in PR #36896, generalised with an in-process L1 layer and rate-limit cooldown support |
| `agent/secret_sources/onepassword.py` | SDK-based 1Password backend |
| `tools/onepassword_tool.py` | Four in-session tools (`onepassword_list_vaults`, `onepassword_list_items`, `onepassword_get_item`, `onepassword_resolve_field`) |
| `tests/test_onepassword_secrets.py` | Unit + live-integration tests |

### Modified files

| File | Change |
|------|--------|
| `agent/secret_sources/__init__.py` | Docstring update |
| `hermes_cli/env_loader.py` | Factor out `_apply_bitwarden`, add `_apply_onepassword` |
| `hermes_cli/main.py` | Wire `hermes secrets onepassword` subparser |
| `hermes_cli/secrets_cli.py` | Add `register_onepassword_cli` + all CLI handlers |
| `toolsets.py` | Register `onepassword` toolset |
| `cli-config.yaml.example` | Commented example for both backends |

## Key design decisions

### Two mapping modes

1. **Explicit** — list env-var → `op://` references (like Bitwarden):
   ```yaml
   secrets:
     onepassword:
       enabled: true
       env:
         OPENAI_API_KEY: "op://Private/OpenAI/api key"
   ```

2. **Auto-discovery** — scan a vault and map credential fields → env vars:
   ```yaml
   secrets:
     onepassword:
       enabled: true
       vault: "Private"
       auto_discover: true
   ```

Both modes can be used together; explicit mappings take precedence on
naming collisions.

### Two-layer cache with rate-limit cooldown

The 1Password Service Account API throttles at **1,000 reads/hour**.
A naive single-disk-layer cache can't protect against N sibling
processes (gateway + dashboard + slash workers) retrying in lockstep.

- **L1**: in-process dict (instant, no I/O)
- **L2**: disk-persisted JSON (shared across processes)
- **Rate-limit cooldown**: when a `429` is hit, ALL processes back off
  for one hour, preventing `N × retries` call amplification

### Fail-open

Missing SDK, expired token, bad reference, empty vault — everything
produces a one-line warning and Hermes continues with whatever
credentials `.env` already had.  This backend cannot block startup.

### In-session tools

Four tools registered under the `onepassword` toolset for mid-session
vault access.  The `onepassword_resolve_field` tool uses a
**vault-contents cache** — on first access it fetches ALL items+fields
from the vault, then resolves from a dict.  Subsequent resolves within
the TTL are O(1) dictionary lookups with zero API calls.

## Credit

The shared `_cache.py` pattern (`DiskCache`, `FetchResult`, atomic
0600 disk writes) was first proposed by @hwrdprkns in PR #36896.
This module generalises it with two additions:

- An **in-process L1 cache layer** (critical for multi-process
  deployments where the per-call disk overhead adds up)
- **Rate-limit cooldown** gating (critical for APIs with per-hour
  budgets shared across many long-lived processes)

## Testing

```bash
# Unit tests (always run)
pytest tests/test_onepassword_secrets.py -v -k "not TestLive"

# Live integration tests (requires OP_SERVICE_ACCOUNT_TOKEN)
OP_SERVICE_ACCOUNT_TOKEN=*** pytest tests/test_onepassword_secrets.py -v
```
