### PR TITLE
fix(gateway): prefer installer-canonical venv/ over .venv in detection fallback

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2119,7 +2119,10 @@ def _detect_venv_dir() -> Path | None:
             return venv
 
     # Fallback: check common virtualenv directory names under the project root.
-    for candidate in (".venv", "venv"):
+    # Prefer the installer-canonical "venv/" (scripts/install.sh creates it via
+    # `python -m venv venv` / `uv venv venv`). Checking ".venv" first picked up
+    # stale sibling uv-default envs that diverge from the install location.
+    for candidate in ("venv", ".venv"):
         venv = PROJECT_ROOT / candidate
         if venv.is_dir():
             return venv

--- a/tests/hermes_cli/test_gateway_venv_pref.py
+++ b/tests/hermes_cli/test_gateway_venv_pref.py
@@ -1,0 +1,23 @@
+"""Regression: venv fallback must prefer installer-canonical ``venv/`` over ``.venv/``."""
+import sys
+import hermes_cli.gateway as gw
+
+
+def _force_fallback(monkeypatch, root):
+    # Pretend we're NOT inside a venv so the directory-probe fallback runs.
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(gw, "PROJECT_ROOT", root)
+
+
+def test_prefers_canonical_venv_when_both_exist(tmp_path, monkeypatch):
+    (tmp_path / "venv").mkdir()
+    (tmp_path / ".venv").mkdir()
+    _force_fallback(monkeypatch, tmp_path)
+    assert gw._detect_venv_dir() == tmp_path / "venv"
+
+
+def test_falls_back_to_dotvenv_when_only_dotvenv(tmp_path, monkeypatch):
+    (tmp_path / ".venv").mkdir()
+    _force_fallback(monkeypatch, tmp_path)
+    assert gw._detect_venv_dir() == tmp_path / ".venv"


### PR DESCRIPTION
## Problem
`_detect_venv_dir()`'s directory-probe fallback checks `.venv` before `venv`:
```python
for candidate in (".venv", "venv"):
```
But the installer creates **`venv/`** (`scripts/install.sh`: `python -m venv venv`, `uv venv venv`, `UV_PROJECT_ENVIRONMENT=$INSTALL_DIR/venv`).

On a machine that also has a stale sibling `.venv/` (e.g. a prior uv-default `uv sync` that landed in `.venv`), the fallback selects the **wrong, divergent environment** for subprocess `PATH`/`VIRTUAL_ENV`. Observed in the wild: gateway ran from `venv` (py3.12) but pushed `.venv` (py3.11, stale) onto terminal/code-exec subprocess PATH — the classic "works in hermes, fails in `python3`" split.

## Fix
Prefer the installer-canonical `venv` in the fallback; still fall back to `.venv` when it's the only env present. `sys.prefix`/`VIRTUAL_ENV` detection is unchanged and still takes precedence.

## Tests
Adds `tests/hermes_cli/test_gateway_venv_pref.py` covering both orderings (prefers `venv` when both exist; falls back to `.venv` when only `.venv`). Green locally.

> Note: separately observed that subprocess PATH can accumulate duplicate venv-bin prepends under a persistent shell (cosmetic). Not addressed here to keep this change focused.