### PR TITLE
fix(tools): block path traversal in skill_view name resolution (#38643)

### DIFF
--- a/tests/tools/test_skill_view_traversal.py
+++ b/tests/tools/test_skill_view_traversal.py
@@ -2,6 +2,9 @@
 
 Regression tests for issue #220: skill_view file_path parameter allowed
 reading arbitrary files (e.g., ~/.hermes/.env) via path traversal.
+
+Regression tests for issue #38643: skill_view name parameter allowed
+reading arbitrary files via path traversal in the skill name itself.
 """
 
 import json
@@ -80,3 +83,53 @@ class TestPathTraversalBlocked:
         assert result["success"] is False
         assert "sk-do-not-leak" not in result.get("content", "")
         assert "sk-do-not-leak" not in json.dumps(result)
+
+
+class TestNameTraversalBlocked:
+    """Regression tests for #38643: path traversal via the skill name parameter.
+
+    The 'name' is used in Path arithmetic (search_dir / name), so a name
+    containing '..' components or absolute path separators can escape the
+    skills directory and read arbitrary files.
+    """
+
+    def test_dotdot_in_name_rejected(self, fake_skills):
+        """A name containing '..' should be rejected before any file I/O."""
+        result = json.loads(skill_view("../../.env"))
+        assert result["success"] is False
+        assert "traversal" in result["error"].lower()
+
+    def test_dotdot_nested_in_name_rejected(self, fake_skills):
+        """Nested '..' in the skill name should also be rejected."""
+        result = json.loads(skill_view("mlops/../../.env"))
+        assert result["success"] is False
+        assert "traversal" in result["error"].lower()
+
+    def test_absolute_path_name_rejected(self, fake_skills, tmp_path):
+        """An absolute path as skill name should be rejected."""
+        sensitive = tmp_path / ".env"
+        result = json.loads(skill_view(str(sensitive)))
+        assert result["success"] is False
+        # Either the absolute-path guard or the outside-dir guard fires
+        assert result["error"]
+
+    def test_sensitive_content_not_leaked_via_name(self, fake_skills):
+        """Secret file content must never appear in the response for a traversal name."""
+        result = json.loads(skill_view("../../.env"))
+        assert result["success"] is False
+        assert "sk-do-not-leak" not in result.get("content", "")
+        assert "sk-do-not-leak" not in json.dumps(result)
+
+    def test_valid_name_still_loads(self, fake_skills):
+        """A legitimate skill name must still load successfully after the guard."""
+        result = json.loads(skill_view("test-skill"))
+        assert result["success"] is True
+
+    def test_categorized_name_still_loads(self, fake_skills):
+        """A category/skill-name path (no '..') must still load successfully."""
+        skills_dir = fake_skills["skills_dir"]
+        cat_dir = skills_dir / "mlops" / "axolotl"
+        cat_dir.mkdir(parents=True)
+        (cat_dir / "SKILL.md").write_text("---\nname: axolotl\ndescription: Fine-tuning skill\n---\n# Axolotl")
+        result = json.loads(skill_view("mlops/axolotl"))
+        assert result["success"] is True

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -848,6 +848,34 @@ def skill_view(
     """
     try:
         local_category_name: str | None = None
+
+        # ── Security: block path traversal in skill name ─────────────
+        # Reject names that contain '..' components or are absolute paths.
+        # The name is used directly in Path arithmetic (search_dir / name),
+        # so an attacker could read arbitrary files with a name like
+        # '../../.env' or '/etc/passwd'.
+        from tools.path_security import has_traversal_component
+
+        _name_path = Path(name)
+        if has_traversal_component(name):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "Path traversal ('..') is not allowed in skill names.",
+                    "hint": "Use a plain skill name or relative category/skill-name path",
+                },
+                ensure_ascii=False,
+            )
+        if _name_path.is_absolute():
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "Absolute paths are not allowed as skill names.",
+                    "hint": "Use a plain skill name or relative category/skill-name path",
+                },
+                ensure_ascii=False,
+            )
+
         # ── Qualified name dispatch (plugin skills) ──────────────────
         # Names containing ':' are routed to the plugin skill registry.
         # Bare names fall through to the existing flat-tree scan below.
@@ -1037,7 +1065,10 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Security: warn if skill is loaded from outside trusted directories
+        # Security: block skill files resolved outside trusted directories.
+        # This is a defence-in-depth check that catches traversal via the
+        # skill name (e.g. '../../.env') even if the early name check above
+        # were somehow bypassed, as well as symlink escapes.
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
         _trusted_dirs = [SKILLS_DIR.resolve()]
@@ -1053,18 +1084,33 @@ def skill_view(
             except ValueError:
                 continue
 
+        if _outside_skills_dir:
+            logging.getLogger(__name__).warning(
+                "Skill security: '%s' resolved outside trusted directories (%s)",
+                name, skill_md,
+            )
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Skill '{name}' resolves outside the trusted skills directory "
+                        "and cannot be loaded."
+                    ),
+                    "hint": "Use a plain skill name or relative category/skill-name path",
+                },
+                ensure_ascii=False,
+            )
+
         # Security: detect common prompt injection patterns
         # (pattern list at module level as _INJECTION_PATTERNS)
         _content_lower = content.lower()
         _injection_detected = any(p in _content_lower for p in _INJECTION_PATTERNS)
 
-        if _outside_skills_dir or _injection_detected:
-            _warnings = []
-            if _outside_skills_dir:
-                _warnings.append(f"skill file is outside the trusted skills directory (~/.hermes/skills/): {skill_md}")
-            if _injection_detected:
-                _warnings.append("skill content contains patterns that may indicate prompt injection")
-            logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
+        if _injection_detected:
+            logging.getLogger(__name__).warning(
+                "Skill security warning for '%s': skill content contains patterns that may indicate prompt injection",
+                name,
+            )
 
         parsed_frontmatter: Dict[str, Any] = {}
         try:


### PR DESCRIPTION
﻿## Summary
- 	ools/skills_tool.py: added early name guard rejecting .. components and absolute paths before any file I/O; promoted existing post-resolution boundary check from warn-only to hard reject (catches symlink escapes)
- Tests: 6 new tests in 	ests/tools/test_skill_view_traversal.py

## Root cause (fixes #38643)
skill_view accepted raw user input as a skill filename without validating it. A name like ../../.env would resolve outside the trusted skills directory and serve the file contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
