### PR TITLE
fix: catch BaseException in MCP shutdown guards to suppress double-Ctrl+C traceback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -974,7 +974,7 @@ def _run_cleanup():
     try:
         from tools.mcp_tool import shutdown_mcp_servers
         shutdown_mcp_servers()
-    except Exception:
+    except BaseException:
         pass
     # Close cached auxiliary LLM clients (sync + async) so that
     # AsyncHttpxClientWrapper.__del__ doesn't fire on a closed event loop

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3800,7 +3800,7 @@ def shutdown_mcp_servers():
         if future is not None:
             try:
                 future.result(timeout=15)
-            except Exception as exc:
+            except BaseException as exc:
                 logger.debug("Error during MCP shutdown: %s", exc)
 
     _stop_mcp_loop()


### PR DESCRIPTION
## Summary
A second Ctrl+C during MCP shutdown now exits cleanly instead of printing a `KeyboardInterrupt` traceback.

The CLI's `_signal_handler_q` raises `KeyboardInterrupt` (a `BaseException`, not `Exception`). The two best-effort teardown guards on the shutdown path caught only `Exception`, so a second interrupt during the up-to-15s `future.result(timeout=15)` wait escaped cleanup and surfaced as an unhandled traceback.

Salvage of #39453 by @HeLLGURD onto current `main` (the original branch was stale — its diff also showed a `_branched_from` block already present on main; that phantom chunk drops out on cherry-pick). Closes #39367.

## Changes
- `cli.py` `_run_cleanup()`: `except Exception` → `except BaseException`
- `tools/mcp_tool.py` `shutdown_mcp_servers()`: `except Exception` → `except BaseException`

Both guards are pure best-effort teardown (`pass` / log-and-continue), so the wider catch only lets cleanup finish and the process exit without a traceback.

## Validation
E2E (real source from worktree):

| | `except Exception` (old) | `except BaseException` (new) |
|---|---|---|
| 2nd Ctrl+C → KeyboardInterrupt | escapes guard → traceback | swallowed → clean exit |

Both files compile clean.

Credit: @HeLLGURD (commits cherry-picked with authorship preserved).

## Infographic

![mcp-shutdown-guard-fix](https://v3b.fal.media/files/b/0a9d0490/ocNf0z_6KmZHwuEmbr_4V_XjFtkbOF.png)
