### PR TITLE
fix(agent): preserve explicit CLI session source

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -90,7 +90,7 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
 
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
-# The other `# noqa: F401` re-exports below cover names accessed via
+# The other noqa-style re-exports below cover names accessed via
 # `mock.patch("run_agent.<X>")`, `from run_agent import <X>` in production
 # siblings, or the `_ra().<X>` indirection in agent/system_prompt.py — none
 # of which ruff's in-module usage scan can see.
@@ -100,6 +100,14 @@ from agent.process_bootstrap import (
     _get_proxy_for_base_url,
 )
 from agent.iteration_budget import IterationBudget
+
+
+def _session_source_for_platform(platform: Optional[str]) -> str:
+    requested_source = (os.environ.get("HERMES_SESSION_SOURCE") or "").strip()
+    platform_source = (platform or "").strip()
+    if requested_source and platform_source in ("", "cli"):
+        return requested_source
+    return platform_source or requested_source or "cli"
 
 
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -501,7 +509,7 @@ class AIAgent:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = _session_source_for_platform(self.platform)
         try:
             self._session_db.create_session(
                 session_id=self.session_id,
@@ -567,7 +575,7 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
-                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "platform": _session_source_for_platform(getattr(self, "platform", None)),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),

--- a/tests/run_agent/test_session_source_attribution.py
+++ b/tests/run_agent/test_session_source_attribution.py
@@ -1,0 +1,51 @@
+import os
+from unittest.mock import patch
+
+
+def _make_agent(session_db, *, platform: str, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            platform=platform,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_cli_session_source_env_overrides_cli_platform(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        with patch.dict(os.environ, {"HERMES_SESSION_SOURCE": "flashbyte-dashboard"}):
+            agent = _make_agent(db, platform="cli", session_id="cli-custom-source")
+            agent._ensure_db_session()
+
+        row = db.get_session("cli-custom-source")
+        assert row is not None
+        assert row["source"] == "flashbyte-dashboard"
+    finally:
+        db.close()
+
+
+def test_gateway_platform_ignores_cli_source_env(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        with patch.dict(os.environ, {"HERMES_SESSION_SOURCE": "flashbyte-dashboard"}):
+            agent = _make_agent(db, platform="telegram", session_id="telegram-source")
+            agent._ensure_db_session()
+
+        row = db.get_session("telegram-source")
+        assert row is not None
+        assert row["source"] == "telegram"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- preserve an explicit `HERMES_SESSION_SOURCE` for CLI-created agent sessions instead of always storing them as `cli`
- keep real gateway platform sources, such as `telegram`, from being overridden by a globally-set CLI source env var
- reuse the same source resolution for context-engine session start metadata

This addresses the source attribution part of #39372. It does not close the full issue.

## Validation
- RED first: `.\.venv\Scripts\python.exe -m pytest tests\run_agent\test_session_source_attribution.py -q --timeout-method=thread` failed with `source == "cli"`
- `.\.venv\Scripts\python.exe -m pytest tests\run_agent\test_session_source_attribution.py tests\gateway\test_session_list_allowed_sources.py -q --timeout-method=thread`
- `wsl -e bash -lc 'cd /mnt/d/project/hermes/hermes-agent-work && UV_PROJECT_ENVIRONMENT=/tmp/hermes-agent-uv-env uv run --extra dev --extra all python -m pytest tests/run_agent/test_session_source_attribution.py tests/run_agent/test_860_dedup.py tests/gateway/test_session_list_allowed_sources.py -q'`
- `.\.venv\Scripts\ruff.exe check run_agent.py tests\run_agent\test_session_source_attribution.py`
- `.\.venv\Scripts\python.exe -m py_compile run_agent.py tests\run_agent\test_session_source_attribution.py`
- `git diff --check`

Note: the combined Windows run including `tests\run_agent\test_860_dedup.py` hit an existing temp SQLite file-lock cleanup failure after assertions completed; the same target passed under WSL/Linux.