### PR TITLE
fix(cli): drain completion notifications before blocking for input (#21904)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12569,6 +12569,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             ] if item is not None
         ]
 
+    def _drain_process_notifications(self) -> None:
+        try:
+            from tools.process_registry import process_registry
+            for _evt, _synth in process_registry.drain_notifications():
+                self._pending_input.put(_synth)
+        except Exception as exc:
+            logger.debug("failed to drain process notifications: %s", exc)
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
@@ -14606,6 +14614,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         def process_loop():
             while not self._should_exit:
                 try:
+                    # Pull completion/watch notifications before blocking on input
+                    # so already-queued user input cannot starve synthetic events.
+                    self._drain_process_notifications()
+
                     # Check for pending input with timeout
                     try:
                         user_input = self._pending_input.get(timeout=0.1)
@@ -14613,14 +14625,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:
                             self._check_config_mcp_changes()
-                            # Check for background process notifications (completions
-                            # and watch pattern matches) while agent is idle.
-                            try:
-                                from tools.process_registry import process_registry
-                                for _evt, _synth in process_registry.drain_notifications():
-                                    self._pending_input.put(_synth)
-                            except Exception:
-                                pass
                         continue
                     
                     if not user_input:
@@ -14768,12 +14772,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
                         # Drain process notifications (completions + watch matches)
                         # that arrived while the agent was running.
-                        try:
-                            from tools.process_registry import process_registry
-                            for _evt, _synth in process_registry.drain_notifications():
-                                self._pending_input.put(_synth)
-                        except Exception:
-                            pass  # Non-fatal — don't break the main loop
+                        self._drain_process_notifications()
 
                 except Exception as e:
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)

--- a/tests/cli/test_cli_process_notifications.py
+++ b/tests/cli/test_cli_process_notifications.py
@@ -1,0 +1,21 @@
+import queue
+
+
+def test_process_notification_drain_does_not_wait_for_empty_input(monkeypatch):
+    import cli as cli_mod
+    import tools.process_registry as pr_mod
+
+    cli_obj = object.__new__(cli_mod.HermesCLI)
+    cli_obj._pending_input = queue.Queue()
+    cli_obj._pending_input.put("already queued")
+
+    class _FakeRegistry:
+        def drain_notifications(self):
+            return [("completed", "synthetic completion")]
+
+    monkeypatch.setattr(pr_mod, "process_registry", _FakeRegistry())
+
+    cli_obj._drain_process_notifications()
+
+    assert cli_obj._pending_input.get_nowait() == "already queued"
+    assert cli_obj._pending_input.get_nowait() == "synthetic completion"


### PR DESCRIPTION
## Summary

CLI background-process notifications are drained only when `_pending_input.get(timeout=0.1)` times out or after an agent turn finishes. If user input is already queued, the idle drain path is skipped, so `notify_on_complete` messages can be delayed during active CLI usage.

This extracts the notification drain into a small helper and calls it before blocking for input on each process-loop iteration, while preserving the existing post-agent drain. Drain failures remain non-fatal and now emit a debug log instead of disappearing completely.

Fixes #21904.

## Changes

- `cli.py`: drain `process_registry` notifications before waiting on `_pending_input`, and reuse the helper after agent turns.
- `tests/cli/test_cli_process_notifications.py`: add regression coverage for queued user input plus a queued completion notification.

## Validation

| Scenario | Before | After |
|---|---|---|
| User input already queued and process notification queued | Notification drain waited for an idle timeout or later turn boundary | Notification is drained before blocking for the next input |
| Already queued user input | Preserved | Still preserved ahead of the synthetic notification |
| Drain failure | Silently ignored | Still non-fatal, debug logged |

## Test plan

- `python -m pytest tests/cli -k "background or notification or process" -v --timeout=0`: 35 passed, 854 deselected, 1 warning
- Opus cross-provider review: PASS
