### PR TITLE
fix(desktop): pass --no-sandbox when launching as root on Linux

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7541,9 +7541,23 @@ def cmd_gui(args: argparse.Namespace):
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
         return
 
+    # Electron has a hard guard that aborts (FATAL electron_main_delegate.cc)
+    # when launched as root unless --no-sandbox is passed. The SUID
+    # chrome-sandbox helper does not satisfy this check — root is rejected
+    # outright. On this single-user VPS everything runs as root, so detect that
+    # and disable the sandbox. (geteuid is POSIX-only; guard for Windows.)
+    electron_extra_args: list[str] = []
+    if sys.platform != "win32" and hasattr(os, "geteuid") and os.geteuid() == 0:
+        electron_extra_args.append("--no-sandbox")
+
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        if electron_extra_args:
+            print(f"  (running as root — passing {' '.join(electron_extra_args)})")
+        launch_result = subprocess.run(
+            [npm, "exec", "--", "electron", ".", *electron_extra_args],
+            cwd=desktop_dir, env=env, check=False,
+        )
         sys.exit(launch_result.returncode)
 
     if packaged_executable is None:
@@ -7555,7 +7569,12 @@ def cmd_gui(args: argparse.Namespace):
         sys.exit(1)
 
     print(f"→ Launching packaged Hermes Desktop: {packaged_executable}")
-    launch_result = subprocess.run([str(packaged_executable)], cwd=desktop_dir, env=env, check=False)
+    if electron_extra_args:
+        print(f"  (running as root — passing {' '.join(electron_extra_args)})")
+    launch_result = subprocess.run(
+        [str(packaged_executable), *electron_extra_args],
+        cwd=desktop_dir, env=env, check=False,
+    )
     sys.exit(launch_result.returncode)
 
 


### PR DESCRIPTION
## Problem

On a server where Hermes runs as `root`, `hermes desktop` aborts immediately:

```
[FATAL:electron/shell/app/electron_main_delegate.cc:216] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

`cmd_gui` already configures the `chrome-sandbox` SUID helper (`_desktop_linux_sandbox_fixup`), but Electron has a **separate** hard guard that rejects launching as root *outright* unless `--no-sandbox` is passed — the SUID helper does not satisfy it. So the desktop GUI is unusable on single-user root servers/VPSes.

## Fix

In `cmd_gui`, detect `os.geteuid() == 0` (POSIX-only, guarded for Windows) and append `--no-sandbox` to **both** launch paths:
- source build (`electron .`)
- packaged executable

A note is printed when the flag is added so it isn't silent.

## Testing

On an affected VPS (everything runs as root), before the change `hermes desktop` died with the FATAL above. After the change the packaged app boots past the guard and runs normally (verified headless under Xvfb and over an SSH X-forwarded display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)