### PR TITLE
fix(cli): keep /reload-mcp off the input thread

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10874,7 +10874,7 @@ class HermesCLI:
 
         if not confirm_required:
             with self._busy_command(self._slow_command_status(cmd_original)):
-                self._reload_mcp()
+                self._run_reload_mcp_with_timeout()
             return
 
         # Render warning + prompt.  Use the same prompt_toolkit-native composer
@@ -10914,7 +10914,20 @@ class HermesCLI:
                 print("⚠️  Couldn't persist opt-out — reloading once.")
 
         with self._busy_command(self._slow_command_status(cmd_original)):
-            self._reload_mcp()
+            self._run_reload_mcp_with_timeout()
+
+    def _run_reload_mcp_with_timeout(self, timeout_seconds: float = 30.0) -> bool:
+        """Run MCP reload on a worker thread so slash-command input stays recoverable."""
+        reload_thread = threading.Thread(target=self._reload_mcp, daemon=True)
+        reload_thread.start()
+        reload_thread.join(timeout=timeout_seconds)
+        if reload_thread.is_alive():
+            print(
+                f"  ⚠️  MCP reload timed out ({timeout_seconds:g}s). "
+                "Some servers may still be reconnecting."
+            )
+            return False
+        return True
 
     def _reload_mcp(self):
         """Reload MCP servers: disconnect all, re-read config.yaml, reconnect.

--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -1,5 +1,7 @@
 """Regression tests for loading feedback on slow slash commands."""
 
+import threading
+import time
 from unittest.mock import patch
 
 from cli import HermesCLI
@@ -47,6 +49,7 @@ class TestCLILoadingIndicator:
         def fake_reload():
             seen["running"] = cli_obj._command_running
             seen["status"] = cli_obj._command_status
+            seen["thread_id"] = threading.get_ident()
             print("reload done")
 
         # /reload-mcp now wraps the actual reload in a prompt-cache-invalidation
@@ -66,7 +69,29 @@ class TestCLILoadingIndicator:
         assert seen == {
             "running": True,
             "status": "Reloading MCP servers...",
+            "thread_id": seen["thread_id"],
         }
+        assert seen["thread_id"] != threading.get_ident()
         assert cli_obj._command_running is False
         assert cli_obj._command_status == ""
         assert invalidate_mock.call_count == 2
+
+    def test_reload_mcp_timeout_warns_without_blocking_forever(self, capsys):
+        cli_obj = self._make_cli()
+        stop_event = threading.Event()
+
+        def fake_reload():
+            stop_event.wait(0.1)
+
+        with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
+             patch.object(cli_obj, "_invalidate"):
+            start = time.monotonic()
+            result = cli_obj._run_reload_mcp_with_timeout(timeout_seconds=0.01)
+            elapsed = time.monotonic() - start
+
+        stop_event.set()
+
+        output = capsys.readouterr().out
+        assert result is False
+        assert elapsed < 0.05
+        assert "MCP reload timed out (0.01s)." in output


### PR DESCRIPTION
## Summary

Fixes the interactive CLI `/reload-mcp` freeze by moving the user-triggered reload path onto a worker thread with the same 30s timeout behavior the config-watcher reload path already uses. This keeps the prompt/input thread recoverable even if an MCP server hangs during shutdown or reconnect.

Closes #39418.

## What changed

- route both confirmed and pre-approved `/reload-mcp` executions through `_run_reload_mcp_with_timeout()` instead of calling `_reload_mcp()` inline on the CLI thread
- warn and return control if the reload thread is still alive after the timeout
- add CLI regression coverage proving `/reload-mcp` now executes off the main thread and surfaces the timeout warning without blocking forever

## Verification

- `../.base/.venv/bin/python -m pytest -o addopts='' tests/cli/test_cli_loading_indicator.py`
- `../.base/.venv/bin/python -m ruff check cli.py tests/cli/test_cli_loading_indicator.py`
- `git diff --check`
