### PR TITLE
fix(desktop): omit invalid dashboard web dist env

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -29,6 +29,7 @@ const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { applyDashboardWebDist, resolveDashboardWebDist } = require('./web-dist.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const {
@@ -4539,13 +4540,13 @@ async function spawnPoolBackend(profile, entry) {
   const dashboardArgs = ['--profile', profile, 'dashboard', '--no-open', '--host', '127.0.0.1', '--port', String(port)]
   const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
   const hermesCwd = resolveHermesCwd()
-  const webDist = resolveWebDist()
+  const webDist = resolveDashboardWebDist(APP_ROOT)
 
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const child = spawn(backend.command, backend.args, hiddenWindowsChildOptions({
     cwd: hermesCwd,
-    env: {
+    env: applyDashboardWebDist({
       ...process.env,
       HERMES_HOME,
       ...backend.env,
@@ -4556,9 +4557,8 @@ async function spawnPoolBackend(profile, entry) {
       HERMES_DASHBOARD_SESSION_TOKEN: token,
       // Marks this dashboard backend as desktop-spawned so it runs the cron
       // scheduler tick loop (the gateway isn't running under the app).
-      HERMES_DESKTOP: '1',
-      HERMES_WEB_DIST: webDist
-    },
+      HERMES_DESKTOP: '1'
+    }, webDist),
     shell: backend.shell,
     stdio: ['ignore', 'pipe', 'pipe']
   }))
@@ -4738,14 +4738,14 @@ async function startHermes() {
     await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
     const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
     const hermesCwd = resolveHermesCwd()
-    const webDist = resolveWebDist()
+    const webDist = resolveDashboardWebDist(APP_ROOT)
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)
 
     hermesProcess = spawn(backend.command, backend.args, hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
+      env: applyDashboardWebDist({
         ...process.env,
         // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
         // resolves to the SAME location our resolveHermesHome() picked. Without
@@ -4761,9 +4761,8 @@ async function startHermes() {
         HERMES_DASHBOARD_SESSION_TOKEN: token,
         // Marks this dashboard backend as desktop-spawned so it runs the cron
         // scheduler tick loop (the gateway isn't running under the app).
-        HERMES_DESKTOP: '1',
-        HERMES_WEB_DIST: webDist
-      },
+        HERMES_DESKTOP: '1'
+      }, webDist),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     }))

--- a/apps/desktop/electron/web-dist.cjs
+++ b/apps/desktop/electron/web-dist.cjs
@@ -1,0 +1,47 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+function directoryExists(candidate) {
+  try {
+    return fs.statSync(candidate).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function unpackedPathFor(filePath) {
+  return filePath.replace(/app\.asar(?=$|[\\/])/, 'app.asar.unpacked')
+}
+
+function resolveDashboardWebDist(appRoot, options = {}) {
+  const env = options.env || process.env
+  const exists = options.directoryExists || directoryExists
+
+  const override = env.HERMES_DESKTOP_WEB_DIST
+  if (override) {
+    const resolved = path.resolve(override)
+    if (exists(resolved)) return resolved
+  }
+
+  const unpackedDist = path.join(unpackedPathFor(appRoot), 'dist')
+  if (exists(unpackedDist)) return unpackedDist
+
+  return null
+}
+
+function applyDashboardWebDist(env, webDist) {
+  const next = { ...env }
+
+  if (webDist) {
+    next.HERMES_WEB_DIST = webDist
+  } else {
+    delete next.HERMES_WEB_DIST
+  }
+
+  return next
+}
+
+module.exports = {
+  applyDashboardWebDist,
+  resolveDashboardWebDist
+}

--- a/apps/desktop/electron/web-dist.test.cjs
+++ b/apps/desktop/electron/web-dist.test.cjs
@@ -1,0 +1,78 @@
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  applyDashboardWebDist,
+  resolveDashboardWebDist
+} = require('./web-dist.cjs')
+
+function existingPaths(...paths) {
+  const normalized = new Set(paths.map(item => path.resolve(item)))
+
+  return item => normalized.has(path.resolve(item))
+}
+
+test('resolveDashboardWebDist prefers an existing desktop override', () => {
+  const override = path.join('tmp', 'hermes-web-dist')
+  const appRoot = path.join('Applications', 'Hermes.app', 'Contents', 'Resources', 'app.asar')
+
+  assert.equal(
+    resolveDashboardWebDist(appRoot, {
+      env: { HERMES_DESKTOP_WEB_DIST: override },
+      directoryExists: existingPaths(override)
+    }),
+    path.resolve(override)
+  )
+})
+
+test('resolveDashboardWebDist uses unpacked dist when packaged asar has one', () => {
+  const appRoot = path.join('Applications', 'Hermes.app', 'Contents', 'Resources', 'app.asar')
+  const unpackedDist = path.join(
+    appRoot.replace(/app\.asar(?=$|[\\/])/, 'app.asar.unpacked'),
+    'dist'
+  )
+
+  assert.equal(
+    resolveDashboardWebDist(appRoot, {
+      env: {},
+      directoryExists: existingPaths(unpackedDist)
+    }),
+    unpackedDist
+  )
+})
+
+test('resolveDashboardWebDist does not fall back to asar-internal dist', () => {
+  const appRoot = path.join('Applications', 'Hermes.app', 'Contents', 'Resources', 'app.asar')
+
+  assert.equal(
+    resolveDashboardWebDist(appRoot, {
+      env: {},
+      directoryExists: () => false
+    }),
+    null
+  )
+})
+
+test('applyDashboardWebDist removes inherited HERMES_WEB_DIST when no usable dist exists', () => {
+  assert.deepEqual(
+    applyDashboardWebDist(
+      {
+        HERMES_WEB_DIST: path.join('Applications', 'Hermes.app', 'Contents', 'Resources', 'app.asar', 'dist'),
+        OTHER: 'kept'
+      },
+      null
+    ),
+    { OTHER: 'kept' }
+  )
+})
+
+test('applyDashboardWebDist sets HERMES_WEB_DIST when a usable dist exists', () => {
+  assert.deepEqual(
+    applyDashboardWebDist({ OTHER: 'kept' }, path.resolve('dist')),
+    {
+      OTHER: 'kept',
+      HERMES_WEB_DIST: path.resolve('dist')
+    }
+  )
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -8,7 +8,7 @@ const path = require('node:path')
 const ELECTRON_DIR = __dirname
 
 function readElectronFile(name) {
-  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8')
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
 }
 
 function requireHiddenChildOptions(source, needle) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/web-dist.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
- add a pure desktop helper for resolving the Dashboard web dist passed to the Python backend
- prefer `HERMES_DESKTOP_WEB_DIST` and `app.asar.unpacked/dist` only when they exist as normal directories
- omit inherited/invalid `HERMES_WEB_DIST` when no usable backend dist exists, so `hermes_cli.web_server` can fall back to its packaged default
- keep the renderer-facing `resolveWebDist()` path unchanged for Electron's own ASAR loading

Fixes #39472.

## Validation
- RED first: `node --test electron/web-dist.test.cjs` failed with `Cannot find module './web-dist.cjs'`
- `node --test electron/web-dist.test.cjs`
- `npm run test:desktop:platforms`
- `npx eslint electron/main.cjs electron/web-dist.cjs electron/web-dist.test.cjs`
- `node --check electron/main.cjs; node --check electron/web-dist.cjs; node --check electron/web-dist.test.cjs`
- `npm run type-check`
- `git diff --check`