### PR TITLE
fix(dashboard): fall back when HERMES_WEB_DIST is invalid

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -87,8 +87,33 @@ except ImportError:
             f"Install with: {sys.executable} -m pip install 'fastapi' 'uvicorn[standard]'"
         )
 
-WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
+_DEFAULT_WEB_DIST = Path(__file__).parent / "web_dist"
+
+
+def _resolve_web_dist() -> Path:
+    """Prefer a valid override, but fail closed to the packaged dashboard."""
+    raw_override = os.environ.get("HERMES_WEB_DIST")
+    if not raw_override:
+        return _DEFAULT_WEB_DIST
+
+    override = Path(raw_override)
+    if override.is_dir() and (override / "index.html").is_file():
+        return override
+
+    packaged = _DEFAULT_WEB_DIST
+    if packaged.is_dir() and (packaged / "index.html").is_file():
+        _log.warning(
+            "Ignoring invalid HERMES_WEB_DIST=%s; falling back to %s",
+            override,
+            packaged,
+        )
+        return packaged
+
+    return override
+
+
+WEB_DIST = _resolve_web_dist()
 
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -30,6 +30,36 @@ _EXAMPLE_PLUGIN_FIXTURE = (
 )
 
 
+class TestResolveWebDist:
+    def test_prefers_valid_override(self, tmp_path, monkeypatch):
+        from hermes_cli import web_server
+
+        packaged = tmp_path / "packaged"
+        packaged.mkdir()
+        (packaged / "index.html").write_text("packaged")
+
+        override = tmp_path / "override"
+        override.mkdir()
+        (override / "index.html").write_text("override")
+
+        monkeypatch.setattr(web_server, "_DEFAULT_WEB_DIST", packaged)
+        monkeypatch.setenv("HERMES_WEB_DIST", str(override))
+
+        assert web_server._resolve_web_dist() == override
+
+    def test_falls_back_when_override_is_not_a_real_directory(self, tmp_path, monkeypatch):
+        from hermes_cli import web_server
+
+        packaged = tmp_path / "packaged"
+        packaged.mkdir()
+        (packaged / "index.html").write_text("packaged")
+
+        monkeypatch.setattr(web_server, "_DEFAULT_WEB_DIST", packaged)
+        monkeypatch.setenv("HERMES_WEB_DIST", str(tmp_path / "app.asar" / "dist"))
+
+        assert web_server._resolve_web_dist() == packaged
+
+
 @pytest.fixture
 def _install_example_plugin(_isolate_hermes_home):
     """Drop the example-dashboard fixture into the per-test HERMES_HOME


### PR DESCRIPTION
## Summary
- ignore `HERMES_WEB_DIST` overrides that do not point to a real built dashboard
- fall back to the packaged `hermes_cli/web_dist` when it exists
- add regression tests for valid and invalid override paths

## Verification
- `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_web_server.py::TestResolveWebDist`
- `uv run --frozen --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Closes #39472