### PR TITLE
feat(matrix): add session and always approval reactions for dangerous commands

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -481,6 +481,8 @@ class MatrixAdapter(BasePlatformAdapter):
         # Matrix reaction-based dangerous command approvals.
         self._approval_reaction_map = {
             "✅": "once",
+            "🔄": "session",
+            "♾️": "always",
             "❎": "deny",
         }
         self._approval_prompts_by_event: Dict[str, _MatrixApprovalPrompt] = {}
@@ -1281,9 +1283,11 @@ class MatrixAdapter(BasePlatformAdapter):
             f"Reason: {description}\n\n"
             "Reply `/approve` to execute, `/approve session` to approve this pattern for the session, "
             "`/approve always` to approve permanently, or `/deny` to cancel.\n\n"
-            "You can also click the reaction to approve:\n"
-            "✅ = /approve\n"
-            "❎ = /deny"
+            "You can also click a reaction:\n"
+            "✅ = approve once\n"
+            "🔄 = approve session\n"
+            "♾️ = approve always\n"
+            "❎ = deny"
         )
 
         result = await self.send(chat_id, text, metadata=metadata)
@@ -1301,7 +1305,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
-        for emoji in ("✅", "❎"):
+        for emoji in ("✅", "🔄", "♾️", "❎"):
             try:
                 reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)
                 # Save the bot's reaction event_id for later cleanup


### PR DESCRIPTION
Problem: dangerous command approval only had approve-once and deny reactions, even though /approve session and /approve always already existed. Add reactions for all four modes.

Changes: Add approval_reaction_map entries and emoji reactions for approve-session and approve-always.

Tested on Linux.