### PR TITLE
fix(cli): use canonical get_hermes_home() fallback in load_hermes_dotenv

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
+from hermes_constants import get_hermes_home
 from utils import atomic_replace
 
 
@@ -216,15 +217,20 @@ def load_hermes_dotenv(
 ) -> list[Path]:
     """Load Hermes environment files with user config taking precedence.
 
+    When ``hermes_home`` is not passed, the user env directory is resolved via
+    :func:`hermes_constants.get_hermes_home`, so native Windows installs read
+    ``%LOCALAPPDATA%\\hermes\\.env`` instead of ``~/.hermes/.env`` (where
+    ``install.ps1`` never writes keys).
+
     Behavior:
-    - `~/.hermes/.env` overrides stale shell-exported values when present.
+    - the user `.env` overrides stale shell-exported values when present.
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    home_path = Path(hermes_home) if hermes_home else get_hermes_home()
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "drexux0@gmail.com": "Drexuxux",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -1,7 +1,9 @@
 import importlib
 import os
 import sys
+from pathlib import Path
 
+import hermes_constants
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
@@ -84,6 +86,51 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert loaded == [env_file]
     assert os.getenv("GLM_API_KEY") == "abc"
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
+
+
+def test_no_hermes_home_falls_back_to_localappdata_on_windows(tmp_path, monkeypatch):
+    """Parameterless load on native Windows reads %LOCALAPPDATA%\\hermes\\.env.
+
+    Regression for the fallback that hardcoded ``Path.home() / ".hermes"`` and
+    so missed the keys ``install.ps1`` writes under ``%LOCALAPPDATA%\\hermes``.
+    """
+    local_appdata = tmp_path / "LocalAppData"
+    win_home = local_appdata / "hermes"
+    win_home.mkdir(parents=True)
+    (win_home / ".env").write_text("WIN_ENV_MARKER=from-localappdata\n", encoding="utf-8")
+    # A ~/.hermes/.env that must be IGNORED on native Windows.
+    legacy_home = tmp_path / "Home" / ".hermes"
+    legacy_home.mkdir(parents=True)
+    (legacy_home / ".env").write_text("WIN_ENV_MARKER=from-userprofile\n", encoding="utf-8")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("WIN_ENV_MARKER", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "Home")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    loaded = load_hermes_dotenv()
+
+    assert loaded == [win_home / ".env"]
+    assert os.getenv("WIN_ENV_MARKER") == "from-localappdata"
+
+
+def test_no_hermes_home_falls_back_to_dot_hermes_on_posix(tmp_path, monkeypatch):
+    """Parameterless load on POSIX still resolves to ~/.hermes/.env."""
+    home = tmp_path / "Home"
+    posix_home = home / ".hermes"
+    posix_home.mkdir(parents=True)
+    (posix_home / ".env").write_text("POSIX_ENV_MARKER=from-dot-hermes\n", encoding="utf-8")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("POSIX_ENV_MARKER", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+
+    loaded = load_hermes_dotenv()
+
+    assert loaded == [posix_home / ".env"]
+    assert os.getenv("POSIX_ENV_MARKER") == "from-dot-hermes"
 
 
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## What?
When `load_hermes_dotenv()` is called with no arguments and `HERMES_HOME`
is unset, it fell back to a hardcoded `Path.home() / ".hermes"`, bypassing
the canonical platform-native home returned by `get_hermes_home()`. At the
parameterless call sites (`tools/mcp_tool.py`, `hermes_cli/mcp_config.py`,
`gateway/platforms/feishu_comment_rules.py`), keys written by the installer
to the platform-native home could not be found, so API keys, the Bitwarden
token, and MCP `${VAR}` references failed to resolve.

## Fix
Resolve the home directory via the canonical `get_hermes_home()`
(override → `HERMES_HOME` → platform-native default) instead of hardcoding
`Path.home() / ".hermes"`. This aligns with the rule in `AGENTS.md` to never
hardcode `Path.home() / ".hermes"` for state paths.

## Tests
Added 2 regression tests covering both home-resolution fallback paths.

    $ python -m pytest tests/hermes_cli/test_env_loader.py
    8 passed