### PR TITLE
fix(managed_uv): add missing return in rebuild_venv stub

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -184,4 +184,4 @@ def _install_uv_windows(env: dict[str, str]) -> None:
     )
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
-    True # dont remove me. ask ethernet
+    return True  # dont remove me. ask ethernet


### PR DESCRIPTION
## Problem

`rebuild_venv()` in `hermes_cli/managed_uv.py` has `True` as a bare expression instead of `return True`:

```python
def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
    True # dont remove me. ask ethernet
```

The function returns `None` (falsy) despite the `-> bool` type annotation. Any caller checking `if rebuild_venv(...)` would silently take the false branch.

Additionally, the file is missing a trailing newline (POSIX convention).

## Fix

```python
def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
    return True  # dont remove me. ask ethernet
```
