### PR TITLE
fix(models): keep GMI fallback deterministic

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2160,6 +2160,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
+        return list(_PROVIDER_MODELS.get("gmi", []))
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -121,6 +121,30 @@ class TestGmiModelCatalog:
 
         assert provider_model_ids("gmi") == list(_PROVIDER_MODELS["gmi"])
 
+    def test_provider_model_ids_falls_back_to_static_models_without_generic_refetch(self, monkeypatch):
+        class GenericGmiProfile:
+            auth_type = "api_key"
+            base_url = "https://api.gmi-serving.com/v1"
+            fallback_models = []
+
+            @staticmethod
+            def fetch_models(api_key):
+                return ["unexpected-live-model"]
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "gmi-live-key",
+                "base_url": "https://api.gmi-serving.com/v1",
+                "source": "GMI_API_KEY",
+            },
+        )
+        monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda api_key, base_url: None)
+        monkeypatch.setattr("providers.get_provider_profile", lambda provider: GenericGmiProfile())
+
+        assert provider_model_ids("gmi") == list(_PROVIDER_MODELS["gmi"])
+
 
 class TestGmiProvidersModule:
     def test_overlay_exists(self):


### PR DESCRIPTION
Found while reviewing the CI failure on #39573.

## Summary
- stop `provider_model_ids("gmi")` from falling through to the generic provider-profile live fetch after the GMI-specific live fetch returns no models
- keep the documented/tested fallback as the curated static `_PROVIDER_MODELS["gmi"]` list
- add a deterministic regression where the generic profile would otherwise return an unexpected live list

## Red
- `.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_gmi_provider.py::TestGmiModelCatalog::test_provider_model_ids_falls_back_to_static_models_without_generic_refetch -q --timeout-method=thread`
  - failed with `['unexpected-live-model']` instead of the static GMI list

## Proof
- `.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_gmi_provider.py::TestGmiModelCatalog::test_provider_model_ids_prefers_live_api tests\hermes_cli\test_gmi_provider.py::TestGmiModelCatalog::test_provider_model_ids_falls_back_to_static_models tests\hermes_cli\test_gmi_provider.py::TestGmiModelCatalog::test_provider_model_ids_falls_back_to_static_models_without_generic_refetch -q --timeout-method=thread`
- `.venv\Scripts\ruff.exe check hermes_cli\models.py tests\hermes_cli\test_gmi_provider.py`
- `.venv\Scripts\python.exe -m py_compile hermes_cli\models.py tests\hermes_cli\test_gmi_provider.py`
- `git diff --check` (only Windows CRLF warnings for touched files)

## Note
- A full `tests\hermes_cli\test_gmi_provider.py` run on this Windows host still hits an existing locale decode failure reading `config.yaml` with GBK; the targeted catalog tests cover this change.