### PR TITLE
fix(cron): resolve wechat alias to weixin for delivery targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -203,6 +203,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
+# Platform name aliases for cron delivery.  ``wechat`` is commonly used by
+# users as a synonym for ``weixin`` (the gateway/platform adapter name),
+# but the scheduler only recognises canonical names in ``_KNOWN_DELIVERY_PLATFORMS``.
+# Resolve these aliases so that jobs created with ``deliver: wechat`` work
+# transparently alongside ``deliver: weixin``.
+_DELIVERY_PLATFORM_ALIASES = {
+    "wechat": "weixin",
+}
+
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -564,6 +573,11 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     }
 
 
+def _resolve_platform_alias(platform_name: str) -> str:
+    """Resolve a platform name through the alias map (e.g. ``wechat`` → ``weixin``)."""
+    return _DELIVERY_PLATFORM_ALIASES.get(platform_name.lower(), platform_name)
+
+
 def _normalize_deliver_value(deliver) -> str:
     """Normalize a stored/submitted ``deliver`` value to its canonical string form.
 
@@ -575,13 +589,30 @@ def _normalize_deliver_value(deliver) -> str:
     string ``"['telegram']"``, which is not a known platform and fails
     resolution silently.  Flatten lists/tuples into a comma-separated string
     so both forms work.  Returns ``"local"`` for anything falsy.
+
+    Also resolves platform name aliases (e.g. ``wechat`` → ``weixin``) so that
+    jobs created with common synonyms work transparently.
     """
     if deliver is None or deliver == "":
         return "local"
     if isinstance(deliver, (list, tuple)):
         parts = [str(p).strip() for p in deliver if str(p).strip()]
         return ",".join(parts) if parts else "local"
-    return str(deliver)
+    raw = str(deliver)
+    if "," in raw:
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        resolved = []
+        for p in parts:
+            if ":" in p:
+                platform, rest = p.split(":", 1)
+                resolved.append(f"{_resolve_platform_alias(platform)}:{rest}")
+            else:
+                resolved.append(_resolve_platform_alias(p))
+        return ",".join(resolved)
+    if ":" in raw:
+        platform, rest = raw.split(":", 1)
+        return f"{_resolve_platform_alias(platform)}:{rest}"
+    return _resolve_platform_alias(raw)
 
 
 # Routing intent tokens — resolved at fire time, not create time, so a

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -398,6 +398,66 @@ class TestResolveDeliveryTarget:
         assert _resolve_delivery_targets({"deliver": []}) == []
 
 
+class TestPlatformAliases:
+    """Platform name aliases (e.g. wechat → weixin) resolve in cron delivery."""
+
+    def test_wechat_resolves_to_weixin(self, monkeypatch):
+        """deliver='wechat' should resolve to weixin platform with WEIXIN_HOME_CHANNEL."""
+        from cron.scheduler import _resolve_delivery_target
+
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "wxid_test")
+        result = _resolve_delivery_target({"deliver": "wechat"})
+        assert result is not None
+        assert result["platform"] == "weixin"
+        assert result["chat_id"] == "wxid_test"
+
+    def test_wechat_with_explicit_chat_id(self, monkeypatch):
+        """deliver='wechat:specific_chat' passes chat_id through alias resolution."""
+        from cron.scheduler import _resolve_delivery_target
+
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "wxid_test")
+        result = _resolve_delivery_target({"deliver": "wechat:my_chat_id"})
+        assert result is not None
+        assert result["platform"] == "weixin"
+        assert result["chat_id"] == "my_chat_id"
+
+    def test_wechat_in_comma_separated_deliver(self, monkeypatch):
+        """deliver='telegram:-111,wechat' resolves wechat to weixin in multi-target."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "wxid_test")
+        result = _resolve_delivery_targets({"deliver": "telegram:-111,wechat"})
+        platforms = sorted(t["platform"] for t in result)
+        assert platforms == ["telegram", "weixin"]
+
+    def test_weixin_still_works_directly(self, monkeypatch):
+        """deliver='weixin' continues to work without alias resolution."""
+        from cron.scheduler import _resolve_delivery_target
+
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "wxid_test")
+        result = _resolve_delivery_target({"deliver": "weixin"})
+        assert result is not None
+        assert result["platform"] == "weixin"
+        assert result["chat_id"] == "wxid_test"
+
+    def test_unknown_alias_passes_through(self, monkeypatch):
+        """Non-aliased unknown platforms still fail resolution (no new platforms added)."""
+        from cron.scheduler import _resolve_delivery_target
+
+        result = _resolve_delivery_target({"deliver": "unknown_platform"})
+        assert result is None
+
+    def test_case_insensitive_alias(self, monkeypatch):
+        """deliver='WeChat' (mixed case) also resolves to weixin."""
+        from cron.scheduler import _resolve_delivery_target
+
+        monkeypatch.setenv("WEIXIN_HOME_CHANNEL", "wxid_test")
+        result = _resolve_delivery_target({"deliver": "WeChat"})
+        assert result is not None
+        assert result["platform"] == "weixin"
+
+
 class TestRoutingIntents:
     """``all`` routing intent expands at fire time."""
 
@@ -480,6 +540,22 @@ class TestRoutingIntents:
 
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
+        # Clean up any other home channels that might leak from the environment.
+        monkeypatch.delenv("WEIXIN_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SIGNAL_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("MATRIX_HOME_ROOM", raising=False)
+        monkeypatch.delenv("MATTERMOST_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SMS_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("EMAIL_HOME_ADDRESS", raising=False)
+        monkeypatch.delenv("DINGTALK_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("FEISHU_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("WECOM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("QQBOT_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("QQ_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("BLUEBUBBLES_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("YUANBAO_HOME_CHANNEL", raising=False)
 
         for token in ("ALL", "All", "all"):
             targets = _resolve_delivery_targets({"deliver": token, "origin": None})


### PR DESCRIPTION
## Problem / 问题

Cron jobs created with `deliver: wechat` were silently dropped with `no delivery target resolved for deliver=wechat`. The gateway/platform adapter uses the canonical name `weixin` but users commonly use `wechat` as the platform name — and the `send_message` tool has its own alias mapping that makes interactive sending work fine. The cron scheduler, however, only recognises names in `_KNOWN_DELIVERY_PLATFORMS` which has `weixin` but not `wechat`.

**Affected**: Any cron job created via the TUI, Web UI, or CLI that uses `deliver: wechat`.

使用 `deliver: wechat` 创建的 cron 任务会被静默丢弃，报错 `no delivery target resolved for deliver=wechat`。Gateway/平台适配器使用的标准名称是 `weixin`，但用户通常使用 `wechat` 作为平台名。`send_message` 工具有自己的别名映射，所以交互发送正常。但 cron scheduler 只认 `_KNOWN_DELIVERY_PLATFORMS` 里的名称（只有 `weixin`，没有 `wechat`）。

**影响范围**: 所有通过 TUI、Web UI 或 CLI 创建且使用 `deliver: wechat` 的 cron 任务。

---

## Solution / 解决方案

Add a `_DELIVERY_PLATFORM_ALIASES` mapping in `cron/scheduler.py` and resolve aliases in `_normalize_deliver_value` so that `wechat` transparently maps to `weixin`. The alias resolution handles all deliver value shapes:

在 `cron/scheduler.py` 中添加 `_DELIVERY_PLATFORM_ALIASES` 映射表，在 `_normalize_deliver_value` 中解析别名，使 `wechat` 透明地映射到 `weixin`。别名解析覆盖所有 deliver 值形态：

- Plain names: `wechat` → `weixin`
- Explicit targets: `wechat:chat_id` → `weixin:chat_id`
- Comma-separated: `telegram:-111,wechat` → `telegram:-111,weixin`
- Case-insensitive: `WeChat` → `weixin`

The alias map is extensible for future platform synonyms without touching `_KNOWN_DELIVERY_PLATFORMS`.

别名映射表可扩展，未来添加其他平台别名时无需修改 `_KNOWN_DELIVERY_PLATFORMS`。

---

## Changes / 变更

- **cron/scheduler.py**: Add `_DELIVERY_PLATFORM_ALIASES` + `_resolve_platform_alias()`, extend `_normalize_deliver_value()` to resolve aliases on all input shapes
- **tests/cron/test_scheduler.py**: Add `TestPlatformAliases` (6 tests covering all shapes), fix `test_all_token_case_insensitive` to clean up leaked env vars

- **cron/scheduler.py**: 新增 `_DELIVERY_PLATFORM_ALIASES` + `_resolve_platform_alias()`，扩展 `_normalize_deliver_value()` 在所有输入形态下解析别名
- **tests/cron/test_scheduler.py**: 新增 `TestPlatformAliases`（6 个测试覆盖所有形态），修复 `test_all_token_case_insensitive` 的环境变量泄漏问题

---

## Testing / 测试

```
135 passed, 1 warning in 3.05s
```

All existing scheduler tests pass + 6 new tests for alias resolution.

所有已有 scheduler 测试通过 + 6 个新的别名解析测试。