### PR TITLE
fix(feishu): route voice messages to STT pipeline

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3615,7 +3615,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            # Feishu "audio" messages are real-time voice messages (Opus/OGG),
+            # not file attachments — map to VOICE so gateway/run.py sends
+            # them through the STT pipeline instead of treating them as
+            # audio file attachments (which would skip transcription).
+            return MessageType.VOICE
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu real-time voice message routing: maps audio messages to `VOICE` instead of `AUDIO` so the gateway routes them through the STT pipeline for speech-to-text transcription instead of treating them as file attachments.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/feishu.py`:
  - `_resolve_normalized_message_type`: maps Feishu `audio` → `VOICE` instead of `AUDIO`

## How to Test

1. Send a voice message to the bot in Feishu
2. Verify the bot transcribes it via STT instead of treating it as an audio file attachment

## Checklist

### Code
- [x] Commits follow Conventional Commits
- [x] PR contains only related changes
- [ ] Tests added — N/A
- [x] Tested on platform: Linux