### PR TITLE
fix(cli): replace ANSI-Rich markup mixing in _restore_session_cwd

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5378,7 +5378,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"{_DIM}{_escape(msg)}{_RST}")
             return
 
         try:
@@ -5388,7 +5388,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"{_DIM}{_escape(msg)}{_RST}")
             return
 
         # Retarget the terminal/code-exec tools to match the process cwd.
@@ -5398,7 +5398,7 @@ class HermesCLI:
         if quiet:
             print(msg, file=sys.stderr)
         else:
-            self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+            self._console_print(f"{_DIM}{_escape(msg)}{_RST}")
 
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).


### PR DESCRIPTION
## Bug Description

Session resume crashes with `rich.errors.MarkupError: closing tag [/] at position 30 has nothing to close` because ANSI escape codes and Rich markup tags are mixed incorrectly.

Fixes #39469

## Root Cause

`_DIM` is an ANSI escape code (`\x1b[2;3m`), not a Rich markup tag. But `_restore_session_cwd()` wraps it in Rich-style brackets and closes with `[/]`:

```python
self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
```

Rich parses `[/]` as a close tag, but since no Rich tag was opened (the `[` was followed by ANSI ESC, not a valid tag character), it raises `MarkupError`.

## Fix

Replace the 3 occurrences in `_restore_session_cwd()` (lines 5381, 5391, 5401) with the pure ANSI pattern used everywhere else in the codebase:

```python
# Before:
self._console_print(f"[{_DIM}]{_escape(msg)}[/]")

# After:
self._console_print(f"{_DIM}{_escape(msg)}{_RST}")
```

`_RST = "\033[0m"` (ANSI reset) is already defined at line 1601. This pattern `{_DIM}...{_RST}` is the standard ANSI-only convention used throughout `cli.py`.

## How to Verify

1. Start a Hermes session from a directory
2. Exit
3. Resume from a different working directory: `hermes chat -r <session_id>`
4. Confirm the session resumes cleanly with the working directory message displayed in dim style

## Test Plan

- [ ] The fix is a 3-line ANSI-only change identical to every other `_DIM` usage in `cli.py`
- [ ] Manual verification of session resume flow
- [ ] No new dependencies or imports needed

## Risk Assessment

**Low** — The change replaces a broken pattern with the same ANSI-only pattern used in hundreds of other places in the codebase. No logic change, only string formatting.