### PR TITLE
feat(tui): add fuzzy filtering across list overlays

### DIFF
--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -4,6 +4,8 @@ import {
   activeSessionCountLabel,
   canTypeOrchestratorPrompt,
   clampOrchestratorSelection,
+  clampSessionSel,
+  classifySessionsListKey,
   closeFallbackAfterClose,
   currentSessionSelectionIndex,
   draftModelArgFromPickerValue,
@@ -20,6 +22,7 @@ import {
   orchestratorHintSegmentColor,
   orchestratorRowClickAction,
   orchestratorVisibleRowIndexes,
+  rankByText,
   relativeSessionAge,
   resumableHistory,
   selectedSessionRowStyle,
@@ -206,5 +209,119 @@ describe('unified Sessions overlay helpers', () => {
     expect(relativeSessionAge(nowSec - 3 * 86400)).toBe('3d ago')
     expect(relativeSessionAge(undefined)).toBe('')
     expect(relativeSessionAge(0)).toBe('')
+  })
+})
+
+describe('Sessions overlay fuzzy filtering', () => {
+  const live = [
+    { id: 's1', status: 'idle', title: 'refactor the auth module' },
+    { id: 's2', status: 'working', title: 'write billing tests' }
+  ] satisfies SessionActiveItem[]
+
+  const history = [
+    { id: 'h1', message_count: 4, preview: '', started_at: 0, title: 'parser cleanup' },
+    { id: 'h2', message_count: 9, preview: '', started_at: 0, title: 'auth follow-up' }
+  ] satisfies SessionListItem[]
+
+  it('keeps the full list for an empty query', () => {
+    expect(rankByText(live, '')).toEqual(live)
+    expect(rankByText(history, '   ')).toEqual(history)
+  })
+
+  it('filters live + resumable rows by title, id and preview', () => {
+    expect(rankByText(live, 'auth').map(s => s.id)).toEqual(['s1'])
+    expect(rankByText(history, 'auth').map(h => h.id)).toEqual(['h2'])
+    expect(rankByText(live, 's2').map(s => s.id)).toContain('s2')
+  })
+
+  it('drops rows that do not match', () => {
+    expect(rankByText(live, 'zzzz')).toEqual([])
+  })
+})
+
+describe('Sessions overlay key gating', () => {
+  const ctx = (over: Partial<Parameters<typeof classifySessionsListKey>[2]> = {}) => ({
+    filterActive: false,
+    onNewRow: false,
+    selectedKind: 'live' as const,
+    ...over
+  })
+
+  it('routes Ctrl chords and Tab regardless of filter', () => {
+    expect(classifySessionsListKey('n', { ctrl: true }, ctx())).toEqual({ kind: 'newSession' })
+    expect(classifySessionsListKey('r', { ctrl: true }, ctx({ filterActive: true }))).toEqual({ kind: 'refresh' })
+    expect(classifySessionsListKey('', { tab: true }, ctx({ onNewRow: true, selectedKind: 'new' }))).toEqual({
+      kind: 'pickModel'
+    })
+  })
+
+  it('closes a live session with Ctrl+D only when not filtering', () => {
+    expect(classifySessionsListKey('d', { ctrl: true }, ctx())).toEqual({ kind: 'closeLive' })
+    expect(classifySessionsListKey('d', { ctrl: true }, ctx({ filterActive: true }))).toEqual({ kind: 'ignore' })
+  })
+
+  it('arms delete on `d` only on a resumable row when not filtering', () => {
+    expect(classifySessionsListKey('d', {}, ctx({ selectedKind: 'history' }))).toEqual({ kind: 'armDelete' })
+    // While filtering, `d` types into the filter instead of arming a delete.
+    expect(classifySessionsListKey('d', {}, ctx({ filterActive: true, selectedKind: 'history' }))).toEqual({
+      ch: 'd',
+      kind: 'filterAppend'
+    })
+  })
+
+  it('routes printable keys to the draft on the new row, the filter on a session row', () => {
+    expect(classifySessionsListKey('a', {}, ctx({ onNewRow: true, selectedKind: 'new' }))).toEqual({ kind: 'draft' })
+    expect(classifySessionsListKey('a', {}, ctx({ selectedKind: 'history' }))).toEqual({
+      ch: 'a',
+      kind: 'filterAppend'
+    })
+  })
+
+  it('clears a non-empty filter on Esc before cancelling', () => {
+    expect(classifySessionsListKey('', { escape: true }, ctx({ filterActive: true }))).toEqual({ kind: 'clearFilter' })
+    expect(classifySessionsListKey('', { escape: true }, ctx())).toEqual({ kind: 'cancel' })
+  })
+
+  it('edits the filter with Backspace / Ctrl+U only on a session row while filtering', () => {
+    expect(classifySessionsListKey('', { backspace: true }, ctx({ filterActive: true }))).toEqual({
+      kind: 'filterBackspace'
+    })
+    expect(classifySessionsListKey('', { backspace: true }, ctx())).toEqual({ kind: 'ignore' })
+    expect(classifySessionsListKey('u', { ctrl: true }, ctx({ filterActive: true }))).toEqual({ kind: 'clearFilter' })
+  })
+
+  it('keeps arrows + Enter navigating regardless of filter state', () => {
+    expect(classifySessionsListKey('', { upArrow: true }, ctx({ filterActive: true }))).toEqual({ kind: 'navUp' })
+    expect(classifySessionsListKey('', { downArrow: true }, ctx())).toEqual({ kind: 'navDown' })
+    expect(classifySessionsListKey('', { return: true }, ctx({ filterActive: true }))).toEqual({ kind: 'select' })
+  })
+
+  it('does not start a filter on a leading space, but allows spaces mid-query', () => {
+    expect(classifySessionsListKey(' ', {}, ctx({ selectedKind: 'history' }))).toEqual({ kind: 'ignore' })
+    expect(classifySessionsListKey(' ', {}, ctx({ filterActive: true, selectedKind: 'history' }))).toEqual({
+      ch: ' ',
+      kind: 'filterAppend'
+    })
+  })
+})
+
+describe('Sessions overlay selection clamp (clampSessionSel)', () => {
+  it('floors the cursor at row 1 while filtering so it never lands on the new row', () => {
+    // Rows are [new=0][live/history=1..matchCount]; filtering floors at 1.
+    expect(clampSessionSel(0, 3, true)).toBe(1)
+    expect(clampSessionSel(-2, 3, true)).toBe(1)
+    // Even with zero matches, sel stays at the benign row-1 sentinel (not 0).
+    expect(clampSessionSel(0, 0, true)).toBe(1)
+  })
+
+  it('allows the new row (index 0) when not filtering', () => {
+    expect(clampSessionSel(0, 3, false)).toBe(0)
+    expect(clampSessionSel(-1, 3, false)).toBe(0)
+  })
+
+  it('clamps down to the last matching row', () => {
+    expect(clampSessionSel(9, 3, true)).toBe(3)
+    expect(clampSessionSel(9, 3, false)).toBe(3)
+    expect(clampSessionSel(2, 3, true)).toBe(2)
   })
 })

--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -12,6 +12,7 @@ import {
   draftModelDisplayLabel,
   draftTitleFromPrompt,
   fixedSessionColumnStyle,
+  fullSessionSelectionForId,
   isNewSessionRow,
   newSessionMarkerColor,
   newSessionRowIndex,
@@ -23,6 +24,7 @@ import {
   orchestratorRowClickAction,
   orchestratorVisibleRowIndexes,
   rankByText,
+  reanchorFilteredSessionSelection,
   relativeSessionAge,
   resumableHistory,
   selectedSessionRowStyle,
@@ -323,5 +325,45 @@ describe('Sessions overlay selection clamp (clampSessionSel)', () => {
     expect(clampSessionSel(9, 3, true)).toBe(3)
     expect(clampSessionSel(9, 3, false)).toBe(3)
     expect(clampSessionSel(2, 3, true)).toBe(2)
+  })
+})
+
+describe('Sessions overlay filtered poll selection', () => {
+  const row = (id: string, title: string) => ({ id, title })
+
+  it('keeps the same session selected when a new match is inserted ahead of it', () => {
+    const previous = [row('a', 'auth cleanup'), row('b', 'auth tests')]
+    const next = [row('c', 'auth api'), ...previous]
+
+    expect(reanchorFilteredSessionSelection(2, previous, [], next, [], 'auth')).toBe(3)
+  })
+
+  it('maps a filtered selection back to the same row when the filter clears', () => {
+    const live = [row('a', 'auth cleanup'), row('b', 'billing tests')]
+    const history = [row('c', 'parser cleanup'), row('d', 'billing follow-up')]
+
+    expect(fullSessionSelectionForId('b', live, history)).toBe(2)
+    expect(fullSessionSelectionForId('d', live, history)).toBe(4)
+    expect(fullSessionSelectionForId(undefined, live, history)).toBe(1)
+    expect(fullSessionSelectionForId(undefined, [], [])).toBe(0)
+  })
+
+  it('tracks a selected session that moves between live and history matches', () => {
+    const selected = row('b', 'billing follow-up')
+
+    expect(reanchorFilteredSessionSelection(1, [selected], [], [], [selected], 'billing')).toBe(1)
+  })
+
+  it('clamps safely when the selected session no longer matches', () => {
+    expect(
+      reanchorFilteredSessionSelection(
+        2,
+        [row('a', 'auth cleanup'), row('b', 'auth tests')],
+        [],
+        [row('a', 'auth cleanup')],
+        [],
+        'auth'
+      )
+    ).toBe(1)
   })
 })

--- a/ui-tui/src/__tests__/agentsOverlay.test.ts
+++ b/ui-tui/src/__tests__/agentsOverlay.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyAgentsListKey, rankSubagentRows } from '../components/agentsOverlay.js'
+import { clampIndex } from '../components/overlayControls.js'
+import type { SubagentNode } from '../types.js'
+
+// Minimal node factory — rankSubagentRows only reads item.goal / id / model.
+const node = (id: string, goal: string, model?: string): SubagentNode =>
+  ({ aggregate: {}, children: [], item: { goal, id, model } }) as unknown as SubagentNode
+
+describe('agents overlay fuzzy filtering', () => {
+  const rows = [
+    node('a1', 'review the auth module', 'opus'),
+    node('a2', 'write tests for billing', 'sonnet'),
+    node('a3', 'refactor the parser', 'haiku')
+  ]
+
+  it('keeps the full row list for an empty query', () => {
+    expect(rankSubagentRows(rows, '')).toEqual(rows)
+    expect(rankSubagentRows(rows, '   ')).toEqual(rows)
+  })
+
+  it('filters rows by goal text', () => {
+    expect(rankSubagentRows(rows, 'auth').map(n => n.item.id)).toEqual(['a1'])
+    expect(rankSubagentRows(rows, 'parser').map(n => n.item.id)).toEqual(['a3'])
+  })
+
+  it('matches on subagent id and model too', () => {
+    expect(rankSubagentRows(rows, 'a2').map(n => n.item.id)).toContain('a2')
+    expect(rankSubagentRows(rows, 'sonnet').map(n => n.item.id)).toContain('a2')
+  })
+
+  it('drops rows that do not match', () => {
+    expect(rankSubagentRows(rows, 'zzzz')).toEqual([])
+  })
+})
+
+describe('agents overlay list-mode key gating', () => {
+  it('fires reserved single-key shortcuts only when no filter is active', () => {
+    expect(classifyAgentsListKey('q', {}, false, true)).toEqual({ kind: 'close' })
+    expect(classifyAgentsListKey('s', {}, false, true)).toEqual({ kind: 'cycleSort' })
+    expect(classifyAgentsListKey('f', {}, false, true)).toEqual({ kind: 'cycleFilter' })
+    expect(classifyAgentsListKey('x', {}, false, true)).toEqual({ kind: 'killOne' })
+    expect(classifyAgentsListKey('X', {}, false, true)).toEqual({ kind: 'killSubtree' })
+    expect(classifyAgentsListKey('p', {}, false, true)).toEqual({ kind: 'pause' })
+    expect(classifyAgentsListKey('g', {}, false, true)).toEqual({ kind: 'cursorTop' })
+    expect(classifyAgentsListKey('G', {}, false, true)).toEqual({ kind: 'cursorBottom' })
+    expect(classifyAgentsListKey('[', {}, false, true)).toEqual({ kind: 'historyOlder' })
+    expect(classifyAgentsListKey(']', {}, false, true)).toEqual({ kind: 'historyNewer' })
+  })
+
+  it('types the same reserved keys into the filter once it is active', () => {
+    expect(classifyAgentsListKey('s', {}, true, true)).toEqual({ ch: 's', kind: 'filterAppend' })
+    expect(classifyAgentsListKey('q', {}, true, true)).toEqual({ ch: 'q', kind: 'filterAppend' })
+    expect(classifyAgentsListKey('x', {}, true, true)).toEqual({ ch: 'x', kind: 'filterAppend' })
+  })
+
+  it('starts a filter when a non-reserved printable key is pressed', () => {
+    expect(classifyAgentsListKey('z', {}, false, true)).toEqual({ ch: 'z', kind: 'filterAppend' })
+  })
+
+  it('does not start a filter on a leading space, but allows spaces mid-query', () => {
+    expect(classifyAgentsListKey(' ', {}, false, true)).toEqual({ kind: 'ignore' })
+    expect(classifyAgentsListKey(' ', {}, true, true)).toEqual({ ch: ' ', kind: 'filterAppend' })
+  })
+
+  it('clamps the cursor into the filtered rows when the list shrinks (clampIndex)', () => {
+    // The list-mode cursor clamp uses clampIndex(cursor, visibleRows.length).
+    expect(clampIndex(7, 3)).toBe(2)
+    expect(clampIndex(2, 3)).toBe(2)
+    expect(clampIndex(1, 0)).toBe(0)
+  })
+
+  it('clears a non-empty filter on Esc before closing the overlay', () => {
+    expect(classifyAgentsListKey('', { escape: true }, true, true)).toEqual({ kind: 'filterClear' })
+    expect(classifyAgentsListKey('', { escape: true }, false, true)).toEqual({ kind: 'close' })
+  })
+
+  it('edits the filter with Backspace / Ctrl+U only while filtering', () => {
+    expect(classifyAgentsListKey('', { backspace: true }, true, true)).toEqual({ kind: 'filterBackspace' })
+    expect(classifyAgentsListKey('', { backspace: true }, false, true)).toEqual({ kind: 'ignore' })
+    expect(classifyAgentsListKey('u', { ctrl: true }, true, true)).toEqual({ kind: 'filterClear' })
+  })
+
+  it('keeps arrows / wheel / Enter navigating regardless of filter state', () => {
+    expect(classifyAgentsListKey('', { upArrow: true }, true, true)).toEqual({ kind: 'cursorUp' })
+    expect(classifyAgentsListKey('', { downArrow: true }, true, true)).toEqual({ kind: 'cursorDown' })
+    expect(classifyAgentsListKey('', { wheelUp: true }, true, true)).toEqual({ kind: 'cursorUp' })
+    expect(classifyAgentsListKey('', { return: true }, true, true)).toEqual({ kind: 'open' })
+  })
+
+  it('routes vim-style j/k/l only when not filtering', () => {
+    expect(classifyAgentsListKey('j', {}, false, true)).toEqual({ kind: 'cursorDown' })
+    expect(classifyAgentsListKey('k', {}, false, true)).toEqual({ kind: 'cursorUp' })
+    expect(classifyAgentsListKey('l', {}, false, true)).toEqual({ kind: 'open' })
+    expect(classifyAgentsListKey('j', {}, true, true)).toEqual({ ch: 'j', kind: 'filterAppend' })
+  })
+
+  it('does not open on Enter when nothing is selected', () => {
+    expect(classifyAgentsListKey('', { return: true }, false, false)).toEqual({ kind: 'ignore' })
+  })
+
+  it('ignores modified chords as filter input', () => {
+    expect(classifyAgentsListKey('a', { meta: true }, true, true)).toEqual({ kind: 'ignore' })
+  })
+})

--- a/ui-tui/src/__tests__/overlayControls.test.ts
+++ b/ui-tui/src/__tests__/overlayControls.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampIndex, windowOffset } from '../components/overlayControls.js'
+
+describe('clampIndex', () => {
+  it('keeps an in-range index unchanged', () => {
+    expect(clampIndex(0, 5)).toBe(0)
+    expect(clampIndex(2, 5)).toBe(2)
+    expect(clampIndex(4, 5)).toBe(4)
+  })
+
+  it('snaps a stale index to the last row when the list shrinks', () => {
+    expect(clampIndex(5, 3)).toBe(2)
+    expect(clampIndex(99, 1)).toBe(0)
+  })
+
+  it('returns 0 for an empty list or negative index', () => {
+    expect(clampIndex(3, 0)).toBe(0)
+    expect(clampIndex(-4, 5)).toBe(0)
+  })
+})
+
+describe('windowOffset', () => {
+  it('never produces a negative offset', () => {
+    expect(windowOffset(3, 0, 12)).toBe(0)
+    expect(windowOffset(0, 0, 12)).toBe(0)
+  })
+
+  it('keeps the selection roughly centered for long lists', () => {
+    expect(windowOffset(100, 50, 12)).toBe(44)
+  })
+})

--- a/ui-tui/src/__tests__/petPicker.test.ts
+++ b/ui-tui/src/__tests__/petPicker.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { rankPets } from '../components/petPicker.js'
+
+describe('pet picker fuzzy filtering', () => {
+  const pets = [
+    { curated: true, displayName: 'Space Cat', installed: false, slug: 'space-cat' },
+    { displayName: 'Rubber Duck', installed: true, slug: 'rubber-duck' },
+    { displayName: 'Clawd Placeholder', installed: true, slug: 'clawd-test' }
+  ]
+
+  it('keeps active and installed pets ahead when no query is active', () => {
+    expect(rankPets(pets, '', true, 'space-cat').map(pet => pet.slug)).toEqual(['space-cat', 'rubber-duck'])
+  })
+
+  it('supports fuzzy subsequence matches across display name and slug', () => {
+    expect(rankPets(pets, 'rbdk', false, '').map(pet => pet.slug)).toEqual(['rubber-duck'])
+    expect(rankPets(pets, 'sp cat', false, '').map(pet => pet.slug)).toEqual(['space-cat'])
+  })
+
+  it('continues to hide clawd placeholders', () => {
+    expect(rankPets(pets, 'clawd', false, '')).toEqual([])
+  })
+})

--- a/ui-tui/src/__tests__/pluginsHub.test.ts
+++ b/ui-tui/src/__tests__/pluginsHub.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyPluginsListKey, rankPluginRows } from '../components/pluginsHub.js'
+
+describe('plugins hub fuzzy filtering', () => {
+  const rows = [
+    { description: 'Sync issues and pull requests', name: 'github', source: 'user', status: 'enabled' },
+    { description: 'Manage team messages', name: 'slack-tools', source: 'bundled', status: 'disabled' },
+    { description: 'Inspect calendar events', name: 'agenda', source: 'user', status: 'enabled' }
+  ]
+
+  it('keeps source order for an empty query', () => {
+    expect(rankPluginRows(rows, '')).toEqual(rows)
+  })
+
+  it('matches and ranks across plugin metadata', () => {
+    expect(rankPluginRows(rows, 'slk').map(row => row.name)).toEqual(['slack-tools'])
+    expect(rankPluginRows(rows, 'pull request').map(row => row.name)).toEqual(['github'])
+    expect(rankPluginRows(rows, 'bundled')[0]?.name).toBe('slack-tools')
+  })
+})
+
+describe('plugins hub list key gating', () => {
+  it('preserves q, Space, and number shortcuts before filtering', () => {
+    expect(classifyPluginsListKey('q', {}, false)).toEqual({ kind: 'close' })
+    expect(classifyPluginsListKey(' ', {}, false)).toEqual({ kind: 'select' })
+    expect(classifyPluginsListKey('1', {}, false)).toEqual({ kind: 'quick', n: 1 })
+  })
+
+  it('routes the same printable keys into an active filter', () => {
+    expect(classifyPluginsListKey('q', {}, true)).toEqual({ ch: 'q', kind: 'append' })
+    expect(classifyPluginsListKey(' ', {}, true)).toEqual({ ch: ' ', kind: 'append' })
+    expect(classifyPluginsListKey('1', {}, true)).toEqual({ ch: '1', kind: 'append' })
+  })
+
+  it('clears before closing and keeps navigation available', () => {
+    expect(classifyPluginsListKey('', { escape: true }, true)).toEqual({ kind: 'clearFilter' })
+    expect(classifyPluginsListKey('', { escape: true }, false)).toEqual({ kind: 'close' })
+    expect(classifyPluginsListKey('', { downArrow: true }, true)).toEqual({ kind: 'down' })
+    expect(classifyPluginsListKey('', { tab: true }, true)).toEqual({ kind: 'toggleScope' })
+  })
+
+  it('edits an active filter without capturing unrelated chords', () => {
+    expect(classifyPluginsListKey('', { backspace: true }, true)).toEqual({ kind: 'backspace' })
+    expect(classifyPluginsListKey('u', { ctrl: true }, true)).toEqual({ kind: 'clearFilter' })
+    expect(classifyPluginsListKey(String.fromCharCode(21), { ctrl: true }, true)).toEqual({ kind: 'clearFilter' })
+    expect(classifyPluginsListKey('g', { ctrl: true }, true)).toEqual({ kind: 'ignore' })
+  })
+})

--- a/ui-tui/src/__tests__/skillsHub.test.ts
+++ b/ui-tui/src/__tests__/skillsHub.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifySkillsListKey, rankSkillCategories, rankSkills } from '../components/skillsHub.js'
+
+describe('skills hub fuzzy filtering', () => {
+  const skillsByCat = {
+    github: ['pr-review', 'issue-triage'],
+    mlops: ['train-model', 'deploy-endpoint'],
+    security: ['threat-model', 'secret-scan']
+  }
+
+  const cats = Object.keys(skillsByCat).sort()
+
+  it('keeps the full category list for an empty query', () => {
+    expect(rankSkillCategories(cats, skillsByCat, '')).toEqual(cats)
+    expect(rankSkillCategories(cats, skillsByCat, '   ')).toEqual(cats)
+  })
+
+  it('ranks categories by name, best match first', () => {
+    const ranked = rankSkillCategories(cats, skillsByCat, 'sec')
+
+    expect(ranked[0]).toBe('security')
+  })
+
+  it('surfaces a category by the names of the skills it contains', () => {
+    // "deploy" is a skill in mlops, not a category name.
+    expect(rankSkillCategories(cats, skillsByCat, 'deploy')).toContain('mlops')
+  })
+
+  it('drops categories that do not match', () => {
+    expect(rankSkillCategories(cats, skillsByCat, 'zzzz')).toEqual([])
+  })
+
+  it('filters and ranks skills within a category', () => {
+    const skills = skillsByCat.security
+
+    expect(rankSkills(skills, '')).toEqual(skills)
+    expect(rankSkills(skills, 'scan')).toEqual(['secret-scan'])
+    expect(rankSkills(skills, 'zzzz')).toEqual([])
+  })
+})
+
+describe('skills hub list-stage key gating', () => {
+  it('fires reserved single-key shortcuts only when no filter is active', () => {
+    expect(classifySkillsListKey('q', {}, false)).toEqual({ kind: 'close' })
+    expect(classifySkillsListKey('1', {}, false)).toEqual({ kind: 'quick', n: 1 })
+    expect(classifySkillsListKey('0', {}, false)).toEqual({ kind: 'quick', n: 10 })
+  })
+
+  it('types the same reserved keys into the filter once it is active', () => {
+    expect(classifySkillsListKey('q', {}, true)).toEqual({ ch: 'q', kind: 'append' })
+    expect(classifySkillsListKey('1', {}, true)).toEqual({ ch: '1', kind: 'append' })
+  })
+
+  it('starts a filter when a non-reserved printable key is pressed', () => {
+    expect(classifySkillsListKey('a', {}, false)).toEqual({ ch: 'a', kind: 'append' })
+  })
+
+  it('does not start a filter on a leading space, but allows spaces mid-query', () => {
+    expect(classifySkillsListKey(' ', {}, false)).toEqual({ kind: 'ignore' })
+    expect(classifySkillsListKey(' ', {}, true)).toEqual({ ch: ' ', kind: 'append' })
+  })
+
+  it('clears a non-empty filter on Esc before navigating back', () => {
+    expect(classifySkillsListKey('', { escape: true }, true)).toEqual({ kind: 'clearFilter' })
+    expect(classifySkillsListKey('', { escape: true }, false)).toEqual({ kind: 'escape' })
+  })
+
+  it('edits the filter with Backspace / Ctrl+U only while filtering', () => {
+    expect(classifySkillsListKey('', { backspace: true }, true)).toEqual({ kind: 'backspace' })
+    expect(classifySkillsListKey('', { backspace: true }, false)).toEqual({ kind: 'ignore' })
+    expect(classifySkillsListKey('u', { ctrl: true }, true)).toEqual({ kind: 'clearFilter' })
+    expect(classifySkillsListKey('u', { ctrl: true }, false)).toEqual({ kind: 'ignore' })
+  })
+
+  it('routes navigation keys regardless of filter state', () => {
+    expect(classifySkillsListKey('', { upArrow: true }, true)).toEqual({ kind: 'up' })
+    expect(classifySkillsListKey('', { downArrow: true }, false)).toEqual({ kind: 'down' })
+    expect(classifySkillsListKey('', { return: true }, true)).toEqual({ kind: 'select' })
+  })
+
+  it('does not treat modified chords as filter input', () => {
+    expect(classifySkillsListKey('g', { ctrl: true }, true)).toEqual({ kind: 'ignore' })
+    expect(classifySkillsListKey('g', { meta: true }, true)).toEqual({ kind: 'ignore' })
+  })
+})

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { sessionScopedModelArg } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
@@ -11,6 +11,7 @@ import type {
   SessionListItem,
   SessionListResponse
 } from '../gatewayTypes.js'
+import { fuzzyRank } from '../lib/fuzzy.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -87,6 +88,146 @@ export const resumableHistory = (history: readonly SessionListItem[], live: read
   const liveIds = new Set(live.map(s => s.id))
 
   return history.filter(h => !liveIds.has(h.id))
+}
+
+// ── Type-to-filter (fuzzy search) ────────────────────────────────────
+//
+// The live + resumable rows support fuzzy type-to-filter, separate from the
+// "+ new" row's draft prompt: printable keys feed the draft when the new row is
+// selected, and the filter when a session row is selected. The list logic and
+// the key-gating decision are pure functions so they can be unit-tested.
+
+/** Fuzzy-rank live/resumable rows by title + preview + id. Empty query keeps order. */
+export const rankByText = <T extends { id: string; preview?: string; title?: string }>(
+  items: readonly T[],
+  query: string
+): T[] =>
+  query.trim()
+    ? fuzzyRank(items, query, x => `${x.title ?? ''} ${x.preview ?? ''} ${x.id}`).map(r => r.item)
+    : [...items]
+
+/**
+ * Clamp the flat Sessions selection. Rows are [new][live…][history…], so the
+ * valid range is `[0, matchCount]` (index 0 is the pinned "+ new" row, indices
+ * 1..matchCount are session rows). While a filter is active the floor is 1 so
+ * the cursor can never land on the new row — which would divert printable keys
+ * to the draft prompt instead of the filter.
+ */
+export const clampSessionSel = (sel: number, matchCount: number, filtering: boolean): number =>
+  Math.max(filtering ? 1 : 0, Math.min(sel, matchCount))
+
+/** Subset of the Ink key flags the Sessions handler inspects. */
+export interface SessionsKeyFlags {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  return?: boolean
+  tab?: boolean
+  upArrow?: boolean
+}
+
+export interface SessionsKeyContext {
+  filterActive: boolean
+  onNewRow: boolean
+  selectedKind: SessionRowKind
+}
+
+export type SessionsKeyAction =
+  | { ch: string; kind: 'filterAppend' }
+  | { kind: 'armDelete' }
+  | { kind: 'cancel' }
+  | { kind: 'clearFilter' }
+  | { kind: 'closeLive' }
+  | { kind: 'draft' }
+  | { kind: 'filterBackspace' }
+  | { kind: 'ignore' }
+  | { kind: 'navDown' }
+  | { kind: 'navUp' }
+  | { kind: 'newSession' }
+  | { kind: 'pickModel' }
+  | { kind: 'refresh' }
+  | { kind: 'select' }
+
+/**
+ * Decide what a keypress does on the Sessions overlay. Ctrl chords (new /
+ * refresh / close), Tab, arrows and Enter are always available. Esc clears an
+ * active filter before cancelling. On the "+ new" row, printable keys feed the
+ * draft prompt; on a session row they start / extend the fuzzy filter. `d` arms
+ * a delete only when not filtering, so it can be typed into the filter.
+ */
+export function classifySessionsListKey(ch: string, key: SessionsKeyFlags, ctx: SessionsKeyContext): SessionsKeyAction {
+  const { filterActive, onNewRow, selectedKind } = ctx
+  const lower = ch ? ch.toLowerCase() : ''
+  const isCtrl = (letter: string) => !!key.ctrl && (lower === letter || ch === ctrlChar(letter))
+
+  if (isCtrl('n')) {
+    return { kind: 'newSession' }
+  }
+
+  if (isCtrl('r')) {
+    return { kind: 'refresh' }
+  }
+
+  if (key.tab) {
+    return onNewRow ? { kind: 'pickModel' } : { kind: 'ignore' }
+  }
+
+  if (isCtrl('d')) {
+    return !filterActive && selectedKind === 'live' ? { kind: 'closeLive' } : { kind: 'ignore' }
+  }
+
+  if (key.escape) {
+    return filterActive ? { kind: 'clearFilter' } : { kind: 'cancel' }
+  }
+
+  // `d` arms two-press delete on a resumable row — only when not filtering and
+  // not on the new row, so the same key can be typed into the filter.
+  if (lower === 'd' && !key.ctrl && !key.meta && !filterActive && !onNewRow && selectedKind === 'history') {
+    return { kind: 'armDelete' }
+  }
+
+  if (key.upArrow) {
+    return { kind: 'navUp' }
+  }
+
+  if (key.downArrow) {
+    return { kind: 'navDown' }
+  }
+
+  if (key.return) {
+    return { kind: 'select' }
+  }
+
+  // The new row owns the draft prompt; printable keys belong to its TextInput.
+  if (onNewRow) {
+    return ch && !key.ctrl && !key.meta && ch.length === 1 && ch >= ' ' ? { kind: 'draft' } : { kind: 'ignore' }
+  }
+
+  // On a session row: Backspace / Ctrl+U edit the filter; any other printable
+  // key starts / extends it.
+  if ((key.backspace || key.delete) && filterActive) {
+    return { kind: 'filterBackspace' }
+  }
+
+  if (isCtrl('u') && filterActive) {
+    return { kind: 'clearFilter' }
+  }
+
+  if (ch && !key.ctrl && !key.meta && ch.length === 1 && ch >= ' ') {
+    // A leading space must not start a filter (it would read as "active" while
+    // the trimmed query leaves the list unfiltered). Spaces inside a query are
+    // fine (multi-token match).
+    if (ch === ' ' && !filterActive) {
+      return { kind: 'ignore' }
+    }
+
+    return { ch, kind: 'filterAppend' }
+  }
+
+  return { kind: 'ignore' }
 }
 
 export const resumeRowContextHintSegments: OrchestratorHintSegment[] = [
@@ -298,6 +439,8 @@ export function ActiveSessionSwitcher({
   const [loading, setLoading] = useState(true)
   const [draft, setDraft] = useState('')
   const [draftModel, setDraftModel] = useState('')
+  // Type-to-filter query for the live + resumable list (not the new-row draft).
+  const [filter, setFilter] = useState('')
   const [pickingModel, setPickingModel] = useState(false)
   const [closingId, setClosingId] = useState('')
   // When non-null, the user pressed `d` on this (history) session and we await
@@ -317,6 +460,8 @@ export function ActiveSessionSwitcher({
   // than keeping a now-stale flat index.
   const itemsRef = useRef<SessionActiveItem[]>([])
   const historyDisplayRef = useRef<SessionListItem[]>([])
+  // Mirror the live filter for the quiet poll's selection re-anchor (below).
+  const filterRef = useRef('')
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
   const promptColumns = Math.max(20, width - 11)
@@ -324,8 +469,21 @@ export function ActiveSessionSwitcher({
   // Rows are [new][live…][history…]: the "+ new" row is pinned first (index 0,
   // always rendered) and the live+history list is windowed below it. `total`
   // is the count of selectable rows (incl. the new row).
-  const liveCount = items.length
-  const histCount = history.length
+  // A non-empty filter narrows the rendered + navigable lists; the "+ new" row
+  // (index 0) stays pinned. All index math below uses these display lists, while
+  // `items` / `history` remain the full state used for fetching + destructive
+  // actions (which are gated behind an empty filter).
+  const filterActive = filter.trim() !== ''
+
+  const displayItems = useMemo(() => (filterActive ? rankByText(items, filter) : items), [filterActive, items, filter])
+
+  const displayHistory = useMemo(
+    () => (filterActive ? rankByText(history, filter) : history),
+    [filterActive, history, filter]
+  )
+
+  const liveCount = displayItems.length
+  const histCount = displayHistory.length
   const listLen = liveCount + histCount
   const total = listLen + 1
   const rowKind = useCallback((index: number) => sessionRowKindAt(index, liveCount), [liveCount])
@@ -396,6 +554,17 @@ export function ActiveSessionSwitcher({
             return next.length ? Math.min(currentSessionSelectionIndex(next, currentSessionId) + 1, maxSel) : 0
           }
 
+          // While filtering, `s` indexes the display list (query-stable across
+          // status-only polls); just clamp it to the filtered bounds rather than
+          // re-anchoring against the full live/history lists. The floor of 1
+          // keeps the cursor off the new row so keystrokes stay with the filter.
+          if (filterRef.current.trim() !== '') {
+            const dNext = rankByText(next, filterRef.current)
+            const dHist = rankByText(hist, filterRef.current)
+
+            return clampSessionSel(s, dNext.length + dHist.length, true)
+          }
+
           if (s <= 0) {
             return 0 // "+ new" row
           }
@@ -434,6 +603,10 @@ export function ActiveSessionSwitcher({
     itemsRef.current = items
     historyDisplayRef.current = history
   }, [items, history])
+
+  useEffect(() => {
+    filterRef.current = filter
+  }, [filter])
 
   useEffect(() => {
     void load()
@@ -535,21 +708,25 @@ export function ActiveSessionSwitcher({
 
       if (kind === 'live') {
         setSel(clamped)
-        onSelect(items[index - 1]!.id)
+        onSelect(displayItems[index - 1]!.id)
 
         return
       }
 
       if (kind === 'history') {
         setSel(clamped)
-        onResume(history[index - 1 - items.length]!.id)
+        onResume(displayHistory[index - 1 - liveCount]!.id)
 
         return
       }
 
+      // Clicking the "+ new" row expresses intent to compose a new session, so
+      // exit any active filter — otherwise sel=0 would sit on the new row while
+      // filtering and divert keystrokes to the draft (see clampSessionSel).
+      setFilter('')
       setSel(0)
     },
-    [history, items, onResume, onSelect, rowKind, total]
+    [displayHistory, displayItems, liveCount, onResume, onSelect, rowKind, total]
   )
 
   const selectedKind = rowKind(sel)
@@ -575,75 +752,89 @@ export function ActiveSessionSwitcher({
       return
     }
 
-    const lower = ch?.toLowerCase() ?? ''
-    const isCtrl = (letter: string) => key.ctrl && (lower === letter || ch === ctrlChar(letter))
+    const action = classifySessionsListKey(ch, key, { filterActive, onNewRow: newSelected, selectedKind })
 
-    if (key.escape) {
-      return onCancel()
-    }
+    switch (action.kind) {
+      case 'newSession':
+        return onNew()
 
-    if (isCtrl('n')) {
-      return onNew()
-    }
+      case 'refresh':
+        return void load()
 
-    if (isCtrl('r')) {
-      void load()
-
-      return
-    }
-
-    if (key.tab) {
-      if (newSelected) {
+      case 'pickModel':
         setPickingModel(true)
-      }
 
-      return
-    }
+        return
 
-    if (isCtrl('d')) {
-      if (selectedKind === 'live') {
+      case 'closeLive':
         void closeSelected()
-      }
 
-      return
-    }
+        return
 
-    // `d` arms deletion on a resumable history row. (On the New row `d` is
-    // captured by the prompt's TextInput, so it never reaches here.)
-    if (lower === 'd' && !key.ctrl && selectedKind === 'history') {
-      setConfirmDelete(history[sel - 1 - items.length]?.id ?? null)
+      case 'cancel':
+        return onCancel()
 
-      return
-    }
+      case 'clearFilter':
+        setFilter('')
 
-    if (newSelected && draftHasText) {
-      return
-    }
+        return
 
-    if (key.upArrow && sel > 0) {
-      return setSel(s => Math.max(0, s - 1))
-    }
+      case 'armDelete':
+        setConfirmDelete(displayHistory[sel - 1 - liveCount]?.id ?? null)
 
-    if (key.downArrow && sel < total - 1) {
-      return setSel(s => Math.min(total - 1, s + 1))
-    }
+        return
 
-    if (key.return) {
-      if (newSelected) {
-        if (!draftHasText) {
-          return onNew()
+      case 'navUp':
+        // The new row owns its draft mid-compose; don't steal navigation keys.
+        // While filtering, clampSessionSel floors at row 1 so Up can't reach the
+        // new row (which would divert keystrokes to the draft instead of filter).
+        if (!(newSelected && draftHasText)) {
+          setSel(s => clampSessionSel(s - 1, listLen, filterActive))
         }
 
         return
-      }
 
-      if (selectedKind === 'live' && items[sel - 1]) {
-        return onSelect(items[sel - 1]!.id)
-      }
+      case 'navDown':
+        if (!(newSelected && draftHasText)) {
+          setSel(s => clampSessionSel(s + 1, listLen, filterActive))
+        }
 
-      if (selectedKind === 'history' && history[sel - 1 - items.length]) {
-        return onResume(history[sel - 1 - items.length]!.id)
-      }
+        return
+
+      case 'select':
+        if (newSelected) {
+          // With draft text the TextInput's onSubmit starts the session.
+          return draftHasText ? undefined : onNew()
+        }
+
+        if (selectedKind === 'live' && displayItems[sel - 1]) {
+          return onSelect(displayItems[sel - 1]!.id)
+        }
+
+        if (selectedKind === 'history' && displayHistory[sel - 1 - liveCount]) {
+          return onResume(displayHistory[sel - 1 - liveCount]!.id)
+        }
+
+        return
+
+      case 'filterAppend':
+        setFilter(v => v + action.ch)
+        // Keep the cursor on the first matching session row (never the new row,
+        // which would flip into draft mode and swallow further keystrokes).
+        setSel(1)
+
+        return
+
+      case 'filterBackspace':
+        setFilter(v => v.slice(0, -1))
+        setSel(1)
+
+        return
+
+      default:
+        // 'draft' (printable on the new row) + 'ignore' fall through to the
+        // new-row TextInput, which owns its own input.
+        return
     }
   })
 
@@ -686,6 +877,11 @@ export function ActiveSessionSwitcher({
         Sessions
       </Text>
       <Text color={t.color.muted}>{sessionsCountLabel(items.length, history.length)}</Text>
+      <Text color={filterActive ? t.color.accent : t.color.muted} wrap="truncate-end">
+        {filterActive
+          ? `filter: ${filter}▎ · ${listLen} match${listLen === 1 ? '' : 'es'}`
+          : 'type to filter a session row'}
+      </Text>
 
       {err && <Text color={t.color.label}>error: {err}</Text>}
 
@@ -726,7 +922,11 @@ export function ActiveSessionSwitcher({
       </Box>
 
       {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
-      {!listLen && <Text color={t.color.muted}>no other sessions — Enter on +new to start one</Text>}
+      {!listLen && (
+        <Text color={t.color.muted}>
+          {filterActive ? 'no sessions match the filter' : 'no other sessions — Enter on +new to start one'}
+        </Text>
+      )}
 
       {visibleRows.map(i => {
         const selected = sel === i
@@ -735,7 +935,7 @@ export function ActiveSessionSwitcher({
         const kind = rowKind(i)
 
         if (kind === 'history') {
-          const h = history[i - 1 - items.length]!
+          const h = displayHistory[i - 1 - liveCount]!
           const pendingDelete = confirmDelete === h.id
 
           const title = pendingDelete
@@ -793,7 +993,7 @@ export function ActiveSessionSwitcher({
           )
         }
 
-        const s = items[i - 1]!
+        const s = displayItems[i - 1]!
         const status = s.status ?? 'idle'
         const current = s.current || s.id === currentSessionId
         const title = closingId === s.id ? 'closing…' : s.title || s.preview || '(untitled)'
@@ -855,7 +1055,16 @@ export function ActiveSessionSwitcher({
 
       {offset + VISIBLE < listLen && <Text color={t.color.muted}> ↓ {listLen - offset - VISIBLE} more</Text>}
 
-      {newSelected ? (
+      {filterActive ? (
+        // While filtering the cursor stays on session rows: delete (`d`) is
+        // unavailable and Esc clears the filter, so show filter-specific hints
+        // instead of the misleading row/global hints.
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={t.color.muted} wrap="truncate-end">
+            Enter select · ↑/↓ move · Backspace edit · Esc clear filter
+          </Text>
+        </Box>
+      ) : newSelected ? (
         <>
           <Box marginTop={1}>
             <Text color={t.color.label}>prompt › </Text>
@@ -880,7 +1089,7 @@ export function ActiveSessionSwitcher({
         </Box>
       )}
 
-      <OrchestratorHintText segments={orchestratorGlobalHotkeyHintSegments} t={t} />
+      {!filterActive && <OrchestratorHintText segments={orchestratorGlobalHotkeyHintSegments} t={t} />}
     </Box>
   )
 }

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -116,6 +116,55 @@ export const rankByText = <T extends { id: string; preview?: string; title?: str
 export const clampSessionSel = (sel: number, matchCount: number, filtering: boolean): number =>
   Math.max(filtering ? 1 : 0, Math.min(sel, matchCount))
 
+/**
+ * Preserve the selected session across a live-status poll while filtering.
+ * Matching rows can be inserted, removed, or re-ranked as their metadata
+ * changes, so clamping the old numeric index is not enough: re-anchor by id,
+ * just like the unfiltered quiet-poll path does.
+ */
+export function reanchorFilteredSessionSelection(
+  sel: number,
+  previousLive: readonly SessionSearchRow[],
+  previousHistory: readonly SessionSearchRow[],
+  nextLive: readonly SessionSearchRow[],
+  nextHistory: readonly SessionSearchRow[],
+  query: string
+): number {
+  const previousRows = [...rankByText(previousLive, query), ...rankByText(previousHistory, query)]
+  const nextRows = [...rankByText(nextLive, query), ...rankByText(nextHistory, query)]
+  const selectedId = previousRows[sel - 1]?.id
+  const nextIndex = selectedId ? nextRows.findIndex(row => row.id === selectedId) : -1
+
+  return nextIndex >= 0 ? nextIndex + 1 : clampSessionSel(sel, nextRows.length, true)
+}
+
+/** Map a filtered row back to its position in the full session list. */
+export function fullSessionSelectionForId(
+  id: string | undefined,
+  live: readonly SessionSearchRow[],
+  history: readonly SessionSearchRow[]
+): number {
+  const liveIndex = id ? live.findIndex(row => row.id === id) : -1
+
+  if (liveIndex >= 0) {
+    return liveIndex + 1
+  }
+
+  const historyIndex = id ? history.findIndex(row => row.id === id) : -1
+
+  if (historyIndex >= 0) {
+    return live.length + historyIndex + 1
+  }
+
+  return live.length + history.length > 0 ? 1 : 0
+}
+
+interface SessionSearchRow {
+  id: string
+  preview?: string
+  title?: string
+}
+
 /** Subset of the Ink key flags the Sessions handler inspects. */
 export interface SessionsKeyFlags {
   backspace?: boolean
@@ -554,15 +603,20 @@ export function ActiveSessionSwitcher({
             return next.length ? Math.min(currentSessionSelectionIndex(next, currentSessionId) + 1, maxSel) : 0
           }
 
-          // While filtering, `s` indexes the display list (query-stable across
-          // status-only polls); just clamp it to the filtered bounds rather than
-          // re-anchoring against the full live/history lists. The floor of 1
-          // keeps the cursor off the new row so keystrokes stay with the filter.
-          if (filterRef.current.trim() !== '') {
-            const dNext = rankByText(next, filterRef.current)
-            const dHist = rankByText(hist, filterRef.current)
+          // Filtering can reorder the display list as live metadata changes or
+          // matching sessions appear/disappear. Preserve the selected session
+          // by id instead of letting the old numeric index drift to another row.
+          const activeFilter = filterRef.current
 
-            return clampSessionSel(s, dNext.length + dHist.length, true)
+          if (activeFilter.trim() !== '') {
+            return reanchorFilteredSessionSelection(
+              s,
+              itemsRef.current,
+              historyDisplayRef.current,
+              next,
+              hist,
+              activeFilter
+            )
           }
 
           if (s <= 0) {
@@ -775,6 +829,13 @@ export function ActiveSessionSwitcher({
         return onCancel()
 
       case 'clearFilter':
+        setSel(
+          fullSessionSelectionForId(
+            selectedKind === 'live' ? displayItems[sel - 1]?.id : displayHistory[sel - 1 - liveCount]?.id,
+            items,
+            history
+          )
+        )
         setFilter('')
 
         return

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -13,6 +13,7 @@ import { $spawnDiff, $spawnHistory, clearDiffPair, type SpawnSnapshot } from '..
 import { useTurnSelector } from '../app/turnStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { DelegationPauseResponse, DelegationStatusResponse, SubagentInterruptResponse } from '../gatewayTypes.js'
+import { fuzzyRank } from '../lib/fuzzy.js'
 import { asRpcResult } from '../lib/rpc.js'
 import {
   buildSubagentTree,
@@ -32,6 +33,7 @@ import { compactPreview } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { SubagentNode, SubagentProgress } from '../types.js'
 
+import { clampIndex } from './overlayControls.js'
 import { OverlayScrollbar } from './overlayScrollbar.js'
 
 // ── Types + lookup tables ────────────────────────────────────────────
@@ -130,6 +132,159 @@ const statusGlyph = (item: SubagentProgress, t: Theme) => {
 
 const prepareRows = (tree: SubagentNode[], sort: SortMode, filter: FilterMode): SubagentNode[] =>
   tree.length === 0 ? [] : flattenTree([...tree].sort(SORT_COMPARATORS[sort])).filter(FILTER_PREDICATES[filter])
+
+// ── Type-to-filter (fuzzy search) ────────────────────────────────────
+//
+// A free-text fuzzy query is a third, orthogonal concern layered on top of the
+// existing sort + FilterMode: it ranks the already-sorted+filtered rows by the
+// subagent goal / id / model. The list logic and the (list-mode) key-gating
+// decision are pure functions so they can be unit-tested without rendering Ink.
+
+/** Subset of the Ink key flags the list-mode handler inspects. */
+export interface AgentsKeyFlags {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  return?: boolean
+  rightArrow?: boolean
+  upArrow?: boolean
+  wheelDown?: boolean
+  wheelUp?: boolean
+}
+
+/** Fuzzy-rank flattened rows by goal/id/model. Empty query keeps order. */
+export const rankSubagentRows = (rows: readonly SubagentNode[], query: string): SubagentNode[] =>
+  query.trim()
+    ? fuzzyRank(rows, query, n => `${n.item.goal ?? ''} ${n.item.id} ${n.item.model ?? ''}`).map(r => r.item)
+    : [...rows]
+
+export type AgentsListAction =
+  | { ch: string; kind: 'filterAppend' }
+  | { kind: 'close' }
+  | { kind: 'cursorBottom' }
+  | { kind: 'cursorDown' }
+  | { kind: 'cursorTop' }
+  | { kind: 'cursorUp' }
+  | { kind: 'cycleFilter' }
+  | { kind: 'cycleSort' }
+  | { kind: 'filterBackspace' }
+  | { kind: 'filterClear' }
+  | { kind: 'historyNewer' }
+  | { kind: 'historyOlder' }
+  | { kind: 'ignore' }
+  | { kind: 'killOne' }
+  | { kind: 'killSubtree' }
+  | { kind: 'open' }
+  | { kind: 'pause' }
+
+/**
+ * Decide what a keypress does in list mode. Arrows / wheel / Enter / → always
+ * navigate, and Esc clears an active filter before closing. Reserved single-key
+ * shortcuts (q, p, x, X, s, f, g, G, j, k, l, history brackets) fire only when
+ * no filter is active, so the same keys extend the filter once the user is
+ * typing one. Any other printable key starts / extends the filter.
+ */
+export function classifyAgentsListKey(
+  ch: string,
+  key: AgentsKeyFlags,
+  hasQuery: boolean,
+  hasSelected: boolean
+): AgentsListAction {
+  if (key.escape) {
+    return hasQuery ? { kind: 'filterClear' } : { kind: 'close' }
+  }
+
+  if ((key.backspace || key.delete) && hasQuery) {
+    return { kind: 'filterBackspace' }
+  }
+
+  if (key.ctrl && ch === 'u' && hasQuery) {
+    return { kind: 'filterClear' }
+  }
+
+  // Navigation that is always available (never swallowed by the filter).
+  if (key.upArrow || key.wheelUp) {
+    return { kind: 'cursorUp' }
+  }
+
+  if (key.downArrow || key.wheelDown) {
+    return { kind: 'cursorDown' }
+  }
+
+  if ((key.return || key.rightArrow) && hasSelected) {
+    return { kind: 'open' }
+  }
+
+  // Reserved shortcuts fire only when not actively filtering.
+  if (!hasQuery) {
+    if (ch === 'q') {
+      return { kind: 'close' }
+    }
+
+    if (ch === '<' || ch === '[') {
+      return { kind: 'historyOlder' }
+    }
+
+    if (ch === '>' || ch === ']') {
+      return { kind: 'historyNewer' }
+    }
+
+    if (ch === 'p') {
+      return { kind: 'pause' }
+    }
+
+    if (ch === 'x' && hasSelected) {
+      return { kind: 'killOne' }
+    }
+
+    if (ch === 'X' && hasSelected) {
+      return { kind: 'killSubtree' }
+    }
+
+    if (ch === 'l' && hasSelected) {
+      return { kind: 'open' }
+    }
+
+    if (ch === 'k') {
+      return { kind: 'cursorUp' }
+    }
+
+    if (ch === 'j') {
+      return { kind: 'cursorDown' }
+    }
+
+    if (ch === 'g') {
+      return { kind: 'cursorTop' }
+    }
+
+    if (ch === 'G') {
+      return { kind: 'cursorBottom' }
+    }
+
+    if (ch === 's') {
+      return { kind: 'cycleSort' }
+    }
+
+    if (ch === 'f') {
+      return { kind: 'cycleFilter' }
+    }
+  }
+
+  if (ch && !key.ctrl && !key.meta && ch.length === 1 && ch >= ' ') {
+    // A leading space must not start a filter (it would read as "active" while
+    // the trimmed query leaves the list unfiltered and disable the shortcuts).
+    if (ch === ' ' && !hasQuery) {
+      return { kind: 'ignore' }
+    }
+
+    return { ch, kind: 'filterAppend' }
+  }
+
+  return { kind: 'ignore' }
+}
 
 const diffMetricLine = (name: string, a: number, b: number, fmt: (n: number) => string) => {
   const d = b - a
@@ -605,6 +760,8 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
   const [sort, setSort] = useState<SortMode>('depth-first')
   const [filter, setFilter] = useState<FilterMode>('all')
+  // Free-text fuzzy query (list mode only), orthogonal to the FilterMode above.
+  const [query, setQuery] = useState('')
   const [cursor, setCursor] = useState(0)
   const [flash, setFlash] = useState<string>('')
   const [now, setNow] = useState(() => Date.now())
@@ -631,8 +788,10 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const spark = useMemo(() => sparkline(widths), [widths])
   const peak = useMemo(() => peakHotness(tree), [tree])
   const rows = useMemo(() => prepareRows(tree, sort, filter), [tree, sort, filter])
+  // Apply the fuzzy query as a final pass; navigation + rendering index into this.
+  const visibleRows = useMemo(() => rankSubagentRows(rows, query), [rows, query])
 
-  const selected = rows[cursor] ?? null
+  const selected = visibleRows[cursor] ?? null
 
   const cols = stdout?.columns ?? 80
   const rowsH = Math.max(8, (stdout?.rows ?? 24) - 10)
@@ -683,10 +842,8 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   }, [gw])
 
   useEffect(() => {
-    if (cursor >= rows.length) {
-      setCursor(Math.max(0, rows.length - 1))
-    }
-  }, [cursor, rows.length])
+    setCursor(c => clampIndex(c, visibleRows.length))
+  }, [visibleRows.length])
 
   // ── Actions ────────────────────────────────────────────────────────
 
@@ -752,38 +909,35 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const scrollDetail = (dy: number) => detailScrollRef.current?.scrollBy(dy)
 
   useInput((ch, key) => {
-    if (ch === 'q') {
-      return closeWithCleanup()
-    }
-
-    if (key.escape) {
-      return mode === 'detail' ? setMode('list') : closeWithCleanup()
-    }
-
-    // Shared actions (both modes).
-    if (ch === '<' || ch === '[') {
-      return stepHistory(1)
-    }
-
-    if (ch === '>' || ch === ']') {
-      return stepHistory(-1)
-    }
-
-    if (ch === 'p') {
-      return togglePause()
-    }
-
-    if (ch === 'x' && selected) {
-      return killOne(selected.item.id)
-    }
-
-    if (ch === 'X' && selected) {
-      return killSubtree(selected)
-    }
-
+    // Detail mode: scroll-focused, unchanged. The fuzzy query is only edited in
+    // list mode, so detail keeps every existing binding (incl. shared actions).
     if (mode === 'detail') {
-      if (key.leftArrow || ch === 'h') {
+      if (ch === 'q') {
+        return closeWithCleanup()
+      }
+
+      if (key.escape || key.leftArrow || ch === 'h') {
         return setMode('list')
+      }
+
+      if (ch === '<' || ch === '[') {
+        return stepHistory(1)
+      }
+
+      if (ch === '>' || ch === ']') {
+        return stepHistory(-1)
+      }
+
+      if (ch === 'p') {
+        return togglePause()
+      }
+
+      if (ch === 'x' && selected) {
+        return killOne(selected.item.id)
+      }
+
+      if (ch === 'X' && selected) {
+        return killSubtree(selected)
       }
 
       if (key.pageUp || (key.ctrl && ch === 'u')) {
@@ -821,33 +975,68 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       return
     }
 
-    // List mode.
-    if ((key.return || key.rightArrow || ch === 'l') && selected) {
-      return setMode('detail')
-    }
+    // List mode: type-to-filter aware. Reserved single-key shortcuts gate behind
+    // an empty query so the same keys can be typed into the filter (see
+    // classifyAgentsListKey).
+    const action = classifyAgentsListKey(ch, key, query.trim() !== '', selected !== null)
 
-    if (key.upArrow || ch === 'k' || key.wheelUp) {
-      return setCursor(c => Math.max(0, c - 1))
-    }
+    switch (action.kind) {
+      case 'close':
+        return closeWithCleanup()
 
-    if (key.downArrow || ch === 'j' || key.wheelDown) {
-      return setCursor(c => Math.min(Math.max(0, rows.length - 1), c + 1))
-    }
+      case 'cursorBottom':
+        return setCursor(Math.max(0, visibleRows.length - 1))
 
-    if (ch === 'g') {
-      return setCursor(0)
-    }
+      case 'cursorDown':
+        return setCursor(c => Math.min(Math.max(0, visibleRows.length - 1), c + 1))
 
-    if (ch === 'G') {
-      return setCursor(Math.max(0, rows.length - 1))
-    }
+      case 'cursorTop':
+        return setCursor(0)
 
-    if (ch === 's') {
-      return setSort(m => cycle(SORT_ORDER, m))
-    }
+      case 'cursorUp':
+        return setCursor(c => Math.max(0, c - 1))
 
-    if (ch === 'f') {
-      return setFilter(m => cycle(FILTER_ORDER, m))
+      case 'cycleFilter':
+        return setFilter(m => cycle(FILTER_ORDER, m))
+
+      case 'cycleSort':
+        return setSort(m => cycle(SORT_ORDER, m))
+
+      case 'filterAppend':
+        setQuery(q => q + action.ch)
+
+        return setCursor(0)
+
+      case 'filterBackspace':
+        setQuery(q => q.slice(0, -1))
+
+        return setCursor(0)
+
+      case 'filterClear':
+        setQuery('')
+
+        return setCursor(0)
+
+      case 'historyNewer':
+        return stepHistory(-1)
+
+      case 'historyOlder':
+        return stepHistory(1)
+
+      case 'killOne':
+        return selected ? killOne(selected.item.id) : undefined
+
+      case 'killSubtree':
+        return selected ? killSubtree(selected) : undefined
+
+      case 'open':
+        return selected ? setMode('detail') : undefined
+
+      case 'pause':
+        return togglePause()
+
+      default:
+        return
     }
   })
 
@@ -905,16 +1094,20 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
         </Text>
       </Box>
 
-      {rows.length === 0 ? (
+      {mode === 'list' && visibleRows.length === 0 ? (
         <Box flexDirection="column" flexGrow={1}>
-          <Text color={t.color.muted}>No subagents this turn. Trigger delegate_task to populate the tree.</Text>
+          <Text color={t.color.muted}>
+            {query.trim()
+              ? `No agents match "${query}". Esc to clear the filter.`
+              : 'No subagents this turn. Trigger delegate_task to populate the tree.'}
+          </Text>
         </Box>
       ) : mode === 'list' ? (
         <Box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0}>
-          <GanttStrip cols={cols} cursor={cursor} flatNodes={rows} maxRows={6} now={now} t={t} />
+          <GanttStrip cols={cols} cursor={cursor} flatNodes={visibleRows} maxRows={6} now={now} t={t} />
 
           <Box flexDirection="column" flexGrow={0} flexShrink={0} overflow="hidden">
-            {rows.slice(listWindowStart, listWindowStart + rowsH).map((node, i) => (
+            {visibleRows.slice(listWindowStart, listWindowStart + rowsH).map((node, i) => (
               <ListRow
                 active={listWindowStart + i === cursor}
                 index={listWindowStart + i}
@@ -944,10 +1137,25 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       <Box flexDirection="column" marginTop={1}>
         {flash ? <Text color={t.color.accent}>{flash}</Text> : null}
 
-        {mode === 'list' ? (
+        {mode === 'list' && query.trim() ? (
+          <Text color={t.color.accent} wrap="truncate-end">
+            filter: {query}▎
+          </Text>
+        ) : null}
+
+        {mode === 'list' && query.trim() ? (
+          // While filtering, the single-letter shortcuts feed the query, so only
+          // advertise the keys that still do what they say (and drop the
+          // selection keys when nothing matches).
+          <Text color={t.color.muted}>
+            {visibleRows.length
+              ? '↑↓ move · Enter/→ open detail · Backspace edit · Esc clear filter'
+              : 'Backspace edit · Esc clear filter'}
+          </Text>
+        ) : mode === 'list' ? (
           <Text color={t.color.muted}>
             ↑↓/jk move · g/G top/bottom · Enter/→ open detail{controlsHint} · s sort:{SORT_LABEL[sort]} · f filter:
-            {FILTER_LABEL[filter]}
+            {FILTER_LABEL[filter]} · type to filter
             {history.length > 0 ? ` · [ / ] history ${historyIndex}/${history.length}` : ''}
             {' · q close'}
           </Text>

--- a/ui-tui/src/components/overlayControls.tsx
+++ b/ui-tui/src/components/overlayControls.tsx
@@ -38,6 +38,14 @@ export function windowItems<T>(items: T[], selected: number, visible: number) {
   }
 }
 
+/**
+ * Clamp a selection index into `[0, length - 1]`, returning 0 for an empty
+ * list. Shared by the type-to-filter overlays to keep a cursor in bounds when
+ * the filtered list shrinks beneath it.
+ */
+export const clampIndex = (index: number, length: number): number =>
+  length <= 0 ? 0 : Math.max(0, Math.min(index, length - 1))
+
 interface OverlayHintProps {
   children: string
   t: Theme

--- a/ui-tui/src/components/petPicker.tsx
+++ b/ui-tui/src/components/petPicker.tsx
@@ -2,16 +2,17 @@ import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useMemo, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
+import { fuzzyRank } from '../lib/fuzzy.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, windowItems } from './overlayControls.js'
+import { clampIndex, OverlayHint, windowItems } from './overlayControls.js'
 
 const VISIBLE = 10
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
-interface GalleryPet {
+export interface GalleryPet {
   slug: string
   displayName: string
   installed: boolean
@@ -22,6 +23,19 @@ interface Gallery {
   enabled: boolean
   active: string
   pets: GalleryPet[]
+}
+
+export function rankPets(pets: readonly GalleryPet[], query: string, enabled: boolean, active: string): GalleryPet[] {
+  const available = pets.filter(pet => !/^clawd(-|$)/i.test(pet.slug))
+
+  const statusRank = (pet: GalleryPet) =>
+    (enabled && pet.slug === active ? 4 : 0) + (pet.installed ? 2 : 0) + (pet.curated ? 1 : 0)
+
+  const ranked = [...available].sort((a, b) => statusRank(b) - statusRank(a))
+
+  return query.trim()
+    ? fuzzyRank(ranked, query, pet => `${pet.displayName} ${pet.slug}`).map(result => result.item)
+    : ranked
 }
 
 /**
@@ -54,20 +68,10 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
   const enabled = gallery?.enabled ?? false
   const active = gallery?.active ?? ''
 
-  // Rank by the signals petdex gives us — active, then installed, then curated
-  // (its official set), then the rest — and hide the clawd placeholders.
-  const view = useMemo(() => {
-    const pets = (gallery?.pets ?? []).filter(p => !/^clawd(-|$)/i.test(p.slug))
-    const needle = query.trim().toLowerCase()
-
-    const matched = needle
-      ? pets.filter(p => p.slug.toLowerCase().includes(needle) || p.displayName.toLowerCase().includes(needle))
-      : pets
-
-    const rank = (p: GalleryPet) => (enabled && p.slug === active ? 4 : 0) + (p.installed ? 2 : 0) + (p.curated ? 1 : 0)
-
-    return [...matched].sort((a, b) => rank(b) - rank(a))
-  }, [gallery, query, enabled, active])
+  // Rank by fuzzy match quality while retaining the petdex status priority
+  // (active, installed, curated) as the stable tie-break order.
+  const view = useMemo(() => rankPets(gallery?.pets ?? [], query, enabled, active), [gallery, query, enabled, active])
+  const clampedIdx = clampIndex(idx, view.length)
 
   const adopt = (slug: string) => {
     setBusy(true)
@@ -86,6 +90,13 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
     }
 
     if (key.escape) {
+      if (query) {
+        setQuery('')
+        setIdx(0)
+
+        return
+      }
+
       return onClose()
     }
 
@@ -94,11 +105,11 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
     }
 
     if (key.downArrow) {
-      return setIdx(i => Math.min(view.length - 1, i + 1))
+      return setIdx(i => clampIndex(i + 1, view.length))
     }
 
     if (key.return) {
-      const pet = view[idx]
+      const pet = view[clampedIdx]
 
       return pet ? adopt(pet.slug) : undefined
     }
@@ -109,8 +120,18 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
       return setIdx(0)
     }
 
+    if (key.ctrl && (input.toLowerCase() === 'u' || input === String.fromCharCode(21))) {
+      setQuery('')
+
+      return setIdx(0)
+    }
+
     // Printable char → extend the filter (ignore control/chorded keys).
     if (input && input.length === 1 && input >= ' ' && !key.ctrl && !key.meta) {
+      if (input === ' ' && !query) {
+        return
+      }
+
       setQuery(q => q + input)
       setIdx(0)
     }
@@ -129,7 +150,7 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
     )
   }
 
-  const { items, offset } = windowItems(view, idx, VISIBLE)
+  const { items, offset } = windowItems(view, clampedIdx, VISIBLE)
 
   return (
     <Box flexDirection="column" width={width}>
@@ -147,7 +168,7 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
         <Text color={t.color.muted}>{query ? `no pets match "${query}"` : 'no pets available'}</Text>
       ) : (
         items.map((pet, i) => {
-          const at = offset + i === idx
+          const at = offset + i === clampedIdx
           const isActive = enabled && pet.slug === active
           const mark = isActive ? '●' : pet.installed ? '✓' : ' '
           const tag = pet.installed ? '' : pet.curated ? ' · official' : ''
@@ -171,7 +192,11 @@ export function PetPicker({ gw, onClose, t }: PetPickerProps) {
       {err ? <Text color={t.color.label}>error: {err}</Text> : null}
       {busy ? <Text color={t.color.accent}>adopting…</Text> : null}
 
-      <OverlayHint t={t}>↑/↓ select · Enter adopt · type to filter · Esc cancel</OverlayHint>
+      <OverlayHint t={t}>
+        {query
+          ? '↑/↓ select · Enter adopt · Backspace edit · Ctrl+U clear · Esc clear filter'
+          : '↑/↓ select · Enter adopt · type to filter · Esc cancel'}
+      </OverlayHint>
     </Box>
   )
 }

--- a/ui-tui/src/components/pluginsHub.tsx
+++ b/ui-tui/src/components/pluginsHub.tsx
@@ -1,17 +1,18 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
+import { fuzzyRank } from '../lib/fuzzy.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
+import { clampIndex, OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
 
 const VISIBLE = 12
 const MIN_WIDTH = 44
 const MAX_WIDTH = 96
 
-interface PluginRow {
+export interface PluginRow {
   description?: string
   name: string
   source?: string
@@ -39,12 +40,104 @@ const GLYPH: Record<string, string> = {
   enabled: '✓'
 }
 
+const ctrlChar = (letter: string) => String.fromCharCode(letter.charCodeAt(0) - 96)
+
+export const rankPluginRows = (rows: readonly PluginRow[], query: string): PluginRow[] =>
+  query.trim()
+    ? fuzzyRank(rows, query, row =>
+        [row.name, row.description, row.source, row.version, row.status].filter(Boolean).join(' ')
+      ).map(result => result.item)
+    : [...rows]
+
+export interface PluginsListKeyFlags {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  return?: boolean
+  tab?: boolean
+  upArrow?: boolean
+}
+
+export type PluginsListKeyAction =
+  | { ch: string; kind: 'append' }
+  | { kind: 'backspace' }
+  | { kind: 'clearFilter' }
+  | { kind: 'close' }
+  | { kind: 'down' }
+  | { kind: 'ignore' }
+  | { kind: 'quick'; n: number }
+  | { kind: 'select' }
+  | { kind: 'toggleScope' }
+  | { kind: 'up' }
+
+export function classifyPluginsListKey(
+  ch: string,
+  key: PluginsListKeyFlags,
+  filterActive: boolean
+): PluginsListKeyAction {
+  if (key.escape) {
+    return filterActive ? { kind: 'clearFilter' } : { kind: 'close' }
+  }
+
+  if (key.upArrow) {
+    return { kind: 'up' }
+  }
+
+  if (key.downArrow) {
+    return { kind: 'down' }
+  }
+
+  if (key.return) {
+    return { kind: 'select' }
+  }
+
+  if (key.tab) {
+    return { kind: 'toggleScope' }
+  }
+
+  if ((key.backspace || key.delete) && filterActive) {
+    return { kind: 'backspace' }
+  }
+
+  if (key.ctrl && (ch.toLowerCase() === 'u' || ch === ctrlChar('u')) && filterActive) {
+    return { kind: 'clearFilter' }
+  }
+
+  if (!filterActive && ch === 'q') {
+    return { kind: 'close' }
+  }
+
+  // Preserve Space-to-toggle when no query is active; once filtering has
+  // started, spaces belong to multi-token search text.
+  if (!filterActive && ch === ' ') {
+    return { kind: 'select' }
+  }
+
+  if (!filterActive) {
+    const n = ch === '0' ? 10 : parseInt(ch, 10)
+
+    if (!Number.isNaN(n) && n >= 1 && n <= 10) {
+      return { kind: 'quick', n }
+    }
+  }
+
+  if (ch && ch.length === 1 && ch >= ' ' && !key.ctrl && !key.meta) {
+    return { ch, kind: 'append' }
+  }
+
+  return { kind: 'ignore' }
+}
+
 export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
   const [rows, setRows] = useState<PluginRow[]>([])
   const [bundledCount, setBundledCount] = useState(0)
   const [userCount, setUserCount] = useState(0)
   const [idx, setIdx] = useState(0)
   const [scope, setScope] = useState<Scope>('user')
+  const [filter, setFilter] = useState('')
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
@@ -71,12 +164,22 @@ export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
 
   // Default to user plugins; fall back to all when there are none so the
   // overlay is never empty when bundled plugins exist.
-  const visibleRows = scope === 'user' ? rows.filter(r => r.source !== 'bundled') : rows
-  const effectiveRows = scope === 'user' && !visibleRows.length && rows.length ? rows : visibleRows
-  const effectiveScope: Scope = effectiveRows === visibleRows ? scope : 'all'
-  const clampedIdx = Math.min(idx, Math.max(0, effectiveRows.length - 1))
+  const { effectiveRows, effectiveScope } = useMemo(() => {
+    const visibleRows = scope === 'user' ? rows.filter(r => r.source !== 'bundled') : rows
+    const fellBackToAll = scope === 'user' && !visibleRows.length && rows.length > 0
+    const scopedRows = fellBackToAll ? rows : visibleRows
 
-  useOverlayKeys({ disabled: busy, onClose })
+    return {
+      effectiveRows: rankPluginRows(scopedRows, filter),
+      effectiveScope: (fellBackToAll ? 'all' : scope) as Scope
+    }
+  }, [filter, rows, scope])
+
+  const clampedIdx = clampIndex(idx, effectiveRows.length)
+
+  // On the populated list, q/Esc are filter-aware and handled locally. Keep
+  // the shared close behavior for loading, empty, and error states.
+  useOverlayKeys({ disabled: busy || rows.length > 0, onClose })
 
   const toggle = (row: PluginRow) => {
     if (busy || !row) {
@@ -100,52 +203,82 @@ export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
   }
 
   useInput((ch, key) => {
-    if (busy) {
+    if (busy || !rows.length) {
       return
     }
 
     const count = effectiveRows.length
+    const action = classifyPluginsListKey(ch, key, filter.trim() !== '')
 
-    if (key.upArrow && clampedIdx > 0) {
-      setIdx(clampedIdx - 1)
+    switch (action.kind) {
+      case 'close':
+        return onClose()
 
-      return
-    }
+      case 'clearFilter':
+        setFilter('')
+        setIdx(0)
 
-    if (key.downArrow && clampedIdx < count - 1) {
-      setIdx(clampedIdx + 1)
+        return
 
-      return
-    }
+      case 'backspace':
+        setFilter(value => value.slice(0, -1))
+        setIdx(0)
 
-    // Tab toggles user-only vs all (bundled) scope.
-    if (key.tab) {
-      setScope(s => (s === 'user' ? 'all' : 'user'))
-      setIdx(0)
+        return
 
-      return
-    }
+      case 'append':
+        setFilter(value => value + action.ch)
+        setIdx(0)
 
-    if (key.return || ch === ' ') {
-      const row = effectiveRows[clampedIdx]
+        return
 
-      if (row) {
-        toggle(row)
+      case 'up':
+        if (clampedIdx > 0) {
+          setIdx(clampedIdx - 1)
+        }
+
+        return
+
+      case 'down':
+        if (clampedIdx < count - 1) {
+          setIdx(clampedIdx + 1)
+        }
+
+        return
+
+      case 'toggleScope':
+        setScope(value => (value === 'user' ? 'all' : 'user'))
+        setIdx(0)
+
+        return
+      case 'select': {
+        const row = effectiveRows[clampedIdx]
+
+        if (row) {
+          toggle(row)
+        }
+
+        return
       }
 
-      return
-    }
+      case 'quick': {
+        if (action.n > count) {
+          return
+        }
 
-    const n = ch === '0' ? 10 : parseInt(ch, 10)
+        const next = windowOffset(count, clampedIdx, VISIBLE) + action.n - 1
+        const row = effectiveRows[next]
 
-    if (!Number.isNaN(n) && n >= 1 && n <= Math.min(10, count)) {
-      const next = windowOffset(count, clampedIdx, VISIBLE) + n - 1
-      const row = effectiveRows[next]
+        if (row) {
+          setIdx(next)
+          toggle(row)
+        }
 
-      if (row) {
-        setIdx(next)
-        toggle(row)
+        return
       }
+
+      default:
+        return
     }
   })
 
@@ -199,25 +332,34 @@ export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
       </Text>
 
       <Text color={t.color.muted}>{scopeLabel}</Text>
+      <Text color={filter ? t.color.accent : t.color.muted} wrap="truncate-end">
+        {filter
+          ? `filter: ${filter}▎ · ${effectiveRows.length} match${effectiveRows.length === 1 ? '' : 'es'}`
+          : 'type to filter'}
+      </Text>
       {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
 
-      {items.map((row, i) => {
-        const lineIdx = offset + i
-        const active = clampedIdx === lineIdx
+      {effectiveRows.length === 0 && filter ? (
+        <Text color={t.color.muted}>no plugins match the filter</Text>
+      ) : (
+        items.map((row, i) => {
+          const lineIdx = offset + i
+          const active = clampedIdx === lineIdx
 
-        return (
-          <Text
-            bold={active}
-            color={active ? t.color.accent : t.color.muted}
-            inverse={active}
-            key={effectiveRows[lineIdx]?.name ?? row}
-            wrap="truncate-end"
-          >
-            {active ? '▸ ' : '  '}
-            {i + 1}. {row}
-          </Text>
-        )
-      })}
+          return (
+            <Text
+              bold={active}
+              color={active ? t.color.accent : t.color.muted}
+              inverse={active}
+              key={effectiveRows[lineIdx]?.name ?? row}
+              wrap="truncate-end"
+            >
+              {active ? '▸ ' : '  '}
+              {i + 1}. {row}
+            </Text>
+          )
+        })
+      )}
 
       {offset + VISIBLE < labels.length && (
         <Text color={t.color.muted}> ↓ {labels.length - offset - VISIBLE} more</Text>
@@ -226,7 +368,13 @@ export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
       {err ? <Text color={t.color.label}>error: {err}</Text> : null}
       {busy ? <Text color={t.color.accent}>updating…</Text> : null}
 
-      <OverlayHint t={t}>↑/↓ select · Enter/Space toggle · Tab user/all · 1-9,0 quick · Esc/q close</OverlayHint>
+      <OverlayHint t={t}>
+        {filter
+          ? effectiveRows.length
+            ? '↑/↓ select · Enter toggle · Tab user/all · Backspace edit · Esc clear filter'
+            : 'Tab user/all · Backspace edit · Esc clear filter'
+          : '↑/↓ select · Enter/Space toggle · Tab user/all · 1-9,0 quick · type to filter · Esc/q close'}
+      </OverlayHint>
     </Box>
   )
 }

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -1,15 +1,121 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
+import { fuzzyRank } from '../lib/fuzzy.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
+import { clampIndex, OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
 
 const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
+
+// ── Type-to-filter helpers ───────────────────────────────────────────
+//
+// The category + skill list stages support fuzzy type-to-filter, mirroring
+// modelPicker. The list logic and the key-gating decision are factored into
+// pure functions so they can be unit-tested without rendering Ink.
+
+/** Subset of the Ink key flags the list-stage handler inspects. */
+export interface SkillsKeyFlags {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  return?: boolean
+  upArrow?: boolean
+}
+
+/**
+ * Rank skill categories by a fuzzy query against the category name plus the
+ * names of the skills it contains, so typing a skill name surfaces its
+ * category. An empty query keeps the original (sorted) order.
+ */
+export const rankSkillCategories = (
+  cats: readonly string[],
+  skillsByCat: Record<string, string[]>,
+  query: string
+): string[] =>
+  query.trim() ? fuzzyRank(cats, query, c => `${c} ${(skillsByCat[c] ?? []).join(' ')}`).map(r => r.item) : [...cats]
+
+/** Rank skills within a category by a fuzzy query. Empty query keeps order. */
+export const rankSkills = (skills: readonly string[], query: string): string[] =>
+  query.trim() ? fuzzyRank(skills, query, s => s).map(r => r.item) : [...skills]
+
+export type SkillsListAction =
+  | { ch: string; kind: 'append' }
+  | { kind: 'backspace' }
+  | { kind: 'clearFilter' }
+  | { kind: 'close' }
+  | { kind: 'down' }
+  | { kind: 'escape' }
+  | { kind: 'ignore' }
+  | { kind: 'quick'; n: number }
+  | { kind: 'select' }
+  | { kind: 'up' }
+
+/**
+ * Decide what a keypress does on a list stage. Reserved single-key shortcuts
+ * (`q` to close, `1`-`9`/`0` quick-select) only fire when no filter is active,
+ * so the same keys extend the filter once the user is typing one. Navigation,
+ * Backspace, Ctrl+U and Esc are always available. Any other printable key
+ * starts/extends the filter.
+ */
+export function classifySkillsListKey(ch: string, key: SkillsKeyFlags, hasFilter: boolean): SkillsListAction {
+  if (key.escape) {
+    return hasFilter ? { kind: 'clearFilter' } : { kind: 'escape' }
+  }
+
+  if (key.upArrow) {
+    return { kind: 'up' }
+  }
+
+  if (key.downArrow) {
+    return { kind: 'down' }
+  }
+
+  if (key.return) {
+    return { kind: 'select' }
+  }
+
+  if (key.backspace || key.delete) {
+    return hasFilter ? { kind: 'backspace' } : { kind: 'ignore' }
+  }
+
+  if (key.ctrl && ch === 'u') {
+    return hasFilter ? { kind: 'clearFilter' } : { kind: 'ignore' }
+  }
+
+  // Reserved shortcuts fire only when not actively filtering.
+  if (!hasFilter) {
+    if (ch === 'q' && !key.ctrl && !key.meta) {
+      return { kind: 'close' }
+    }
+
+    const n = ch === '0' ? 10 : Number.parseInt(ch, 10)
+
+    if (!Number.isNaN(n) && n >= 1 && n <= 10) {
+      return { kind: 'quick', n }
+    }
+  }
+
+  if (ch && !key.ctrl && !key.meta && ch.length === 1 && ch >= ' ') {
+    // A leading space must not start a filter: it would read as "active" (and
+    // disable the reserved shortcuts) while the trimmed query leaves the list
+    // unfiltered. Spaces inside an existing query are fine (multi-token match).
+    if (ch === ' ' && !hasFilter) {
+      return { kind: 'ignore' }
+    }
+
+    return { ch, kind: 'append' }
+  }
+
+  return { kind: 'ignore' }
+}
 
 export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   const [skillsByCat, setSkillsByCat] = useState<Record<string, string[]>>({})
@@ -21,6 +127,8 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   const [installing, setInstalling] = useState(false)
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
+  // Type-to-filter query, scoped per list stage (cleared on stage change).
+  const [filter, setFilter] = useState('')
 
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
@@ -38,9 +146,26 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       })
   }, [gw])
 
-  const cats = Object.keys(skillsByCat).sort()
-  const skills = selectedCat ? (skillsByCat[selectedCat] ?? []) : []
+  // Memoized so the filtered useMemos below have stable inputs (otherwise the
+  // fuzzy rank would re-run every render).
+  const cats = useMemo(() => Object.keys(skillsByCat).sort(), [skillsByCat])
+  const skills = useMemo(() => (selectedCat ? (skillsByCat[selectedCat] ?? []) : []), [selectedCat, skillsByCat])
   const skillName = skills[skillIdx] ?? ''
+
+  // Filtered views drive navigation + rendering; indices point into these.
+  const filteredCats = useMemo(() => rankSkillCategories(cats, skillsByCat, filter), [cats, skillsByCat, filter])
+  const filteredSkills = useMemo(() => rankSkills(skills, filter), [skills, filter])
+
+  const listStage = stage === 'category' || stage === 'skill'
+
+  // Keep the active selection within the (possibly shrunk) filtered list.
+  useEffect(() => {
+    setCatIdx(i => clampIndex(i, filteredCats.length))
+  }, [filteredCats.length])
+
+  useEffect(() => {
+    setSkillIdx(i => clampIndex(i, filteredSkills.length))
+  }, [filteredSkills.length])
 
   const back = () => {
     if (stage === 'actions') {
@@ -54,6 +179,7 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
     if (stage === 'skill') {
       setStage('category')
       setSkillIdx(0)
+      setFilter('')
 
       return
     }
@@ -61,7 +187,9 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
     onClose()
   }
 
-  useOverlayKeys({ disabled: installing, onBack: back, onClose })
+  // Disable the shared overlay q/Esc handler on the list stages so those keys
+  // can be typed into / used to clear the filter (handled locally below).
+  useOverlayKeys({ disabled: installing || listStage, onBack: back, onClose })
 
   const inspect = (name: string) => {
     setInfo(null)
@@ -80,6 +208,37 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       .then(() => onClose())
       .catch((e: unknown) => setErr(rpcErrorMessage(e)))
       .finally(() => setInstalling(false))
+  }
+
+  // Open the category at `idx` in the filtered list, re-anchoring catIdx to the
+  // full (sorted) list so it stays valid once the filter clears.
+  const openCategory = (idx: number) => {
+    const cat = filteredCats[idx]
+
+    if (!cat) {
+      return
+    }
+
+    setSelectedCat(cat)
+    setCatIdx(Math.max(0, cats.indexOf(cat)))
+    setSkillIdx(0)
+    setStage('skill')
+    setFilter('')
+  }
+
+  // Open the skill at `idx` in the filtered list, re-anchoring skillIdx to the
+  // full category list so the actions stage reads the right skill name.
+  const openSkill = (idx: number) => {
+    const name = filteredSkills[idx]
+
+    if (!name) {
+      return
+    }
+
+    setSkillIdx(Math.max(0, skills.indexOf(name)))
+    setStage('actions')
+    setFilter('')
+    inspect(name)
   }
 
   useInput((ch, key) => {
@@ -109,72 +268,75 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       return
     }
 
-    const count = stage === 'category' ? cats.length : skills.length
+    const list = stage === 'category' ? filteredCats : filteredSkills
+    const count = list.length
     const sel = stage === 'category' ? catIdx : skillIdx
     const setSel = stage === 'category' ? setCatIdx : setSkillIdx
+    const action = classifySkillsListKey(ch, key, filter.trim() !== '')
 
-    if (key.upArrow && sel > 0) {
-      setSel(v => v - 1)
+    switch (action.kind) {
+      case 'append':
+        setFilter(v => v + action.ch)
+        setSel(0)
 
-      return
-    }
+        return
 
-    if (key.downArrow && sel < count - 1) {
-      setSel(v => v + 1)
+      case 'backspace':
+        setFilter(v => v.slice(0, -1))
+        setSel(0)
 
-      return
-    }
+        return
 
-    if (key.return) {
-      if (stage === 'category') {
-        const cat = cats[catIdx]
+      case 'clearFilter':
+        setFilter('')
+        setSel(0)
 
-        if (!cat) {
-          return
+        return
+
+      case 'close':
+        return onClose()
+
+      case 'down':
+        if (sel < count - 1) {
+          setSel(v => v + 1)
         }
 
-        setSelectedCat(cat)
-        setSkillIdx(0)
-        setStage('skill')
+        return
+
+      case 'escape':
+        return back()
+
+      case 'select':
+        if (stage === 'category') {
+          openCategory(catIdx)
+        } else {
+          openSkill(skillIdx)
+        }
+
+        return
+
+      case 'up':
+        if (sel > 0) {
+          setSel(v => v - 1)
+        }
+
+        return
+      case 'quick': {
+        if (action.n <= Math.min(10, count)) {
+          const next = windowOffset(count, sel, VISIBLE) + action.n - 1
+
+          if (stage === 'category') {
+            openCategory(next)
+          } else {
+            openSkill(next)
+          }
+        }
 
         return
       }
 
-      const name = skills[skillIdx]
-
-      if (name) {
-        setStage('actions')
-        inspect(name)
-      }
-
-      return
-    }
-
-    const n = ch === '0' ? 10 : parseInt(ch, 10)
-
-    if (!Number.isNaN(n) && n >= 1 && n <= Math.min(10, count)) {
-      const next = windowOffset(count, sel, VISIBLE) + n - 1
-
-      if (stage === 'category') {
-        const cat = cats[next]
-
-        if (cat) {
-          setSelectedCat(cat)
-          setCatIdx(next)
-          setSkillIdx(0)
-          setStage('skill')
-        }
-
+      default:
         return
-      }
-
-      const name = skills[next]
-
-      if (name) {
-        setSkillIdx(next)
-        setStage('actions')
-        inspect(name)
-      }
     }
   })
 
@@ -201,8 +363,9 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   }
 
   if (stage === 'category') {
-    const rows = cats.map(c => `${c} · ${skillsByCat[c]?.length ?? 0} skills`)
+    const rows = filteredCats.map(c => `${c} · ${skillsByCat[c]?.length ?? 0} skills`)
     const { items, offset } = windowItems(rows, catIdx, VISIBLE)
+    const noMatches = filter.trim() !== '' && rows.length === 0
 
     return (
       <Box flexDirection="column" width={width}>
@@ -211,33 +374,49 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
         </Text>
 
         <Text color={t.color.muted}>select a category</Text>
+        <Text color={filter ? t.color.accent : t.color.muted} wrap="truncate-end">
+          {filter ? `filter: ${filter}▎` : 'type to filter · ↑/↓ select'}
+        </Text>
         {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
 
-        {items.map((row, i) => {
-          const idx = offset + i
+        {noMatches ? (
+          <Text color={t.color.muted}>no categories match</Text>
+        ) : (
+          items.map((row, i) => {
+            const idx = offset + i
 
-          return (
-            <Text
-              bold={catIdx === idx}
-              color={catIdx === idx ? t.color.accent : t.color.muted}
-              inverse={catIdx === idx}
-              key={row}
-              wrap="truncate-end"
-            >
-              {catIdx === idx ? '▸ ' : '  '}
-              {i + 1}. {row}
-            </Text>
-          )
-        })}
+            return (
+              <Text
+                bold={catIdx === idx}
+                color={catIdx === idx ? t.color.accent : t.color.muted}
+                inverse={catIdx === idx}
+                key={row}
+                wrap="truncate-end"
+              >
+                {catIdx === idx ? '▸ ' : '  '}
+                {i + 1}. {row}
+              </Text>
+            )
+          })
+        )}
 
         {offset + VISIBLE < rows.length && <Text color={t.color.muted}> ↓ {rows.length - offset - VISIBLE} more</Text>}
-        <OverlayHint t={t}>↑/↓ select · Enter open · 1-9,0 quick · Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>
+          {filter.trim()
+            ? filteredCats.length
+              ? '↑/↓ select · Enter open · Backspace edit · Esc clear filter'
+              : 'Backspace edit · Esc clear filter'
+            : '↑/↓ select · Enter open · 1-9,0 quick · type to filter · q close'}
+        </OverlayHint>
       </Box>
     )
   }
 
   if (stage === 'skill') {
-    const { items, offset } = windowItems(skills, skillIdx, VISIBLE)
+    const { items, offset } = windowItems(filteredSkills, skillIdx, VISIBLE)
+    // Only a non-empty category can show "no matches"; an empty category keeps
+    // its own "no skills in this category" message (avoid showing both).
+    const noMatches = filter.trim() !== '' && skills.length > 0 && filteredSkills.length === 0
 
     return (
       <Box flexDirection="column" width={width}>
@@ -246,7 +425,11 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
         </Text>
 
         <Text color={t.color.muted}>{skills.length} skill(s)</Text>
+        <Text color={filter ? t.color.accent : t.color.muted} wrap="truncate-end">
+          {filter ? `filter: ${filter}▎` : 'type to filter · ↑/↓ select'}
+        </Text>
         {!skills.length ? <Text color={t.color.muted}>no skills in this category</Text> : null}
+        {noMatches ? <Text color={t.color.muted}>no skills match</Text> : null}
         {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
 
         {items.map((row, i) => {
@@ -266,11 +449,17 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
           )
         })}
 
-        {offset + VISIBLE < skills.length && (
-          <Text color={t.color.muted}> ↓ {skills.length - offset - VISIBLE} more</Text>
+        {offset + VISIBLE < filteredSkills.length && (
+          <Text color={t.color.muted}> ↓ {filteredSkills.length - offset - VISIBLE} more</Text>
         )}
         <OverlayHint t={t}>
-          {skills.length ? '↑/↓ select · Enter open · 1-9,0 quick · Esc back · q close' : 'Esc back · q close'}
+          {filter.trim()
+            ? filteredSkills.length
+              ? '↑/↓ select · Enter open · Backspace edit · Esc clear filter'
+              : 'Backspace edit · Esc clear filter'
+            : filteredSkills.length
+              ? '↑/↓ select · Enter open · 1-9,0 quick · type to filter · Esc back · q close'
+              : 'Esc back · q close'}
         </OverlayHint>
       </Box>
     )


### PR DESCRIPTION
## Why

The model picker established fuzzy type-to-filter search, but several long,
dynamic TUI list overlays still required scrolling. This brings the same
interaction contract to the session switcher, skills hub, agents overlay, and
the newer Plugins Hub. It also moves the existing Pets picker from substring
matching to the shared fuzzy matcher.

## What

- Type to filter, ranked best-first with the shared `fuzzyRank` helper.
- Backspace edits, Ctrl+U clears, and Esc clears before closing or navigating
  back.
- Existing single-key and numeric shortcuts still fire when the filter is
  empty; once filtering starts, those printable keys extend the query.
- Session filtering keeps the cursor off the `+ new` draft row and preserves
  the selected session by id across quiet status polls and filter clearing.
- Plugins keep their user/all scope and toggle controls; Pets retain active,
  installed, and curated status as fuzzy-ranking tie-breakers.
- Empty-result states and contextual control hints are included throughout.

The audit also covered the newer billing, prompt, and Journey interactions.
Billing and prompts are short fixed-choice forms, while Journey is a tree with
edit/delete/navigation bindings; adding search there would be a separate
interaction design rather than this picker behavior.

No new dependencies.

## Validation

- `cd ui-tui && npm run check` — build, typecheck, and 1,181 tests pass
  (4 skipped).
- ESLint and Prettier pass on every file touched by this PR.
- The repository-wide lint command still reports pre-existing errors in three
  files outside this diff.
