### PR TITLE
fix(cli): resolve load_hermes_dotenv home via get_hermes_home() for profile-scoped cron MCP init

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -224,7 +224,21 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    if hermes_home:
+        home_path = Path(hermes_home)
+    else:
+        # No explicit home: resolve through get_hermes_home() rather than
+        # reading os.environ["HERMES_HOME"] directly.  get_hermes_home()
+        # also honors the context-local override that profile-scoped cron
+        # jobs install via set_hermes_home_override() — those jobs leave
+        # HERMES_HOME pointing at the scheduler root, so a direct env read
+        # reloaded the root .env with override=True and stomped the
+        # profile's freshly-loaded MCP credentials.  It also gives the
+        # platform-native default (%LOCALAPPDATA%\hermes on Windows)
+        # instead of a hardcoded ~/.hermes.
+        from hermes_constants import get_hermes_home
+
+        home_path = get_hermes_home()
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "drexux0@gmail.com": "Drexuxux",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,59 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
 
 
+def test_no_arg_load_honors_context_local_home_override(tmp_path, monkeypatch):
+    """Parameterless load_hermes_dotenv() must honor the context-local home
+    override, not just os.environ["HERMES_HOME"].
+
+    Regression: profile-scoped cron jobs install a context-local override via
+    set_hermes_home_override(profile_home) while leaving HERMES_HOME pointing
+    at the scheduler root. discover_mcp_tools() -> _load_mcp_config() calls
+    load_hermes_dotenv() with no args; the old code read HERMES_HOME from the
+    environment and reloaded the ROOT .env with override=True, stomping the
+    profile credentials run_job() had just loaded.
+    """
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / ".env").write_text("MCP_KEY=root-value\n", encoding="utf-8")
+
+    profile_home = tmp_path / "profiles" / "support"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text("MCP_KEY=profile-value\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("MCP_KEY", raising=False)
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        loaded = load_hermes_dotenv()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert loaded == [profile_home / ".env"]
+    assert os.getenv("MCP_KEY") == "profile-value"
+
+
+def test_no_arg_load_falls_back_to_env_home_without_override(tmp_path, monkeypatch):
+    """Without a context-local override, the no-arg path still resolves
+    HERMES_HOME from the environment (unchanged behavior)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("MCP_KEY=env-value\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("MCP_KEY", raising=False)
+
+    loaded = load_hermes_dotenv()
+
+    assert loaded == [home / ".env"]
+    assert os.getenv("MCP_KEY") == "env-value"
+
+
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()


### PR DESCRIPTION


## What?
Profile-scoped cron jobs set a context-local `HERMES_HOME` override (via `set_hermes_home_override()`) while leaving `os.environ["HERMES_HOME"]` pointed at the scheduler root. But `load_hermes_dotenv()` resolved its home from `os.getenv("HERMES_HOME", Path.home()/".hermes")`, ignoring that override. So when `discover_mcp_tools()` → `_load_mcp_config()` called `load_hermes_dotenv()` during a profile cron tick, it reloaded the **root** `.env` with `override=True` and stomped the profile's freshly-loaded MCP credentials — breaking `${ENV_VAR}` interpolation for profile-specific `mcp_servers`. It also hardcoded `~/.hermes` instead of the platform-native default, violating the documented "use `get_hermes_home()`" rule.

## Fix
In `load_hermes_dotenv()`, when no explicit `hermes_home` is passed, resolve through `get_hermes_home()` instead of reading `os.environ["HERMES_HOME"]` directly. This honors the context-local profile override (and the platform-native default), fixing all parameterless callers at the source. Explicit-path callers are unchanged.

## Tests
Added two regression tests in `tests/hermes_cli/test_env_loader.py`:
- `test_no_arg_load_honors_context_local_home_override` — with root + profile `.env` defining the same key and an active override, the profile value wins. (Verified it fails on the old code and passes with the fix.)
- `test_no_arg_load_falls_back_to_env_home_without_override` — without an override, the existing `HERMES_HOME` env behavior is preserved.

## Test results
- `tests/hermes_cli/test_env_loader.py` — 8 passed (incl. 2 new)
- `tests/cron/test_cron_profile.py` — passed
- `tests/test_env_loader_secret_sources.py` — passed
- MCP tool/config/discovery/startup suites — 252 passed