### PR TITLE
feat: add Kiro ACP model provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -354,8 +354,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "kiro-acp"}
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -708,7 +708,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "kiro-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1269,7 +1269,8 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    base_url_str = str(client_kwargs.get("base_url", ""))
+    if agent.provider in {"copilot-acp", "kiro-acp"} or base_url_str.startswith("acp://"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,6 +155,9 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "kiro": "kiro-acp",
+    "kiro-cli": "kiro-acp",
+    "kiro-cli-acp": "kiro-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -3820,7 +3823,7 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "kiro-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1315,8 +1315,8 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider == "copilot-acp"
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "kiro-acp"}
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "kiro-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",
@@ -1695,7 +1695,7 @@ def get_model_context_length(
     # This catches account-specific models (e.g. claude-opus-4.6-1m) that
     # don't exist in models.dev. For models that ARE in models.dev, this
     # returns the provider-enforced limit which is what users can actually use.
-    if effective_provider in {"copilot", "copilot-acp", "github-copilot"}:
+    if effective_provider in {"copilot", "copilot-acp", "kiro-acp", "github-copilot"}:
         try:
             from hermes_cli.models import get_copilot_model_context
             ctx = get_copilot_model_context(model, api_key=api_key)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -90,6 +90,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_KIRO_ACP_BASE_URL = "acp://kiro"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -228,6 +229,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "kiro-acp": ProviderConfig(
+        id="kiro-acp",
+        name="Kiro CLI ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_KIRO_ACP_BASE_URL,
+        base_url_env_var="KIRO_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1499,6 +1507,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "kiro": "kiro-acp", "kiro-cli": "kiro-acp", "kiro-cli-acp": "kiro-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -5709,19 +5718,61 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+_EXTERNAL_PROCESS_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "copilot-acp": {
+        "command_env": "HERMES_COPILOT_ACP_COMMAND",
+        "command_alias_env": "COPILOT_CLI_PATH",
+        "default_command": "copilot",
+        "args_env": "HERMES_COPILOT_ACP_ARGS",
+        "default_args": ["--acp", "--stdio"],
+        "missing_code": "missing_copilot_cli",
+        "missing_message": (
+            "Could not find the Copilot CLI command '{command}'. "
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        ),
+        "api_key_marker": "copilot-acp",
+    },
+    "kiro-acp": {
+        "command_env": "HERMES_KIRO_ACP_COMMAND",
+        "command_alias_env": "KIRO_CLI_PATH",
+        "default_command": "kiro-cli-chat",
+        "args_env": "HERMES_KIRO_ACP_ARGS",
+        "default_args": ["acp", "--trust-all-tools"],
+        "missing_code": "missing_kiro_cli",
+        "missing_message": (
+            "Could not find the Kiro CLI command '{command}'. "
+            "Install kiro-cli-chat or set HERMES_KIRO_ACP_COMMAND/KIRO_CLI_PATH."
+        ),
+        "api_key_marker": "kiro-acp",
+    },
+}
+
+
+def _resolve_external_process_command(provider_id: str) -> str:
+    defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id, {})
+    command_env = defaults.get("command_env", "")
+    alias_env = defaults.get("command_alias_env", "")
+    return (
+        os.getenv(command_env, "").strip()
+        or os.getenv(alias_env, "").strip()
+        or defaults.get("default_command", "")
+    )
+
+
+def _resolve_external_process_args(provider_id: str) -> List[str]:
+    defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id, {})
+    raw_args = os.getenv(defaults.get("args_env", ""), "").strip()
+    return shlex.split(raw_args) if raw_args else list(defaults.get("default_args", []))
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command = _resolve_external_process_command(provider_id)
+    args = _resolve_external_process_args(provider_id)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -5758,12 +5809,12 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
-        return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
+        return get_external_process_provider_status(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -5912,25 +5963,25 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command = _resolve_external_process_command(provider_id)
+    args = _resolve_external_process_args(provider_id)
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id, {})
+        missing_message = defaults.get(
+            "missing_message",
+            "Could not find the external-process command '{command}'.",
+        )
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            missing_message.format(command=command),
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=defaults.get("missing_code", "missing_external_process_cli"),
         )
 
+    defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id, {})
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": defaults.get("api_key_marker", provider_id),
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2747,6 +2747,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "kiro-acp":
+        _model_flow_kiro_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -5289,6 +5291,72 @@ def _model_flow_copilot_acp(config, current_model=""):
         )
         or selected
     )
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_kiro_acp(config, current_model=""):
+    """Kiro CLI ACP flow using the local Kiro CLI."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "kiro-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "kiro-cli-chat"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Kiro CLI ACP delegates Hermes turns to `kiro-cli-chat acp --trust-all-tools`.")
+    print("  Kiro handles backend model choice internally; Hermes stores `kiro-cli` as the model label.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Set HERMES_KIRO_ACP_COMMAND or KIRO_CLI_PATH if Kiro CLI is installed elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, ["kiro-cli"])
+    selected = _prompt_model_selection(
+        model_list,
+        current_model=current_model if current_model in model_list else "kiro-cli",
+    )
+
+    if not selected:
+        print("No change.")
+        return
+
     _save_model_choice(selected)
 
     cfg = load_config()

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "kiro-acp",
     "openai-codex",
 })
 
@@ -421,7 +422,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     and live-catalog lookups.  Without this, vendor-prefixed or
     #     dash-notation Claude IDs survive to the Copilot API and hit
     #     HTTP 400 "model_not_supported".  See issue #6879.
-    if provider in {"copilot", "copilot-acp"}:
+    if provider in {"copilot", "copilot-acp", "kiro-acp"}:
         try:
             from hermes_cli.models import normalize_copilot_model_id
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1438,7 +1438,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp", "kiro-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -216,6 +216,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "kiro-acp": [
+        "kiro-cli",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -920,6 +923,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("kiro-acp",       "Kiro CLI (ACP)",           "Kiro CLI ACP (Spawns kiro-cli-chat acp --trust-all-tools)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
@@ -1081,6 +1085,9 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "kiro": "kiro-acp",
+    "kiro-cli": "kiro-acp",
+    "kiro-cli-acp": "kiro-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -2066,6 +2073,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         return get_codex_model_ids(access_token=access_token)
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
+    if normalized == "kiro-acp":
+        return list(_PROVIDER_MODELS.get("kiro-acp", ["kiro-cli"]))
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "kiro-acp": HermesOverlay(
+        transport="chat_completions",
+        auth_type="external_process",
+        base_url_override="acp://kiro",
+        base_url_env_var="KIRO_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -284,6 +290,9 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
+    "kiro": "kiro-acp",
+    "kiro-cli": "kiro-acp",
+    "kiro-cli-acp": "kiro-acp",
 
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
@@ -368,6 +377,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "kiro-acp": "Kiro CLI (ACP)",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1452,10 +1452,10 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "kiro-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,9 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "kiro-acp": [
+        "kiro-cli",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/plugins/model-providers/kiro-acp/__init__.py
+++ b/plugins/model-providers/kiro-acp/__init__.py
@@ -1,0 +1,36 @@
+"""Kiro CLI ACP provider profile.
+
+kiro-acp uses an external ACP subprocess. The local Kiro CLI handles auth.
+Hermes routes this provider through the existing ACP subprocess client.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class KiroACPProfile(ProviderProfile):
+    """Kiro CLI ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Kiro does not expose a REST /models catalog through Hermes."""
+        return None
+
+
+kiro_acp = KiroACPProfile(
+    name="kiro-acp",
+    aliases=("kiro-cli-acp", "kiro-cli", "kiro"),
+    api_mode="chat_completions",
+    display_name="Kiro CLI (ACP)",
+    description="Kiro CLI via ACP subprocess",
+    env_vars=(),
+    base_url="acp://kiro",
+    auth_type="external_process",
+    fallback_models=("kiro-cli",),
+)
+
+register_provider(kiro_acp)

--- a/plugins/model-providers/kiro-acp/plugin.yaml
+++ b/plugins/model-providers/kiro-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: kiro-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Kiro CLI via ACP subprocess
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -30,6 +30,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("kiro-acp", "Kiro CLI ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -113,6 +114,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["kiro-acp"].inference_base_url == "acp://kiro"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
@@ -147,6 +149,8 @@ PROVIDER_ENV_VARS = (
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
+    "HERMES_KIRO_ACP_COMMAND", "KIRO_CLI_PATH", "HERMES_KIRO_ACP_ARGS",
+    "KIRO_ACP_BASE_URL",
 )
 
 
@@ -228,6 +232,11 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_kiro_acp(self):
+        assert resolve_provider("kiro") == "kiro-acp"
+        assert resolve_provider("kiro-cli") == "kiro-acp"
+        assert resolve_provider("kiro-cli-acp") == "kiro-acp"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -373,6 +382,40 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_kiro_acp_status_uses_kiro_defaults(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_external_process_provider_status("kiro-acp")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "kiro-cli-chat"
+        assert status["resolved_command"] == "/opt/bin/kiro-cli-chat"
+        assert status["args"] == ["acp", "--trust-all-tools"]
+        assert status["base_url"] == "acp://kiro"
+
+    def test_kiro_acp_status_respects_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KIRO_ACP_COMMAND", "custom-kiro")
+        monkeypatch.setenv("HERMES_KIRO_ACP_ARGS", "acp --trust-all-tools --debug")
+        monkeypatch.setenv("KIRO_ACP_BASE_URL", "acp+tcp://127.0.0.1:5555")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_external_process_provider_status("kiro-acp")
+
+        assert status["command"] == "custom-kiro"
+        assert status["resolved_command"] == "/opt/bin/custom-kiro"
+        assert status["args"] == ["acp", "--trust-all-tools", "--debug"]
+        assert status["base_url"] == "acp+tcp://127.0.0.1:5555"
+
+    def test_kiro_acp_status_uses_alias_command_env(self, monkeypatch):
+        monkeypatch.setenv("KIRO_CLI_PATH", "kiro-from-alias")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_external_process_provider_status("kiro-acp")
+
+        assert status["command"] == "kiro-from-alias"
+        assert status["resolved_command"] == "/opt/bin/kiro-from-alias"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -478,6 +521,27 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
         assert creds["source"] == "process"
+
+    def test_resolve_kiro_acp_with_local_cli(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("kiro-acp")
+
+        assert creds["provider"] == "kiro-acp"
+        assert creds["api_key"] == "kiro-acp"
+        assert creds["base_url"] == "acp://kiro"
+        assert creds["command"] == "/usr/local/bin/kiro-cli-chat"
+        assert creds["args"] == ["acp", "--trust-all-tools"]
+        assert creds["source"] == "process"
+
+    def test_resolve_kiro_acp_missing_cli_raises_provider_specific_error(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+
+        with pytest.raises(AuthError) as excinfo:
+            resolve_external_process_provider_credentials("kiro-acp")
+
+        assert excinfo.value.code == "missing_kiro_cli"
+        assert "Kiro CLI" in str(excinfo.value)
 
     def test_resolve_kimi_with_key(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-secret-key")
@@ -683,6 +747,20 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_kiro_acp_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="kiro-acp")
+
+        assert result["provider"] == "kiro-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "kiro-acp"
+        assert result["base_url"] == "acp://kiro"
+        assert result["command"] == "/usr/local/bin/kiro-cli-chat"
+        assert result["args"] == ["acp", "--trust-all-tools"]
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -269,6 +269,46 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "chat_completions"
 
+    def test_kiro_acp_provider_saved_when_selected(self, config_home):
+        """_model_flow_kiro_acp should persist provider/base_url/model together."""
+        from hermes_cli.main import _model_flow_kiro_acp
+        from hermes_cli.config import load_config
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "resolved_command": "/usr/local/bin/kiro-cli-chat",
+                "command": "kiro-cli-chat",
+                "base_url": "acp://kiro",
+            },
+        ), patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "kiro-acp",
+                "api_key": "kiro-acp",
+                "base_url": "acp://kiro",
+                "command": "/usr/local/bin/kiro-cli-chat",
+                "args": ["acp", "--trust-all-tools"],
+                "source": "process",
+            },
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="kiro-cli",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_kiro_acp(load_config(), "old-model")
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict), f"model should be dict, got {type(model)}"
+        assert model.get("provider") == "kiro-acp"
+        assert model.get("base_url") == "acp://kiro"
+        assert model.get("default") == "kiro-cli"
+        assert model.get("api_mode") == "chat_completions"
+
     def test_opencode_go_models_are_selectable_and_persist_normalized(self, config_home, monkeypatch):
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -159,6 +159,8 @@ class TestNormalizeProvider:
         assert normalize_provider("moonshot") == "kimi-coding"
         assert normalize_provider("step") == "stepfun"
         assert normalize_provider("github-copilot") == "copilot"
+        assert normalize_provider("kiro") == "kiro-acp"
+        assert normalize_provider("kiro-cli") == "kiro-acp"
 
     def test_case_insensitive(self):
         assert normalize_provider("OpenRouter") == "openrouter"
@@ -171,6 +173,7 @@ class TestProviderLabel:
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("kiro-acp") == "Kiro CLI (ACP)"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):
@@ -214,6 +217,9 @@ class TestProviderModelIds:
         with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):
             assert provider_model_ids("copilot-acp") == ["gpt-5.4", "claude-sonnet-4.6"]
+
+    def test_kiro_acp_returns_kiro_cli_label(self):
+        assert provider_model_ids("kiro-acp") == ["kiro-cli"]
 
 
 # -- fetch_api_models --------------------------------------------------------

--- a/tests/plugins/model_providers/test_kiro_acp_profile.py
+++ b/tests/plugins/model_providers/test_kiro_acp_profile.py
@@ -1,0 +1,28 @@
+"""Kiro ACP model-provider plugin profile tests."""
+
+from providers import get_provider_profile
+
+
+def test_kiro_acp_profile_registered():
+    profile = get_provider_profile("kiro-acp")
+
+    assert profile is not None
+    assert profile.name == "kiro-acp"
+    assert profile.auth_type == "external_process"
+    assert profile.base_url == "acp://kiro"
+    assert profile.api_mode == "chat_completions"
+    assert profile.display_name == "Kiro CLI (ACP)"
+    assert profile.fallback_models == ("kiro-cli",)
+
+
+def test_kiro_acp_aliases_resolve_to_canonical_provider():
+    for alias in ("kiro", "kiro-cli", "kiro-cli-acp"):
+        profile = get_provider_profile(alias)
+        assert profile is not None
+        assert profile.name == "kiro-acp"
+
+
+def test_kiro_acp_fetch_models_returns_none():
+    profile = get_provider_profile("kiro-acp")
+    assert profile is not None
+    assert profile.fetch_models() is None

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1494,8 +1494,8 @@ class TestCopilotACPStreamingDecision:
             if getattr(agent, "_disable_streaming", False):
                 _use_streaming = False
             elif (
-                agent.provider == "copilot-acp"
-                or str(agent.base_url or "").lower().startswith("acp://copilot")
+                agent.provider in {"copilot-acp", "kiro-acp"}
+                or str(agent.base_url or "").lower().startswith("acp://")
                 or str(agent.base_url or "").lower().startswith("acp+tcp://")
             ):
                 _use_streaming = False
@@ -1518,8 +1518,8 @@ class TestCopilotACPStreamingDecision:
 
         _use_streaming = True
         if (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
+            agent.provider in {"copilot-acp", "kiro-acp"}
+            or str(agent.base_url or "").lower().startswith("acp://")
             or str(agent.base_url or "").lower().startswith("acp+tcp://")
         ):
             _use_streaming = False
@@ -1539,8 +1539,8 @@ class TestCopilotACPStreamingDecision:
 
         _use_streaming = True
         if (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
+            agent.provider in {"copilot-acp", "kiro-acp"}
+            or str(agent.base_url or "").lower().startswith("acp://")
             or str(agent.base_url or "").lower().startswith("acp+tcp://")
         ):
             _use_streaming = False
@@ -1566,8 +1566,8 @@ class TestCopilotACPStreamingDecision:
         if getattr(agent, "_disable_streaming", False):
             _use_streaming = False
         elif (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
+            agent.provider in {"copilot-acp", "kiro-acp"}
+            or str(agent.base_url or "").lower().startswith("acp://")
             or str(agent.base_url or "").lower().startswith("acp+tcp://")
         ):
             _use_streaming = False


### PR DESCRIPTION
## Summary
- add bundled `kiro-acp` model-provider plugin for Kiro CLI over ACP
- generalize external-process provider auth/runtime handling for Kiro defaults and env overrides
- wire `kiro-acp` into model selection, setup defaults, runtime routing, auxiliary clients, and ACP streaming exclusions

## Testing
- `uv run python -m pytest tests/plugins/model_providers/test_kiro_acp_profile.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_provider_persistence.py tests/run_agent/test_streaming.py::TestCopilotACPStreamingDecision -o 'addopts=' -q`

## Notes
- Kiro CLI owns backend model selection; Hermes stores `kiro-cli` as the model label.
- The provider uses `external_process` auth with defaults `kiro-cli-chat acp --trust-all-tools` and marker base URL `acp://kiro`.