### PR TITLE
feat(desktop): add system tray with minimize-to-tray on close

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -14,7 +14,8 @@ const {
   safeStorage,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } = require('electron')
 const crypto = require('node:crypto')
 const fs = require('node:fs')
@@ -259,6 +260,15 @@ const APP_ICON_PATHS = [
 
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
+
+// System tray state (Windows/Linux): tray icon lives while app is running.
+// `forceQuit` distinguishes "real quit" (from tray menu or OS) from
+// "minimize to tray" (close button hides window instead of destroying it).
+// `closeToTray` is user-preference (from Settings) — when false, Alt+F4/X
+// closes the app normally even with the tray icon present.
+let tray = null
+let forceQuit = false
+let closeToTray = true
 
 function isHexColor(value) {
   return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value)
@@ -2765,6 +2775,109 @@ function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
 
+function createTray() {
+  if (tray) return
+  if (IS_MAC) return // macOS uses the dock; no system tray needed.
+
+  const iconPath = getAppIconPath()
+  if (!iconPath) {
+    rememberLog('[tray] no icon file found; skipping tray creation')
+    return
+  }
+
+  const icon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 })
+  tray = new Tray(icon)
+  tray.setToolTip('Hermes')
+
+  // Toggle window visibility on single click (Windows/Linux convention)
+  tray.on('click', () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return
+    if (mainWindow.isVisible()) {
+      mainWindow.hide()
+    } else {
+      mainWindow.show()
+      mainWindow.focus()
+    }
+  })
+
+  tray.on('double-click', () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return
+    mainWindow.show()
+    mainWindow.focus()
+  })
+
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Abrir Hermes',
+      click: () => {
+        if (!mainWindow || mainWindow.isDestroyed()) return
+        mainWindow.show()
+        mainWindow.focus()
+      }
+    },
+    {
+      label: 'Esconder Hermes',
+      click: () => {
+        if (!mainWindow || mainWindow.isDestroyed()) return
+        mainWindow.hide()
+      }
+    },
+    { type: 'separator' },
+    {
+      label: 'Sair',
+      click: () => {
+        forceQuit = true
+        app.quit()
+      }
+    }
+  ])
+
+  tray.setContextMenu(contextMenu)
+  rememberLog('[tray] system tray icon created')
+}
+
+const DESKTOP_PREFERENCES_PATH = path.join(HERMES_HOME, 'desktop-preferences.json')
+
+function loadDesktopPreferences() {
+  try {
+    if (!fileExists(DESKTOP_PREFERENCES_PATH)) return
+    const raw = fs.readFileSync(DESKTOP_PREFERENCES_PATH, 'utf8')
+    const prefs = JSON.parse(raw)
+    if (typeof prefs.closeToTray === 'boolean') closeToTray = prefs.closeToTray
+    rememberLog(`[tray] preferences loaded: closeToTray=${closeToTray}`)
+  } catch (err) {
+    rememberLog(`[tray] failed to load preferences: ${err.message}`)
+  }
+}
+
+function saveDesktopPreference(key, value) {
+  try {
+    let prefs = {}
+    if (fileExists(DESKTOP_PREFERENCES_PATH)) {
+      prefs = JSON.parse(fs.readFileSync(DESKTOP_PREFERENCES_PATH, 'utf8'))
+    }
+    prefs[key] = value
+    fs.writeFileSync(DESKTOP_PREFERENCES_PATH, JSON.stringify(prefs, null, 2), 'utf8')
+  } catch (err) {
+    rememberLog(`[tray] failed to save preference ${key}: ${err.message}`)
+  }
+}
+
+// ── Tray IPC ────────────────────────────────────────────────────
+
+ipcMain.handle('hermes:tray:get-state', () => ({
+  closeToTray,
+  trayActive: !!tray,
+  isMac: IS_MAC
+}))
+
+ipcMain.handle('hermes:tray:set-close-behavior', (_event, minimizeToTray) => {
+  closeToTray = Boolean(minimizeToTray)
+  saveDesktopPreference('closeToTray', closeToTray)
+  rememberLog(`[tray] close behavior set to ${closeToTray ? 'minimize to tray' : 'quit'}`)
+  return { ok: true }
+})
+
 function sendOpenUpdatesRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) return
   const { webContents } = mainWindow
@@ -3920,6 +4033,21 @@ function createWindow() {
   mainWindow.on('will-leave-full-screen', () => sendWindowStateChanged(false))
   mainWindow.on('leave-full-screen', () => sendWindowStateChanged(false))
 
+  // Intercept close: hide to tray instead of quitting (Windows/Linux).
+  // macOS already preserves the app when windows close (dock convention).
+  mainWindow.on('close', (event) => {
+    if (!forceQuit && tray && closeToTray) {
+      event.preventDefault()
+      mainWindow.hide()
+      return
+    }
+    // Not minimizing to tray — destroy tray so window-all-closed can quit.
+    if (tray) {
+      tray.destroy()
+      tray = null
+    }
+  })
+
   installPreviewShortcut(mainWindow)
   installDevToolsShortcut(mainWindow)
   installZoomShortcuts(mainWindow)
@@ -4604,6 +4732,8 @@ app.whenReady().then(() => {
   configureSpellChecker()
   registerPowerResumeListeners()
   createWindow()
+  createTray()
+  loadDesktopPreferences()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
@@ -4656,5 +4786,8 @@ app.on('before-quit', () => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
+  // When tray is active, the close event was intercepted — the window was
+  // hidden, not destroyed. window-all-closed shouldn't fire in that case,
+  // but guard with !tray for safety (clean exit if tray creation failed).
+  if (process.platform !== 'darwin' && !tray) app.quit()
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2775,6 +2775,24 @@ function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
 
+// ── Tray translations ──────────────────────────────────────────
+// Matched against app.getLocale() language prefix (e.g. 'pt-BR' → 'pt').
+
+const TRAY_LABELS = Object.freeze({
+  open:  { en: 'Open Hermes',   pt: 'Abrir Hermes',    es: 'Abrir Hermes',    zh: '打开 Hermes' },
+  hide:  { en: 'Hide Hermes',   pt: 'Esconder Hermes',  es: 'Ocultar Hermes',  zh: '隐藏 Hermes' },
+  quit:  { en: 'Quit',          pt: 'Sair',             es: 'Salir',            zh: '退出'        }
+})
+
+function tr(key) {
+  try {
+    const lang = (app.getLocale() || 'en').split('-')[0]
+    return TRAY_LABELS[key]?.[lang] || TRAY_LABELS[key]?.en || key
+  } catch {
+    return TRAY_LABELS[key]?.en || key
+  }
+}
+
 function createTray() {
   if (tray) return
   if (IS_MAC) return // macOS uses the dock; no system tray needed.
@@ -2808,7 +2826,7 @@ function createTray() {
 
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: 'Abrir Hermes',
+      label: tr('open'),
       click: () => {
         if (!mainWindow || mainWindow.isDestroyed()) return
         mainWindow.show()
@@ -2816,7 +2834,7 @@ function createTray() {
       }
     },
     {
-      label: 'Esconder Hermes',
+      label: tr('hide'),
       click: () => {
         if (!mainWindow || mainWindow.isDestroyed()) return
         mainWindow.hide()
@@ -2824,7 +2842,7 @@ function createTray() {
     },
     { type: 'separator' },
     {
-      label: 'Sair',
+      label: tr('quit'),
       click: () => {
         forceQuit = true
         app.quit()

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -40,6 +40,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setDefaultProjectDir: dir => ipcRenderer.invoke('hermes:setting:defaultProjectDir:set', dir),
     pickDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:pick')
   },
+  tray: {
+    getState: () => ipcRenderer.invoke('hermes:tray:get-state'),
+    setCloseBehavior: minimizeToTray => ipcRenderer.invoke('hermes:tray:set-close-behavior', minimizeToTray)
+  },
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 
 import { SegmentedControl } from '@/components/ui/segmented-control'
@@ -80,6 +80,28 @@ export function AppearanceSettings() {
       .catch(() => { /* prefs not available — use default */ })
   }, [])
 
+  const trayLabels = useMemo(() => {
+    const lang = (typeof navigator !== 'undefined' ? navigator.language : 'en').split('-')[0]
+    const L: Record<string, Record<string, string>> = {
+      minimizeTitle: {
+        en: 'Minimize to Tray on Close',
+        pt: 'Minimizar para a bandeja ao fechar',
+        es: 'Minimizar a la bandeja al cerrar',
+        zh: '关闭时最小化到托盘'
+      },
+      minimizeDesc: {
+        en: 'When enabled, closing the window hides Hermes to the system tray instead of quitting.',
+        pt: 'Quando ativado, fechar a janela esconde o Hermes na bandeja do sistema em vez de sair.',
+        es: 'Cuando está activado, cerrar la ventana oculta Hermes en la bandeja del sistema en lugar de salir.',
+        zh: '启用后，关闭窗口会将 Hermes 隐藏到系统托盘而不是退出。'
+      }
+    }
+    return {
+      title: L.minimizeTitle[lang] || L.minimizeTitle.en,
+      description: L.minimizeDesc[lang] || L.minimizeDesc.en
+    }
+  }, [])
+
   return (
     <SettingsContent>
       <div className="grid gap-8">
@@ -139,8 +161,8 @@ export function AppearanceSettings() {
                 }}
               />
             }
-            description="When enabled, closing the window hides Hermes to the system tray instead of quitting."
-            title="Minimize to Tray on Close"
+            description={trayLabels.description}
+            title={trayLabels.title}
           />
         </section>
 

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -1,7 +1,9 @@
 import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -69,6 +71,14 @@ function SectionHead({ title, description, control }: { title: string; descripti
 export function AppearanceSettings() {
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const [closeToTray, setCloseToTray] = useState(true)
+
+  useEffect(() => {
+    window.hermesDesktop.tray
+      ?.getState()
+      .then(state => setCloseToTray(state.closeToTray))
+      .catch(() => { /* prefs not available — use default */ })
+  }, [])
 
   return (
     <SettingsContent>
@@ -114,6 +124,23 @@ export function AppearanceSettings() {
             }
             description="Product hides raw tool payloads; Technical shows full input/output."
             title="Tool Call Display"
+          />
+        </section>
+
+        <section>
+          <SectionHead
+            control={
+              <Switch
+                checked={closeToTray}
+                onCheckedChange={checked => {
+                  setCloseToTray(checked)
+                  window.hermesDesktop.tray?.setCloseBehavior(checked)
+                  triggerHaptic('crisp')
+                }}
+              />
+            }
+            description="When enabled, closing the window hides Hermes to the system tray instead of quitting."
+            title="Minimize to Tray on Close"
           />
         </section>
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -36,6 +36,10 @@ declare global {
         pickDefaultProjectDir: () => Promise<{ canceled: boolean; dir: null | string }>
         setDefaultProjectDir: (dir: null | string) => Promise<{ dir: null | string }>
       }
+      tray: {
+        getState: () => Promise<{ closeToTray: boolean; trayActive: boolean; isMac: boolean }>
+        setCloseBehavior: (minimizeToTray: boolean) => Promise<{ ok: boolean }>
+      }
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
       readDir: (path: string) => Promise<HermesReadDirResult>


### PR DESCRIPTION
## Summary

Adds system tray support to Hermes Desktop on **Windows and Linux**. When closing the window, the app minimizes to the system tray instead of quitting — keeping the backend alive and the session hot. macOS continues using its native dock convention (unchanged).

A user preference toggle is included in **Settings → Appearance** so users who prefer the old "close = quit" behavior can switch back.

## Motivation

Currently on Windows/Linux, clicking the window close button kills the entire app. This is jarring — most desktop apps (Discord, Slack, Spotify, Telegram) minimize to the system tray on close. Users lose their session context and have to wait for a full backend restart every time.

After the initial feature request, the community asked for a **toggle** so users could choose between:
- **Tray mode** (default) — close hides to tray
- **Quit mode** — close quits completely

This PR delivers both.

## Changes

```
apps/desktop/electron/main.cjs                     | 137 ++++++++++++++++++++
apps/desktop/electron/preload.cjs                  |   4 +
apps/desktop/src/app/settings/appearance-settings.tsx |  27 ++++
apps/desktop/src/global.d.ts                       |   4 +
4 files changed, 170 insertions(+), 2 deletions(-)
```

### `electron/main.cjs`
- **Import** `Tray` from Electron
- **State:** `tray`, `forceQuit`, `closeToTray` (the user preference)
- **`createTray()`** — creates system tray icon using existing `apple-touch-icon.png`, sets up click handlers (single = toggle, double = show), builds context menu (Open, Hide, separator, Quit)
- **`loadDesktopPreferences()` / `saveDesktopPreference()`** — JSON file persistence at `~/.hermes/desktop-preferences.json`
- **IPC handlers:** `hermes:tray:get-state`, `hermes:tray:set-close-behavior` — query and update close behavior
- **Close interception:** `mainWindow.on('close')` — when `closeToTray=true`, prevents close and hides window; when `closeToTray=false`, destroys tray before close so `app.quit()` runs cleanly
- **`window-all-closed`** — guarded with `!tray` check so hidden windows don't trigger quit
- **No changes to existing lifecycle** — `before-quit` cleanup (backend kill, log flush, watchers) is untouched

### `electron/preload.cjs`
- Exposes `window.hermesDesktop.tray.getState()` and `.setCloseBehavior(minimizeToTray)` to the renderer

### `src/global.d.ts`
- TypeScript definitions for the tray API surface

### `src/app/settings/appearance-settings.tsx`
- Imports `Switch` component and React hooks
- Loads initial preference from IPC on mount
- Renders the "Minimize to Tray on Close" toggle switch in the Appearance section
- On toggle change, calls `setCloseBehavior()` to persist immediately

## Behavior Matrix

| Platform | Toggle | Close Window | Tray Menu "Quit" |
|----------|--------|-------------|------------------|
| Windows/Linux | ON (default) | Minimizes to tray | Full quit + cleanup |
| Windows/Linux | OFF | Quits + destroys tray | Same |
| macOS | N/A | Window closes, app stays in dock | N/A (no tray on macOS) |

## Testing

Tested on **Windows 10** with Hermes Desktop dev server:
- [x] Close with toggle ON → tray icon appears, window hides
- [x] Click tray icon → window toggles visibility
- [x] Double-click tray icon → shows window
- [x] Right-click tray → context menu works (Open, Hide, Quit)
- [x] "Quit" from tray menu → full cleanup (backend killed, logs flushed)
- [x] Close with toggle OFF → window closes, tray destroyed, app fully exits
- [x] Toggle preference persists across app restarts
- [x] macOS path untouched (no tray created)
- [x] `tsc --noEmit` passes with zero errors
- [x] `node -c` syntax check passes for both .cjs files

## Screenshots

<!-- Add screenshots of the tray icon in the system tray and the toggle in Settings → Appearance -->

---

Closes #<!-- add issue number if applicable -->
