### PR TITLE
fix(dashboard): self-heal broken uvicorn bootstrap installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12286,6 +12286,76 @@ def _report_dashboard_status() -> int:
     return len(pids)
 
 
+def _probe_dashboard_runtime_import_error() -> "ImportError | None":
+    """Return the dashboard runtime's first import failure, if any.
+
+    ``uvicorn`` can be present but partially broken (for example a corrupt
+    wheel cache can leave ``uvicorn.supervisors`` missing). Probing through
+    ``import_module()`` lets the dashboard distinguish that case from a fully
+    healthy install before it decides whether to self-heal or just print the
+    generic reinstall guidance.
+    """
+    import importlib
+
+    try:
+        importlib.import_module("fastapi")
+        importlib.import_module("uvicorn")
+    except ImportError as exc:
+        return exc
+    return None
+
+
+def _attempt_dashboard_uvicorn_repair(import_error: ImportError) -> bool:
+    """Try a one-shot pip reinstall when the bundled uvicorn install is corrupt."""
+    msg = str(import_error)
+    if "uvicorn" not in msg or "fastapi" in msg:
+        return False
+
+    print(
+        "Detected a broken uvicorn install; attempting a one-time pip repair "
+        "for the dashboard runtime..."
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "--no-cache-dir",
+            "uvicorn[standard]==0.41.0",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        print("Automatic uvicorn repair failed.")
+        if result.stderr.strip():
+            print(result.stderr.strip())
+        elif result.stdout.strip():
+            print(result.stdout.strip())
+        return False
+
+    import importlib
+
+    importlib.invalidate_caches()
+    sys.modules.pop("uvicorn", None)
+    sys.modules.pop("uvicorn.supervisors", None)
+    print("✓ Repaired uvicorn; retrying dashboard startup.")
+    return True
+
+
+def _ensure_dashboard_runtime_deps() -> "ImportError | None":
+    """Return the remaining dashboard import error after any safe self-heal."""
+    import_error = _probe_dashboard_runtime_import_error()
+    if import_error is None:
+        return None
+    if _attempt_dashboard_uvicorn_repair(import_error):
+        return _probe_dashboard_runtime_import_error()
+    return import_error
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     # --status: report running dashboards and exit, no deps needed.
@@ -12314,10 +12384,8 @@ def cmd_dashboard(args):
     except Exception:
         pass
 
-    try:
-        import fastapi  # noqa: F401
-        import uvicorn  # noqa: F401
-    except ImportError as e:
+    import_error = _ensure_dashboard_runtime_deps()
+    if import_error is not None:
         print("Web UI dependencies not installed (need fastapi + uvicorn).")
         print(
             f"Re-install the package into this interpreter so metadata updates apply:\n"
@@ -12325,7 +12393,7 @@ def cmd_dashboard(args):
             f"  {sys.executable} -m pip install -e .\n"
             "If `pip` is missing in this venv, use:  uv pip install -e ."
         )
-        print(f"Import error: {e}")
+        print(f"Import error: {import_error}")
         sys.exit(1)
 
     # Seed bundled skills on first dashboard launch so the desktop GUI's

--- a/tests/hermes_cli/test_dashboard_dependency_repair.py
+++ b/tests/hermes_cli/test_dashboard_dependency_repair.py
@@ -1,0 +1,77 @@
+"""Tests for dashboard dependency self-healing on broken uvicorn installs."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.main import (
+    _attempt_dashboard_uvicorn_repair,
+    _ensure_dashboard_runtime_deps,
+)
+
+
+def test_ensure_dashboard_runtime_deps_repairs_broken_uvicorn_install():
+    calls = {"uvicorn": 0}
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "fastapi":
+            return object()
+        if name == "uvicorn":
+            calls["uvicorn"] += 1
+            if calls["uvicorn"] == 1:
+                raise ImportError("No module named 'uvicorn.supervisors'")
+            return object()
+        return real_import_module(name)
+
+    with patch("importlib.import_module", side_effect=fake_import_module), patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+    ) as mock_run:
+        assert _ensure_dashboard_runtime_deps() is None
+
+    assert calls["uvicorn"] == 2
+    cmd = mock_run.call_args.args[0]
+    assert cmd[1:] == [
+        "-m",
+        "pip",
+        "install",
+        "--force-reinstall",
+        "--no-cache-dir",
+        "uvicorn[standard]==0.41.0",
+    ]
+
+
+def test_ensure_dashboard_runtime_deps_does_not_repair_missing_fastapi():
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "fastapi":
+            raise ImportError("No module named 'fastapi'")
+        return real_import_module(name)
+
+    with patch("importlib.import_module", side_effect=fake_import_module), patch(
+        "subprocess.run"
+    ) as mock_run:
+        error = _ensure_dashboard_runtime_deps()
+
+    assert isinstance(error, ImportError)
+    assert "fastapi" in str(error)
+    mock_run.assert_not_called()
+
+
+def test_attempt_dashboard_uvicorn_repair_reports_failure(capsys):
+    with patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+    ):
+        repaired = _attempt_dashboard_uvicorn_repair(
+            ImportError("No module named 'uvicorn.supervisors'")
+        )
+
+    assert repaired is False
+    out = capsys.readouterr().out
+    assert "Automatic uvicorn repair failed." in out
+    assert "boom" in out


### PR DESCRIPTION
Fixes #39505.

## Summary
- probe the dashboard runtime imports before startup so Hermes can distinguish a broken `uvicorn` install from a healthy environment
- add a one-shot `pip --force-reinstall --no-cache-dir uvicorn[standard]==0.41.0` repair path when `uvicorn` is partially installed
- keep the existing generic reinstall guidance for other dependency failures and cover the new behavior with targeted dashboard dependency tests

## Proof
- `/Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --extra dev pytest -q tests/hermes_cli/test_dashboard_dependency_repair.py tests/hermes_cli/test_dashboard_lifecycle_flags.py`
- `/Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --extra dev ruff check hermes_cli/main.py tests/hermes_cli/test_dashboard_dependency_repair.py`
- `git diff --check`
