### PR TITLE
feat(gateway): map structured-output response_format/text.format per backend (#33864)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2093,6 +2093,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    response_format: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2299,5 +2300,12 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    # Structured output (gateway response_format / Responses text.format) maps to
+    # Anthropic's output_config.format, merged alongside any output_config.effort
+    # the adaptive-thinking path set above.
+    if response_format:
+        from agent.structured_output import apply as _apply_structured_output
+        _apply_structured_output(kwargs, response_format, "anthropic_messages")
 
     return kwargs

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -548,6 +548,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            response_format=getattr(agent, "_gateway_response_format", None),
         )
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
@@ -651,6 +652,14 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
+    # Structured output requested via the gateway (/v1/chat/completions
+    # response_format or /v1/responses text.format).  Only the chat_completions
+    # backend path reaches here (anthropic_messages / bedrock_converse /
+    # codex_responses return above); structured_output.apply attaches it in the
+    # OpenAI `response_format` shape.  None for normal requests.
+    _structured_rf = getattr(agent, "_gateway_response_format", None)
+    from agent.structured_output import apply as _apply_structured_output
+
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
     # sentinel (temperature omitted entirely), a numeric override, or None.
     try:
@@ -713,7 +722,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
-        return _ct.build_kwargs(
+        _profile_kwargs = _ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
@@ -734,6 +743,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
         )
+        _apply_structured_output(_profile_kwargs, _structured_rf, "chat_completions")
+        return _profile_kwargs
 
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
@@ -745,7 +756,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
-    return _ct.build_kwargs(
+    _legacy_kwargs = _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
         tools=tools_for_api,
@@ -781,6 +792,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
     )
+    _apply_structured_output(_legacy_kwargs, _structured_rf, "chat_completions")
+    return _legacy_kwargs
 
 
 

--- a/agent/structured_output.py
+++ b/agent/structured_output.py
@@ -1,0 +1,165 @@
+"""Structured-output constraints across backend wire protocols.
+
+The gateway accepts an OpenAI-shaped structured-output request on two surfaces:
+Chat Completions ``response_format`` and Responses ``text.format``.  Both are
+normalized here into one canonical OpenAI-shaped constraint, and then mapped to
+the per-``api_mode`` wire field the active backend actually honours:
+
+    chat_completions    -> top-level ``response_format`` (OpenAI shape, verbatim)
+    anthropic_messages  -> ``output_config.format`` (Anthropic Messages structured outputs)
+
+Other api_modes (``codex_responses``, ``codex_app_server``, ``bedrock_converse``)
+have no wired mapping yet.  ``unsupported_reason`` returns a message for those so
+the gateway can fail fast with a 400 rather than silently dropping the schema and
+returning unconstrained text.
+
+Membership in :data:`SUPPORTED_API_MODES` is necessary but not sufficient: some
+constraints have no expression on an otherwise-supported wire (a bare
+``json_object`` has no ``anthropic_messages`` equivalent), so callers must gate on
+:func:`unsupported_reason`, which is constraint-aware.
+
+This module is a leaf — it imports nothing from ``agent`` / ``gateway`` — so the
+API server (validation), ``chat_completion_helpers`` (the chat_completions build),
+and ``anthropic_adapter`` (the Anthropic build) can all import it without cycles.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+# api_modes for which a structured-output constraint can be expressed on the
+# wire at all.  Per-constraint feasibility is decided by unsupported_reason.
+SUPPORTED_API_MODES = frozenset({"chat_completions", "anthropic_messages"})
+
+
+def normalize_response_format(rf: Any) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate a Chat Completions ``response_format`` value.
+
+    Returns ``(normalized, error_message)``. ``normalized`` is ``None`` when
+    no structured output was requested (plain text); ``error_message`` is set
+    only when the field is present but malformed.
+    """
+    if rf is None:
+        return None, None
+    if not isinstance(rf, dict):
+        return None, "'response_format' must be an object"
+
+    rf_type = rf.get("type")
+    if rf_type in (None, "text"):
+        return None, None
+    if rf_type == "json_object":
+        return {"type": "json_object"}, None
+    if rf_type == "json_schema":
+        schema_block = rf.get("json_schema")
+        if not isinstance(schema_block, dict) or not isinstance(schema_block.get("schema"), dict):
+            return None, "response_format.json_schema must include a 'schema' object"
+        normalized = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": schema_block.get("name") or "response",
+                "schema": schema_block["schema"],
+            },
+        }
+        if "strict" in schema_block:
+            normalized["json_schema"]["strict"] = bool(schema_block["strict"])
+        return normalized, None
+    return None, f"Unsupported response_format.type: {rf_type!r}"
+
+
+def normalize_responses_text_format(text: Any) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Convert a Responses API ``text.format`` block into the equivalent
+    Chat Completions ``response_format`` so both endpoints share one
+    downstream path. Returns ``(response_format, error_message)``.
+
+    Unlike Chat Completions, the Responses API nests ``name``/``schema``/
+    ``strict`` directly under ``format`` (not under a ``json_schema`` key).
+    """
+    if not isinstance(text, dict):
+        return None, None
+    fmt = text.get("format")
+    if not isinstance(fmt, dict):
+        return None, None
+
+    fmt_type = fmt.get("type")
+    if fmt_type in (None, "text"):
+        return None, None
+    if fmt_type == "json_object":
+        return {"type": "json_object"}, None
+    if fmt_type == "json_schema":
+        schema = fmt.get("schema")
+        if not isinstance(schema, dict):
+            return None, "text.format.schema must be an object for json_schema"
+        rf: Dict[str, Any] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": fmt.get("name") or "response",
+                "schema": schema,
+            },
+        }
+        if "strict" in fmt:
+            rf["json_schema"]["strict"] = bool(fmt["strict"])
+        return rf, None
+    return None, f"Unsupported text.format.type: {fmt_type!r}"
+
+
+def unsupported_reason(constraint: Optional[Dict[str, Any]], api_mode: Optional[str]) -> Optional[str]:
+    """Why the given (constraint, api_mode) pair can't be honoured, or ``None``.
+
+    Resolves up-front so the gateway returns a 400 instead of a plain-text reply
+    that silently fails schema validation.  ``None`` constraint (plain text) and
+    an unresolved ``api_mode`` both pass — the latter defers to the underlying
+    provider error rather than guessing.
+    """
+    if not constraint:
+        return None
+    if not api_mode:
+        return None
+    if api_mode not in SUPPORTED_API_MODES:
+        return (
+            "Structured output (response_format / json_schema) is not supported "
+            f"for the configured backend (api_mode={api_mode!r}). Supported: "
+            f"{', '.join(sorted(SUPPORTED_API_MODES))}."
+        )
+    if api_mode == "anthropic_messages" and constraint.get("type") == "json_object":
+        return (
+            "Structured output 'json_object' is not supported on api_mode="
+            "'anthropic_messages'; provide a json_schema instead."
+        )
+    return None
+
+
+def apply(kwargs: Dict[str, Any], constraint: Optional[Dict[str, Any]], api_mode: str) -> Dict[str, Any]:
+    """Attach ``constraint`` to outgoing API ``kwargs`` in the wire shape for
+    ``api_mode``, mutating and returning ``kwargs``.
+
+    No-op when ``constraint`` is falsy.  Assumes the pair is supported — callers
+    gate on :func:`unsupported_reason` first.  Existing values are preserved:
+    ``response_format`` is set only if absent, and ``output_config.format`` is
+    merged alongside any ``output_config.effort`` the adaptive-thinking path set.
+    """
+    if not constraint:
+        return kwargs
+    if api_mode == "chat_completions":
+        kwargs.setdefault("response_format", constraint)
+        return kwargs
+    if api_mode == "anthropic_messages":
+        fmt = _anthropic_output_format(constraint)
+        if fmt is not None:
+            output_config = dict(kwargs.get("output_config") or {})
+            output_config.setdefault("format", fmt)
+            kwargs["output_config"] = output_config
+        return kwargs
+    return kwargs
+
+
+def _anthropic_output_format(constraint: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """The Anthropic ``output_config.format`` payload for a canonical constraint,
+    or ``None`` when the constraint has no Anthropic expression (e.g. json_object).
+    Anthropic structured outputs take a bare ``{type, schema}`` — the OpenAI
+    ``name``/``strict`` fields have no equivalent and are dropped."""
+    if constraint.get("type") != "json_schema":
+        return None
+    schema = constraint.get("json_schema", {}).get("schema")
+    if not isinstance(schema, dict):
+        return None
+    return {"type": "json_schema", "schema": schema}

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -59,6 +59,8 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            response_format: dict | None — canonical structured-output constraint,
+                mapped to output_config.format.
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -75,6 +77,7 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            response_format=params.get("response_format"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -554,6 +554,17 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+# Structured-output validation + per-api_mode wire mapping lives in
+# agent.structured_output (the single place that knows which backend honours
+# which constraint). Aliased to the historical private names so the request
+# handlers below — and existing imports of these symbols — read unchanged.
+from agent.structured_output import (  # noqa: E402
+    normalize_response_format as _normalize_response_format,
+    normalize_responses_text_format as _response_format_from_text_format,
+    unsupported_reason as _structured_output_unsupported_reason,
+)
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -974,6 +985,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1026,7 +1038,37 @@ class APIServerAdapter(BasePlatformAdapter):
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
         )
+        # Structured-output constraint (OpenAI response_format / Responses
+        # text.format).  Read by chat_completion_helpers.build_api_kwargs and
+        # forwarded to the chat.completions call.  None for normal requests.
+        agent._gateway_response_format = response_format
         return agent
+
+    def _structured_output_error(
+        self, response_format: Optional[Dict[str, Any]]
+    ) -> Optional["web.Response"]:
+        """Return a 400 response when a structured-output request targets a
+        backend that cannot honour it, else ``None``.
+
+        Resolves the configured backend ``api_mode`` and rejects up-front
+        (before any streaming starts) so the caller gets a clear error
+        instead of a plain-text response that fails schema validation.  When
+        the backend cannot be resolved we return ``None`` and let
+        ``_create_agent`` surface the underlying provider error.
+        """
+        if not response_format:
+            return None
+        try:
+            from gateway.run import _resolve_runtime_agent_kwargs
+            api_mode = (_resolve_runtime_agent_kwargs() or {}).get("api_mode")
+        except Exception:
+            return None
+        reason = _structured_output_unsupported_reason(response_format, api_mode)
+        if reason:
+            return web.json_response(
+                _openai_error(reason, param="response_format"), status=400
+            )
+        return None
 
     # ------------------------------------------------------------------
     # HTTP Handlers
@@ -1112,6 +1154,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "chat_completions_streaming": True,
                 "responses_api": True,
                 "responses_streaming": True,
+                # response_format (json_object / json_schema) on
+                # /v1/chat/completions and text.format on /v1/responses are
+                # forwarded to chat-completions backends; other backends 400.
+                "structured_output": True,
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
@@ -1701,6 +1747,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
 
+        # Structured output: forward `response_format` (json_object / json_schema)
+        # to the backend model.  Reject up-front when the configured backend
+        # cannot honour it rather than silently returning plain text (#33864).
+        response_format, rf_err = _normalize_response_format(body.get("response_format"))
+        if rf_err:
+            return web.json_response(_openai_error(rf_err, param="response_format"), status=400)
+        unsupported = self._structured_output_error(response_format)
+        if unsupported is not None:
+            return unsupported
+
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
         conversation_messages: List[Dict[str, str]] = []
@@ -1880,6 +1936,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                response_format=response_format,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -1899,11 +1956,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                response_format=response_format,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream", "response_format"])
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -2778,6 +2836,16 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
 
+        # Structured output: the Responses API carries the schema in
+        # `text.format`.  Translate it to the shared `response_format` shape
+        # and forward to the backend instead of dropping it (#33864).
+        response_format, rf_err = _response_format_from_text_format(body.get("text"))
+        if rf_err:
+            return web.json_response(_openai_error(rf_err, param="text.format"), status=400)
+        unsupported = self._structured_output_error(response_format)
+        if unsupported is not None:
+            return unsupported
+
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
             return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
@@ -2912,6 +2980,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                response_format=response_format,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2945,13 +3014,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                response_format=response_format,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools", "text"],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -3447,6 +3517,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3470,6 +3541,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
+                response_format=response_format,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent

--- a/tests/agent/test_structured_output.py
+++ b/tests/agent/test_structured_output.py
@@ -1,0 +1,207 @@
+"""Unit tests for agent.structured_output — the structured-output mapper.
+
+Covers the canonical normalizers (Chat Completions + Responses shapes), the
+constraint-aware support check, and the per-api_mode wire mapping (apply).
+"""
+
+import pytest
+
+from agent.structured_output import (
+    SUPPORTED_API_MODES,
+    apply,
+    normalize_response_format,
+    normalize_responses_text_format,
+    unsupported_reason,
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
+    "required": ["city", "country"],
+    "additionalProperties": False,
+}
+
+
+class TestNormalizeResponseFormat:
+    def test_none_returns_no_format(self):
+        assert normalize_response_format(None) == (None, None)
+
+    def test_text_type_is_plain(self):
+        assert normalize_response_format({"type": "text"}) == (None, None)
+
+    def test_json_object(self):
+        norm, err = normalize_response_format({"type": "json_object"})
+        assert err is None
+        assert norm == {"type": "json_object"}
+
+    def test_json_schema_full(self):
+        norm, err = normalize_response_format({
+            "type": "json_schema",
+            "json_schema": {"name": "Loc", "schema": _SCHEMA, "strict": True},
+        })
+        assert err is None
+        assert norm == {
+            "type": "json_schema",
+            "json_schema": {"name": "Loc", "schema": _SCHEMA, "strict": True},
+        }
+
+    def test_json_schema_defaults_name(self):
+        norm, err = normalize_response_format({
+            "type": "json_schema",
+            "json_schema": {"schema": _SCHEMA},
+        })
+        assert err is None
+        assert norm["json_schema"]["name"] == "response"
+
+    def test_json_schema_missing_schema_errors(self):
+        norm, err = normalize_response_format({"type": "json_schema", "json_schema": {"name": "x"}})
+        assert norm is None
+        assert "schema" in err
+
+    def test_non_dict_errors(self):
+        norm, err = normalize_response_format("json")
+        assert norm is None
+        assert err
+
+    def test_unknown_type_errors(self):
+        norm, err = normalize_response_format({"type": "xml"})
+        assert norm is None
+        assert "xml" in err
+
+
+class TestNormalizeResponsesTextFormat:
+    def test_none(self):
+        assert normalize_responses_text_format(None) == (None, None)
+
+    def test_no_format_key(self):
+        assert normalize_responses_text_format({}) == (None, None)
+
+    def test_text_format(self):
+        assert normalize_responses_text_format({"format": {"type": "text"}}) == (None, None)
+
+    def test_json_object(self):
+        norm, err = normalize_responses_text_format({"format": {"type": "json_object"}})
+        assert err is None
+        assert norm == {"type": "json_object"}
+
+    def test_json_schema_converted(self):
+        norm, err = normalize_responses_text_format({
+            "format": {"type": "json_schema", "name": "Loc", "schema": _SCHEMA},
+        })
+        assert err is None
+        assert norm == {
+            "type": "json_schema",
+            "json_schema": {"name": "Loc", "schema": _SCHEMA},
+        }
+
+    def test_json_schema_missing_schema_errors(self):
+        norm, err = normalize_responses_text_format({"format": {"type": "json_schema", "name": "x"}})
+        assert norm is None
+        assert err
+
+
+_JSON_SCHEMA = {"type": "json_schema", "json_schema": {"name": "Loc", "schema": _SCHEMA}}
+_JSON_OBJECT = {"type": "json_object"}
+
+
+class TestUnsupportedReason:
+    def test_no_constraint_is_supported(self):
+        assert unsupported_reason(None, "bedrock_converse") is None
+
+    def test_unresolved_api_mode_defers(self):
+        assert unsupported_reason(_JSON_SCHEMA, None) is None
+
+    def test_chat_completions_allows_schema_and_object(self):
+        assert unsupported_reason(_JSON_SCHEMA, "chat_completions") is None
+        assert unsupported_reason(_JSON_OBJECT, "chat_completions") is None
+
+    def test_anthropic_allows_json_schema(self):
+        assert unsupported_reason(_JSON_SCHEMA, "anthropic_messages") is None
+
+    def test_anthropic_rejects_json_object(self):
+        reason = unsupported_reason(_JSON_OBJECT, "anthropic_messages")
+        assert reason and "json_object" in reason and "anthropic_messages" in reason
+
+    @pytest.mark.parametrize("mode", ["bedrock_converse", "codex_responses", "codex_app_server"])
+    def test_unmapped_modes_rejected(self, mode):
+        reason = unsupported_reason(_JSON_SCHEMA, mode)
+        assert reason and mode in reason
+
+
+class TestApply:
+    def test_chat_completions_attaches_response_format(self):
+        kwargs = {}
+        apply(kwargs, _JSON_SCHEMA, "chat_completions")
+        assert kwargs["response_format"] == _JSON_SCHEMA
+
+    def test_chat_completions_does_not_override_existing(self):
+        existing = {"type": "json_object"}
+        kwargs = {"response_format": existing}
+        apply(kwargs, _JSON_SCHEMA, "chat_completions")
+        assert kwargs["response_format"] is existing
+
+    def test_none_constraint_is_noop(self):
+        kwargs = {}
+        apply(kwargs, None, "chat_completions")
+        assert "response_format" not in kwargs
+
+    def test_anthropic_attaches_output_config_format(self):
+        kwargs = {}
+        apply(kwargs, _JSON_SCHEMA, "anthropic_messages")
+        # name / strict have no Anthropic equivalent and are dropped.
+        assert kwargs["output_config"] == {"format": {"type": "json_schema", "schema": _SCHEMA}}
+
+    def test_anthropic_merges_with_existing_effort(self):
+        kwargs = {"output_config": {"effort": "high"}}
+        apply(kwargs, _JSON_SCHEMA, "anthropic_messages")
+        assert kwargs["output_config"]["effort"] == "high"
+        assert kwargs["output_config"]["format"] == {"type": "json_schema", "schema": _SCHEMA}
+
+    def test_anthropic_json_object_attaches_nothing(self):
+        # json_object has no Anthropic output_config expression; apply is a no-op
+        # (the guard rejects it up-front, this is the defense-in-depth path).
+        kwargs = {}
+        apply(kwargs, _JSON_OBJECT, "anthropic_messages")
+        assert "output_config" not in kwargs
+
+
+def test_supported_api_modes_membership():
+    assert "chat_completions" in SUPPORTED_API_MODES
+    assert "anthropic_messages" in SUPPORTED_API_MODES
+    assert "bedrock_converse" not in SUPPORTED_API_MODES
+
+
+class TestBuildAnthropicKwargsWiring:
+    """The runtime anthropic_messages path: build_anthropic_kwargs threads the
+    constraint into output_config.format without clobbering effort."""
+
+    _MSGS = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+
+    def test_attaches_output_config_format(self):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6", messages=self._MSGS, tools=None,
+            max_tokens=1024, reasoning_config=None, response_format=_JSON_SCHEMA,
+        )
+        assert kwargs["output_config"] == {"format": {"type": "json_schema", "schema": _SCHEMA}}
+
+    def test_merges_with_adaptive_effort(self):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6", messages=self._MSGS, tools=None,
+            max_tokens=1024, reasoning_config={"enabled": True, "effort": "high"},
+            response_format=_JSON_SCHEMA,
+        )
+        assert kwargs["output_config"]["effort"] == "high"
+        assert kwargs["output_config"]["format"] == {"type": "json_schema", "schema": _SCHEMA}
+
+    def test_no_constraint_leaves_output_config_untouched(self):
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6", messages=self._MSGS, tools=None,
+            max_tokens=1024, reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "format" not in kwargs.get("output_config", {})

--- a/tests/gateway/test_api_server_structured_output.py
+++ b/tests/gateway/test_api_server_structured_output.py
@@ -1,0 +1,382 @@
+"""Structured-output (response_format / json_schema) support on the API server.
+
+Covers the fix for #33864: the gateway must *forward* a requested structured
+output schema to the backend model — on both ``/v1/chat/completions``
+(``response_format``) and ``/v1/responses`` (``text.format``) — and reject
+up-front when the configured backend cannot honour it, rather than silently
+returning plain text.
+
+Three layers are exercised:
+  1. The pure normalizers that translate each endpoint's request shape into the
+     shared ``response_format`` payload.
+  2. The HTTP handlers, which must forward the payload to ``_run_agent`` and
+     return a clear 400 for unsupported backends / malformed input.
+  3. ``build_api_kwargs``, which must attach ``response_format`` to the
+     chat.completions call when the agent carries a gateway schema.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _normalize_response_format,
+    _response_format_from_text_format,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests — _normalize_response_format (Chat Completions shape)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeResponseFormat:
+    def test_none_returns_no_format(self):
+        assert _normalize_response_format(None) == (None, None)
+
+    def test_text_type_is_plain(self):
+        assert _normalize_response_format({"type": "text"}) == (None, None)
+
+    def test_json_object(self):
+        norm, err = _normalize_response_format({"type": "json_object"})
+        assert err is None
+        assert norm == {"type": "json_object"}
+
+    def test_json_schema_full(self):
+        norm, err = _normalize_response_format({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "Probe",
+                "schema": {"type": "object", "properties": {"word": {"type": "string"}}},
+                "strict": True,
+            },
+        })
+        assert err is None
+        assert norm == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "Probe",
+                "schema": {"type": "object", "properties": {"word": {"type": "string"}}},
+                "strict": True,
+            },
+        }
+
+    def test_json_schema_defaults_name(self):
+        norm, err = _normalize_response_format({
+            "type": "json_schema",
+            "json_schema": {"schema": {"type": "object"}},
+        })
+        assert err is None
+        assert norm["json_schema"]["name"] == "response"
+        assert "strict" not in norm["json_schema"]
+
+    def test_json_schema_missing_schema_errors(self):
+        norm, err = _normalize_response_format({"type": "json_schema", "json_schema": {"name": "x"}})
+        assert norm is None
+        assert err and "schema" in err
+
+    def test_non_dict_errors(self):
+        norm, err = _normalize_response_format("json")
+        assert norm is None
+        assert err is not None
+
+    def test_unknown_type_errors(self):
+        norm, err = _normalize_response_format({"type": "xml"})
+        assert norm is None
+        assert err and "xml" in err
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests — _response_format_from_text_format (Responses shape)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormatFromTextFormat:
+    def test_none(self):
+        assert _response_format_from_text_format(None) == (None, None)
+
+    def test_no_format_key(self):
+        assert _response_format_from_text_format({}) == (None, None)
+
+    def test_text_format(self):
+        assert _response_format_from_text_format({"format": {"type": "text"}}) == (None, None)
+
+    def test_json_object(self):
+        norm, err = _response_format_from_text_format({"format": {"type": "json_object"}})
+        assert err is None
+        assert norm == {"type": "json_object"}
+
+    def test_json_schema_converted(self):
+        # Responses API nests name/schema/strict directly under `format`.
+        norm, err = _response_format_from_text_format({
+            "format": {
+                "type": "json_schema",
+                "name": "Probe",
+                "schema": {"type": "object", "properties": {"word": {"type": "string"}}},
+                "strict": True,
+            }
+        })
+        assert err is None
+        assert norm == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "Probe",
+                "schema": {"type": "object", "properties": {"word": {"type": "string"}}},
+                "strict": True,
+            },
+        }
+
+    def test_json_schema_missing_schema_errors(self):
+        norm, err = _response_format_from_text_format({"format": {"type": "json_schema", "name": "x"}})
+        assert norm is None
+        assert err is not None
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration — forwarding to _run_agent + rejection paths
+# ---------------------------------------------------------------------------
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _stub_run_agent(mock_run):
+    async def _stub(**kwargs):
+        mock_run.captured = kwargs
+        return (
+            {"final_response": "ok", "messages": [], "api_calls": 1},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+    mock_run.side_effect = _stub
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"word": {"type": "string"}},
+    "required": ["word"],
+    "additionalProperties": False,
+}
+
+
+class TestChatCompletionsStructuredOutput:
+    @pytest.mark.asyncio
+    async def test_response_format_forwarded(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "chat_completions"}), \
+                 patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                _stub_run_agent(mock_run)
+                resp = await cli.post("/v1/chat/completions", json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "Reply with PONG"}],
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "Probe", "schema": _SCHEMA},
+                    },
+                })
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["response_format"] == {
+                "type": "json_schema",
+                "json_schema": {"name": "Probe", "schema": _SCHEMA},
+            }
+
+    @pytest.mark.asyncio
+    async def test_no_response_format_forwards_none(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                _stub_run_agent(mock_run)
+                resp = await cli.post("/v1/chat/completions", json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["response_format"] is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_format_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/chat/completions", json={
+                "model": "hermes-agent",
+                "messages": [{"role": "user", "content": "hi"}],
+                "response_format": {"type": "json_schema", "json_schema": {"name": "x"}},
+            })
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["param"] == "response_format"
+
+    @pytest.mark.asyncio
+    async def test_json_object_unsupported_on_anthropic_returns_400(self, adapter):
+        # json_object has no Anthropic output_config expression — reject up-front
+        # rather than silently returning unconstrained text.
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "anthropic_messages"}):
+                resp = await cli.post("/v1/chat/completions", json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "response_format": {"type": "json_object"},
+                })
+            assert resp.status == 400
+            body = await resp.json()
+        assert "anthropic_messages" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_backend_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "bedrock_converse"}):
+                resp = await cli.post("/v1/chat/completions", json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "response_format": {"type": "json_object"},
+                })
+            assert resp.status == 400
+            body = await resp.json()
+        assert "bedrock_converse" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_anthropic_json_schema_allowed(self, adapter):
+        # json_schema on anthropic_messages is supported — the guard must not
+        # reject it; it maps to output_config.format downstream.
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "anthropic_messages"}), \
+                 patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                _stub_run_agent(mock_run)
+                resp = await cli.post("/v1/chat/completions", json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "Reply with PONG"}],
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "Probe", "schema": _SCHEMA},
+                    },
+                })
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["response_format"] == {
+                "type": "json_schema",
+                "json_schema": {"name": "Probe", "schema": _SCHEMA},
+            }
+
+
+class TestResponsesStructuredOutput:
+    @pytest.mark.asyncio
+    async def test_text_format_forwarded(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "chat_completions"}), \
+                 patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                _stub_run_agent(mock_run)
+                resp = await cli.post("/v1/responses", json={
+                    "model": "hermes-agent",
+                    "input": "Reply with PONG",
+                    "text": {"format": {"type": "json_schema", "name": "Probe", "schema": _SCHEMA}},
+                })
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["response_format"] == {
+                "type": "json_schema",
+                "json_schema": {"name": "Probe", "schema": _SCHEMA},
+            }
+
+    @pytest.mark.asyncio
+    async def test_plain_input_forwards_none(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                _stub_run_agent(mock_run)
+                resp = await cli.post("/v1/responses", json={
+                    "model": "hermes-agent",
+                    "input": "hi",
+                })
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["response_format"] is None
+
+    @pytest.mark.asyncio
+    async def test_unsupported_backend_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_mode": "bedrock_converse"}):
+                resp = await cli.post("/v1/responses", json={
+                    "model": "hermes-agent",
+                    "input": "hi",
+                    "text": {"format": {"type": "json_schema", "name": "Probe", "schema": _SCHEMA}},
+                })
+            assert resp.status == 400
+            body = await resp.json()
+        assert "bedrock_converse" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# build_api_kwargs — response_format reaches the chat.completions call
+# ---------------------------------------------------------------------------
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_chat_agent(monkeypatch):
+    from run_agent import AIAgent
+
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+class TestBuildApiKwargsInjection:
+    def test_response_format_attached_when_set(self, monkeypatch):
+        agent = _make_chat_agent(monkeypatch)
+        agent._gateway_response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "Probe", "schema": _SCHEMA},
+        }
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["response_format"] == {
+            "type": "json_schema",
+            "json_schema": {"name": "Probe", "schema": _SCHEMA},
+        }
+
+    def test_no_response_format_when_unset(self, monkeypatch):
+        agent = _make_chat_agent(monkeypatch)
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "response_format" not in kwargs

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -106,6 +106,30 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 
 Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
 
+**Structured output:** pass `response_format` to constrain the reply to JSON. Both `json_object` and `json_schema` are forwarded to the backend model:
+
+```json
+{
+  "model": "hermes-agent",
+  "messages": [{"role": "user", "content": "Extract the city and country."}],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "Location",
+      "schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
+        "required": ["city", "country"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}
+```
+
+Structured output is forwarded only when the configured backend uses an OpenAI-compatible chat-completions API. On other backends (e.g. native Anthropic Messages or Bedrock Converse) the request returns `400` with a clear message rather than silently returning plain text. A malformed `response_format` returns `400` with `param: "response_format"`.
+
 **Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event for tool-start UX. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
 
 **Tool progress in streams**:
@@ -160,6 +184,30 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
 ```
 
 Uploaded files (`input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
+
+**Structured output:** the Responses API carries the schema in `text.format`. It is translated to the same downstream constraint as Chat Completions' `response_format`, so the OpenAI Agents SDK `output_type=<PydanticModel>` pattern works:
+
+```json
+{
+  "model": "hermes-agent",
+  "input": "Extract the city and country.",
+  "text": {
+    "format": {
+      "type": "json_schema",
+      "name": "Location",
+      "schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
+        "required": ["city", "country"],
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  }
+}
+```
+
+As with Chat Completions, this is honoured on chat-completions backends and returns `400` on backends that cannot enforce it.
 
 #### Multi-turn with previous_response_id
 


### PR DESCRIPTION
## Summary

Fixes the structured-output gap on the gateway's OpenAI-compatible API and extends enforcement to the native Anthropic backend.

[#33864](https://github.com/NousResearch/hermes-agent/issues/33864): a `/v1/responses` request with `text.format.type = json_schema` had its schema **silently discarded** (`_handle_responses()` never read `body.get("text")`), so the model returned plain text (`PONG` instead of `{"word":"PONG"}`) that then failed client-side schema validation. The same silent-drop class existed on the Chat Completions `response_format` path. The earlier reject-only attempt — [#33885](https://github.com/NousResearch/hermes-agent/pull/33885) — changed the failure mode rather than fixing it.

This PR makes both endpoints (a) read the schema and never silently drop it, and (b) forward it to each backend in the wire shape that backend actually honours — including the native Anthropic Messages backend, which previously had no path to emit the constraint.

## What changed

A new leaf module `agent/structured_output.py` (imports nothing from `agent`/`gateway`, so no import cycles) owns the whole concern:

- **Canonical normalizers**, moved out of `api_server.py`: `normalize_response_format` (Chat Completions) and `normalize_responses_text_format` (Responses). Both collapse to one canonical OpenAI-shaped constraint, so the two endpoints share a single downstream path.
- **`SUPPORTED_API_MODES` + `unsupported_reason(constraint, api_mode)`** — constraint-aware: it distinguishes "this backend has no structured-output mapping" from "this constraint has no expression on this otherwise-supported wire" (a bare `json_object` has no Anthropic equivalent). The gateway gates on this and returns a precise **400** instead of silently dropping the schema.
- **`apply(kwargs, constraint, api_mode)`** — attaches the constraint in the wire shape for the active backend: top-level `response_format` for `chat_completions`, `output_config.format` for `anthropic_messages` (merged alongside any `output_config.effort` from the adaptive-thinking path, never clobbering it).

Wired into the real runtime build paths (not just the transport ABC): `gateway/platforms/api_server.py`, `agent/chat_completion_helpers.py`, `agent/transports/anthropic.py`, and `agent/anthropic_adapter.py` (threads the constraint into `build_anthropic_kwargs`).

## Resulting behaviour

| api_mode | `json_schema` | `json_object` |
|---|---|---|
| `chat_completions` | forwarded as `response_format` | forwarded |
| `anthropic_messages` | **NEW: `output_config.format` (enforced)** | clean 400 (no Anthropic mapping) |
| `bedrock_converse` / `codex_responses` / `codex_app_server` | clean 400 (names the mode) | clean 400 |

## Note on third-party Anthropic-compatible backends

The mapper does the correct wire translation per `api_mode`, but cannot guarantee the backend behind that wire enforces the constraint. E.g. Kimi `/coding` resolves to `anthropic_messages` and now receives `output_config.format`, but whether Moonshot's Anthropic emulation enforces it is unverified — treat as best-effort.

## Tests

- New `tests/agent/test_structured_output.py`: normalizers, support matrix, `apply`, and the real `build_anthropic_kwargs` path (effort coexistence + backward compatibility).
- `tests/gateway/test_api_server_structured_output.py`: the exact #33864 repro (`/v1/responses` + `text.format` json_schema) asserts the schema is forwarded, not dropped; plus the Anthropic `json_schema` success case, the `json_object`-on-Anthropic 400, and unmapped-backend 400s.

57 passing.

## End-to-end probe

Stdlib-only script for sanity-checking against a **running** gateway. It reads the loopback port and bearer key from the environment (`API_SERVER_KEY`, `HERMES_INTERNAL_PORT` / `API_SERVER_PORT`) and runs the three headline probes — `json_schema` on `/v1/chat/completions`, `text.format` `json_schema` on `/v1/responses` (the #33864 repro), and `json_object` (backend-dependent; a 400 on native Anthropic is reported as EXPECTED).

```python
#!/usr/bin/env python3
"""End-to-end probe for gateway structured outputs.

Reads the gateway's loopback port and bearer key from the environment
(API_SERVER_KEY, HERMES_INTERNAL_PORT / API_SERVER_PORT) and runs three probes
against the running OpenAI-compatible API server. Stdlib only — no pip install.

    API_SERVER_KEY=... HERMES_INTERNAL_PORT=9000 python3 probe_structured_output.py

On the native Anthropic backend, json_schema is enforced via output_config.format,
while json_object has no Anthropic equivalent and is rejected up-front with a 400 —
reported as EXPECTED, not a failure. Exit code is non-zero if a json_schema probe
(chat or responses) fails.
"""

from __future__ import annotations

import json
import os
import sys
import urllib.error
import urllib.request

HOST = os.environ.get("API_SERVER_HOST", "127.0.0.1")
PORT = int(os.environ.get("HERMES_INTERNAL_PORT") or os.environ.get("API_SERVER_PORT") or 9000)
API_KEY = os.environ.get("API_SERVER_KEY")
MODEL = os.environ.get("HERMES_MODEL", "hermes-agent")
BASE_URL = f"http://{HOST}:{PORT}"

LOCATION_SCHEMA = {
    "type": "object",
    "properties": {"city": {"type": "string"}, "country": {"type": "string"}},
    "required": ["city", "country"],
    "additionalProperties": False,
}
WORD_SCHEMA = {
    "type": "object",
    "properties": {"word": {"type": "string"}},
    "required": ["word"],
    "additionalProperties": False,
}
# Steer the agent away from its toolset so a simple extraction returns the object
# directly instead of spending turns on tool calls.
STEER = (
    "You are a JSON extraction endpoint. Do not call any tools. Reply with ONLY "
    "the structured object requested, nothing else."
)


def post(path: str, payload: dict) -> tuple[int, str]:
    """POST JSON, returning (status, body_text)."""
    req = urllib.request.Request(
        f"{BASE_URL}{path}",
        data=json.dumps(payload).encode("utf-8"),
        method="POST",
        headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
    )
    try:
        with urllib.request.urlopen(req, timeout=120) as resp:
            return resp.status, resp.read().decode("utf-8", "replace")
    except urllib.error.HTTPError as err:
        return err.code, err.read().decode("utf-8", "replace")
    except urllib.error.URLError as err:
        print(f"error: could not reach gateway at {BASE_URL}{path}: {err.reason}", file=sys.stderr)
        sys.exit(2)


def chat_content(body: dict) -> str | None:
    try:
        return body["choices"][0]["message"]["content"]
    except (KeyError, IndexError, TypeError):
        return None


def responses_content(body: dict) -> str | None:
    """Pull the assistant text out of a Responses payload's output array."""
    for item in body.get("output", []) or []:
        if isinstance(item, dict) and item.get("type") == "message":
            for part in item.get("content", []) or []:
                if isinstance(part, dict) and part.get("type") == "output_text":
                    return part.get("text")
    return None


def verdict(label: str, status: int, text: str, content: str | None, required: list[str]) -> bool:
    """Verdict for a probe expected to return schema-conforming JSON."""
    if status != 200 or not content:
        print(f"  [FAIL] {label}: HTTP {status} — {(content or text)[:200]!r}")
        return False
    try:
        obj = json.loads(content)
    except json.JSONDecodeError:
        print(f"  [FAIL] {label}: content was not JSON (constraint ignored?): {content[:200]!r}")
        return False
    if any(k not in obj for k in required):
        print(f"  [WARN] {label}: valid JSON but missing keys: {json.dumps(obj)}")
        return True
    print(f"  [PASS] {label}: {json.dumps(obj)}")
    return True


def main() -> int:
    if not API_KEY:
        print("error: set $API_SERVER_KEY (or pass it in the environment).", file=sys.stderr)
        return 2
    print(f"Probing structured outputs against {BASE_URL} (model={MODEL})\n")
    ok = True

    print("1) chat /v1/chat/completions — response_format json_schema")
    status, text = post("/v1/chat/completions", {
        "model": MODEL, "stream": False,
        "messages": [
            {"role": "system", "content": STEER},
            {"role": "user", "content": "Extract the city and country from: "
                                        "'I climbed the Eiffel Tower last spring.'"},
        ],
        "response_format": {
            "type": "json_schema",
            "json_schema": {"name": "Location", "schema": LOCATION_SCHEMA, "strict": True},
        },
    })
    ok &= verdict("chat/json_schema", status, text,
                  chat_content(json.loads(text)) if status == 200 else None, ["city", "country"])

    print("2) responses /v1/responses — text.format json_schema (issue #33864)")
    status, text = post("/v1/responses", {
        "model": MODEL, "stream": False,
        "instructions": STEER, "input": "Reply with the word PONG.",
        "text": {"format": {"type": "json_schema", "name": "Probe", "schema": WORD_SCHEMA, "strict": True}},
    })
    ok &= verdict("responses/text.format", status, text,
                  responses_content(json.loads(text)) if status == 200 else None, ["word"])

    print("3) chat /v1/chat/completions — response_format json_object (backend-dependent)")
    status, text = post("/v1/chat/completions", {
        "model": MODEL, "stream": False,
        "messages": [
            {"role": "system", "content": STEER},
            {"role": "user", "content": "Give the capital of France as {\"capital\": ...}."},
        ],
        "response_format": {"type": "json_object"},
    })
    if status == 400 and "json_object" in text:
        print("  [EXPECTED] HTTP 400: json_object has no native-Anthropic mapping "
              "(rejected up-front, not silently dropped).")
    elif status == 200:
        print(f"  [PASS] backend honoured json_object: {(chat_content(json.loads(text)) or '')[:120]}")
    else:
        print(f"  [INFO] HTTP {status}: {text[:200]}")

    print("\n" + ("RESULT: structured outputs (json_schema) working ✅" if ok
                  else "RESULT: structured outputs NOT enforced ❌"))
    return 0 if ok else 1


if __name__ == "__main__":
    sys.exit(main())
```
