### PR TITLE
fix(run_agent): reorder _supports_reasoning_extra_body gate for custom providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4455,10 +4455,10 @@ class AIAgent:
         if any(model.startswith(prefix) for prefix in reasoning_model_prefixes):
             return True
 
-        # Unknown URL + unknown model → safe default: don't send reasoning params.
-        if "openrouter" not in self._base_url_lower:
-            return False
-        return True
+        # Unknown model → safe default: don't send reasoning params. This applies
+        # to OpenRouter and custom providers alike; OpenRouter in particular
+        # forwards unknown extra_body fields upstream where they may 400.
+        return False
 
     def _lmstudio_reasoning_options_cached(self) -> list[str]:
         """Probe LM Studio's published reasoning ``allowed_options`` once per

--- a/run_agent.py
+++ b/run_agent.py
@@ -4435,8 +4435,7 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
-        if "openrouter" not in self._base_url_lower:
-            return False
+        # Mistral's API rejects `reasoning` — reject early regardless of model.
         if "api.mistral.ai" in self._base_url_lower:
             return False
 
@@ -4452,7 +4451,14 @@ class AIAgent:
             "tencent/hy3-preview",
             "xiaomi/",
         )
-        return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
+        # Model prefix match → reasoning is safe for this model on any provider
+        if any(model.startswith(prefix) for prefix in reasoning_model_prefixes):
+            return True
+
+        # Unknown URL + unknown model → safe default: don't send reasoning params.
+        if "openrouter" not in self._base_url_lower:
+            return False
+        return True
 
     def _lmstudio_reasoning_options_cached(self) -> list[str]:
         """Probe LM Studio's published reasoning ``allowed_options`` once per

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6310,6 +6310,33 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    @pytest.mark.parametrize(
+        "base_url, model, expected",
+        [
+            # Custom provider (e.g. SGLang) + known reasoning model → enabled.
+            # This is the case the gate reorder was meant to fix.
+            ("http://localhost:30000/v1", "qwen/qwen3.6", True),
+            # Custom provider + unknown model → safe default: disabled.
+            ("http://localhost:30000/v1", "my-org/custom-llm", False),
+            # OpenRouter + known reasoning model → enabled.
+            ("https://openrouter.ai/api/v1", "qwen/qwen3-235b-a22b", True),
+            # OpenRouter + unknown model → disabled. Regression guard: the
+            # reorder must not flip this from False to True (could 400 upstream).
+            ("https://openrouter.ai/api/v1", "some/unknown-model", False),
+            # Mistral rejects `reasoning` and must be off regardless of model,
+            # even when the model name matches a known reasoning prefix.
+            ("https://api.mistral.ai/v1", "mistral-large-latest", False),
+            ("https://api.mistral.ai/v1", "qwen/qwen3-235b-a22b", False),
+        ],
+    )
+    def test_reasoning_gate_by_provider_and_model(self, base_url, model, expected):
+        agent = self._make_agent()
+        agent.provider = ""
+        agent.base_url = base_url
+        agent._base_url_lower = base_url.lower()
+        agent.model = model
+        assert agent._supports_reasoning_extra_body() is expected, (base_url, model)
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## Problem
`_supports_reasoning_extra_body()` checked for "openrouter" in the base URL first
and returned False for any non-OpenRouter host. This made the model-prefix
allowlist unreachable for custom providers (SGLang, local vLLM, etc.), so
`supports_reasoning` was False and the transport never sent reasoning params.

Concretely: on SGLang + Qwen3.6 with `reasoning_effort: "none"` in config, the
param was silently dropped, the server ran its default thinking mode, and the
model's chain-of-thought leaked into output (e.g. cron reports delivered to
messaging platforms).

## Fix
Reorder so known model prefixes (qwen/qwen3, deepseek/, anthropic/, etc.) are
checked before the URL gate — reasoning params are safe for these models on any
provider. Unknown models on non-OpenRouter hosts keep the original safe default
(don't send reasoning). OpenRouter behavior is unchanged.

## Verification
Tested on SGLang serving Qwen/Qwen3.6-35B-A3B-FP8:
- Before: supports_reasoning=False, reasoning_effort never sent, reasoning_tokens > 0, thinking leaked
- After: outgoing request carries `reasoning_effort: "none"`, response `reasoning_tokens: 0`, clean output
- Control: `reasoning_effort: high` → reasoning_tokens > 0 (toggles correctly)

Related: this is the same per-provider reasoning-gate class of issue already
fixed for other providers (Kimi, Tencent, etc.).