### PR TITLE
fix(desktop): inline local files for remote prompts

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -247,6 +247,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
           label: pathLabel(path),
           detail: rel,
           refText: `@${kind}:${formatRefValue(rel)}`,
+          localPath: path,
           path
         })
       }
@@ -255,7 +256,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
   )
 
   const attachContextFilePath = useCallback(
-    (filePath: string) => {
+    (filePath: string, options: { local?: boolean } = {}) => {
       if (!filePath) {
         return false
       }
@@ -268,6 +269,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         label: pathLabel(filePath),
         detail: rel,
         refText: `@file:${formatRefValue(rel)}`,
+        ...(options.local && { localPath: filePath }),
         path: filePath
       })
 
@@ -276,7 +278,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
     [currentCwd]
   )
 
-  const attachImagePath = useCallback(async (filePath: string) => {
+  const attachImagePath = useCallback(async (filePath: string, options: { local?: boolean } = {}) => {
     if (!filePath) {
       return false
     }
@@ -286,6 +288,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
       kind: 'image',
       label: pathLabel(filePath),
       detail: filePath,
+      ...(options.local && { localPath: filePath }),
       path: filePath
     }
 
@@ -327,7 +330,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
           return false
         }
 
-        return attachImagePath(savedPath)
+        return attachImagePath(savedPath, { local: true })
       } catch (err) {
         notifyError(err, 'Image attach failed')
 
@@ -354,7 +357,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
     }
 
     for (const path of paths) {
-      await attachImagePath(path)
+      await attachImagePath(path, { local: true })
     }
   }, [attachImagePath, currentCwd])
 
@@ -372,14 +375,14 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         return
       }
 
-      await attachImagePath(path)
+      await attachImagePath(path, { local: true })
     } catch (err) {
       notifyError(err, 'Clipboard paste failed')
     }
   }, [attachImagePath])
 
   const attachContextFolderPath = useCallback(
-    (folderPath: string) => {
+    (folderPath: string, options: { local?: boolean } = {}) => {
       if (!folderPath) {
         return false
       }
@@ -392,6 +395,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         label: pathLabel(folderPath),
         detail: rel,
         refText: `@folder:${formatRefValue(rel)}`,
+        ...(options.local && { localPath: folderPath }),
         path: folderPath
       })
 
@@ -456,7 +460,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {
-          if ((filePath && (await attachImagePath(filePath))) || (await attachImageBlob(file))) {
+          if ((filePath && (await attachImagePath(filePath, { local: true }))) || (await attachImageBlob(file))) {
             attached = true
 
             continue
@@ -467,7 +471,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
           continue
         }
 
-        if (filePath && attachContextFilePath(filePath)) {
+        if (filePath && attachContextFilePath(filePath, { local: true })) {
           attached = true
 
           continue

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -3,12 +3,15 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $sessions, setSessions } from '@/store/session'
+import { $sessions, setConnection, setSessions } from '@/store/session'
+import type { ComposerAttachment } from '@/store/composer'
 import type { SessionInfo } from '@/types/hermes'
 
 import { usePromptActions } from './use-prompt-actions'
 
 vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
 }))
 
@@ -39,7 +42,7 @@ function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 interface HarnessHandle {
-  submitText: (text: string) => Promise<boolean>
+  submitText: (text: string, options?: { attachments?: ComposerAttachment[] }) => Promise<boolean>
 }
 
 function Harness({
@@ -78,6 +81,33 @@ function Harness({
   return null
 }
 
+function setRemoteConnection() {
+  setConnection({
+    authMode: 'token',
+    baseUrl: 'https://remote.example',
+    isFullscreen: false,
+    logs: [],
+    mode: 'remote',
+    nativeOverlayWidth: 0,
+    source: 'settings',
+    token: 'redacted',
+    windowButtonPosition: null,
+    wsUrl: 'wss://remote.example/ws'
+  })
+}
+
+function localTextAttachment(overrides: Partial<ComposerAttachment> = {}): ComposerAttachment {
+  return {
+    id: 'file:/Users/mark/Desktop/note.txt',
+    kind: 'file',
+    label: 'note.txt',
+    localPath: '/Users/mark/Desktop/note.txt',
+    path: '/Users/mark/Desktop/note.txt',
+    refText: '@file:/Users/mark/Desktop/note.txt',
+    ...overrides
+  }
+}
+
 describe('usePromptActions /title', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])
@@ -85,6 +115,7 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    setConnection(null)
     vi.restoreAllMocks()
   })
 
@@ -162,5 +193,90 @@ describe('usePromptActions /title', () => {
     expect(requestGateway).toHaveBeenCalledWith('session.title', expect.objectContaining({ title: 'way too long title' }))
     expect(refreshSessions).not.toHaveBeenCalled()
     expect($sessions.get()[0]?.title).toBe('Old title')
+  })
+})
+
+describe('usePromptActions remote local attachments', () => {
+  afterEach(() => {
+    cleanup()
+    setConnection(null)
+    vi.restoreAllMocks()
+  })
+
+  it('inlines Desktop-local text attachments before submitting to a remote backend', async () => {
+    setRemoteConnection()
+
+    const readFileText = vi.fn(async () => ({
+      binary: false,
+      byteSize: 22,
+      language: 'markdown',
+      mimeType: 'text/markdown',
+      path: '/Users/mark/Desktop/note.txt',
+      text: '# Note\nhello remote',
+      truncated: false
+    }))
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileText }
+    })
+
+    const refreshSessions = vi.fn(async () => undefined)
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={refreshSessions} requestGateway={requestGateway} />)
+
+    const submitted = await handle!.submitText('review this', { attachments: [localTextAttachment()] })
+
+    expect(submitted).toBe(true)
+    expect(readFileText).toHaveBeenCalledWith('/Users/mark/Desktop/note.txt')
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({
+        session_id: RUNTIME_SESSION_ID,
+        text: expect.stringContaining('Attached local file: note.txt')
+      })
+    )
+    const promptSubmit = requestGateway.mock.calls
+      .map(call => call as unknown[])
+      .find(call => call[0] === 'prompt.submit')?.[1] as { text: string } | undefined
+    if (!promptSubmit) {
+      throw new Error('prompt.submit call missing')
+    }
+    expect(promptSubmit.text).toContain('```markdown\n# Note\nhello remote\n```')
+    expect(promptSubmit.text).toContain('review this')
+    expect(promptSubmit.text).not.toContain('@file:/Users/mark/Desktop/note.txt')
+  })
+
+  it('fails visibly instead of sending an unreadable remote @file for binary local files', async () => {
+    setRemoteConnection()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        readFileText: vi.fn(async () => ({
+          binary: true,
+          byteSize: 12,
+          language: 'text',
+          mimeType: 'application/octet-stream',
+          path: '/Users/mark/Desktop/blob.bin',
+          text: '',
+          truncated: false
+        }))
+      }
+    })
+
+    const refreshSessions = vi.fn(async () => undefined)
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={refreshSessions} requestGateway={requestGateway} />)
+
+    const submitted = await handle!.submitText('review this', {
+      attachments: [localTextAttachment({ label: 'blob.bin', localPath: '/Users/mark/Desktop/blob.bin' })]
+    })
+
+    expect(submitted).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -33,6 +33,7 @@ import { requestDesktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $busy,
+  $connection,
   $messages,
   $yoloActive,
   setAwaitingResponse,
@@ -94,6 +95,62 @@ interface PromptActionsOptions {
 interface SubmitTextOptions {
   attachments?: ComposerAttachment[]
   fromQueue?: boolean
+}
+
+function fencedAttachmentBlock(label: string, language: string, text: string, truncated: boolean, byteSize: number) {
+  const fence = text.includes('```') ? '````' : '```'
+  const suffix = truncated ? `\n\n_[truncated: showing Desktop text preview of ${byteSize} bytes total]_` : ''
+
+  return [`Attached local file: ${label}`, `${fence}${language || 'text'}\n${text}\n${fence}${suffix}`].join('\n')
+}
+
+async function attachmentContextRefsForSubmit(attachments: ComposerAttachment[]) {
+  const remoteMode = $connection.get()?.mode === 'remote'
+  const refs: string[] = []
+
+  for (const attachment of attachments) {
+    const localPath = attachment.localPath?.trim()
+
+    if (remoteMode && localPath) {
+      if (attachment.kind === 'file') {
+        const result = await window.hermesDesktop?.readFileText(localPath)
+
+        if (!result) {
+          throw new Error(`Could not read ${attachment.label || localPath} on the Desktop client.`)
+        }
+
+        if (result.binary) {
+          throw new Error(`Remote mode cannot attach binary local file ${attachment.label || localPath} yet.`)
+        }
+
+        refs.push(
+          fencedAttachmentBlock(
+            attachment.label || result.path || localPath,
+            result.language || 'text',
+            result.text || '',
+            result.truncated === true,
+            result.byteSize || 0
+          )
+        )
+
+        continue
+      }
+
+      if (attachment.kind === 'folder') {
+        throw new Error(`Remote mode cannot attach local folder ${attachment.label || localPath} yet.`)
+      }
+
+      if (attachment.kind === 'image') {
+        throw new Error(`Remote mode cannot attach local image ${attachment.label || localPath} yet.`)
+      }
+    }
+
+    if (attachment.refText) {
+      refs.push(attachment.refText)
+    }
+  }
+
+  return refs.join('\n')
 }
 
 function renderCommandsCatalog(catalog: CommandsCatalogLike): string {
@@ -224,10 +281,15 @@ export function usePromptActions({
       const usingComposerAttachments = !options?.attachments
       const attachments = options?.attachments ?? $composerAttachments.get()
 
-      const contextRefs = attachments
-        .map(a => a.refText)
-        .filter(Boolean)
-        .join('\n')
+      let contextRefs = ''
+
+      try {
+        contextRefs = await attachmentContextRefsForSubmit(attachments)
+      } catch (err) {
+        notifyError(err, 'Attach files failed')
+
+        return false
+      }
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -10,6 +10,8 @@ export interface ComposerAttachment {
   refText?: string
   previewUrl?: string
   path?: string
+  /** Absolute path on the Desktop client. Remote backends cannot read this directly. */
+  localPath?: string
   attachedSessionId?: string
 }
 


### PR DESCRIPTION
## Summary
- Preserve selected local file metadata in composer attachments
- Read and inline local text files before sending prompts from Desktop remote mode
- Add regression coverage for prompt submission with local file attachments

## Test Plan
- npm run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx
- npm run type-check