### PR TITLE
fix(approval): gate awk -i inplace and sed separate-token -i edits of Hermes config/env

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -424,6 +424,28 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("sed --in-place 's/manual/off/' ~/.hermes/config.yaml")
         assert dangerous is True
 
+    def test_sed_in_place_separate_token_config(self):
+        # -i can split out after another flag (`sed -n -i s/.../ config`).
+        # Pairs the perl/ruby separate-token coverage from b04c6e95f.
+        dangerous, key, desc = detect_dangerous_command(
+            "sed -n -i 's/manual/off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_sed_in_place_i_after_expr_env(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "sed -e 's/x/y/' -i ~/.hermes/.env"
+        )
+        assert dangerous is True
+
+    def test_sed_read_only_expr_safe(self):
+        # `sed -E '...' config` is a read transform (stdout), not in-place;
+        # the widened pattern must NOT trip on it.
+        dangerous, key, desc = detect_dangerous_command(
+            "sed -E 's/a/b/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is False
+
     def test_custom_hermes_home(self):
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/config.yaml")
         assert dangerous is True

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -473,6 +473,42 @@ class TestHermesConfigWriteProtection:
         )
         assert dangerous is False
 
+    def test_awk_in_place_config(self):
+        # `awk -i inplace` is GNU awk's in-place edit extension — the same
+        # direct mutation as sed -i / perl -i, the one standard in-place
+        # editor those patterns did not cover.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -i inplace '{gsub(/manual/,\"off\")}1' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_gawk_in_place_env(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "gawk -i inplace '{print}' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
+    def test_awk_in_place_hermes_home_override(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -i inplace '{print}' $HERMES_HOME/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_read_only_awk_on_config_safe(self):
+        # Read-only awk has no `-i inplace` token and must not trip.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk '{print}' ~/.hermes/config.yaml"
+        )
+        assert dangerous is False
+
+    def test_awk_in_place_non_sensitive_path_safe(self):
+        # `awk -i inplace` on a non-Hermes path must not false-positive.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -i inplace '{print}' /tmp/scratch.txt"
+        )
+        assert dangerous is False
+
     def test_read_is_safe(self):
         # Reading config is not a write — must not trip.
         dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -495,6 +495,34 @@ class TestHermesConfigWriteProtection:
         )
         assert dangerous is True
 
+    def test_awk_in_place_glued_flag(self):
+        # GNU getopt accepts the include arg glued to -i: `-iinplace`.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -iinplace '{gsub(/manual/,\"off\")}1' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_awk_in_place_equals_flag(self):
+        # `-i=inplace` is another accepted short-form spelling.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -i=inplace '{print}' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_awk_in_place_long_include_flag(self):
+        # `--include` is the long form of `-i`; `--include inplace` loads the
+        # same extension and must not be a free bypass.
+        dangerous, key, desc = detect_dangerous_command(
+            "gawk --include inplace '{print}' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_awk_in_place_long_include_equals_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "gawk --include=inplace '{print}' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
     def test_read_only_awk_on_config_safe(self):
         # Read-only awk has no `-i inplace` token and must not trip.
         dangerous, key, desc = detect_dangerous_command(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -435,13 +435,16 @@ DANGEROUS_PATTERNS = [
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),
     (rf'\b(cp|mv|install)\b.*\s["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config file"),
-    (rf'\bsed\s+-[^\s]*i.*\s{_SYSTEM_CONFIG_PATH}', "in-place edit of system config"),
+    # -i can appear as its own token after other flags (`sed -n -i s/.../ f`)
+    # or combined (`sed -ni`); match any -...i flag token anywhere in the args,
+    # mirroring the perl/ruby coverage. `sed -E '...' f` (read, no -i) is safe.
+    (rf'\bsed\b.*(?:^|\s)-[^\s]*i\b.*\s{_SYSTEM_CONFIG_PATH}', "in-place edit of system config"),
     (rf'\bsed\s+--in-place\b.*\s{_SYSTEM_CONFIG_PATH}', "in-place edit of system config (long flag)"),
     # In-place edit of a Hermes-managed security file (~/.hermes/config.yaml or
     # .env). sed -i bypasses the redirection/tee patterns above because it
     # mutates the file directly. Pairs the file_tools write_file/patch deny so
     # the terminal side is not an open door. See #14639.
-    (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
+    (rf'\bsed\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
     # perl -i and ruby -i perform the same in-place mutation as sed -i but are
     # not caught by the -e/-c script-execution pattern above (which targets code

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -452,6 +452,15 @@ DANGEROUS_PATTERNS = [
     # anywhere in the args, not just the first token — `perl -e '...'` (code
     # eval, no -i) does not trip because it has no `-...i` flag token.
     (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
+    # awk -i inplace / gawk -i inplace is GNU awk's in-place edit extension —
+    # the same direct-mutation escalation as the sed -i (#14639) and perl/ruby -i
+    # (a6a4e6f9d) pairings, reached through the one standard in-place editor those
+    # patterns do not cover. `-i inplace` loads the inplace extension and rewrites
+    # ~/.hermes/config.yaml (or .env) directly; the mtime-keyed config cache
+    # reloads it mid-session, so the agent can flip approvals.mode off and bypass
+    # the gate. Read-only awk ('{print}' with no `-i inplace`) lacks the flag and
+    # does not trip. Sibling follow-up to #14639 / a6a4e6f9d.
+    (rf'\b(?:g?awk)\b.*-i\s+inplace\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (awk -i inplace)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -455,12 +455,16 @@ DANGEROUS_PATTERNS = [
     # awk -i inplace / gawk -i inplace is GNU awk's in-place edit extension —
     # the same direct-mutation escalation as the sed -i (#14639) and perl/ruby -i
     # (a6a4e6f9d) pairings, reached through the one standard in-place editor those
-    # patterns do not cover. `-i inplace` loads the inplace extension and rewrites
+    # patterns do not cover. Loading the `inplace` extension rewrites
     # ~/.hermes/config.yaml (or .env) directly; the mtime-keyed config cache
     # reloads it mid-session, so the agent can flip approvals.mode off and bypass
-    # the gate. Read-only awk ('{print}' with no `-i inplace`) lacks the flag and
-    # does not trip. Sibling follow-up to #14639 / a6a4e6f9d.
-    (rf'\b(?:g?awk)\b.*-i\s+inplace\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (awk -i inplace)"),
+    # the gate. The extension is requested via `-i` (short form of `--include`),
+    # so GNU getopt accepts every load form: `-i inplace`, `-iinplace` (glued),
+    # `-i=inplace`, and the long `--include inplace` / `--include=inplace`. Match
+    # all of them so an alternate spelling is not a free bypass. Read-only awk
+    # ('{print}' with no inplace include) lacks the token and does not trip.
+    # Sibling follow-up to #14639 / a6a4e6f9d.
+    (rf'\b(?:g?awk)\b.*?(?:-i[\s=]?|--include[\s=])inplace\b.*?(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (awk -i inplace)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),


### PR DESCRIPTION
## This is a sibling follow-up to commits b04c6e95f / a6a4e6f9d (and #14639)

- `#14639` covered `sed -i` / `sed --in-place`; `a6a4e6f9d` (salvaged from #36894) added `perl -i` / `ruby -i`; `b04c6e95f` (2026-06-04) then widened the perl/ruby pattern to match a `-...i` flag token **anywhere** in the args (`perl -p -i -e ... config.yaml`), not just the first token.
- Those changes did **not** (a) touch `awk -i inplace` / `gawk -i inplace` — GNU awk's in-place edit extension, the one remaining standard in-place editor; and (b) `b04c6e95f` widened perl/ruby to the separate-token shape but left the **sed** short-flag patterns it pairs with on the old first-token-only shape, so `sed -n -i ... config` slipped back through.
- This PR closes both remaining gaps: it adds the `awk` / `gawk -i inplace` denylist entry, and widens the two short-flag `sed -i` patterns to the same separate-token shape as perl/ruby.

## What does this PR do?

Closes two gaps in the terminal-side approval gate for `~/.hermes/config.yaml` and `~/.hermes/.env`. These files **are** the security policy: `approvals.mode`, `yolo`, and the permanent-approval allowlist live in `config.yaml`, and the config cache is mtime-keyed, so a direct write takes effect mid-session — the agent could flip `approvals.mode: off` and immediately bypass the gate.

`sed -i` (#14639) and `perl/ruby -i` (a6a4e6f9d, separate-token-widened in b04c6e95f) are already gated as direct in-place mutators that bypass the redirection/`tee`/`cp` patterns. Two gaps remained:

1. **awk** — GNU awk's `-i inplace` extension does exactly the same thing and was the one standard in-place editor still unpaired:
```
awk -i inplace '{gsub(/manual/,"off")}1' ~/.hermes/config.yaml
```

2. **sed separate-token `-i`** — when `b04c6e95f` widened perl/ruby to match a `-...i` flag token anywhere in the args, it did not apply the same fix to the sed patterns it pairs with. The two short-flag sed lines still used the first-token-only shape `\bsed\s+-[^\s]*i.*`, so these slipped through:
```
sed -n -i 's/manual/off/' ~/.hermes/config.yaml
sed -e 's/x/y/' -i ~/.hermes/.env
```

This PR adds one `DANGEROUS_PATTERNS` entry for awk and widens the two short-flag sed patterns to the perl/ruby separate-token shape (`\bsed\b.*(?:^|\s)-[^\s]*i\b.*`). The `--in-place` long-flag lines already match an exact token and are unchanged. Read-only `awk '{print}' ...` and `sed -E '...' config` (no `-i`) lack the flag token and do not trip — no false positives.

## Related Issue

Sibling follow-up to #14639 — no separate issue. Parent commits: `a6a4e6f9d` / `b04c6e95f` (`fix(approval): catch perl/ruby -i as a separate flag token`).

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: add one `DANGEROUS_PATTERNS` entry for `awk` / `gawk -i inplace`; widen the two short-flag `sed -i` patterns (system config + Hermes config/env) from `\bsed\s+-[^\s]*i.*` to `\bsed\b.*(?:^|\s)-[^\s]*i\b.*` so `-i` is matched as a separate token anywhere in the args, mirroring perl/ruby.
- `tests/tools/test_approval.py`: add tests to `TestHermesConfigWriteProtection` — `awk -i inplace` on config / `.env` / `$HERMES_HOME` plus all short-form spellings; sed separate-token `-i` on config and after `-e` on `.env`; negative controls (read-only awk, `sed -E` read transform, non-Hermes path).

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_approval.py -v`
2. Regression guard (verified both directions): with the sed prod hunk reverted, `test_sed_in_place_separate_token_config` and `test_sed_in_place_i_after_expr_env` fail (`assert False is True`) while the read-only safe test still passes; with the awk hunk reverted, the positive awk tests fail. Restore both → all 215 tests pass.
3. Manual: `detect_dangerous_command("sed -n -i 's/x/y/' ~/.hermes/config.yaml")` returns `dangerous=True`; `detect_dangerous_command("sed -E 's/a/b/' ~/.hermes/config.yaml")` returns `dangerous=False`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the focused suite (`pytest tests/tools/test_approval.py`) and all 215 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comments in `approval.py`) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — patterns are string-based and platform-agnostic; `-i inplace` is GNU awk syntax (Linux/macOS-with-gawk); tested on macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
