### PR TITLE
fix(streaming): correct stream-unsupported detection (phrasings + downstream false-positive)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -39,6 +39,43 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+_STREAM_UNSUPPORTED_PHRASE_GROUPS: tuple[tuple[str, ...], ...] = (
+    (r"stream", r"not supported"),
+    (r"streaming", r"not supported"),
+    (r"streaming", r"not available"),
+    (r"streaming", r"not enabled"),
+    (r"stream", r"unsupported"),
+    (r"does not support", r"stream"),
+    (r"doesn't support", r"stream"),
+    (r"cannot stream",),
+    (r"streaming is disabled",),
+)
+
+
+def _compile_phrase(part: str) -> "re.Pattern[str]":
+    # Word boundaries keep "stream"/"streaming" from matching inside
+    # "downstream"/"upstream", which would misclassify unrelated errors.
+    if part in ("stream", "streaming"):
+        return re.compile(r"\bstream(?:ing)?\b")
+    return re.compile(r"\b" + re.escape(part) + r"\b")
+
+
+_STREAM_UNSUPPORTED_COMPILED: tuple[tuple[re.Pattern[str], ...], ...] = tuple(
+    tuple(_compile_phrase(part) for part in group)
+    for group in _STREAM_UNSUPPORTED_PHRASE_GROUPS
+)
+
+
+def is_stream_unsupported_error(error: BaseException) -> bool:
+    """Return True when a provider error means streaming itself is unsupported."""
+    msg = str(error).lower()
+    if not msg:
+        return False
+    return any(
+        all(pat.search(msg) for pat in group) for group in _STREAM_UNSUPPORTED_COMPILED
+    )
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -2253,11 +2290,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "try again in a moment."
                         )
                     else:
-                        _err_lower = str(e).lower()
-                        _is_stream_unsupported = (
-                            "stream" in _err_lower
-                            and "not supported" in _err_lower
-                        )
+                        _is_stream_unsupported = is_stream_unsupported_error(e)
                         if _is_stream_unsupported:
                             agent._disable_streaming = True
                             agent._safe_print(

--- a/tests/agent/test_stream_unsupported_detection.py
+++ b/tests/agent/test_stream_unsupported_detection.py
@@ -1,0 +1,64 @@
+"""Regression tests for streaming-unsupported error detection."""
+
+from openai import APIError
+
+import pytest
+
+from agent.chat_completion_helpers import is_stream_unsupported_error
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "stream is not supported for this model",
+        "Streaming is not supported for this model.",
+        "streaming is not available on this endpoint",
+        "Streaming is not enabled for the requested model",
+        "This model does not support streaming.",
+        "the selected model doesn't support stream mode",
+        "stream: unsupported parameter",
+        "unsupported request: stream is not allowed -> error code stream unsupported",
+        "model cannot stream responses",
+        "streaming is disabled for this deployment",
+        "ERROR 400: STREAMING IS NOT SUPPORTED",
+        "Bad request (param=stream): streaming is not supported here",
+    ],
+)
+def test_detects_stream_unsupported_phrasings(message):
+    assert is_stream_unsupported_error(Exception(message)) is True
+
+
+def test_detects_on_real_openai_apierror():
+    err = APIError(
+        "This model does not support streaming.",
+        request=None,  # type: ignore[arg-type]
+        body=None,
+    )
+    assert is_stream_unsupported_error(err) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "The requested model is not supported.",
+        "model_not_supported",
+        "HTTP 404: 404 page not found",
+        "HTTP 400: invalid api key",
+        "rate limit exceeded",
+        "context length exceeded",
+        "connection reset by peer",
+        "The downstream service is not supported in your region",
+        "downstream provider not supported",
+        "upstream is not supported by the gateway",
+        "this tool is not supported",
+        "live streaming feed unavailable",
+    ],
+)
+def test_ignores_unrelated_errors(message):
+    assert is_stream_unsupported_error(Exception(message)) is False
+
+
+def test_model_not_supported_does_not_downgrade_streaming():
+    err = Exception("The requested model is not supported.")
+    assert is_stream_unsupported_error(err) is False


### PR DESCRIPTION
## What

Harden the detection that decides whether a pre-delivery streaming failure
should set `agent._disable_streaming` (read at the top of each
conversation-loop iteration to drop later attempts to non-streaming).

`agent/chat_completion_helpers.py` gated this on a plain substring test:

```python
_err_lower = str(e).lower()
_is_stream_unsupported = "stream" in _err_lower and "not supported" in _err_lower
```

Two problems:

1. **False negatives** — real provider phrasings that mean "this model cannot
   stream" do not contain both literal tokens, so the flag was never set:
   - `"This model does not support streaming."`
   - `"streaming is not available on this endpoint"`
   - `"streaming is not enabled for ..."`
   - `"model cannot stream"`

2. **False positive** — bare `"stream" in msg` matches the substring inside
   `"downstream"` / `"upstream"`, so an unrelated error such as
   `"downstream service is not supported"` was classified as
   streaming-unsupported and disabled streaming for the rest of the session.

## Effect

`_disable_streaming` is read at the start of each conversation-loop iteration
(`agent/conversation_loop.py`). A genuine "streaming not supported" error is
typically an HTTP 400, which the error classifier treats as a non-retryable
client error, so the current turn still aborts (or activates a fallback) after
one attempt — setting the flag does not rescue that turn by itself.

The flag takes effect on the paths that re-enter the loop with the same agent:
a fallback-provider iteration (the loop `continue`s after
`_try_activate_fallback()`), and subsequent turns on a long-lived agent
(gateway / desktop), which otherwise repeat a doomed streaming attempt. The
word-boundary change additionally prevents a legitimate downstream/upstream
error from disabling streaming.

This is a robustness and correctness fix (CONTRIBUTING priority #4). It does
not change the streaming transport, delta extraction, retry/backoff, or
provider-fallback machinery, and it does not affect invalid-model-config
errors (e.g. an unsupported model slug returning HTTP 400), which are out of
scope.

## Change

Extract the gate into a unit-testable `is_stream_unsupported_error(error)`:

- Match the known phrasings via ALL-of phrase groups.
- Match `stream` / `streaming` on word boundaries (`\bstream(?:ing)?\b`) so
  `downstream` / `upstream` no longer false-positive.
- Keep the conservative contract: unrelated errors such as
  `"The requested model is not supported."` do not trigger a downgrade.

## Tests

New `tests/agent/test_stream_unsupported_detection.py` (27 cases): positive
phrasings including a real `openai.APIError`, the downstream/upstream
false-positive guards, and the model-not-supported non-trigger.

```
27 passed   tests/agent/test_stream_unsupported_detection.py
39 passed   tests/run_agent/test_streaming.py + test_stream_interrupt_retry.py
```
