### PR TITLE
fix(model-metadata): gate Ollama api/show probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -417,6 +417,39 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+_OLLAMA_API_SHOW_PROVIDERS: frozenset[str] = frozenset({"ollama", "ollama-cloud", "local"})
+
+
+def _should_query_ollama_api_show(base_url: str, provider: str = "") -> bool:
+    """Return True when a context resolver should try Ollama's native /api/show.
+
+    /api/show is useful for Ollama-compatible servers, including local Ollama,
+    Ollama Cloud, and unknown custom endpoints that might be Ollama behind a
+    reverse proxy.  It should not be sprayed at known hosted non-Ollama
+    providers such as OpenRouter, OpenAI, or Anthropic; those endpoints return
+    404/405 and can show up as noisy authenticated requests in proxies.
+    """
+    if not base_url:
+        return False
+
+    provider_normalized = (provider or "").strip().lower()
+    inferred_provider = _infer_provider_from_url(base_url)
+
+    # A recognized hostname is stronger evidence than a possibly stale or
+    # mismatched explicit provider value.
+    if inferred_provider in _OLLAMA_API_SHOW_PROVIDERS:
+        return True
+    if inferred_provider:
+        return False
+
+    if provider_normalized in _OLLAMA_API_SHOW_PROVIDERS:
+        return True
+
+    # Unknown custom endpoints may still be Ollama-compatible.  Keep probing
+    # only when the caller did not name a known non-Ollama provider.
+    return provider_normalized in {"", "custom"}
+
+
 def is_local_endpoint(base_url: str) -> bool:
     """Return True if base_url points to a local machine.
 
@@ -1507,7 +1540,7 @@ def get_model_context_length(
           portal-derived values are persisted to disk.
        c. Codex OAuth /models probe
        d. GMI /models endpoint
-       e. Ollama native /api/show probe (any base_url, provider-agnostic)
+       e. Ollama native /api/show probe (Ollama/local/unknown custom only)
        f. models.dev registry lookup (with :cloud/-cloud suffix fallback)
     6. OpenRouter live API metadata (Kimi-family 32k guard)
     7. Hardcoded defaults (broad family patterns, longest-key-first)
@@ -1733,16 +1766,12 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
-    # 5e. Ollama native /api/show probe — runs for ANY provider with a
-    # base_url, not just ollama-cloud.  Ollama-compatible servers expose
-    # this endpoint regardless of hostname (local Ollama, Ollama Cloud,
-    # custom Ollama hosting).  The OpenAI-compat /v1/models endpoint
-    # correctly omits context_length per the OpenAI schema, but /api/show
-    # returns the authoritative GGUF model_info.context_length.
-    # For non-Ollama servers (OpenAI, Anthropic, etc.), the POST returns
-    # 404/405 quickly.  Results are cached, so the hit is per-model+URL,
-    # once per hour.
-    if base_url:
+    # 5e. Ollama native /api/show probe.  Only run this for Ollama-like
+    # providers or unknown custom endpoints that may be Ollama-compatible.
+    # Known hosted non-Ollama providers (OpenRouter, OpenAI, Anthropic, etc.)
+    # skip this path and use provider metadata/defaults below instead; sending
+    # an Ollama POST to them creates noisy authenticated 404/405s.
+    if _should_query_ollama_api_show(base_url, effective_provider):
         ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
         if ctx is not None:
             save_context_length(model, base_url, ctx)

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -8,7 +8,7 @@ Covers:
 from unittest.mock import patch, MagicMock
 
 
-from agent.model_metadata import query_ollama_num_ctx
+from agent.model_metadata import query_ollama_num_ctx, get_model_context_length
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -132,3 +132,76 @@ class TestQueryOllamaNumCtx:
                 result = query_ollama_num_ctx("model", "http://localhost:11434")
 
         assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Level 2: get_model_context_length — /api/show probe gating
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestGetModelContextLengthOllamaApiShowGate:
+    """Provider-aware context resolution should not probe Ollama everywhere."""
+
+    def test_openrouter_base_url_does_not_probe_ollama_api_show(self):
+        """OpenRouter is a known hosted provider, not an Ollama server."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=999999) as mock_show, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=131072):
+            result = get_model_context_length(
+                "openai/gpt-4o",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+
+        assert result == 131072
+        mock_show.assert_not_called()
+
+    def test_openrouter_base_url_without_provider_still_does_not_probe_ollama_api_show(self):
+        """Known provider hosts are inferred even when callers omit provider."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=999999) as mock_show, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=131072):
+            result = get_model_context_length(
+                "openai/gpt-4o",
+                base_url="https://openrouter.ai/api/v1",
+            )
+
+        assert result == 131072
+        mock_show.assert_not_called()
+
+    def test_ollama_cloud_still_probes_ollama_api_show(self):
+        """Ollama Cloud uses the native /api/show endpoint for GGUF context."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=262144) as mock_show, \
+             patch("agent.model_metadata.save_context_length"):
+            result = get_model_context_length(
+                "qwen3-coder:480b-cloud",
+                base_url="https://ollama.com/v1",
+                provider="ollama-cloud",
+            )
+
+        assert result == 262144
+        mock_show.assert_called_once_with(
+            "qwen3-coder:480b-cloud",
+            "https://ollama.com/v1",
+            api_key="",
+        )
+
+    def test_unknown_custom_endpoint_still_probes_ollama_api_show(self):
+        """Unknown custom endpoints may be Ollama-compatible and keep probing."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=32768) as mock_show, \
+             patch("agent.model_metadata.save_context_length"):
+            result = get_model_context_length(
+                "llama3.1:8b",
+                base_url="https://custom-ollama.example/v1",
+                provider="custom",
+            )
+
+        assert result == 32768
+        mock_show.assert_called_once_with(
+            "llama3.1:8b",
+            "https://custom-ollama.example/v1",
+            api_key="",
+        )


### PR DESCRIPTION
## What does this PR do?

Prevents the model context-length resolver from sending Ollama-native `POST /api/show` probes to known hosted non-Ollama providers such as OpenRouter.

The proxy-observed failure was OpenRouter receiving:

`POST https://openrouter.ai/api/api/show` → `404`

That URL comes from treating the OpenRouter OpenAI-compatible base URL (`https://openrouter.ai/api/v1`) as if it were an Ollama server: strip `/v1`, then append `/api/show`.

The fix adds a small provider/URL gate for the Ollama `/api/show` probe:

- allow explicit Ollama-like providers (`ollama`, `ollama-cloud`, `local`)
- allow hosts inferred as Ollama Cloud (`ollama.com`)
- allow unknown or `custom` endpoints, because they may be Ollama-compatible behind a proxy
- skip known non-Ollama provider hosts like OpenRouter, OpenAI, Anthropic, Gemini, etc.

This is a clean, rebased alternative to #31569, which currently reports `mergeable_state=dirty` against `main`.

## Related Issue

Fixes #31555

Related: #31569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`
  - Add `_should_query_ollama_api_show(base_url, provider)`.
  - Gate step 5e of `get_model_context_length(...)` so Ollama `/api/show` only runs for Ollama-like or unknown/custom endpoints.
  - Update the resolution-order/comment text to reflect the narrower probe behavior.
- `tests/test_ollama_num_ctx.py`
  - Add regression coverage proving OpenRouter does not call `_query_ollama_api_show` when provider is explicit.
  - Add regression coverage proving OpenRouter does not call `_query_ollama_api_show` when provider is omitted but URL inference identifies OpenRouter.
  - Preserve coverage that Ollama Cloud and unknown custom endpoints still use the native probe.

## How to Test

1. Reproduce the previous bad path with an OpenRouter base URL such as `https://openrouter.ai/api/v1`; before this fix the resolver can construct `https://openrouter.ai/api/api/show` and receive 404.
2. Run focused regression tests:

   ```bash
   venv/bin/python -m pytest tests/test_ollama_num_ctx.py -q
   ```

   Actual result on Linux:

   ```text
   12 passed in 0.27s
   ```
3. Syntax check:

   ```bash
   venv/bin/python -m py_compile agent/model_metadata.py tests/test_ollama_num_ctx.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate; #31569 exists for the same issue but is currently dirty/unmergeable, so this is a clean rebased alternative
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; focused affected tests above pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A; inline resolver comments/docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent Python resolver change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add or modify skills.

## Screenshots / Logs

Focused verification:

```text
venv/bin/python -m py_compile agent/model_metadata.py tests/test_ollama_num_ctx.py
venv/bin/python -m pytest tests/test_ollama_num_ctx.py -q
............                                                             [100%]
12 passed in 0.27s
```
