### PR TITLE
fix(cli): use Rich [dim] style for resume status lines instead of raw ANSI (fixes MarkupError on resume)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5097,7 +5097,7 @@ class HermesCLI:
                 resolved_id = self.session_id
             if resolved_id and resolved_id != self.session_id:
                 ChatConsole().print(
-                    f"[{_DIM}]Session {_escape(self.session_id)} was compressed into "
+                    f"[dim]Session {_escape(self.session_id)} was compressed into "
                     f"{_escape(resolved_id)}; resuming the descendant with your "
                     f"transcript.[/]"
                 )
@@ -5378,7 +5378,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"[dim]{_escape(msg)}[/]")
             return
 
         try:
@@ -5388,7 +5388,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(f"[dim]{_escape(msg)}[/]")
             return
 
         # Retarget the terminal/code-exec tools to match the process cwd.
@@ -5398,7 +5398,7 @@ class HermesCLI:
         if quiet:
             print(msg, file=sys.stderr)
         else:
-            self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+            self._console_print(f"[dim]{_escape(msg)}[/]")
 
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).


### PR DESCRIPTION
## Summary

Resuming a session crashes with `rich.errors.MarkupError` before the transcript can load, whenever the session recorded a working directory.

```
File "cli.py", line 5401, in _restore_session_cwd
    self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
...
rich.errors.MarkupError: closing tag '[/]' at position 59 has nothing to close
```

## Root cause

`_DIM` is a **raw ANSI escape sequence**:

```python
_DIM = "\x1b[2;3m"
```

Several resume-path status lines interpolate it *inside Rich markup brackets*:

```python
self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
```

That expands to `[<ESC>[2;3m]...[/]`. The literal escape bytes sit between the markup brackets, so the opening tag never validly opens, and the trailing `[/]` has nothing to close — Rich raises `MarkupError`.

This fires on **every** resume of a session that recorded a `cwd` (via `_restore_session_cwd()`), plus the compression-redirect notice — aborting startup before the conversation history loads.

## Fix

Use Rich's actual `dim` style — the same convention already used a few lines below in the same function (e.g. the `[dim]...[/]` blocks around lines 5423–5424). Four call sites in `cli.py`:

- `_restore_session_cwd()` — missing-dir warning, chdir-failure warning, and the "↻ Working directory" status line.
- `_init_agent()` compression-redirect notice.

```diff
- self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+ self._console_print(f"[dim]{_escape(msg)}[/]")
```

## Verification

Reproduced against the venv's Rich (the one the CLI uses):

```
OLD raises: MarkupError - closing tag '[/]' at position 59 has nothing to close   # exact crash
NEW: RENDER_OK                                                                    # renders clean
```

- `python -m py_compile cli.py` passes.
- Zero `[{_DIM}]` markup sites remain.

## Test plan

- [ ] Resume a session that has a recorded working directory (`hermes --resume <id>`) — should print the dim "↻ Working directory: …" line and load the transcript instead of crashing.
- [ ] Resume a session whose recorded cwd no longer exists — should print the dim "⚠ working directory is gone" warning, not crash.
