### PR TITLE
[codex] Hide internal agent sessions by default

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -179,6 +179,8 @@ def init_agent(
     request_overrides: Dict[str, Any] = None,
     prefill_messages: List[Dict[str, Any]] = None,
     platform: str = None,
+    session_source: str = None,
+    session_visibility: str = None,
     user_id: str = None,
     user_id_alt: str = None,
     user_name: str = None,
@@ -262,6 +264,8 @@ def init_agent(
     agent.quiet_mode = quiet_mode
     agent.ephemeral_system_prompt = ephemeral_system_prompt
     agent.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+    agent._session_source = session_source
+    agent._session_visibility = session_visibility
     agent._user_id = user_id  # Platform user identifier (gateway sessions)
     agent._user_id_alt = user_id_alt  # Optional stable alternate platform identifier
     agent._user_name = user_name

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -514,12 +514,23 @@ def compress_context(
             except Exception:
                 os.environ["HERMES_SESSION_ID"] = agent.session_id
             agent._session_db_created = False
+            session_source = (
+                agent._session_db_source()
+                if hasattr(agent, "_session_db_source")
+                else agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+            )
+            session_visibility = (
+                agent._session_db_visibility()
+                if hasattr(agent, "_session_db_visibility")
+                else os.environ.get("HERMES_SESSION_VISIBILITY", "user")
+            )
             agent._session_db.create_session(
                 session_id=agent.session_id,
-                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=session_source,
                 model=agent.model,
                 model_config=agent._session_init_model_config,
                 parent_session_id=old_session_id,
+                visibility=session_visibility,
             )
             agent._session_db_created = True
             # Auto-number the title for the continuation session

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -277,6 +277,7 @@ export interface SessionInfo {
   started_at: number
   title: null | string
   tool_call_count: number
+  visibility?: 'hidden' | 'internal' | 'user' | string
 }
 
 export interface SessionMessage {

--- a/cli.py
+++ b/cli.py
@@ -5187,6 +5187,8 @@ class HermesCLI:
                 openrouter_min_coding_score=self._openrouter_min_coding_score,
                 session_id=self.session_id,
                 platform="cli",
+                session_source=os.environ.get("HERMES_SESSION_SOURCE"),
+                session_visibility=os.environ.get("HERMES_SESSION_VISIBILITY"),
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
@@ -6702,6 +6704,7 @@ class HermesCLI:
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
                         },
+                        visibility=os.environ.get("HERMES_SESSION_VISIBILITY", "user"),
                     )
                     self.agent._session_db_created = True
                 except Exception:
@@ -7177,6 +7180,7 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                visibility=os.environ.get("HERMES_SESSION_VISIBILITY", "user"),
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")
@@ -9285,6 +9289,8 @@ class HermesCLI:
                     verbose_logging=False,
                     session_id=task_id,
                     platform="cli",
+                    session_source="background",
+                    session_visibility="internal",
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1757,6 +1757,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
+            session_visibility="internal",
             session_id=_cron_session_id,
             session_db=_session_db,
         )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1263,12 +1263,12 @@ class APIServerAdapter(BasePlatformAdapter):
     def _session_response(session: Dict[str, Any]) -> Dict[str, Any]:
         """Return a stable, client-safe session representation."""
         safe_keys = (
-            "id", "source", "user_id", "model", "title", "started_at", "ended_at",
-            "end_reason", "message_count", "tool_call_count", "input_tokens",
-            "output_tokens", "cache_read_tokens", "cache_write_tokens",
-            "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
-            "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "id", "source", "visibility", "user_id", "model", "title",
+            "started_at", "ended_at", "end_reason", "message_count",
+            "tool_call_count", "input_tokens", "output_tokens",
+            "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+            "estimated_cost_usd", "actual_cost_usd", "api_call_count",
+            "parent_session_id", "last_active", "preview", "_lineage_root_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;
@@ -1327,6 +1327,15 @@ class APIServerAdapter(BasePlatformAdapter):
         limit = self._parse_nonnegative_int(request.query.get("limit"), default=50, maximum=200)
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
+        visibility = str(request.query.get("visibility") or "user").strip().lower()
+        if visibility not in {"user", "internal", "hidden", "all"}:
+            return web.json_response(
+                _openai_error(
+                    "visibility must be one of: user, internal, hidden, all",
+                    code="invalid_visibility",
+                ),
+                status=400,
+            )
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
         sessions = db.list_sessions_rich(
             source=source,
@@ -1334,6 +1343,7 @@ class APIServerAdapter(BasePlatformAdapter):
             offset=offset,
             include_children=include_children,
             order_by_last_active=True,
+            visibility=visibility,
         )
         return web.json_response({
             "object": "list",
@@ -1369,7 +1379,16 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
-        db.create_session(session_id, "api_server", model=str(model) if model else None, system_prompt=system_prompt)
+        visibility = str(body.get("visibility") or "user").strip().lower()
+        if visibility not in {"user", "internal", "hidden"}:
+            return web.json_response(_openai_error("visibility must be one of: user, internal, hidden", code="invalid_visibility"), status=400)
+        db.create_session(
+            session_id,
+            "api_server",
+            model=str(model) if model else None,
+            system_prompt=system_prompt,
+            visibility=visibility,
+        )
         title = body.get("title")
         if title is not None:
             try:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -369,7 +369,13 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--source",
         default=None,
-        help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",
+        help="Session source tag for filtering (default: cli). Use with --session-visibility internal for third-party integrations.",
+    )
+    chat_parser.add_argument(
+        "--session-visibility",
+        choices=["user", "internal", "hidden"],
+        default=None,
+        help="How this run appears in session lists (default: user). Integrations should use internal.",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2054,6 +2054,8 @@ def cmd_chat(args):
     # --source: tag session source for filtering (e.g. 'tool' for third-party integrations)
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
+    if getattr(args, "session_visibility", None):
+        os.environ["HERMES_SESSION_VISIBILITY"] = args.session_visibility
 
     _pin_kanban_board_env()
 
@@ -14897,6 +14899,12 @@ Examples:
         "--source", help="Filter by source (cli, telegram, discord, etc.)"
     )
     sessions_list.add_argument(
+        "--visibility",
+        choices=["user", "internal", "hidden", "all"],
+        default=None,
+        help="Filter by session visibility (default: user, or all when --source is explicit)",
+    )
+    sessions_list.add_argument(
         "--limit", type=int, default=20, help="Max sessions to show"
     )
 
@@ -14950,6 +14958,12 @@ Examples:
         "--source", help="Filter by source (cli, telegram, discord, etc.)"
     )
     sessions_browse.add_argument(
+        "--visibility",
+        choices=["user", "internal", "hidden", "all"],
+        default=None,
+        help="Filter by session visibility (default: user, or all when --source is explicit)",
+    )
+    sessions_browse.add_argument(
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
     )
 
@@ -14973,13 +14987,17 @@ Examples:
 
         action = args.sessions_action
 
-        # Hide third-party tool sessions by default, but honour explicit --source
+        # Hide internal integration sessions by default, but honour explicit --source.
         _source = getattr(args, "source", None)
         _exclude = None if _source else ["tool"]
+        _visibility = getattr(args, "visibility", None) or ("all" if _source else "user")
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+                visibility=_visibility,
             )
             if not sessions:
                 print("No sessions found.")
@@ -15086,8 +15104,12 @@ Examples:
             limit = getattr(args, "limit", 500) or 500
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
+            _browse_visibility = getattr(args, "visibility", None) or ("all" if source else "user")
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                visibility=_browse_visibility,
             )
             db.close()
             if not sessions:
@@ -15135,12 +15157,12 @@ Examples:
             )
 
         elif action == "stats":
-            total = db.session_count()
+            total = db.session_count(visibility="all")
             msgs = db.message_count()
             print(f"Total sessions: {total}")
             print(f"Total messages: {msgs}")
             for src in ["cli", "telegram", "discord", "whatsapp", "slack"]:
-                c = db.session_count(source=src)
+                c = db.session_count(source=src, visibility="all")
                 if c > 0:
                     print(f"  {src}: {c} sessions")
             db_path = db.db_path

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -341,6 +341,8 @@ def _run_agent(
         enabled_toolsets=toolsets_list,
         quiet_mode=True,
         platform="cli",
+        session_source=os.environ.get("HERMES_SESSION_SOURCE"),
+        session_visibility=os.environ.get("HERMES_SESSION_VISIBILITY"),
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1550,6 +1550,7 @@ async def get_sessions(
     min_messages: int = 0,
     archived: str = "exclude",
     order: str = "created",
+    visibility: str = "user",
 ):
     """List sessions.
 
@@ -1573,6 +1574,12 @@ async def get_sessions(
             status_code=400,
             detail="order must be one of: created, recent",
         )
+    visibility = (visibility or "user").strip().lower()
+    if visibility not in ("user", "internal", "hidden", "all"):
+        raise HTTPException(
+            status_code=400,
+            detail="visibility must be one of: user, internal, hidden, all",
+        )
     try:
         from hermes_state import SessionDB
         db = SessionDB()
@@ -1587,11 +1594,13 @@ async def get_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                visibility=visibility,
             )
             total = db.session_count(
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
+                visibility=visibility,
             )
             now = time.time()
             for s in sessions:
@@ -1601,6 +1610,7 @@ async def get_sessions(
                 )
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
+                s["visibility"] = s.get("visibility") or "user"
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
         finally:
             db.close()
@@ -1610,7 +1620,7 @@ async def get_sessions(
 
 
 @app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
+async def search_sessions(q: str = "", limit: int = 20, visibility: str = "user"):
     """Search sessions by ID plus full-text message content using FTS5.
 
     Direct session-id matches are surfaced first, then FTS message-content
@@ -1623,6 +1633,12 @@ async def search_sessions(q: str = "", limit: int = 20):
     """
     if not q or not q.strip():
         return {"results": []}
+    visibility = (visibility or "user").strip().lower()
+    if visibility not in ("user", "internal", "hidden", "all"):
+        raise HTTPException(
+            status_code=400,
+            detail="visibility must be one of: user, internal, hidden, all",
+        )
     try:
         from hermes_state import SessionDB
         db = SessionDB()
@@ -1720,7 +1736,12 @@ async def search_sessions(q: str = "", limit: int = 20):
             # logs, or another Hermes surface. FTS can't find those unless the
             # id happens to appear in message text. search_sessions_by_id is
             # SQL-bounded, so this stays cheap even with thousands of sessions.
-            for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
+            for row in db.search_sessions_by_id(
+                q,
+                limit=safe_limit,
+                include_archived=True,
+                visibility=visibility,
+            ):
                 sid = row.get("id")
                 preview = (row.get("preview") or "").strip()
                 snippet = preview or f"Session ID: {sid}"
@@ -1749,7 +1770,11 @@ async def search_sessions(q: str = "", limit: int = 20):
             # Over-fetch so lineage dedup can still surface `limit` distinct
             # conversations even when several hits collapse onto one root.
             fetch_limit = max(safe_limit * 5, 50)
-            matches = db.search_messages(query=prefix_query, limit=fetch_limit)
+            matches = db.search_messages(
+                query=prefix_query,
+                limit=fetch_limit,
+                visibility=visibility,
+            )
 
             for m in matches:
                 if len(seen) >= safe_limit:
@@ -4675,13 +4700,17 @@ async def get_session_stats():
 
     db = SessionDB()
     try:
-        total = db.session_count(include_archived=True)
-        active_store = db.session_count(include_archived=False)
-        archived = db.session_count(archived_only=True)
+        total = db.session_count(include_archived=True, visibility="all")
+        active_store = db.session_count(include_archived=False, visibility="all")
+        archived = db.session_count(archived_only=True, visibility="all")
         messages = db.message_count()
         by_source: Dict[str, int] = {}
         try:
-            for s in db.list_sessions_rich(limit=10000, include_archived=True):
+            for s in db.list_sessions_rich(
+                limit=10000,
+                include_archived=True,
+                visibility="all",
+            ):
                 src = str(s.get("source") or "cli")
                 by_source[src] = by_source.get(src, 0) + 1
         except Exception:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,56 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
+
+SESSION_VISIBILITY_USER = "user"
+SESSION_VISIBILITY_INTERNAL = "internal"
+SESSION_VISIBILITY_HIDDEN = "hidden"
+SESSION_VISIBILITY_ALL = "all"
+SESSION_VISIBILITY_VALUES = {
+    SESSION_VISIBILITY_USER,
+    SESSION_VISIBILITY_INTERNAL,
+    SESSION_VISIBILITY_HIDDEN,
+}
+SESSION_VISIBILITY_FILTER_VALUES = SESSION_VISIBILITY_VALUES | {SESSION_VISIBILITY_ALL}
+
+
+def normalize_session_visibility(value: Any, default: str = SESSION_VISIBILITY_USER) -> str:
+    """Normalize persisted session visibility values.
+
+    Unknown values fall back to ``default`` so a bad environment variable does
+    not prevent the session row from being created.
+    """
+    fallback = default if default in SESSION_VISIBILITY_VALUES else SESSION_VISIBILITY_USER
+    if value is None:
+        return fallback
+    normalized = str(value).strip().lower()
+    if normalized in {"", SESSION_VISIBILITY_ALL}:
+        return fallback
+    if normalized == "visible":
+        return SESSION_VISIBILITY_USER
+    if normalized in SESSION_VISIBILITY_VALUES:
+        return normalized
+    return fallback
+
+
+def normalize_session_visibility_filter(
+    value: Any,
+    default: str | None = SESSION_VISIBILITY_USER,
+) -> Optional[str]:
+    """Return a visibility filter value, or ``None`` for all visibilities."""
+    if value is None:
+        value = default
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"", SESSION_VISIBILITY_ALL}:
+        return None
+    if normalized == "visible":
+        return SESSION_VISIBILITY_USER
+    if normalized in SESSION_VISIBILITY_VALUES:
+        return normalized
+    return normalize_session_visibility(default)
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -264,6 +313,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_platform TEXT,
     handoff_error TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
+    visibility TEXT NOT NULL DEFAULT 'user',
     archived INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
@@ -315,6 +365,8 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_visibility
+    ON sessions(visibility);
 """
 
 FTS_SQL = """
@@ -917,13 +969,16 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        visibility: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
+        visibility_value = normalize_session_visibility(visibility)
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, cwd, visibility, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -933,6 +988,7 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     cwd,
+                    visibility_value,
                     time.time(),
                 ),
             )
@@ -1566,6 +1622,7 @@ class SessionDB:
         include_archived: bool = False,
         archived_only: bool = False,
         id_query: str = None,
+        visibility: str | None = SESSION_VISIBILITY_USER,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -1618,6 +1675,10 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+        visibility_filter = normalize_session_visibility_filter(visibility)
+        if visibility_filter is not None:
+            where_clauses.append("COALESCE(s.visibility, 'user') = ?")
+            params.append(visibility_filter)
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
@@ -2740,6 +2801,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        visibility: str | None = SESSION_VISIBILITY_USER,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -2810,6 +2872,11 @@ class SessionDB:
             where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
             params.extend(exclude_sources)
 
+        visibility_filter = normalize_session_visibility_filter(visibility)
+        if visibility_filter is not None:
+            where_clauses.append("COALESCE(s.visibility, 'user') = ?")
+            params.append(visibility_filter)
+
         if role_filter:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
@@ -2828,6 +2895,7 @@ class SessionDB:
                 m.timestamp,
                 m.tool_name,
                 s.source,
+                s.visibility,
                 s.model,
                 s.started_at AS session_started
             FROM messages_fts
@@ -2886,6 +2954,9 @@ class SessionDB:
                 if exclude_sources is not None:
                     tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     tri_params.extend(exclude_sources)
+                if visibility_filter is not None:
+                    tri_where.append("COALESCE(s.visibility, 'user') = ?")
+                    tri_params.append(visibility_filter)
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
@@ -2899,6 +2970,7 @@ class SessionDB:
                         m.timestamp,
                         m.tool_name,
                         s.source,
+                        s.visibility,
                         s.model,
                         s.started_at AS session_started
                     FROM messages_fts_trigram
@@ -2941,6 +3013,9 @@ class SessionDB:
                 if exclude_sources is not None:
                     like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                     like_params.extend(exclude_sources)
+                if visibility_filter is not None:
+                    like_where.append("COALESCE(s.visibility, 'user') = ?")
+                    like_params.append(visibility_filter)
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
@@ -2950,7 +3025,7 @@ class SessionDB:
                                   max(1, instr(m.content, ?) - 40),
                                   120) AS snippet,
                            m.content, m.timestamp, m.tool_name,
-                           s.source, s.model, s.started_at AS session_started
+                           s.source, s.visibility, s.model, s.started_at AS session_started
                     FROM messages m
                     JOIN sessions s ON s.id = m.session_id
                     WHERE {' AND '.join(like_where)}
@@ -3046,6 +3121,7 @@ class SessionDB:
         query: str,
         limit: int = 20,
         include_archived: bool = True,
+        visibility: str | None = SESSION_VISIBILITY_USER,
     ) -> List[Dict[str, Any]]:
         """Search surfaced sessions by exact/prefix/substring session id.
 
@@ -3071,6 +3147,7 @@ class SessionDB:
             include_archived=include_archived,
             order_by_last_active=True,
             id_query=needle,
+            visibility=visibility,
         )
 
         def score(row: Dict[str, Any]) -> int:
@@ -3134,6 +3211,7 @@ class SessionDB:
         min_message_count: int = 0,
         include_archived: bool = False,
         archived_only: bool = False,
+        visibility: str | None = SESSION_VISIBILITY_USER,
     ) -> int:
         """Count sessions, optionally filtered by source."""
         where_clauses = []
@@ -3142,6 +3220,10 @@ class SessionDB:
         if source:
             where_clauses.append("source = ?")
             params.append(source)
+        visibility_filter = normalize_session_visibility_filter(visibility)
+        if visibility_filter is not None:
+            where_clauses.append("COALESCE(visibility, 'user') = ?")
+            params.append(visibility_filter)
         if min_message_count > 0:
             where_clauses.append("message_count >= ?")
             params.append(min_message_count)

--- a/run_agent.py
+++ b/run_agent.py
@@ -385,6 +385,8 @@ class AIAgent:
         request_overrides: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
+        session_source: str = None,
+        session_visibility: str = None,
         user_id: str = None,
         user_id_alt: str = None,
         user_name: str = None,
@@ -455,6 +457,8 @@ class AIAgent:
             request_overrides=request_overrides,
             prefill_messages=prefill_messages,
             platform=platform,
+            session_source=session_source,
+            session_visibility=session_visibility,
             user_id=user_id,
             user_id_alt=user_id_alt,
             user_name=user_name,
@@ -497,11 +501,31 @@ class AIAgent:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
             return None
 
+    def _session_db_source(self) -> str:
+        explicit_source = getattr(self, "_session_source", None)
+        if explicit_source:
+            return str(explicit_source)
+        platform = getattr(self, "platform", None)
+        env_source = os.environ.get("HERMES_SESSION_SOURCE")
+        if env_source and (not platform or platform == "cli"):
+            return env_source
+        return platform or env_source or "cli"
+
+    def _session_db_visibility(self) -> str:
+        explicit_visibility = getattr(self, "_session_visibility", None)
+        if explicit_visibility:
+            return str(explicit_visibility)
+        platform = getattr(self, "platform", None)
+        env_visibility = os.environ.get("HERMES_SESSION_VISIBILITY")
+        if env_visibility and (not platform or platform == "cli"):
+            return env_visibility
+        return "user"
+
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = self._session_db_source()
         try:
             self._session_db.create_session(
                 session_id=self.session_id,
@@ -512,6 +536,7 @@ class AIAgent:
                 user_id=None,
                 parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source),
+                visibility=self._session_db_visibility(),
             )
             self._session_db_created = True
         except Exception as e:
@@ -567,7 +592,7 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
-                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "platform": self._session_db_source(),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -297,6 +297,56 @@ class TestWebServerEndpoints:
         assert captured["list"] == 3
         assert captured["count"] == 3
 
+    def test_get_sessions_hides_internal_visibility_by_default(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="visible-session", source="cli")
+            db.create_session(
+                session_id="internal-session",
+                source="flashbyte-dashboard",
+                visibility="internal",
+            )
+        finally:
+            db.close()
+
+        default_rows = self.client.get("/api/sessions?limit=20&offset=0").json()
+        assert {s["id"] for s in default_rows["sessions"]} == {"visible-session"}
+        assert default_rows["total"] == 1
+
+        all_rows = self.client.get("/api/sessions?limit=20&offset=0&visibility=all").json()
+        assert {s["id"] for s in all_rows["sessions"]} == {
+            "visible-session",
+            "internal-session",
+        }
+        assert all_rows["total"] == 2
+
+    def test_session_search_hides_internal_visibility_by_default(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="visible-search", source="cli")
+            db.append_message("visible-search", "user", "needle visible")
+            db.create_session(
+                session_id="internal-search",
+                source="flashbyte-dashboard",
+                visibility="internal",
+            )
+            db.append_message("internal-search", "user", "needle internal")
+        finally:
+            db.close()
+
+        default_results = self.client.get("/api/sessions/search?q=needle").json()
+        assert {r["session_id"] for r in default_results["results"]} == {"visible-search"}
+
+        all_results = self.client.get("/api/sessions/search?q=needle&visibility=all").json()
+        assert {r["session_id"] for r in all_results["results"]} == {
+            "visible-search",
+            "internal-search",
+        }
+
     def test_rename_session_updates_title(self):
         """PATCH /api/sessions/{id} renames a session (regression: the route
         was missing entirely, so the desktop rename dialog got a 405)."""
@@ -3967,4 +4017,3 @@ class TestValidateProviderCredential:
     def test_empty_value_rejected(self):
         data = self._post("OPENAI_API_KEY", "   ").json()
         assert data["ok"] is False
-

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -14,9 +14,16 @@ class _FakeSessionDB:
 
     closed = False
 
-    def search_sessions_by_id(self, query, limit=20, include_archived=True):
+    def search_sessions_by_id(
+        self,
+        query,
+        limit=20,
+        include_archived=True,
+        visibility="user",
+    ):
         assert query == "20260603"
         assert include_archived is True
+        assert visibility == "user"
         return [
             {
                 "id": "20260603_090200_exact",
@@ -27,8 +34,9 @@ class _FakeSessionDB:
             }
         ]
 
-    def search_messages(self, query, limit=20):
+    def search_messages(self, query, limit=20, visibility="user"):
         assert query == "20260603*"
+        assert visibility == "user"
         return [
             {
                 "session_id": "20260603_090200_exact",

--- a/tests/run_agent/test_session_id_env.py
+++ b/tests/run_agent/test_session_id_env.py
@@ -14,8 +14,12 @@ from run_agent import AIAgent
 def _cleanup_env():
     """Remove HERMES_SESSION_ID before/after each test."""
     os.environ.pop("HERMES_SESSION_ID", None)
+    os.environ.pop("HERMES_SESSION_SOURCE", None)
+    os.environ.pop("HERMES_SESSION_VISIBILITY", None)
     yield
     os.environ.pop("HERMES_SESSION_ID", None)
+    os.environ.pop("HERMES_SESSION_SOURCE", None)
+    os.environ.pop("HERMES_SESSION_VISIBILITY", None)
 
 
 def test_session_id_env_set_on_init():
@@ -59,3 +63,57 @@ def test_session_id_contextvar_set():
     )
     from gateway.session_context import get_session_env
     assert get_session_env("HERMES_SESSION_ID") == custom_id
+
+
+def test_cli_session_source_env_is_persisted(tmp_path, monkeypatch):
+    """CLI integrations can tag their persisted session source and visibility."""
+    from hermes_state import SessionDB
+
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "flashbyte-dashboard")
+    monkeypatch.setenv("HERMES_SESSION_VISIBILITY", "internal")
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            session_id="flashbyte-test",
+            platform="cli",
+            session_db=db,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._ensure_db_session()
+        row = db.get_session("flashbyte-test")
+    finally:
+        db.close()
+
+    assert row["source"] == "flashbyte-dashboard"
+    assert row["visibility"] == "internal"
+
+
+def test_non_cli_platform_ignores_cli_session_source_env(tmp_path, monkeypatch):
+    """A CLI source env var must not relabel gateway platform sessions."""
+    from hermes_state import SessionDB
+
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "flashbyte-dashboard")
+    monkeypatch.setenv("HERMES_SESSION_VISIBILITY", "internal")
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            session_id="telegram-test",
+            platform="telegram",
+            session_db=db,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._ensure_db_session()
+        row = db.get_session("telegram-test")
+    finally:
+        db.close()
+
+    assert row["source"] == "telegram"
+    assert row["visibility"] == "user"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2994,6 +2994,56 @@ class TestExcludeSources:
         assert "cli" in sources
         assert "tool" not in sources
 
+
+class TestSessionVisibility:
+    """Tests for user-visible versus internal session rows."""
+
+    def test_internal_sessions_hidden_from_default_lists(self, db):
+        db.create_session("user-session", "cli")
+        db.create_session(
+            "internal-session",
+            "flashbyte-dashboard",
+            visibility="internal",
+        )
+
+        assert [s["id"] for s in db.list_sessions_rich()] == ["user-session"]
+        assert db.session_count() == 1
+
+        all_ids = {s["id"] for s in db.list_sessions_rich(visibility="all")}
+        assert all_ids == {"user-session", "internal-session"}
+        assert db.session_count(visibility="all") == 2
+
+    def test_visibility_filter_finds_internal_sessions(self, db):
+        db.create_session("user-session", "cli")
+        db.create_session(
+            "internal-session",
+            "flashbyte-dashboard",
+            visibility="internal",
+        )
+
+        sessions = db.list_sessions_rich(visibility="internal")
+
+        assert [s["id"] for s in sessions] == ["internal-session"]
+
+    def test_search_messages_hides_internal_sessions_by_default(self, db):
+        db.create_session("user-session", "cli")
+        db.append_message("user-session", "user", "Python user question")
+        db.create_session(
+            "internal-session",
+            "flashbyte-dashboard",
+            visibility="internal",
+        )
+        db.append_message("internal-session", "user", "Python internal ping")
+
+        default_results = db.search_messages("Python")
+        all_results = db.search_messages("Python", visibility="all")
+
+        assert {r["session_id"] for r in default_results} == {"user-session"}
+        assert {r["session_id"] for r in all_results} == {
+            "user-session",
+            "internal-session",
+        }
+
     def test_search_messages_no_exclusion_returns_all_sources(self, db):
         db.create_session("s1", "cli")
         db.append_message("s1", "user", "Rust deployment question")


### PR DESCRIPTION
﻿## Summary

- add persisted session visibility (`user`, `internal`, `hidden`) and default user-facing session list/search/count behavior to `user`
- thread visibility through agent/session creation so background and cron runs persist as `internal`
- add CLI/API/Desktop-facing visibility filters, including `visibility=all` for admin/debug surfaces and stats

## Root Cause

Background and integration-driven agents wrote ordinary user-visible session rows. Desktop and session API callers therefore accumulated internal implementation runs alongside real conversations.

## User Impact

User-facing session lists stay focused on human conversations by default, while internal sessions remain queryable for diagnostics through explicit visibility filters.

Fixes #39372.

## Validation

- `python -m pytest -o addopts='' -p no:timeout tests\test_hermes_state.py tests\run_agent\test_session_id_env.py tests\hermes_cli\test_web_server_session_search.py tests\tools\test_session_search.py tests\gateway\test_api_server.py -q` (`457 passed, 1 skipped`)
- `python -m pytest -o addopts='' -p no:timeout tests\hermes_cli\test_web_server.py::TestWebServerEndpoints::test_get_sessions_hides_internal_visibility_by_default tests\hermes_cli\test_web_server.py::TestWebServerEndpoints::test_session_search_hides_internal_visibility_by_default tests\hermes_cli\test_web_server.py::TestWebServerEndpoints::test_get_sessions_forwards_min_messages tests\hermes_cli\test_web_server.py::TestWebServerEndpoints::test_get_sessions_order_recent_surfaces_compression_tip -q` (`4 passed`)
- `python -m py_compile hermes_state.py run_agent.py agent\agent_init.py agent\conversation_compression.py cli.py cron\scheduler.py hermes_cli\_parser.py hermes_cli\main.py hermes_cli\oneshot.py hermes_cli\web_server.py gateway\platforms\api_server.py`
- `git diff --check`
- temp DB smoke verified default hidden internal sessions and explicit `visibility=all`
- live DB smoke verified no visible Flashbyte/dashboard CLI worker rows

## Note

One unrelated Windows-local profile wrapper test still fails at the base commit because the helper creates `writer.bat` while the test expects extensionless `writer`. That failure predates this branch and is not part of this fix.
