### PR TITLE
fix(desktop): show update-handoff message before quitting

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1349,11 +1349,11 @@ async function applyUpdates(opts = {}) {
 
     rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
 
-    // Give the OS a beat to register the new process, then quit. The updater
-    // rebuilds and relaunches us when it's done.
+    // Give the renderer time to show the "Handing off" message, then quit.
+    // The updater runs detached and will relaunch the desktop when done.
     setTimeout(() => {
       app.quit()
-    }, 600)
+    }, 2000)
 
     return { ok: true, handedOff: true, updater }
   } finally {
@@ -1540,7 +1540,9 @@ fi
   child.unref()
   rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${rebuiltApp} -> ${targetApp})`)
 
-  setTimeout(() => app.quit(), 600)
+  // Give the renderer time to show the "Restarting" state, then hand off
+  // to the detached swap script which will replace the .app and relaunch.
+  setTimeout(() => app.quit(), 2000)
   return { ok: true, handedOff: true, rebuiltApp, targetApp }
 }
 

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -203,6 +203,9 @@ function IdleView({
         <DialogDescription className="text-center text-sm">
           A new version of Hermes is ready to install.
         </DialogDescription>
+        <p className="text-center text-xs text-muted-foreground">
+          Hermes will close and reopen once the update is complete.
+        </p>
       </div>
 
       <div className="grid gap-3 rounded-xl border border-border/70 bg-muted/20 px-4 py-3">
@@ -318,7 +321,7 @@ function ApplyingView({ apply }: { apply: UpdateApplyState }) {
 
         <DialogTitle className="text-center text-xl">{label}</DialogTitle>
         <DialogDescription className="text-center text-sm">
-          The Hermes updater will take over in its own window and reopen Hermes when it&rsquo;s done.
+          Hermes will close to run the update in the background and reopen when it&rsquo;s done.
         </DialogDescription>
       </div>
 


### PR DESCRIPTION
## Problem

When clicking the version badge in the desktop app's status bar (bottom-right) → "Update now", the entire Electron window disappears after only 600ms with **no visible progress feedback**. The user has no way to tell whether the update is running, has failed, or what happened.

The root cause: the staged updater (Tauri `hermes-setup`) path spawns the updater detached and calls `app.quit()` after a mere 600ms — too fast for the renderer to show the "Restarting Hermes…" / "Handing off" state before the window closes.

## Changes

### 1. `apps/desktop/electron/main.cjs` — Increase quit timeout

- Both the staged-updater path and the in-app (macOS swap+relaunch) path: increased `setTimeout(() => app.quit(), 600)` → **2000ms**
- Updated comments to explain why the delay exists (give the renderer time to show status)

### 2. `apps/desktop/src/app/updates-overlay.tsx` — Better pre-click messaging

Before clicking "Update now", the user now sees:
> *Hermes will close and reopen once the update is complete.*

This sets expectations before the destructive action.

### 3. `apps/desktop/src/app/updates-overlay.tsx` — Better applying description

Changed from (Tauri-specific phrasing):
> The Hermes updater will take over in its own window and reopen Hermes when it's done.

To (generic, covers both staged-updater and CLI-install paths):
> Hermes will close to run the update in the background and reopen when it's done.

## Screenshots

**Before:** User sees "A new version of Hermes is ready to install" — no indication the app will close.
**After:** Same dialog now includes "Hermes will close and reopen once the update is complete." in muted text below the description.

**Before:** After clicking "Update now", the app vanishes in 600ms.
**After:** The "Restarting Hermes…" / "Handing off to the Hermes updater…" message is visible for 2 full seconds before quitting — enough to read.

## Test Plan

1. Open the desktop app with updates available
2. Click the version badge at bottom-right
3. Verify the "New update available" dialog shows the new muted-text note
4. Click "Update now"
5. Verify the progress overlay shows "Restarting Hermes…" / progress bar before the app closes
6. (The actual update + relaunch works as before — only the UX before the quit changed)