### PR TITLE
fix(windows): tolerate localized taskkill decode errors

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import locale
 import os
 import shlex
 import signal
@@ -112,6 +113,8 @@ def terminate_pid(pid: int, *, force: bool = False) -> None:
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
                 capture_output=True,
                 text=True,
+                encoding=locale.getpreferredencoding(False),
+                errors="replace",
                 timeout=10,
                 creationflags=windows_hide_flags(),
             )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -272,6 +272,7 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import locale
 import shlex
 import shutil
 import stat
@@ -6149,6 +6150,8 @@ def _kill_stale_dashboard_processes(
                     ["taskkill", "/PID", str(pid), "/F"],
                     capture_output=True,
                     text=True,
+                    encoding=locale.getpreferredencoding(False),
+                    errors="replace",
                     timeout=10,
                 )
                 if result.returncode == 0:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -722,8 +722,9 @@ class TestTerminatePid:
         calls = []
         monkeypatch.setattr(status, "_IS_WINDOWS", True)
 
-        def fake_run(cmd, capture_output=False, text=False, timeout=None, creationflags=0):
-            calls.append((cmd, capture_output, text, timeout, creationflags))
+        def fake_run(cmd, capture_output=False, text=False, timeout=None,
+                     encoding=None, errors=None, creationflags=0):
+            calls.append((cmd, capture_output, text, timeout, encoding, errors, creationflags))
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(status.subprocess, "run", fake_run)
@@ -736,8 +737,10 @@ class TestTerminatePid:
         # creationflags value); on real Windows it is CREATE_NO_WINDOW.
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        import locale
         assert calls == [
-            (["taskkill", "/PID", "123", "/T", "/F"], True, True, 10, windows_hide_flags())
+            (["taskkill", "/PID", "123", "/T", "/F"], True, True, 10,
+             locale.getpreferredencoding(False), "replace", windows_hide_flags())
         ]
 
     def test_force_falls_back_to_sigterm_when_taskkill_missing(self, monkeypatch):

--- a/tests/gateway/test_windows_subprocess_decoding.py
+++ b/tests/gateway/test_windows_subprocess_decoding.py
@@ -1,0 +1,51 @@
+import locale
+import subprocess
+
+
+def _cp1251_readerthread_decode_error():
+    return UnicodeDecodeError(
+        "charmap",
+        b"\x98",
+        0,
+        1,
+        "character maps to <undefined>",
+    )
+
+
+def _fail_like_cp1251_readerthread_without_replace(cmd, **kwargs):
+    if kwargs.get("text") is True and kwargs.get("capture_output") is True:
+        if kwargs.get("errors") != "replace":
+            raise _cp1251_readerthread_decode_error()
+        # Assert the encoding matches the locale preference so the test
+        # validates both decode-error-protection kwargs.
+        expected_enc = locale.getpreferredencoding(False)
+        actual_enc = kwargs.get("encoding")
+        assert actual_enc == expected_enc, (
+            f"subprocess.run encoding={actual_enc!r}, expected {expected_enc!r}"
+        )
+    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+
+def test_windows_force_terminate_decodes_taskkill_output_lossily(monkeypatch):
+    """taskkill output can contain bytes that fail under cp1251 (#39029)."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_IS_WINDOWS", True)
+    monkeypatch.setattr(status.subprocess, "run", _fail_like_cp1251_readerthread_without_replace)
+
+    status.terminate_pid(12345, force=True)
+
+
+def test_windows_dashboard_kill_decodes_taskkill_output_lossily(monkeypatch, capsys):
+    """Dashboard cleanup should not leak taskkill decode errors on localized Windows."""
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    monkeypatch.setattr(cli_main, "_find_stale_dashboard_pids", lambda exclude_pids=None: [12345])
+    monkeypatch.setattr(cli_main.subprocess, "run", _fail_like_cp1251_readerthread_without_replace)
+
+    cli_main._kill_stale_dashboard_processes(reason="test")
+
+    out = capsys.readouterr().out
+    assert "✓ stopped PID 12345" in out

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import locale
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -255,6 +256,8 @@ def test_gateway_force_kill_hides_taskkill_window(monkeypatch):
                 "capture_output": True,
                 "text": True,
                 "timeout": 10,
+                "encoding": locale.getpreferredencoding(False),
+                "errors": "replace",
                 "creationflags": _CREATE_NO_WINDOW,
             },
         )


### PR DESCRIPTION
### What

- Decode Windows `taskkill` subprocess output with the active locale encoding and `errors="replace"`.
- Covers gateway forced termination and stale dashboard cleanup paths.
- Adds regression coverage that simulates the cp1251 `subprocess._readerthread` decode failure reported in #39029.

### Why

On localized Windows systems, `subprocess.run(..., capture_output=True, text=True)` uses the default locale decoder unless the call supplies an explicit decode policy. If `taskkill` emits bytes that the locale codec cannot decode, Python's internal subprocess reader thread can raise `UnicodeDecodeError` and surface noisy tracebacks during gateway/dashboard lifecycle operations.

Using the locale encoding preserves localized output when possible, while `errors="replace"` prevents undecodable bytes from crashing the reader thread.

Fixes #39029.

### Validation

- `python -m pytest tests/gateway/test_windows_subprocess_decoding.py -v --tb=short --timeout-method=thread`
  - Before the fix: 2 failed with simulated `UnicodeDecodeError: 'charmap' codec can't decode byte 0x98`.
  - After the fix: 2 passed.
- `python -m pytest tests/gateway/test_windows_subprocess_decoding.py tests/hermes_cli/test_dashboard_lifecycle_flags.py tests/gateway/test_runner_startup_failures.py -q --tb=short --timeout-method=thread`
  - 21 passed after final rebase.
- `python -m py_compile gateway/status.py hermes_cli/main.py tests/gateway/test_windows_subprocess_decoding.py`

### Notes for reviewers

There is an overlapping broader open PR, #32002, that changes more subprocess decode sites. This PR is intentionally narrower: it targets the Windows `taskkill` text/capture call sites involved in gateway/dashboard lifecycle operations and uses locale decoding plus replacement instead of forcing UTF-8.
