### PR TITLE
fix(gateway): tolerate non-UTF-8 status/pid files in gateway status reads

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -227,7 +227,10 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
         return None
     try:
         raw = path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # OSError: file vanished or permission flipped between exists() and
+        # read. UnicodeDecodeError: file holds non-UTF-8 / binary garbage
+        # (a truncated or clobbered status file). Either way it's unusable.
         return None
     if not raw:
         return None
@@ -249,8 +252,9 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
 
     try:
         raw = pid_path.read_text().strip()
-    except OSError:
-        # File was deleted between exists() and read_text(), or permission flipped.
+    except (OSError, UnicodeDecodeError):
+        # File was deleted between exists() and read_text(), permission
+        # flipped, or it holds non-UTF-8 / binary garbage.
         return None
     if not raw:
         return None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1036,3 +1036,28 @@ class TestReadProcessCmdlinePsFallback:
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+
+class TestCorruptStatusFiles:
+    """A status / pid file holding non-UTF-8 (binary) bytes must read as
+    None, not crash the gateway status path with UnicodeDecodeError."""
+
+    def test_read_json_file_returns_none_on_binary_garbage(self, tmp_path):
+        p = tmp_path / "runtime.json"
+        p.write_bytes(b"\xff\xfe\x00\x80not utf-8\x81")
+        assert status._read_json_file(p) is None
+
+    def test_read_json_file_still_parses_valid_json(self, tmp_path):
+        p = tmp_path / "runtime.json"
+        p.write_text(json.dumps({"pid": 7}), encoding="utf-8")
+        assert status._read_json_file(p) == {"pid": 7}
+
+    def test_read_pid_record_returns_none_on_binary_garbage(self, tmp_path):
+        p = tmp_path / "gateway.pid"
+        p.write_bytes(b"\xff\xfe\x00\x80\x81")
+        assert status._read_pid_record(p) is None
+
+    def test_read_pid_record_still_parses_bare_pid(self, tmp_path):
+        p = tmp_path / "gateway.pid"
+        p.write_text("4242", encoding="utf-8")
+        assert status._read_pid_record(p) == {"pid": 4242}


### PR DESCRIPTION
## Summary
A gateway status or pid file holding binary / non-UTF-8 bytes is now read as "unreadable" (None) instead of crashing the status path with `UnicodeDecodeError`.

Salvages #38313 (@brian-doherty), widened to the sibling read site.

## Root cause
`gateway/status.py` `_read_json_file` did `path.read_text(encoding="utf-8")` inside a `try/except OSError`. `UnicodeDecodeError` is a `ValueError` subclass — not an `OSError` — so a truncated or clobbered status file with non-UTF-8 bytes raised an uncaught exception.

## Changes
- `gateway/status.py`: widen the catch to `(OSError, UnicodeDecodeError)` in `_read_json_file` **and** the sibling `_read_pid_record`, which read the gateway pid/lock files with the identical gap.
- `tests/gateway/test_status.py`: `TestCorruptStatusFiles` — binary input returns None, valid input still parses, for both functions.

## Why wider than the original
@brian-doherty's PR fixed `_read_json_file`. `_read_pid_record` (the pid/lock-file reader, same module) had the exact same `except OSError` gap and reads files written by the same gateway lifecycle code — so a corrupt pid/lock file would crash status/liveness checks. Fixed both rather than leaving a known sibling hole.

## Validation
| | Before | After |
|---|---|---|
| Binary status/pid file | `UnicodeDecodeError` | reads as None |
| `tests/gateway/test_status.py -k CorruptStatusFiles` | — | 4 passed |
