### PR TITLE
fix(cli): use Rich [dim] tag instead of ANSI escape in session resume messages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5097,9 +5097,9 @@ class HermesCLI:
                 resolved_id = self.session_id
             if resolved_id and resolved_id != self.session_id:
                 ChatConsole().print(
-                    f"[{_DIM}]Session {_escape(self.session_id)} was compressed into "
+                    f"[dim]Session {_escape(self.session_id)} was compressed into "
                     f"{_escape(resolved_id)}; resuming the descendant with your "
-                    f"transcript.[/]"
+                    f"transcript.[/dim]"
                 )
                 self.session_id = resolved_id
                 resolved_meta = self._session_db.get_session(self.session_id)
@@ -5378,7 +5378,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"[dim]{_escape(msg)}[/dim]")
             return
 
         try:
@@ -5388,7 +5388,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"[dim]{_escape(msg)}[/dim]")
             return
 
         # Retarget the terminal/code-exec tools to match the process cwd.
@@ -5398,7 +5398,7 @@ class HermesCLI:
         if quiet:
             print(msg, file=sys.stderr)
         else:
-            self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+            self._console_print(f"[dim]{_escape(msg)}[/dim]")
 
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -221,3 +221,69 @@ class TestPendingResumeNumberedSelection:
 
         # A non-resume command disarms the one-shot prompt (#34584).
         assert cli_obj._pending_resume_sessions is None
+
+
+class TestRestoreSessionCwdMarkup:
+    """Regression: _restore_session_cwd must not crash with Rich MarkupError.
+
+    Lines that used ``[{_DIM}]`` inside Rich markup triggered
+    ``rich.errors.MarkupError: closing tag [/] at position N has nothing to
+    close`` because ``_DIM`` is an ANSI escape (``\\x1b[2;3m``), not a valid
+    Rich tag.  The fix replaces ``[{_DIM}]`` with Rich's native ``[dim]`` tag.
+    See: https://github.com/NousResearch/hermes-agent/issues/39469
+    """
+
+    def test_missing_dir_does_not_raise_markup_error(self):
+        """Session cwd gone → dim warning, no MarkupError."""
+        cli_obj = _make_cli()
+        console = MagicMock()
+        cli_obj._output_console = MagicMock(return_value=console)
+
+        # Use a path that definitely does not exist.
+        cli_obj._restore_session_cwd({"cwd": "/nonexistent/path/to/nowhere"})
+
+        # Should have printed a warning via console.print, not crashed.
+        assert console.print.called
+        printed = str(console.print.call_args)
+        assert "Working directory is gone" in printed or "gone" in printed.lower()
+
+    def test_chdir_failure_does_not_raise_markup_error(self, tmp_path):
+        """os.chdir fails → dim warning, no MarkupError."""
+        import os
+        cli_obj = _make_cli()
+        console = MagicMock()
+        cli_obj._output_console = MagicMock(return_value=console)
+
+        # Create a directory, then make it unreadable (simulate chdir failure).
+        target = tmp_path / "locked"
+        target.mkdir()
+
+        # Patch os.chdir to raise OSError for our target path.
+        original_chdir = os.chdir
+        def fake_chdir(path):
+            if str(path) == str(target):
+                raise OSError("Permission denied")
+            return original_chdir(path)
+
+        with patch("os.chdir", side_effect=fake_chdir):
+            cli_obj._restore_session_cwd({"cwd": str(target)})
+
+        assert console.print.called
+        printed = str(console.print.call_args)
+        assert "Could not enter" in printed or "permission" in printed.lower()
+
+    def test_success_path_does_not_raise_markup_error(self, tmp_path):
+        """Successful cwd switch → dim info, no MarkupError."""
+        import os
+        cli_obj = _make_cli()
+        console = MagicMock()
+        cli_obj._output_console = MagicMock(return_value=console)
+
+        original_cwd = os.getcwd()
+        try:
+            cli_obj._restore_session_cwd({"cwd": str(tmp_path)})
+            assert console.print.called
+            printed = str(console.print.call_args)
+            assert "Working directory" in printed or "working" in printed.lower()
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## What does this PR do?

Fixes a `rich.errors.MarkupError` crash when resuming a session whose recorded working directory is missing or inaccessible. The CLI uses Rich's markup system for styled console output, but 4 locations in `_restore_session_cwd` and `_preload_resumed_session` injected an ANSI escape code (`_DIM = \x1b[2;3m`) inside Rich's `[...]` tag syntax. Rich interprets the escape bytes as an invalid tag, then fails on the matching `[/]` close tag.

## Related Issue

Fixes #39469

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Replaced `[{_DIM}]...[/]` with `[dim]...[/dim]` in 4 locations where `_DIM` (ANSI escape) was used inside Rich Console.print() markup. This uses Rich's native `dim` style tag, consistent with existing usage elsewhere in the file (e.g., lines 4322, 4350, 5314).
- `tests/cli/test_cli_resume_command.py`: Added 3 regression tests covering the missing-directory, chdir-failure, and success paths of `_restore_session_cwd`.

## How to Test

1. Start a session: `hermes chat`
2. Exit the session
3. Move or delete the directory the session was started from
4. Resume the session: `hermes chat -r <session_id>`
5. Verify the CLI shows a dim warning instead of crashing with `MarkupError`
6. Run `pytest tests/cli/test_cli_resume_command.py -xvs` — all 15 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cli.py:_restore_session_cwd()` (lines 5350-5401), `cli.py:_preload_resumed_session()` (line 5100)
- Callers: `_preload_resumed_session` called from `run()`, `_restore_session_cwd` called from `_preload_resumed_session` and `_do_resume`
- Blast radius: LOW — 4 string-literal replacements in a single method; no control flow changes, no API changes
- Related patterns: `[dim]` Rich tag already used at lines 4322, 4350, 5314 in the same file; `_DIM` ANSI escape remains safe in `_cprint()` calls (prompt_toolkit renderer, not Rich)
