### PR TITLE
fix(desktop): validate remote gateway websocket readiness

### DIFF
--- a/apps/desktop/electron/gateway-ws-probe.cjs
+++ b/apps/desktop/electron/gateway-ws-probe.cjs
@@ -1,0 +1,120 @@
+/**
+ * gateway-ws-probe.cjs
+ *
+ * Lightweight live-WebSocket probe for Hermes Desktop remote gateway checks.
+ * `/api/status` alone is not enough to prove the desktop can actually chat:
+ * the renderer opens a separate `/api/ws` socket, so a remote URL that points
+ * at an API-only endpoint (for example `/v1`) can look "ready" while the live
+ * gateway socket is unusable. This helper verifies the socket opens and stays
+ * open briefly before the desktop declares the remote gateway ready.
+ */
+
+const DEFAULT_GATEWAY_WS_PROBE_TIMEOUT_MS = 3_000
+const DEFAULT_GATEWAY_WS_STABLE_MS = 250
+
+function resolveProbeTiming(value, fallback) {
+  const num = Number(value)
+  return Number.isFinite(num) && num > 0 ? Math.floor(num) : fallback
+}
+
+function closeReason(event) {
+  if (!event || typeof event !== 'object') {
+    return 'unknown close event'
+  }
+
+  const code = Number.isFinite(event.code) ? `code ${event.code}` : 'unknown code'
+  const reason = typeof event.reason === 'string' && event.reason.trim() ? `: ${event.reason.trim()}` : ''
+  return `${code}${reason}`
+}
+
+function eventError(event) {
+  if (event?.error instanceof Error) {
+    return event.error
+  }
+
+  if (event instanceof Error) {
+    return event
+  }
+
+  return new Error('WebSocket connection failed before the gateway became usable.')
+}
+
+function probeGatewayWebSocket(wsUrl, options = {}) {
+  const target = String(wsUrl || '').trim()
+
+  if (!target) {
+    throw new Error('Gateway WebSocket URL is required.')
+  }
+
+  const WebSocketImpl = options.WebSocketImpl || globalThis.WebSocket
+
+  if (typeof WebSocketImpl !== 'function') {
+    throw new Error('WebSocket is unavailable in this runtime.')
+  }
+
+  const timeoutMs = resolveProbeTiming(options.timeoutMs, DEFAULT_GATEWAY_WS_PROBE_TIMEOUT_MS)
+  const stableMs = resolveProbeTiming(options.stableMs, DEFAULT_GATEWAY_WS_STABLE_MS)
+
+  return new Promise((resolve, reject) => {
+    let socket
+    let settled = false
+    let deadlineTimer = null
+    let stableTimer = null
+
+    const clearTimers = () => {
+      if (deadlineTimer) clearTimeout(deadlineTimer)
+      if (stableTimer) clearTimeout(stableTimer)
+      deadlineTimer = null
+      stableTimer = null
+    }
+
+    const finish = error => {
+      if (settled) return
+      settled = true
+      clearTimers()
+
+      try {
+        if (socket && socket.readyState < WebSocketImpl.CLOSING) {
+          socket.close(1000, 'probe-complete')
+        }
+      } catch {
+        // Best-effort cleanup only.
+      }
+
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+
+    try {
+      socket = new WebSocketImpl(target)
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+      return
+    }
+
+    deadlineTimer = setTimeout(() => {
+      finish(new Error(`Timed out opening live gateway WebSocket after ${timeoutMs}ms.`))
+    }, timeoutMs)
+
+    socket.onopen = () => {
+      stableTimer = setTimeout(() => finish(null), stableMs)
+    }
+
+    socket.onerror = event => {
+      finish(eventError(event))
+    }
+
+    socket.onclose = event => {
+      finish(new Error(`Gateway WebSocket closed before becoming stable (${closeReason(event)}).`))
+    }
+  })
+}
+
+module.exports = {
+  DEFAULT_GATEWAY_WS_PROBE_TIMEOUT_MS,
+  DEFAULT_GATEWAY_WS_STABLE_MS,
+  probeGatewayWebSocket
+}

--- a/apps/desktop/electron/gateway-ws-probe.test.cjs
+++ b/apps/desktop/electron/gateway-ws-probe.test.cjs
@@ -1,0 +1,107 @@
+const assert = require('node:assert/strict')
+const crypto = require('node:crypto')
+const http = require('node:http')
+const test = require('node:test')
+
+const {
+  DEFAULT_GATEWAY_WS_PROBE_TIMEOUT_MS,
+  DEFAULT_GATEWAY_WS_STABLE_MS,
+  probeGatewayWebSocket
+} = require('./gateway-ws-probe.cjs')
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  return server.address().port
+}
+
+function closeServer(server) {
+  return new Promise(resolve => server.close(() => resolve()))
+}
+
+function acceptWebSocket(req, socket) {
+  const key = req.headers['sec-websocket-key']
+  const accept = crypto
+    .createHash('sha1')
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`, 'utf8')
+    .digest('base64')
+
+  socket.write(
+    [
+      'HTTP/1.1 101 Switching Protocols',
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      `Sec-WebSocket-Accept: ${accept}`,
+      '',
+      ''
+    ].join('\r\n')
+  )
+}
+
+test('probeGatewayWebSocket resolves once the socket stays open briefly', async t => {
+  const server = http.createServer()
+  t.after(async () => closeServer(server))
+
+  server.on('upgrade', (req, socket) => {
+    acceptWebSocket(req, socket)
+    socket.on('data', () => socket.end())
+    socket.on('end', () => socket.destroy())
+  })
+
+  const port = await listen(server)
+  await assert.doesNotReject(
+    probeGatewayWebSocket(`ws://127.0.0.1:${port}/api/ws?token=test`, {
+      timeoutMs: 1_000,
+      stableMs: 50
+    })
+  )
+})
+
+test('probeGatewayWebSocket rejects when the endpoint is not a websocket route', async t => {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(404)
+    res.end('no ws here')
+  })
+  t.after(async () => closeServer(server))
+
+  const port = await listen(server)
+
+  await assert.rejects(
+    probeGatewayWebSocket(`ws://127.0.0.1:${port}/api/ws?token=test`, {
+      timeoutMs: 1_000,
+      stableMs: 50
+    }),
+    error => error instanceof Error
+  )
+})
+
+test('probeGatewayWebSocket rejects when the socket closes immediately after upgrade', async t => {
+  const server = http.createServer()
+  t.after(async () => closeServer(server))
+
+  server.on('upgrade', (req, socket) => {
+    acceptWebSocket(req, socket)
+    socket.end()
+  })
+
+  const port = await listen(server)
+
+  await assert.rejects(
+    probeGatewayWebSocket(`ws://127.0.0.1:${port}/api/ws?token=test`, {
+      timeoutMs: 1_000,
+      stableMs: 150
+    }),
+    error => error instanceof Error
+  )
+})
+
+test('probe defaults stay positive', () => {
+  assert.equal(DEFAULT_GATEWAY_WS_PROBE_TIMEOUT_MS > 0, true)
+  assert.equal(DEFAULT_GATEWAY_WS_STABLE_MS > 0, true)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -44,6 +44,7 @@ const {
   resolveReadableFileForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 
 let nodePty = null
 
@@ -2740,6 +2741,22 @@ async function waitForHermes(baseUrl, token) {
   throw new Error(`Hermes backend did not become ready: ${lastError?.message || 'timeout'}`)
 }
 
+async function verifyRemoteGatewaySocket(connection) {
+  try {
+    await probeGatewayWebSocket(connection.wsUrl, {
+      stableMs: 250,
+      timeoutMs: 3_000
+    })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Hermes Desktop reached ${connection.baseUrl}/api/status but could not open the live gateway WebSocket at /api/ws. ` +
+        `Use the Hermes dashboard base URL, not an API-only /v1 or /health endpoint, and make sure the remote gateway accepts desktop WebSocket connections. ` +
+        `Probe error: ${detail}`
+    )
+  }
+}
+
 function getWindowButtonPosition() {
   if (!IS_MAC) return null
   return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
@@ -3747,17 +3764,38 @@ async function testDesktopConnectionConfig(input = {}) {
   // for local we fall back to the resolved/started backend.
   let baseUrl
   let token = null
+  let remote = null
   if (config.mode === 'remote') {
     baseUrl = normalizeRemoteBaseUrl(config.remote.url)
-    if ((config.remote.authMode || 'token') !== 'oauth') {
+    if ((config.remote.authMode || 'token') === 'oauth') {
+      if (!(await hasOauthSessionCookie(baseUrl))) {
+        throw new Error('Remote Hermes gateway uses OAuth, but you are not signed in yet.')
+      }
+      const ticket = await mintGatewayWsTicket(baseUrl)
+      remote = {
+        authMode: 'oauth',
+        baseUrl,
+        token: null,
+        wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket)
+      }
+    } else {
       token = decryptDesktopSecret(config.remote.token)
+      remote = {
+        authMode: 'token',
+        baseUrl,
+        token,
+        wsUrl: buildGatewayWsUrl(baseUrl, token)
+      }
     }
   } else {
-    const remote = (await resolveRemoteBackend()) || (await startHermes())
+    remote = (await resolveRemoteBackend()) || (await startHermes())
     baseUrl = remote.baseUrl
     token = remote.token
   }
   const status = await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000 })
+  if (config.mode === 'remote') {
+    await verifyRemoteGatewaySocket(remote)
+  }
 
   return {
     ok: true,
@@ -4014,6 +4052,7 @@ async function startHermes() {
     if (remote) {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
       await waitForHermes(remote.baseUrl, remote.token)
+      await verifyRemoteGatewaySocket(remote)
       updateBootProgress({
         phase: 'backend.ready',
         message: 'Remote Hermes backend is ready',

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
- treat remote Hermes Desktop readiness as `/api/status` plus a live `/api/ws` probe, so API-only endpoints stop being reported as usable remote gateways
- reuse the same live websocket validation in Settings → Gateway → Test remote to keep runtime boot and manual testing aligned
- add a focused desktop electron probe test and wire it into `test:desktop:platforms`

## Testing
- `/opt/homebrew/opt/node/bin/node --test electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs`
- `/opt/homebrew/opt/node/bin/node --check electron/main.cjs`
- `/opt/homebrew/opt/node/bin/node --check electron/gateway-ws-probe.cjs`
- `/opt/homebrew/opt/node/bin/node --check electron/gateway-ws-probe.test.cjs`
- `git diff --check`

Fixes #38873.
