### PR TITLE
fix(desktop): prefer supported POSIX Python

### DIFF
--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -33,8 +33,10 @@
  */
 
 const { execFileSync } = require('node:child_process')
+const path = require('node:path')
 
 const PROBE_TIMEOUT_MS = 5000
+const POSIX_MIN_PYTHON_MINOR = 10
 
 /**
  * Return true iff `python -c "import hermes_cli"` exits 0.
@@ -99,8 +101,101 @@ function verifyHermesCli(hermesCommand, opts = {}) {
   }
 }
 
+/**
+ * Return true iff the given POSIX Python reports version >= 3.10.
+ *
+ * macOS Finder/Dock launches often inherit a minimal PATH where
+ * `/usr/bin/python3` (3.9) wins even when a newer Homebrew or
+ * `/usr/local/bin` install exists. Hermes itself only needs to know
+ * whether the interpreter is modern enough to import hermes_cli; the
+ * desktop bootstrap later verifies the module import separately.
+ *
+ * @param {string} pythonPath
+ * @param {object} [opts]
+ * @param {typeof execFileSync} [opts.execFileSyncImpl]
+ * @returns {boolean}
+ */
+function isSupportedPosixPython(pythonPath, opts = {}) {
+  if (!pythonPath) return false
+  const execFileSyncImpl = opts.execFileSyncImpl || execFileSync
+  try {
+    const raw = execFileSyncImpl(
+      pythonPath,
+      ['-c', 'import sys; print(".".join(map(str, sys.version_info[:2])))'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: PROBE_TIMEOUT_MS,
+        windowsHide: true
+      }
+    )
+    const [major, minor] = String(raw)
+      .trim()
+      .split('.')
+      .map(value => Number.parseInt(value, 10))
+    return major > 3 || (major === 3 && minor >= POSIX_MIN_PYTHON_MINOR)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the first supported POSIX Python candidate.
+ *
+ * On macOS we check the common Homebrew/install locations first because
+ * GUI-launched apps frequently do not inherit `/opt/homebrew/bin` or
+ * `/usr/local/bin` in PATH. We still fall back to PATH-based discovery,
+ * but only after filtering out 3.9-era interpreters that would crash on
+ * Hermes' Python 3.10+ syntax.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.platform]
+ * @param {(command: string) => string | null} [opts.resolveCommand]
+ * @param {(candidate: string) => boolean} [opts.fileExists]
+ * @param {typeof execFileSync} [opts.execFileSyncImpl]
+ * @param {typeof path} [opts.pathModule]
+ * @returns {string | null}
+ */
+function findSupportedPosixPython(opts = {}) {
+  const platform = opts.platform || process.platform
+  const resolveCommand = opts.resolveCommand || (() => null)
+  const fileExists = opts.fileExists || (() => false)
+  const execFileSyncImpl = opts.execFileSyncImpl || execFileSync
+  const pathModule = opts.pathModule || path
+  const commands = ['python3', 'python']
+  const candidates = []
+
+  if (platform === 'darwin') {
+    for (const dir of ['/opt/homebrew/bin', '/usr/local/bin']) {
+      for (const command of commands) {
+        const candidate = pathModule.join(dir, command)
+        if (fileExists(candidate)) candidates.push(candidate)
+      }
+    }
+  }
+
+  for (const command of commands) {
+    const candidate = resolveCommand(command)
+    if (candidate) candidates.push(candidate)
+  }
+
+  const seen = new Set()
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) continue
+    seen.add(candidate)
+    if (isSupportedPosixPython(candidate, { execFileSyncImpl })) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
 module.exports = {
   canImportHermesCli,
+  findSupportedPosixPython,
+  isSupportedPosixPython,
+  POSIX_MIN_PYTHON_MINOR,
   verifyHermesCli,
   PROBE_TIMEOUT_MS
 }

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -11,7 +11,12 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const {
+  canImportHermesCli,
+  findSupportedPosixPython,
+  isSupportedPosixPython,
+  verifyHermesCli
+} = require('./backend-probes.cjs')
 
 // Resolve the host's own Node binary -- guaranteed to be on disk and
 // runnable. We use it as both a stand-in for "a python that doesn't
@@ -79,4 +84,64 @@ test('verifyHermesCli swallows timeouts (does not throw)', () => {
   // (because the binary is missing) returns false rather than
   // propagating. Same code path the timeout case takes.
   assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+})
+
+test('isSupportedPosixPython rejects Python 3.9 and accepts 3.10+', () => {
+  const versions = new Map([
+    ['/usr/bin/python3', '3.9\n'],
+    ['/usr/local/bin/python3', '3.10\n'],
+    ['/opt/homebrew/bin/python3', '3.14\n']
+  ])
+
+  const execFileSyncImpl = pythonPath => {
+    const version = versions.get(pythonPath)
+    if (!version) throw new Error(`unexpected path: ${pythonPath}`)
+    return version
+  }
+
+  assert.equal(isSupportedPosixPython('/usr/bin/python3', { execFileSyncImpl }), false)
+  assert.equal(isSupportedPosixPython('/usr/local/bin/python3', { execFileSyncImpl }), true)
+  assert.equal(isSupportedPosixPython('/opt/homebrew/bin/python3', { execFileSyncImpl }), true)
+})
+
+test('findSupportedPosixPython prefers supported macOS well-known locations over PATH', () => {
+  const versions = new Map([
+    ['/opt/homebrew/bin/python3', '3.14\n'],
+    ['/usr/bin/python3', '3.9\n']
+  ])
+
+  const candidateByCommand = new Map([
+    ['python3', '/usr/bin/python3'],
+    ['python', null]
+  ])
+
+  const candidate = findSupportedPosixPython({
+    platform: 'darwin',
+    resolveCommand: command => candidateByCommand.get(command) || null,
+    fileExists: pythonPath => versions.has(pythonPath),
+    execFileSyncImpl: pythonPath => versions.get(pythonPath)
+  })
+
+  assert.equal(candidate, '/opt/homebrew/bin/python3')
+})
+
+test('findSupportedPosixPython skips unsupported POSIX PATH hits before returning a newer one', () => {
+  const versions = new Map([
+    ['/usr/bin/python3', '3.9\n'],
+    ['/usr/local/bin/python', '3.11\n']
+  ])
+
+  const candidateByCommand = new Map([
+    ['python3', '/usr/bin/python3'],
+    ['python', '/usr/local/bin/python']
+  ])
+
+  const candidate = findSupportedPosixPython({
+    platform: 'linux',
+    resolveCommand: command => candidateByCommand.get(command) || null,
+    fileExists: pythonPath => versions.has(pythonPath),
+    execFileSyncImpl: pythonPath => versions.get(pythonPath)
+  })
+
+  assert.equal(candidate, '/usr/local/bin/python')
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -26,7 +26,7 @@ const { fileURLToPath, pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
-const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { canImportHermesCli, findSupportedPosixPython, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const {
   authModeFromStatus,
@@ -934,12 +934,11 @@ function findPythonForRoot(root) {
 
 function findSystemPython() {
   if (!IS_WINDOWS) {
-    // POSIX systems: PATH lookup is safe.
-    for (const command of ['python3', 'python']) {
-      const candidate = findOnPath(command)
-      if (candidate) return candidate
-    }
-    return null
+    return findSupportedPosixPython({
+      platform: process.platform,
+      resolveCommand: findOnPath,
+      fileExists
+    })
   }
 
   // Windows: PATH-based detection has TWO landmines we have to dodge.


### PR DESCRIPTION
## Summary
- prefer supported POSIX Python interpreters instead of blindly taking the first PATH hit
- check common macOS Homebrew install locations before PATH so Finder launches can escape /usr/bin/python3
- add targeted backend probe tests for Python version filtering and candidate ordering

## Testing
- git diff --check HEAD^ HEAD
- /Users/leongong/.bun/bin/bun test apps/desktop/electron/backend-probes.test.cjs
- /Users/leongong/.bun/bin/bun -e "const fs=require('fs'); new Function(fs.readFileSync('apps/desktop/electron/backend-probes.cjs','utf8')); new Function(fs.readFileSync('apps/desktop/electron/backend-probes.test.cjs','utf8')); new Function(fs.readFileSync('apps/desktop/electron/main.cjs','utf8')); console.log('syntax-ok')"

Closes #39536