### PR TITLE
Fix/google chat bot id cache home

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -688,9 +688,22 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # Bot identity resolution
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
-        """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
-        return _Path(base) / "google_chat_bot_id.json"
+        """Location where the resolved bot user_id is cached across restarts.
+
+        Resolved via ``get_hermes_home()`` so it lands under the SAME
+        HERMES_HOME as the thread-count store (and every other piece of
+        adapter state). A raw ``os.getenv("HERMES_HOME", ~/.hermes)`` would
+        diverge on native Windows (``%LOCALAPPDATA%\\hermes`` vs
+        ``%USERPROFILE%\\.hermes``) and ignore context-local profile
+        overrides, splitting persistence across two homes and forcing a
+        members.list re-resolve on every restart.
+        """
+        try:
+            from hermes_constants import get_hermes_home as _get_hermes_home
+            base = _get_hermes_home()
+        except (ModuleNotFoundError, ImportError):
+            base = _Path.home() / ".hermes"
+        return base / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:
         path = self._bot_id_cache_path()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1444,6 +1444,7 @@ AUTHOR_MAP = {
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
+    "drexux0@gmail.com": "Drexuxux",  # fix(gateway): align Google Chat bot_id cache path with get_hermes_home()
 }
 
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2110,6 +2110,84 @@ class TestThreadCountStore:
 
 
 # ===========================================================================
+# Bot-id cache path alignment (HERMES_HOME parity with thread-count store)
+# ===========================================================================
+
+
+class TestBotIdCachePathAlignment:
+    """The bot-id cache must live under the SAME HERMES_HOME as the rest of
+    the adapter's state.
+
+    The original code resolved the bot-id cache with a raw
+    ``os.getenv("HERMES_HOME", Path.home() / ".hermes")`` while the
+    thread-count store used ``get_hermes_home()``. On native Windows with
+    HERMES_HOME unset the two diverged — thread counts landed in
+    ``%LOCALAPPDATA%\\hermes`` but the bot-id cache in
+    ``%USERPROFILE%\\.hermes`` — so the cache always missed across restarts
+    and the bot re-ran members.list on every boot. Context-local profile
+    overrides hit the same split-brain. These tests pin the alignment.
+    """
+
+    def test_bot_id_cache_under_hermes_home_env(self, adapter, tmp_path, monkeypatch):
+        """With HERMES_HOME set, the cache resolves directly under it (and
+        under the same home the thread-count store would use)."""
+        from hermes_constants import get_hermes_home
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path = adapter._bot_id_cache_path()
+        assert path == tmp_path / "google_chat_bot_id.json"
+        assert path.parent == get_hermes_home()
+
+    def test_bot_id_cache_matches_native_home_on_windows(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """Native Windows, HERMES_HOME unset: the bot-id cache must share the
+        platform-native ``%LOCALAPPDATA%\\hermes`` home with the thread-count
+        store — not split off into ``%USERPROFILE%\\.hermes``.
+        """
+        import hermes_constants
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        # Simulate native Windows with a controlled LOCALAPPDATA.
+        local_appdata = tmp_path / "AppData" / "Local"
+        local_appdata.mkdir(parents=True)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+        # Distinct fake home so the OLD (buggy) %USERPROFILE%\.hermes path
+        # would resolve elsewhere and fail the assertion below.
+        fake_home = tmp_path / "userprofile"
+        fake_home.mkdir()
+        monkeypatch.setattr(hermes_constants.Path, "home", lambda: fake_home)
+
+        expected_home = local_appdata / "hermes"
+        assert hermes_constants.get_hermes_home() == expected_home
+        assert adapter._bot_id_cache_path().parent == expected_home
+        # Explicitly NOT the pre-fix USERPROFILE/.hermes location.
+        assert adapter._bot_id_cache_path().parent != fake_home / ".hermes"
+
+    def test_bot_id_cache_honors_context_local_override(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """A context-local profile override (set without mutating os.environ)
+        must steer the bot-id cache too — the raw getenv read ignored it."""
+        from hermes_constants import (
+            set_hermes_home_override,
+            reset_hermes_home_override,
+        )
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        override_home = tmp_path / "profiles" / "coder"
+        override_home.mkdir(parents=True)
+        token = set_hermes_home_override(override_home)
+        try:
+            assert adapter._bot_id_cache_path() == (
+                override_home / "google_chat_bot_id.json"
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+
+# ===========================================================================
 # Inbound attachment download SSRF guard
 # ===========================================================================
 


### PR DESCRIPTION
## What?

The Google Chat adapter resolved `HERMES_HOME` two different ways: the
thread-count store used `get_hermes_home()`, but `_bot_id_cache_path()` used a
raw `os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))`. When `HERMES_HOME`
is unset or a context-local profile override is active, the two diverge — so the
bot-id cache lands in a different home than the rest of the adapter's state. The
cache then misses on every gateway restart, triggering redundant `members.list`
calls and leaving self-filtering on the "bot_user_id not yet resolved" fallback.

## Fix

`_bot_id_cache_path()` now resolves through `get_hermes_home()`, using the same
import fallback already used by the thread-count store and `oauth.py`. All
persistence paths in the plugin now share a single `HERMES_HOME`, and profile
overrides are honored. Behavior is unchanged when `HERMES_HOME` is set.

## Tests

Added `TestBotIdCachePathAlignment` (3 cases: env-set parity, unset-fallback
alignment, context-local override). Verified the new tests fail against the
pre-fix code and pass after the fix.

​```
$ pytest tests/gateway/test_google_chat.py
163 passed
​```