### PR TITLE
feat(desktop): "send to all" broadcast across profiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -221,6 +221,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
+  onSendToAll: (text: string) => Promise<number> | void
 }
 
 export function ChatSidebar({
@@ -231,7 +232,8 @@ export function ChatSidebar({
   onResumeSession,
   onDeleteSession,
   onArchiveSession,
-  onNewSessionInWorkspace
+  onNewSessionInWorkspace,
+  onSendToAll
 }: ChatSidebarProps) {
   const sidebarOpen = useStore($sidebarOpen)
   const panesFlipped = useStore($panesFlipped)
@@ -746,7 +748,7 @@ export function ChatSidebar({
 
         {sidebarOpen && (
           <div className="shrink-0 px-0.5 pb-1 pt-0.5">
-            <ProfileRail />
+            <ProfileRail onSendToAll={onSendToAll} />
           </div>
         )}
       </SidebarContent>

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -25,6 +25,7 @@ import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { triggerHaptic } from '@/lib/haptics'
@@ -51,6 +52,8 @@ import { CreateProfileDialog } from '../../profiles/create-profile-dialog'
 import { DeleteProfileDialog } from '../../profiles/delete-profile-dialog'
 import { RenameProfileDialog } from '../../profiles/rename-profile-dialog'
 import { PROFILES_ROUTE } from '../../routes'
+
+import { SendToAllDialog } from './send-to-all-dialog'
 
 const RAIL_GAP = 4 // px — matches gap-1 between squares.
 
@@ -92,6 +95,7 @@ export function ProfileRail() {
   const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
+  const [sendAllOpen, setSendAllOpen] = useState(false)
   const [pendingRename, setPendingRename] = useState<null | ProfileInfo>(null)
   const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -245,8 +249,37 @@ export function ProfileRail() {
         </Tip>
       </div>
 
+      {/* The "…" overflow: broadcast a prompt to every profile, or jump to the
+          profiles settings page (its old single-tap destination). */}
       {multiProfile && (
-        <ProfilePill active={false} glyph="ellipsis" label="Manage profiles…" onSelect={() => navigate(PROFILES_ROUTE)} />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label="More profile actions"
+              className="bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+              size="icon-xs"
+              type="button"
+              variant="ghost"
+            >
+              <Codicon name="ellipsis" size="0.875rem" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="w-44"
+            collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}
+            sideOffset={6}
+          >
+            <DropdownMenuItem onSelect={() => setSendAllOpen(true)}>
+              <Codicon name="send" size="0.875rem" />
+              <span>Send to all</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => navigate(PROFILES_ROUTE)}>
+              <Codicon name="settings-gear" size="0.875rem" />
+              <span>Settings</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
 
       {/* Land in the new profile on a fresh chat (selectProfile triggers the
@@ -273,6 +306,8 @@ export function ProfileRail() {
         open={pendingDelete !== null}
         profile={pendingDelete}
       />
+
+      <SendToAllDialog onOpenChange={setSendAllOpen} open={sendAllOpen} />
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -86,7 +86,11 @@ const stepThroughCells: Modifier = ({ containerNodeRect, draggingNodeRect, trans
 // The active profile pops in its own color — the "where am I" cue. Single-
 // profile users see only the "+" (create their first profile); everything else
 // appears once a second profile exists.
-export function ProfileRail() {
+interface ProfileRailProps {
+  onSendToAll: (text: string) => Promise<number> | void
+}
+
+export function ProfileRail({ onSendToAll }: ProfileRailProps) {
   const profiles = useStore($profiles)
   const scope = useStore($profileScope)
   const gatewayProfile = useStore($activeGatewayProfile)
@@ -275,8 +279,8 @@ export function ProfileRail() {
               <span>Send to all</span>
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => navigate(PROFILES_ROUTE)}>
-              <Codicon name="settings-gear" size="0.875rem" />
-              <span>Settings</span>
+              <Codicon name="account" size="0.875rem" />
+              <span>Manage</span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -307,7 +311,7 @@ export function ProfileRail() {
         profile={pendingDelete}
       />
 
-      <SendToAllDialog onOpenChange={setSendAllOpen} open={sendAllOpen} />
+      <SendToAllDialog onOpenChange={setSendAllOpen} onSend={onSendToAll} open={sendAllOpen} />
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { triggerHaptic } from '@/lib/haptics'
+import { sendToAllProfiles } from '@/store/profile'
+
+interface SendToAllDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// A bare composer that fans one message out to every profile at once. Closes
+// itself the moment the broadcast is dispatched — the turns run in the
+// background, so there's no point holding the user on N backends.
+export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
+  const [text, setText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const close = (next: boolean) => {
+    if (!next) {
+      setText('')
+    }
+
+    onOpenChange(next)
+  }
+
+  const send = async () => {
+    const body = text.trim()
+
+    if (!body || sending) {
+      return
+    }
+
+    setSending(true)
+    triggerHaptic('success')
+
+    try {
+      await sendToAllProfiles(body)
+      close(false)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={close} open={open}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Send to all profiles</DialogTitle>
+          <DialogDescription>Opens a fresh session in every profile and sends this message to each. ⌘↵ to send.</DialogDescription>
+        </DialogHeader>
+        <Textarea
+          autoFocus
+          disabled={sending}
+          onChange={event => setText(event.target.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault()
+              void send()
+            } else if (event.key === 'Escape') {
+              close(false)
+            }
+          }}
+          placeholder="Message every profile…"
+          rows={4}
+          value={text}
+        />
+        <DialogFooter>
+          <Button disabled={sending} onClick={() => close(false)} type="button" variant="ghost">
+            Cancel
+          </Button>
+          <Button disabled={!text.trim() || sending} onClick={() => void send()} type="button">
+            {sending ? 'Sending…' : 'Send to all'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
@@ -11,17 +11,18 @@ import {
 } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
 import { triggerHaptic } from '@/lib/haptics'
-import { sendToAllProfiles } from '@/store/profile'
+import { setShowAllProfiles } from '@/store/profile'
 
 interface SendToAllDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onSend: (text: string) => Promise<number> | void
 }
 
 // A bare composer that fans one message out to every profile at once. Closes
 // itself the moment the broadcast is dispatched — the turns run in the
 // background, so there's no point holding the user on N backends.
-export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
+export function SendToAllDialog({ onOpenChange, onSend, open }: SendToAllDialogProps) {
   const [text, setText] = useState('')
 
   const close = (next: boolean) => {
@@ -32,9 +33,9 @@ export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
     onOpenChange(next)
   }
 
-  // Fire-and-forget: the broadcast boots each profile's backend sequentially
-  // (can take a few seconds across many profiles), so dispatch and close right
-  // away — progress comes back as toasts rather than a blocking spinner.
+  // Fire-and-forget: booting cold backends serially can take a few seconds, so
+  // dispatch and close immediately — progress arrives as toasts. Flip to the
+  // all-profiles view so the broadcast's sessions are visible as they land.
   const send = () => {
     const body = text.trim()
 
@@ -43,7 +44,8 @@ export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
     }
 
     triggerHaptic('success')
-    void sendToAllProfiles(body)
+    setShowAllProfiles(true)
+    void onSend(body)
     close(false)
   }
 

--- a/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/send-to-all-dialog.tsx
@@ -23,7 +23,6 @@ interface SendToAllDialogProps {
 // background, so there's no point holding the user on N backends.
 export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
   const [text, setText] = useState('')
-  const [sending, setSending] = useState(false)
 
   const close = (next: boolean) => {
     if (!next) {
@@ -33,22 +32,19 @@ export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
     onOpenChange(next)
   }
 
-  const send = async () => {
+  // Fire-and-forget: the broadcast boots each profile's backend sequentially
+  // (can take a few seconds across many profiles), so dispatch and close right
+  // away — progress comes back as toasts rather than a blocking spinner.
+  const send = () => {
     const body = text.trim()
 
-    if (!body || sending) {
+    if (!body) {
       return
     }
 
-    setSending(true)
     triggerHaptic('success')
-
-    try {
-      await sendToAllProfiles(body)
-      close(false)
-    } finally {
-      setSending(false)
-    }
+    void sendToAllProfiles(body)
+    close(false)
   }
 
   return (
@@ -60,12 +56,11 @@ export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
         </DialogHeader>
         <Textarea
           autoFocus
-          disabled={sending}
           onChange={event => setText(event.target.value)}
           onKeyDown={event => {
             if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
               event.preventDefault()
-              void send()
+              send()
             } else if (event.key === 'Escape') {
               close(false)
             }
@@ -75,11 +70,11 @@ export function SendToAllDialog({ onOpenChange, open }: SendToAllDialogProps) {
           value={text}
         />
         <DialogFooter>
-          <Button disabled={sending} onClick={() => close(false)} type="button" variant="ghost">
+          <Button onClick={() => close(false)} type="button" variant="ghost">
             Cancel
           </Button>
-          <Button disabled={!text.trim() || sending} onClick={() => void send()} type="button">
-            {sending ? 'Sending…' : 'Send to all'}
+          <Button disabled={!text.trim()} onClick={send} type="button">
+            Send to all
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -439,6 +439,7 @@ export function DesktopController() {
     removeSession,
     resumeSession,
     selectSidebarItem,
+    sendToAllProfiles,
     startFreshSessionDraft
   } = useSessionActions({
     activeSessionId,
@@ -629,6 +630,7 @@ export function DesktopController() {
       onNavigate={selectSidebarItem}
       onNewSessionInWorkspace={startSessionInWorkspace}
       onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
+      onSendToAll={sendToAllProfiles}
     />
   )
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -426,24 +426,29 @@ export function useSessionActions({
 
       for (const profile of $profiles.get()) {
         const key = normalizeProfileKey(profile.name)
+        let runtimeId: null | string = null
+        let stored: null | string = null
 
         try {
           const created = await requestGatewayForProfile<SessionCreateResponse>(key, 'session.create', { cols: 96 })
-          const stored = created.stored_session_id ?? null
-          ensureSessionState(created.session_id, stored)
+          runtimeId = created.session_id
+          stored = created.stored_session_id ?? null
+          ensureSessionState(runtimeId, stored)
 
           if (stored) {
             upsertOptimisticSession(created, stored, null, body, key)
           }
 
-          updateSessionState(
-            created.session_id,
-            state => ({ ...state, awaitingResponse: true, busy: true }),
-            stored
-          )
-          await requestGatewayForProfile(key, 'prompt.submit', { session_id: created.session_id, text: body })
+          updateSessionState(runtimeId, state => ({ ...state, awaitingResponse: true, busy: true }), stored)
+          await requestGatewayForProfile(key, 'prompt.submit', { session_id: runtimeId, text: body })
           sent += 1
         } catch {
+          // If create landed but submit didn't, drop the busy flag so the row
+          // doesn't spin forever waiting on a turn that never started.
+          if (runtimeId) {
+            updateSessionState(runtimeId, state => ({ ...state, awaitingResponse: false, busy: false }), stored)
+          }
+
           failed += 1
         }
       }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -9,10 +9,17 @@ import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-ima
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearComposerAttachments, clearComposerDraft } from '@/store/composer'
 import { clearQueuedPrompts } from '@/store/composer-queue'
+import { requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $profiles,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   $currentCwd,
   $messages,
@@ -171,13 +178,16 @@ function upsertOptimisticSession(
   created: SessionCreateResponse,
   id: string,
   title: string | null = null,
-  preview: string | null = null
+  preview: string | null = null,
+  profile?: string
 ) {
   const now = Date.now() / 1000
-  // Stamp the profile the session was just created on (= the live gateway's
-  // profile) so the scoped sidebar shows the new row immediately instead of
-  // filtering it out as "default" until the aggregator re-fetches.
-  const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  // Stamp the profile the session was just created on so the scoped sidebar
+  // shows the new row immediately instead of filtering it out as "default"
+  // until the aggregator re-fetches. Defaults to the live gateway's profile;
+  // "send to all" passes each target profile explicitly (it creates sessions
+  // off other profiles' sockets, not the active one).
+  const profileKey = normalizeProfileKey(profile ?? $activeGatewayProfile.get())
 
   const session: SessionInfo = {
     cwd: created.info?.cwd ?? null,
@@ -391,6 +401,64 @@ export function useSessionActions({
       selectedStoredSessionIdRef,
       updateSessionState
     ]
+  )
+
+  // Fan one prompt into EVERY profile at once. For each profile we open (or
+  // reuse) its background gateway, create a fresh session there, register it
+  // exactly like a foreground send (runtime↔stored mapping + optimistic row +
+  // busy flag) so it streams, survives sidebar merges, and clears on completion,
+  // then submit the text — all without touching the user's current session.
+  //
+  // Profiles are walked SEQUENTIALLY: a cold profile lazily boots its own Hermes
+  // backend, and the Electron port picker races if several boot at once (they
+  // grab the same free port and all but one dies). Serial is correct and gentle
+  // on the machine; the turns still run concurrently server-side.
+  const sendToAllProfiles = useCallback(
+    async (text: string): Promise<number> => {
+      const body = text.trim()
+
+      if (!body) {
+        return 0
+      }
+
+      let sent = 0
+      let failed = 0
+
+      for (const profile of $profiles.get()) {
+        const key = normalizeProfileKey(profile.name)
+
+        try {
+          const created = await requestGatewayForProfile<SessionCreateResponse>(key, 'session.create', { cols: 96 })
+          const stored = created.stored_session_id ?? null
+          ensureSessionState(created.session_id, stored)
+
+          if (stored) {
+            upsertOptimisticSession(created, stored, null, body, key)
+          }
+
+          updateSessionState(
+            created.session_id,
+            state => ({ ...state, awaitingResponse: true, busy: true }),
+            stored
+          )
+          await requestGatewayForProfile(key, 'prompt.submit', { session_id: created.session_id, text: body })
+          sent += 1
+        } catch {
+          failed += 1
+        }
+      }
+
+      if (sent) {
+        notify({ durationMs: 2_500, kind: 'success', message: `Sent to ${sent} profile${sent === 1 ? '' : 's'}` })
+      }
+
+      if (failed) {
+        notify({ durationMs: 4_000, kind: 'error', message: `${failed} profile${failed === 1 ? '' : 's'} failed` })
+      }
+
+      return sent
+    },
+    [ensureSessionState, updateSessionState]
   )
 
   const selectSidebarItem = useCallback(
@@ -847,6 +915,7 @@ export function useSessionActions({
     removeSession,
     resumeSession,
     selectSidebarItem,
+    sendToAllProfiles,
     startFreshSessionDraft
   }
 }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -215,6 +215,37 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   setActive(key)
 }
 
+// Run one RPC against a specific profile's gateway WITHOUT moving the active
+// pointer — opening (and keeping) its background socket if needed. Used by
+// "send to all", which fires a prompt into every profile's backend while the
+// user stays on their current session. The primary is the fast path.
+export async function requestGatewayForProfile<T>(
+  profile: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<T> {
+  const key = normKey(profile)
+
+  if (key === primaryProfile) {
+    if (!primaryGateway) {
+      throw new Error('Hermes gateway unavailable')
+    }
+
+    return primaryGateway.request<T>(method, params)
+  }
+
+  const entry = secondaries.get(key) ?? createSecondary(key)
+  entry.wantOpen = true
+
+  if (!isOpen(entry.gateway)) {
+    clearTimer(entry)
+    entry.reconnectAttempt = 0
+    await openSecondary(entry)
+  }
+
+  return entry.gateway.request<T>(method, params)
+}
+
 // Reconnect the active gateway after a transient request failure. Primary
 // reconnects are owned by use-gateway-boot, so we only drive secondaries here.
 export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -11,8 +11,9 @@ import {
   storedStringArray,
   storedStringRecord
 } from '@/lib/storage'
-import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
-import type { ProfileInfo } from '@/types/hermes'
+import { $gateway, ensureGatewayForProfile, requestGatewayForProfile } from '@/store/gateway'
+import { notify } from '@/store/notifications'
+import type { ProfileInfo, SessionCreateResponse } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
 // compare a session's owning profile against the live gateway's profile.
@@ -282,6 +283,40 @@ export function newSessionInProfile(name: string): void {
   $newChatProfile.set(target)
   requestFreshSession()
   void ensureGatewayProfile(target)
+}
+
+// Fire one prompt into EVERY profile at once: open (or reuse) each profile's
+// background gateway, create a fresh session there, and submit the text — all
+// without moving the user off their current profile/session. Turns run
+// concurrently server-side and stream into the background sockets; the new
+// sessions surface in the sidebar (All profiles view) as they persist.
+export async function sendToAllProfiles(text: string): Promise<number> {
+  const body = text.trim()
+
+  if (!body) {
+    return 0
+  }
+
+  const results = await Promise.allSettled(
+    $profiles.get().map(async (profile: ProfileInfo) => {
+      const key = normalizeProfileKey(profile.name)
+      const created = await requestGatewayForProfile<SessionCreateResponse>(key, 'session.create', { cols: 96 })
+      await requestGatewayForProfile(key, 'prompt.submit', { session_id: created.session_id, text: body })
+    })
+  )
+
+  const sent = results.filter(result => result.status === 'fulfilled').length
+  const failed = results.length - sent
+
+  if (sent) {
+    notify({ durationMs: 2_500, kind: 'success', message: `Sent to ${sent} profile${sent === 1 ? '' : 's'}` })
+  }
+
+  if (failed) {
+    notify({ durationMs: 4_000, kind: 'error', message: `${failed} profile${failed === 1 ? '' : 's'} failed` })
+  }
+
+  return sent
 }
 
 export function setShowAllProfiles(value: boolean): void {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -11,9 +11,8 @@ import {
   storedStringArray,
   storedStringRecord
 } from '@/lib/storage'
-import { $gateway, ensureGatewayForProfile, requestGatewayForProfile } from '@/store/gateway'
-import { notify } from '@/store/notifications'
-import type { ProfileInfo, SessionCreateResponse } from '@/types/hermes'
+import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
+import type { ProfileInfo } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
 // compare a session's owning profile against the live gateway's profile.
@@ -283,50 +282,6 @@ export function newSessionInProfile(name: string): void {
   $newChatProfile.set(target)
   requestFreshSession()
   void ensureGatewayProfile(target)
-}
-
-// Fire one prompt into EVERY profile: open (or reuse) each profile's background
-// gateway, create a fresh session there, and submit the text — all without
-// moving the user off their current profile/session. Turns run concurrently
-// server-side and stream into the background sockets; the new sessions surface
-// in the sidebar (All profiles view) as they persist.
-//
-// Profiles are walked SEQUENTIALLY on purpose: a cold profile lazily boots its
-// own Hermes backend, and the Electron port picker races if several boot at
-// once (they grab the same free port and all but one dies). Once a socket is
-// open the create+submit is quick, so serial is correct without being slow, and
-// it avoids stampeding the machine with N backends at once.
-export async function sendToAllProfiles(text: string): Promise<number> {
-  const body = text.trim()
-
-  if (!body) {
-    return 0
-  }
-
-  let sent = 0
-  let failed = 0
-
-  for (const profile of $profiles.get()) {
-    const key = normalizeProfileKey(profile.name)
-
-    try {
-      const created = await requestGatewayForProfile<SessionCreateResponse>(key, 'session.create', { cols: 96 })
-      await requestGatewayForProfile(key, 'prompt.submit', { session_id: created.session_id, text: body })
-      sent += 1
-    } catch {
-      failed += 1
-    }
-  }
-
-  if (sent) {
-    notify({ durationMs: 2_500, kind: 'success', message: `Sent to ${sent} profile${sent === 1 ? '' : 's'}` })
-  }
-
-  if (failed) {
-    notify({ durationMs: 4_000, kind: 'error', message: `${failed} profile${failed === 1 ? '' : 's'} failed` })
-  }
-
-  return sent
 }
 
 export function setShowAllProfiles(value: boolean): void {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -285,11 +285,17 @@ export function newSessionInProfile(name: string): void {
   void ensureGatewayProfile(target)
 }
 
-// Fire one prompt into EVERY profile at once: open (or reuse) each profile's
-// background gateway, create a fresh session there, and submit the text — all
-// without moving the user off their current profile/session. Turns run
-// concurrently server-side and stream into the background sockets; the new
-// sessions surface in the sidebar (All profiles view) as they persist.
+// Fire one prompt into EVERY profile: open (or reuse) each profile's background
+// gateway, create a fresh session there, and submit the text — all without
+// moving the user off their current profile/session. Turns run concurrently
+// server-side and stream into the background sockets; the new sessions surface
+// in the sidebar (All profiles view) as they persist.
+//
+// Profiles are walked SEQUENTIALLY on purpose: a cold profile lazily boots its
+// own Hermes backend, and the Electron port picker races if several boot at
+// once (they grab the same free port and all but one dies). Once a socket is
+// open the create+submit is quick, so serial is correct without being slow, and
+// it avoids stampeding the machine with N backends at once.
 export async function sendToAllProfiles(text: string): Promise<number> {
   const body = text.trim()
 
@@ -297,16 +303,20 @@ export async function sendToAllProfiles(text: string): Promise<number> {
     return 0
   }
 
-  const results = await Promise.allSettled(
-    $profiles.get().map(async (profile: ProfileInfo) => {
-      const key = normalizeProfileKey(profile.name)
+  let sent = 0
+  let failed = 0
+
+  for (const profile of $profiles.get()) {
+    const key = normalizeProfileKey(profile.name)
+
+    try {
       const created = await requestGatewayForProfile<SessionCreateResponse>(key, 'session.create', { cols: 96 })
       await requestGatewayForProfile(key, 'prompt.submit', { session_id: created.session_id, text: body })
-    })
-  )
-
-  const sent = results.filter(result => result.status === 'fulfilled').length
-  const failed = results.length - sent
+      sent += 1
+    } catch {
+      failed += 1
+    }
+  }
 
   if (sent) {
     notify({ durationMs: 2_500, kind: 'success', message: `Sent to ${sent} profile${sent === 1 ? '' : 's'}` })


### PR DESCRIPTION
Broadcast one prompt into **every profile at once** from the profile rail. Builds on the concurrent multi-profile gateway sockets — each profile's background socket is opened (or reused) via the registry, so the turns run concurrently and stream live without moving the user off their current session. **Single-profile users never see the rail, so this is inert for them.**

- The rail's **"…"** pill becomes a menu: **Send to all** / **Manage** (Manage keeps the old single-tap destination, the profiles page; now under the `account` codicon).
- **Send to all** opens a bare composer dialog (⌘↵ to send). On dispatch it flips to the **All profiles** view, fans the message out, and closes itself immediately. For each profile: open/reuse its gateway, `session.create`, register the session like a foreground send (runtime↔stored mapping + optimistic sidebar row stamped with its profile + busy flag), then `prompt.submit`.
- Because each session registers exactly like a real send, the new rows **appear instantly** (stamped with the right profile), stream live, survive sidebar merges, and clear their spinner on completion — instead of silently waiting to persist.
- Delivery is best-effort per profile: a toast reports how many sent / failed, so one dead backend doesn't sink the batch. A submit that fails after create clears its busy flag so the row never spins forever.
- Profiles are walked **sequentially**, not in parallel: a cold profile lazily boots its own Hermes backend, and the Electron port picker races if several boot at once (they grab the same free port and all but one dies). Serial is correct and gentle; turns still run concurrently server-side.

### Registry
- `requestGatewayForProfile(profile, method, params)` — run a single RPC against a named profile's socket **without** moving the active pointer (opens/keeps the background socket if needed). The primary is the fast path.

## Test plan
- [x] `npm run type-check` + `npm run lint` (apps/desktop) clean
- [ ] Manual: with ≥2 profiles, `…` → Send to all → type a message → ⌘↵; every profile gets a new session running that prompt, visible immediately in All profiles; dialog closes; toast shows the count
- [ ] Single-profile user: rail (and this menu) never appears — no behavior change