### PR TITLE
fix(desktop): stop scroll and composer jumps

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -59,6 +59,7 @@ import {
   type InlineRefInput,
   insertInlineRefsIntoEditor
 } from './inline-refs'
+import { composerUsesStackedLayout } from './layout'
 import { QueuePanel } from './queue-panel'
 import {
   composerPlainText,
@@ -75,11 +76,6 @@ import { UrlDialog } from './url-dialog'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
 
 const COMPOSER_STACK_BREAKPOINT_PX = 320
-
-// A single editor line is ~28px (--composer-input-min-height 1.625rem + 0.5rem
-// vertical padding). Anything taller means the text wrapped to a second line,
-// which is when the composer should expand to the stacked layout.
-const COMPOSER_SINGLE_LINE_MAX_PX = 36
 
 const COMPOSER_FADE_BACKGROUND =
   'linear-gradient(to bottom, transparent, color-mix(in srgb, var(--dt-background) 10%, transparent))'
@@ -168,7 +164,6 @@ export function ChatBar({
 
   const [urlOpen, setUrlOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
-  const [expanded, setExpanded] = useState(false)
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const [tight, setTight] = useState(false)
   const [dragActive, setDragActive] = useState(false)
@@ -183,7 +178,7 @@ export function ChatBar({
   const at = useAtCompletions({ gateway: gateway ?? null, sessionId: sessionId ?? null, cwd: cwd ?? null })
   const slash = useSlashCompletions({ gateway: gateway ?? null })
 
-  const stacked = expanded || narrow || tight
+  const stacked = composerUsesStackedLayout({ draft, narrow, tight })
   const hasComposerPayload = draft.trim().length > 0 || attachments.length > 0
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
@@ -318,28 +313,11 @@ export function ChatBar({
     }
   }, [urlOpen])
 
-  // Expansion (input on its own full-width row, controls below) is driven by
-  // the editor's *actual* rendered height via the ResizeObserver in
-  // syncComposerMetrics — it only fires when the text genuinely wraps to a
-  // second line, so the layout flips exactly at the wrap point rather than at
-  // a guessed character count. We only handle the two cases the observer
-  // can't: an explicit newline (expand before layout settles) and an emptied
-  // draft (collapse back). We never read scrollHeight per keystroke.
-  useEffect(() => {
-    if (!draft) {
-      setExpanded(false)
-
-      return
-    }
-
-    if (expanded) {
-      return
-    }
-
-    if (draft.includes('\n')) {
-      setExpanded(true)
-    }
-  }, [draft, expanded])
+  // Stacked layout is intentionally not driven by rendered wrap height.
+  // Switching from inline controls to a two-row composer changes the measured
+  // composer height, which changes the thread viewport height and makes the
+  // prompt appear to jump under the user's cursor. Long single-line prompts
+  // stay inline; explicit multiline input still uses the stacked layout.
 
   // Bucket measured heights so we only invalidate the global CSS var when
   // the size crosses a meaningful threshold. Without bucketing, the editor
@@ -370,18 +348,6 @@ export function ChatBar({
         lastTightRef.current = nextTight
         setTight(nextTight)
       }
-    }
-
-    // Expand once the input has actually wrapped past a single line. The
-    // observer only fires on real size changes, so this reads scrollHeight at
-    // most once per wrap (not per keystroke). One line ≈ 28px (1.625rem
-    // min-height + padding); a second line clears ~36px. We only ever expand
-    // here — collapse is handled by the emptied-draft effect to avoid
-    // oscillating across the wrap boundary as the input switches widths.
-    const editor = editorRef.current
-
-    if (editor && editor.scrollHeight > COMPOSER_SINGLE_LINE_MAX_PX) {
-      setExpanded(true)
     }
 
     if (height > 0) {

--- a/apps/desktop/src/app/chat/composer/layout.test.ts
+++ b/apps/desktop/src/app/chat/composer/layout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { composerUsesStackedLayout, draftRequestsStackedComposer } from './layout'
+
+describe('composer layout mode', () => {
+  it('does not switch to stacked layout for a long single-line prompt', () => {
+    const longSingleLine = 'explain this without moving the prompt box under my cursor '.repeat(12)
+
+    expect(draftRequestsStackedComposer(longSingleLine)).toBe(false)
+    expect(composerUsesStackedLayout({ draft: longSingleLine, narrow: false, tight: false })).toBe(false)
+  })
+
+  it('uses stacked layout for explicit multiline prompts and constrained widths', () => {
+    expect(composerUsesStackedLayout({ draft: 'line one\nline two', narrow: false, tight: false })).toBe(true)
+    expect(composerUsesStackedLayout({ draft: 'short', narrow: true, tight: false })).toBe(true)
+    expect(composerUsesStackedLayout({ draft: 'short', narrow: false, tight: true })).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/layout.ts
+++ b/apps/desktop/src/app/chat/composer/layout.ts
@@ -1,0 +1,15 @@
+export function draftRequestsStackedComposer(draft: string): boolean {
+  return draft.includes('\n')
+}
+
+export function composerUsesStackedLayout({
+  draft,
+  narrow,
+  tight
+}: {
+  draft: string
+  narrow: boolean
+  tight: boolean
+}): boolean {
+  return draftRequestsStackedComposer(draft) || narrow || tight
+}

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -566,6 +566,43 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('honors upward scrollbar movement even when content grows in the same frame', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 800
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
   it('keeps following final code-highlight growth when a run completes at bottom', async () => {
     const { container } = render(<StreamingHarness />)
 
@@ -589,6 +626,11 @@ describe('assistant-ui streaming renderer', () => {
     await wait(650)
 
     scrollHeight = 1_700
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_700)
+      }
+    })
     await wait(0)
 
     expect(viewport.scrollTop).toBe(1_700)

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -20,6 +20,7 @@ const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
 const POST_RUN_BOTTOM_LOCK_MS = 1_200
+const USER_SCROLL_DISARM_PX = 24
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -326,16 +327,20 @@ function useThreadScrollAnchor({
         return
       }
 
-      // Disarm only when `scrollTop` decreases while both content height and
-      // viewport height are stable. A bare `top < lastTopRef.current` check is
-      // unsafe: virtualizer measurement, streaming markdown, composer resizing,
-      // window resizing, and toolbar/status updates can all move scrollTop as a
-      // layout side effect. Wheel-up and touchmove still disarm immediately via
-      // their own listeners below, so real user intent remains covered.
+      // Disarm when the viewport moves upward by a user-scale amount. Do not
+      // require content height to be stable: scrollbar drags / trackpad inertia
+      // often race with streaming growth, and the old "height must be stable"
+      // rule let the app yank the viewport back down while the user was trying
+      // to read. Keep a threshold so tiny virtualizer measurement jitters don't
+      // count as intent. Viewport height changes are still ignored because they
+      // naturally lower scrollTop when the window/composer grows.
       const heightGrew = el.scrollHeight > lastHeightRef.current
       const clientHeightChanged = Math.abs(el.clientHeight - lastClientHeightRef.current) > 1
+      const upwardDelta = lastTopRef.current - top
 
-      if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
+      if (upwardDelta > USER_SCROLL_DISARM_PX && !clientHeightChanged) {
+        setMutableRef(stickyBottomRef, false)
+      } else if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
         setMutableRef(stickyBottomRef, false)
       }
 
@@ -358,13 +363,23 @@ function useThreadScrollAnchor({
       }
     }
 
+    const onPointerDown = () => {
+      // Direct interaction with the scroll pane means the user, not the
+      // auto-follow loop, owns the viewport now. This catches scrollbar-thumb
+      // drags and text selection, both of which can happen without a wheel-up
+      // event.
+      disarm()
+    }
+
     el.addEventListener('scroll', onScroll, { passive: true })
     el.addEventListener('wheel', onWheel, { passive: true })
+    el.addEventListener('pointerdown', onPointerDown, { passive: true })
     el.addEventListener('touchmove', disarm, { passive: true })
 
     return () => {
       el.removeEventListener('scroll', onScroll)
       el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('pointerdown', onPointerDown)
       el.removeEventListener('touchmove', disarm)
     }
   }, [scrollerRef, stickyBottomRef])
@@ -469,9 +484,11 @@ function useThreadScrollAnchor({
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
 
   // Completion swaps streaming placeholders/plain code for final rendered DOM
-  // (notably Shiki-highlighted code). Keep following the bottom briefly after
-  // `isRunning` flips false so that final measurement pass cannot strand the
-  // viewport near the top of a large code block.
+  // (notably Shiki-highlighted code). Follow actual content growth briefly
+  // after `isRunning` flips false, but do NOT run a per-frame bottom lock —
+  // that was the reported self-scrolling/jumping behavior. Resize-only
+  // following keeps final syntax-highlight growth visible without yanking the
+  // viewport when nothing changed.
   const prevIsRunningForLayoutRef = useRef(isRunning)
   useLayoutEffect(() => {
     const finishedRun = prevIsRunningForLayoutRef.current && !isRunning
@@ -481,32 +498,29 @@ function useThreadScrollAnchor({
       return undefined
     }
 
-    const lockUntil = performance.now() + POST_RUN_BOTTOM_LOCK_MS
-    let lockRaf: number | null = null
+    pinToBottom()
 
-    const lockFrame = () => {
-      lockRaf = null
+    const el = scrollerRef.current
+    const content = el?.firstElementChild
 
-      if (!stickyBottomRef.current) {
-        return
-      }
-
-      pinToBottom()
-
-      if (performance.now() < lockUntil) {
-        lockRaf = requestAnimationFrame(lockFrame)
-      }
+    if (!content) {
+      return undefined
     }
 
-    pinToBottom()
-    lockRaf = requestAnimationFrame(lockFrame)
+    const observer = new ResizeObserver(() => {
+      if (stickyBottomRef.current) {
+        pinToBottom()
+      }
+    })
+    const timeout = window.setTimeout(() => observer.disconnect(), POST_RUN_BOTTOM_LOCK_MS)
+
+    observer.observe(content)
 
     return () => {
-      if (lockRaf !== null) {
-        cancelAnimationFrame(lockRaf)
-      }
+      window.clearTimeout(timeout)
+      observer.disconnect()
     }
-  }, [enabled, isRunning, pinToBottom, stickyBottomRef])
+  }, [enabled, isRunning, pinToBottom, scrollerRef, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }


### PR DESCRIPTION
## Summary
- Disarm bottom auto-follow when the user scrolls upward or directly interacts with the scroll pane
- Replace the post-run per-frame bottom lock with ResizeObserver-based follow for real layout growth
- Stops the composer from switching to stacked/two-row layout just because a long single-line prompt wraps
- Keeps stacked layout for explicit multiline drafts and constrained widths
- Adds regression coverage for both streaming scroll movement and long single-line composer prompts

## Test Plan
- npm run test:ui -- streaming.test.tsx -t "scroll|sticky-bottom|code-highlight|auto-follow|viewport"
- npm run test:ui -- src/app/chat/composer/layout.test.ts src/app/chat/composer/text-utils.test.ts src/app/chat/composer/rich-editor.test.ts src/app/chat/composer/slash-nav-dom-repro.test.tsx
- npm run type-check
- npx eslint src/app/chat/composer/index.tsx src/app/chat/composer/layout.ts src/app/chat/composer/layout.test.ts