### PR TITLE
[codex] fix(desktop): keep composer draft synced while typing

### DIFF
--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -16,3 +16,29 @@ describe('renderComposerContents', () => {
     expect(composerPlainText(editor)).toBe('@file:`<img src=x onerror=alert(1)>` <b>raw</b>')
   })
 })
+
+describe('composerPlainText', () => {
+  it('does not add a trailing newline for browser-created block wrappers', () => {
+    const editor = document.createElement('div')
+    const line = document.createElement('div')
+
+    editor.dataset.slot = RICH_INPUT_SLOT
+    line.textContent = 'help me debug this'
+    editor.append(line)
+
+    expect(composerPlainText(editor)).toBe('help me debug this')
+  })
+
+  it('keeps newlines between browser-created block wrappers', () => {
+    const editor = document.createElement('div')
+    const first = document.createElement('div')
+    const second = document.createElement('div')
+
+    editor.dataset.slot = RICH_INPUT_SLOT
+    first.textContent = 'first line'
+    second.textContent = 'second line'
+    editor.append(first, second)
+
+    expect(composerPlainText(editor)).toBe('first line\nsecond line')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -172,7 +172,7 @@ export function composerPlainText(node: Node): string {
   const text = Array.from(node.childNodes).map(composerPlainText).join('')
   const block = el.tagName === 'DIV' || el.tagName === 'P'
 
-  return block && text && el.dataset.slot !== RICH_INPUT_SLOT ? `${text}\n` : text
+  return block && text && el.dataset.slot !== RICH_INPUT_SLOT && el.nextSibling ? `${text}\n` : text
 }
 
 export function placeCaretEnd(element: HTMLElement) {


### PR DESCRIPTION
## Summary

- keep the focused contenteditable editor as the source of truth while typing so stale assistant-ui draft updates cannot overwrite `draftRef`
- defer per-keystroke assistant-ui composer state writes to the next animation frame, while submit/queue paths synchronously resync from the live editor DOM
- avoid serializing browser-created block wrappers with an extra trailing newline

Fixes #39473.

## Validation

- `npm run test:ui -- src/app/chat/composer/rich-editor.test.ts src/app/chat/composer/slash-nav-dom-repro.test.tsx src/app/chat/composer/text-utils.test.ts`
- `npm run test:ui -- src/app/chat/composer`
- `npm run type-check`
- `npx eslint src/app/chat/composer/index.tsx src/app/chat/composer/rich-editor.ts src/app/chat/composer/rich-editor.test.ts`
- `git diff --check`