### PR TITLE
fix(profiles): skip 'default' in named profiles scan to prevent duplicates

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -635,6 +635,8 @@ def list_profiles() -> List[ProfileInfo]:
             if not entry.is_dir():
                 continue
             name = entry.name
+            if name == "default":
+                continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)


### PR DESCRIPTION
## Problem

When `~/.hermes/profiles/default/` exists as a directory, `list_profiles()` returns `default` twice:
1. As the built-in default profile (path=`~/.hermes`)
2. From the directory scan (path=`~/.hermes/profiles/default`)

This causes the cron dashboard API (`profile=all`) to read the same `jobs.json` twice, showing every default-profile job duplicated in the UI. The CLI `hermes cron list` is unaffected (it reads directly from disk), but the dashboard/API path iterates all profiles and calls `_call_cron_for_profile` for each, producing duplicate job entries.

## Root cause

`list_profiles()` in `hermes_cli/profiles.py:631-639` scans `~/.hermes/profiles/*` without skipping a directory named `default`, even though the built-in default profile is already added at line 609-629.

## Fix

Skip `name == "default"` in the named profiles loop:

```python
if name == "default":
    continue  # already added as the built-in default above
```

## Testing

- Verified `list_profiles()` returns `default` exactly once with `~/.hermes/profiles/default/` present
- Verified normal behavior preserved without the directory
- Verified non-default profiles (e.g. `coder`) still appear correctly
- Verified `_cron_profile_dicts()` (used by the dashboard API) also shows no duplicates

Fixes #39346