### PR TITLE
fix(agent): refund api_call_count when refunding an execute_code iteration

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4003,8 +4003,16 @@ def run_conversation(
                 # Refund the iteration if the ONLY tool(s) called were
                 # execute_code (programmatic tool calling).  These are
                 # cheap RPC-style calls that shouldn't eat the budget.
+                # Both counters must move together: the while-loop condition
+                # (~L801) gates on api_call_count < max_iterations AND
+                # iteration_budget.remaining > 0, so refunding only the budget
+                # would still let execute_code burn down max_iterations. This
+                # mirrors the other refund sites (the Ollama-context bailout
+                # and the compression restart).
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
                     agent.iteration_budget.refund()
                 
                 # Use real token counts from the API response to decide

--- a/tests/run_agent/test_execute_code_iteration_refund.py
+++ b/tests/run_agent/test_execute_code_iteration_refund.py
@@ -1,0 +1,135 @@
+"""Regression test for the execute_code iteration refund.
+
+When the only tool(s) called in a turn are ``execute_code`` (programmatic
+tool calling), that iteration is "free" — it must be refunded against BOTH
+the iteration budget AND ``api_call_count``. The while-loop condition in
+``run_conversation`` gates on ``api_call_count < max_iterations`` *and*
+``iteration_budget.remaining > 0``, so refunding only the budget would let
+execute_code burn down ``max_iterations`` anyway.
+
+Bug: the execute_code refund site decremented only the budget, so a run
+that made N execute_code-only turns still consumed N toward max_iterations.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    # Class-level queues, reset per test.
+    response_queue: list = []
+    captured: list = []
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(n).decode())
+        type(self).captured.append(req)
+        is_stream = req.get("stream") is True
+        resp = (
+            type(self).response_queue.pop(0)
+            if type(self).response_queue
+            else _text("FALLBACK")
+        )
+        msg = resp["choices"][0]["message"]
+        if is_stream:
+            content = msg.get("content") or ""
+            tcs = msg.get("tool_calls")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if tcs:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"tool_calls": [
+                    {"index": 0, "id": tc["id"], "type": "function",
+                     "function": {"name": tc["function"]["name"], "arguments": tc["function"]["arguments"]}}
+                    for tc in tcs]}, "finish_reason": None}]})
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]})
+            else:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            b = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(b)))
+            self.end_headers()
+            self.wfile.write(b)
+
+    def log_message(self, *a, **k):
+        pass
+
+
+def _exec_call(i: int) -> dict:
+    return {"id": "m", "choices": [{"index": 0, "message": {"role": "assistant", "content": "", "tool_calls": [
+        {"id": f"c{i}", "type": "function",
+         "function": {"name": "execute_code", "arguments": json.dumps({"code": "print(1)"})}}]},
+        "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}}
+
+
+def _text(t: str) -> dict:
+    return {"id": "m", "choices": [{"index": 0, "message": {"role": "assistant", "content": t}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}}
+
+
+@pytest.fixture
+def mock_server(monkeypatch, tmp_path):
+    _MockHandler.response_queue = []
+    _MockHandler.captured = []
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield port
+    finally:
+        srv.shutdown()
+
+
+def _make_agent(port: int) -> AIAgent:
+    return AIAgent(
+        api_key="test-key",
+        base_url=f"http://127.0.0.1:{port}/v1",
+        provider="openai-compat",
+        model="test-model",
+        max_iterations=3,
+        enabled_toolsets=["code_execution"],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        platform="cli",
+    )
+
+
+def test_execute_code_only_turns_are_refunded_against_max_iterations(mock_server):
+    """With max_iterations=3, five execute_code-only turns followed by a
+    text turn must all run — the refund keeps execute_code from counting
+    toward the cap, so the loop exits via a normal text response, not
+    iteration exhaustion."""
+    port = mock_server
+    for i in range(5):
+        _MockHandler.response_queue.append(_exec_call(i))
+    _MockHandler.response_queue.append(_text("finished"))
+
+    agent = _make_agent(port)
+    result = agent.run_conversation("loop", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "finished"
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    # All six provider calls were made despite max_iterations=3.
+    assert len(_MockHandler.captured) == 6
+    # Budget only charged for the single non-execute_code (final) turn.
+    assert agent.iteration_budget.used == 1


### PR DESCRIPTION
## Summary
`execute_code`-only iterations are now truly free — they no longer count toward `max_iterations`, so a run that leans on programmatic tool calling can't hit "iteration budget exhausted" prematurely.

Salvages #39311 (@moizogg), with an end-to-end regression test added.

## Root cause
`agent/conversation_loop.py` refunds the iteration when the only tool(s) called in a turn are `execute_code`. But the refund decremented only `agent.iteration_budget`, while the agent loop's while-condition gates on **both** `api_call_count < agent.max_iterations` **and** `iteration_budget.remaining > 0`. So `api_call_count` kept climbing on every execute_code turn, and a run with enough programmatic calls hit the `max_iterations` ceiling and appended a max-iterations warning to the response.

## Changes
- `agent/conversation_loop.py`: decrement `api_call_count` and sync `agent._api_call_count` alongside the budget refund, matching the two existing refund sites (Ollama-context bailout L1102, compression restart L3505).
- `tests/run_agent/test_execute_code_iteration_refund.py`: E2E test against an in-process mock provider.

## Validation
End-to-end: `max_iterations=3`, queue five `execute_code`-only turns then a text turn.

| | Before | After |
|---|---|---|
| Outcome | exhausted at 3/3, response polluted with max-iter warning | all 5 exec turns + text turn run |
| `turn_exit_reason` | `max_iterations_reached(3/3)` | `text_response(finish_reason=stop)` |
| `iteration_budget.used` | 3 | 1 (only the non-exec turn) |

Confirmed the test fails on unpatched code and passes with the fix.
