### PR TITLE
fix(dashboard): add --tui flag to dashboard subparser (#39503)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -15593,6 +15593,11 @@ Examples:
         "--no-open", action="store_true", help="Don't open browser automatically"
     )
     dashboard_parser.add_argument(
+        "--tui",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    dashboard_parser.add_argument(
         "--insecure",
         action="store_true",
         help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",


### PR DESCRIPTION
## Fixes #39503

The desktop app (`apps/desktop/electron/main.cjs`) spawns the backend with:

```js
const dashboardArgs = ['dashboard', '--no-open', '--tui', '--host', '127.0.0.1', '--port', String(port)]
```

But the `dashboard` subparser in `hermes_cli/main.py` doesn't accept `--tui`, causing argparse to exit with `unrecognized arguments: --tui` (exit code 2).

The actual TUI behavior is controlled by the `HERMES_DASHBOARD_TUI` env var (already set by the desktop app on line ~3238), so `--tui` is added as a **hidden no-op flag** (`argparse.SUPPRESS`) for backward compatibility.

### Verification

```bash
# Before: fails
hermes dashboard --no-open --tui --host 127.0.0.1 --port 9119
# → hermes: error: unrecognized arguments: --tui

# After: works
hermes dashboard --no-open --tui --host 127.0.0.1 --port 9119
# → HTTP 200 on http://127.0.0.1:9119/
```

This supports option 1/3 from the issue: accept `dashboard --tui` as a compatibility flag, while the env var remains the canonical TUI toggle.
