### PR TITLE
fix(gateway): refresh QQBot sessions before timeout

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -159,6 +159,10 @@ class QQAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
+    # QQ gateway sessions have a hard lifetime of roughly 30 minutes. Refresh
+    # slightly earlier so the existing reconnect/resume path runs before the
+    # server closes the connection with 4009.
+    SESSION_REFRESH_SECONDS = 1740.0
 
     @property
     def _log_tag(self) -> str:
@@ -223,6 +227,7 @@ class QQAdapter(BasePlatformAdapter):
         self._http_client: Optional[httpx.AsyncClient] = None
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
+        self._session_refresh_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
@@ -355,6 +360,8 @@ class QQAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             self._heartbeat_task = None
+
+        self._stop_session_refresh()
 
         await self._cleanup()
         self._release_platform_lock()
@@ -682,7 +689,9 @@ class QQAdapter(BasePlatformAdapter):
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
 
-        while self._running and self._ws and not self._ws.closed:
+        while self._running and self._ws:
+            if self._ws.closed:
+                raise QQCloseError(1000, "WebSocket closed")
             msg = await self._ws.receive()
             if msg.type == aiohttp.WSMsgType.TEXT:
                 payload = self._parse_json(msg.data)
@@ -691,10 +700,10 @@ class QQAdapter(BasePlatformAdapter):
             elif msg.type in {aiohttp.WSMsgType.PING,}:
                 # aiohttp auto-replies with PONG
                 pass
-            elif msg.type == aiohttp.WSMsgType.CLOSE:
-                raise QQCloseError(msg.data, msg.extra)
+            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING}:
+                raise QQCloseError(msg.data or 1000, msg.extra or "WebSocket closing")
             elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
-                raise RuntimeError("WebSocket closed")
+                raise QQCloseError(msg.data or 1000, msg.extra or "WebSocket closed")
 
     async def _heartbeat_loop(self) -> None:
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
@@ -785,6 +794,49 @@ class QQAdapter(BasePlatformAdapter):
             self._session_id = None
             self._last_seq = None
 
+    # ------------------------------------------------------------------
+    # Session refresh
+    # ------------------------------------------------------------------
+
+    def _start_session_refresh(self) -> None:
+        """Start a fresh proactive session-refresh timer."""
+        self._stop_session_refresh()
+        task = self._create_task(self._session_refresh_loop())
+        if task is not None:
+            task.add_done_callback(self._consume_session_refresh_result)
+            self._session_refresh_task = task
+
+    def _stop_session_refresh(self) -> None:
+        """Cancel the proactive session-refresh timer, if present."""
+        task = self._session_refresh_task
+        self._session_refresh_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            task.add_done_callback(self._consume_session_refresh_result)
+
+    def _consume_session_refresh_result(self, task: asyncio.Task) -> None:
+        """Consume timer cancellation/errors so refresh restarts do not leak tasks."""
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.debug("[%s] Session refresh task failed: %s", self._log_tag, exc)
+
+    async def _session_refresh_loop(self) -> None:
+        """Close the WebSocket before QQ's session lifetime expires."""
+        await asyncio.sleep(self.SESSION_REFRESH_SECONDS)
+        if not self._running:
+            return
+        ws = self._ws
+        if ws and not ws.closed:
+            logger.info(
+                "[%s] Session lifetime reached (%.0fs), refreshing via reconnect",
+                self._log_tag,
+                self.SESSION_REFRESH_SECONDS,
+            )
+            await ws.close(code=1000, message=b"session refresh")
+
     @staticmethod
     def _create_task(coro):
         """Schedule a coroutine, silently skipping if no event loop is running.
@@ -833,6 +885,7 @@ class QQAdapter(BasePlatformAdapter):
                 self._handle_ready(d)
             elif t == "RESUMED":
                 logger.info("[%s] Session resumed", self._log_tag)
+                self._start_session_refresh()
             elif t in {
                     "C2C_MESSAGE_CREATE",
                     "GROUP_AT_MESSAGE_CREATE",
@@ -883,6 +936,7 @@ class QQAdapter(BasePlatformAdapter):
         """Handle the READY event — store session_id for resume."""
         if isinstance(d, dict):
             self._session_id = d.get("session_id")
+            self._start_session_refresh()
             logger.info("[%s] Ready, session_id=%s", self._log_tag, self._session_id)
 
     # ------------------------------------------------------------------

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -801,7 +801,10 @@ class QQAdapter(BasePlatformAdapter):
     def _start_session_refresh(self) -> None:
         """Start a fresh proactive session-refresh timer."""
         self._stop_session_refresh()
-        task = self._create_task(self._session_refresh_loop())
+        ws = self._ws
+        if ws is None:
+            return
+        task = self._create_task(self._session_refresh_loop(ws))
         if task is not None:
             task.add_done_callback(self._consume_session_refresh_result)
             self._session_refresh_task = task
@@ -823,13 +826,14 @@ class QQAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Session refresh task failed: %s", self._log_tag, exc)
 
-    async def _session_refresh_loop(self) -> None:
+    async def _session_refresh_loop(self, ws: Optional[aiohttp.ClientWebSocketResponse] = None) -> None:
         """Close the WebSocket before QQ's session lifetime expires."""
         await asyncio.sleep(self.SESSION_REFRESH_SECONDS)
         if not self._running:
             return
-        ws = self._ws
-        if ws and not ws.closed:
+        if ws is None or ws is not self._ws:
+            return
+        if not ws.closed:
             logger.info(
                 "[%s] Session lifetime reached (%.0fs), refreshing via reconnect",
                 self._log_tag,
@@ -848,6 +852,7 @@ class QQAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             return loop.create_task(coro)
         except RuntimeError:
+            coro.close()
             return None
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -476,6 +476,128 @@ class TestReadyHandling:
         assert adapter._session_id == "old_sess"
         assert adapter._last_seq == 60
 
+    @pytest.mark.asyncio
+    async def test_ready_starts_session_refresh_task(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 60.0
+
+        adapter._dispatch_payload({
+            "op": 0, "t": "READY",
+            "s": 1,
+            "d": {"session_id": "sess_abc123"},
+        })
+
+        assert adapter._session_refresh_task is not None
+        assert not adapter._session_refresh_task.done()
+
+        adapter._stop_session_refresh()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_resumed_restarts_session_refresh_task(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 60.0
+
+        adapter._dispatch_payload({
+            "op": 0, "t": "READY",
+            "s": 1,
+            "d": {"session_id": "sess_abc123"},
+        })
+        old_task = adapter._session_refresh_task
+
+        adapter._dispatch_payload({
+            "op": 0, "t": "RESUMED",
+            "s": 2,
+            "d": {},
+        })
+        await asyncio.sleep(0)
+
+        assert adapter._session_refresh_task is not None
+        assert adapter._session_refresh_task is not old_task
+        assert old_task is not None
+        assert old_task.cancelled()
+
+        adapter._stop_session_refresh()
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_session_refresh_task(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 60.0
+        adapter._dispatch_payload({
+            "op": 0, "t": "READY",
+            "s": 1,
+            "d": {"session_id": "sess_abc123"},
+        })
+
+        task = adapter._session_refresh_task
+        await adapter.disconnect()
+        await asyncio.sleep(0)
+
+        assert adapter._session_refresh_task is None
+        assert task is not None
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_session_refresh_loop_closes_websocket(self):
+        class FakeWebSocket:
+            closed = False
+
+            def __init__(self):
+                self.close_kwargs = None
+
+            async def close(self, **kwargs):
+                self.close_kwargs = kwargs
+                self.closed = True
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 0
+        adapter._running = True
+        ws = FakeWebSocket()
+        adapter._ws = ws
+
+        await adapter._session_refresh_loop()
+
+        assert ws.closed is True
+        assert ws.close_kwargs == {"code": 1000, "message": b"session refresh"}
+
+    @pytest.mark.asyncio
+    async def test_read_events_closed_websocket_raises_close_error(self):
+        from gateway.platforms.qqbot import QQCloseError
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=True)
+
+        with pytest.raises(QQCloseError) as exc_info:
+            await adapter._read_events()
+
+        assert exc_info.value.code == 1000
+
+    @pytest.mark.asyncio
+    async def test_read_events_closing_frame_raises_close_error(self):
+        import gateway.platforms.qqbot.adapter as qq_module
+        from gateway.platforms.qqbot import QQCloseError
+
+        class FakeWebSocket:
+            closed = False
+
+            async def receive(self):
+                return SimpleNamespace(
+                    type=qq_module.aiohttp.WSMsgType.CLOSING,
+                    data=1000,
+                    extra="closing",
+                )
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = FakeWebSocket()
+
+        with pytest.raises(QQCloseError) as exc_info:
+            await adapter._read_events()
+
+        assert exc_info.value.code == 1000
+
 
 # ---------------------------------------------------------------------------
 # _parse_json

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -465,6 +465,22 @@ class TestReadyHandling:
         })
         assert adapter._session_id == "sess_abc123"
 
+    def test_ready_sync_dispatch_does_not_leak_refresh_coroutine(self, recwarn):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+
+        adapter._dispatch_payload({
+            "op": 0, "t": "READY",
+            "s": 1,
+            "d": {"session_id": "sess_abc123"},
+        })
+
+        coroutine_warnings = [
+            warning for warning in recwarn
+            if issubclass(warning.category, RuntimeWarning)
+            and "coroutine" in str(warning.message)
+        ]
+        assert coroutine_warnings == []
+
     def test_resumed_preserves_session(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter._session_id = "old_sess"
@@ -478,8 +494,12 @@ class TestReadyHandling:
 
     @pytest.mark.asyncio
     async def test_ready_starts_session_refresh_task(self):
+        class FakeWebSocket:
+            closed = False
+
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter.SESSION_REFRESH_SECONDS = 60.0
+        adapter._ws = FakeWebSocket()
 
         adapter._dispatch_payload({
             "op": 0, "t": "READY",
@@ -495,8 +515,12 @@ class TestReadyHandling:
 
     @pytest.mark.asyncio
     async def test_resumed_restarts_session_refresh_task(self):
+        class FakeWebSocket:
+            closed = False
+
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter.SESSION_REFRESH_SECONDS = 60.0
+        adapter._ws = FakeWebSocket()
 
         adapter._dispatch_payload({
             "op": 0, "t": "READY",
@@ -522,8 +546,15 @@ class TestReadyHandling:
 
     @pytest.mark.asyncio
     async def test_disconnect_cancels_session_refresh_task(self):
+        class FakeWebSocket:
+            closed = False
+
+            async def close(self):
+                self.closed = True
+
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter.SESSION_REFRESH_SECONDS = 60.0
+        adapter._ws = FakeWebSocket()
         adapter._dispatch_payload({
             "op": 0, "t": "READY",
             "s": 1,
@@ -556,10 +587,66 @@ class TestReadyHandling:
         ws = FakeWebSocket()
         adapter._ws = ws
 
-        await adapter._session_refresh_loop()
+        await adapter._session_refresh_loop(ws)
 
         assert ws.closed is True
         assert ws.close_kwargs == {"code": 1000, "message": b"session refresh"}
+
+    @pytest.mark.asyncio
+    async def test_session_refresh_loop_ignores_replaced_websocket(self):
+        class FakeWebSocket:
+            closed = False
+
+            def __init__(self):
+                self.close_called = False
+
+            async def close(self, **_kwargs):
+                self.close_called = True
+                self.closed = True
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 0
+        adapter._running = True
+        stale_ws = FakeWebSocket()
+        current_ws = FakeWebSocket()
+        adapter._ws = current_ws
+
+        await adapter._session_refresh_loop(stale_ws)
+
+        assert stale_ws.close_called is False
+        assert current_ws.close_called is False
+
+    @pytest.mark.asyncio
+    async def test_start_session_refresh_without_websocket_is_noop(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 0
+        adapter._ws = None
+
+        adapter._start_session_refresh()
+
+        assert adapter._session_refresh_task is None
+
+    @pytest.mark.asyncio
+    async def test_session_refresh_loop_none_websocket_is_noop(self):
+        class FakeWebSocket:
+            closed = False
+
+            def __init__(self):
+                self.close_called = False
+
+            async def close(self, **_kwargs):
+                self.close_called = True
+                self.closed = True
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter.SESSION_REFRESH_SECONDS = 0
+        adapter._running = True
+        current_ws = FakeWebSocket()
+        adapter._ws = current_ws
+
+        await adapter._session_refresh_loop(None)
+
+        assert current_ws.close_called is False
 
     @pytest.mark.asyncio
     async def test_read_events_closed_websocket_raises_close_error(self):


### PR DESCRIPTION
## What does this PR do?

Fixes QQBot gateway session refresh so long-running sessions proactively reconnect/resume before the QQ gateway closes them with `4009 Session timed out`.

The adapter now:
- starts a proactive session-refresh timer after `READY`;
- restarts the timer after `RESUMED`;
- scopes each timer to the websocket active when the timer was created, so stale timers cannot close newer websockets;
- avoids scheduling refresh timers when no websocket is active;
- treats closed/closing websocket states as `QQCloseError` so the existing reconnect/resume path runs instead of silently returning.

## Related Issue

No issue number.

Related PRs checked to avoid duplication:
- #21073 preserves session state on 4009/reconnect. Current `main` already preserves 4009 as resumable; this PR adds proactive refresh after READY/RESUMED.
- #31333 fixes a closed-websocket busy-loop subset. This PR needs equivalent close-state handling so proactive refresh deterministically reaches reconnect/resume, and adds scoped refresh lifecycle coverage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`
  - Add `SESSION_REFRESH_SECONDS` and `_session_refresh_task` lifecycle.
  - Start/restart refresh timer on `READY` / `RESUMED`.
  - Cancel refresh timer on disconnect.
  - Ensure refresh timers are bound to the captured websocket and do not act on stale or missing sockets.
  - Convert closed/CLOSING/CLOSED/ERROR websocket states to `QQCloseError` for reconnect handling.
- `tests/gateway/test_qqbot.py`
  - Cover READY/RESUMED refresh lifecycle.
  - Cover disconnect cancellation.
  - Cover stale websocket and `None` websocket no-op behavior.
  - Cover closed/CLOSING frame handling.
  - Cover no-loop synchronous dispatch without coroutine warnings.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_qqbot.py`
2. `venv/bin/python scripts/check-windows-footguns.py --diff origin/main`
3. `git diff --check origin/main..HEAD`

All passed locally after rebasing onto latest `origin/main`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the relevant test suite and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Linux.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, behavior is covered by tests and inline comments.
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys added.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no workflow/architecture docs changed.
- [x] I've considered cross-platform impact; Windows footgun check passed.
- [x] I've updated tool descriptions/schemas — N/A, no tool schema changed.

## Screenshots / Logs

Validation:

```text
scripts/run_tests.sh tests/gateway/test_qqbot.py
=> 169 tests passed

venv/bin/python scripts/check-windows-footguns.py --diff origin/main
=> No Windows footguns found (2 file(s) scanned)

git diff --check origin/main..HEAD
=> passed
```
