### PR TITLE
fix(compressor): guard against None/empty response from call_llm

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1393,6 +1393,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
+            if response is None or not response.choices:
+                raise RuntimeError("Context compression LLM returned empty response")
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):


### PR DESCRIPTION
## Summary

`call_llm()` can return `None` on certain error paths (e.g., when no provider is configured). The current code accesses `response.choices[0].message.content` immediately after, which raises `AttributeError` on `None`.

While this is caught by the generic `except Exception` handler at line 1418, that handler has specific logic for model fallback (checking `status_code`). An `AttributeError` from a `None` response would incorrectly trigger model fallback logic instead of the dedicated `RuntimeError` handler that applies proper cooldown.

## Fix

Add an explicit guard after `call_llm()` that raises `RuntimeError` when the response is `None` or has empty `choices`. This routes the failure through the correct handler (line 1409) with proper cooldown behavior.

```python
response = call_llm(**call_kwargs)
if response is None or not response.choices:
    raise RuntimeError("Context compression LLM returned empty response")
content = response.choices[0].message.content
```
