### PR TITLE
fix(desktop): clip sidebar overflow while sessions run

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -81,7 +81,7 @@ export function SidebarSessionRow({
     >
       <div
         className={cn(
-          'group relative grid min-h-[1.625rem] cursor-pointer grid-cols-[minmax(0,1fr)_1.375rem] items-center rounded-md transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:transition-none',
+          'group relative grid min-h-[1.625rem] min-w-0 cursor-pointer grid-cols-[minmax(0,1fr)_1.375rem] items-center overflow-hidden rounded-md transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:transition-none',
           isSelected && 'bg-(--ui-row-active-background)',
           isWorking && 'text-foreground',
           dragging && 'z-10 cursor-grabbing opacity-60 shadow-sm',

--- a/apps/desktop/src/components/ui/sidebar.test.tsx
+++ b/apps/desktop/src/components/ui/sidebar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { SidebarContent, SidebarGroupContent } from './sidebar'
+
+describe('Sidebar overflow guards', () => {
+  it('clips horizontal overflow in the sidebar scroller', () => {
+    render(
+      <SidebarContent data-testid="sidebar-content">
+        <div style={{ width: '200%' }}>wide child</div>
+      </SidebarContent>
+    )
+
+    expect(screen.getByTestId('sidebar-content').className).toContain('overflow-x-hidden')
+    expect(screen.getByTestId('sidebar-content').className).toContain('min-w-0')
+  })
+
+  it('keeps section bodies shrinkable inside the sidebar width', () => {
+    render(
+      <SidebarGroupContent data-testid="sidebar-group-content">
+        section body
+      </SidebarGroupContent>
+    )
+
+    expect(screen.getByTestId('sidebar-group-content').className).toContain('min-w-0')
+  })
+})

--- a/apps/desktop/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/components/ui/sidebar.tsx
@@ -347,7 +347,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        'flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden',
         className
       )}
       data-sidebar="content"
@@ -415,7 +415,7 @@ function SidebarGroupAction({
 function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      className={cn('w-full text-sm', className)}
+      className={cn('w-full min-w-0 text-sm', className)}
       data-sidebar="group-content"
       data-slot="sidebar-group-content"
       {...props}


### PR DESCRIPTION
## Summary
- clip the desktop sidebar scroller horizontally so running session chrome cannot create a left/right scrollbar
- keep sidebar section bodies shrinkable and clip row-level running decorations inside each session row
- add a desktop regression test that locks in the overflow guards

## Verification
- `node ./node_modules/eslint/bin/eslint.js -c apps/desktop/eslint.config.mjs apps/desktop/src/components/ui/sidebar.tsx apps/desktop/src/app/chat/sidebar/session-row.tsx apps/desktop/src/components/ui/sidebar.test.tsx`
- `node ../../node_modules/vitest/vitest.mjs run src/components/ui/sidebar.test.tsx --config vite.config.ts --environment jsdom`
- `git diff --check`
