### PR TITLE
feat(gateway): hot-reload memory_char_limit and user_char_limit

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16083,6 +16083,11 @@ class GatewayRunner:
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
+        # memory_char_limit / user_char_limit are passed to MemoryStore at
+        # agent construction; changing them mid-session must rebuild the
+        # cached agent so the new limits take effect on the next message.
+        ("memory", "memory_char_limit"),
+        ("memory", "user_char_limit"),
     )
 
     _HONCHO_CACHE_BUSTING_KEYS = (

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -237,6 +237,50 @@ class TestExtractCacheBustingConfig:
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
 
+    def test_reads_memory_char_limit_subkeys(self):
+        """memory_char_limit / user_char_limit must be picked up so editing
+        the cap in config.yaml invalidates the cached agent on the next
+        message (no gateway restart)."""
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "memory": {
+                    "memory_char_limit": 5000,
+                    "user_char_limit": 2500,
+                    "provider": "mem0",  # unrelated — should not affect these
+                }
+            }
+        )
+        assert out["memory.memory_char_limit"] == 5000
+        assert out["memory.user_char_limit"] == 2500
+
+    def test_memory_char_limit_change_busts_signature(self):
+        """Changing memory_char_limit between messages must produce a
+        different agent-config signature, so the gateway rebuilds the
+        cached AIAgent and the new cap takes effect immediately."""
+        from gateway.run import GatewayRunner
+
+        sig_default = GatewayRunner._agent_config_signature(
+            model="minimax/MiniMax-M2.7",
+            runtime={"api_key": "k", "base_url": "u", "provider": "p", "api_mode": ""},
+            enabled_toolsets=["memory"],
+            ephemeral_prompt="",
+            cache_keys=GatewayRunner._extract_cache_busting_config(
+                {"memory": {"memory_char_limit": 2200, "user_char_limit": 1375}}
+            ),
+        )
+        sig_bumped = GatewayRunner._agent_config_signature(
+            model="minimax/MiniMax-M2.7",
+            runtime={"api_key": "k", "base_url": "u", "provider": "p", "api_mode": ""},
+            enabled_toolsets=["memory"],
+            ephemeral_prompt="",
+            cache_keys=GatewayRunner._extract_cache_busting_config(
+                {"memory": {"memory_char_limit": 5000, "user_char_limit": 2500}}
+            ),
+        )
+        assert sig_default != sig_bumped
+
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""
         from gateway.run import GatewayRunner

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -651,7 +651,7 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 
 :::tip Gateway hot-reload of compression and context length
-As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
+As of recent releases, editing `model.context_length`, any `compression.*` key, or `memory.memory_char_limit` / `memory.user_char_limit` in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
 :::
 
 ### Common setups


### PR DESCRIPTION
## What does this PR do?

Adds `memory.memory_char_limit` and `memory.user_char_limit` to the gateway's cache-busting config keys, so edits to either cap in `config.yaml` take effect on the next message — no gateway restart required.

## Why

Sister keys (`model.context_length`, `compression.*`, `memory.provider`) are already picked up transparently. `memory_char_limit` / `user_char_limit` were the only memory-related config values still requiring a restart, which is inconsistent and surprising — operators hit it the first time they tried to bump the cap and saw no effect until they restarted the gateway.

The fix is two entries in `_CACHE_BUSTING_CONFIG_KEYS` (the same mechanism used for the other hot-reloadable keys).

## Related Issue

No specific issue filed; this was discovered while investigating why an in-place cap bump did not take effect.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` — add 2 entries to `_CACHE_BUSTING_CONFIG_KEYS` with an inline comment explaining why
- `tests/gateway/test_agent_cache.py` — 2 new tests:
  - `test_reads_memory_char_limit_subkeys` — caps are extracted from config
  - `test_memory_char_limit_change_busts_signature` — changing the cap changes the signature (so cache is invalidated)
- `website/docs/user-guide/configuration.md` — extend the hot-reload tip to mention the new keys

## How to Test

1. Start a gateway with the default cap: `memory: { memory_char_limit: 2200, user_char_limit: 1375 }` in `~/.hermes/config.yaml`
2. Send a message, observe the system prompt memory header
3. Edit `~/.hermes/config.yaml` to `memory_char_limit: 5000` (no restart)
4. Send another message
5. The system prompt memory header should now show "5000 chars" capacity

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant tests (manual + targeted unit tests; full pytest run blocked locally on Windows by pytest-timeout SIGALRM limitation on this venv, not by the patch)
- [x] I've added tests for my changes
- [x] Tested on: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation
- [x] I've considered cross-platform impact (the change is a constant-tuple edit, OS-agnostic)
