### PR TITLE
fix(tools): include QQBot REST error details in standalone sends

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -9,11 +9,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# python-telegram-bot is an optional dep — skip the entire module when
-# it isn't installed (e.g. CI bare env). Tests that patch telegram.Bot
-# or call _send_telegram need it; tests for other platforms don't but
-# keeping the whole file consistent is simpler.
-_HAS_TELEGRAM = pytest.importorskip("telegram", reason="python-telegram-bot not installed") is not None
+# python-telegram-bot is optional. Keep a tiny stub available so non-Telegram
+# tests in this mixed module still run in the hermetic wrapper when the real
+# dependency is absent.
+try:
+    import telegram as _telegram_module  # noqa: F401
+    _HAS_TELEGRAM = True
+except ImportError:
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode)
+
+    class _MissingTelegramBot:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    telegram_mod = SimpleNamespace(
+        Bot=_MissingTelegramBot,
+        MessageEntity=lambda **_kw: SimpleNamespace(**_kw),
+        constants=constants_mod,
+    )
+    sys.modules["telegram"] = telegram_mod
+    sys.modules["telegram.constants"] = constants_mod
+    _HAS_TELEGRAM = False
 
 
 @pytest.fixture(autouse=True)
@@ -30,6 +47,7 @@ from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
     _send_matrix_via_adapter,
+    _send_qqbot,
     _send_signal,
     _send_telegram,
     _send_to_platform,
@@ -1407,6 +1425,174 @@ class TestSendToPlatformDiscordThread:
         send_mock.assert_awaited_once()
         _, call_kwargs = send_mock.await_args
         assert call_kwargs["thread_id"] is None
+
+
+class _FakeQQBotResponse:
+    def __init__(self, status_code, *, data=None, text=""):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = text
+
+    def json(self):
+        return self._data
+
+
+class _FakeQQBotHttp:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, *_args, **_kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        if not self.responses:
+            raise AssertionError("Unexpected QQBot POST")
+        return self.responses.pop(0)
+
+
+def _install_qqbot_http(monkeypatch, fake):
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient", fake)
+
+
+class TestSendQQBotDiagnostics:
+    def test_token_failure_includes_endpoint_status_body_and_redacts_secrets(self, monkeypatch):
+        secret = "qq-client-secret-raw"
+        echoed_access_token = "qq-access-token-from-error"
+        fake = _FakeQQBotHttp([
+            _FakeQQBotResponse(
+                401,
+                text=(
+                    '{"error":"invalid secret","clientSecret":"%s",'
+                    '"accessToken":"%s"} Authorization: QQBot raw-auth-token'
+                ) % (secret, echoed_access_token),
+            )
+        ])
+        _install_qqbot_http(monkeypatch, fake)
+
+        result = asyncio.run(
+            _send_qqbot(
+                SimpleNamespace(token=secret, extra={"app_id": "appid-123"}),
+                "target-1",
+                "hello",
+            )
+        )
+
+        error = result["error"]
+        assert "QQBot token request failed" in error
+        assert "token endpoint=https://bots.qq.com/app/getAppAccessToken" in error
+        assert "status=401" in error
+        assert "invalid secret" in error
+        assert secret not in error
+        assert echoed_access_token not in error
+        assert "raw-auth-token" not in error
+        assert '"clientSecret":"***"' in error
+        assert '"accessToken":"***"' in error
+        assert "Authorization: QQBot ***" in error
+
+    def test_missing_access_token_includes_token_response_body(self, monkeypatch):
+        secret = "qq-client-secret-raw"
+        fake = _FakeQQBotHttp([
+            _FakeQQBotResponse(
+                200,
+                data={"expires_in": 7200},
+                text='{"expires_in":7200,"client_secret":"echoed-secret"}',
+            )
+        ])
+        _install_qqbot_http(monkeypatch, fake)
+
+        result = asyncio.run(
+            _send_qqbot(
+                SimpleNamespace(token=secret, extra={"app_id": "appid-123"}),
+                "target-1",
+                "hello",
+            )
+        )
+
+        error = result["error"]
+        assert "QQBot: no access_token in response" in error
+        assert "token endpoint=https://bots.qq.com/app/getAppAccessToken" in error
+        assert "status=200" in error
+        assert "expires_in" in error
+        assert secret not in error
+        assert "echoed-secret" not in error
+        assert '"client_secret":"***"' in error
+
+    def test_all_send_endpoint_failures_include_each_body_and_redact_tokens(self, monkeypatch):
+        access_token = "qq-access-token-raw"
+        fake = _FakeQQBotHttp([
+            _FakeQQBotResponse(200, data={"access_token": access_token}),
+            _FakeQQBotResponse(400, text="channel missing"),
+            _FakeQQBotResponse(
+                403,
+                text='{"message":"c2c denied","access_token":"echoed-access-token"}',
+            ),
+            _FakeQQBotResponse(404, text="group failed accessToken=echoed-camel-token"),
+        ])
+        _install_qqbot_http(monkeypatch, fake)
+
+        result = asyncio.run(
+            _send_qqbot(
+                SimpleNamespace(token="qq-client-secret-raw", extra={"app_id": "appid-123"}),
+                "target-1",
+                "hello",
+            )
+        )
+
+        error = result["error"]
+        assert "QQBot send failed" in error
+        assert "channel endpoint=https://api.sgroup.qq.com/channels/target-1/messages status=400 body=channel missing" in error
+        assert "c2c endpoint=https://api.sgroup.qq.com/v2/users/target-1/messages status=403" in error
+        assert "c2c denied" in error
+        assert "group endpoint=https://api.sgroup.qq.com/v2/groups/target-1/messages status=404" in error
+        assert "group failed" in error
+        assert access_token not in error
+        assert "echoed-access-token" not in error
+        assert "echoed-camel-token" not in error
+        assert '"access_token": "***"' in error
+        assert "accessToken=***" in error
+
+    def test_long_response_body_secret_is_redacted_before_truncation(self, monkeypatch):
+        long_token = "qq-" + ("access-token-" * 80)
+        long_secret = "qq-" + ("client-secret-" * 80)
+        fake = _FakeQQBotHttp([
+            _FakeQQBotResponse(
+                500,
+                text=(
+                    '{"message":"token failure",'
+                    f'"access_token":"{long_token}",'
+                    f'"clientSecret":"{long_secret}"'
+                ),
+            )
+        ])
+        _install_qqbot_http(monkeypatch, fake)
+
+        result = asyncio.run(
+            _send_qqbot(
+                SimpleNamespace(token=long_secret, extra={"app_id": "appid-123"}),
+                "target-1",
+                "hello",
+            )
+        )
+
+        error = result["error"]
+        assert "QQBot token request failed" in error
+        assert "status=500" in error
+        assert "token failure" in error
+        assert long_token not in error
+        assert long_secret not in error
+        assert "access-token-access-token" not in error
+        assert "client-secret-client-secret" not in error
+        assert '"access_token": "***"' in error
+        assert '"clientSecret":"***"' in error
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -65,19 +65,68 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
 )
+_CAMEL_SECRET_JSON_RE = re.compile(
+    r'("?(?:accessToken|clientSecret|client_secret|access_token)"?\s*:\s*")([^"\s,}]+)("?)',
+    re.IGNORECASE,
+)
+_CAMEL_SECRET_ASSIGN_RE = re.compile(
+    r"\b(accessToken|clientSecret|client_secret)\s*=\s*([^\s,;]+)",
+    re.IGNORECASE,
+)
+_QQBOT_AUTH_HEADER_RE = re.compile(
+    r"(Authorization:\s*QQBot\s+)(\S+)",
+    re.IGNORECASE,
+)
+_QQBOT_DIAGNOSTIC_BODY_LIMIT = 500
 
 
 def _sanitize_error_text(text) -> str:
     """Redact secrets from error text before surfacing it to users/models."""
-    redacted = redact_sensitive_text(text)
+    redacted = redact_sensitive_text(text, force=True)
     redacted = _URL_SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}***", redacted)
     redacted = _GENERIC_SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
+    redacted = _CAMEL_SECRET_JSON_RE.sub(lambda m: f"{m.group(1)}***{m.group(3)}", redacted)
+    redacted = _CAMEL_SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
+    redacted = _QQBOT_AUTH_HEADER_RE.sub(lambda m: f"{m.group(1)}***", redacted)
     return redacted
 
 
 def _error(message: str) -> dict:
     """Build a standardized error payload with redacted content."""
     return {"error": _sanitize_error_text(message)}
+
+
+def _http_response_body_for_diagnostics(resp) -> str:
+    """Return a compact response body string for user-visible diagnostics."""
+    body = ""
+    try:
+        body = getattr(resp, "text", "")
+        if callable(body):
+            body = body()
+    except Exception:
+        body = ""
+
+    if not body:
+        try:
+            body = json.dumps(resp.json(), ensure_ascii=False, sort_keys=True)
+        except Exception:
+            body = ""
+
+    body = str(body).strip()
+    body = _sanitize_error_text(body)
+    if len(body) > _QQBOT_DIAGNOSTIC_BODY_LIMIT:
+        body = f"{body[:_QQBOT_DIAGNOSTIC_BODY_LIMIT]}…"
+    return body
+
+
+def _http_response_diagnostic(label: str, url: str, resp) -> str:
+    """Format endpoint, status, and response body for HTTP send failures."""
+    status = getattr(resp, "status_code", getattr(resp, "status", "unknown"))
+    detail = f"{label} endpoint={url} status={status}"
+    body = _http_response_body_for_diagnostics(resp)
+    if body:
+        detail += f" body={body}"
+    return detail
 
 
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
@@ -1715,11 +1764,25 @@ async def _send_qqbot(pconfig, chat_id, message):
                 json={"appId": str(appid), "clientSecret": str(secret)},
             )
             if token_resp.status_code != 200:
-                return _error(f"QQBot token request failed: {token_resp.status_code}")
+                return _error(
+                    "QQBot token request failed: "
+                    + _http_response_diagnostic(
+                        "token",
+                        "https://bots.qq.com/app/getAppAccessToken",
+                        token_resp,
+                    )
+                )
             token_data = token_resp.json()
             access_token = token_data.get("access_token")
             if not access_token:
-                return _error(f"QQBot: no access_token in response")
+                return _error(
+                    "QQBot: no access_token in response: "
+                    + _http_response_diagnostic(
+                        "token",
+                        "https://bots.qq.com/app/getAppAccessToken",
+                        token_resp,
+                    )
+                )
 
             # Step 2: Send message via REST
             # QQ Bot API has separate endpoints for channels, C2C, and groups.
@@ -1755,7 +1818,16 @@ async def _send_qqbot(pconfig, chat_id, message):
                         "message_id": data.get("id")}
 
             # All endpoints failed — return the most informative error
-            return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+            return _error(
+                "QQBot send failed: "
+                + "; ".join(
+                    [
+                        _http_response_diagnostic("channel", url, resp),
+                        _http_response_diagnostic("c2c", url_c2c, resp_c2c),
+                        _http_response_diagnostic("group", url_group, resp_group),
+                    ]
+                )
+            )
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 


### PR DESCRIPTION
## What

Improves QQBot standalone REST send failure diagnostics in `send_message`.

Failures now include endpoint, status, and sanitized response body details for:
- QQBot app access-token request failures
- token responses missing `access_token`
- channel / C2C / group send endpoint failures

## Why

Previously QQBot standalone send failures could return only status codes, leaving operators without the response body needed to diagnose QQBot API errors.

## Safety

- Response bodies are sanitized before truncation.
- Final errors are sanitized again before being returned.
- Redaction covers `access_token`, `accessToken`, `client_secret`, `clientSecret`, and `Authorization: QQBot ...`.
- Request bodies are not included in diagnostics.

## Scope

Only QQBot standalone send diagnostics are changed. This PR intentionally does not include session refresh, media delivery, cron timeout, MEDIA parsing, local config, Google, or Weixin changes.

## Tests

- `scripts/run_tests.sh tests/tools/test_send_message_tool.py` — 133 passed
- `python3 scripts/check-windows-footguns.py --diff origin/main` — clean
- `git diff --check origin/main...HEAD` — clean
- `graphify update .` — completed
