### PR TITLE
fix(doctor): catch OSError/PermissionError in _gh_authenticated

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1989,7 +1989,7 @@ def run_doctor(args):
                 capture_output=True, timeout=10,
             )
             return result.returncode == 0
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired):
             return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")


### PR DESCRIPTION
## Problem

`hermes doctor` crashes with an uncaught `PermissionError` when the `gh` CLI is present in PATH but not executable (e.g. WSL users with Windows' `gh.exe` reachable via PATH interop).

The `_gh_authenticated()` function in `hermes_cli/doctor.py` only catches `FileNotFoundError` and `subprocess.TimeoutExpired`, so any other `OSError`/`PermissionError` from `subprocess.run` propagates as a full traceback.

## Root cause

Line 1992:
```python
except (FileNotFoundError, subprocess.TimeoutExpired):
    return False
```

## Fix

Broaden the exception handler to also catch `OSError` (parent of `PermissionError`):

```python
except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired):
    return False
```

This ensures the check is non-fatal regardless of host environment — the doctor gracefully reports "No GITHUB_TOKEN" instead of crashing.

## Testing

- Verified all three exception types (PermissionError, FileNotFoundError, OSError) are caught
- Verified `hermes doctor` runs cleanly end-to-end

Fixes #39540