### PR TITLE
feat(desktop): add 'choose provider later' skip to first-run onboarding

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -25,6 +25,7 @@ function setProviders(providers: OAuthProvider[]) {
     providers,
     reason: null,
     requested: false,
+    firstRunSkipped: false,
     manual: false
   } satisfies DesktopOnboardingState)
 }
@@ -33,6 +34,13 @@ const ctx: OnboardingContext = { requestGateway: async () => undefined as never 
 
 afterEach(() => {
   cleanup()
+
+  try {
+    window.localStorage.clear()
+  } catch {
+    // jsdom localStorage should always be present; ignore if not.
+  }
+
   $desktopOnboarding.set({
     configured: null,
     flow: { status: 'idle' },
@@ -40,6 +48,7 @@ afterEach(() => {
     providers: null,
     reason: null,
     requested: false,
+    firstRunSkipped: false,
     manual: false
   })
 })
@@ -67,5 +76,25 @@ describe('onboarding Picker', () => {
     expect(screen.getByText('OpenAI OAuth (ChatGPT)')).toBeTruthy()
     expect(screen.queryByText('Other sign-in options')).toBeNull()
     expect(screen.queryByText('Recommended')).toBeNull()
+  })
+
+  it('offers "choose later" on first run and persists the skip', () => {
+    setProviders([provider('nous', 'Nous Portal')])
+    render(<Picker ctx={ctx} />)
+
+    const skip = screen.getByRole('button', { name: "I'll choose a provider later" })
+
+    fireEvent.click(skip)
+
+    expect($desktopOnboarding.get().firstRunSkipped).toBe(true)
+    expect(window.localStorage.getItem('hermes-onboarding-skipped-v1')).toBe('1')
+  })
+
+  it('hides "choose later" in manual (add-provider) mode', () => {
+    setProviders([provider('nous', 'Nous Portal')])
+    $desktopOnboarding.set({ ...$desktopOnboarding.get(), manual: true })
+    render(<Picker ctx={ctx} />)
+
+    expect(screen.queryByRole('button', { name: "I'll choose a provider later" })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -29,6 +29,7 @@ import {
   confirmOnboardingModel,
   copyDeviceCode,
   copyExternalCommand,
+  dismissFirstRunOnboarding,
   type OnboardingContext,
   type OnboardingFlow,
   peekPendingProviderOAuth,
@@ -189,6 +190,13 @@ export function DesktopOnboardingOverlay({ enabled, onCompleted, requestGateway 
     return null
   }
 
+  // The user chose "I'll choose a provider later" on first run. Stay out of the
+  // way on every subsequent launch — they re-enter via Settings → Providers
+  // (manual mode), which sets manual=true and bypasses this gate.
+  if (onboarding.firstRunSkipped && !onboarding.manual) {
+    return null
+  }
+
   const { flow } = onboarding
   const rawReason = onboarding.reason?.trim() || null
   const reason = rawReason && !isProviderSetupErrorMessage(rawReason) ? rawReason : null
@@ -304,18 +312,25 @@ const persistShowAll = (value: boolean) => {
 }
 
 export function Picker({ ctx }: { ctx: OnboardingContext }) {
-  const { mode, providers } = useStore($desktopOnboarding)
+  const { manual, mode, providers } = useStore($desktopOnboarding)
   const [showAll, setShowAll] = useState(readShowAll)
   const ordered = useMemo(() => (providers ? sortProviders(providers) : []), [providers])
   const hasOauth = ordered.length > 0
 
   if (mode === 'apikey' || !hasOauth) {
     return (
-      <ApiKeyForm
-        canGoBack={hasOauth}
-        onBack={() => setOnboardingMode('oauth')}
-        onSave={(envKey, value, name) => saveOnboardingApiKey(envKey, value, name, ctx)}
-      />
+      <div className="grid gap-3">
+        <ApiKeyForm
+          canGoBack={hasOauth}
+          onBack={() => setOnboardingMode('oauth')}
+          onSave={(envKey, value, name) => saveOnboardingApiKey(envKey, value, name, ctx)}
+        />
+        {manual ? null : (
+          <div className="flex justify-center border-t border-(--ui-stroke-tertiary) pt-3">
+            <ChooseLaterLink />
+          </div>
+        )}
+      </div>
     )
   }
 
@@ -352,7 +367,11 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
           <ChevronDown className={cn('size-3.5 transition', showAll && 'rotate-180')} />
         </button>
       ) : null}
-      <div className="flex justify-end pt-1">
+      <div className="flex items-center justify-between gap-3 pt-1">
+        {/* First run only: let the user defer the choice and land in the app.
+            In manual mode the overlay already has a close affordance, so the
+            "choose later" escape would be redundant — hide it. */}
+        {manual ? <span /> : <ChooseLaterLink />}
         <button
           className="text-xs font-medium text-muted-foreground hover:text-foreground"
           onClick={() => setOnboardingMode('apikey')}
@@ -362,6 +381,21 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
         </button>
       </div>
     </div>
+  )
+}
+
+// "I'll choose a provider later" — dismisses the first-run picker and persists
+// the skip so it never re-nags. The user connects a provider any time from
+// Settings → Providers. Rendered only on the unconfigured first-run flow.
+function ChooseLaterLink() {
+  return (
+    <button
+      className="text-xs font-medium text-muted-foreground hover:text-foreground"
+      onClick={() => dismissFirstRunOnboarding()}
+      type="button"
+    >
+      I'll choose a provider later
+    </button>
   )
 }
 

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -30,6 +30,7 @@ function baseState(overrides: Partial<DesktopOnboardingState> = {}): DesktopOnbo
     providers: null,
     reason: null,
     requested: false,
+    firstRunSkipped: false,
     manual: false,
     ...overrides
   }

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -60,6 +60,13 @@ export interface DesktopOnboardingState {
   providers: null | OAuthProvider[]
   reason: null | string
   requested: boolean
+  /** True when the user explicitly chose "I'll choose a provider later" on the
+   *  first-run picker. Persisted to localStorage so the blocking overlay never
+   *  re-nags on subsequent launches — the user can connect a provider any time
+   *  from Settings → Providers (or the model picker's "Add provider"). Distinct
+   *  from `configured`: the app still has no usable provider, so chat won't work
+   *  until one is connected; we just stop forcing the choice up front. */
+  firstRunSkipped: boolean
   /** True when the user explicitly opened the provider selector to add /
    *  switch providers from an already-configured app (e.g. via the model
    *  picker's "Add provider" button). Forces the overlay to show the picker
@@ -73,6 +80,7 @@ export interface OnboardingContext {
 }
 
 const CONFIGURED_CACHE_KEY = 'hermes-desktop-onboarded-v1'
+const SKIP_CACHE_KEY = 'hermes-onboarding-skipped-v1'
 const POLL_MS = 2000
 const COPY_FLASH_MS = 1500
 const DEFAULT_ONBOARDING_REASON = 'No inference provider is configured.'
@@ -105,6 +113,34 @@ function writeCachedConfigured(value: boolean) {
   }
 }
 
+function readCachedSkipped(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  try {
+    return window.localStorage.getItem(SKIP_CACHE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeCachedSkipped(value: boolean) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    if (value) {
+      window.localStorage.setItem(SKIP_CACHE_KEY, '1')
+    } else {
+      window.localStorage.removeItem(SKIP_CACHE_KEY)
+    }
+  } catch {
+    // localStorage unavailable — degrade silently.
+  }
+}
+
 const INITIAL: DesktopOnboardingState = {
   configured: readCachedConfigured(),
   flow: { status: 'idle' },
@@ -112,6 +148,7 @@ const INITIAL: DesktopOnboardingState = {
   providers: null,
   reason: null,
   requested: false,
+  firstRunSkipped: readCachedSkipped(),
   manual: false
 }
 
@@ -398,6 +435,9 @@ export function closeManualOnboarding() {
 export function completeDesktopOnboarding() {
   clearPoll()
   writeCachedConfigured(true)
+  // A real provider is now connected, so any earlier "choose later" skip is
+  // moot — clear it so the flag never lingers in a configured install.
+  writeCachedSkipped(false)
   $desktopOnboarding.set({
     configured: true,
     flow: { status: 'idle' },
@@ -405,8 +445,21 @@ export function completeDesktopOnboarding() {
     providers: null,
     reason: null,
     requested: false,
+    firstRunSkipped: false,
     manual: false
   })
+}
+
+// "I'll choose a provider later" on the first-run picker. Persists the skip so
+// the blocking overlay never re-nags on future launches, and dismisses it now
+// so the user lands in the app. Chat won't work until a provider is connected
+// (from Settings → Providers or the model picker's "Add provider") — this only
+// stops forcing the choice up front. Distinct from completeDesktopOnboarding,
+// which marks the app actually configured.
+export function dismissFirstRunOnboarding() {
+  clearPoll()
+  writeCachedSkipped(true)
+  patch({ firstRunSkipped: true, requested: false, manual: false, flow: { status: 'idle' } })
 }
 
 export function setOnboardingMode(mode: OnboardingMode) {


### PR DESCRIPTION
## Summary
First-run desktop onboarding now has an "I'll choose a provider later" escape — users can skip provider selection, land in the app, and connect a provider any time from Settings → Providers.

Previously the first-run picker was a hard gate (`fixed inset-0 z-1300` modal) with no way out except connecting a provider. The skip is persisted to localStorage so it never re-nags on subsequent launches.

## Changes
- `store/onboarding.ts`: new `firstRunSkipped` state seeded from `localStorage["hermes-onboarding-skipped-v1"]`; `dismissFirstRunOnboarding()` action persists the skip + dismisses the overlay. `completeDesktopOnboarding()` clears the flag once a real provider connects (so it never lingers in a configured install).
- `desktop-onboarding-overlay.tsx`: skip gate (`firstRunSkipped && !manual → return null`); `ChooseLaterLink` rendered in both the OAuth picker footer and the API-key fallback. First-run only — manual mode (Settings "Add provider") already has a close X and bypasses the skip gate.
- Tests: skip click persists + sets state; hidden in manual mode; full-state fixtures updated across both onboarding test files.

## Behavior
- Skip is **persistent** — chat still won't work without a provider, but the blocking overlay won't re-appear; Settings → Providers is the re-entry point.
- Connecting a provider (manual onboarding or runtime-ready auto-complete) clears the skip flag.

## Validation
| | Result |
|---|---|
| `tsc -b` (apps/desktop) | exit 0 |
| `eslint` (4 changed files) | 0 errors |
| `vitest` onboarding suites | 10/10 pass (2 new) |

## Infographic

![choose-provider-later](https://v3b.fal.media/files/b/0a9d049a/8XAVKpU0tGySYIu3y8KqQ_tXaL8jpV.png)
