### PR TITLE
fix(dashboard): preserve injected session token

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -38,6 +38,9 @@ _SECRET_SOURCES: dict[str, str] = {}
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
 
+_DASHBOARD_SESSION_TOKEN_ENV = "HERMES_DASHBOARD_SESSION_TOKEN"
+_MISSING = object()
+
 
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
@@ -227,6 +230,10 @@ def load_hermes_dotenv(
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
+    dashboard_session_token = os.environ.get(
+        _DASHBOARD_SESSION_TOKEN_ENV,
+        _MISSING,
+    )
 
     # Fix corrupted .env files before python-dotenv parses them (#8908).
     if user_env.exists():
@@ -243,6 +250,9 @@ def load_hermes_dotenv(
         loaded.append(project_env_path)
 
     _apply_external_secret_sources(home_path)
+
+    if dashboard_session_token is not _MISSING:
+        os.environ[_DASHBOARD_SESSION_TOKEN_ENV] = dashboard_session_token
 
     return loaded
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -136,7 +136,8 @@ app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 # on every server start. Either way it dies when the process exits and is
 # injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
+_DASHBOARD_SESSION_TOKEN_ENV = "HERMES_DASHBOARD_SESSION_TOKEN"
+_SESSION_TOKEN = os.environ.get(_DASHBOARD_SESSION_TOKEN_ENV) or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
@@ -9254,7 +9255,13 @@ def start_server(
     allow_public: bool = False,
 ):
     """Start the web UI server."""
+    global _SESSION_TOKEN
+
     import uvicorn
+
+    env_session_token = os.environ.get(_DASHBOARD_SESSION_TOKEN_ENV)
+    if env_session_token:
+        _SESSION_TOKEN = env_session_token
 
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
     # injection / WS-auth paths can branch on it consistently.  Phase 3.5

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -132,6 +132,20 @@ def test_start_server_loopback_sets_auth_required_false(monkeypatch):
     assert web_server.app.state.auth_required is False
 
 
+def test_start_server_resyncs_session_token_from_env(monkeypatch):
+    """start_server adopts a desktop-injected token even after early import."""
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "stale-module-token")
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "live-desktop-token")
+
+    web_server.start_server(
+        host="127.0.0.1", port=9119,
+        open_browser=False, allow_public=False,
+    )
+
+    assert web_server._SESSION_TOKEN == "live-desktop-token"
+
+
 def test_start_server_insecure_public_sets_auth_required_false(monkeypatch):
     """``--insecure`` (allow_public=True) on a public host: gate stays OFF."""
     _stub_uvicorn_run(monkeypatch)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -19,6 +19,23 @@ def test_user_env_overrides_stale_shell_values(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
 
 
+def test_dashboard_session_token_not_overwritten_by_user_env(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=stale-dotenv-token\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "live-desktop-token")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") == "live-desktop-token"
+
+
 def test_project_env_overrides_stale_shell_values_when_user_env_missing(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     project_env = tmp_path / ".env"


### PR DESCRIPTION
## Summary
- Preserve a process-injected `HERMES_DASHBOARD_SESSION_TOKEN` when loading `.env` files.
- Resync the dashboard server session token from the environment at startup if the module was imported early.
- Add regression coverage for dotenv token preservation and `start_server()` token sync.

## Tests
- `.venv\Scripts\python -m pytest tests\hermes_cli\test_env_loader.py tests\hermes_cli\test_dashboard_auth_gate.py -q -p no:timeout -o addopts=`

Fixes #39349