### PR TITLE
fix(file-sync): use posixpath for remote dir prefix in _infer_host_path

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -377,6 +377,50 @@ class TestInferHostPath:
         expected = str(tmp_path / "host" / "skills" / "b.py")
         assert result == expected
 
+    def test_infer_remote_prefix_uses_posix_separators(self, tmp_path):
+        """The remote directory prefix must be derived with POSIX semantics so
+        sync-back can infer the host path even when the host process is Windows.
+
+        ``remote`` is always a remote (Linux) path. Building its prefix with
+        ``str(Path(remote).parent)`` renders backslashes on a Windows host
+        (``\\root\\.hermes\\skills``), so the subsequent
+        ``remote_path.startswith(remote_dir + "/")`` never matches and the
+        newly-created remote file is silently dropped. ``posixpath.dirname``
+        keeps the prefix separator-stable on every host.
+
+        Sibling of commit 46abf0401, which fixed the identical
+        ``str(Path(remote).parent)`` separator bug in ``unique_parent_dirs()``
+        but left ``_infer_host_path()`` unconverted.
+        """
+        import posixpath as _pp
+
+        host_file = tmp_path / "host" / "skills" / "a.py"
+        _write_file(host_file, b"content")
+        mapping = [(str(host_file), "/root/.hermes/skills/a.py")]
+        mgr = _make_manager(tmp_path, file_mapping=mapping)
+
+        called = {}
+        real_dirname = _pp.dirname
+
+        def _spy(p):
+            called["remote"] = p
+            return real_dirname(p)
+
+        with patch(
+            "tools.environments.file_sync.posixpath.dirname",
+            side_effect=_spy,
+        ):
+            result = mgr._infer_host_path(
+                "/root/.hermes/skills/b.py",
+                file_mapping=mapping,
+            )
+
+        # The remote prefix must go through posixpath.dirname. Old code used
+        # str(Path(remote).parent) and never called it, leaving `called` empty.
+        assert called.get("remote") == "/root/.hermes/skills/a.py"
+        # And the sibling remote file still resolves to its host path.
+        assert result is not None and result.endswith("b.py")
+
 
 class TestSyncBackSIGINT:
     """SIGINT deferral during sync-back."""

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -377,49 +377,58 @@ class TestInferHostPath:
         expected = str(tmp_path / "host" / "skills" / "b.py")
         assert result == expected
 
-    def test_infer_remote_prefix_uses_posix_separators(self, tmp_path):
-        """The remote directory prefix must be derived with POSIX semantics so
-        sync-back can infer the host path even when the host process is Windows.
+    def test_infer_remote_prefix_uses_posix_separators_on_windows_host(
+        self, tmp_path
+    ):
+        """The remote directory prefix must use POSIX separators even when the
+        host process renders paths Windows-style, so sync-back can still infer
+        the host path for a newly-created remote file.
 
-        ``remote`` is always a remote (Linux) path. Building its prefix with
+        ``remote`` is always a remote (Linux) path. Deriving its prefix with
         ``str(Path(remote).parent)`` renders backslashes on a Windows host
-        (``\\root\\.hermes\\skills``), so the subsequent
-        ``remote_path.startswith(remote_dir + "/")`` never matches and the
-        newly-created remote file is silently dropped. ``posixpath.dirname``
-        keeps the prefix separator-stable on every host.
+        (``\\root\\.hermes\\skills``); the subsequent
+        ``startswith(remote_dir + "/")`` then never matches a forward-slash
+        remote path and the file is silently dropped. This test simulates a
+        Windows host by pointing the module's ``Path`` at ``PureWindowsPath``
+        and asserts the OBSERVABLE behavior (a sibling remote file resolves)
+        rather than which helper is called.
 
         Sibling of commit 46abf0401, which fixed the identical
         ``str(Path(remote).parent)`` separator bug in ``unique_parent_dirs()``
         but left ``_infer_host_path()`` unconverted.
         """
-        import posixpath as _pp
+        from pathlib import PureWindowsPath
 
-        host_file = tmp_path / "host" / "skills" / "a.py"
-        _write_file(host_file, b"content")
-        mapping = [(str(host_file), "/root/.hermes/skills/a.py")]
-        mgr = _make_manager(tmp_path, file_mapping=mapping)
+        # Host paths expressed Windows-style so the simulated PureWindowsPath
+        # parent/str round-trip stays correct for the host side.
+        mapping = [(r"C:\Users\me\.hermes\skills\a.py", "/root/.hermes/skills/a.py")]
+        mgr = _make_manager(tmp_path, file_mapping=mapping, seed_pushed_state=False)
 
-        called = {}
-        real_dirname = _pp.dirname
-
-        def _spy(p):
-            called["remote"] = p
-            return real_dirname(p)
-
-        with patch(
-            "tools.environments.file_sync.posixpath.dirname",
-            side_effect=_spy,
-        ):
+        # Simulate a Windows host: pathlib.Path renders backslashes. With the
+        # old remote-prefix code this makes startswith() fail; the fix routes
+        # the remote prefix through posixpath, which is separator-stable.
+        with patch("tools.environments.file_sync.Path", PureWindowsPath):
             result = mgr._infer_host_path(
                 "/root/.hermes/skills/b.py",
                 file_mapping=mapping,
             )
 
-        # The remote prefix must go through posixpath.dirname. Old code used
-        # str(Path(remote).parent) and never called it, leaving `called` empty.
-        assert called.get("remote") == "/root/.hermes/skills/a.py"
-        # And the sibling remote file still resolves to its host path.
-        assert result is not None and result.endswith("b.py")
+        assert result == r"C:\Users\me\.hermes\skills/b.py"
+
+    def test_infer_matching_prefix_remote_root(self, tmp_path):
+        """A remote file directly under the POSIX root resolves correctly.
+
+        Guards the ``remote_dir == "/"`` edge: the prefix must not become
+        ``"//"`` and the suffix must keep its leading separator.
+        """
+        host_file = tmp_path / "host" / "a.py"
+        _write_file(host_file, b"content")
+        mapping = [(str(host_file), "/a.py")]
+
+        mgr = _make_manager(tmp_path, file_mapping=mapping)
+        result = mgr._infer_host_path("/b.py", file_mapping=mapping)
+        expected = str(tmp_path / "host" / "b.py")
+        assert result == expected
 
 
 class TestSyncBackSIGINT:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -398,8 +398,16 @@ class FileSyncManager:
             # `remote` is always a remote (POSIX) path; use posixpath so the
             # prefix keeps forward slashes even when the host is Windows.
             remote_dir = posixpath.dirname(remote)
-            if remote_path.startswith(remote_dir + "/"):
+            # ``remote_dir`` is "/" when the mapped file sits directly under
+            # the POSIX root; the directory separator is then already part of
+            # the prefix, so don't append a second one (which would yield
+            # "//" and never match, and would mis-slice the suffix).
+            base = remote_dir.rstrip("/")
+            if remote_path.startswith(base + "/"):
                 host_dir = str(Path(host).parent)
-                suffix = remote_path[len(remote_dir):]
+                # Slice off only the directory portion (without any trailing
+                # slash) so the suffix always keeps its leading "/" separator,
+                # including when ``remote_dir`` is the POSIX root.
+                suffix = remote_path[len(base):]
                 return host_dir + suffix
         return None

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -395,7 +395,9 @@ class FileSyncManager:
         """
         mapping = file_mapping if file_mapping is not None else []
         for host, remote in mapping:
-            remote_dir = str(Path(remote).parent)
+            # `remote` is always a remote (POSIX) path; use posixpath so the
+            # prefix keeps forward slashes even when the host is Windows.
+            remote_dir = posixpath.dirname(remote)
             if remote_path.startswith(remote_dir + "/"):
                 host_dir = str(Path(host).parent)
                 suffix = remote_path[len(remote_dir):]


### PR DESCRIPTION
## This is a sibling follow-up to commit 46abf0401

- `46abf0401` / `dfe6fbb0b` covered: `unique_parent_dirs()` — switched `str(Path(remote).parent)` to `posixpath.dirname(remote)` and added `import posixpath`, so remote (Linux) directory prefixes keep forward slashes when the host is Windows.
- That commit did NOT touch: `_infer_host_path()` in the same file, which still derives the remote directory prefix with `str(Path(remote).parent)` — the identical host-separator bug, reaching a different code path (sync-back host-path inference for newly-created remote files).
- This PR applies the same `posixpath.dirname(remote)` conversion for the remote prefix in `_infer_host_path()`.

## What does this PR do?

`FileSyncManager._infer_host_path()` maps a newly-created remote file back to a host path by matching it against the remote directory prefixes of the existing `(host, remote)` mapping. `remote` is always a remote Linux path (e.g. `/root/.hermes/skills/a.py`). The prefix was built with `str(Path(remote).parent)`, which on a Windows host renders backslashes (`\root\.hermes\skills`). The subsequent `remote_path.startswith(remote_dir + "/")` then compares a forward-slash remote path against a backslash prefix and never matches, so sync-back silently drops files newly created on the remote. Switching the remote-side prefix to `posixpath.dirname(remote)` (already imported) keeps it separator-stable on every host. The host side (`Path(host).parent`) is intentionally left host-aware.

## Related Issue

Fixes # (no separate issue — sibling-widening of commit 46abf0401)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/file_sync.py`: in `_infer_host_path()`, derive the remote directory prefix with `posixpath.dirname(remote)` instead of `str(Path(remote).parent)` so it stays POSIX on Windows hosts. Host-side `Path(host).parent` unchanged.
- `tests/tools/test_file_sync_back.py`: add a regression test under `TestInferHostPath` proving the remote prefix is computed with POSIX semantics and a sibling remote file still resolves to its host path.

## How to Test

1. `pytest tests/tools/test_file_sync_back.py -q`
2. Revert the one-line prod change -> new test goes RED (remote prefix backslash-mismatch).
3. Restore -> GREEN.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Windows separator path covered by test)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this PR is the cross-platform fix