### PR TITLE
fix(ollama): set default_max_tokens=4096 for custom/Ollama provider

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -63,6 +63,7 @@ custom = CustomProfile(
     ),
     env_vars=(),  # No fixed key — custom endpoint
     base_url="",  # User-configured
+    default_max_tokens=4096,
 )
 
 register_provider(custom)


### PR DESCRIPTION
## Problem

Gemma4 (and other models) with the Ollama backend produce truncated responses
with `finish_reason='length'` — the model hits the output cap after just a few
tokens.

## Root cause

The custom/Ollama provider profile (`plugins/model-providers/custom/__init__.py`)
had no `default_max_tokens` set. This means no `max_tokens` parameter was sent
in API requests, and Ollama used its own default `num_predict` of 128 tokens —
far too small for normal responses.

Other provider profiles (qwen-oauth: 65536, kimi-coding: 32000, nvidia: 16384)
all set explicit defaults; custom/Ollama was the only one missing it.

## Fix

Set `default_max_tokens=4096` on the CustomProfile constructor. This is a safe
middle ground that allows complete responses without overwhelming most models.
Users can still override per-model via `model.max_tokens` in config.yaml.

## Testing

- Verified `custom.get_max_tokens('gemma4')` returns 4096
- All 49 existing provider tests pass (test_provider_profiles.py + test_e2e_wiring.py)

Fixes #39281