### PR TITLE
change(desktop): show up to 50 models in list per provider

### DIFF
--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -7,7 +7,7 @@ const STORAGE_KEY = 'hermes.desktop.visible-models'
 
 /** Models shown per provider in the status-bar dropdown before the user has
  *  customized the list. Backend `models` are already relevance-ordered. */
-export const DEFAULT_VISIBLE_PER_PROVIDER = 5
+export const DEFAULT_VISIBLE_PER_PROVIDER = 50
 
 /** Stable key for a provider/model pair (`::` avoids colliding with model ids
  *  that contain a single colon, e.g. `model:tag`). */


### PR DESCRIPTION
## What does this PR do?
Previously showed only 5 models per list by default.

before:
<img width="293" height="275" alt="image" src="https://github.com/user-attachments/assets/ff1e3633-0c70-437d-a84c-b7fc6453ec67" />


after
<img width="376" height="446" alt="image" src="https://github.com/user-attachments/assets/67a0419e-78c4-4fa9-b34b-8c42479f5f18" />
