### PR TITLE
fix(profiles): avoid nesting custom profiles roots

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -217,10 +217,15 @@ def _get_profiles_root() -> Path:
     can see all profiles.
 
     In Docker/custom deployments where HERMES_HOME points outside
-    ``~/.hermes``, profiles live under ``HERMES_HOME/profiles/`` so
-    they persist on the mounted volume.
+    ``~/.hermes``, profiles normally live under ``HERMES_HOME/profiles/`` so
+    they persist on the mounted volume. If ``HERMES_HOME`` itself is an
+    explicitly chosen shared profiles root (for example ``/opt/hermes/profiles``),
+    reuse it directly instead of nesting ``profiles/profiles``.
     """
-    return _get_default_hermes_home() / "profiles"
+    root = _get_default_hermes_home()
+    if root.name == "profiles":
+        return root
+    return root / "profiles"
 
 
 def _get_default_hermes_home() -> Path:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1144,6 +1144,26 @@ class TestInternalHelpers:
         root = _get_profiles_root()
         assert root == docker_home / "profiles"
 
+    def test_profiles_root_custom_profiles_dir_not_nested(self, tmp_path, monkeypatch):
+        """Custom HERMES_HOME paths ending in profiles stay single-level."""
+        custom_profiles_root = tmp_path / "opt" / "hermes" / "profiles"
+        custom_profiles_root.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(custom_profiles_root))
+        root = _get_profiles_root()
+        assert root == custom_profiles_root
+
+    def test_create_profile_custom_profiles_dir_not_nested(self, tmp_path, monkeypatch):
+        """Named profiles under a custom profiles root do not get profiles/profiles."""
+        custom_profiles_root = tmp_path / "opt" / "hermes" / "profiles"
+        custom_profiles_root.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(custom_profiles_root))
+
+        profile_dir = create_profile("coder", no_alias=True)
+
+        assert profile_dir == custom_profiles_root / "coder"
+
     def test_default_hermes_home_docker(self, tmp_path, monkeypatch):
         """In Docker, _get_default_hermes_home() returns HERMES_HOME itself."""
         docker_home = tmp_path / "opt" / "data"


### PR DESCRIPTION
## Summary
- treat a custom `HERMES_HOME` path that already ends in `profiles` as the named-profiles root
- avoid creating named profiles under `profiles/profiles/<name>` in that deployment layout
- add focused regression coverage for root resolution and `create_profile()` in that custom-root case

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/pytest -o addopts= tests/hermes_cli/test_profiles.py -k "custom_profiles_dir_not_nested or profiles_root_docker_deployment or create_profile_docker or profile_mode"`
- `git diff --check`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`

## Attribution
- Recent company PRs `#39530`, `#39522`, and `#39501` do not show shared blocking baseline red relevant to this diff.

Fixes #39470