### PR TITLE
fix(desktop): use draftRef for hasComposerPayload to fix stale send-button and truncation

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -178,7 +178,7 @@ export function ChatBar({
   const slash = useSlashCompletions({ gateway: gateway ?? null })
 
   const stacked = expanded || narrow || tight
-  const hasComposerPayload = draft.trim().length > 0 || attachments.length > 0
+  const hasComposerPayload = draftRef.current.trim().length > 0 || attachments.length > 0
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
   const busyAction = busy && hasComposerPayload ? 'queue' : 'stop'
@@ -917,11 +917,11 @@ export function ChatBar({
   }
 
   const queueCurrentDraft = useCallback(() => {
-    if (!activeQueueSessionKey || (!draft.trim() && attachments.length === 0)) {
+    if (!activeQueueSessionKey || (!draftRef.current.trim() && attachments.length === 0)) {
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: draft, attachments })) {
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: draftRef.current, attachments })) {
       return false
     }
 
@@ -1045,8 +1045,8 @@ export function ChatBar({
       // busy guard for commands that genuinely need an idle session (skill
       // /send directives).  Queuing them would make every slash command wait
       // for the current turn to finish, which is how the TUI never behaves.
-      if (!attachments.length && SLASH_COMMAND_RE.test(draft.trim())) {
-        const submitted = draft
+      if (!attachments.length && SLASH_COMMAND_RE.test(draftRef.current.trim())) {
+        const submitted = draftRef.current
         triggerHaptic('submit')
         clearDraft()
         void onSubmit(submitted)


### PR DESCRIPTION
## Summary

The send button in the desktop chat composer was hidden until the user typed an extra character, and queued messages were sometimes truncated. Both bugs share the same root cause: `hasComposerPayload` and the `queueCurrentDraft`/`submitDraft` paths read the React state variable `draft`, which is stale between `aui.composer().setText()` being called and the async state update resolving.

`draftRef.current` is updated synchronously inside `handleEditorInput` before `setText` is queued, so it always has the current value.

## Changes

- `hasComposerPayload` now reads `draftRef.current.trim()` instead of `draft.trim()` → send button appears immediately after input
- `queueCurrentDraft`: guard and `text:` payload both use `draftRef.current` → no truncated queued messages
- `submitDraft` slash-command path: regex test and `submitted` capture both use `draftRef.current` → no truncated slash command submissions

## Testing

- [ ] Type a message via `aui.composer().setText()` — send button should be visible without typing an extra space
- [ ] Queue a message while busy — confirm queued text matches full input
- [ ] Slash command submission — confirm full command string is submitted
- [ ] All existing tests pass

## Related Issues

Closes #39436