### PR TITLE
fix(cli): resolve dashboard auth audit log path via get_hermes_home()

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -4,10 +4,12 @@ Profile-aware location: ``$HERMES_HOME/logs/dashboard-auth.log``.
 Format: one JSON object per line. Token-like fields are stripped before
 serialisation to avoid leaking refresh tokens or JWTs to disk.
 
-This module deliberately keeps a minimal dependency surface — no imports
-from ``hermes_constants`` or other hermes_cli modules — so it can be
+This module keeps a minimal *import-time* dependency surface so it can be
 imported safely from middleware code that loads early in the startup
-sequence.
+sequence. The Hermes-home lookup is deferred to call time (inside
+``_resolve_log_path``) via ``hermes_constants.get_hermes_home`` — the single
+source of truth for the profile- and platform-native data directory — so the
+only import this module adds is itself stdlib-only and import-safe.
 """
 from __future__ import annotations
 
@@ -15,7 +17,6 @@ import datetime as _dt
 import enum
 import json
 import logging
-import os
 import threading
 from pathlib import Path
 from typing import Any
@@ -50,14 +51,21 @@ class AuditEvent(enum.Enum):
 
 
 def _resolve_log_path() -> Path:
-    """``$HERMES_HOME/logs/dashboard-auth.log`` with the standard fallback.
+    """Return ``<HERMES_HOME>/logs/dashboard-auth.log``.
 
-    Mirrors ``hermes_constants.get_hermes_home`` semantics: env var wins,
-    else ``~/.hermes``. A local copy avoids an import cycle with the
-    middleware which lives below ``hermes_cli``.
+    Delegates to ``hermes_constants.get_hermes_home`` so the audit trail lands
+    in the same profile- and platform-native location as every other Hermes
+    log: ``%LOCALAPPDATA%\\hermes`` on native Windows, ``~/.hermes`` on POSIX,
+    honoring any active profile / ``HERMES_HOME`` override. The previous
+    hand-rolled fallback hardcoded ``~/.hermes`` and so wrote auth audit events
+    to the wrong directory on native Windows. The import is deferred to call
+    time to keep this module's import-time dependency surface minimal for
+    early-loading middleware; ``hermes_constants`` is stdlib-only and
+    import-safe.
     """
-    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
-    return Path(home) / "logs" / "dashboard-auth.log"
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "logs" / "dashboard-auth.log"
 
 
 def audit_log(event: AuditEvent, **fields: Any) -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1444,6 +1444,7 @@ AUTHOR_MAP = {
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
+    "drexux0@gmail.com": "Drexuxux",
 }
 
 

--- a/tests/hermes_cli/test_dashboard_auth_audit.py
+++ b/tests/hermes_cli/test_dashboard_auth_audit.py
@@ -7,6 +7,8 @@ serialisation so we never leak refresh tokens or JWTs to disk.
 from __future__ import annotations
 
 import json
+import sys
+
 import pytest
 
 from hermes_cli.dashboard_auth.audit import audit_log, AuditEvent
@@ -79,3 +81,31 @@ def test_audit_creates_logs_dir_if_missing(tmp_path, monkeypatch):
     audit_log(AuditEvent.LOGIN_START, provider="nous")
     assert (home / "logs").is_dir()
     assert (home / "logs" / "dashboard-auth.log").exists()
+
+
+def test_audit_uses_platform_native_home_on_windows(tmp_path, monkeypatch):
+    """On native Windows with HERMES_HOME unset, the audit log must land under
+    %LOCALAPPDATA%\\hermes\\logs — the same platform-native location as every
+    other Hermes log — not under %USERPROFILE%\\.hermes\\logs.
+
+    Regression for the hand-rolled ``Path.home() / '.hermes'`` fallback that
+    diverged from ``get_hermes_home`` on native Windows, scattering login /
+    logout / WS-ticket audit events into the wrong directory.
+    """
+    local_appdata = tmp_path / "AppData" / "Local"
+    local_appdata.mkdir(parents=True)
+    user_profile = tmp_path / "userprofile"
+    user_profile.mkdir()
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    # Old code fell back here via Path.home(); pin it so we can assert it stays empty.
+    monkeypatch.setattr("pathlib.Path.home", lambda: user_profile)
+
+    audit_log(AuditEvent.WS_TICKET_MINTED, provider="nous")
+
+    native = local_appdata / "hermes" / "logs" / "dashboard-auth.log"
+    legacy = user_profile / ".hermes" / "logs" / "dashboard-auth.log"
+    assert native.exists(), f"audit log not written to platform-native home: {native}"
+    assert not legacy.exists(), f"audit log leaked to legacy ~/.hermes path: {legacy}"


### PR DESCRIPTION
## What?
The dashboard auth audit log path was resolved with a hand-rolled fallback that
hardcoded `~/.hermes`, diverging from `get_hermes_home()` — the single source of
truth for the profile- and platform-native Hermes home. As a result, auth audit
events (login / logout / WS-ticket) could be written outside the active Hermes
home, breaking the documented `$HERMES_HOME/logs/dashboard-auth.log` contract and
losing operational visibility.

## Fix
`_resolve_log_path()` in `hermes_cli/dashboard_auth/audit.py` now delegates to
`hermes_constants.get_hermes_home()` instead of duplicating the resolution logic.
The import is deferred to call time to keep the module's minimal import-time
dependency surface. Removed the now-unused `os` import.

## Tests
- Added a regression test for the unset-`HERMES_HOME` resolution path: asserts the
  audit log lands under the home returned by `get_hermes_home()`, not the hardcoded
  fallback.
- `pytest tests/hermes_cli/test_dashboard_auth_audit.py tests/hermes_cli/test_dashboard_auth_ws_auth.py` → **51 passed**.
- Confirmed the new test **fails on the pre-fix code** and **passes after the fix**.