### PR TITLE
fix: install xz before extracting Node.js archive

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -641,6 +641,88 @@ attempt_install_git() {
     return 1
 }
 
+# Node release tarballs default to .tar.xz, which GNU tar can only unpack when
+# the external `xz` binary is present — otherwise tar dies with the opaque
+# "xz: Cannot exec: No such file or directory". Best-effort install of xz so
+# install_node can keep using the smaller .xz artifact. Returns 0 if xz is
+# available afterwards, non-zero otherwise (caller falls back to .tar.gz or
+# prints a manual-install hint).
+attempt_install_xz() {
+    if command -v xz >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_info "Installing xz via pkg..."
+        pkg install -y xz-utils >/dev/null 2>&1 || true
+        command -v xz >/dev/null 2>&1 && return 0
+        return 1
+    fi
+
+    case "$OS" in
+        macos)
+            if command -v brew >/dev/null 2>&1; then
+                log_info "Installing xz via Homebrew..."
+                brew install xz >/dev/null 2>&1 || true
+            fi
+            command -v xz >/dev/null 2>&1 && return 0
+            return 1
+            ;;
+        linux)
+            local sudo_cmd=""
+            if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
+                if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+                    sudo_cmd="sudo"
+                fi
+            fi
+            case "$DISTRO" in
+                ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                    log_info "Installing xz via apt..."
+                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
+                    $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq xz-utils >/dev/null 2>&1 || true
+                    ;;
+                fedora|rhel|centos|rocky|alma)
+                    log_info "Installing xz via dnf..."
+                    $sudo_cmd dnf install -y xz >/dev/null 2>&1 || true
+                    ;;
+                arch|manjaro|cachyos|endeavouros|garuda)
+                    log_info "Installing xz via pacman..."
+                    $sudo_cmd pacman -S --noconfirm --needed xz >/dev/null 2>&1 || true
+                    ;;
+                opensuse*|sles)
+                    log_info "Installing xz via zypper..."
+                    $sudo_cmd zypper install -y xz >/dev/null 2>&1 || true
+                    ;;
+                *)
+                    return 1
+                    ;;
+            esac
+            command -v xz >/dev/null 2>&1 && return 0
+            return 1
+            ;;
+    esac
+    return 1
+}
+
+# Print distro-appropriate manual install instructions for xz.
+show_xz_install_hint() {
+    log_info "To install xz manually:"
+    case "$OS" in
+        linux)
+            case "$DISTRO" in
+                ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                    log_info "  sudo apt install xz-utils" ;;
+                fedora|rhel|centos|rocky|alma) log_info "  sudo dnf install xz" ;;
+                arch|manjaro|cachyos|endeavouros|garuda) log_info "  sudo pacman -S xz" ;;
+                opensuse*|sles) log_info "  sudo zypper install xz" ;;
+                *) log_info "  Use your package manager to install xz (xz-utils)" ;;
+            esac
+            ;;
+        android) log_info "  pkg install xz-utils" ;;
+        macos) log_info "  brew install xz" ;;
+    esac
+}
+
 check_git() {
     log_info "Checking Git..."
 
@@ -786,14 +868,33 @@ install_node() {
             ;;
     esac
 
-    # Resolve the latest v22.x.x tarball name from the index page
-    local index_url="https://nodejs.org/dist/latest-v${NODE_VERSION}.x/"
-    local tarball_name
-    tarball_name=$(curl -fsSL "$index_url" \
-        | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
-        | head -1)
+    # Node ships each release as .tar.xz (smaller) and .tar.gz. GNU tar can
+    # only unpack the .xz variant when the external `xz` binary is present;
+    # without it tar aborts with "xz: Cannot exec". Make sure xz is available
+    # (installing it via the detected distro when possible) before preferring
+    # .tar.xz, and fall back to .tar.gz when xz can't be provisioned.
+    local have_xz=true
+    if ! command -v xz >/dev/null 2>&1; then
+        log_info "xz not found — needed to extract Node.js .tar.xz archives"
+        if attempt_install_xz; then
+            log_success "xz installed"
+        else
+            have_xz=false
+            log_warn "Could not install xz automatically — falling back to .tar.gz archive"
+        fi
+    fi
 
-    # Fallback to .tar.gz if .tar.xz not available
+    # Resolve the latest v22.x.x tarball name from the index page. Prefer the
+    # smaller .tar.xz only when xz is available to extract it.
+    local index_url="https://nodejs.org/dist/latest-v${NODE_VERSION}.x/"
+    local tarball_name=""
+    if [ "$have_xz" = true ]; then
+        tarball_name=$(curl -fsSL "$index_url" \
+            | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
+            | head -1)
+    fi
+
+    # Fallback to .tar.gz if .tar.xz not available (or xz is missing)
     if [ -z "$tarball_name" ]; then
         tarball_name=$(curl -fsSL "$index_url" \
             | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \
@@ -801,8 +902,14 @@ install_node() {
     fi
 
     if [ -z "$tarball_name" ]; then
-        log_warn "Could not find Node.js $NODE_VERSION binary for $node_os-$node_arch"
-        log_info "Install manually: https://nodejs.org/en/download/"
+        if [ "$have_xz" = false ]; then
+            log_error "xz is not installed and no .tar.gz Node.js archive was found."
+            show_xz_install_hint
+            log_info "Then re-run this installer."
+        else
+            log_warn "Could not find Node.js $NODE_VERSION binary for $node_os-$node_arch"
+            log_info "Install manually: https://nodejs.org/en/download/"
+        fi
         HAS_NODE=false
         return 0
     fi


### PR DESCRIPTION
## What does this PR do?

Attempts to install `xz` if it is not already installed. If cant determine the Linux distro, it simply prints a message advising the user to install the package manually, which is clearer than the current behaviour:
<img width="873" height="452" alt="image" src="https://github.com/user-attachments/assets/2433e157-842d-4afe-89ae-48f5717a032f" />



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

