### PR TITLE
fix(mcp): seed OAuth disk-watch baseline before reload

### DIFF
--- a/tests/tools/test_mcp_oauth_integration.py
+++ b/tests/tools/test_mcp_oauth_integration.py
@@ -69,7 +69,9 @@ async def test_external_refresh_picked_up_without_restart(tmp_path, monkeypatch)
     # automatically via the HermesMCPOAuthProvider.async_auth_flow
     # pre-hook on the first real request, but we exercise it directly
     # here for test determinism).
-    await mgr.invalidate_if_disk_changed("srv")
+    baseline_changed = await mgr.invalidate_if_disk_changed("srv")
+    assert baseline_changed is False
+    assert provider._initialized is True
 
     # EXTERNAL PROCESS: cron rewrites the tokens file with fresh creds.
     # The old refresh_token has been consumed by this external exchange.

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -83,7 +83,7 @@ def test_hermes_provider_subclass_exists():
 
 @pytest.mark.asyncio
 async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
-    """When the tokens file mtime changes, provider._initialized flips False.
+    """When the tokens file mtime changes after baseline, provider reloads.
 
     This is the behaviour Claude Code ships as
     invalidateOAuthCacheIfDiskChanged (CC-1096 / GH#24317) and is the core
@@ -105,10 +105,14 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     mgr = MCPOAuthManager()
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
     assert provider is not None
+    await provider._initialize()
+    assert provider._initialized is True
 
-    # First call: records mtime (zero -> real) -> returns True
+    # First call only records the baseline mtime. Reloading here would reset
+    # the provider during its first auth handshake.
     changed1 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed1 is True
+    assert changed1 is False
+    assert provider._initialized is True
 
     # No file change -> False
     changed2 = await mgr.invalidate_if_disk_changed("srv")
@@ -138,4 +142,3 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert _HERMES_PROVIDER_CLS is not None
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
-

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -488,6 +488,11 @@ class MCPOAuthManager:
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns
+                if old == 0:
+                    # First observation only seeds the baseline. Forcing a
+                    # reload here can reset the provider in the middle of its
+                    # first auth handshake and tear down HTTP MCP discovery.
+                    return False
                 # Force the SDK's OAuthClientProvider to reload from storage
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).


### PR DESCRIPTION
## Summary
- seed the MCP OAuth disk-watch baseline on first token-file observation instead of forcing an immediate reload
- keep later mtime changes invalidating `_initialized` so external token refreshes still reload correctly
- update MCP OAuth regression tests to cover the new baseline-first behavior

## Why
`MCPOAuthManager.invalidate_if_disk_changed()` treated the first observed token-file mtime as an external change. For HTTP/StreamableHTTP OAuth servers, that could reset the provider in the middle of the first auth flow and tear down server discovery before tools were registered.

This addresses the first confirmed root cause from #39551. It does not claim to close every remaining report in that issue.

## Verification
- `python -m pytest -o addopts='' tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_bidirectional.py`
- `uv run --frozen ruff check tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py`
- `git diff --check`
