### PR TITLE
fix(dashboard): reap orphaned embedded-chat sessions to stop slash_worker leak

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -876,6 +876,73 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):
+    """A detached WS session past its grace window has its slash_worker closed.
+
+    Regression for #38591 fallout: every dashboard refresh spawned a fresh
+    session + _SlashWorker but never reaped the previous one, leaking one
+    python subprocess per refresh.
+    """
+    closed = {"worker": False}
+
+    class _FakeWorker:
+        def close(self):
+            closed["worker"] = True
+
+    server._sessions["orphan-sid"] = _session(
+        transport=server._stdio_transport,
+        slash_worker=_FakeWorker(),
+        running=False,
+    )
+    # Run the reap body synchronously (no real timer/grace) to assert behaviour.
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    try:
+        # Directly invoke the orphaned-check + teardown the timer would run.
+        assert server._ws_session_is_orphaned(server._sessions["orphan-sid"]) is True
+        session = server._sessions.pop("orphan-sid")
+        server._teardown_session(session)
+        assert closed["worker"] is True
+    finally:
+        server._sessions.pop("orphan-sid", None)
+
+
+def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
+    """A session that rebinds a live transport is NOT considered orphaned."""
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    # Reattached: transport is a live (non-stdio) transport.
+    reattached = _session(transport=_LiveTransport(), running=False)
+    assert server._ws_session_is_orphaned(reattached) is False
+
+    # Mid-turn sessions are also spared even if detached.
+    mid_turn = _session(transport=server._stdio_transport, running=True)
+    assert server._ws_session_is_orphaned(mid_turn) is False
+
+    # Already finalized sessions are spared (idempotency).
+    done = _session(transport=server._stdio_transport, running=False, _finalized=True)
+    assert server._ws_session_is_orphaned(done) is False
+
+
+def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
+    """Grace=0 disables the reaper entirely (pre-fix park-forever behaviour)."""
+    fired = {"timer": False}
+
+    class _Timer:
+        def __init__(self, *a, **k):
+            fired["timer"] = True
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.0)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    server._schedule_ws_orphan_reap("any-sid")
+    assert fired["timer"] is False
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -134,6 +134,24 @@ try:
 except (ValueError, TypeError):
     _slash_timeout = 45.0
 _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
+
+# When a WebSocket client (the dashboard's embedded-chat tab / desktop app)
+# disconnects, ``tui_gateway.ws`` detaches the transport but intentionally
+# leaves the session parked so a quick reconnect can reattach it (see ws.py).
+# That park is unbounded, though: a browser refresh spins up a brand-new
+# ``session.create`` (new sid + a fresh _SlashWorker via _deferred_build) and
+# never reattaches the OLD sid, so the old session's slash-worker subprocess
+# lingers forever — one leaked python process per refresh (#38591 fallout).
+# After this grace window, an orphaned (transport-detached, not-running) WS
+# session is reaped: its _SlashWorker is closed and the session finalized.
+# Set to 0 to disable (park forever, pre-fix behaviour).
+try:
+    _ws_orphan_reap_grace = float(
+        os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S") or "20"
+    )
+except (ValueError, TypeError):
+    _ws_orphan_reap_grace = 20.0
+_WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
@@ -322,6 +340,78 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
                 db.end_session(session_id, end_reason)
         except Exception:
             pass
+
+
+def _teardown_session(session: dict | None) -> None:
+    """Fully tear down a session: finalize, unregister, close agent + worker.
+
+    Shared by ``session.close`` and the orphaned-WS-session reaper so the
+    slash-worker subprocess is always closed exactly once via the same path.
+    Idempotent: the ``_finalized`` guard in ``_finalize_session`` and the
+    ``poll()`` guard in ``_SlashWorker.close`` make repeat calls harmless.
+    """
+    if not session:
+        return
+    _finalize_session(session)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        unregister_gateway_notify(session["session_key"])
+    except Exception:
+        pass
+    try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+
+
+def _ws_session_is_orphaned(session: dict | None) -> bool:
+    """True if a WS session has no live transport and no in-flight turn.
+
+    After ``handle_ws`` detaches a disconnected client it points the session
+    at ``_stdio_transport``. In the dashboard's in-process gateway there is no
+    real stdio peer reading those frames, so a session left on the stdio
+    transport (and not mid-turn) is genuinely orphaned and safe to reap.
+    """
+    if not session or session.get("_finalized"):
+        return False
+    if session.get("running"):
+        return False
+    return session.get("transport") is _stdio_transport
+
+
+def _schedule_ws_orphan_reap(sid: str) -> None:
+    """After a grace window, reap session ``sid`` iff it's still orphaned.
+
+    Called from the WS-disconnect path. The grace window lets a transient
+    reconnect (or a ``session.resume`` that reattaches the transport) cancel
+    the reap by re-binding a live transport. Disabled when the grace is 0.
+    """
+    if _WS_ORPHAN_REAP_GRACE_S <= 0:
+        return
+
+    def _reap() -> None:
+        with _session_resume_lock:
+            session = _sessions.get(sid)
+            if not _ws_session_is_orphaned(session):
+                return
+            _sessions.pop(sid, None)
+        try:
+            _teardown_session(session)
+        except Exception:
+            pass
+
+    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _reap)
+    timer.daemon = True
+    timer.start()
 
 
 def _shutdown_sessions() -> None:
@@ -3651,25 +3741,7 @@ def _(rid, params: dict) -> dict:
         session = _sessions.pop(sid, None)
         if not session:
             return _ok(rid, {"closed": False})
-        _finalize_session(session)
-        try:
-            from tools.approval import unregister_gateway_notify
-
-            unregister_gateway_notify(session["session_key"])
-        except Exception:
-            pass
-        try:
-            agent = session.get("agent")
-            if agent and hasattr(agent, "close"):
-                agent.close()
-        except Exception:
-            pass
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+        _teardown_session(session)
     return _ok(rid, {"closed": True})
 
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -262,15 +262,32 @@ async def handle_ws(ws: Any) -> None:
                 break
     finally:
         detached_sessions = 0
+        reaped_scheduled = 0
         if transport is not None:
             transport.close()
 
             # Detach the transport from any sessions it owned so later emits
             # fall back to stdio instead of crashing into a closed socket.
-            for _, sess in list(server._sessions.items()):
+            #
+            # In the dashboard's in-process gateway that stdio fallback has no
+            # real reader, so a detached session would otherwise sit forever
+            # holding its _SlashWorker subprocess open (one leaked python proc
+            # per browser refresh — #38591 fallout). Schedule a grace-delayed
+            # reap; a quick reconnect / session.resume re-binds a live
+            # transport and cancels it (see _ws_session_is_orphaned).
+            for _sid, sess in list(server._sessions.items()):
                 if sess.get("transport") is transport:
                     sess["transport"] = server._stdio_transport
                     detached_sessions += 1
+                    try:
+                        server._schedule_ws_orphan_reap(_sid)
+                        reaped_scheduled += 1
+                    except Exception:
+                        _log.exception(
+                            "ws orphan-reap schedule failed peer=%s sid=%s",
+                            peer,
+                            _sid,
+                        )
         try:
             await ws.close()
         except Exception as exc:


### PR DESCRIPTION
## Summary

Since #38591 made the dashboard's embedded **Chat** surface unconditional, every browser refresh of `/chat` leaks a `tui_gateway.slash_worker` Python subprocess — they accumulate one-per-refresh until the box is buried in idle workers (user report: ~20 workers after a session of refreshing).

## Root cause

The dashboard runs **one long-lived in-process `tui_gateway`** (the PTY child node attaches to it over `/api/ws` via `HERMES_TUI_GATEWAY_URL` rather than spawning its own Python gateway — see `_resolve_chat_argv`). So the topology is:

```
hermes dashboard  (long-lived web_server + in-process tui_gateway)
└─ /api/pty → node entry.js  (ATTACHES via /api/ws — does NOT spawn a gateway)
     in-process gateway spawns →  _SlashWorker → python -m tui_gateway.slash_worker
```

On every refresh the fresh Ink boot calls `session.create` (new sid + a fresh `_SlashWorker` via `_deferred_build`). The old tab's `/api/ws` disconnect, however, only **detaches the transport** in `tui_gateway/ws.py` (`sess["transport"] = _stdio_transport`) to allow reconnects — it never closes the old session or its slash worker. Because the dashboard process never exits, the detached `_SlashWorker.proc.stdin` write-end stays open forever, the worker never hits EOF, and it leaks.

This was dormant before #38591 because the whole `/api/ws` + `session.create` + `_SlashWorker` path was gated off on a plain dashboard.

Note: this is **not** a PTY signal-timing / atexit problem. Verified empirically that a worker whose owning process dies (even via `os._exit(0)` or `SIGKILL`) is always reaped via stdin-EOF; the leak is specifically the long-lived dashboard keeping detached sessions parked indefinitely.

## Fix

Reap orphaned embedded-chat sessions at the session-lifecycle layer. On WS disconnect, schedule a grace-delayed reap of any session left orphaned (transport detached to stdio, not mid-turn). A quick reconnect / `session.resume` / `prompt.submit` rebinds a live transport and cancels the reap, preserving the intentional detach-for-reconnect window.

- **`tui_gateway/server.py`**: extract `_teardown_session()` (shared with `session.close`), add `_ws_session_is_orphaned()` + `_schedule_ws_orphan_reap()`. Gated by `HERMES_TUI_WS_ORPHAN_REAP_GRACE_S` (default **20s**; `0` disables = pre-fix park-forever behaviour).
- **`tui_gateway/ws.py`**: schedule the reap for each detached session on disconnect.
- **tests**: reap-closes-worker, spares reattached / mid-turn / finalized sessions, disabled-when-grace-zero.

## Testing

- New unit tests pass; `tests/test_tui_gateway_server.py` + `tests/tui_gateway/` (305) + `tests/gateway/test_ws_auth_retry.py` + `tests/hermes_cli/test_web_server.py` (234) all green.
- **Real-code-path reproduction**: drove `tui_gateway.ws.handle_ws` through 6 simulated refreshes against the real in-process gateway (stubbed `_make_agent` so the real `_SlashWorker` subprocess still spawns).
  - Pre-fix (`grace=0`): 6 refreshes → **6 leaked workers**, none reaped.
  - With fix (`grace=3`): only **1** worker alive at any time during the refreshes, **0** remaining after the grace window.
  - Separate test confirms a session that rebinds a live transport within the grace window is **not** reaped.
- **Manual browser verification**: ran `hermes dashboard` from this branch, refreshed `/chat` repeatedly while watching `pgrep -f tui_gateway.slash_worker` — count bumps to 2 briefly after a refresh and settles back to 1 within the grace window; no accumulation. Confirmed working.

## Review note

Touches `tui_gateway/`, so this needs @teknium1 review (outside the Docker lane).

Fixes the slash-worker accumulation introduced as fallout from #38591.
