### PR TITLE
fix(nix): stage consolidated lockfile hash

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -77,7 +77,7 @@ jobs:
 
           # Ensure only nix files were modified — prevents accidental
           # self-triggering if fix-lockfiles ever touches package files.
-          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          unexpected="$(git diff --name-only | grep -Ev '^nix/lib\.nix$' || true)"
           if [ -n "$unexpected" ]; then
             echo "::error::Unexpected modified files: $unexpected"
             exit 1
@@ -89,7 +89,7 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): auto-refresh npm lockfile hashes" \
             -m "Source: $GITHUB_SHA" \
             -m "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -216,7 +216,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): refresh npm lockfile hashes"
           git push
 

--- a/tests/test_nix_lockfile_fix_workflow.py
+++ b/tests/test_nix_lockfile_fix_workflow.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import re
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "nix-lockfile-fix.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_lockfile_fix_workflow_stages_consolidated_hash_file() -> None:
+    text = _workflow_text()
+
+    assert text.count("git add nix/lib.nix") == 2
+    assert "git add nix/tui.nix nix/web.nix" not in text
+
+
+def test_lockfile_fix_workflow_guard_allows_only_consolidated_hash_file() -> None:
+    text = _workflow_text()
+
+    match = re.search(r"grep -Ev '([^']+)'", text)
+    assert match is not None
+    allowlist = re.compile(match.group(1))
+
+    assert allowlist.fullmatch("nix/lib.nix")
+    assert not allowlist.fullmatch("nix/tui.nix")
+    assert not allowlist.fullmatch("nix/web.nix")
+    assert not allowlist.fullmatch("package-lock.json")
+    assert "nix/(tui|web)" not in text


### PR DESCRIPTION
## Summary
- update nix-lockfile-fix workflow to allow and stage nix/lib.nix, where the consolidated npmDepsHash now lives
- stop staging the removed/pre-refactor nix/tui.nix and nix/web.nix hash files
- add regression coverage for the workflow guard and staging targets

Fixes #39455

## Test Plan
- python -m pytest tests/test_nix_lockfile_fix_workflow.py -q -o 'addopts='
- python YAML parse check for .github/workflows/nix-lockfile-fix.yml
