### PR TITLE
ci(osv): scan all tracked first-party lockfiles

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,8 +1,10 @@
 name: OSV-Scanner
 
-# Scans lockfiles (uv.lock, package-lock.json) against the OSV vulnerability
-# database. Runs on every PR/push (via the ci.yml orchestrator's workflow_call)
-# and on a weekly schedule against main.
+# Scans every tracked first-party lockfile — uv.lock plus the four
+# package-lock.json files (root workspace, website, WhatsApp bridge, Photon
+# sidecar) — against the OSV vulnerability database. Runs on every PR/push
+# (via the ci.yml orchestrator's workflow_call) and on a weekly schedule
+# against main.
 #
 # This is detection-only — OSV-Scanner does NOT open PRs or modify pins.
 # It reports known CVEs in currently-pinned dependency versions so we can
@@ -43,11 +45,13 @@ jobs:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       # Scan explicit lockfiles rather than recursing, so we only look at
-      # the three sources of truth and skip vendored / test / worktree dirs.
+      # the five sources of truth and skip vendored / test / worktree dirs.
       scan-args: |-
         --lockfile=uv.lock
         --lockfile=package-lock.json
         --lockfile=website/package-lock.json
+        --lockfile=scripts/whatsapp-bridge/package-lock.json
+        --lockfile=plugins/platforms/photon/sidecar/package-lock.json
       # The upstream reusable workflow uploads this exact file under its
       # fixed artifact name, which the wrapper downloads below.
       results-file-name: osv-results.sarif


### PR DESCRIPTION
Adds the two tracked first-party lockfiles OSV wasn't scanning — `scripts/whatsapp-bridge/package-lock.json` and `plugins/platforms/photon/sidecar/package-lock.json` — bringing explicit coverage to all five.

Rebased onto current `main`. `osv-scanner.yml` has moved twice since this branch was last refreshed, so the change is re-expressed against the workflow as it stands today — the pinned reusable-workflow form with an explicit `scan-args:` block — rather than replayed. Nothing else in the file is touched: the pinned action SHA, `results-file-name`, `fail-on-vuln: false`, the `emit-status` wrapper and the `ci.yml` invocation are all unchanged. This branch also predated `05c896cf5 ci: refactor paths & clones`, so the stale trigger-filter half stays **dropped rather than restored**: `osv-scanner.yml` is `workflow_call`-only now and `ci.yml` invokes it with no `needs`/`if` gate, so the scan already runs on every PR and every push to `main` — there is nothing left to path-filter. The diff is one file: the two `scan-args` lines plus the two coverage comments.

Coverage is now every lockfile tracked in the repo:

| lockfile | tree |
| --- | --- |
| `uv.lock` | Python |
| `package-lock.json` | root npm workspace |
| `website/package-lock.json` | docs site |
| `scripts/whatsapp-bridge/package-lock.json` | **new** — `hermes-whatsapp-bridge` |
| `plugins/platforms/photon/sidecar/package-lock.json` | **new** — `@hermes-agent/photon-sidecar` |

`optional-skills/finance/dcf-model/requirements.txt` is the only other dependency file in the tree, and it stays out of scope deliberately: it pins ranges (`openpyxl>=3.0.0`, `requests>=2.28.0`), so it's a manifest rather than a lockfile and doesn't identify installed versions. Scanning ranged manifests is a separate policy call — happy to take it in a follow-up if you want it.

### What this will surface

I re-queried both new lockfiles' resolved package sets against the OSV API immediately before this push. **The result changed since the last refresh of this PR, and the change is the clearest argument for merging it.**

**WhatsApp bridge** — 163 resolved packages, 1 advisory:

- `body-parser@1.20.5` — [GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6). Low, availability-only (an invalid `limit` value silently disables size enforcement). Transitive, via `express@^4.21.0`. Fixed in 1.20.6.

**Photon sidecar** — 133 resolved packages, 3 advisories:

- `@opentelemetry/core@2.7.1` — [GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf) / CVE-2026-54285. Moderate, availability-only — `W3CBaggagePropagator.extract()` doesn't bound inbound `baggage` header size. Fixed in 2.8.0. Worth noting the top-level `node_modules/@opentelemetry/core` is **already 2.8.0**; the 2.7.1 copies are nested under six `@opentelemetry/*` packages.
- `protobufjs@8.6.1` — [GHSA-j3f2-48v5-ccww](https://github.com/advisories/GHSA-j3f2-48v5-ccww), moderate, DoS via infinite loop in `.proto` option parsing. Fixed in 8.6.6.
- `protobufjs@8.6.1` — [GHSA-jfj6-75fj-8934](https://github.com/advisories/GHSA-jfj6-75fj-8934), moderate, Text Format string-map parsing can mutate the returned map's prototype. Fixed in 8.6.5.

Both `protobufjs` findings are transitive, via `spectrum-ts@8.0.0`.

**Three of those four advisories were published on 2026-07-20** — after this PR was last refreshed. The resolved package sets did **not** change (163 and 133, same as before), so these are not new dependencies: they are newly-published advisories against versions that were already installed and already unscanned. That is precisely the "currently-pinned dep became known-vulnerable" case this workflow's own header says it exists to catch, and it went undetected here for five days because these two lockfiles aren't in `scan-args`.

Detection-only and unchanged: `fail-on-vuln: false`, so the job stays green and the `all-checks-pass` required-check story is untouched — findings land in the Security tab as alerts, not merge blocks. Bumping any of these is a separate change; happy to open those if you want them.

(The `overrides` block in the sidecar's `package.json` doesn't interfere: the npm extractor reads resolved versions out of the lockfile's `packages` map, so OSV matches what's actually installed.)

---

One note on the scan-args contract, since it constrains future PRs: OSV-Scanner **hard-errors on a missing `--lockfile` path** (`failed to resolve path`), and `fail-on-vuln: false` does not suppress that — it only suppresses findings. So any PR that deletes or renames one of these five packages needs to drop its `--lockfile` line in the same change. I deliberately did **not** add "skip if absent" handling, since that would silently weaken the coverage this PR is promising. All five paths are verified present on `main` as of this push.
