### PR TITLE
Fix clarify prompt Enter submission

### DIFF
--- a/ui-tui/src/__tests__/approvalAction.test.ts
+++ b/ui-tui/src/__tests__/approvalAction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { approvalAction } from '../components/prompts.js'
+import { approvalAction } from '../components/promptActions.js'
 
 describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
   it('maps Esc to deny — parity with global Ctrl+C cancellation', () => {

--- a/ui-tui/src/__tests__/clarifyAction.test.ts
+++ b/ui-tui/src/__tests__/clarifyAction.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { clarifyAction } from '../components/promptActions.js'
+
+describe('clarifyAction — pure key dispatch for ClarifyPrompt', () => {
+  it('submits the current free-text answer on Enter', () => {
+    expect(
+      clarifyAction('', { return: true }, { choices: ['A', 'B'], custom: 'typed answer', sel: 2, typing: true })
+    ).toEqual({ kind: 'choose', answer: 'typed answer' })
+  })
+
+  it('uses Esc to leave free-text mode when choices exist', () => {
+    expect(
+      clarifyAction('', { escape: true }, { choices: ['A'], custom: 'typed answer', sel: 1, typing: true })
+    ).toEqual({ kind: 'back' })
+  })
+
+  it('uses Esc to cancel open-ended clarify prompts', () => {
+    expect(
+      clarifyAction('', { escape: true }, { choices: [], custom: 'typed answer', sel: 0, typing: true })
+    ).toEqual({ kind: 'cancel' })
+  })
+
+  it('enters free-text mode when Enter targets the Other row', () => {
+    expect(
+      clarifyAction('', { return: true }, { choices: ['A', 'B'], custom: '', sel: 2, typing: false })
+    ).toEqual({ kind: 'startTyping' })
+  })
+
+  it('submits the highlighted canned choice on Enter', () => {
+    expect(
+      clarifyAction('', { return: true }, { choices: ['A', 'B'], custom: '', sel: 1, typing: false })
+    ).toEqual({ kind: 'choose', answer: 'B' })
+  })
+
+  it('accepts numeric quick-picks in choice mode', () => {
+    expect(
+      clarifyAction('2', {}, { choices: ['A', 'B'], custom: '', sel: 0, typing: false })
+    ).toEqual({ kind: 'choose', answer: 'B' })
+  })
+})

--- a/ui-tui/src/components/promptActions.ts
+++ b/ui-tui/src/components/promptActions.ts
@@ -1,0 +1,110 @@
+export const OPTS = ['once', 'session', 'always', 'deny'] as const
+
+export type ApprovalKey = {
+  downArrow?: boolean
+  escape?: boolean
+  return?: boolean
+  upArrow?: boolean
+}
+
+export type ApprovalAction =
+  | { kind: 'choose'; choice: (typeof OPTS)[number] }
+  | { kind: 'move'; delta: -1 | 1 }
+  | { kind: 'noop' }
+
+export type ClarifyKey = {
+  downArrow?: boolean
+  escape?: boolean
+  return?: boolean
+  upArrow?: boolean
+}
+
+export type ClarifyAction =
+  | { kind: 'back' }
+  | { kind: 'cancel' }
+  | { kind: 'choose'; answer: string }
+  | { kind: 'move'; delta: -1 | 1 }
+  | { kind: 'startTyping' }
+  | { kind: 'noop' }
+
+/**
+ * Pure key-dispatch for the approval prompt.
+ */
+export function approvalAction(ch: string, key: ApprovalKey, sel: number): ApprovalAction {
+  if (key.escape) {
+    return { kind: 'choose', choice: 'deny' }
+  }
+
+  const n = parseInt(ch, 10)
+
+  if (n >= 1 && n <= OPTS.length) {
+    return { kind: 'choose', choice: OPTS[n - 1]! }
+  }
+
+  if (key.return) {
+    return { kind: 'choose', choice: OPTS[sel]! }
+  }
+
+  if (key.upArrow && sel > 0) {
+    return { kind: 'move', delta: -1 }
+  }
+
+  if (key.downArrow && sel < OPTS.length - 1) {
+    return { kind: 'move', delta: 1 }
+  }
+
+  return { kind: 'noop' }
+}
+
+/**
+ * Pure key-dispatch for the clarify prompt.
+ *
+ * Free-text clarify must not depend solely on ``TextInput.onSubmit`` because
+ * prompt overlays can intercept Enter before the input widget turns it into a
+ * submit callback. Handling Enter/Esc here keeps the clarify flow responsive
+ * even when the surrounding overlay stack changes its input ordering.
+ */
+export function clarifyAction(
+  ch: string,
+  key: ClarifyKey,
+  state: {
+    choices: string[]
+    custom: string
+    sel: number
+    typing: boolean
+  }
+): ClarifyAction {
+  const { choices, custom, sel, typing } = state
+
+  if (key.escape) {
+    return typing && choices.length ? { kind: 'back' } : { kind: 'cancel' }
+  }
+
+  if (typing || !choices.length) {
+    if (key.return) {
+      return { kind: 'choose', answer: custom }
+    }
+
+    return { kind: 'noop' }
+  }
+
+  if (key.upArrow && sel > 0) {
+    return { kind: 'move', delta: -1 }
+  }
+
+  if (key.downArrow && sel < choices.length) {
+    return { kind: 'move', delta: 1 }
+  }
+
+  if (key.return) {
+    return sel === choices.length ? { kind: 'startTyping' } : { kind: 'choose', answer: choices[sel] ?? '' }
+  }
+
+  const n = parseInt(ch, 10)
+
+  if (n >= 1 && n <= choices.length) {
+    return { kind: 'choose', answer: choices[n - 1] ?? '' }
+  }
+
+  return { kind: 'noop' }
+}

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -5,23 +5,11 @@ import { isMac } from '../lib/platform.js'
 import type { Theme } from '../theme.js'
 import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 
+import { approvalAction, clarifyAction, OPTS } from './promptActions.js'
 import { TextInput } from './textInput.js'
 
-const OPTS = ['once', 'session', 'always', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
 const CMD_PREVIEW_LINES = 10
-
-type ApprovalKey = {
-  downArrow?: boolean
-  escape?: boolean
-  return?: boolean
-  upArrow?: boolean
-}
-
-type ApprovalAction =
-  | { kind: 'choose'; choice: (typeof OPTS)[number] }
-  | { kind: 'move'; delta: -1 | 1 }
-  | { kind: 'noop' }
 
 /**
  * Pure key-dispatch for the approval prompt — exported so the regression
@@ -34,32 +22,6 @@ type ApprovalAction =
  * for approvals).  Numbers 1..OPTS.length pick the labelled choice.  Enter
  * confirms the current selection.  ↑/↓ moves the selection within bounds.
  */
-export function approvalAction(ch: string, key: ApprovalKey, sel: number): ApprovalAction {
-  if (key.escape) {
-    return { kind: 'choose', choice: 'deny' }
-  }
-
-  const n = parseInt(ch, 10)
-
-  if (n >= 1 && n <= OPTS.length) {
-    return { kind: 'choose', choice: OPTS[n - 1]! }
-  }
-
-  if (key.return) {
-    return { kind: 'choose', choice: OPTS[sel]! }
-  }
-
-  if (key.upArrow && sel > 0) {
-    return { kind: 'move', delta: -1 }
-  }
-
-  if (key.downArrow && sel < OPTS.length - 1) {
-    return { kind: 'move', delta: 1 }
-  }
-
-  return { kind: 'noop' }
-}
-
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
 
@@ -127,32 +89,18 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
   )
 
   useInput((ch, key) => {
-    if (key.escape) {
-      typing && choices.length ? setTyping(false) : onCancel()
+    const action = clarifyAction(ch, key, { choices, custom, sel, typing })
 
-      return
-    }
-
-    if (typing || !choices.length) {
-      return
-    }
-
-    if (key.upArrow && sel > 0) {
-      setSel(s => s - 1)
-    }
-
-    if (key.downArrow && sel < choices.length) {
-      setSel(s => s + 1)
-    }
-
-    if (key.return) {
-      sel === choices.length ? setTyping(true) : choices[sel] && onAnswer(choices[sel]!)
-    }
-
-    const n = parseInt(ch)
-
-    if (n >= 1 && n <= choices.length) {
-      onAnswer(choices[n - 1]!)
+    if (action.kind === 'cancel') {
+      onCancel()
+    } else if (action.kind === 'back') {
+      setTyping(false)
+    } else if (action.kind === 'move') {
+      setSel(s => s + action.delta)
+    } else if (action.kind === 'startTyping') {
+      setTyping(true)
+    } else if (action.kind === 'choose') {
+      onAnswer(action.answer)
     }
   })
 
@@ -163,7 +111,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
 
         <Box>
           <Text color={t.color.label}>{'> '}</Text>
-          <TextInput columns={Math.max(20, cols - 6)} onChange={setCustom} onSubmit={onAnswer} value={custom} />
+          <TextInput columns={Math.max(20, cols - 6)} onChange={setCustom} value={custom} />
         </Box>
 
         <Text color={t.color.muted}>


### PR DESCRIPTION
## Summary
- move prompt key-dispatch into a pure helper module so approval and clarify behavior are testable without Ink input plumbing
- handle free-text clarify Enter/Esc at the prompt layer so typed answers can be submitted without interrupting the agent
- add regressions for clarify free-text submission and keep approval key coverage on the extracted helper

## Testing
- `git diff --check`
- `./node_modules/.bin/eslint src/components/promptActions.ts src/components/prompts.tsx src/__tests__/approvalAction.test.ts src/__tests__/clarifyAction.test.ts`
- `npm test -- --run src/__tests__/clarifyAction.test.ts src/__tests__/approvalAction.test.ts`

Closes #39341