### PR TITLE
fix(desktop): preserve interim assistant text

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -120,4 +120,57 @@ describe('useMessageStream', () => {
     expect(assistant?.parts.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
     expect(chatMessageText(assistant!)).toBe('Planning.Done.')
   })
+
+  it('does not duplicate streamed text when completion text contains the full final response', () => {
+    let state = initialState()
+
+    const updateSessionState = vi.fn(
+      (
+        sessionId: string,
+        updater: (state: ClientSessionState) => ClientSessionState,
+        _storedSessionId?: string | null
+      ) => {
+        expect(sessionId).toBe(SESSION_ID)
+        state = updater(state)
+
+        return state
+      }
+    )
+
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={h => (handle = h)} updateSessionState={updateSessionState} />)
+
+    handle!.handleGatewayEvent({ payload: {}, session_id: SESSION_ID, type: 'message.start' } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { text: 'Planning. ' },
+      session_id: SESSION_ID,
+      type: 'message.delta'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { args: { command: 'pwd' }, name: 'terminal', tool_id: 'tc-1' },
+      session_id: SESSION_ID,
+      type: 'tool.start'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { args: { command: 'pwd' }, name: 'terminal', result: 'ok', tool_id: 'tc-1' },
+      session_id: SESSION_ID,
+      type: 'tool.complete'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { text: 'Done.' },
+      session_id: SESSION_ID,
+      type: 'message.delta'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { text: 'Planning. Done.' },
+      session_id: SESSION_ID,
+      type: 'message.complete'
+    } as RpcEvent)
+
+    const assistant = state.messages.find(message => message.role === 'assistant')
+
+    expect(assistant?.parts.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(chatMessageText(assistant!)).toBe('Planning. Done.')
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient } from '@tanstack/react-query'
+import { cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { chatMessageText } from '@/lib/chat-messages'
+import type { RpcEvent } from '@/types/hermes'
+
+import type { ClientSessionState } from '../../types'
+
+import { useMessageStream } from './use-message-stream'
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: vi.fn()
+}))
+
+const SESSION_ID = 'rt-39558'
+
+function initialState(): ClientSessionState {
+  return {
+    awaitingResponse: false,
+    branch: '',
+    busy: false,
+    cwd: '',
+    interrupted: false,
+    messages: [],
+    needsInput: false,
+    pendingBranchGroup: null,
+    sawAssistantPayload: false,
+    storedSessionId: 'stored-39558',
+    streamId: null
+  }
+}
+
+interface HarnessHandle {
+  handleGatewayEvent: (event: RpcEvent) => void
+}
+
+function Harness({
+  onReady,
+  updateSessionState
+}: {
+  onReady: (handle: HarnessHandle) => void
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}) {
+  const activeSessionIdRef = useRef<string | null>(SESSION_ID)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: async () => undefined,
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    onReady({ handleGatewayEvent: stream.handleGatewayEvent })
+  }, [onReady, stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps assistant text streamed before a tool call when final text completes the turn', () => {
+    let state = initialState()
+
+    const updateSessionState = vi.fn(
+      (
+        sessionId: string,
+        updater: (state: ClientSessionState) => ClientSessionState,
+        _storedSessionId?: string | null
+      ) => {
+        expect(sessionId).toBe(SESSION_ID)
+        state = updater(state)
+
+        return state
+      }
+    )
+
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={h => (handle = h)} updateSessionState={updateSessionState} />)
+
+    handle!.handleGatewayEvent({ payload: {}, session_id: SESSION_ID, type: 'message.start' } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { text: 'Planning.' },
+      session_id: SESSION_ID,
+      type: 'message.delta'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { args: { command: 'pwd' }, name: 'terminal', tool_id: 'tc-1' },
+      session_id: SESSION_ID,
+      type: 'tool.start'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { args: { command: 'pwd' }, name: 'terminal', result: 'ok', tool_id: 'tc-1' },
+      session_id: SESSION_ID,
+      type: 'tool.complete'
+    } as RpcEvent)
+    handle!.handleGatewayEvent({
+      payload: { text: 'Done.' },
+      session_id: SESSION_ID,
+      type: 'message.complete'
+    } as RpcEvent)
+
+    const assistant = state.messages.find(message => message.role === 'assistant')
+
+    expect(assistant?.pending).toBe(false)
+    expect(assistant?.parts.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(chatMessageText(assistant!)).toBe('Planning.Done.')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -451,9 +451,14 @@ export function useMessageStream({
         const dedupeReference = normalize(finalText)
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
-          const kept = parts.filter(part => {
+          const lastToolPartIndex = parts.reduce(
+            (lastIndex, part, index) => (part.type === 'tool-call' ? index : lastIndex),
+            -1
+          )
+
+          const kept = parts.filter((part, index) => {
             if (part.type === 'text') {
-              return false
+              return lastToolPartIndex >= 0 && index < lastToolPartIndex
             }
 
             if (part.type !== 'reasoning' || !dedupeReference) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -450,6 +450,25 @@ export function useMessageStream({
         const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
         const dedupeReference = normalize(finalText)
 
+        const finalTailAfterKeptText = (kept: ChatMessagePart[]) => {
+          let tail = finalText
+
+          for (const part of kept) {
+            if (part.type !== 'text') {
+              continue
+            }
+
+            const text = part.text.trim()
+            const candidate = tail.trimStart()
+
+            if (text && candidate.startsWith(text)) {
+              tail = candidate.slice(text.length).trimStart()
+            }
+          }
+
+          return tail
+        }
+
         const replaceTextPart = (parts: ChatMessagePart[]) => {
           const lastToolPartIndex = parts.reduce(
             (lastIndex, part, index) => (part.type === 'tool-call' ? index : lastIndex),
@@ -470,7 +489,9 @@ export function useMessageStream({
             return !(r && (dedupeReference.startsWith(r) || r.startsWith(dedupeReference)))
           })
 
-          return finalText ? [...kept, assistantTextPart(finalText)] : kept
+          const tail = finalTailAfterKeptText(kept)
+
+          return tail ? [...kept, assistantTextPart(tail)] : kept
         }
 
         const completeMessage = (message: ChatMessage): ChatMessage =>


### PR DESCRIPTION
Fixes #39558.

## Summary
- preserve text parts that streamed before the last tool call when `message.complete` replaces the final assistant text
- keep the existing behavior for normal no-tool completions by replacing all streamed text when no tool call was present
- add a hook-level regression test for `message.delta -> tool.start -> tool.complete -> message.complete`

## Red
- `npm run test:ui -- src/app/session/hooks/use-message-stream.test.tsx`
  - failed with parts `['tool-call', 'text']` instead of `['text', 'tool-call', 'text']`

## Proof
- `npm run test:ui -- src/app/session/hooks/use-message-stream.test.tsx src/lib/chat-messages.test.ts`
- `npx eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx`
- `npm run type-check`
- `git diff --check` (only Windows CRLF warning for `apps/desktop/src/app/session/hooks/use-message-stream.ts`)