### PR TITLE
Draft: add lightweight model profiles for model routing presets

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -4,16 +4,27 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
+  applyModelProfile,
+  createModelProfile,
+  deleteModelProfile,
   getAuxiliaryModels,
   getGlobalModelInfo,
   getGlobalModelOptions,
+  getModelProfiles,
   getRecommendedDefaultModel,
   setEnvVar,
-  setModelAssignment
+  setModelAssignment,
+  updateModelProfile
 } from '@/hermes'
-import type { AuxiliaryModelsResponse, ModelOptionProvider, StaleAuxAssignment } from '@/hermes'
+import type {
+  AuxiliaryModelsResponse,
+  ModelOptionProvider,
+  ModelProfilesResponse,
+  ModelRoutingPayload,
+  StaleAuxAssignment
+} from '@/hermes'
 import { useI18n } from '@/i18n'
-import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
+import { AlertTriangle, Cpu, Layers3, Loader2, Save, Sparkles, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { startManualProviderOAuth } from '@/store/onboarding'
 
@@ -47,6 +58,18 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
 ]
 
 const NO_PROVIDERS: readonly ModelOptionProvider[] = [{ name: '—', slug: '', models: [] }]
+const NO_PROFILE_VALUE = '__none__'
+
+type PendingAction =
+  | 'aux-reset'
+  | 'main-apply'
+  | 'profile-apply'
+  | 'profile-delete'
+  | 'profile-save'
+  | 'profile-update'
+  | `aux-${string}`
+
+type AuxiliaryTaskAssignment = AuxiliaryModelsResponse['tasks'][number]
 
 interface StaleAuxWarningProps {
   applying: boolean
@@ -87,6 +110,34 @@ interface ModelSettingsProps {
   onMainModelChanged?: (provider: string, model: string) => void
 }
 
+function normalizeAuxiliaryTasks(tasks: readonly Partial<AuxiliaryTaskAssignment>[] | undefined) {
+  return AUX_TASKS.map(meta => {
+    const entry = tasks?.find(task => task.task === meta.key)
+
+    return {
+      base_url: entry?.base_url || '',
+      model: entry?.model || '',
+      provider: entry?.provider || 'auto',
+      task: meta.key
+    }
+  })
+}
+
+function routingSignature(routing: ModelRoutingPayload) {
+  return JSON.stringify({
+    auxiliary: normalizeAuxiliaryTasks(routing.auxiliary).map(task => ({
+      base_url: task.base_url || '',
+      model: task.model || '',
+      provider: task.provider || 'auto',
+      task: task.task
+    })),
+    main: {
+      model: routing.main.model || '',
+      provider: routing.main.provider || ''
+    }
+  })
+}
+
 export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const { t } = useI18n()
   const m = t.settings.model
@@ -97,7 +148,11 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const [selectedProvider, setSelectedProvider] = useState('')
   const [selectedModel, setSelectedModel] = useState('')
   const [auxiliary, setAuxiliary] = useState<AuxiliaryModelsResponse | null>(null)
-  const [applying, setApplying] = useState(false)
+  const [currentAuxiliary, setCurrentAuxiliary] = useState<AuxiliaryModelsResponse | null>(null)
+  const [modelProfiles, setModelProfiles] = useState<ModelProfilesResponse>({ active: '', profiles: [] })
+  const [selectedProfileId, setSelectedProfileId] = useState(NO_PROFILE_VALUE)
+  const [newProfileName, setNewProfileName] = useState('')
+  const [pendingAction, setPendingAction] = useState<null | PendingAction>(null)
   const [editingAuxTask, setEditingAuxTask] = useState<null | string>(null)
   const [auxDraft, setAuxDraft] = useState<{ model: string; provider: string }>({ model: '', provider: '' })
   // Aux slots reported stale by the backend immediately after a main-model
@@ -119,11 +174,26 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         getAuxiliaryModels()
       ])
 
+      const profiles = await getModelProfiles()
+
       setMainModel({ model: modelInfo.model, provider: modelInfo.provider })
       setProviders(modelOptions.providers || [])
       setSelectedProvider(prev => prev || modelInfo.provider)
       setSelectedModel(prev => prev || modelInfo.model)
+      setCurrentAuxiliary(auxiliaryModels)
       setAuxiliary(auxiliaryModels)
+      setModelProfiles(profiles)
+      setSelectedProfileId(prev => {
+        if (profiles.active && profiles.profiles.some(profile => profile.id === profiles.active)) {
+          return profiles.active
+        }
+
+        if (prev !== NO_PROFILE_VALUE && profiles.profiles.some(profile => profile.id === prev)) {
+          return prev
+        }
+
+        return NO_PROFILE_VALUE
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -136,6 +206,18 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   }, [refresh])
 
   const providerOptions = providers.length ? providers : NO_PROVIDERS
+  const selectedProfile = modelProfiles.profiles.find(profile => profile.id === selectedProfileId)
+  const activeProfile = modelProfiles.profiles.find(profile => profile.id === modelProfiles.active)
+  const busy = pendingAction !== null
+
+  const duplicateProfileName = useMemo(() => {
+    const normalized = newProfileName.trim().toLowerCase()
+
+    return Boolean(
+      normalized &&
+        modelProfiles.profiles.some(profile => profile.name.trim().toLowerCase() === normalized)
+    )
+  }, [modelProfiles.profiles, newProfileName])
 
   const selectedProviderRow = useMemo(
     () => providers.find(provider => provider.slug === selectedProvider),
@@ -231,70 +313,249 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     }
   }, [selectedProviderRow])
 
-  const applyMainModel = useCallback(async () => {
-    if (!selectedProvider || !selectedModel) {
+  useEffect(() => {
+    if (!selectedProfile) {
       return
     }
 
-    setApplying(true)
+    setSelectedProvider(selectedProfile.main.provider)
+    setSelectedModel(selectedProfile.main.model)
+    setAuxiliary({
+      main: selectedProfile.main,
+      tasks: normalizeAuxiliaryTasks(selectedProfile.auxiliary)
+    })
+  }, [selectedProfile])
+
+  const draftRouting = useMemo<ModelRoutingPayload>(
+    () => ({
+      auxiliary: normalizeAuxiliaryTasks(auxiliary?.tasks),
+      main: { model: selectedModel, provider: selectedProvider }
+    }),
+    [auxiliary, selectedModel, selectedProvider]
+  )
+
+  const selectedProfileRouting = useMemo<ModelRoutingPayload | null>(() => {
+    if (!selectedProfile) {
+      return null
+    }
+
+    return {
+      auxiliary: normalizeAuxiliaryTasks(selectedProfile.auxiliary),
+      main: selectedProfile.main
+    }
+  }, [selectedProfile])
+
+  const selectedProfileDirty = selectedProfileRouting
+    ? routingSignature(draftRouting) !== routingSignature(selectedProfileRouting)
+    : false
+
+  const selectProfile = useCallback(
+    (profileId: string) => {
+      setSelectedProfileId(profileId)
+
+      if (profileId === NO_PROFILE_VALUE && currentAuxiliary) {
+        setSelectedProvider(currentAuxiliary.main.provider)
+        setSelectedModel(currentAuxiliary.main.model)
+        setAuxiliary(currentAuxiliary)
+      }
+    },
+    [currentAuxiliary]
+  )
+
+  const applyDraftRouting = useCallback(
+    async (pending: PendingAction, options: { preferSavedProfile?: boolean } = {}) => {
+      const routing = draftRouting
+
+      if (options.preferSavedProfile && selectedProfile && !selectedProfileDirty) {
+        setPendingAction(pending)
+        setError('')
+
+        try {
+          const result = await applyModelProfile(selectedProfile.id)
+
+          if (result.profile?.main.provider && result.profile.main.model) {
+            setSelectedProvider(result.profile.main.provider)
+            setSelectedModel(result.profile.main.model)
+            onMainModelChanged?.(result.profile.main.provider, result.profile.main.model)
+          }
+
+          setSwitchStaleAux([])
+          await refresh()
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err))
+        } finally {
+          setPendingAction(null)
+        }
+
+        return
+      }
+
+      if (!routing.main.provider || !routing.main.model) {
+        setError('Provider and model required')
+
+        return
+      }
+
+      setPendingAction(pending)
+      setError('')
+
+      try {
+        const result = await setModelAssignment({
+          model: routing.main.model,
+          provider: routing.main.provider,
+          scope: 'main'
+        })
+
+        await setModelAssignment({
+          model: routing.main.model,
+          provider: routing.main.provider,
+          scope: 'auxiliary',
+          task: '__reset__'
+        })
+
+        for (const task of routing.auxiliary) {
+          if (!task.provider || task.provider === 'auto') {
+            continue
+          }
+
+          await setModelAssignment({
+            model: task.model || '',
+            provider: task.provider,
+            scope: 'auxiliary',
+            task: task.task
+          })
+        }
+
+        const provider = result.provider || routing.main.provider
+        const model = result.model || routing.main.model
+        const appliedAuxiliary = { main: { provider, model }, tasks: routing.auxiliary }
+        setMainModel({ provider, model })
+        setSelectedProvider(provider)
+        setSelectedModel(model)
+        setAuxiliary(appliedAuxiliary)
+        setCurrentAuxiliary(appliedAuxiliary)
+        setSelectedProfileId(NO_PROFILE_VALUE)
+        setSwitchStaleAux([])
+        onMainModelChanged?.(provider, model)
+        await refresh()
+        setSelectedProfileId(NO_PROFILE_VALUE)
+        setSelectedProvider(provider)
+        setSelectedModel(model)
+        setAuxiliary(appliedAuxiliary)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setPendingAction(null)
+      }
+    },
+    [draftRouting, onMainModelChanged, refresh, selectedProfile, selectedProfileDirty]
+  )
+
+  const applyRouting = useCallback(async () => {
+    await applyDraftRouting('main-apply')
+  }, [applyDraftRouting])
+
+  const saveCurrentAsProfile = useCallback(async () => {
+    const name = newProfileName.trim()
+
+    if (!name) {
+      setError('Profile name required')
+
+      return
+    }
+
+    if (duplicateProfileName) {
+      setError('Profile name already exists')
+
+      return
+    }
+
+    setPendingAction('profile-save')
     setError('')
 
     try {
-      const result = await setModelAssignment({ model: selectedModel, provider: selectedProvider, scope: 'main' })
-      const provider = result.provider || selectedProvider
-      const model = result.model || selectedModel
-      setMainModel({ provider, model })
-      setSwitchStaleAux(result.stale_aux ?? [])
-      onMainModelChanged?.(provider, model)
+      const result = await createModelProfile(name, draftRouting)
+      setNewProfileName('')
+      setSelectedProfileId(result.profile?.id || result.active || NO_PROFILE_VALUE)
       await refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
-      setApplying(false)
+      setPendingAction(null)
     }
-  }, [onMainModelChanged, refresh, selectedModel, selectedProvider])
+  }, [draftRouting, duplicateProfileName, newProfileName, refresh])
 
-  const setAuxiliaryToMain = useCallback(
-    async (task: string) => {
-      if (!mainModel) {
-        return
-      }
+  const applySelectedProfile = useCallback(async () => {
+    if (selectedProfileId === NO_PROFILE_VALUE) {
+      return
+    }
 
-      setApplying(true)
-      setError('')
+    await applyDraftRouting('profile-apply', { preferSavedProfile: true })
+  }, [applyDraftRouting, selectedProfileId])
 
-      try {
-        await setModelAssignment({ model: mainModel.model, provider: mainModel.provider, scope: 'auxiliary', task })
-        await refresh()
-      } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
-      } finally {
-        setApplying(false)
-      }
-    },
-    [mainModel, refresh]
-  )
+  const updateSelectedProfile = useCallback(async () => {
+    if (selectedProfileId === NO_PROFILE_VALUE) {
+      return
+    }
+
+    setPendingAction('profile-update')
+    setError('')
+
+    try {
+      await updateModelProfile(selectedProfileId, { routing: draftRouting })
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPendingAction(null)
+    }
+  }, [draftRouting, refresh, selectedProfileId])
+
+  const deleteSelectedProfile = useCallback(async () => {
+    if (selectedProfileId === NO_PROFILE_VALUE) {
+      return
+    }
+
+    setPendingAction('profile-delete')
+    setError('')
+
+    try {
+      await deleteModelProfile(selectedProfileId)
+      setSelectedProfileId(NO_PROFILE_VALUE)
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPendingAction(null)
+    }
+  }, [refresh, selectedProfileId])
+
+  const setAuxiliaryToMain = useCallback((task: string) => {
+    setAuxiliary(prev => ({
+      main: { model: selectedModel, provider: selectedProvider },
+      tasks: normalizeAuxiliaryTasks(prev?.tasks).map(entry =>
+        entry.task === task ? { ...entry, base_url: '', model: '', provider: 'auto' } : entry
+      )
+    }))
+  }, [selectedModel, selectedProvider])
 
   const applyAuxiliaryDraft = useCallback(
-    async (task: string) => {
+    (task: string) => {
       if (!auxDraft.provider || !auxDraft.model) {
         return
       }
 
-      setApplying(true)
-      setError('')
-
-      try {
-        await setModelAssignment({ model: auxDraft.model, provider: auxDraft.provider, scope: 'auxiliary', task })
-        setEditingAuxTask(null)
-        await refresh()
-      } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
-      } finally {
-        setApplying(false)
-      }
+      setAuxiliary(prev => ({
+        main: { model: selectedModel, provider: selectedProvider },
+        tasks: normalizeAuxiliaryTasks(prev?.tasks).map(entry =>
+          entry.task === task
+            ? { ...entry, base_url: '', model: auxDraft.model, provider: auxDraft.provider }
+            : entry
+        )
+      }))
+      setEditingAuxTask(null)
     },
-    [auxDraft, refresh]
+    [auxDraft, selectedModel, selectedProvider]
   )
 
   const beginAuxiliaryEdit = useCallback(
@@ -302,38 +563,22 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       const current = auxiliary?.tasks.find(entry => entry.task === task)
 
       const initialProvider =
-        current?.provider && current.provider !== 'auto' ? current.provider : (mainModel?.provider ?? '')
+        current?.provider && current.provider !== 'auto' ? current.provider : selectedProvider
 
-      const initialModel = current?.model || mainModel?.model || ''
+      const initialModel = current?.model || selectedModel
       setAuxDraft({ provider: initialProvider, model: initialModel })
       setEditingAuxTask(task)
     },
-    [auxiliary, mainModel]
+    [auxiliary, selectedModel, selectedProvider]
   )
 
-  const resetAuxiliaryModels = useCallback(async () => {
-    if (!mainModel) {
-      return
-    }
-
-    setApplying(true)
-    setError('')
-
-    try {
-      await setModelAssignment({
-        model: mainModel.model,
-        provider: mainModel.provider,
-        scope: 'auxiliary',
-        task: '__reset__'
-      })
-      setSwitchStaleAux([])
-      await refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setApplying(false)
-    }
-  }, [mainModel, refresh])
+  const resetAuxiliaryModels = useCallback(() => {
+    setAuxiliary({
+      main: { model: selectedModel, provider: selectedProvider },
+      tasks: normalizeAuxiliaryTasks(undefined)
+    })
+    setSwitchStaleAux([])
+  }, [selectedModel, selectedProvider])
 
   if (loading && !mainModel) {
     return <LoadingState label={m.loading} />
@@ -341,6 +586,106 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
   return (
     <div className="grid gap-6">
+      <section>
+        <SectionHeading
+          icon={Layers3}
+          meta={activeProfile ? `active · ${activeProfile.name}` : undefined}
+          title="Model profiles"
+        />
+        <p className="mb-3 text-xs text-muted-foreground">
+          Save and switch named combinations of the main model plus auxiliary model assignments.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select onValueChange={selectProfile} value={selectedProfileId}>
+            <SelectTrigger className={cn('min-w-64', CONTROL_TEXT)}>
+              <SelectValue placeholder="Model profile" />
+            </SelectTrigger>
+            <SelectContent>
+              {modelProfiles.profiles.length ? (
+                <>
+                  <SelectItem value={NO_PROFILE_VALUE}>No profile selected</SelectItem>
+                  {modelProfiles.profiles.map(profile => (
+                    <SelectItem key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </SelectItem>
+                  ))}
+                </>
+              ) : (
+                <SelectItem disabled value={NO_PROFILE_VALUE}>
+                  No model profiles
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          <Button
+            disabled={selectedProfileId === NO_PROFILE_VALUE || busy}
+            onClick={() => void applySelectedProfile()}
+            size="sm"
+          >
+            {pendingAction === 'profile-apply' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="size-3.5" />
+            )}
+            {pendingAction === 'profile-apply' ? 'Applying...' : 'Apply profile'}
+          </Button>
+          <Button
+            disabled={selectedProfileId === NO_PROFILE_VALUE || busy}
+            onClick={() => void updateSelectedProfile()}
+            size="sm"
+            variant="outline"
+          >
+            {pendingAction === 'profile-update' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Save className="size-3.5" />
+            )}
+            {pendingAction === 'profile-update' ? 'Updating...' : 'Update profile'}
+          </Button>
+          <Button
+            disabled={selectedProfileId === NO_PROFILE_VALUE || busy}
+            onClick={() => void deleteSelectedProfile()}
+            size="sm"
+            variant="ghost"
+          >
+            {pendingAction === 'profile-delete' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5" />
+            )}
+            {pendingAction === 'profile-delete' ? 'Deleting...' : 'Delete'}
+          </Button>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <Input
+            className={cn('min-w-64', CONTROL_TEXT)}
+            onChange={event => setNewProfileName(event.target.value)}
+            placeholder="New profile name"
+            value={newProfileName}
+          />
+          <Button
+            disabled={!newProfileName.trim() || duplicateProfileName || busy}
+            onClick={() => void saveCurrentAsProfile()}
+            size="sm"
+          >
+            {pendingAction === 'profile-save' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Save className="size-3.5" />
+            )}
+            {pendingAction === 'profile-save' ? 'Saving...' : 'Save as profile'}
+          </Button>
+          {duplicateProfileName && <span className="text-xs text-destructive">Profile name already exists.</span>}
+        </div>
+        {selectedProfile && (
+          <div className="mt-2 font-mono text-[0.68rem] text-muted-foreground">
+            {selectedProfile.main.provider || '(no provider)'} · {selectedProfile.main.model || '(no model)'} ·{' '}
+            {selectedProfile.auxiliary_overrides} auxiliary override
+            {selectedProfile.auxiliary_overrides === 1 ? '' : 's'}
+          </div>
+        )}
+      </section>
+
       <section>
         <p className="mb-3 text-xs text-muted-foreground">
           {m.appliesDesc}
@@ -403,12 +748,12 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 </SelectContent>
               </Select>
               <Button
-                disabled={!selectedProvider || !selectedModel || applying}
-                onClick={() => void applyMainModel()}
+                disabled={!selectedProvider || !selectedModel || busy}
+                onClick={() => void applyRouting()}
                 size="sm"
               >
-                {applying && <Loader2 className="size-3.5 animate-spin" />}
-                {applying ? m.applying : t.common.apply}
+                {pendingAction === 'main-apply' && <Loader2 className="size-3.5 animate-spin" />}
+                {pendingAction === 'main-apply' ? m.applying : t.common.apply}
               </Button>
             </>
           )}
@@ -424,7 +769,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         {switchStaleAux.length > 0 && (
           <div className="mt-2">
             <StaleAuxWarning
-              applying={applying}
+              applying={busy}
               onReset={() => void resetAuxiliaryModels()}
               slots={switchStaleAux}
               taskLabel={auxiliaryTaskLabel}
@@ -437,8 +782,8 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         <div className="mb-2.5 flex items-center justify-between">
           <SectionHeading icon={Cpu} title={m.auxiliaryTitle} />
           <Button
-            disabled={!mainModel || applying}
-            onClick={() => void resetAuxiliaryModels()}
+            disabled={busy}
+            onClick={() => resetAuxiliaryModels()}
             size="sm"
             variant="textStrong"
           >
@@ -451,7 +796,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         {switchStaleAux.length === 0 && persistentStaleAux.length > 0 && (
           <div className="mb-2.5">
             <StaleAuxWarning
-              applying={applying}
+              applying={busy}
               onReset={() => void resetAuxiliaryModels()}
               slots={persistentStaleAux}
               taskLabel={auxiliaryTaskLabel}
@@ -471,15 +816,15 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   !isEditing && (
                     <div className="flex shrink-0 items-center gap-1.5">
                       <Button
-                        disabled={!mainModel || applying}
-                        onClick={() => void setAuxiliaryToMain(meta.key)}
+                        disabled={busy}
+                        onClick={() => setAuxiliaryToMain(meta.key)}
                         size="sm"
                         variant="text"
                       >
                         {m.setToMain}
                       </Button>
                       <Button
-                        disabled={!providers.length || applying}
+                        disabled={!providers.length || busy}
                         onClick={() => beginAuxiliaryEdit(meta.key)}
                         size="sm"
                         variant="textStrong"
@@ -523,11 +868,11 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                         </SelectContent>
                       </Select>
                       <Button
-                        disabled={!auxDraft.provider || !auxDraft.model || applying}
-                        onClick={() => void applyAuxiliaryDraft(meta.key)}
+                        disabled={!auxDraft.provider || !auxDraft.model || busy}
+                        onClick={() => applyAuxiliaryDraft(meta.key)}
                         size="sm"
                       >
-                        {applying ? m.applying : t.common.apply}
+                        {t.common.apply}
                       </Button>
                       <Button onClick={() => setEditingAuxTask(null)} size="sm" variant="ghost">
                         {t.common.cancel}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -23,6 +23,9 @@ import type {
   ModelAssignmentResponse,
   ModelInfoResponse,
   ModelOptionsResponse,
+  ModelProfileMutationResponse,
+  ModelProfilesResponse,
+  ModelRoutingPayload,
   OAuthPollResponse,
   OAuthProvidersResponse,
   OAuthStartResponse,
@@ -80,6 +83,10 @@ export type {
   ModelInfoResponse,
   ModelOptionProvider,
   ModelOptionsResponse,
+  ModelProfileMutationResponse,
+  ModelProfilesResponse,
+  ModelProfileSummary,
+  ModelRoutingPayload,
   PaginatedSessions,
   ProfileCreatePayload,
   ProfileInfo,
@@ -660,6 +667,45 @@ export function getAuxiliaryModels(): Promise<AuxiliaryModelsResponse> {
   return window.hermesDesktop.api<AuxiliaryModelsResponse>({
     ...profileScoped(),
     path: '/api/model/auxiliary'
+  })
+}
+
+export function getModelProfiles(): Promise<ModelProfilesResponse> {
+  return window.hermesDesktop.api<ModelProfilesResponse>({
+    path: '/api/model/profiles'
+  })
+}
+
+export function createModelProfile(name: string, routing?: ModelRoutingPayload): Promise<ModelProfileMutationResponse> {
+  return window.hermesDesktop.api<ModelProfileMutationResponse>({
+    path: '/api/model/profiles',
+    method: 'POST',
+    body: { name, ...(routing ? { routing } : {}) }
+  })
+}
+
+export function applyModelProfile(id: string): Promise<ModelProfileMutationResponse> {
+  return window.hermesDesktop.api<ModelProfileMutationResponse>({
+    path: `/api/model/profiles/${encodeURIComponent(id)}/apply`,
+    method: 'POST'
+  })
+}
+
+export function updateModelProfile(
+  id: string,
+  body: { from_current?: boolean; name?: string; routing?: ModelRoutingPayload }
+): Promise<ModelProfileMutationResponse> {
+  return window.hermesDesktop.api<ModelProfileMutationResponse>({
+    path: `/api/model/profiles/${encodeURIComponent(id)}`,
+    method: 'PUT',
+    body
+  })
+}
+
+export function deleteModelProfile(id: string): Promise<ModelProfileMutationResponse> {
+  return window.hermesDesktop.api<ModelProfileMutationResponse>({
+    path: `/api/model/profiles/${encodeURIComponent(id)}`,
+    method: 'DELETE'
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -608,6 +608,30 @@ export interface AuxiliaryModelsResponse {
   tasks: AuxiliaryTaskAssignment[]
 }
 
+export interface ModelRoutingPayload {
+  auxiliary: AuxiliaryTaskAssignment[]
+  main: { base_url?: string; model: string; provider: string }
+}
+
+export interface ModelProfileSummary {
+  auxiliary: AuxiliaryTaskAssignment[]
+  auxiliary_overrides: number
+  id: string
+  main: { model: string; provider: string }
+  name: string
+}
+
+export interface ModelProfilesResponse {
+  active: string
+  profiles: ModelProfileSummary[]
+}
+
+export interface ModelProfileMutationResponse {
+  active?: string
+  ok: boolean
+  profile?: ModelProfileSummary
+}
+
 export interface ModelAssignmentRequest {
   /** OpenAI-compatible endpoint URL. Only honored for custom/local providers
    *  on the main slot — wires a self-hosted endpoint into runtime resolution. */

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -801,6 +801,8 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    "active_model_profile": "",
+    "model_profiles": {},
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
@@ -4023,7 +4025,8 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
+    "_config_version", "model", "active_model_profile", "model_profiles",
+    "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 import asyncio
 import base64
 import binascii
+import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hmac
@@ -734,6 +735,22 @@ def _apply_main_model_assignment(
         model_cfg["base_url"] = ""
     model_cfg.pop("context_length", None)
     return model_cfg
+
+
+class ModelProfileCreate(BaseModel):
+    """Save the current main+auxiliary model routing as a named profile."""
+
+    name: str
+    profile_id: str = ""
+    routing: Dict[str, Any] | None = None
+
+
+class ModelProfileUpdate(BaseModel):
+    """Rename a model profile and/or replace it with the current routing."""
+
+    name: str = ""
+    from_current: bool = False
+    routing: Dict[str, Any] | None = None
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -2211,6 +2228,194 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
 )
 
 
+_MODEL_PROFILE_ID_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def _model_profile_id_from_name(name: str) -> str:
+    """Return a stable, URL-safe id candidate for a model profile name."""
+    value = (name or "").strip().lower()
+    value = _MODEL_PROFILE_ID_RE.sub("-", value).strip("-_")
+    return value[:64] if value else "model-profile"
+
+
+def _unique_model_profile_id(profiles: Dict[str, Any], desired: str) -> str:
+    base = _model_profile_id_from_name(desired)
+    if base not in profiles:
+        return base
+    for idx in range(2, 1000):
+        candidate = f"{base}-{idx}"
+        if candidate not in profiles:
+            return candidate
+    raise HTTPException(status_code=400, detail="could not allocate a unique model profile id")
+
+
+def _model_profile_store(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    profiles = cfg.get("model_profiles")
+    if not isinstance(profiles, dict):
+        profiles = {}
+        cfg["model_profiles"] = profiles
+    return profiles
+
+
+def _current_model_profile_snapshot(cfg: Dict[str, Any], *, name: str) -> Dict[str, Any]:
+    """Snapshot only model routing, not provider credentials or auth state."""
+    model_cfg = cfg.get("model", "")
+    auxiliary_cfg = cfg.get("auxiliary", {})
+    return {
+        "name": name.strip() or "Model profile",
+        "model": copy.deepcopy(model_cfg) if isinstance(model_cfg, (dict, str)) else "",
+        "auxiliary": copy.deepcopy(auxiliary_cfg) if isinstance(auxiliary_cfg, dict) else {},
+    }
+
+
+def _model_cfg_from_routing_main(main_cfg: Any) -> Dict[str, Any] | str:
+    if isinstance(main_cfg, str):
+        return main_cfg
+    if not isinstance(main_cfg, dict):
+        return ""
+
+    provider = str(main_cfg.get("provider", "") or "").strip()
+    model = str(
+        main_cfg.get("model", main_cfg.get("default", main_cfg.get("name", ""))) or ""
+    ).strip()
+    if not provider and not model:
+        return ""
+
+    model_cfg: Dict[str, Any] = {}
+    if provider:
+        model_cfg["provider"] = provider
+    if model:
+        model_cfg["default"] = model
+
+    base_url = str(main_cfg.get("base_url", "") or "").strip()
+    if base_url:
+        model_cfg["base_url"] = base_url
+
+    return model_cfg
+
+
+def _auxiliary_cfg_from_routing(auxiliary_cfg: Any) -> Dict[str, Any]:
+    if isinstance(auxiliary_cfg, dict):
+        # Accept either the raw config shape ({task: {provider, model}}) or a
+        # wrapper shape ({tasks: [...]}) from the desktop UI.
+        if isinstance(auxiliary_cfg.get("tasks"), list):
+            auxiliary_cfg = auxiliary_cfg.get("tasks")
+        else:
+            result: Dict[str, Any] = {}
+            for task, value in auxiliary_cfg.items():
+                if task not in _AUX_TASK_SLOTS or not isinstance(value, dict):
+                    continue
+                result[task] = {
+                    "provider": str(value.get("provider", "auto") or "auto"),
+                    "model": str(value.get("model", "") or ""),
+                    "base_url": str(value.get("base_url", "") or ""),
+                }
+            return result
+
+    result: Dict[str, Any] = {}
+    if not isinstance(auxiliary_cfg, list):
+        return result
+
+    for entry in auxiliary_cfg:
+        if not isinstance(entry, dict):
+            continue
+        task = str(entry.get("task", "") or "").strip().lower()
+        if task not in _AUX_TASK_SLOTS:
+            continue
+        result[task] = {
+            "provider": str(entry.get("provider", "auto") or "auto"),
+            "model": str(entry.get("model", "") or ""),
+            "base_url": str(entry.get("base_url", "") or ""),
+        }
+    return result
+
+
+def _model_profile_snapshot_from_routing(
+    routing: Any, *, fallback_cfg: Dict[str, Any], name: str
+) -> Dict[str, Any]:
+    if not isinstance(routing, dict):
+        return _current_model_profile_snapshot(fallback_cfg, name=name)
+    return {
+        "name": name.strip() or "Model profile",
+        "model": _model_cfg_from_routing_main(routing.get("main", {})),
+        "auxiliary": _auxiliary_cfg_from_routing(routing.get("auxiliary", {})),
+    }
+
+
+def _main_model_summary(model_cfg: Any) -> Dict[str, str]:
+    if isinstance(model_cfg, dict):
+        return {
+            "provider": str(model_cfg.get("provider", "") or ""),
+            "model": str(model_cfg.get("default", model_cfg.get("name", "")) or ""),
+        }
+    return {"provider": "", "model": str(model_cfg) if model_cfg else ""}
+
+
+def _auxiliary_override_count(auxiliary_cfg: Any) -> int:
+    if not isinstance(auxiliary_cfg, dict):
+        return 0
+    count = 0
+    for slot_cfg in auxiliary_cfg.values():
+        if not isinstance(slot_cfg, dict):
+            continue
+        provider = str(slot_cfg.get("provider", "auto") or "auto").strip()
+        model = str(slot_cfg.get("model", "") or "").strip()
+        base_url = str(slot_cfg.get("base_url", "") or "").strip()
+        if (provider and provider != "auto") or model or base_url:
+            count += 1
+    return count
+
+
+def _auxiliary_tasks_payload(auxiliary_cfg: Any) -> list[Dict[str, str]]:
+    if not isinstance(auxiliary_cfg, dict):
+        auxiliary_cfg = {}
+
+    tasks = []
+    for slot in _AUX_TASK_SLOTS:
+        slot_cfg = auxiliary_cfg.get(slot, {}) if isinstance(auxiliary_cfg.get(slot), dict) else {}
+        tasks.append({
+            "task": slot,
+            "provider": str(slot_cfg.get("provider", "auto") or "auto"),
+            "model": str(slot_cfg.get("model", "") or ""),
+            "base_url": str(slot_cfg.get("base_url", "") or ""),
+        })
+    return tasks
+
+
+def _model_profile_payload(profile_id: str, profile: Any) -> Dict[str, Any]:
+    profile_cfg = profile if isinstance(profile, dict) else {}
+    auxiliary_cfg = profile_cfg.get("auxiliary", {})
+    return {
+        "id": profile_id,
+        "name": str(profile_cfg.get("name", "") or profile_id),
+        "main": _main_model_summary(profile_cfg.get("model", "")),
+        "auxiliary": _auxiliary_tasks_payload(auxiliary_cfg),
+        "auxiliary_overrides": _auxiliary_override_count(auxiliary_cfg),
+    }
+
+
+def _profile_name_exists(
+    profiles: Dict[str, Any], name: str, *, exclude_profile_id: str = ""
+) -> bool:
+    normalized = name.strip().casefold()
+    if not normalized:
+        return False
+    for profile_id, profile in profiles.items():
+        if profile_id == exclude_profile_id:
+            continue
+        if not isinstance(profile, dict):
+            continue
+        if str(profile.get("name", "") or profile_id).strip().casefold() == normalized:
+            return True
+    return False
+
+
+def _clear_active_model_profile(cfg: Dict[str, Any]) -> None:
+    """Direct model edits make the current routing diverge from any saved profile."""
+    if cfg.get("active_model_profile"):
+        cfg["active_model_profile"] = ""
+
+
 @app.get("/api/model/options")
 def get_model_options():
     """Return authenticated providers + their curated model lists.
@@ -2361,6 +2566,153 @@ def get_auxiliary_models():
         raise HTTPException(status_code=500, detail="Failed to read auxiliary config")
 
 
+@app.get("/api/model/profiles")
+def get_model_profiles():
+    """Return saved main+auxiliary model routing profiles."""
+    try:
+        cfg = load_config()
+        profiles = cfg.get("model_profiles", {})
+        if not isinstance(profiles, dict):
+            profiles = {}
+        active = str(cfg.get("active_model_profile", "") or "")
+        return {
+            "active": active if active in profiles else "",
+            "profiles": [
+                _model_profile_payload(profile_id, profile)
+                for profile_id, profile in profiles.items()
+            ],
+        }
+    except Exception:
+        _log.exception("GET /api/model/profiles failed")
+        raise HTTPException(status_code=500, detail="Failed to read model profiles")
+
+
+@app.post("/api/model/profiles")
+async def create_model_profile(body: ModelProfileCreate):
+    """Save the current main+auxiliary routing as a model profile."""
+    name = (body.name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name required")
+
+    try:
+        cfg = load_config()
+        profiles = _model_profile_store(cfg)
+        if _profile_name_exists(profiles, name):
+            raise HTTPException(status_code=409, detail="model profile name already exists")
+        profile_id = _unique_model_profile_id(profiles, body.profile_id or name)
+        profiles[profile_id] = _model_profile_snapshot_from_routing(
+            body.routing, fallback_cfg=cfg, name=name
+        )
+        cfg["active_model_profile"] = profile_id
+        cfg["model_profiles"] = profiles
+        save_config(cfg)
+        return {
+            "ok": True,
+            "active": profile_id,
+            "profile": _model_profile_payload(profile_id, profiles[profile_id]),
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/model/profiles failed")
+        raise HTTPException(status_code=500, detail="Failed to save model profile")
+
+
+@app.post("/api/model/profiles/{profile_id}/apply")
+async def apply_model_profile(profile_id: str):
+    """Apply a saved model profile to the current top-level model routing."""
+    try:
+        cfg = load_config()
+        profiles = cfg.get("model_profiles", {})
+        if not isinstance(profiles, dict) or profile_id not in profiles:
+            raise HTTPException(status_code=404, detail="model profile not found")
+        profile = profiles.get(profile_id)
+        if not isinstance(profile, dict):
+            raise HTTPException(status_code=400, detail="model profile is invalid")
+
+        model_cfg = profile.get("model", "")
+        cfg["model"] = copy.deepcopy(model_cfg) if isinstance(model_cfg, (dict, str)) else ""
+
+        auxiliary_cfg = profile.get("auxiliary", {})
+        if isinstance(auxiliary_cfg, dict):
+            cfg["auxiliary"] = copy.deepcopy(auxiliary_cfg)
+
+        cfg["active_model_profile"] = profile_id
+        save_config(cfg)
+        return {
+            "ok": True,
+            "active": profile_id,
+            "profile": _model_profile_payload(profile_id, profile),
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/model/profiles/%s/apply failed", profile_id)
+        raise HTTPException(status_code=500, detail="Failed to apply model profile")
+
+
+@app.put("/api/model/profiles/{profile_id}")
+async def update_model_profile(profile_id: str, body: ModelProfileUpdate):
+    """Rename a model profile, or replace its routing with the current config."""
+    try:
+        cfg = load_config()
+        profiles = cfg.get("model_profiles", {})
+        if not isinstance(profiles, dict) or profile_id not in profiles:
+            raise HTTPException(status_code=404, detail="model profile not found")
+        current = profiles.get(profile_id)
+        if not isinstance(current, dict):
+            current = {}
+
+        name = (body.name or "").strip() or str(current.get("name", "") or profile_id)
+        if _profile_name_exists(profiles, name, exclude_profile_id=profile_id):
+            raise HTTPException(status_code=409, detail="model profile name already exists")
+
+        if body.routing is not None:
+            profiles[profile_id] = _model_profile_snapshot_from_routing(
+                body.routing, fallback_cfg=cfg, name=name
+            )
+        elif body.from_current:
+            profiles[profile_id] = _current_model_profile_snapshot(cfg, name=name)
+        else:
+            current["name"] = name
+            profiles[profile_id] = current
+
+        cfg["model_profiles"] = profiles
+        save_config(cfg)
+        return {
+            "ok": True,
+            "active": str(cfg.get("active_model_profile", "") or ""),
+            "profile": _model_profile_payload(profile_id, profiles[profile_id]),
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("PUT /api/model/profiles/%s failed", profile_id)
+        raise HTTPException(status_code=500, detail="Failed to update model profile")
+
+
+@app.delete("/api/model/profiles/{profile_id}")
+async def delete_model_profile(profile_id: str):
+    """Delete a saved model profile without changing the current routing."""
+    try:
+        cfg = load_config()
+        profiles = cfg.get("model_profiles", {})
+        if not isinstance(profiles, dict) or profile_id not in profiles:
+            raise HTTPException(status_code=404, detail="model profile not found")
+
+        profiles.pop(profile_id, None)
+        cfg["model_profiles"] = profiles
+        if str(cfg.get("active_model_profile", "") or "") == profile_id:
+            cfg["active_model_profile"] = ""
+        save_config(cfg)
+        return {"ok": True, "active": str(cfg.get("active_model_profile", "") or "")}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("DELETE /api/model/profiles/%s failed", profile_id)
+        raise HTTPException(status_code=500, detail="Failed to delete model profile")
+
+
 @app.post("/api/model/set")
 async def set_model_assignment(body: ModelAssignment):
     """Assign a model to the main slot or an auxiliary task slot.
@@ -2418,6 +2770,7 @@ async def set_model_assignment(body: ModelAssignment):
                     # must never block saving the model assignment.
                     _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
 
+            _clear_active_model_profile(cfg)
             save_config(cfg)
 
             # Surface auxiliary slots still pinned to a *different* provider than
@@ -2474,6 +2827,7 @@ async def set_model_assignment(body: ModelAssignment):
                 slot_cfg["model"] = ""
                 aux[slot] = slot_cfg
             cfg["auxiliary"] = aux
+            _clear_active_model_profile(cfg)
             save_config(cfg)
             return {"ok": True, "scope": "auxiliary", "reset": True}
 
@@ -2492,6 +2846,7 @@ async def set_model_assignment(body: ModelAssignment):
             aux[slot] = slot_cfg
 
         cfg["auxiliary"] = aux
+        _clear_active_model_profile(cfg)
         save_config(cfg)
         return {
             "ok": True,

--- a/tests/hermes_cli/test_model_profiles_api.py
+++ b/tests/hermes_cli/test_model_profiles_api.py
@@ -1,0 +1,141 @@
+"""Tests for dashboard model profile presets."""
+
+from starlette.testclient import TestClient
+
+
+def _test_client():
+    from hermes_cli import web_server
+
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+    client.headers.update({web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN})
+    return client
+
+
+def test_model_profile_save_apply_and_active_sync():
+    from hermes_cli.config import load_config, save_config
+
+    save_config(
+        {
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
+            "auxiliary": {
+                "compression": {"provider": "minimax-oneai-openai", "model": "MiniMax-M3"},
+            },
+        }
+    )
+
+    client = _test_client()
+
+    created = client.post("/api/model/profiles", json={"name": "Stable Codex"})
+    assert created.status_code == 200
+    assert created.json()["profile"]["id"] == "stable-codex"
+    assert {
+        "task": "compression",
+        "provider": "minimax-oneai-openai",
+        "model": "MiniMax-M3",
+        "base_url": "",
+    } in created.json()["profile"]["auxiliary"]
+
+    duplicate = client.post("/api/model/profiles", json={"name": " stable codex "})
+    assert duplicate.status_code == 409
+
+    changed = client.post(
+        "/api/model/set",
+        json={
+            "scope": "main",
+            "provider": "deepseek",
+            "model": "deepseek-chat",
+        },
+    )
+    assert changed.status_code == 200
+
+    applied = client.post("/api/model/profiles/stable-codex/apply")
+    assert applied.status_code == 200
+
+    cfg = load_config()
+    assert cfg["active_model_profile"] == "stable-codex"
+    assert cfg["model"]["provider"] == "openai-codex"
+    assert cfg["model"]["default"] == "gpt-5.4"
+    assert cfg["auxiliary"]["compression"]["provider"] == "minimax-oneai-openai"
+
+    updated_aux = client.post(
+        "/api/model/set",
+        json={
+            "scope": "auxiliary",
+            "task": "compression",
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+        },
+    )
+    assert updated_aux.status_code == 200
+
+    cfg = load_config()
+    saved_profile = cfg["model_profiles"]["stable-codex"]
+    assert cfg["active_model_profile"] == ""
+    assert saved_profile["auxiliary"]["compression"]["provider"] == "minimax-oneai-openai"
+    assert saved_profile["auxiliary"]["compression"]["model"] == "MiniMax-M3"
+
+    saved = client.put("/api/model/profiles/stable-codex", json={"from_current": True})
+    assert saved.status_code == 200
+
+    cfg = load_config()
+    saved_profile = cfg["model_profiles"]["stable-codex"]
+    assert saved_profile["auxiliary"]["compression"]["provider"] == "openai-codex"
+    assert saved_profile["auxiliary"]["compression"]["model"] == "gpt-5.4"
+
+
+def test_model_profile_create_and_update_from_routing_payload():
+    from hermes_cli.config import load_config, save_config
+
+    save_config(
+        {
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
+            "auxiliary": {},
+        }
+    )
+
+    client = _test_client()
+
+    routing = {
+        "main": {"provider": "deepseek", "model": "deepseek-chat"},
+        "auxiliary": [
+            {"task": "vision", "provider": "openai-codex", "model": "gpt-5.5"},
+            {"task": "compression", "provider": "auto", "model": ""},
+        ],
+    }
+    created = client.post(
+        "/api/model/profiles",
+        json={"name": "Draft Routing", "routing": routing},
+    )
+    assert created.status_code == 200
+
+    cfg = load_config()
+    saved_profile = cfg["model_profiles"]["draft-routing"]
+    assert saved_profile["model"]["provider"] == "deepseek"
+    assert saved_profile["model"]["default"] == "deepseek-chat"
+    assert saved_profile["auxiliary"]["vision"]["provider"] == "openai-codex"
+    assert saved_profile["auxiliary"]["vision"]["model"] == "gpt-5.5"
+
+    next_routing = {
+        "main": {"provider": "minimax-oneai-openai", "model": "MiniMax-M3"},
+        "auxiliary": [
+            {"task": "web_extract", "provider": "deepseek", "model": "deepseek-chat"},
+        ],
+    }
+    updated = client.put(
+        "/api/model/profiles/draft-routing",
+        json={"routing": next_routing},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["profile"]["main"] == {
+        "provider": "minimax-oneai-openai",
+        "model": "MiniMax-M3",
+    }
+    assert {
+        "task": "web_extract",
+        "provider": "deepseek",
+        "model": "deepseek-chat",
+        "base_url": "",
+    } in updated.json()["profile"]["auxiliary"]


### PR DESCRIPTION
Draft implementation for #38927.

## Summary

This adds lightweight model profiles inside a single Hermes profile. A model profile stores a named snapshot of the current main model routing plus auxiliary model assignments, without switching the full `HERMES_HOME` profile.

The goal is to let users quickly switch between model-routing combinations while keeping sessions, memories, skills, provider definitions, OAuth state, and API keys shared.

## Behavior

The Model settings page treats the visible model routing as an editable draft.

Users can:
- manually choose a main provider/model and auxiliary model assignments, then click Apply without creating a profile
- select a saved profile to load its saved routing into the visible draft
- click Apply profile to apply the currently visible draft routing
- click Update profile to persist the currently visible draft back into the selected profile
- click Save as profile to save the currently visible draft as a new profile

If a user selects a profile, edits the visible routing, and clicks Apply profile without clicking Update profile, Hermes applies the edited draft routing but does not overwrite the saved profile.

Save as profile rejects duplicate profile names.

## What changed

- Add optional config keys:
  - `active_model_profile`
  - `model_profiles`
- Add REST endpoints for model profiles:
  - `GET /api/model/profiles`
  - `POST /api/model/profiles`
  - `POST /api/model/profiles/{id}/apply`
  - `PUT /api/model/profiles/{id}`
  - `DELETE /api/model/profiles/{id}`
- Add a Desktop Model settings section for:
  - saving the current main + auxiliary routing as a profile
  - applying a saved profile
  - updating a saved profile from the current routing
  - deleting a profile
- Add API regression coverage for save/apply/update behavior.

## Scope

This is intentionally scoped to global/default model routing for new sessions, matching the existing Desktop Model settings behavior.

This does not replace the existing full Hermes profile system. Full Hermes profiles still isolate sessions, memory, skills, config, and runtime state. Model profiles only store `model` and `auxiliary` routing snapshots.

## Notes

- Model profiles do not copy secrets, provider definitions, OAuth state, or API keys.
- Directly editing the main model or auxiliary assignments clears the active model-profile marker, so saved profiles are not silently overwritten.
- Naming is open to maintainer preference: `model_profiles`, `model_presets`, or `routing_presets`.

Closes #38927

