### PR TITLE
feat(memory): allow disabling built-in memory toolfeat(memory): allow disabling built-in memory tool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -32,6 +32,7 @@ from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
+from agent.memory_config import builtin_memory_tool_enabled
 from agent.memory_manager import StreamingContextScrubber
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -1064,6 +1065,7 @@ def init_agent(
     agent._memory_store = None
     agent._memory_enabled = False
     agent._user_profile_enabled = False
+    agent._builtin_memory_tool_enabled = builtin_memory_tool_enabled(_agent_cfg)
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0

--- a/agent/memory_config.py
+++ b/agent/memory_config.py
@@ -1,0 +1,22 @@
+"""Helpers for interpreting memory-related config."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def builtin_memory_tool_enabled(config: Mapping[str, Any] | None) -> bool:
+    """Return whether the built-in global memory tool should be exposed.
+
+    The option defaults to enabled for backward compatibility.  Only an
+    explicit ``memory.builtin_tool.enabled: false`` disables the tool.
+    """
+    if not isinstance(config, Mapping):
+        return True
+    memory_config = config.get("memory", {})
+    if not isinstance(memory_config, Mapping):
+        return True
+    builtin_tool = memory_config.get("builtin_tool", {})
+    if not isinstance(builtin_tool, Mapping):
+        return True
+    return bool(builtin_tool.get("enabled", True))

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -473,6 +473,11 @@ memory:
   
   # User profile: preferences, communication style, expectations
   user_profile_enabled: true
+
+  # Built-in global memory tool (writes to MEMORY.md / USER.md).
+  # Set enabled: false to hide this tool while keeping memory providers active.
+  builtin_tool:
+    enabled: true
   
   # Character limits (~2.75 chars per token, model-independent)
   memory_char_limit: 2200   # ~800 tokens

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1639,6 +1639,9 @@ DEFAULT_CONFIG = {
     "memory": {
         "memory_enabled": True,
         "user_profile_enabled": True,
+        "builtin_tool": {
+            "enabled": True,
+        },
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.memory_config import builtin_memory_tool_enabled
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
 
@@ -261,6 +262,30 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+def _load_builtin_memory_tool_enabled() -> bool:
+    """Read the built-in memory tool exposure flag from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        return builtin_memory_tool_enabled(load_config())
+    except Exception:
+        return True
+
+
+def _filter_builtin_memory_tool(
+    tool_defs: List[Dict[str, Any]],
+    *,
+    enabled: bool,
+) -> List[Dict[str, Any]]:
+    """Remove the built-in ``memory`` tool when config disables it."""
+    if enabled:
+        return tool_defs
+    return [
+        tool
+        for tool in tool_defs
+        if tool.get("function", {}).get("name") != "memory"
+    ]
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -293,6 +318,8 @@ def get_tool_definitions(
     # user-visible config edits that affect dynamic schemas (execute_code
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
+    _builtin_memory_tool_enabled = _load_builtin_memory_tool_enabled()
+
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -306,6 +333,7 @@ def get_tool_definitions(
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            _builtin_memory_tool_enabled,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
         )
@@ -319,8 +347,13 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        builtin_memory_tool_enabled=_builtin_memory_tool_enabled,
+    )
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -339,6 +372,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    builtin_memory_tool_enabled: bool = True,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -399,6 +433,10 @@ def _compute_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    filtered_tools = _filter_builtin_memory_tool(
+        filtered_tools,
+        enabled=builtin_memory_tool_enabled,
+    )
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -7,9 +7,10 @@ from unittest.mock import patch
 class RecordingMemoryProvider:
     name = "recording"
 
-    def __init__(self):
+    def __init__(self, tool_schemas=None):
         self.init_kwargs = None
         self.init_session_id = None
+        self._tool_schemas = list(tool_schemas or [])
 
     def is_available(self):
         return True
@@ -19,7 +20,7 @@ class RecordingMemoryProvider:
         self.init_kwargs = dict(kwargs)
 
     def get_tool_schemas(self):
-        return []
+        return list(self._tool_schemas)
 
     def shutdown(self):
         pass
@@ -90,3 +91,49 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["user_id"] == "open-id"
     assert provider.init_kwargs["user_id_alt"] == "union-id"
     assert provider.init_kwargs["platform"] == "feishu"
+
+
+def test_builtin_memory_tool_can_be_disabled_without_disabling_provider_tools():
+    provider = RecordingMemoryProvider(
+        tool_schemas=[
+            {
+                "name": "recording_recall",
+                "description": "Recall from external memory",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+    )
+    cfg = {
+        "memory": {
+            "provider": "recording",
+            "builtin_tool": {"enabled": False},
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            enabled_toolsets=["memory"],
+            session_id="sess-provider",
+        )
+
+    assert provider.init_session_id == "sess-provider"
+    assert "memory" not in agent.valid_tool_names
+    assert "recording_recall" in agent.valid_tool_names
+    assert all(
+        tool.get("function", {}).get("name") != "memory"
+        for tool in agent.tools
+    )

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -6,8 +6,10 @@ from unittest.mock import ANY, call, patch
 
 from model_tools import (
     handle_function_call,
+    get_tool_definitions,
     get_all_tool_names,
     get_toolset_for_tool,
+    _clear_tool_defs_cache,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
@@ -160,6 +162,38 @@ class TestAgentLoopTools:
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS
         assert "terminal" not in _AGENT_LOOP_TOOLS
+
+
+class TestBuiltinMemoryToolConfig:
+    def teardown_method(self):
+        _clear_tool_defs_cache()
+
+    @staticmethod
+    def _tool_names(tool_defs):
+        return {
+            tool.get("function", {}).get("name")
+            for tool in tool_defs
+            if isinstance(tool, dict)
+        }
+
+    def test_builtin_memory_tool_enabled_by_default(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            tools = get_tool_definitions(
+                enabled_toolsets=["memory"],
+                quiet_mode=True,
+            )
+
+        assert "memory" in self._tool_names(tools)
+
+    def test_builtin_memory_tool_can_be_disabled(self):
+        cfg = {"memory": {"builtin_tool": {"enabled": False}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            tools = get_tool_definitions(
+                enabled_toolsets=["memory"],
+                quiet_mode=True,
+            )
+
+        assert "memory" not in self._tool_names(tools)
 
 
 # =========================================================================

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -524,9 +524,14 @@ When on, any flagged `skill_manage` write surfaces as an approval prompt with th
 memory:
   memory_enabled: true
   user_profile_enabled: true
+  builtin_tool:
+    enabled: true       # set false to hide the built-in memory tool
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```
+
+Set `memory.builtin_tool.enabled: false` to hide the built-in global `memory`
+tool while leaving external memory providers enabled.
 
 ## File Read Safety
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -207,6 +207,8 @@ See [Session Search Tool](/user-guide/sessions#session-search-tool) for the thre
 memory:
   memory_enabled: true
   user_profile_enabled: true
+  builtin_tool:
+    enabled: true       # set false to hide the built-in memory tool
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -453,6 +453,8 @@ skills:
 memory:
   memory_enabled: true
   user_profile_enabled: true
+  builtin_tool:
+    enabled: true       # 设为 false 可隐藏内置 memory 工具
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
@@ -207,6 +207,8 @@ hermes sessions list    # 浏览过去的会话
 memory:
   memory_enabled: true
   user_profile_enabled: true
+  builtin_tool:
+    enabled: true       # 设为 false 可隐藏内置 memory 工具
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```


### PR DESCRIPTION
 Closes #39492
## What does this PR do?

  Adds `memory.builtin_tool.enabled` to allow deployments to hide the built-in global `memory` tool while keeping external memory providers enabled.

  ```yaml
  memory:
    builtin_tool:
      enabled: false

  Default behavior remains unchanged: the built-in memory tool is still exposed unless this option is explicitly set to false.

  This is useful for multi-user API/gateway deployments where external memory providers can scope memory per session/user, but the built-in tool writes to
  global MEMORY.md and USER.md.

  ## Related Issue

  Closes #39492

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - agent/memory_config.py: add helper for reading memory.builtin_tool.enabled
  - model_tools.py: filter the built-in memory tool from tool definitions when disabled
  - agent/agent_init.py: record the built-in memory tool config on the agent
  - hermes_cli/config.py: add the default config value
  - cli-config.yaml.example: document the new config key
  - website/docs/user-guide/configuration.md: document the new config key
  - website/docs/user-guide/features/memory.md: document the new config key
  - tests/test_model_tools.py: add coverage for default enabled and explicit disabled behavior
  - tests/run_agent/test_memory_provider_init.py: verify disabling the built-in tool does not disable external provider tools

  ## How to Test

  1. Run targeted model/tool initialization tests:

  uv run --extra dev python -m pytest tests/test_model_tools.py tests/run_agent/test_memory_provider_init.py tests/tools/test_memory_tool_schema.py -q -o
  addopts=

  2. Run memory provider tests:

  uv run --extra dev python -m pytest tests/agent/test_memory_provider.py -q -o addopts=

  3. Run lint/checks:

  uv run --extra dev ruff check agent/memory_config.py model_tools.py agent/agent_init.py tests/test_model_tools.py tests/run_agent/
  test_memory_provider_init.py
  git diff --check

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Linux container

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
    (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  N/A
