### PR TITLE
fix(skills): accept content fallback in skill_manage

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -545,6 +545,57 @@ class TestSkillManageDispatcher:
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
 
+    def test_create_via_dispatcher_accepts_file_content_fallback(self, tmp_path):
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                file_content=VALID_SKILL_CONTENT,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (tmp_path / "test-skill" / "SKILL.md").exists()
+
+    def test_edit_via_dispatcher_accepts_file_content_fallback(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
+            raw = skill_manage(
+                action="edit",
+                name="test-skill",
+                file_content=VALID_SKILL_CONTENT_2,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Updated description" in (tmp_path / "test-skill" / "SKILL.md").read_text()
+
+    def test_write_file_via_dispatcher_accepts_content_fallback(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
+            raw = skill_manage(
+                action="write_file",
+                name="test-skill",
+                file_path="references/api.md",
+                content="# API\nEndpoint docs.",
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (
+            tmp_path / "test-skill" / "references" / "api.md"
+        ).read_text() == "# API\nEndpoint docs."
+
+    def test_write_file_via_dispatcher_allows_empty_content_fallback(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
+            raw = skill_manage(
+                action="write_file",
+                name="test-skill",
+                file_path="references/empty.md",
+                content="",
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (tmp_path / "test-skill" / "references" / "empty.md").read_text() == ""
+
     def test_create_from_background_review_marks_agent_created(self, tmp_path):
         """Background-review fork creates ARE marked as agent-created."""
         from tools.skill_provenance import set_current_write_origin, BACKGROUND_REVIEW

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -831,14 +831,16 @@ def skill_manage(
     Returns JSON string with results.
     """
     if action == "create":
-        if not content:
+        skill_content = content or file_content
+        if not skill_content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+        result = _create_skill(name, skill_content, category)
 
     elif action == "edit":
-        if not content:
+        skill_content = content or file_content
+        if not skill_content:
             return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
-        result = _edit_skill(name, content)
+        result = _edit_skill(name, skill_content)
 
     elif action == "patch":
         if not old_string:
@@ -853,6 +855,8 @@ def skill_manage(
     elif action == "write_file":
         if not file_path:
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+        if file_content is None:
+            file_content = content
         if file_content is None:
             return tool_error("file_content is required for 'write_file'.", success=False)
         result = _write_file(name, file_path, file_content)


### PR DESCRIPTION
## Summary
- Accept `file_content` as a fallback payload for `create` and `edit` actions.
- Accept `content` as a fallback payload for `write_file` while preserving empty file writes.
- Add dispatcher regression tests for the mixed schema arguments.

## Tests
- `.venv\Scripts\python -m pytest tests\tools\test_skill_manager_tool.py -q -p no:timeout -o addopts=`

Fixes #35736