### PR TITLE
fix(api): keep forked sessions listable

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1477,6 +1477,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "api_server",
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
+            model_config={"_branched_from": source_id},
             parent_session_id=source_id,
         )
         messages = db.get_messages(source_id)

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -141,6 +142,13 @@ async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, se
     assert fork["title"] == "Alternative"
     assert [m["content"] for m in session_db.get_messages(fork["id"])] == ["first path", "answer"]
     assert session_db.get_session(source_id)["end_reason"] == "branched"
+    persisted = session_db.get_session(fork["id"])
+    assert json.loads(persisted["model_config"])["_branched_from"] == source_id
+
+    session_db.reopen_session(source_id)
+    session_db.end_session(source_id, "resumed_other")
+    listed_ids = {session["id"] for session in session_db.list_sessions_rich(source="api_server", limit=10)}
+    assert fork["id"] in listed_ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist `model_config._branched_from` when the API server forks a session
- keep API-created branch sessions visible even if the parent is later reopened/re-ended with a non-`branched` reason
- extend the session API fork regression test to cover persisted marker and `list_sessions_rich()` visibility

Addresses one confirmed API fork creation path for #39471. It does not close the whole issue because other branch-like child creation paths may still need audit.

## Validation
- RED first: `.\.venv\Scripts\python.exe -m pytest tests\gateway\test_session_api.py::test_session_fork_uses_current_sessiondb_branch_primitives -q --timeout-method=thread` failed because fork `model_config` was `None`
- `.\.venv\Scripts\python.exe -m pytest tests\gateway\test_session_api.py::test_session_fork_uses_current_sessiondb_branch_primitives -q --timeout-method=thread`
- `.\.venv\Scripts\python.exe -m pytest tests\gateway\test_session_api.py tests\tui_gateway\test_protocol.py::test_session_branch_persists_branched_from_marker tests\cli\test_branch_command.py -q --timeout-method=thread`
- `.\.venv\Scripts\ruff.exe check gateway\platforms\api_server.py tests\gateway\test_session_api.py`
- `git diff --check`