### PR TITLE
feat(desktop): hide noisy session sources from the dashboard list

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1346,6 +1346,13 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
+        # Session sources hidden from the desktop dashboard's session list
+        # (GET /api/sessions). Defaults to ["tool"] so internal sub-agent runs
+        # stay out of the human-facing browser, matching the TUI resume
+        # picker. Add "cron" here to also hide scheduled-job sessions, which
+        # can otherwise dominate the list for heavy cron users. Hidden rows
+        # remain in the DB and are still reachable via full-text search.
+        "session_list_exclude_sources": ["tool"],
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
         # Which interface bare `hermes` (and `hermes chat`) launches by default:
         #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1555,6 +1555,31 @@ async def get_action_status(name: str, lines: int = 200):
     }
 
 
+def _normalize_exclude_sources(value: Any) -> List[str]:
+    """Coerce the display.session_list_exclude_sources config value to a list.
+
+    The config is normally a YAML list (``["tool", "cron"]``), but
+    ``hermes config set display.session_list_exclude_sources '["tool","cron"]'``
+    stores it as a JSON-ish string. Accept both — and a bare comma-separated
+    string — so a string value can't get iterated character-by-character into
+    a broken ``source NOT IN ('[', '"', 't', ...)`` query.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            parsed = [part.strip() for part in text.split(",")]
+        value = parsed if isinstance(parsed, list) else [parsed]
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
 @app.get("/api/sessions")
 async def get_sessions(
     limit: int = 20,
@@ -1592,15 +1617,29 @@ async def get_sessions(
             min_message_count = max(0, min_messages)
             archived_only = archived == "only"
             include_archived = archived == "include"
+            # Hide noisy/internal session sources (default: "tool" sub-agent
+            # runs) from the human-facing browser. Users can add "cron" here to
+            # also drop scheduled-job sessions, which can otherwise dominate the
+            # list. Hidden rows stay in the DB and remain full-text searchable.
+            exclude_sources = _normalize_exclude_sources(
+                cfg_get(
+                    load_config(),
+                    "display",
+                    "session_list_exclude_sources",
+                    default=["tool"],
+                )
+            )
             sessions = db.list_sessions_rich(
                 limit=limit,
                 offset=offset,
+                exclude_sources=exclude_sources,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
             )
             total = db.session_count(
+                exclude_sources=exclude_sources,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3189,6 +3189,7 @@ class SessionDB:
     def session_count(
         self,
         source: str = None,
+        exclude_sources: List[str] = None,
         min_message_count: int = 0,
         include_archived: bool = False,
         archived_only: bool = False,
@@ -3202,6 +3203,10 @@ class SessionDB:
         is paired with a ``list_sessions_rich`` page (e.g. sidebar "load more"
         totals) so the total matches the number of listable rows — otherwise the
         raw row count is inflated by children and "load more" never settles.
+
+        Pass ``exclude_sources`` to drop rows whose source is in the list (e.g.
+        ``["tool", "cron"]``), mirroring ``list_sessions_rich`` so a filtered
+        list and its total agree.
         """
         where_clauses = []
         params = []
@@ -3220,6 +3225,10 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if exclude_sources:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -297,6 +297,99 @@ class TestWebServerEndpoints:
         assert captured["list"] == 3
         assert captured["count"] == 3
 
+    def test_get_sessions_forwards_exclude_sources_from_config(self, monkeypatch):
+        """display.session_list_exclude_sources must reach both the list query
+        and the total count so the desktop browser hides the configured
+        sources (e.g. cron) and pagination stays consistent."""
+        captured = {}
+
+        class _FakeDB:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def list_sessions_rich(self, exclude_sources=None, **kwargs):
+                captured["list"] = exclude_sources
+                return []
+
+            def session_count(self, exclude_sources=None, **kwargs):
+                captured["count"] = exclude_sources
+                return 0
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
+        monkeypatch.setattr(
+            "hermes_cli.web_server.load_config",
+            lambda: {"display": {"session_list_exclude_sources": ["tool", "cron"]}},
+        )
+
+        resp = self.client.get("/api/sessions")
+        assert resp.status_code == 200
+        assert captured["list"] == ["tool", "cron"]
+        assert captured["count"] == ["tool", "cron"]
+
+    def test_get_sessions_exclude_sources_defaults_to_tool(self, monkeypatch):
+        """With no config override, the default excludes only ``tool`` so
+        internal sub-agent runs stay hidden (matching the TUI picker) while
+        every other source surfaces."""
+        captured = {}
+
+        class _FakeDB:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def list_sessions_rich(self, exclude_sources=None, **kwargs):
+                captured["list"] = exclude_sources
+                return []
+
+            def session_count(self, exclude_sources=None, **kwargs):
+                captured["count"] = exclude_sources
+                return 0
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
+        monkeypatch.setattr("hermes_cli.web_server.load_config", lambda: {})
+
+        resp = self.client.get("/api/sessions")
+        assert resp.status_code == 200
+        assert captured["list"] == ["tool"]
+        assert captured["count"] == ["tool"]
+
+    def test_get_sessions_coerces_string_exclude_sources(self, monkeypatch):
+        """``hermes config set`` stores the list as a JSON-ish string. The
+        handler must coerce it to a real list so it isn't iterated
+        character-by-character into a broken NOT IN query."""
+        captured = {}
+
+        class _FakeDB:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def list_sessions_rich(self, exclude_sources=None, **kwargs):
+                captured["list"] = exclude_sources
+                return []
+
+            def session_count(self, exclude_sources=None, **kwargs):
+                captured["count"] = exclude_sources
+                return 0
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
+        monkeypatch.setattr(
+            "hermes_cli.web_server.load_config",
+            lambda: {"display": {"session_list_exclude_sources": '["tool","cron"]'}},
+        )
+
+        resp = self.client.get("/api/sessions")
+        assert resp.status_code == 200
+        assert captured["list"] == ["tool", "cron"]
+        assert captured["count"] == ["tool", "cron"]
+
     def test_rename_session_updates_title(self):
         """PATCH /api/sessions/{id} renames a session (regression: the route
         was missing entirely, so the desktop rename dialog got a 405)."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1309,6 +1309,18 @@ class TestCounts:
         assert db.session_count(source="cli") == 2
         assert db.session_count(source="telegram") == 1
 
+    def test_session_count_exclude_sources(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cron")
+        db.create_session(session_id="s3", source="tool")
+        db.create_session(session_id="s4", source="telegram")
+        # Excluding cron + tool leaves cli + telegram.
+        assert db.session_count(exclude_sources=["cron", "tool"]) == 2
+        assert db.session_count(exclude_sources=["cron"]) == 3
+        # Empty / None means no exclusion.
+        assert db.session_count(exclude_sources=[]) == 4
+        assert db.session_count(exclude_sources=None) == 4
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Problem

The desktop Sessions browser (`GET /api/sessions`) lists every session source unfiltered. For heavy cron users this means scheduled-job runs dominate the list. On one real install that's 20k+ cron sessions out of ~21.7k total, burying a few hundred actual conversations, with no way to filter them out. The TUI resume picker already deny-lists the internal `tool` source, but the desktop never gained an equivalent.

## Change

Adds a `display.session_list_exclude_sources` config key (default `["tool"]`) that the `/api/sessions` handler applies to both the row query and the total count.

- Default `["tool"]` hides internal sub-agent runs, matching the TUI resume picker.
- Users can set it to e.g. `["tool", "cron"]` to also drop scheduled-job sessions.
- Hidden rows stay in the DB and remain reachable via full-text search and `hermes sessions` CLI commands. This is a display filter, not a delete.

## Details

- `hermes_cli/config.py`: new `display.session_list_exclude_sources` default `["tool"]`. The settings-UI schema picks it up automatically as a list field via the existing `_infer_type` path.
- `hermes_state.py`: `session_count()` gains an `exclude_sources` param mirroring `list_sessions_rich()`, so a filtered list and its total stay consistent for pagination. Purely additive; all existing callers are unaffected.
- `hermes_cli/web_server.py`: `/api/sessions` reads the config key once and forwards it to both `list_sessions_rich()` and `session_count()`.
- `hermes config set` stores the list as a JSON-ish string, so the handler normalizes the config value (JSON list, comma-separated string, or real list) before use, preventing a string from being iterated character-by-character into a broken `NOT IN` query.

## Tests

- `tests/test_hermes_state.py`: `session_count(exclude_sources=...)` filtering, including empty/None means no exclusion.
- `tests/hermes_cli/test_web_server.py`: handler forwards the configured sources to both list and count, and defaults to `["tool"]` with no override.

Targeted suites green:

```
tests/test_hermes_state.py tests/hermes_cli/test_web_server.py tests/gateway/test_session_list_allowed_sources.py
499 passed
```

`ruff check` and `ruff format --check` clean on all changed lines.
