### PR TITLE
fix(tui): use _sessions_lock in _reap() instead of _session_resume_lock

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -401,7 +401,7 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         return
 
     def _reap() -> None:
-        with _session_resume_lock:
+        with _sessions_lock:
             session = _sessions.get(sid)
             if not _ws_session_is_orphaned(session):
                 return


### PR DESCRIPTION
## Problem

`_reap()` in `tui_gateway/server.py` mutates the shared `_sessions` dict (`.get()` + `.pop()`) but uses `_session_resume_lock` instead of `_sessions_lock`.

All other code that reads/writes `_sessions` uses `_sessions_lock`:
- `_init_session()` line 2509
- `_shutdown_sessions()` line 420
- `session.close()` line 3346
- `_finalize_session()` line 3759

The `_session_resume_lock` is intended for session resume/attach operations, not dict mutation. Using the wrong lock means `_reap()` can race with:
- `_init_session()` — KeyError if session is reaped between assignment and later access
- `session.close()` — double-pop or lost cleanup
- `_shutdown_sessions()` — snapshot misses a just-reaped session

## Fix

Change `_session_resume_lock` to `_sessions_lock` in `_reap()`:

```python
def _reap() -> None:
    with _sessions_lock:  # was: _session_resume_lock
        session = _sessions.get(sid)
        if not _ws_session_is_orphaned(session):
            return
        _sessions.pop(sid, None)
```
