### PR TITLE
fix(desktop): make rawText required in SlashItemMetadata

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -16,7 +16,7 @@ interface SlashItemMetadata extends Record<string, string> {
   command: string
   display: string
   meta: string
-  rawText?: string
+  rawText: string
 }
 
 function textValue(value: unknown, fallback = ''): string {


### PR DESCRIPTION
## What does this PR do?

Fixes a TypeScript compilation error (`TS2411`) in the desktop app build. The `SlashItemMetadata` interface extends `Record<string, string>`, which requires all property values to be `string`. However, `rawText` was declared as optional (`string | undefined`), causing `tsc -b` to fail during `npm run pack` on Windows. Since `rawText` is always assigned in `toItem()`, making it required resolves the type incompatibility without changing runtime behavior.

This error appears with TypeScript 6.0.3 and `strict: true` in `apps/desktop/tsconfig.json`.

This PR addresses the TypeScript compilation error described in #39404. The separate updater reliability issue (deletion of existing app on failed update) is not covered here.

## Related Issue

Fixes #39404 (TypeScript build error part)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts`: Changed `rawText?: string` to `rawText: string` in the `SlashItemMetadata` interface.

## How to Test

1. Clone the repo and install dependencies:
   ```bash
   git clone https://github.com/NousResearch/hermes-agent.git
   cd hermes-agent
   npm install
   ```

2. Run the desktop TypeScript build:
   ```bash
   cd apps/desktop
   npx tsc -b
   ```

**Before the fix:** `error TS2411: Property 'rawText' of type 'string | undefined' is not assignable to 'string' index type 'string'.`

**After the fix:** Build completes successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A — TypeScript/desktop change, no Python tests affected)
- [ ] I've added tests for my changes (N/A — type-level fix, runtime behavior unchanged)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — This is a type-only change with no runtime effect; safe across platforms.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Build error before fix:

```
src/app/chat/composer/hooks/use-slash-completions.ts(19,3): error TS2411: Property 'rawText' of type 'string | undefined' is not assignable to 'string' index type 'string'.
```

Build passes after fix.