### PR TITLE
fix(cli): resolve symlinked skill paths in gateway slash-command menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -736,6 +736,14 @@ def _collect_gateway_skill_entries(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
+            # Normalize symlinks on BOTH sides: _allowed_prefixes / _hub_dir
+            # are built from SKILLS_DIR.resolve() (symlinks followed), but
+            # get_skill_commands() stores skill_md_path unresolved. When the
+            # profile skills dir is a symlink (e.g. ~/.hermes/profiles/<p>/
+            # skills -> vault), the raw startswith() check fails for every
+            # skill and the whole tier is silently dropped from the menu
+            # while /skill-name dispatch still works (extends #8110).
+            skill_path = os.path.realpath(skill_path)
             if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
                 continue
             if skill_path.startswith(_hub_dir):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -738,7 +738,7 @@ def _collect_gateway_skill_entries(
         for _ext in get_external_skills_dirs():
             try:
                 _allowed_roots.append(_P(_ext).resolve())
-            except (OSError, RuntimeError):
+            except (OSError, RuntimeError, ValueError):
                 continue
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
@@ -757,7 +757,7 @@ def _collect_gateway_skill_entries(
             # the outer ``except``.
             try:
                 sp = _P(skill_path).resolve()
-            except (OSError, RuntimeError):
+            except (OSError, RuntimeError, ValueError):
                 continue
             if not any(sp.is_relative_to(root) for root in _allowed_roots):
                 continue

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -715,38 +715,53 @@ def _collect_gateway_skill_entries(
 
     skill_triples: list[tuple[str, str, str]] = []
     try:
+        from pathlib import Path as _P
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
-        # Build set of allowed directory prefixes: local skills dir + any
-        # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
-        # Without this widening, external skills are visible in
-        # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
-        # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
-        )
+        # Allowed roots: local skills dir + any user-configured
+        # ``skills.external_dirs``. Kept as resolved ``Path`` objects so
+        # containment is decided by :meth:`Path.is_relative_to` (component-wise)
+        # rather than string prefixes — this avoids the ``/my-skills`` vs
+        # ``/my-skills-extra`` boundary trap and platform separator issues, and
+        # mirrors ``discord_skill_commands_by_category``. Without this widening,
+        # external skills are visible in ``hermes skills list`` and the agent's
+        # ``/skill-name`` dispatch but silently excluded from gateway slash
+        # menus (#8110).
+        _skills_dir = SKILLS_DIR.resolve()
+        _hub_dir = (SKILLS_DIR / ".hub").resolve()
+        _allowed_roots = [_skills_dir]
+        # Resolve each external root defensively: a single broken root (symlink
+        # loop -> RuntimeError, unreadable -> OSError) must not wipe the whole
+        # skill tier, including healthy local skills. Mirrors the per-root guard
+        # in ``discord_skill_commands_by_category``.
+        for _ext in get_external_skills_dirs():
+            try:
+                _allowed_roots.append(_P(_ext).resolve())
+            except (OSError, RuntimeError):
+                continue
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            # Normalize symlinks on BOTH sides: _allowed_prefixes / _hub_dir
-            # are built from SKILLS_DIR.resolve() (symlinks followed), but
-            # get_skill_commands() stores skill_md_path unresolved. When the
-            # profile skills dir is a symlink (e.g. ~/.hermes/profiles/<p>/
-            # skills -> vault), the raw startswith() check fails for every
-            # skill and the whole tier is silently dropped from the menu
-            # while /skill-name dispatch still works (extends #8110).
-            skill_path = os.path.realpath(skill_path)
-            if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
+            # Resolve symlinks on the skill side too: the roots above follow
+            # symlinks via ``.resolve()``, but ``get_skill_commands()`` stores
+            # ``skill_md_path`` unresolved. When the profile skills dir is a
+            # symlink (e.g. ~/.hermes/profiles/<p>/skills -> vault), a raw
+            # comparison fails for every skill and the whole tier is silently
+            # dropped from the menu while /skill-name dispatch still works.
+            # A per-skill guard keeps one unresolvable path (symlink loop ->
+            # RuntimeError) from dropping every alphabetically-later skill via
+            # the outer ``except``.
+            try:
+                sp = _P(skill_path).resolve()
+            except (OSError, RuntimeError):
                 continue
-            if skill_path.startswith(_hub_dir):
+            if not any(sp.is_relative_to(root) for root in _allowed_roots):
+                continue
+            if sp.is_relative_to(_hub_dir):
                 continue
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:

--- a/tests/hermes_cli/test_gateway_skill_menu_symlink.py
+++ b/tests/hermes_cli/test_gateway_skill_menu_symlink.py
@@ -1,0 +1,95 @@
+"""Regression: symlinked profile skills dir must not drop skills from the menu.
+
+Local patch ``gateway-skill-menu-symlink-resolve`` (hermes tooling/patches,
+issue NousResearch/hermes-agent#8108). Extends the #8110 external-dir fix.
+
+``_collect_gateway_skill_entries`` builds its allowed prefixes from
+``SKILLS_DIR.resolve()`` (symlinks followed) but ``get_skill_commands()`` stores
+``skill_md_path`` unresolved. When a profile's skills dir is a symlink to a
+shared source (``~/.hermes/profiles/<p>/skills -> vault``), the raw
+``startswith()`` check fails for every skill and the whole skill tier is
+silently dropped from the Telegram/Discord menu — while ``/skill-name`` dispatch
+still works. The fix normalizes ``skill_path`` with ``os.path.realpath`` so both
+sides live in the same symlink-resolved namespace.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.commands import telegram_menu_commands
+
+
+def _write_min_config(tmp_path):
+    """HERMES_HOME config with no disabled skills, so the platform-disabled
+    filter does not interfere with what we are actually asserting."""
+    (tmp_path / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+
+
+class TestSymlinkedSkillsDirMenu:
+    def test_skill_under_symlinked_skills_dir_appears_in_menu(self, tmp_path, monkeypatch):
+        # Real source the symlink points at, plus the symlinked skills dir
+        # (mirrors ~/.hermes/profiles/<p>/skills -> vault).
+        real_src = tmp_path / "vault-skills"
+        real_src.mkdir()
+        link_dir = tmp_path / "skills"  # the symlink == patched SKILLS_DIR
+        link_dir.symlink_to(real_src, target_is_directory=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_min_config(tmp_path)
+
+        # skill_md_path stored UNRESOLVED (via the symlink), as get_skill_commands does.
+        fake_cmds = {
+            "/frontend-design": {
+                "name": "frontend-design",
+                "description": "Distinctive frontend UI",
+                "skill_md_path": f"{link_dir}/creative/frontend-design/SKILL.md",
+                "skill_dir": f"{link_dir}/creative/frontend-design",
+            },
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", link_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "frontend_design" in {n for n, _ in menu}, (
+            "skill under a symlinked SKILLS_DIR must appear in the menu "
+            "(realpath normalization of skill_md_path)"
+        )
+
+    def test_hub_skill_under_symlinked_dir_still_excluded(self, tmp_path, monkeypatch):
+        """The .hub exclusion must survive realpath normalization."""
+        real_src = tmp_path / "vault-skills"
+        real_src.mkdir()
+        link_dir = tmp_path / "skills"
+        link_dir.symlink_to(real_src, target_is_directory=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_min_config(tmp_path)
+
+        fake_cmds = {
+            "/normal-skill": {
+                "name": "normal-skill",
+                "description": "Regular skill",
+                "skill_md_path": f"{link_dir}/creative/normal-skill/SKILL.md",
+                "skill_dir": f"{link_dir}/creative/normal-skill",
+            },
+            "/hub-skill": {
+                "name": "hub-skill",
+                "description": "Hub-installed, lives under .hub",
+                "skill_md_path": f"{link_dir}/.hub/hub-skill/SKILL.md",
+                "skill_dir": f"{link_dir}/.hub/hub-skill",
+            },
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", link_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        names = {n for n, _ in menu}
+        assert "normal_skill" in names, "non-hub skill must appear"
+        assert "hub_skill" not in names, ".hub skill must stay excluded after realpath"

--- a/tests/hermes_cli/test_gateway_skill_menu_symlink.py
+++ b/tests/hermes_cli/test_gateway_skill_menu_symlink.py
@@ -15,7 +15,19 @@ sides live in the same symlink-resolved namespace.
 
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.commands import telegram_menu_commands
+
+
+def _symlink_dir_or_skip(link, target):
+    """Create a directory symlink, skipping on platforms without symlink
+    support (e.g. Windows without Developer Mode). Mirrors the
+    ``_symlink_file_or_skip`` helper in test_profile_distribution.py."""
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
 
 
 def _write_min_config(tmp_path):
@@ -31,7 +43,7 @@ class TestSymlinkedSkillsDirMenu:
         real_src = tmp_path / "vault-skills"
         real_src.mkdir()
         link_dir = tmp_path / "skills"  # the symlink == patched SKILLS_DIR
-        link_dir.symlink_to(real_src, target_is_directory=True)
+        _symlink_dir_or_skip(link_dir, real_src)
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         _write_min_config(tmp_path)
@@ -63,7 +75,7 @@ class TestSymlinkedSkillsDirMenu:
         real_src = tmp_path / "vault-skills"
         real_src.mkdir()
         link_dir = tmp_path / "skills"
-        link_dir.symlink_to(real_src, target_is_directory=True)
+        _symlink_dir_or_skip(link_dir, real_src)
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         _write_min_config(tmp_path)

--- a/tests/hermes_cli/test_gateway_skill_menu_symlink.py
+++ b/tests/hermes_cli/test_gateway_skill_menu_symlink.py
@@ -9,8 +9,12 @@ issue NousResearch/hermes-agent#8108). Extends the #8110 external-dir fix.
 shared source (``~/.hermes/profiles/<p>/skills -> vault``), the raw
 ``startswith()`` check fails for every skill and the whole skill tier is
 silently dropped from the Telegram/Discord menu — while ``/skill-name`` dispatch
-still works. The fix normalizes ``skill_path`` with ``os.path.realpath`` so both
-sides live in the same symlink-resolved namespace.
+still works. The fix resolves both sides with ``Path.resolve()`` and tests
+containment with ``Path.is_relative_to()`` (mirroring
+``discord_skill_commands_by_category``), so both live in the same
+symlink-resolved namespace. Per-skill and per-external-root resolution are
+guarded so a single unresolvable path (symlink loop) cannot drop unrelated
+skills.
 """
 
 from unittest.mock import patch
@@ -105,3 +109,94 @@ class TestSymlinkedSkillsDirMenu:
         names = {n for n, _ in menu}
         assert "normal_skill" in names, "non-hub skill must appear"
         assert "hub_skill" not in names, ".hub skill must stay excluded after realpath"
+
+    def test_symlink_loop_path_does_not_drop_other_skills(self, tmp_path, monkeypatch):
+        """A single unresolvable skill_md_path (symlink loop -> RuntimeError
+        from Path.resolve) must skip only that skill, not every
+        alphabetically-later one via the collector's outer ``except``."""
+        real_src = tmp_path / "vault-skills"
+        real_src.mkdir()
+        link_dir = tmp_path / "skills"
+        _symlink_dir_or_skip(link_dir, real_src)
+
+        # Build an actual symlink loop: loop-a -> loop-b -> loop-a.
+        loop_a = tmp_path / "loop-a"
+        loop_b = tmp_path / "loop-b"
+        try:
+            loop_a.symlink_to(loop_b)
+            loop_b.symlink_to(loop_a)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_min_config(tmp_path)
+
+        # "/aaa-broken" sorts before "/zzz-good"; the broken one loops.
+        fake_cmds = {
+            "/aaa-broken": {
+                "name": "aaa-broken",
+                "description": "Path runs through a symlink loop",
+                "skill_md_path": f"{loop_a}/SKILL.md",
+                "skill_dir": f"{loop_a}",
+            },
+            "/zzz-good": {
+                "name": "zzz-good",
+                "description": "Healthy skill under the real dir",
+                "skill_md_path": f"{link_dir}/creative/zzz-good/SKILL.md",
+                "skill_dir": f"{link_dir}/creative/zzz-good",
+            },
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", link_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        names = {n for n, _ in menu}
+        assert "zzz_good" in names, (
+            "a healthy skill must survive even when an alphabetically-earlier "
+            "skill has an unresolvable (symlink-loop) path"
+        )
+        assert "aaa_broken" not in names, "the unresolvable skill is skipped"
+
+    def test_broken_external_root_does_not_drop_local_skills(self, tmp_path, monkeypatch):
+        """A broken entry from get_external_skills_dirs() (symlink loop) must
+        not wipe the whole tier while building _allowed_roots — local skills
+        under the real SKILLS_DIR must still appear."""
+        real_src = tmp_path / "vault-skills"
+        real_src.mkdir()
+        link_dir = tmp_path / "skills"
+        _symlink_dir_or_skip(link_dir, real_src)
+
+        ext_a = tmp_path / "ext-a"
+        ext_b = tmp_path / "ext-b"
+        try:
+            ext_a.symlink_to(ext_b)
+            ext_b.symlink_to(ext_a)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_min_config(tmp_path)
+
+        fake_cmds = {
+            "/local-skill": {
+                "name": "local-skill",
+                "description": "Healthy local skill",
+                "skill_md_path": f"{link_dir}/creative/local-skill/SKILL.md",
+                "skill_dir": f"{link_dir}/creative/local-skill",
+            },
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", link_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[str(ext_a)]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "local_skill" in {n for n, _ in menu}, (
+            "a broken external root must not drop healthy local skills"
+        )


### PR DESCRIPTION
## Summary

Fixes #8108 (profile gateways register only the core command set instead of the full skill menu) **for the case where a profile's skills directory is a symlink**.

`gateway`'s `_collect_gateway_skill_entries` (in `hermes_cli/commands.py`) builds its allowed-prefix set from `SKILLS_DIR.resolve()` (symlinks followed), but `get_skill_commands()` stores each `skill_md_path` **unresolved**. When the profile skills dir is a symlink to a shared source — e.g. `~/.hermes/profiles/<profile>/skills -> /some/shared/skills` — the `skill_path.startswith(prefix)` check is `False` for **every** skill, so the entire skill tier is silently dropped from the Telegram/Discord slash-command menu. Dispatch is unaffected (`resolve_skill_command_key` does not do this prefix check), so `/skill-name` keeps working while the menu shows nothing — which is what makes it easy to misdiagnose.

## Fix

Normalize `skill_path` with `os.path.realpath` before the prefix and `.hub` checks, so both sides are compared in the same symlink-resolved namespace. One line; the `.hub` exclusion and `external_dirs` matching are unaffected (both already resolved).

## Test

Adds `tests/hermes_cli/test_gateway_skill_menu_symlink.py`:
- a skill under a symlinked `SKILLS_DIR` now appears in the menu (the regression), and
- a `.hub` skill under a symlinked `SKILLS_DIR` stays excluded (proves the exclusion survives normalization).

Verified red-without / green-with the fix.

## Related

- Extends #8110 (the `external_dirs` prefix-widening fix) to the symlinked-`SKILLS_DIR` case.
- Complements #27662 (symlinked skill *dispatch* loading) — that addresses `_load_skill_payload`/`skill_view`; this addresses the gateway *menu* filter, a separate code path.
