### PR TITLE
fix(windows-tests): address parallel runner encoding and symlink privilege errors

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -599,6 +599,14 @@ def _slice_files(
 
 
 def main() -> int:
+    # Reconfigure stdout/stderr to UTF-8 to prevent UnicodeEncodeError on Windows
+    # when printing checkmarks/crosses and box-drawing symbols.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:
+                pass
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -76,6 +76,7 @@ class TestWorktreeIncludeSecurity:
         finally:
             _force_remove_worktree(info)
 
+    @pytest.mark.require_symlinks
     def test_rejects_symlink_that_resolves_outside_repo(self, git_repo):
         import cli as cli_mod
 
@@ -110,6 +111,7 @@ class TestWorktreeIncludeSecurity:
         finally:
             _force_remove_worktree(info)
 
+    @pytest.mark.require_symlinks
     def test_allows_valid_directory_include(self, git_repo):
         import cli as cli_mod
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ test runner at ``scripts/run_tests.sh``.
 
 import asyncio
 import os
+
 import sys
 from pathlib import Path
 
@@ -533,6 +534,37 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         "(only for tests that genuinely need real os.kill / subprocess "
         "behaviour — e.g. PTY tests that signal their own child).",
     )
+    config.addinivalue_line(
+        "markers",
+        "require_symlinks: skip the test if symbolic links cannot be created in the current environment.",
+    )
+
+
+_symlink_supported_cache = None
+
+def _check_symlink_support() -> bool:
+    global _symlink_supported_cache
+    if _symlink_supported_cache is not None:
+        return _symlink_supported_cache
+
+    import tempfile
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.touch()
+            lnk = Path(d) / "lnk"
+            lnk.symlink_to(src)
+            _symlink_supported_cache = True
+            return True
+    except OSError:
+        _symlink_supported_cache = False
+        return False
+
+
+def pytest_runtest_setup(item):
+    if item.get_closest_marker("require_symlinks"):
+        if not _check_symlink_support():
+            pytest.skip("Environment does not support symbolic links (requires admin/developer mode on Windows)")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -37,6 +37,7 @@ def _write_tmp(dir_: Path, content: str) -> Path:
     return tmp
 
 
+@pytest.mark.require_symlinks
 def test_atomic_replace_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.yaml"
     link = tmp_path / "link.yaml"
@@ -94,6 +95,7 @@ def test_atomic_replace_accepts_pathlike_and_str(tmp_path: Path) -> None:
 # ─── atomic_json_write / atomic_yaml_write wiring ──────────────────────────
 
 
+@pytest.mark.require_symlinks
 def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.json"
     link = tmp_path / "link.json"
@@ -107,6 +109,7 @@ def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     assert loaded == {"hello": "world"}
 
 
+@pytest.mark.require_symlinks
 def test_atomic_yaml_write_preserves_symlink(tmp_path: Path) -> None:
     real = tmp_path / "real.yaml"
     link = tmp_path / "link.yaml"
@@ -120,6 +123,7 @@ def test_atomic_yaml_write_preserves_symlink(tmp_path: Path) -> None:
     assert data == {"model": {"provider": "openrouter"}}
 
 
+@pytest.mark.require_symlinks
 def test_atomic_json_write_preserves_symlink_permissions(tmp_path: Path) -> None:
     """Symlinked targets keep the real file's permission bits."""
     if os.name != "posix":
@@ -141,6 +145,7 @@ def test_atomic_json_write_preserves_symlink_permissions(tmp_path: Path) -> None
 # ─── Broken-symlink edge case ─────────────────────────────────────────────
 
 
+@pytest.mark.require_symlinks
 def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
     """A symlink pointing at a missing file: the write should create the
     real target (resolving via realpath) rather than leaving the dangling

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -277,6 +277,7 @@ class TestSecureParentDir:
         # Should not raise
         secure_parent_dir(target)
 
+    @pytest.mark.require_symlinks
     def test_symlink_resolved(self, tmp_path, monkeypatch):
         """Symlinks should be resolved before checking depth."""
         real_dir = tmp_path / "a" / "b"


### PR DESCRIPTION
This PR addresses Windows compatibility test failures (Fixes #39480). It keeps the parallel-runner encoding fix and the symlink privilege handling, but drops the obsolete timeout edit and cosmetic churn as requested by reviewers.