### PR TITLE
[codex] fix(desktop): ignore installer link in artifacts

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -24,6 +24,8 @@ const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)
 const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$/i
 const FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|mp3|wav|mp4|mov)(?:\?.*)?$/i
 const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target)/i
+const HERMES_ASSETS_HOST = 'hermes-assets.nousresearch.com'
+const HERMES_BOOTSTRAP_INSTALLER_RE = /^Hermes-Setup\.dmg$/i
 
 function artifactSessionTitle(session: SessionInfo): string {
   return session.title?.trim() || session.preview?.trim() || 'Untitled session'
@@ -58,7 +60,22 @@ function looksLikePathOrUrl(value: string): boolean {
   )
 }
 
+function isIgnoredArtifactUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    const filename = decodeURIComponent(url.pathname.split('/').filter(Boolean).pop() || '')
+
+    return url.hostname.toLowerCase() === HERMES_ASSETS_HOST && HERMES_BOOTSTRAP_INSTALLER_RE.test(filename)
+  } catch {
+    return false
+  }
+}
+
 function looksLikeArtifact(value: string): boolean {
+  if (isIgnoredArtifactUrl(value)) {
+    return false
+  }
+
   if (/^(?:https?:\/\/|data:image\/)/.test(value)) {
     return true
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -48,6 +48,25 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('does not index the Hermes bootstrap installer as a session artifact', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content:
+          'Installer: https://hermes-assets.nousresearch.com/Hermes-Setup.dmg\n' +
+          'Generated page: https://example.com/artifacts/report.html',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      href: 'https://example.com/artifacts/report.html',
+      kind: 'link',
+      value: 'https://example.com/artifacts/report.html'
+    })
+  })
+
   it('indexes http links present in tool JSON payloads', () => {
     const messages: SessionMessage[] = [
       {


### PR DESCRIPTION
## Summary

- exclude the official Hermes bootstrap installer URL from Desktop artifact indexing
- keep ordinary HTTPS links and generated artifact URLs visible in the Artifacts view
- add a regression test for issue #39380

## Root cause

The Desktop Artifacts view scans assistant/tool text for candidate artifact URLs. Because `looksLikeArtifact()` treated every `http://` and `https://` value as an artifact, the static installer URL `https://hermes-assets.nousresearch.com/Hermes-Setup.dmg` could be indexed and opened from the Artifacts surface.

Fixes #39380.

## Validation

- `npm run test:ui -- --run src/app/artifacts/index.test.ts`
- `npm run type-check`
- `npx eslint src/app/artifacts/index.tsx src/app/artifacts/index.test.ts`
- `git diff --check`