### PR TITLE
fix(line): map inbound message types to the correct MessageType

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -133,6 +133,21 @@ MEDIA_TOKEN_TTL_SECONDS = 1800  # 30 minutes; LINE caches the URL aggressively
 LINE_IMAGE_MAX_BYTES = 10 * 1024 * 1024  # 10 MB per LINE docs
 LINE_AV_MAX_BYTES = 200 * 1024 * 1024  # 200 MB for voice/video
 
+# Map LINE webhook message types to the normalized MessageType the gateway
+# routes on. LINE has no separate "voice" type — audio messages are recorded
+# voice clips, so they map to VOICE (which the gateway sends through STT),
+# mirroring how Telegram/WhatsApp classify voice notes. Anything unknown
+# falls back to TEXT.
+_LINE_MESSAGE_TYPES = {
+    "text": MessageType.TEXT,
+    "image": MessageType.PHOTO,
+    "video": MessageType.VIDEO,
+    "audio": MessageType.VOICE,
+    "file": MessageType.DOCUMENT,
+    "location": MessageType.LOCATION,
+    "sticker": MessageType.STICKER,
+}
+
 # A 1×1 transparent PNG used as fallback video preview thumbnail when no
 # explicit preview is supplied — LINE requires ``previewImageUrl`` for
 # video messages. Sourced from the Python stdlib (no Pillow dependency).
@@ -968,7 +983,7 @@ class LineAdapter(BasePlatformAdapter):
 
         event_obj = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT if msg_type == "text" else MessageType.IMAGE,
+            message_type=_LINE_MESSAGE_TYPES.get(msg_type, MessageType.TEXT),
             source=source_obj,
             raw_message=event,
             message_id=message_id,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -641,3 +641,36 @@ class TestAdapterInit:
         assert asyncio.run(ad.get_chat_info("U123"))["type"] == "dm"
         assert asyncio.run(ad.get_chat_info("C123"))["type"] == "group"
         assert asyncio.run(ad.get_chat_info("R123"))["type"] == "channel"
+
+
+# ---------------------------------------------------------------------------
+# 9. Inbound message-type classification
+# ---------------------------------------------------------------------------
+
+class TestMessageTypeMapping:
+    """LINE webhook message types must map to the right normalized
+    MessageType so the gateway routes media correctly (e.g. voice → STT,
+    files → document handling). Regression guard for the old code that
+    referenced the non-existent ``MessageType.IMAGE`` and collapsed every
+    non-text message onto a single type."""
+
+    def test_image_event_not_attributeerror_regression(self):
+        # The bug: MessageType.IMAGE doesn't exist on the enum.
+        MessageType = _line.MessageType
+        assert not hasattr(MessageType, "IMAGE")
+
+    def test_every_line_type_maps_to_correct_enum(self):
+        MessageType = _line.MessageType
+        mapping = _line._LINE_MESSAGE_TYPES
+        assert mapping["text"] == MessageType.TEXT
+        assert mapping["image"] == MessageType.PHOTO
+        assert mapping["video"] == MessageType.VIDEO
+        # LINE has no separate voice type — audio clips are voice notes.
+        assert mapping["audio"] == MessageType.VOICE
+        assert mapping["file"] == MessageType.DOCUMENT
+        assert mapping["location"] == MessageType.LOCATION
+        assert mapping["sticker"] == MessageType.STICKER
+
+    def test_unknown_type_falls_back_to_text(self):
+        MessageType = _line.MessageType
+        assert _line._LINE_MESSAGE_TYPES.get("flex", MessageType.TEXT) == MessageType.TEXT


### PR DESCRIPTION
## Summary
Non-text LINE messages no longer crash, and they're now classified as the correct media type instead of all being treated as images.

Salvages #38528 (@sahibzada-allahyar), with a wider fix on top.

## Root cause
`plugins/platforms/line/adapter.py` built every non-text inbound `MessageEvent` with `message_type=MessageType.IMAGE`. That enum member doesn't exist (the enum has `PHOTO`, not `IMAGE`), so every image/video/audio/file/sticker/location message raised `AttributeError` at construction time.

## Changes
- `plugins/platforms/line/adapter.py`: replace the `IMAGE`/`TEXT` ternary with a `_LINE_MESSAGE_TYPES` lookup table mapping each LINE webhook type to its proper `MessageType` (`image→PHOTO`, `video→VIDEO`, `audio→VOICE`, `file→DOCUMENT`, `location→LOCATION`, `sticker→STICKER`), unknown types fall back to `TEXT`.
- `tests/gateway/test_line_plugin.py`: add `TestMessageTypeMapping` — regression guard for the missing `IMAGE` member plus full mapping coverage.

## Why wider than the original
@sahibzada-allahyar's PR correctly swapped `IMAGE→PHOTO`, which stops the crash. But the surrounding code still mapped **all** non-text messages to one type. The gateway routes on `MessageType` — voice notes go through STT, files through document handling — so a LINE voice clip or PDF was being mishandled as a photo. The lookup table gives each type its correct classification, matching how the WhatsApp/Telegram/BlueBubbles adapters already do it.

## Validation
| | Before | After |
|---|---|---|
| Non-text LINE message | `AttributeError: IMAGE` | classified correctly |
| `tests/gateway/test_line_plugin.py` | — | 76 passed |
