### PR TITLE
fix(installer): repair corrupt uvicorn dashboard installs

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1463,8 +1463,9 @@ except Exception:
 
     # Verify the dashboard deps specifically -- they're the most common thing
     # users hit and lazy-import errors from `hermes dashboard` are confusing.
-    # If tier 1 failed (the common case), [web] was still picked up by tiers
-    # 2-3; only tier 4 leaves you without it.
+    # A stale/corrupt uv cache can leave uvicorn's dist metadata present while
+    # subpackages such as uvicorn.supervisors are missing, so probe a real
+    # dashboard import path and repair uvicorn via pip without using uv's cache.
     $pythonExe = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
     if (Test-Path $pythonExe) {
         $webOk = $false
@@ -1476,18 +1477,31 @@ except Exception:
         $prevEAP = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
         try {
-            & $pythonExe -c "import fastapi, uvicorn" 2>&1 | Out-Null
+            & $pythonExe -c "import fastapi, uvicorn; from uvicorn.supervisors import ChangeReload" 2>&1 | Out-Null
             if ($LASTEXITCODE -eq 0) { $webOk = $true }
         } catch { }
         $ErrorActionPreference = $prevEAP
         if (-not $webOk) {
-            Write-Warn "fastapi/uvicorn not importable -- `hermes dashboard` will not work."
-            Write-Info "Attempting targeted install of [web] extra as last resort..."
-            & $UvCmd pip install -e ".[web]"
+            Write-Warn "fastapi/uvicorn not importable or uvicorn subpackage is corrupt -- `hermes dashboard` may not work."
+            Write-Info "Attempting pip repair of uvicorn to bypass stale uv cache..."
+            & $pythonExe -m pip install --force-reinstall --no-cache-dir "uvicorn[standard]==0.41.0"
             if ($LASTEXITCODE -eq 0) {
-                Write-Success "[web] extra installed; `hermes dashboard` should now work."
+                $prevEAP = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                try {
+                    & $pythonExe -c "import fastapi, uvicorn; from uvicorn.supervisors import ChangeReload" 2>&1 | Out-Null
+                    $webOk = ($LASTEXITCODE -eq 0)
+                } catch {
+                    $webOk = $false
+                }
+                $ErrorActionPreference = $prevEAP
+                if ($webOk) {
+                    Write-Success "uvicorn repaired; `hermes dashboard` should now work."
+                } else {
+                    Write-Warn "uvicorn repair completed, but dashboard imports still failed. Run manually: $pythonExe -m pip install --force-reinstall --no-cache-dir `"uvicorn[standard]==0.41.0`""
+                }
             } else {
-                Write-Warn "Could not install [web] extra. Run manually: uv pip install --python `"$pythonExe`" `"fastapi>=0.104,<1`" `"uvicorn[standard]>=0.24,<1`""
+                Write-Warn "Could not repair uvicorn. Run manually: $pythonExe -m pip install --force-reinstall --no-cache-dir `"uvicorn[standard]==0.41.0`""
             }
         }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1196,6 +1196,39 @@ setup_venv() {
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
 }
 
+verify_dashboard_deps() {
+    local dashboard_python=""
+    if [ "$USE_VENV" = true ]; then
+        dashboard_python="$INSTALL_DIR/venv/bin/python"
+    else
+        dashboard_python="$PYTHON_PATH"
+    fi
+
+    if [ ! -x "$dashboard_python" ]; then
+        log_warn "Could not find Python for dashboard dependency check: $dashboard_python"
+        return 0
+    fi
+
+    # A stale/corrupt uv cache can leave uvicorn metadata present while
+    # subpackages are missing. Probe the dashboard path that needs them.
+    if "$dashboard_python" -c 'import fastapi, uvicorn; from uvicorn.supervisors import ChangeReload' >/dev/null 2>&1; then
+        log_success "Dashboard imports verified"
+        return 0
+    fi
+
+    log_warn "fastapi/uvicorn not importable or uvicorn subpackage is corrupt -- hermes dashboard may not work."
+    log_info "Attempting pip repair of uvicorn to bypass stale uv cache..."
+    if "$dashboard_python" -m pip install --force-reinstall --no-cache-dir 'uvicorn[standard]==0.41.0'; then
+        if "$dashboard_python" -c 'import fastapi, uvicorn; from uvicorn.supervisors import ChangeReload' >/dev/null 2>&1; then
+            log_success "uvicorn repaired; hermes dashboard should now work."
+        else
+            log_warn "uvicorn repair completed, but dashboard imports still failed. Run manually: $dashboard_python -m pip install --force-reinstall --no-cache-dir 'uvicorn[standard]==0.41.0'"
+        fi
+    else
+        log_warn "Could not repair uvicorn. Run manually: $dashboard_python -m pip install --force-reinstall --no-cache-dir 'uvicorn[standard]==0.41.0'"
+    fi
+}
+
 install_deps() {
     log_info "Installing dependencies..."
 
@@ -1336,6 +1369,7 @@ install_deps() {
         # gracefully when stdout/stderr aren't terminals.
         if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
+            verify_dashboard_deps
             log_success "All dependencies installed"
             return 0
         fi
@@ -1446,6 +1480,8 @@ PY
     fi
 
     log_success "Main package installed"
+
+    verify_dashboard_deps
 
     log_success "All dependencies installed"
 }

--- a/tests/test_install_dashboard_web_deps.py
+++ b/tests/test_install_dashboard_web_deps.py
@@ -1,0 +1,26 @@
+"""Regression tests for dashboard dependency verification in installers."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def test_posix_installer_repairs_corrupt_uvicorn_subpackage_with_pip() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert "from uvicorn.supervisors import ChangeReload" in text
+    assert "--force-reinstall" in text
+    assert "--no-cache-dir" in text
+    assert "uvicorn[standard]==0.41.0" in text
+
+
+def test_windows_installer_repairs_corrupt_uvicorn_subpackage_with_pip() -> None:
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "from uvicorn.supervisors import ChangeReload" in text
+    assert "--force-reinstall" in text
+    assert "--no-cache-dir" in text
+    assert "uvicorn[standard]==0.41.0" in text


### PR DESCRIPTION
Refs #39505. Complements #39530 by covering the installer/bootstrap dependency path.

## Summary
- probe dashboard imports in the Windows and POSIX installers with `from uvicorn.supervisors import ChangeReload`, which catches stale/corrupt uvicorn installs that plain dist metadata or `import uvicorn` can miss
- repair uvicorn with the target interpreter via `pip install --force-reinstall --no-cache-dir "uvicorn[standard]==0.41.0"` so recovery bypasses uv's stale cache
- add a focused regression test that keeps both installer scripts on the corrupt-subpackage probe and pip repair path

## Proof
- `.venv\Scripts\python.exe -m pytest tests\test_install_dashboard_web_deps.py -q --timeout-method=thread`
- `.venv\Scripts\ruff.exe check tests\test_install_dashboard_web_deps.py`
- `.venv\Scripts\python.exe -m py_compile tests\test_install_dashboard_web_deps.py`
- PowerShell parser check for `scripts\install.ps1`
- `wsl bash -lc "cd /mnt/d/project/hermes/hermes-agent-work && bash -n scripts/install.sh"`
- `git diff --check` (only Windows CRLF warning for `scripts/install.ps1`)