### PR TITLE
fix(prompt_builder): scan SOUL.md with scope=all to prevent false positives on literary/common words

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -42,18 +42,26 @@ logger = logging.getLogger(__name__)
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 
 
-def _scan_context_content(content: str, filename: str) -> str:
+def _scan_context_content(content: str, filename: str, scope: str = "context") -> str:
     """Scan context file content for injection. Returns sanitized content.
 
-    Uses the "context" scope from the shared threat-pattern library, which
-    covers classic injection + promptware/C2 patterns + role-play hijack.
-    Strict-scope patterns (SSH backdoor, persistence, exfil-URL) are NOT
-    applied here — those are too aggressive for a context file in a
-    cloned repo (security research, infra docs).  Content matching is
-    BLOCKED at this layer because the file would otherwise enter the
-    system prompt verbatim and the user has no chance to intervene.
+    Uses the "context" scope from the shared threat-pattern library by
+    default, which covers classic injection + promptware/C2 patterns +
+    role-play hijack.  Strict-scope patterns (SSH backdoor, persistence,
+    exfil-URL) are NOT applied here — those are too aggressive for a
+    context file in a cloned repo (security research, infra docs).
+
+    Pass ``scope="all"`` for *user-authored* files (e.g. SOUL.md) where
+    C2 framework name patterns would produce false positives on ordinary
+    literary or fantasy vocabulary (e.g. "Sliver" in a Mistborn-themed
+    persona).  The "all" scope still checks classic prompt-injection and
+    exfiltration patterns, just not the C2 framework name list.
+
+    Content matching is BLOCKED at this layer because the file would
+    otherwise enter the system prompt verbatim and the user has no chance
+    to intervene.
     """
-    findings = _scan_for_threats(content, scope="context")
+    findings = _scan_for_threats(content, scope=scope)
     if findings:
         logger.warning("Context file %s blocked: %s", filename, ", ".join(findings))
         return f"[BLOCKED: {filename} contained potential prompt injection ({', '.join(findings)}). Content not loaded.]"
@@ -1386,7 +1394,7 @@ def load_soul_md() -> Optional[str]:
         content = soul_path.read_text(encoding="utf-8").strip()
         if not content:
             return None
-        content = _scan_context_content(content, "SOUL.md")
+        content = _scan_context_content(content, "SOUL.md", scope="all")
         content = _truncate_content(content, "SOUL.md")
         return content
     except Exception as e:


### PR DESCRIPTION
## Problem

`SOUL.md` is blocked at load time with:

```
[BLOCKED: SOUL.md contained potential prompt injection (known_c2_framework). Content not loaded.]
```

### Root cause

`load_soul_md()` calls `_scan_context_content(content, "SOUL.md")` which internally uses `scope="context"`. The `context` scope includes the `known_c2_framework` pattern:

```python
# tools/threat_patterns.py line 95
(r'\b(?:praxis|cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
```

This causes a false positive when a user's `SOUL.md` contains the word **"Sliver"** — a reference to *Shards of Adonalsium* in Brandon Sanderson's Mistborn/Cosmere fantasy universe — which happens to exactly match the BishopFox [Sliver C2 framework](https://github.com/BishopFox/sliver) name.

### Repro

Create `~/.hermes/SOUL.md` containing a Mistborn persona reference:

```markdown
You are Hermes, a Sliver of Preservation given digital form...
```

Start hermes-agent — `SOUL.md` will be blocked and the persona won't load.

```python
from tools.threat_patterns import scan_for_threats
print(scan_for_threats('I am a Sliver of Preservation', scope='context'))
# → ['known_c2_framework']  ← false positive
```

## Fix

Add a `scope` parameter to `_scan_context_content()` (defaulting to `"context"` to preserve existing behaviour for AGENTS.md, .cursorrules, etc.) and call it with `scope="all"` for `SOUL.md`.

The `"all"` scope still applies all classic prompt-injection and credential-exfiltration patterns — the only things excluded are context-scoped patterns like C2 framework name matching that produce false positives in ordinary prose.

```python
# After fix:
from tools.threat_patterns import scan_for_threats
print(scan_for_threats('I am a Sliver of Preservation', scope='all'))
# → []  ← no false positive
```

**Changed files:**
- `agent/prompt_builder.py`: `_scan_context_content()` gains an optional `scope` parameter; `load_soul_md()` passes `scope="all"`

**No behaviour change** for any other caller (`AGENTS.md`, `.cursorrules`, HERMES.md) — they all use the default `scope="context"`.

---

*Note: supersedes the empty PR #27006 (prior attempt).*