### PR TITLE
fix(cron): normalize script paths before validation (#26595)

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -573,7 +573,7 @@ class TestUnifiedCronjobTool:
         assert created["job"]["script"] == "check.py"
         assert get_job(created["job_id"])["script"] == "check.py"
 
-    def test_create_rejects_missing_script(self):
+    def test_create_allows_missing_script_and_stores_normalized_path(self):
         created = json.loads(
             cronjob(
                 action="create",
@@ -583,10 +583,10 @@ class TestUnifiedCronjobTool:
             )
         )
 
-        assert created["success"] is False
-        assert "not found" in created["error"].lower()
+        assert created["success"] is True
+        assert created["job"]["script"] == "missing.py"
 
-    def test_update_rejects_missing_script(self):
+    def test_update_allows_missing_script_and_stores_normalized_path(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
 
         updated = json.loads(
@@ -597,8 +597,8 @@ class TestUnifiedCronjobTool:
             )
         )
 
-        assert updated["success"] is False
-        assert "not found" in updated["error"].lower()
+        assert updated["success"] is True
+        assert updated["job"]["script"] == "missing.py"
 
     def test_update_strips_scripts_prefix_before_storing(self):
         from cron.jobs import get_job

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -247,6 +247,14 @@ class TestUnifiedCronjobTool:
         monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
         monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
 
+    def _write_script(self, relative_path="check.py"):
+        from hermes_constants import get_hermes_home
+
+        script = get_hermes_home() / "scripts" / relative_path
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("print('ok')\n", encoding="utf-8")
+        return script
+
     def test_create_and_list(self):
         created = json.loads(
             cronjob(
@@ -527,6 +535,129 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
+
+    def test_create_with_existing_script_stores_relative_path(self):
+        from cron.jobs import get_job
+
+        self._write_script("check.py")
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script="check.py",
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["script"] == "check.py"
+        assert get_job(created["job_id"])["script"] == "check.py"
+
+    @pytest.mark.parametrize("script_input", ["scripts/check.py", "./scripts/check.py", "scripts\\check.py"])
+    def test_create_strips_scripts_prefix_before_storing(self, script_input):
+        from cron.jobs import get_job
+
+        self._write_script("check.py")
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script=script_input,
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["script"] == "check.py"
+        assert get_job(created["job_id"])["script"] == "check.py"
+
+    def test_create_rejects_missing_script(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script="missing.py",
+            )
+        )
+
+        assert created["success"] is False
+        assert "not found" in created["error"].lower()
+
+    def test_update_rejects_missing_script(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                script="missing.py",
+            )
+        )
+
+        assert updated["success"] is False
+        assert "not found" in updated["error"].lower()
+
+    def test_update_strips_scripts_prefix_before_storing(self):
+        from cron.jobs import get_job
+
+        self._write_script("check.py")
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                script="scripts/check.py",
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["script"] == "check.py"
+        assert get_job(created["job_id"])["script"] == "check.py"
+
+    @pytest.mark.parametrize(
+        "script_input,error_text",
+        [
+            ("/tmp/check.py", "absolute"),
+            ("C:\\Users\\evil\\check.py", "absolute"),
+            ("~/check.py", "absolute"),
+            ("../check.py", "traversal"),
+            ("scripts/../check.py", "traversal"),
+        ],
+    )
+    def test_create_rejects_unsafe_script_paths(self, script_input, error_text):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script=script_input,
+            )
+        )
+
+        assert created["success"] is False
+        assert error_text in created["error"].lower()
+
+    def test_update_empty_string_clears_script(self):
+        self._write_script("check.py")
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script="check.py",
+            )
+        )
+
+        updated = json.loads(
+            cronjob(action="update", job_id=created["job_id"], script="")
+        )
+
+        assert updated["success"] is True
+        assert "script" not in updated["job"]
 
 
 # =========================================================================

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -578,14 +578,7 @@ def _validate_cron_script_path(script: Optional[str]) -> tuple[Optional[str], Op
             f"Script path escapes the scripts directory via traversal: {raw!r}"
         )
 
-    resolved = candidate.resolve()
-    if not resolved.is_file():
-        return None, (
-            f"Script path not found under ~/.hermes/scripts/: {raw!r}. "
-            f"Place the script in ~/.hermes/scripts/ and use its relative path."
-        )
-
-    normalized_relative = resolved.relative_to(scripts_dir.resolve()).as_posix()
+    normalized_relative = candidate.relative_to(scripts_dir).as_posix()
     return normalized_relative, None
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -9,7 +9,7 @@ import json
 import logging
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import display_hermes_home
@@ -444,7 +444,6 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     text = str(value).strip()
     return text or None
 
-
 def _validate_cron_base_url(
     provider: Optional[Any], base_url: Optional[Any]
 ) -> Optional[str]:
@@ -525,43 +524,69 @@ def _validate_cron_base_url(
     )
 
 
-def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
-    """Validate a cron job script path at the API boundary.
+def _validate_cron_script_path(script: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Normalize and validate a cron job script path at the API boundary.
 
     Scripts must be relative paths that resolve within HERMES_HOME/scripts/.
     Absolute paths and ~ expansion are rejected to prevent arbitrary script
     execution via prompt injection.
 
-    Returns an error string if blocked, else None (valid).
+    Returns ``(normalized_path, error)``. Empty/None script values return
+    ``(None, None)`` so callers can clear the field.
     """
-    if not script or not script.strip():
-        return None  # empty/None = clearing the field, always OK
+    if script is None:
+        return None, None
 
     from hermes_constants import get_hermes_home
 
-    raw = script.strip()
+    raw = str(script).strip()
+    if not raw:
+        return None, None  # empty = clearing the field, always OK
 
     # Reject absolute paths and ~ expansion at the API boundary.
     # Only relative paths within ~/.hermes/scripts/ are allowed.
-    if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
-        return (
+    if (
+        raw.startswith(("/", "\\", "~"))
+        or (len(raw) >= 2 and raw[1] == ":")
+        or PureWindowsPath(raw).is_absolute()
+    ):
+        return None, (
             f"Script path must be relative to ~/.hermes/scripts/. "
             f"Got absolute or home-relative path: {raw!r}. "
             f"Place scripts in ~/.hermes/scripts/ and use just the filename."
         )
 
-    # Validate containment after resolution
+    normalized = raw.replace("\\", "/")
+    if normalized.startswith("./scripts/"):
+        normalized = normalized[len("./scripts/"):]
+    elif normalized.startswith("scripts/"):
+        normalized = normalized[len("scripts/"):]
+
     from tools.path_security import validate_within_dir
 
-    scripts_dir = get_hermes_home() / "scripts"
-    scripts_dir.mkdir(parents=True, exist_ok=True)
-    containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
-    if containment_error:
-        return (
+    if ".." in Path(normalized).parts:
+        return None, (
             f"Script path escapes the scripts directory via traversal: {raw!r}"
         )
 
-    return None
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    candidate = scripts_dir / normalized
+    containment_error = validate_within_dir(candidate, scripts_dir)
+    if containment_error:
+        return None, (
+            f"Script path escapes the scripts directory via traversal: {raw!r}"
+        )
+
+    resolved = candidate.resolve()
+    if not resolved.is_file():
+        return None, (
+            f"Script path not found under ~/.hermes/scripts/: {raw!r}. "
+            f"Place the script in ~/.hermes/scripts/ and use its relative path."
+        )
+
+    normalized_relative = resolved.relative_to(scripts_dir.resolve()).as_posix()
+    return normalized_relative, None
 
 
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
@@ -685,8 +710,9 @@ def cronjob(
             #     (and irrelevant to execution).
             #   - no_agent=False (default) → at least one of prompt/skills must
             #     be set, same as before.
+            script_value = _normalize_optional_job_value(script)
             if _no_agent:
-                if not script:
+                if not script_value:
                     return tool_error(
                         "create with no_agent=True requires a script — "
                         "the script is the job.",
@@ -699,9 +725,9 @@ def cronjob(
                 if scan_error:
                     return tool_error(scan_error, success=False)
 
-            # Validate script path before storing
-            if script:
-                script_error = _validate_cron_script_path(script)
+            normalized_script = None
+            if script_value:
+                normalized_script, script_error = _validate_cron_script_path(script_value)
                 if script_error:
                     return tool_error(script_error, success=False)
 
@@ -734,7 +760,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
-                script=_normalize_optional_job_value(script),
+                script=normalized_script,
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
@@ -886,11 +912,10 @@ def cronjob(
                 return tool_error(base_url_error, success=False)
             if script is not None:
                 # Pass empty string to clear an existing script
-                if script:
-                    script_error = _validate_cron_script_path(script)
-                    if script_error:
-                        return tool_error(script_error, success=False)
-                updates["script"] = _normalize_optional_job_value(script) if script else None
+                normalized_script, script_error = _validate_cron_script_path(script)
+                if script_error:
+                    return tool_error(script_error, success=False)
+                updates["script"] = normalized_script
             if context_from is not None:
                 # Empty string / empty list clears the field; otherwise validate
                 # each referenced job exists before storing. Normalized to a list

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -144,10 +144,11 @@ If a job ran and failed, you may see error context in:
 ### Check 2: Common error patterns
 
 **"No such file or directory" for scripts**
-The `script` path must be an absolute path (or relative to the Hermes config directory). Verify:
+The `script` path must be relative to `~/.hermes/scripts/`. Verify:
 ```bash
 ls ~/.hermes/scripts/your-script.py   # Must exist
-hermes cron edit <job_id> --script ~/.hermes/scripts/your-script.py
+hermes cron edit <job_id> --script your-script.py
+# `scripts/your-script.py` is also accepted and normalized before storage.
 ```
 
 **"Skill not found" at job execution**


### PR DESCRIPTION
## Summary

Cron script paths are documented as relative to `~/.hermes/scripts/`, but the cron tool currently joins the raw user string directly to that directory. A user-provided `scripts/check.py` therefore resolves as `~/.hermes/scripts/scripts/check.py`.

This normalizes script paths at the cron tool boundary, accepts one leading `scripts/` prefix as user-friendly input, rejects absolute and traversal paths, and persists the normalized relative path on create and update. Missing scripts still use deferred resolution: the stored job remains valid, and execution reports the missing file later from the scheduler.

Fixes #26595.

## Changes

- `tools/cronjob_tools.py`: normalize cron script paths and return the normalized storage value on create and update.
- `tests/tools/test_cronjob_tools.py`: add regression coverage for `scripts/` prefix normalization, Windows separator normalization, deferred missing-script storage, traversal and absolute-path rejection, and update clearing.
- `website/docs/guides/cron-troubleshooting.md`: document the profile-relative `--script` form that matches the tool and scheduler behavior.

## Validation

| Scenario | Before | After |
|---|---|---|
| `script="scripts/check.py"` | Stored as `scripts/check.py`, resolving under a duplicate scripts directory | Stored as `check.py` |
| `script="scripts\\check.py"` | Stored with the raw separator form | Stored as `check.py` |
| Missing script file | Job could be stored and fail later at runtime | Job is still stored, but the normalized path is preserved and the runtime failure stays deferred |
| Empty script on update | Cleared the script field | Still clears the script field |

## Test plan

- `python -m pytest tests/tools/test_cronjob_tools.py -v --timeout=0`: 72 passed
- Opus cross-provider review: PASS after fixing the reviewer-requested `script_value` consistency issue and adding Windows separator coverage
