### PR TITLE
Fix active model visibility and NVIDIA Nemotron Ultra reasoning controls

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.ts
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ModelOptionProvider } from '@/types/hermes'
+
+import { groupModels } from './model-menu-panel'
+
+describe('model-menu-panel', () => {
+  it('keeps the current provider first in the dropdown', () => {
+    const providers: ModelOptionProvider[] = [
+      { slug: 'anthropic', name: 'Anthropic', models: ['anthropic/claude-sonnet'] },
+      { slug: 'nvidia', name: 'NVIDIA NIM', models: ['nvidia/nemotron-3-ultra-550b-a55b'] },
+      { slug: 'google', name: 'Google', models: ['google/gemini-3-pro'] }
+    ]
+
+    const groups = groupModels(
+      providers,
+      '',
+      { provider: 'nvidia', model: 'nvidia/nemotron-3-ultra-550b-a55b' },
+      null
+    )
+
+    expect(groups.map(group => group.provider.slug)).toEqual(['nvidia', 'anthropic', 'google'])
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -228,7 +228,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 // spans every available model so anything is reachable past the cut.
 const PER_PROVIDER_SEARCH = 12
 
-function groupModels(
+export function groupModels(
   providers: ModelOptionProvider[],
   search: string,
   current: { model: string; provider: string },
@@ -284,9 +284,17 @@ function groupModels(
     }
   }
 
-  // Stable, logical group order: alphabetical by provider name. (The backend
-  // floats the current provider first, which would reshuffle on every switch.)
-  groups.sort((a, b) => a.provider.name.localeCompare(b.provider.name))
+  // Keep the active provider first so the status-bar menu opens on the model
+  // the user is actually running; non-active providers remain alphabetical.
+  groups.sort((a, b) => {
+    const aCurrent = a.provider.slug === current.provider
+    const bCurrent = b.provider.slug === current.provider
+    if (aCurrent !== bCurrent) {
+      return aCurrent ? -1 : 1
+    }
+
+    return a.provider.name.localeCompare(b.provider.name)
+  })
 
   return groups
 }

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -150,6 +150,7 @@ def build_models_payload(
         custom_providers=ctx.custom_providers,
         max_models=max_models,
     )
+    _ensure_current_model_visible(rows, ctx)
 
     if include_unconfigured:
         rows = list(rows) + _append_unconfigured_rows(rows, ctx)
@@ -167,6 +168,38 @@ def build_models_payload(
         "model": ctx.current_model,
         "provider": ctx.current_provider,
     }
+
+
+def _ensure_current_model_visible(rows: list[dict], ctx: ConfigContext) -> None:
+    """Append the active model to its provider row when a capped slice omitted it.
+
+    ``list_authenticated_providers(..., max_models=N)`` intentionally returns a
+    capped, relevance-ordered slice for large provider catalogs.  The desktop
+    status-bar picker builds per-model option rows from that slice, so if the
+    configured active model sits beyond the cap (common for newly launched
+    hosted catalogs) the UI can display the active model in the status bar but
+    cannot show/select its option submenu.  Keep the cap for the rest of the
+    provider while guaranteeing the active model is present.
+    """
+    current_model = (ctx.current_model or "").strip()
+    current_provider = (ctx.current_provider or "").strip().lower()
+    if not current_model:
+        return
+
+    for row in rows:
+        slug = str(row.get("slug") or "").strip().lower()
+        if not (row.get("is_current") or (current_provider and slug == current_provider)):
+            continue
+
+        models = list(row.get("models") or [])
+        if current_model not in models:
+            models.append(current_model)
+            row["models"] = models
+            try:
+                row["total_models"] = max(int(row.get("total_models") or 0), len(models))
+            except Exception:
+                row["total_models"] = len(models)
+        return
 
 
 def _apply_capabilities(rows: list[dict]) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2006,6 +2006,15 @@ def get_model_info():
                 }
         except Exception:
             pass
+        if not caps and provider == "nvidia" and "nemotron-3-ultra" in model_name.lower():
+            caps = {
+                "supports_tools": True,
+                "supports_vision": False,
+                "supports_reasoning": True,
+                "context_window": effective_ctx or auto_ctx or 131072,
+                "max_output_tokens": 16384,
+                "model_family": "nemotron-3-ultra",
+            }
 
         return {
             "model": model_name,

--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -1,9 +1,48 @@
 """NVIDIA NIM provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-nvidia = ProviderProfile(
+
+class NvidiaProfile(ProviderProfile):
+    """NVIDIA hosted NIM.
+
+    Nemotron 3 Ultra exposes thinking controls through request-body fields
+    specific to its chat template, not through OpenRouter-style
+    ``extra_body.reasoning`` or OpenAI-style ``reasoning_effort``.
+    """
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        model_l = (model or "").strip().lower()
+        if "nemotron-3-ultra" not in model_l:
+            return {}, {}
+
+        enabled = True
+        effort = "medium"
+        if reasoning_config and isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                enabled = False
+            raw_effort = str(reasoning_config.get("effort") or "").strip().lower()
+            if raw_effort:
+                effort = raw_effort
+
+        if not enabled or effort == "none":
+            return {"chat_template_kwargs": {"enable_thinking": False}}, {}
+
+        chat_template_kwargs: dict[str, Any] = {"enable_thinking": True}
+        if effort in {"minimal", "low", "medium"}:
+            # NVIDIA's Build page exposes a binary high-vs-medium switch for
+            # Ultra: medium uses this flag; high/default omit it.
+            chat_template_kwargs["medium_effort"] = True
+
+        return {"chat_template_kwargs": chat_template_kwargs}, {}
+
+
+nvidia = NvidiaProfile(
     name="nvidia",
     aliases=("nvidia-nim",),
     env_vars=("NVIDIA_API_KEY",),

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -156,6 +156,28 @@ def test_build_models_payload_returns_expected_shape():
     assert payload["providers"] == rows
 
 
+def test_build_models_payload_keeps_current_model_when_curated_slice_omits_it():
+    """The desktop status-bar picker receives a capped provider model slice.
+
+    Newly launched provider models can be outside that slice (NVIDIA Ultra was
+    model #84 in the live NVIDIA list while /api/model/options requested only
+    50).  The active model still has to be present so the UI can render its row
+    and expose the per-model options submenu.
+    """
+    current = "nvidia/nemotron-3-ultra-550b-a55b"
+    rows = [
+        {"slug": "nvidia", "name": "NVIDIA", "models": ["nvidia/model-1"],
+         "total_models": 120, "is_current": True, "is_user_defined": False,
+         "source": "built-in"},
+    ]
+    ctx = _empty_ctx(provider="nvidia", model=current, base_url="")
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+    nvidia = payload["providers"][0]
+    assert nvidia["models"] == ["nvidia/model-1", current]
+    assert nvidia["total_models"] == 120
+
+
 def test_build_models_payload_does_not_call_provider_model_ids():
     """``build_models_payload`` is a thin shape adapter — it delegates the
     actual curation to ``list_authenticated_providers`` (which DOES call

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2661,6 +2661,25 @@ class TestModelInfoEndpoint:
         assert caps["max_output_tokens"] == 32000
         assert caps["model_family"] == "claude-opus"
 
+    def test_model_info_nvidia_ultra_reasoning_fallback(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "nvidia/nemotron-3-ultra-550b-a55b",
+                "provider": "nvidia",
+            }
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=131072), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None):
+            resp = self.client.get("/api/model/info")
+
+        caps = resp.json()["capabilities"]
+        assert caps["supports_reasoning"] is True
+        assert caps["context_window"] == 131072
+        assert caps["model_family"] == "nemotron-3-ultra"
+
     def test_model_info_graceful_on_metadata_error(self, monkeypatch):
         """Endpoint should return zeros on import/resolution errors, not 500."""
         import hermes_cli.web_server as ws

--- a/tests/providers/test_e2e_wiring.py
+++ b/tests/providers/test_e2e_wiring.py
@@ -78,6 +78,63 @@ class TestNvidiaProfileWiring:
         )
         assert kwargs["messages"] == msgs
 
+    def test_nvidia_ultra_disables_thinking_when_reasoning_off(self, transport):
+        profile = get_provider_profile("nvidia")
+        kwargs = transport.build_kwargs(
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            messages=_msgs(),
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config={"enabled": False},
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        assert kwargs["extra_body"]["chat_template_kwargs"] == {"enable_thinking": False}
+        assert "reasoning_budget" not in kwargs["extra_body"]
+
+    def test_nvidia_ultra_maps_medium_reasoning_effort(self, transport):
+        profile = get_provider_profile("nvidia")
+        kwargs = transport.build_kwargs(
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            messages=_msgs(),
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        assert kwargs["extra_body"]["chat_template_kwargs"] == {
+            "enable_thinking": True,
+            "medium_effort": True,
+        }
+        assert "reasoning_budget" not in kwargs["extra_body"]
+
+    def test_nvidia_ultra_maps_high_reasoning_effort(self, transport):
+        profile = get_provider_profile("nvidia")
+        kwargs = transport.build_kwargs(
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            messages=_msgs(),
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config={"enabled": True, "effort": "high"},
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        assert kwargs["extra_body"]["chat_template_kwargs"] == {"enable_thinking": True}
+        assert "reasoning_budget" not in kwargs["extra_body"]
+
 
 class TestDeepSeekProfileWiring:
     def test_deepseek_no_forced_max_tokens(self, transport):


### PR DESCRIPTION
## Summary
- Keep the currently selected model visible in model option payloads even when a provider catalog is capped.
- Prioritize the active provider in the desktop model menu so users can find the model they are actually running.
- Add NVIDIA Nemotron 3 Ultra thinking parameter mapping and model-info capability fallback for newly launched catalog entries.

## Why
The desktop status bar could show an active model while the dropdown could not expose that model's options. This can happen when a large provider catalog is capped before the active model appears in the list. In practice, NVIDIA Nemotron 3 Ultra can sit beyond the `/api/model/options` provider slice while still being the configured active model.

NVIDIA Nemotron 3 Ultra also requires NIM-specific `chat_template_kwargs` for thinking controls instead of generic `extra_body.reasoning` / `reasoning_effort` fields. Without this mapping, the desktop reasoning controls can be visible but not actually drive the Ultra API correctly.

Finally, newly released models can lag behind `models.dev` metadata. The model-info endpoint now falls back to known Ultra capabilities so the desktop can expose reasoning controls while the external catalog catches up.

## Test Plan
- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py::TestModelInfoEndpoint::test_model_info_nvidia_ultra_reasoning_fallback tests/hermes_cli/test_inventory.py::test_build_models_payload_keeps_current_model_when_curated_slice_omits_it tests/providers/test_e2e_wiring.py::TestNvidiaProfileWiring::test_nvidia_ultra_disables_thinking_when_reasoning_off tests/providers/test_e2e_wiring.py::TestNvidiaProfileWiring::test_nvidia_ultra_maps_medium_reasoning_effort tests/providers/test_e2e_wiring.py::TestNvidiaProfileWiring::test_nvidia_ultra_maps_high_reasoning_effort -q --timeout-method=thread`
- `npx vitest run --environment jsdom src/app/shell/model-menu-panel.test.ts`
- `npm run type-check`
