### PR TITLE
fix(wecom): handle legal media and stale replies

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -90,10 +90,12 @@ NON_RESPONSE_COMMANDS = CALLBACK_COMMANDS | {APP_CMD_EVENT_CALLBACK}
 MAX_MESSAGE_LENGTH = 4000
 CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
+DEFAULT_REPLY_REQ_ID_TTL_SECONDS = 10.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 
 DEDUP_MAX_SIZE = 1000
+REPLY_REQUIRED_CHAT_TYPES = {"group", "channel", "forum", "thread"}
 
 IMAGE_MAX_BYTES = 10 * 1024 * 1024
 VIDEO_MAX_BYTES = 10 * 1024 * 1024
@@ -182,7 +184,18 @@ class WeComAdapter(BasePlatformAdapter):
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
-        self._reply_req_ids: Dict[str, str] = {}
+        ttl_raw = (
+            extra.get("reply_req_id_ttl_seconds")
+            or extra.get("replyReqIdTtlSeconds")
+            or os.getenv("WECOM_REPLY_REQ_ID_TTL_SECONDS")
+        )
+        try:
+            self._reply_req_id_ttl_seconds = (
+                float(ttl_raw) if ttl_raw is not None else DEFAULT_REPLY_REQ_ID_TTL_SECONDS
+            )
+        except (TypeError, ValueError):
+            self._reply_req_id_ttl_seconds = DEFAULT_REPLY_REQ_ID_TTL_SECONDS
+        self._reply_req_ids: Dict[str, Tuple[str, float, str]] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
@@ -191,7 +204,8 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex
-        self._last_chat_req_ids: Dict[str, str] = {}
+        self._last_chat_req_ids: Dict[str, Tuple[str, float, str]] = {}
+        self._chat_types: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -499,7 +513,6 @@ class WeComAdapter(BasePlatformAdapter):
         if self._dedup.is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s ignored", self.name, msg_id)
             return
-        self._remember_reply_req_id(msg_id, self._payload_req_id(payload))
 
         sender = body.get("from") if isinstance(body.get("from"), dict) else {}
         sender_id = str(sender.get("userid") or "").strip()
@@ -509,6 +522,7 @@ class WeComAdapter(BasePlatformAdapter):
             return
 
         is_group = str(body.get("chattype") or "").lower() == "group"
+        chat_type = "group" if is_group else "dm"
         if is_group:
             if not self._is_group_allowed(chat_id, sender_id):
                 logger.debug("[%s] Group %s / sender %s blocked by policy", self.name, chat_id, sender_id)
@@ -517,10 +531,12 @@ class WeComAdapter(BasePlatformAdapter):
             logger.debug("[%s] DM sender %s blocked by policy", self.name, sender_id)
             return
 
-        # Cache the inbound req_id after policy checks so proactive sends to
-        # this chat can fall back to APP_CMD_RESPONSE (required for groups —
-        # WeCom AI Bots cannot initiate APP_CMD_SEND in group chats).
-        self._remember_chat_req_id(chat_id, self._payload_req_id(payload))
+        # Cache the inbound req_id after policy checks. Groups require
+        # APP_CMD_RESPONSE, while DMs can fall back to APP_CMD_SEND after the
+        # short callback reply window expires.
+        inbound_req_id = self._payload_req_id(payload)
+        self._remember_reply_req_id(msg_id, inbound_req_id, chat_type=chat_type)
+        self._remember_chat_req_id(chat_id, inbound_req_id, chat_type=chat_type)
 
         text, reply_text = self._extract_text(body)
         # Strip leading @mention in group chats so slash commands like
@@ -717,6 +733,14 @@ class WeComAdapter(BasePlatformAdapter):
                 item_type = str(item.get("msgtype") or "").lower()
                 if item_type == "image" and isinstance(item.get("image"), dict):
                     refs.append(("image", item["image"]))
+                elif item_type == "file" and isinstance(item.get("file"), dict):
+                    refs.append(("file", item["file"]))
+                elif item_type == "appmsg" and isinstance(item.get("appmsg"), dict):
+                    appmsg = item["appmsg"]
+                    if isinstance(appmsg.get("file"), dict):
+                        refs.append(("file", appmsg["file"]))
+                    elif isinstance(appmsg.get("image"), dict):
+                        refs.append(("image", appmsg["image"]))
         else:
             if isinstance(body.get("image"), dict):
                 refs.append(("image", body["image"]))
@@ -891,37 +915,147 @@ class WeComAdapter(BasePlatformAdapter):
         wildcard = self._groups.get("*")
         return wildcard if isinstance(wildcard, dict) else {}
 
-    def _remember_reply_req_id(self, message_id: str, req_id: str) -> None:
+    @staticmethod
+    def _normalize_chat_type(chat_type: str) -> str:
+        return str(chat_type or "").strip().lower()
+
+    @staticmethod
+    def _is_reply_required_chat_type(chat_type: str) -> bool:
+        return WeComAdapter._normalize_chat_type(chat_type) in REPLY_REQUIRED_CHAT_TYPES
+
+    @staticmethod
+    def _req_id_entry_parts(entry: Any) -> Tuple[str, float, str]:
+        if isinstance(entry, (tuple, list)):
+            req_id = str(entry[0] if len(entry) > 0 else "").strip()
+            try:
+                created_at = float(entry[1]) if len(entry) > 1 else time.monotonic()
+            except (TypeError, ValueError):
+                created_at = time.monotonic()
+            chat_type = WeComAdapter._normalize_chat_type(entry[2] if len(entry) > 2 else "")
+            return req_id, created_at, chat_type
+        return str(entry or "").strip(), time.monotonic(), ""
+
+    def _req_id_is_fresh(self, created_at: float) -> bool:
+        ttl_seconds = self._reply_req_id_ttl_seconds
+        return ttl_seconds <= 0 or (time.monotonic() - created_at) <= ttl_seconds
+
+    def _remember_reply_req_id(self, message_id: str, req_id: str, chat_type: str = "") -> None:
         normalized_message_id = str(message_id or "").strip()
         normalized_req_id = str(req_id or "").strip()
         if not normalized_message_id or not normalized_req_id:
             return
-        self._reply_req_ids[normalized_message_id] = normalized_req_id
+        self._reply_req_ids[normalized_message_id] = (
+            normalized_req_id,
+            time.monotonic(),
+            self._normalize_chat_type(chat_type),
+        )
         while len(self._reply_req_ids) > DEDUP_MAX_SIZE:
             self._reply_req_ids.pop(next(iter(self._reply_req_ids)))
 
-    def _remember_chat_req_id(self, chat_id: str, req_id: str) -> None:
+    def _remember_chat_req_id(self, chat_id: str, req_id: str, chat_type: str = "") -> None:
         """Cache the most recent inbound req_id per chat.
 
-        Used as a fallback reply target when we need to send into a group
-        without an explicit ``reply_to`` — WeCom AI Bots are blocked from
-        APP_CMD_SEND in groups and must use APP_CMD_RESPONSE bound to some
-        prior req_id. Bounded like _reply_req_ids so long-running gateways
-        don't leak memory across many chats.
+        Groups use this as a short-lived fallback reply target when we need to
+        send without an explicit ``reply_to`` — WeCom AI Bots are blocked from
+        APP_CMD_SEND in group chats and must use APP_CMD_RESPONSE bound to some
+        prior req_id. DMs keep the metadata only so stale explicit replies can
+        safely fall back to APP_CMD_SEND.
         """
         normalized_chat_id = str(chat_id or "").strip()
         normalized_req_id = str(req_id or "").strip()
         if not normalized_chat_id or not normalized_req_id:
             return
-        self._last_chat_req_ids[normalized_chat_id] = normalized_req_id
+        normalized_chat_type = self._normalize_chat_type(chat_type)
+        self._last_chat_req_ids[normalized_chat_id] = (
+            normalized_req_id,
+            time.monotonic(),
+            normalized_chat_type,
+        )
+        if normalized_chat_type:
+            self._chat_types[normalized_chat_id] = normalized_chat_type
         while len(self._last_chat_req_ids) > DEDUP_MAX_SIZE:
-            self._last_chat_req_ids.pop(next(iter(self._last_chat_req_ids)))
+            evicted_chat_id = next(iter(self._last_chat_req_ids))
+            self._last_chat_req_ids.pop(evicted_chat_id)
+            self._chat_types.pop(evicted_chat_id, None)
 
     def _reply_req_id_for_message(self, reply_to: Optional[str]) -> Optional[str]:
         normalized = str(reply_to or "").strip()
         if not normalized or normalized.startswith("quote:"):
             return None
-        return self._reply_req_ids.get(normalized)
+        entry = self._reply_req_ids.get(normalized)
+        if not entry:
+            return None
+        req_id, created_at, _chat_type = self._req_id_entry_parts(entry)
+        if not req_id or not self._req_id_is_fresh(created_at):
+            self._reply_req_ids.pop(normalized, None)
+            return None
+        return req_id
+
+    def _chat_type_for_chat(self, chat_id: str) -> str:
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_chat_id:
+            return ""
+        chat_type = self._chat_types.get(normalized_chat_id, "")
+        if chat_type:
+            return chat_type
+        entry = self._last_chat_req_ids.get(normalized_chat_id)
+        if not entry:
+            return ""
+        _req_id, _created_at, entry_chat_type = self._req_id_entry_parts(entry)
+        return entry_chat_type
+
+    def _chat_requires_reply(self, chat_id: str) -> bool:
+        return self._is_reply_required_chat_type(self._chat_type_for_chat(chat_id))
+
+    def _chat_reply_req_id_for_send(self, chat_id: str) -> Optional[str]:
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_chat_id or not self._chat_requires_reply(normalized_chat_id):
+            return None
+        entry = self._last_chat_req_ids.get(normalized_chat_id)
+        if not entry:
+            return None
+        req_id, created_at, _chat_type = self._req_id_entry_parts(entry)
+        if not req_id or not self._req_id_is_fresh(created_at):
+            self._last_chat_req_ids.pop(normalized_chat_id, None)
+            return None
+        return req_id
+
+    def _resolve_reply_req_id_for_send(self, chat_id: str, reply_to: Optional[str]) -> Optional[str]:
+        return self._reply_req_id_for_message(reply_to) or self._chat_reply_req_id_for_send(chat_id)
+
+    def _forget_matching_req_id(
+        self,
+        req_id: Optional[str],
+        reply_to: Optional[str] = None,
+        chat_id: Optional[str] = None,
+    ) -> None:
+        normalized_req_id = str(req_id or "").strip()
+        if not normalized_req_id:
+            return
+
+        normalized_reply_to = str(reply_to or "").strip()
+        if normalized_reply_to and not normalized_reply_to.startswith("quote:"):
+            entry = self._reply_req_ids.get(normalized_reply_to)
+            stored_req_id, _created_at, _chat_type = self._req_id_entry_parts(entry)
+            if stored_req_id == normalized_req_id:
+                self._reply_req_ids.pop(normalized_reply_to, None)
+        else:
+            for message_id, entry in list(self._reply_req_ids.items()):
+                stored_req_id, _created_at, _chat_type = self._req_id_entry_parts(entry)
+                if stored_req_id == normalized_req_id:
+                    self._reply_req_ids.pop(message_id, None)
+
+        normalized_chat_id = str(chat_id or "").strip()
+        if normalized_chat_id:
+            entry = self._last_chat_req_ids.get(normalized_chat_id)
+            stored_req_id, _created_at, _chat_type = self._req_id_entry_parts(entry)
+            if stored_req_id == normalized_req_id:
+                self._last_chat_req_ids.pop(normalized_chat_id, None)
+        else:
+            for cached_chat_id, entry in list(self._last_chat_req_ids.items()):
+                stored_req_id, _created_at, _chat_type = self._req_id_entry_parts(entry)
+                if stored_req_id == normalized_req_id:
+                    self._last_chat_req_ids.pop(cached_chat_id, None)
 
     # ------------------------------------------------------------------
     # Outbound messaging
@@ -1302,9 +1436,9 @@ class WeComAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=prepared["reject_reason"])
 
-        reply_req_id = self._reply_req_id_for_message(reply_to)
-        if not reply_req_id and chat_id in self._last_chat_req_ids:
-            reply_req_id = self._last_chat_req_ids[chat_id]
+        reply_req_id = self._resolve_reply_req_id_for_send(chat_id, reply_to)
+        if not reply_req_id and self._chat_requires_reply(chat_id):
+            return SendResult(success=False, error="No fresh WeCom reply req_id available for group chat")
 
         try:
             upload_result = await self._upload_media_bytes(
@@ -1325,6 +1459,7 @@ class WeComAdapter(BasePlatformAdapter):
                     upload_result["media_id"],
                 )
         except asyncio.TimeoutError:
+            self._forget_matching_req_id(reply_req_id, reply_to=reply_to, chat_id=chat_id)
             return SendResult(success=False, error="Timeout sending media to WeCom")
         except Exception as exc:
             logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc)
@@ -1371,11 +1506,11 @@ class WeComAdapter(BasePlatformAdapter):
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
+        reply_req_id = None
         try:
-            reply_req_id = self._reply_req_id_for_message(reply_to)
-
-            if not reply_req_id and chat_id in self._last_chat_req_ids:
-                reply_req_id = self._last_chat_req_ids[chat_id]
+            reply_req_id = self._resolve_reply_req_id_for_send(chat_id, reply_to)
+            if not reply_req_id and self._chat_requires_reply(chat_id):
+                return SendResult(success=False, error="No fresh WeCom reply req_id available for group chat")
 
             if reply_req_id:
                 response = await self._send_reply_markdown(reply_req_id, content)
@@ -1389,6 +1524,7 @@ class WeComAdapter(BasePlatformAdapter):
                     },
                 )
         except asyncio.TimeoutError:
+            self._forget_matching_req_id(reply_req_id, reply_to=reply_to, chat_id=chat_id)
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
             logger.error("[%s] Send failed: %s", self.name, exc)

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import os
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -171,7 +172,7 @@ class TestWeComReplyMode:
         from gateway.platforms.wecom import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
-        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._remember_reply_req_id("msg-1", "req-1", chat_type="dm")
         adapter._send_reply_request = AsyncMock(
             return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
         )
@@ -192,7 +193,7 @@ class TestWeComReplyMode:
         from gateway.platforms.wecom import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
-        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._remember_reply_req_id("msg-1", "req-1", chat_type="dm")
         adapter._prepare_outbound_media = AsyncMock(
             return_value={
                 "data": b"image-bytes",
@@ -218,6 +219,76 @@ class TestWeComReplyMode:
         args = adapter._send_reply_request.await_args.args
         assert args[0] == "req-1"
         assert args[1] == {"msgtype": "image", "image": {"media_id": "media-1"}}
+
+    @pytest.mark.asyncio
+    async def test_dm_media_ignores_cached_chat_req_id_and_uses_app_cmd_send(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._remember_chat_req_id("dm-1", "inbound-req-42", chat_type="dm")
+        adapter._prepare_outbound_media = AsyncMock(
+            return_value={
+                "data": b"docx-bytes",
+                "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "file_name": "demo.docx",
+                "detected_type": "file",
+                "final_type": "file",
+                "rejected": False,
+                "reject_reason": None,
+                "downgraded": False,
+                "downgrade_note": None,
+            }
+        )
+        adapter._upload_media_bytes = AsyncMock(return_value={"media_id": "media-1", "type": "file"})
+        adapter._send_media_message = AsyncMock(
+            return_value={"headers": {"req_id": "new"}, "errcode": 0}
+        )
+        adapter._send_reply_media_message = AsyncMock()
+
+        result = await adapter.send_document("dm-1", "/tmp/demo.docx", reply_to=None)
+
+        assert result.success is True
+        adapter._send_media_message.assert_awaited_once_with("dm-1", "file", "media-1")
+        adapter._send_reply_media_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_expired_reply_to_falls_back_to_app_cmd_send(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = ("req-1", time.monotonic() - 11, "dm")
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "new"}, "errcode": 0}
+        )
+
+        result = await adapter.send("dm-1", "late hello", reply_to="msg-1")
+
+        assert result.success is True
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_awaited_once()
+        assert adapter._send_request.await_args.args[0] == APP_CMD_SEND
+
+    @pytest.mark.asyncio
+    async def test_reply_timeout_clears_req_id_before_fallback_retry(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._remember_reply_req_id("msg-1", "req-1", chat_type="dm")
+        adapter._send_reply_request = AsyncMock(side_effect=asyncio.TimeoutError)
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "new"}, "errcode": 0}
+        )
+
+        first = await adapter.send("dm-1", "markdown", reply_to="msg-1")
+        second = await adapter.send("dm-1", "plain fallback", reply_to="msg-1")
+
+        assert first.success is False
+        assert first.error == "Timeout sending message to WeCom"
+        assert second.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        adapter._send_request.assert_awaited_once()
+        assert adapter._send_request.await_args.args[0] == APP_CMD_SEND
 
 
 class TestExtractText:
@@ -386,6 +457,72 @@ class TestMediaHelpers:
 
         with pytest.raises(ValueError, match="placeholder was not replaced"):
             await adapter._load_outbound_media("<path>")
+
+    @pytest.mark.asyncio
+    async def test_extract_media_reads_image_and_file_from_mixed_message(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        docx_mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        adapter._cache_media = AsyncMock(
+            side_effect=[
+                ("/tmp/wecom-image.jpg", "image/jpeg"),
+                ("/tmp/contract.docx", docx_mime),
+            ]
+        )
+        body = {
+            "msgtype": "mixed",
+            "mixed": {
+                "msg_item": [
+                    {"msgtype": "text", "text": {"content": "contract"}},
+                    {"msgtype": "image", "image": {"url": "https://example.com/chat.jpg"}},
+                    {
+                        "msgtype": "file",
+                        "file": {
+                            "url": "https://example.com/contract.docx",
+                            "filename": "contract.docx",
+                        },
+                    },
+                ]
+            },
+        }
+
+        media_paths, media_types = await adapter._extract_media(body)
+
+        assert media_paths == ["/tmp/wecom-image.jpg", "/tmp/contract.docx"]
+        assert media_types == ["image/jpeg", docx_mime]
+        assert adapter._cache_media.await_args_list[0].args == ("image", body["mixed"]["msg_item"][1]["image"])
+        assert adapter._cache_media.await_args_list[1].args == ("file", body["mixed"]["msg_item"][2]["file"])
+
+    @pytest.mark.asyncio
+    async def test_extract_media_reads_appmsg_file_from_mixed_message(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        docx_mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        adapter._cache_media = AsyncMock(return_value=("/tmp/contract.docx", docx_mime))
+        body = {
+            "msgtype": "mixed",
+            "mixed": {
+                "msg_item": [
+                    {
+                        "msgtype": "appmsg",
+                        "appmsg": {
+                            "file": {
+                                "url": "https://example.com/contract.docx",
+                                "filename": "contract.docx",
+                            }
+                        },
+                    }
+                ]
+            },
+        }
+
+        media_paths, media_types = await adapter._extract_media(body)
+
+        assert media_paths == ["/tmp/contract.docx"]
+        assert media_types == [docx_mime]
+        assert adapter._cache_media.await_args.args == ("file", body["mixed"]["msg_item"][0]["appmsg"]["file"])
 
 
 class TestMediaUpload:
@@ -618,6 +755,39 @@ class TestInboundMessages:
         assert event.media_types == ["image/png"]
 
     @pytest.mark.asyncio
+    async def test_on_message_marks_document_when_file_media_is_present(self):
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(
+            return_value=(
+                ["/tmp/contract.docx"],
+                ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+            )
+        )
+
+        payload = {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-1"},
+            "body": {
+                "msgid": "msg-1",
+                "chatid": "chat-1",
+                "from": {"userid": "user-1"},
+                "msgtype": "mixed",
+                "mixed": {"msg_item": [{"msgtype": "text", "text": {"content": "contract"}}]},
+            },
+        }
+
+        await adapter._on_message(payload)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls == ["/tmp/contract.docx"]
+
+    @pytest.mark.asyncio
     async def test_on_message_preserves_quote_context(self):
         from gateway.platforms.wecom import WeComAdapter
 
@@ -768,7 +938,9 @@ class TestWeComZombieSessionFix:
         }
 
         await adapter._on_message(payload)
-        assert adapter._last_chat_req_ids["group-1"] == "req-abc"
+        cached_req_id, _created_at, chat_type = adapter._last_chat_req_ids["group-1"]
+        assert cached_req_id == "req-abc"
+        assert chat_type == "group"
 
     @pytest.mark.asyncio
     async def test_on_message_does_not_cache_blocked_sender_req_id(self):
@@ -806,11 +978,12 @@ class TestWeComZombieSessionFix:
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
         for i in range(DEDUP_MAX_SIZE + 50):
-            adapter._remember_chat_req_id(f"chat-{i}", f"req-{i}")
+            adapter._remember_chat_req_id(f"chat-{i}", f"req-{i}", chat_type="group")
         assert len(adapter._last_chat_req_ids) <= DEDUP_MAX_SIZE
         # The most recently remembered chat must still be present.
         latest = f"chat-{DEDUP_MAX_SIZE + 49}"
-        assert adapter._last_chat_req_ids[latest] == f"req-{DEDUP_MAX_SIZE + 49}"
+        assert adapter._last_chat_req_ids[latest][0] == f"req-{DEDUP_MAX_SIZE + 49}"
+        assert adapter._chat_types[latest] == "group"
 
     def test_remember_chat_req_id_ignores_empty_values(self):
         from gateway.platforms.wecom import WeComAdapter
@@ -829,7 +1002,7 @@ class TestWeComZombieSessionFix:
         from gateway.platforms.wecom import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
-        adapter._last_chat_req_ids["group-1"] = "inbound-req-42"
+        adapter._remember_chat_req_id("group-1", "inbound-req-42", chat_type="group")
         adapter._send_reply_request = AsyncMock(
             return_value={"headers": {"req_id": "inbound-req-42"}, "errcode": 0}
         )
@@ -847,6 +1020,47 @@ class TestWeComZombieSessionFix:
         assert args[0] == "inbound-req-42"
         assert args[1]["msgtype"] == "markdown"
         assert args[1]["markdown"]["content"] == "ping"
+
+    @pytest.mark.asyncio
+    async def test_stale_group_cached_req_id_does_not_use_app_cmd_send(self):
+        """Groups still require a fresh APP_CMD_RESPONSE req_id."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._last_chat_req_ids["group-1"] = (
+            "inbound-req-42",
+            time.monotonic() - 11,
+            "group",
+        )
+        adapter._chat_types["group-1"] = "group"
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock()
+
+        result = await adapter.send("group-1", "ping", reply_to=None)
+
+        assert result.success is False
+        assert result.error == "No fresh WeCom reply req_id available for group chat"
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_send_ignores_cached_chat_req_id_and_uses_app_cmd_send(self):
+        """DMs should proactively send unless an explicit fresh reply_to exists."""
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._remember_chat_req_id("dm-1", "inbound-req-42", chat_type="dm")
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "new"}, "errcode": 0}
+        )
+
+        result = await adapter.send("dm-1", "ping", reply_to=None)
+
+        assert result.success is True
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_awaited_once()
+        assert adapter._send_request.await_args.args[0] == APP_CMD_SEND
 
     @pytest.mark.asyncio
     async def test_proactive_send_without_cached_req_id_uses_app_cmd_send(self):

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -178,6 +178,24 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is True
 
+    def test_wecom_cos_hostname_allowed_with_benchmark_ip(self):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.101", 0)),
+        ]):
+            assert is_safe_url("https://ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com/file") is True
+
+    def test_wecom_cos_hostname_exception_is_exact_match(self):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.101", 0)),
+        ]):
+            assert is_safe_url("https://evil.ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com/file") is False
+
+    def test_wecom_cos_hostname_exception_requires_https(self):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.101", 0)),
+        ]):
+            assert is_safe_url("http://ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com/file") is False
+
     def test_qq_multimedia_hostname_exception_is_exact_match(self):
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -72,6 +72,7 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com",
 })
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by


### PR DESCRIPTION
## What does this PR do?

Fixes WeCom legal-profile handling for two related gateway issues:

- inbound enterprise WeCom media can arrive from an official COS host that resolves to a private benchmark range behind local proxy infrastructure, and mixed messages may carry files inside `mixed.msg_item` or `appmsg`.
- outbound WeCom callback `req_id` values were cached without expiry, so slow DM replies could keep trying stale `aibot_respond_msg` requests and make both markdown and plain-text fallback wait for timeout.

The fix keeps WeCom group behavior reply-only, while allowing stale DM replies to fall back to proactive `aibot_send_msg`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/url_safety.py`: allow the observed official WeCom COS media hostname as an exact HTTPS-only trusted private-IP exception.
- `gateway/platforms/wecom.py`: extract files and appmsg media from WeCom `mixed.msg_item` payloads.
- `gateway/platforms/wecom.py`: store callback reply req IDs with monotonic timestamps and chat-type metadata, defaulting to a 10s TTL.
- `gateway/platforms/wecom.py`: route stale DM replies to proactive send, keep group/channel reply-only, and clear timed-out req IDs before fallback retries.
- `tests/tools/test_url_safety.py` and `tests/gateway/test_wecom.py`: add regression coverage for WeCom media extraction, URL safety, stale reply routing, timeout cleanup, and media send routing.

## How to Test

1. `venv/bin/python -m pytest tests/gateway/test_wecom.py -q`
2. `venv/bin/python -m pytest tests/tools/test_url_safety.py tests/gateway/test_wecom.py -q`
3. `venv/bin/ruff check gateway/platforms/wecom.py tests/gateway/test_wecom.py`

Additional local check:

- `venv/bin/python -m pytest tests/gateway -q` was attempted. In sandbox it failed on local socket binding permissions. With elevated local permissions it completed with unrelated existing failures in agent cache/network-backed setup, Discord URL safety fixture resolution, Matrix, and Telegram assertion tests; no WeCom tests failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Targeted verification:

```text
54 passed in 0.42s
169 passed in 0.43s
All checks passed!
```
