### PR TITLE
feat(image-gen): add Leonardo.AI image generation provider

### DIFF
--- a/plugins/image_gen/leonardo/__init__.py
+++ b/plugins/image_gen/leonardo/__init__.py
@@ -1,0 +1,456 @@
+"""Leonardo.AI image generation backend.
+
+Exposes Leonardo.AI's platform models (Phoenix, SDXL, Flux) as an
+:class:`ImageGenProvider` implementation.
+
+Features:
+- Text-to-image generation via official REST API
+- Multiple platform models (Phoenix, SDXL, Flux)
+- 31 preset styles (ANIME, DYNAMIC, PHOTOGRAPHY, etc.)
+- Alchemy and Prompt Magic support
+- Image-to-image via init_image_id
+
+Selection precedence (first hit wins):
+1. ``LEONARDO_IMAGE_MODEL`` env var
+2. ``image_gen.leonardo.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Leonardo REST API
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://cloud.leonardo.ai/api/rest/v1"
+_POLL_INTERVAL_S = 4
+_POLL_TIMEOUT_S = 180
+
+# ---------------------------------------------------------------------------
+# Model catalog — platform models available to all users
+# ---------------------------------------------------------------------------
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "phoenix": {
+        "id": "de7d3faf-762f-48e0-b3b7-9d0ac3a3fcf3",
+        "display": "Leonardo Phoenix",
+        "speed": "~8-15s",
+        "strengths": "High quality, versatile, alchemy support",
+        "sd_version": "PHOENIX",
+    },
+    "sdxl": {
+        "id": "1e60896f-3c26-4296-8ecc-53e2afecc132",
+        "display": "Leonardo SDXL",
+        "speed": "~5-10s",
+        "strengths": "Fast, good quality, SDXL-based",
+        "sd_version": "SDXL_1_0",
+    },
+    "flux": {
+        "id": "b2614463-296c-462a-9586-aafdb8f00e36",
+        "display": "Leonardo Flux",
+        "speed": "~10-20s",
+        "strengths": "High fidelity, latest architecture",
+        "sd_version": "FLUX",
+    },
+}
+
+DEFAULT_MODEL = "phoenix"
+
+# Hermes aspect_ratio → Leonardo (width, height)
+_ASPECT_SIZES: Dict[str, Dict[str, int]] = {
+    "landscape": {"width": 1024, "height": 768},
+    "square": {"width": 1024, "height": 1024},
+    "portrait": {"width": 768, "height": 1024},
+}
+
+# Default preset styles that work well
+_DEFAULT_PRESET_STYLE = "DYNAMIC"
+
+# Valid preset styles from Leonardo API
+PRESET_STYLES = [
+    "ANIME",
+    "BOKEH",
+    "CINEMATIC",
+    "CINEMATIC_CLOSEUP",
+    "CREATIVE",
+    "DYNAMIC",
+    "ENVIRONMENT",
+    "FASHION",
+    "FILM",
+    "FOOD",
+    "GENERAL",
+    "HDR",
+    "ILLUSTRATION",
+    "LEONARDO",
+    "LONG_EXPOSURE",
+    "MACRO",
+    "MINIMALISTIC",
+    "MONOCHROME",
+    "MOODY",
+    "NONE",
+    "NEUTRAL",
+    "PHOTOGRAPHY",
+    "PORTRAIT",
+    "RAYTRACED",
+    "RENDER_3D",
+    "RETRO",
+    "SKETCH_BW",
+    "SKETCH_COLOR",
+    "STOCK_PHOTO",
+    "VIBRANT",
+    "UNPROCESSED",
+]
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_leonardo_config() -> Dict[str, Any]:
+    """Load Leonardo-specific config from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        if isinstance(section, dict):
+            leo = section.get("leonardo")
+            if isinstance(leo, dict):
+                return leo
+    except Exception:
+        pass
+    return {}
+
+
+def _resolve_model() -> tuple[str, str, str]:
+    """Return (model_key, model_id, sd_version) for the active model."""
+    # 1. Env var override
+    env_model = os.environ.get("LEONARDO_IMAGE_MODEL", "").strip().lower()
+    if env_model and env_model in _MODELS:
+        m = _MODELS[env_model]
+        return env_model, m["id"], m["sd_version"]
+
+    # 2. Config override
+    cfg = _load_leonardo_config()
+    cfg_model = cfg.get("model", "").strip().lower() if cfg else ""
+    if cfg_model and cfg_model in _MODELS:
+        m = _MODELS[cfg_model]
+        return cfg_model, m["id"], m["sd_version"]
+
+    # 3. Default
+    m = _MODELS[DEFAULT_MODEL]
+    return DEFAULT_MODEL, m["id"], m["sd_version"]
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_api_key() -> Optional[str]:
+    """Get Leonardo API key from env."""
+    key = os.environ.get("LEONARDO_API_KEY", "").strip()
+    return key or None
+
+
+def _headers(api_key: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _create_generation(
+    api_key: str,
+    prompt: str,
+    negative_prompt: str,
+    width: int,
+    height: int,
+    model_id: str,
+    sd_version: str,
+    num_images: int,
+    preset_style: str,
+    guidance_scale: float,
+    num_inference_steps: int,
+    seed: Optional[int],
+    alchemy: bool,
+) -> str:
+    """Submit a generation job. Returns generationId."""
+    payload: Dict[str, Any] = {
+        "prompt": prompt,
+        "negative_prompt": negative_prompt,
+        "width": width,
+        "height": height,
+        "modelId": model_id,
+        "sd_version": sd_version,
+        "num_images": num_images,
+        "presetStyle": preset_style,
+        "guidance_scale": guidance_scale,
+        "num_inference_steps": num_inference_steps,
+        "alchemy": alchemy,
+        "public": False,
+    }
+    if seed is not None:
+        payload["seed"] = seed
+
+    resp = requests.post(
+        f"{_BASE_URL}/generations",
+        headers=_headers(api_key),
+        json=payload,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    # Response: {"sdGenerationJob": {"generationId": "...", "apiCreditCost": ...}}
+    job = data.get("sdGenerationJob") or {}
+    gen_id = job.get("generationId")
+    if not gen_id:
+        raise RuntimeError(f"No generationId in response: {data}")
+    logger.info(
+        "Leonardo generation submitted: %s (cost: %s)", gen_id, job.get("apiCreditCost")
+    )
+    return gen_id
+
+
+def _poll_generation(api_key: str, gen_id: str) -> List[str]:
+    """Poll until generation completes. Returns list of image URLs."""
+    deadline = time.time() + _POLL_TIMEOUT_S
+    while time.time() < deadline:
+        resp = requests.get(
+            f"{_BASE_URL}/generations/{gen_id}",
+            headers=_headers(api_key),
+            timeout=20,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Response: {"generations_by_pk": {"status": "...", "generated_images": [...]}}
+        gen = data.get("generations_by_pk") or {}
+        status = gen.get("status", "").upper()
+
+        if status == "COMPLETE":
+            images = gen.get("generated_images") or []
+            urls = [img["url"] for img in images if img.get("url")]
+            if not urls:
+                raise RuntimeError(f"Generation complete but no image URLs: {gen}")
+            return urls
+
+        if status == "FAILED":
+            raise RuntimeError(f"Leonardo generation failed: {gen}")
+
+        # PENDING or PROCESSING — keep polling
+        logger.debug("Leonardo generation %s status=%s, polling...", gen_id, status)
+        time.sleep(_POLL_INTERVAL_S)
+
+    raise TimeoutError(
+        f"Leonardo generation {gen_id} timed out after {_POLL_TIMEOUT_S}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class LeonardoImageGenProvider(ImageGenProvider):
+    """Leonardo.AI image generation backend."""
+
+    @property
+    def name(self) -> str:
+        return "leonardo"
+
+    @property
+    def display_name(self) -> str:
+        return "Leonardo.AI"
+
+    def is_available(self) -> bool:
+        return _get_api_key() is not None
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": key,
+                "display": meta["display"],
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+            }
+            for key, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Leonardo.AI",
+            "badge": "free-tier",
+            "tag": "Phoenix, SDXL, Flux — 150 free tokens/day",
+            "env_vars": [
+                {
+                    "key": "LEONARDO_API_KEY",
+                    "prompt": "Leonardo.AI API key",
+                    "url": "https://app.leonardo.ai/settings/api",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image via Leonardo.AI REST API."""
+        api_key = _get_api_key()
+        if not api_key:
+            return error_response(
+                error="LEONARDO_API_KEY is not set. Get one at https://app.leonardo.ai/settings/api",
+                error_type="missing_api_key",
+                provider="leonardo",
+            )
+
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        sizes = _ASPECT_SIZES.get(aspect, _ASPECT_SIZES["landscape"])
+
+        model_key, model_id, sd_version = _resolve_model()
+
+        # Optional overrides from kwargs
+        num_images = kwargs.get("num_images", 1)
+        if not isinstance(num_images, int) or num_images < 1:
+            num_images = 1
+        if num_images > 4:
+            num_images = 4
+
+        guidance_scale = kwargs.get("guidance_scale", 7)
+        if not isinstance(guidance_scale, (int, float)) or not (
+            1 <= guidance_scale <= 20
+        ):
+            guidance_scale = 7
+
+        num_inference_steps = kwargs.get("num_inference_steps", 15)
+        if not isinstance(num_inference_steps, int) or not (
+            10 <= num_inference_steps <= 60
+        ):
+            num_inference_steps = 15
+
+        seed = kwargs.get("seed")
+        if seed is not None:
+            try:
+                seed = int(seed)
+            except (TypeError, ValueError):
+                seed = None
+
+        preset_style = kwargs.get("preset_style", _DEFAULT_PRESET_STYLE)
+        if isinstance(preset_style, str):
+            preset_style = preset_style.upper()
+        if preset_style not in PRESET_STYLES:
+            preset_style = _DEFAULT_PRESET_STYLE
+
+        alchemy = kwargs.get("alchemy", True)
+        if not isinstance(alchemy, bool):
+            alchemy = True
+
+        negative_prompt = kwargs.get("negative_prompt", "")
+        if not isinstance(negative_prompt, str):
+            negative_prompt = ""
+
+        try:
+            gen_id = _create_generation(
+                api_key=api_key,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                width=sizes["width"],
+                height=sizes["height"],
+                model_id=model_id,
+                sd_version=sd_version,
+                num_images=num_images,
+                preset_style=preset_style,
+                guidance_scale=guidance_scale,
+                num_inference_steps=num_inference_steps,
+                seed=seed,
+                alchemy=alchemy,
+            )
+
+            urls = _poll_generation(api_key, gen_id)
+
+            # Save first image locally (matches other providers' behaviour)
+            image_path = save_url_image(urls[0], prefix="leonardo")
+            return success_response(
+                image=str(image_path),
+                model=model_key,
+                prompt=prompt,
+                aspect_ratio=aspect,
+                provider="leonardo",
+                extra={"generation_id": gen_id, "urls": urls},
+            )
+
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "?"
+            body = ""
+            if exc.response is not None:
+                try:
+                    body = exc.response.text[:500]
+                except Exception:
+                    pass
+            logger.warning("Leonardo API HTTP %s: %s", status, body)
+            return error_response(
+                error=f"Leonardo API error (HTTP {status}): {body}",
+                error_type="api_error",
+                provider="leonardo",
+                model=model_key,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        except TimeoutError as exc:
+            logger.warning("Leonardo generation timed out: %s", exc)
+            return error_response(
+                error=str(exc),
+                error_type="timeout",
+                provider="leonardo",
+                model=model_key,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Leonardo generation failed: %s", exc, exc_info=True)
+            return error_response(
+                error=f"Leonardo generation failed: {exc}",
+                error_type=type(exc).__name__,
+                provider="leonardo",
+                model=model_key,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire LeonardoImageGenProvider into the registry."""
+    ctx.register_image_gen_provider(LeonardoImageGenProvider())

--- a/plugins/image_gen/leonardo/plugin.yaml
+++ b/plugins/image_gen/leonardo/plugin.yaml
@@ -1,0 +1,7 @@
+name: leonardo
+version: 1.0.0
+description: "Leonardo.AI image generation backend (Phoenix, SDXL, Flux). Text-to-image with multiple styles."
+author: aimanmalib
+kind: backend
+requires_env:
+  - LEONARDO_API_KEY

--- a/tests/plugins/image_gen/test_leonardo_provider.py
+++ b/tests/plugins/image_gen/test_leonardo_provider.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Tests for Leonardo.AI image generation provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure LEONARDO_API_KEY is set for all tests."""
+    monkeypatch.setenv("LEONARDO_API_KEY", "test-key-12345")
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestLeonardoImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        assert provider.name == "leonardo"
+
+    def test_display_name(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        assert provider.display_name == "Leonardo.AI"
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("LEONARDO_API_KEY", "leo-xxx")
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("LEONARDO_API_KEY", raising=False)
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        models = provider.list_models()
+        assert len(models) == 3
+        model_ids = [m["id"] for m in models]
+        assert "phoenix" in model_ids
+        assert "sdxl" in model_ids
+        assert "flux" in model_ids
+
+    def test_default_model(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        assert provider.default_model() == "phoenix"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "Leonardo.AI"
+        assert schema["badge"] == "free-tier"
+        assert len(schema["env_vars"]) == 1
+        assert schema["env_vars"][0]["key"] == "LEONARDO_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.leonardo import _resolve_model
+
+        model_key, model_id, sd_version = _resolve_model()
+        assert model_key == "phoenix"
+        assert sd_version == "PHOENIX"
+
+    def test_custom_model_via_env(self, monkeypatch):
+        monkeypatch.setenv("LEONARDO_IMAGE_MODEL", "flux")
+        from plugins.image_gen.leonardo import _resolve_model
+
+        model_key, _, sd_version = _resolve_model()
+        assert model_key == "flux"
+        assert sd_version == "FLUX"
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("LEONARDO_API_KEY", raising=False)
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        provider = LeonardoImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert "LEONARDO_API_KEY" in result["error"]
+
+    def test_successful_generation(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        # Mock the POST /generations response
+        create_resp = MagicMock()
+        create_resp.status_code = 200
+        create_resp.raise_for_status = MagicMock()
+        create_resp.json.return_value = {
+            "sdGenerationJob": {
+                "generationId": "gen-123",
+                "apiCreditCost": 5,
+            }
+        }
+
+        # Mock the GET /generations/{id} polling response
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "generations_by_pk": {
+                "status": "COMPLETE",
+                "generated_images": [
+                    {"url": "https://cdn.leonardo.ai/gen-123_0.png"},
+                ],
+            }
+        }
+
+        with (
+            patch("plugins.image_gen.leonardo.requests.post", return_value=create_resp),
+            patch("plugins.image_gen.leonardo.requests.get", return_value=poll_resp),
+            patch(
+                "plugins.image_gen.leonardo.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ),
+            patch("plugins.image_gen.leonardo.time.sleep"),
+        ):
+            provider = LeonardoImageGenProvider()
+            result = provider.generate(prompt="A cat playing piano")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/test.png"
+        assert result["provider"] == "leonardo"
+        assert result["model"] == "phoenix"
+
+    def test_api_error(self):
+        import requests as req_lib
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.text = "Unauthorized"
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.leonardo.requests.post", return_value=mock_resp):
+            provider = LeonardoImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+
+    def test_generation_failed_status(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        create_resp = MagicMock()
+        create_resp.status_code = 200
+        create_resp.raise_for_status = MagicMock()
+        create_resp.json.return_value = {
+            "sdGenerationJob": {"generationId": "gen-fail", "apiCreditCost": 0}
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {"generations_by_pk": {"status": "FAILED"}}
+
+        with (
+            patch("plugins.image_gen.leonardo.requests.post", return_value=create_resp),
+            patch("plugins.image_gen.leonardo.requests.get", return_value=poll_resp),
+            patch("plugins.image_gen.leonardo.time.sleep"),
+        ):
+            provider = LeonardoImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert "failed" in result["error"].lower()
+
+    def test_timeout(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        create_resp = MagicMock()
+        create_resp.status_code = 200
+        create_resp.raise_for_status = MagicMock()
+        create_resp.json.return_value = {
+            "sdGenerationJob": {"generationId": "gen-slow", "apiCreditCost": 0}
+        }
+
+        # Poll always returns PENDING
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {"generations_by_pk": {"status": "PENDING"}}
+
+        # time.time is also called by logging internals, so use a
+        # counter function that returns past-deadline after the first
+        # poll cycle instead of a finite side_effect list.
+        call_count = 0
+
+        def fake_time():
+            nonlocal call_count
+            call_count += 1
+            # First call: start of poll (0). Second call: past deadline (999).
+            # All subsequent calls (logging, etc.) also get 999.
+            return 0.0 if call_count <= 1 else 999.0
+
+        with (
+            patch("plugins.image_gen.leonardo.requests.post", return_value=create_resp),
+            patch("plugins.image_gen.leonardo.requests.get", return_value=poll_resp),
+            patch("plugins.image_gen.leonardo.time.sleep"),
+            patch("plugins.image_gen.leonardo.time.time", side_effect=fake_time),
+        ):
+            provider = LeonardoImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_auth_header(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        create_resp = MagicMock()
+        create_resp.status_code = 200
+        create_resp.raise_for_status = MagicMock()
+        create_resp.json.return_value = {
+            "sdGenerationJob": {"generationId": "gen-auth", "apiCreditCost": 1}
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "generations_by_pk": {
+                "status": "COMPLETE",
+                "generated_images": [{"url": "https://cdn.leonardo.ai/test.png"}],
+            }
+        }
+
+        with (
+            patch(
+                "plugins.image_gen.leonardo.requests.post", return_value=create_resp
+            ) as mock_post,
+            patch("plugins.image_gen.leonardo.requests.get", return_value=poll_resp),
+            patch(
+                "plugins.image_gen.leonardo.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ),
+            patch("plugins.image_gen.leonardo.time.sleep"),
+        ):
+            provider = LeonardoImageGenProvider()
+            provider.generate(prompt="test")
+
+        call_args = mock_post.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers")
+        assert "Bearer test-key-12345" in headers["Authorization"]
+
+    def test_payload_contains_required_fields(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider
+
+        create_resp = MagicMock()
+        create_resp.status_code = 200
+        create_resp.raise_for_status = MagicMock()
+        create_resp.json.return_value = {
+            "sdGenerationJob": {"generationId": "gen-fields", "apiCreditCost": 1}
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.json.return_value = {
+            "generations_by_pk": {
+                "status": "COMPLETE",
+                "generated_images": [{"url": "https://cdn.leonardo.ai/test.png"}],
+            }
+        }
+
+        with (
+            patch(
+                "plugins.image_gen.leonardo.requests.post", return_value=create_resp
+            ) as mock_post,
+            patch("plugins.image_gen.leonardo.requests.get", return_value=poll_resp),
+            patch(
+                "plugins.image_gen.leonardo.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ),
+            patch("plugins.image_gen.leonardo.time.sleep"),
+        ):
+            provider = LeonardoImageGenProvider()
+            provider.generate(prompt="A majestic cat", aspect_ratio="square")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get(
+            "json"
+        )
+        assert payload["prompt"] == "A majestic cat"
+        assert payload["width"] == 1024
+        assert payload["height"] == 1024
+        assert payload["modelId"] is not None
+        assert payload["num_images"] == 1
+
+    def test_aspect_ratio_landscape(self):
+        from plugins.image_gen.leonardo import _ASPECT_SIZES
+
+        assert _ASPECT_SIZES["landscape"]["width"] == 1024
+        assert _ASPECT_SIZES["landscape"]["height"] == 768
+
+    def test_aspect_ratio_portrait(self):
+        from plugins.image_gen.leonardo import _ASPECT_SIZES
+
+        assert _ASPECT_SIZES["portrait"]["width"] == 768
+        assert _ASPECT_SIZES["portrait"]["height"] == 1024
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.leonardo import LeonardoImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, LeonardoImageGenProvider)
+        assert provider.name == "leonardo"


### PR DESCRIPTION
## What

Adds Leonardo.AI as a new `image_gen` plugin backend (`plugins/image_gen/leonardo/`).

## Why

Leonardo.AI is a popular image generation platform with a generous free tier (150 tokens/day). Adding it as an official provider gives users a free/low-cost alternative to FAL, OpenAI, and xAI.

## Features

- **Official REST API** with `LEONARDO_API_KEY` auth
- **3 platform models**: Leonardo Phoenix (default), SDXL, Flux
- **31 preset styles**: ANIME, DYNAMIC, PHOTOGRAPHY, PORTRAIT, etc.
- **Alchemy** and **Prompt Magic** support
- Configurable guidance scale, inference steps, seed, negative prompt
- Aspect ratio mapping (landscape → 1024×768, square → 1024×1024, portrait → 768×1024)
- Async polling with 180s timeout
- Image URL caching via `save_url_image()`

## Setup

1. Get API key at https://app.leonardo.ai/settings/api
2. Set `LEONARDO_API_KEY` env var
3. Run `hermes tools` to select Leonardo as the image generation provider

## Models

- `phoenix` — Leonardo Phoenix — ~8-15s — Default, alchemy support
- `sdxl` — Leonardo SDXL — ~5-10s — Fast, SDXL-based
- `flux` — Leonardo Flux — ~10-20s — Latest architecture

## Tests

19 tests included covering:
- Provider class (name, display_name, is_available, list_models, setup_schema)
- Config (default model, custom model via env var)
- Generation (success, missing key, API errors, failed status, timeout, auth headers, payload validation, aspect ratios)
- Plugin registration

```
19 passed in 0.65s
```

## Files

- `plugins/image_gen/leonardo/__init__.py` — provider implementation
- `plugins/image_gen/leonardo/plugin.yaml` — plugin metadata
- `tests/plugins/image_gen/test_leonardo_provider.py` — test suite
