### PR TITLE
[codex] fix(tests): stabilize local interrupt cleanup check

### DIFF
--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -23,6 +23,11 @@ import pytest
 from tools.environments import local as local_mod
 from tools.environments.local import LocalEnvironment
 
+requires_posix_process_groups = pytest.mark.skipif(
+    not hasattr(os, "getpgid") or not hasattr(os, "killpg"),
+    reason="POSIX process-group cleanup semantics",
+)
+
 
 @pytest.fixture(autouse=True)
 def _isolate_hermes_home(tmp_path, monkeypatch):
@@ -33,7 +38,7 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
 def _pgid_still_alive(pgid: int) -> bool:
     """Return True if any process in the given process group is still alive."""
     try:
-        os.killpg(pgid, 0)  # signal 0 = existence check
+        os.killpg(pgid, 0)  # signal 0 = existence check  # windows-footgun: ok
         return True
     except ProcessLookupError:
         return False
@@ -65,6 +70,7 @@ def _wait_for_pgid_exit(pgid: int, timeout: float = 60.0) -> bool:
     return not _pgid_still_alive(pgid)
 
 
+@requires_posix_process_groups
 def test_kill_process_uses_cached_pgid_if_wrapper_already_exited(monkeypatch):
     """If the shell wrapper exits before cleanup, still kill its process group.
 
@@ -97,6 +103,7 @@ def test_kill_process_uses_cached_pgid_if_wrapper_already_exited(monkeypatch):
     assert killpg_calls == [(67890, signal.SIGTERM), (67890, 0)]
 
 
+@requires_posix_process_groups
 def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""


### PR DESCRIPTION
## Summary

- skip only the two POSIX process-group cleanup regressions on platforms where `os.getpgid` / `os.killpg` do not exist
- keep the tests fully active on POSIX and preserve current main's test-runner timeout policy
- mark the gated `os.killpg` probe as an intentional Windows-footgun scanner exception

## Root cause

`tests/tools/test_local_interrupt_cleanup.py` directly uses POSIX-only process-group APIs. On native Windows, current main fails both tests before reaching the behavior under test because `os.getpgid` and `os.killpg` are absent.

The earlier branch also added a per-test `pytest-timeout` marker. Current main removed `pytest-timeout` in `2f9d18711` and now bounds each test file through `scripts/run_tests_parallel.py` (300 seconds), so the rebased patch follows that current policy instead of restoring a stale marker.

## Current-main integration

- rebased onto `11089899fbb3ec1c043427c680e8fd8f4cab06c9`
- skip markers are scoped to the two POSIX-dependent tests rather than the whole module
- the Windows tree-kill regression that previously existed in this file was removed from current main by `39975613b`; this patch does not remove or skip any current Windows-specific test

## Validation

- `.venv\Scripts\python.exe -m pytest tests\tools\test_local_interrupt_cleanup.py -q` (Windows 11: 2 skipped)
- `wsl -e sh -lc "cd /mnt/d/project/hermes/hermes-agent-work && UV_PROJECT_ENVIRONMENT=/tmp/hermes-pr39496-uv-env uv run --extra dev --extra all python -m pytest tests/tools/test_local_interrupt_cleanup.py -q"` (Linux/WSL: 2 passed)
- `scripts/run_tests.sh tests/tools/test_local_interrupt_cleanup.py -q` (canonical runner: file passed)
- `.venv\Scripts\ruff.exe check tests\tools\test_local_interrupt_cleanup.py`
- `.venv\Scripts\python.exe -m py_compile tests\tools\test_local_interrupt_cleanup.py`
- `.venv\Scripts\python.exe scripts\check-windows-footguns.py --diff upstream/main`
- `git diff --check upstream/main...HEAD`

Independent review found no high-confidence issues.