### PR TITLE
fix(config): warn when env shadows gateway config (#13582)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1257,7 +1257,39 @@ def load_gateway_config() -> GatewayConfig:
     4. Built-in defaults
     """
     _home = get_hermes_home()
+    from gateway.yaml_env import YamlEnvLoad
+
+    _managed_keys: set[str] = set()
+    try:
+        from hermes_cli import managed_scope
+
+        _managed_snapshot = managed_scope.apply_managed_overlay({})
+        def _materialized_leaves(value: Any, prefix: str = "") -> set[str]:
+            if not isinstance(value, dict):
+                return {prefix} if prefix else set()
+            leaves: set[str] = set()
+            for key, child in value.items():
+                dotted = f"{prefix}.{key}" if prefix else str(key)
+                leaves.update(_materialized_leaves(child, dotted))
+            return leaves
+
+        _managed_keys = managed_scope.managed_config_keys() & _materialized_leaves(
+            _managed_snapshot
+        )
+    except Exception:
+        _managed_snapshot = {}
+
+    def _source_kind(path: str) -> str:
+        if path in _managed_keys:
+            return "managed-config"
+        return "user-config"
+
+    _yaml_env = YamlEnvLoad(
+        f"gateway-config:{Path(_home).resolve()}",
+        source_resolver=_source_kind,
+    )
     gw_data: dict = {}
+    _yaml_hook_complete = True
 
     # Legacy fallback: gateway.json provides the base layer.
     # config.yaml keys always win when both specify the same setting.
@@ -1487,17 +1519,31 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["platforms"] = platforms_data
             # Iterate built-in platforms plus any registered plugin platforms
             # so plugin authors get the same shared-key bridging (#24836).
+            _yaml_hook_complete = True
             try:
                 from hermes_cli.plugins import discover_plugins
                 discover_plugins()  # idempotent
                 from gateway.platform_registry import platform_registry as _pr
             except Exception as e:
-                logger.debug("plugin discovery skipped: %s", e)
+                _yaml_hook_complete = False
+                logger.debug("plugin discovery incomplete: %s", e)
                 _pr = None
 
             _shared_loop_targets: list = list(Platform)
             if _pr is not None:
-                for _entry in _pr.plugin_entries():
+                try:
+                    _plugin_entries = _pr.plugin_entries()
+                    if _pr.deferred_load_errors:
+                        _yaml_hook_complete = False
+                        logger.debug(
+                            "deferred platform discovery incomplete: %s",
+                            sorted(_pr.deferred_load_errors),
+                        )
+                except Exception as e:
+                    _yaml_hook_complete = False
+                    logger.debug("plugin registry enumeration incomplete: %s", e)
+                    _plugin_entries = []
+                for _entry in _plugin_entries:
                     try:
                         _plat = Platform(_entry.name)
                     except (ValueError, KeyError):
@@ -1646,27 +1692,111 @@ def load_gateway_config() -> GatewayConfig:
             # blocks (below; no-op when a hook already set their env var) →
             # ``_apply_env_overrides()`` after ``GatewayConfig.from_dict``.
             if _pr is not None:
-                for entry in _pr.all_entries():
+                try:
+                    _all_entries = _pr.all_entries()
+                    if _pr.deferred_load_errors:
+                        _yaml_hook_complete = False
+                except Exception as e:
+                    _yaml_hook_complete = False
+                    logger.debug("plugin hook enumeration incomplete: %s", e)
+                    _all_entries = []
+
+                def _record_platform_leaf_sources(
+                    value: dict,
+                    path: str,
+                    source_prefix: str,
+                    source_paths: dict[str, str],
+                ) -> None:
+                    if isinstance(value, dict) and value:
+                        for key, child in value.items():
+                            child_path = f"{path}.{key}" if path else str(key)
+                            _record_platform_leaf_sources(
+                                child, child_path, source_prefix, source_paths
+                            )
+                        return
+                    source_paths[path] = f"{source_prefix}.{path}"
+
+                def _merge_platform_hook_block(
+                    platform_cfg: dict | None,
+                    source_paths: dict[str, str],
+                    candidate: dict,
+                    source_prefix: str,
+                ) -> tuple[dict, dict[str, str]]:
+                    merged = dict(platform_cfg or {})
+                    merged_sources = dict(source_paths)
+                    for key, value in candidate.items():
+                        key = str(key)
+                        if key == "extra" and isinstance(value, dict):
+                            old_extra = merged.get("extra")
+                            merged["extra"] = {
+                                **(old_extra if isinstance(old_extra, dict) else {}),
+                                **value,
+                            }
+                            _record_platform_leaf_sources(
+                                value, "extra", source_prefix, merged_sources
+                            )
+                            continue
+                        for path in list(merged_sources):
+                            if path == key or path.startswith(f"{key}."):
+                                merged_sources.pop(path)
+                        merged[key] = value
+                        _record_platform_leaf_sources(
+                            value, key, source_prefix, merged_sources
+                        )
+                    return merged, merged_sources
+
+                for entry in _all_entries:
                     if entry.apply_yaml_config_fn is None:
                         continue
-                    platform_cfg = yaml_cfg.get(entry.name)
-                    # Fall back to the platform's block under ``platforms`` /
-                    # ``gateway.platforms`` so adapter hooks still run when the
-                    # user configured the platform only under those nested paths
-                    # (e.g. ``platforms.discord.extra.allow_from``) and not via a
-                    # top-level ``discord:`` block.
-                    if not isinstance(platform_cfg, dict):
-                        for _src in (gateway_platforms, yaml_cfg.get("platforms")):
-                            if isinstance(_src, dict):
-                                _candidate = _src.get(entry.name)
-                                if isinstance(_candidate, dict):
-                                    platform_cfg = _candidate
-                                    break
+                    # The effective merge order is gateway.platforms, then
+                    # top-level platforms, then a direct gateway.<platform>
+                    # block.  Build the same effective block for the hook and
+                    # retain the source of every effective leaf for provenance.
+                    platform_cfg = None
+                    _source_paths: dict[str, str] = {}
+                    _source_prefix = entry.name
+                    _platform_sources = (
+                        ("gateway.platforms", gateway_platforms),
+                        ("platforms", yaml_cfg.get("platforms")),
+                        ("gateway", {
+                            entry.name: gateway_cfg.get(entry.name)
+                            if isinstance(gateway_cfg, dict)
+                            else None,
+                        }),
+                    )
+                    for _prefix, _src in _platform_sources:
+                        if not isinstance(_src, dict):
+                            continue
+                        _candidate = _src.get(entry.name)
+                        if not isinstance(_candidate, dict):
+                            continue
+                        platform_cfg, _source_paths = _merge_platform_hook_block(
+                            platform_cfg,
+                            _source_paths,
+                            _candidate,
+                            f"{_prefix}.{entry.name}",
+                        )
+                        _source_prefix = f"{_prefix}.{entry.name}"
+                    _direct_cfg = yaml_cfg.get(entry.name)
+                    if isinstance(_direct_cfg, dict):
+                        platform_cfg, _source_paths = _merge_platform_hook_block(
+                            platform_cfg,
+                            _source_paths,
+                            _direct_cfg,
+                            entry.name,
+                        )
+                        _source_prefix = entry.name
                     if not isinstance(platform_cfg, dict):
                         continue
                     try:
-                        seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
+                        from gateway.yaml_env import yaml_env_context
+
+                        with yaml_env_context(
+                            _yaml_env, _source_prefix, _source_paths
+                        ):
+                            seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
                     except Exception as e:
+                        _yaml_hook_complete = False
                         logger.debug(
                             "apply_yaml_config_fn for %s raised: %s",
                             entry.name, e,
@@ -1699,8 +1829,12 @@ def load_gateway_config() -> GatewayConfig:
                     # require_mention (not a telegram: block), so the telegram plugin's
                     # apply_yaml_config_fn hook — which only runs when a telegram config
                     # block exists — can't cover the no-telegram-block case (#3979).
-                    if not os.getenv("TELEGRAM_REQUIRE_MENTION"):
-                        os.environ["TELEGRAM_REQUIRE_MENTION"] = str(_tl_require_mention).lower()
+                    _yaml_env.set_env_from_yaml(
+                        "TELEGRAM_REQUIRE_MENTION",
+                        str(_tl_require_mention).lower(),
+                        "require_mention",
+                        predicate=lambda: not os.getenv("TELEGRAM_REQUIRE_MENTION"),
+                    )
 
             # Telegram settings → env vars / extra: migrated to the telegram
             # plugin's apply_yaml_config_fn hook
@@ -1713,8 +1847,13 @@ def load_gateway_config() -> GatewayConfig:
             # Signal settings → env vars (env vars take precedence)
             signal_cfg = yaml_cfg.get("signal", {})
             if isinstance(signal_cfg, dict):
-                if "require_mention" in signal_cfg and not os.getenv("SIGNAL_REQUIRE_MENTION"):
-                    os.environ["SIGNAL_REQUIRE_MENTION"] = str(signal_cfg["require_mention"]).lower()
+                if "require_mention" in signal_cfg:
+                    _yaml_env.set_env_from_yaml(
+                        "SIGNAL_REQUIRE_MENTION",
+                        str(signal_cfg["require_mention"]).lower(),
+                        "signal.require_mention",
+                        predicate=lambda: not os.getenv("SIGNAL_REQUIRE_MENTION"),
+                    )
 
             # DingTalk settings → env vars: migrated to the dingtalk plugin's
             # apply_yaml_config_fn hook (plugins/platforms/dingtalk/adapter.py).
@@ -1732,6 +1871,8 @@ def load_gateway_config() -> GatewayConfig:
             # #41112 / #3823.
 
     except Exception as e:
+        _yaml_hook_complete = False
+        _yaml_env.abort()
         logger.warning(
             "Failed to process config.yaml — falling back to .env / gateway.json values. "
             "Check %s for syntax errors. Error: %s",
@@ -1739,13 +1880,22 @@ def load_gateway_config() -> GatewayConfig:
             e,
         )
 
-    config = GatewayConfig.from_dict(gw_data)
+    try:
+        config = GatewayConfig.from_dict(gw_data)
 
-    # Override with environment variables
-    _apply_env_overrides(config)
-    
-    # --- Validate loaded values ---
-    _validate_gateway_config(config)
+        # Override with environment variables
+        _apply_env_overrides(config)
+
+        # --- Validate loaded values ---
+        _validate_gateway_config(config)
+    except Exception:
+        _yaml_env.abort()
+        raise
+
+    if _yaml_hook_complete:
+        _yaml_env.finish()
+    else:
+        _yaml_env.abort()
 
     return config
 

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -127,7 +127,10 @@ class PlatformEntry:
     #
     # Signature: (yaml_cfg: dict, platform_cfg: dict) -> Optional[dict]
     # Called from ``load_gateway_config()`` after the generic shared-key loop
-    # and before ``_apply_env_overrides``.  Mutating ``os.environ`` is allowed
+    # and before ``_apply_env_overrides``.  The active YAML provenance context
+    # is available through ``gateway.yaml_env.get_yaml_env_context()`` while
+    # the hook runs; ``context.source_for(leaf)`` resolves each effective leaf.
+    # Mutating ``os.environ`` is allowed
     # (use ``not os.getenv(...)`` guards to preserve env > YAML precedence);
     # any returned dict is merged into ``PlatformConfig.extra``.  Exceptions
     # are caught and logged at debug level.
@@ -181,6 +184,7 @@ class PlatformRegistry:
         # actually asks for that platform (gateway start, cron delivery,
         # `hermes setup`/`gateway status`, send_message).
         self._deferred: dict[str, Callable[[], None]] = {}
+        self._deferred_load_errors: set[str] = set()
 
     # -- deferred loading ----------------------------------------------------
 
@@ -207,6 +211,7 @@ class PlatformRegistry:
         try:
             loader()
         except Exception as e:
+            self._deferred_load_errors.add(name)
             logger.warning(
                 "Deferred load of platform '%s' failed: %s",
                 name,
@@ -228,6 +233,11 @@ class PlatformRegistry:
         for name in list(self._deferred):
             self._resolve(name)
 
+    @property
+    def deferred_load_errors(self) -> frozenset[str]:
+        """Return deferred platform loaders that failed during discovery."""
+        return frozenset(self._deferred_load_errors)
+
     def register(self, entry: PlatformEntry) -> None:
         """Register a platform adapter entry.
 
@@ -236,6 +246,7 @@ class PlatformRegistry:
         """
         # A concrete registration supersedes any pending deferred loader.
         self._deferred.pop(entry.name, None)
+        self._deferred_load_errors.discard(entry.name)
         if entry.name in self._entries:
             prev = self._entries[entry.name]
             logger.info(
@@ -250,6 +261,7 @@ class PlatformRegistry:
     def unregister(self, name: str) -> bool:
         """Remove a platform entry.  Returns True if it existed."""
         self._deferred.pop(name, None)
+        self._deferred_load_errors.discard(name)
         return self._entries.pop(name, None) is not None
 
     def get(self, name: str) -> Optional[PlatformEntry]:

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -28,7 +28,9 @@ status display, gateway setup, and more.
   Mutating `os.environ` is allowed (use `not os.getenv(...)` guards to
   preserve env > YAML precedence); the returned dict is merged into
   `PlatformConfig.extra`.  Called during `load_gateway_config()` after
-  the generic shared-key loop and before `_apply_env_overrides()`.
+  the generic shared-key loop and before `_apply_env_overrides()`.  During
+  the hook, `get_yaml_env_context()` exposes `context.source_for(leaf)` so
+  provenance records the source of each effective leaf in a merged block.
 - `cron_deliver_env_var: str` — name of the `*_HOME_CHANNEL` env var.  When
   set, `deliver=<name>` cron jobs route to this var without editing
   `cron/scheduler.py`'s hardcoded sets.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1871,6 +1871,26 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
 _config_path = _hermes_home / 'config.yaml'
+from gateway.yaml_env import YamlEnvLoad as _YamlEnvLoad
+
+
+def _bootstrap_yaml_source(path: str) -> str:
+    try:
+        from hermes_cli import managed_scope
+
+        managed_keys = managed_scope.managed_config_keys()
+        if path in managed_keys:
+            return "managed-config"
+    except Exception:
+        pass
+    return "user-config"
+
+
+_bootstrap_yaml_env = _YamlEnvLoad(
+    f"gateway-bootstrap:{Path(_hermes_home).resolve()}",
+    source_resolver=_bootstrap_yaml_source,
+)
+_bootstrap_yaml_complete = True
 if _config_path.exists():
     try:
         # Presence-sensitive env bridge: raw read is deliberate — only keys the
@@ -1895,8 +1915,13 @@ if _config_path.exists():
             pass
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
-            if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
-                os.environ[_key] = str(_val)
+            if isinstance(_val, (str, int, float, bool)):
+                _bootstrap_yaml_env.set_env_from_yaml(
+                    _key,
+                    str(_val),
+                    _key,
+                    predicate=lambda _key=_key: _key not in os.environ,
+                )
         # Terminal config is nested — bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
@@ -2048,10 +2073,12 @@ if _config_path.exists():
             # bridges stay config-authoritative for backwards compatibility.
             if (
                 "busy_steer_ack_enabled" in _display_cfg
-                and "HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED" not in os.environ
             ):
-                os.environ["HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED"] = str(
-                    _display_cfg["busy_steer_ack_enabled"]
+                _bootstrap_yaml_env.set_env_from_yaml(
+                    "HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED",
+                    str(_display_cfg["busy_steer_ack_enabled"]),
+                    "display.busy_steer_ack_enabled",
+                    predicate=lambda: "HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED" not in os.environ,
                 )
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         _tz_cfg = _cfg.get("timezone", "")
@@ -2094,14 +2121,16 @@ if _config_path.exists():
             # Unlike the agent.*/display.* bridges above (config-authoritative),
             # this env var is the manual-override escape hatch, so it WINS if
             # already set explicitly; otherwise config.yaml supplies the value.
-            if (
-                "platform_connect_timeout" in _gateway_cfg
-                and not os.environ.get("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
-            ):
-                os.environ["HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT"] = str(
-                    _gateway_cfg["platform_connect_timeout"]
+            if "platform_connect_timeout" in _gateway_cfg:
+                _bootstrap_yaml_env.set_env_from_yaml(
+                    "HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT",
+                    str(_gateway_cfg["platform_connect_timeout"]),
+                    "gateway.platform_connect_timeout",
+                    predicate=lambda: not os.environ.get("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip(),
                 )
     except Exception as _bridge_err:
+        _bootstrap_yaml_complete = False
+        _bootstrap_yaml_env.abort()
         # Previously this was silent (`except Exception: pass`), which
         # hid partial bridge failures and let .env defaults shadow
         # config.yaml values — users observed max_turns=500 in config
@@ -2119,6 +2148,10 @@ if _config_path.exists():
             "your current config.yaml. Run `hermes doctor` to investigate.",
             file=sys.stderr,
         )
+if _bootstrap_yaml_complete:
+    _bootstrap_yaml_env.finish()
+else:
+    _bootstrap_yaml_env.abort()
 
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:
@@ -9486,12 +9519,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 """
             ).strip()
-            from tools.environments.local import build_subprocess_env
-            watcher_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
-            # This watcher is intentionally outside the running gateway. If it
-            # inherits the gateway marker, `hermes gateway restart` refuses to
-            # run as a self-restart loop guard and the gateway stays stopped.
-            watcher_env.pop("_HERMES_GATEWAY", None)
+            from hermes_cli.gateway import build_gateway_restart_environment
+            watcher_env = build_gateway_restart_environment()
             project_root = Path(__file__).resolve().parent.parent
             # The watcher runs sys.executable (console python) under the
             # CREATE_NO_WINDOW detach kwargs below: it owns one hidden
@@ -9576,9 +9605,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # _HERMES_GATEWAY=1 from us, and the CLI's self-restart loop guard
         # refuses to run when that marker is set — silently (DEVNULL), so the
         # gateway stops and never comes back.
-        from tools.environments.local import build_subprocess_env
-        watcher_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
-        watcher_env.pop("_HERMES_GATEWAY", None)
+        from hermes_cli.gateway import build_gateway_restart_environment
+        watcher_env = build_gateway_restart_environment()
         setsid_bin = shutil.which("setsid")
         if setsid_bin:
             subprocess.Popen(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5415,6 +5415,11 @@ class GatewaySlashCommandsMixin:
         # so the simplest correct thing is: launch an inline Python helper
         # that runs the command and writes both outputs.
         try:
+            from hermes_cli.gateway import build_gateway_restart_environment
+
+            update_env = build_gateway_restart_environment(
+                extra={"PYTHONUNBUFFERED": "1"}
+            )
             if sys.platform == "win32":
                 import textwrap
                 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
@@ -5444,6 +5449,7 @@ class GatewaySlashCommandsMixin:
                     ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    env=update_env,
                     **windows_detach_popen_kwargs(),
                 )
             else:
@@ -5464,6 +5470,7 @@ class GatewaySlashCommandsMixin:
                         [setsid_bin, "bash", "-c", update_cmd],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
+                        env=update_env,
                         start_new_session=True,
                     )
                 else:
@@ -5472,6 +5479,7 @@ class GatewaySlashCommandsMixin:
                         ["bash", "-c", update_cmd],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
+                        env=update_env,
                         start_new_session=True,
                     )
         except Exception as e:

--- a/gateway/yaml_env.py
+++ b/gateway/yaml_env.py
@@ -1,0 +1,180 @@
+"""Track non-secret environment values written by Hermes from YAML."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from contextlib import contextmanager
+from contextvars import ContextVar
+import os
+import threading
+from typing import Callable, Iterator, Mapping
+
+
+_MISSING = object()
+_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True)
+class YamlEnvRecord:
+    owner: str
+    key: str
+    value: str
+    source: str
+
+
+@dataclass(frozen=True)
+class YamlEnvContext:
+    """Scoped provenance state made available to a two-argument YAML hook."""
+
+    load: "YamlEnvLoad"
+    source_prefix: str
+    source_paths: Mapping[str, str]
+
+    def source_for(self, leaf: str) -> str:
+        """Return the source path that supplied an effective leaf."""
+        return self.source_paths.get(leaf, f"{self.source_prefix}.{leaf}")
+
+
+_RECORDS: dict[str, YamlEnvRecord] = {}
+_ACTIVE_CONTEXT: ContextVar[YamlEnvContext | None] = ContextVar(
+    "hermes_yaml_env_context", default=None
+)
+
+
+@contextmanager
+def yaml_env_context(
+    load: "YamlEnvLoad",
+    source_prefix: str,
+    source_paths: Mapping[str, str] | None = None,
+) -> Iterator[None]:
+    """Expose load provenance to a plugin without changing its hook contract."""
+    token = _ACTIVE_CONTEXT.set(
+        YamlEnvContext(load, source_prefix, dict(source_paths or {}))
+    )
+    try:
+        yield
+    finally:
+        _ACTIVE_CONTEXT.reset(token)
+
+
+def get_yaml_env_context() -> YamlEnvContext | None:
+    """Return the active scoped YAML hook context, if one is installed."""
+    return _ACTIVE_CONTEXT.get()
+
+
+def _is_secret_key(name: str) -> bool:
+    try:
+        from hermes_cli.agent_import import is_secret_key
+
+        return is_secret_key(name)
+    except Exception:
+        return True
+
+
+def _source_label(
+    source: str,
+    resolver: Callable[[str], str] | None,
+) -> str:
+    kind = resolver(source) if resolver is not None else "user-config"
+    if kind not in {"user-config", "managed-config"}:
+        kind = "user-config"
+    return f"{kind}:{source}"
+
+
+class YamlEnvLoad:
+    """Own one complete source-resolved YAML environment load."""
+
+    def __init__(
+        self,
+        owner: str,
+        source_resolver: Callable[[str], str] | None = None,
+    ) -> None:
+        self.owner = owner
+        self._source_resolver = source_resolver
+        self._writers: set[str] = set()
+        self._aborted = False
+        self._finished = False
+
+    @property
+    def writer_names(self) -> frozenset[str]:
+        return frozenset(self._writers)
+
+    def set_env_from_yaml(
+        self,
+        name: str,
+        value: str,
+        source: str,
+        *,
+        predicate: Callable[[], bool],
+    ) -> bool:
+        """Offer a source-resolved key, then preserve its caller predicate."""
+        if _is_secret_key(name):
+            return False
+        with _LOCK:
+            self._writers.add(name)
+            record = _RECORDS.get(name)
+            live = os.environ.get(name, _MISSING)
+            if record is not None and record.owner == self.owner:
+                if live == record.value:
+                    os.environ[name] = value
+                    _RECORDS[name] = YamlEnvRecord(
+                        self.owner,
+                        name,
+                        value,
+                        _source_label(source, self._source_resolver),
+                    )
+                    return True
+                _RECORDS.pop(name, None)
+
+            if not predicate():
+                return False
+            os.environ[name] = value
+            _RECORDS[name] = YamlEnvRecord(
+                self.owner,
+                name,
+                value,
+                _source_label(source, self._source_resolver),
+            )
+            return True
+
+    def finish(self) -> None:
+        """Reconcile removed writers after a complete successful load."""
+        if self._finished or self._aborted:
+            return
+        with _LOCK:
+            for name, record in list(_RECORDS.items()):
+                if record.owner != self.owner or name in self._writers:
+                    continue
+                live = os.environ.get(name, _MISSING)
+                if live is not _MISSING and live == record.value:
+                    os.environ.pop(name, None)
+                _RECORDS.pop(name, None)
+        self._finished = True
+
+    def abort(self) -> None:
+        """End an incomplete load without absence-based cleanup."""
+        self._aborted = True
+
+
+def without_yaml_generated_env(
+    env: Mapping[str, str],
+) -> dict[str, str]:
+    """Copy an environment without exact matching recorded YAML values."""
+    result = dict(env)
+    with _LOCK:
+        for name, record in _RECORDS.items():
+            if result.get(name, _MISSING) == record.value:
+                result.pop(name, None)
+    return result
+
+
+def records_snapshot() -> dict[str, YamlEnvRecord]:
+    """Return records for focused contract tests without exposing them in logs."""
+    with _LOCK:
+        return dict(_RECORDS)
+
+
+def clear_records() -> None:
+    """Clear process-local records for isolated tests."""
+    with _LOCK:
+        _RECORDS.clear()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -738,6 +738,25 @@ def launch_detached_profile_gateway_restart(profile: str, old_pid: int) -> bool:
     return _spawn_gateway_restart_watcher(old_pid, _gateway_run_args_for_profile(profile))
 
 
+def build_gateway_restart_environment(
+    base: dict[str, str] | None = None,
+    *,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the environment for a direct replacement gateway process."""
+    if base is None:
+        from tools.environments.local import build_subprocess_env
+
+        base = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+    from gateway.yaml_env import without_yaml_generated_env
+
+    env = without_yaml_generated_env(base)
+    env.pop("_HERMES_GATEWAY", None)
+    if extra:
+        env.update(extra)
+    return env
+
+
 def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
     """Spawn the detached watcher that respawns ``run_argv`` once ``old_pid`` exits."""
     if old_pid <= 0 or not run_argv:
@@ -868,6 +887,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         str(old_pid),
         *run_argv,
     ]
+    watcher_env = build_gateway_restart_environment()
 
     # Same platform-aware detach for the watcher process itself — so
     # closing the user's terminal doesn't kill the watcher.
@@ -876,6 +896,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
             watcher_argv,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=watcher_env,
             **windows_detach_popen_kwargs(),
         )
     except OSError:
@@ -894,6 +915,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
                 watcher_argv,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=watcher_env,
                 **fallback_kwargs,
             )
         except OSError:
@@ -3907,6 +3929,7 @@ def _spawn_detached_gateway() -> bool:
                 stdin=subprocess.DEVNULL,
                 stdout=out,
                 stderr=err,
+                env=build_gateway_restart_environment(),
                 **windows_detach_popen_kwargs(),
             )
     except OSError:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -911,8 +911,9 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     _assert_windows()
     argv, working_dir, env_overlay = _build_gateway_argv()
 
-    # Inherit PATH etc. from the current env, overlay our required vars.
-    env = {**os.environ, **env_overlay}
+    from hermes_cli.gateway import build_gateway_restart_environment
+
+    env = build_gateway_restart_environment(extra=env_overlay)
 
     # CREATE_NEW_PROCESS_GROUP 0x00000200 — child gets its own group, won't
     #                                       receive Ctrl+C from our group

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3717,8 +3717,15 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     # trip the in-process restart-loop guard and exit 1 — silently failing the
     # dashboard's auto-restart paths. The gateway's own restart watcher already
     # drops it (gateway/run.py); mirror that here (#52470).
-    action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
-    action_env.pop("_HERMES_GATEWAY", None)
+    if name in {"gateway-restart", "hermes-update"}:
+        from hermes_cli.gateway import build_gateway_restart_environment
+
+        action_env = build_gateway_restart_environment(
+            extra={"HERMES_NONINTERACTIVE": "1"}
+        )
+    else:
+        action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
+        action_env.pop("_HERMES_GATEWAY", None)
 
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1249,7 +1249,10 @@ def is_connected(config) -> bool:
     return validate_config(config)
 
 
-def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
+def _apply_yaml_config(
+    yaml_cfg: dict,
+    buzz_cfg: dict,
+) -> Optional[dict]:
     """Translate ``config.yaml`` ``buzz.extra`` keys into ``BUZZ_*`` env vars.
 
     Implements the ``apply_yaml_config_fn`` contract.  ``check_requirements``
@@ -1262,7 +1265,25 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     config.yaml update.  ``BUZZ_PRIVATE_KEY`` is a secret and stays in ``.env``;
     it is never sourced from config.yaml here.
     """
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "buzz"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(
+                name, value, source_for(leaf), predicate=predicate
+            )
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
     extra = buzz_cfg.get("extra", buzz_cfg) or {}
+    _extra_prefix = "extra." if isinstance(buzz_cfg.get("extra"), dict) else ""
     if not isinstance(extra, dict):
         return None
     _str_keys = {
@@ -1273,25 +1294,25 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
     }
     for src, env in _str_keys.items():
         val = extra.get(src)
-        if val and not os.getenv(env):
-            os.environ[env] = str(val)
+        if val:
+            _write(env, str(val), f"{_extra_prefix}{src}", lambda env=env: not os.getenv(env))
     interval = extra.get("poll_interval")
-    if interval is not None and not os.getenv("BUZZ_POLL_INTERVAL"):
-        os.environ["BUZZ_POLL_INTERVAL"] = str(interval)
+    if interval is not None:
+        _write("BUZZ_POLL_INTERVAL", str(interval), f"{_extra_prefix}poll_interval", lambda: not os.getenv("BUZZ_POLL_INTERVAL"))
     channels = extra.get("channels")
-    if channels is not None and not os.getenv("BUZZ_CHANNELS"):
+    if channels is not None:
         if isinstance(channels, (list, tuple)):
             channels = ",".join(str(c) for c in channels)
-        os.environ["BUZZ_CHANNELS"] = str(channels)
+        _write("BUZZ_CHANNELS", str(channels), f"{_extra_prefix}channels", lambda: not os.getenv("BUZZ_CHANNELS"))
     allowed = extra.get("allowed_users")
-    if allowed is not None and not os.getenv("BUZZ_ALLOWED_USERS"):
+    if allowed is not None:
         if isinstance(allowed, (list, tuple)):
             allowed = ",".join(str(a) for a in allowed)
-        os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
-    if "allow_all_users" in extra and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
-        os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
-    if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
-        os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
+        _write("BUZZ_ALLOWED_USERS", str(allowed), f"{_extra_prefix}allowed_users", lambda: not os.getenv("BUZZ_ALLOWED_USERS"))
+    if "allow_all_users" in extra:
+        _write("BUZZ_ALLOW_ALL_USERS", str(extra["allow_all_users"]).lower(), f"{_extra_prefix}allow_all_users", lambda: not os.getenv("BUZZ_ALLOW_ALL_USERS"))
+    if "require_mention" in extra:
+        _write("BUZZ_REQUIRE_MENTION", str(extra["require_mention"]).lower(), f"{_extra_prefix}require_mention", lambda: not os.getenv("BUZZ_REQUIRE_MENTION"))
     return None
 
 

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1777,7 +1777,10 @@ def _manual_credential_entry(prompt, save_env_value, print_success) -> None:
     print_success("DingTalk credentials saved")
 
 
-def _apply_yaml_config(yaml_cfg: dict, dingtalk_cfg: dict) -> dict | None:
+def _apply_yaml_config(
+    yaml_cfg: dict,
+    dingtalk_cfg: dict,
+) -> dict | None:
     """Translate config.yaml dingtalk: keys into DINGTALK_* env vars.
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
@@ -1786,20 +1789,35 @@ def _apply_yaml_config(yaml_cfg: dict, dingtalk_cfg: dict) -> dict | None:
     Returns None — everything flows through env.
     """
     import json as _json
-    if "require_mention" in dingtalk_cfg and not os.getenv("DINGTALK_REQUIRE_MENTION"):
-        os.environ["DINGTALK_REQUIRE_MENTION"] = str(dingtalk_cfg["require_mention"]).lower()
-    if "mention_patterns" in dingtalk_cfg and not os.getenv("DINGTALK_MENTION_PATTERNS"):
-        os.environ["DINGTALK_MENTION_PATTERNS"] = _json.dumps(dingtalk_cfg["mention_patterns"])
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "dingtalk"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    if "require_mention" in dingtalk_cfg:
+        _write("DINGTALK_REQUIRE_MENTION", str(dingtalk_cfg["require_mention"]).lower(), "require_mention", lambda: not os.getenv("DINGTALK_REQUIRE_MENTION"))
+    if "mention_patterns" in dingtalk_cfg:
+        _write("DINGTALK_MENTION_PATTERNS", _json.dumps(dingtalk_cfg["mention_patterns"]), "mention_patterns", lambda: not os.getenv("DINGTALK_MENTION_PATTERNS"))
     frc = dingtalk_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("DINGTALK_FREE_RESPONSE_CHATS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["DINGTALK_FREE_RESPONSE_CHATS"] = str(frc)
+        _write("DINGTALK_FREE_RESPONSE_CHATS", str(frc), "free_response_chats", lambda: not os.getenv("DINGTALK_FREE_RESPONSE_CHATS"))
     ac = dingtalk_cfg.get("allowed_chats")
-    if ac is not None and not os.getenv("DINGTALK_ALLOWED_CHATS"):
+    if ac is not None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
-        os.environ["DINGTALK_ALLOWED_CHATS"] = str(ac)
+        _write("DINGTALK_ALLOWED_CHATS", str(ac), "allowed_chats", lambda: not os.getenv("DINGTALK_ALLOWED_CHATS"))
     allowed = dingtalk_cfg.get("allowed_users")
     if allowed is None:
         # Fall back to the documented nested paths (#44928). The docs
@@ -1826,10 +1844,11 @@ def _apply_yaml_config(yaml_cfg: dict, dingtalk_cfg: dict) -> dict | None:
                 if isinstance(_dt_extra, dict) and _dt_extra.get("allowed_users") is not None:
                     allowed = _dt_extra.get("allowed_users")
                     break
-    if allowed is not None and not os.getenv("DINGTALK_ALLOWED_USERS"):
+    if allowed is not None:
         if isinstance(allowed, list):
             allowed = ",".join(str(v) for v in allowed)
-        os.environ["DINGTALK_ALLOWED_USERS"] = str(allowed)
+        leaf = "allowed_users" if "allowed_users" in dingtalk_cfg else "extra.allowed_users"
+        _write("DINGTALK_ALLOWED_USERS", str(allowed), leaf, lambda: not os.getenv("DINGTALK_ALLOWED_USERS"))
     return None
 
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9657,12 +9657,28 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     remains only for existing callers that construct adapters without config
     extras. Returns canonical WebSocket liveness settings to seed that extra.
     """
-    if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
-        os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
-    if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
-        os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
-    if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):
-        os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] = str(discord_cfg["bots_require_inline_mention"]).lower()
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "discord"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    for key, env in (
+        ("require_mention", "DISCORD_REQUIRE_MENTION"),
+        ("thread_require_mention", "DISCORD_THREAD_REQUIRE_MENTION"),
+        ("bots_require_inline_mention", "DISCORD_BOTS_REQUIRE_INLINE_MENTION"),
+    ):
+        if key in discord_cfg:
+            _write(env, str(discord_cfg[key]).lower(), key, lambda env=env: not os.getenv(env))
     platforms_cfg = yaml_cfg.get("platforms")
     platform_extra_cfg = {}
     if isinstance(platforms_cfg, dict):
@@ -9675,55 +9691,57 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         discord_cfg["allow_from"] if "allow_from" in discord_cfg
         else platform_extra_cfg.get("allow_from")
     )
-    if allowed_users_cfg is not None and not os.getenv("DISCORD_ALLOWED_USERS"):
+    if allowed_users_cfg is not None:
         if isinstance(allowed_users_cfg, list):
             allowed_users_cfg = ",".join(str(v) for v in allowed_users_cfg)
-        os.environ["DISCORD_ALLOWED_USERS"] = str(allowed_users_cfg)
+        leaf = "allow_from" if "allow_from" in discord_cfg else "extra.allow_from"
+        _write("DISCORD_ALLOWED_USERS", str(allowed_users_cfg), leaf, lambda: not os.getenv("DISCORD_ALLOWED_USERS"))
     approval_mentions_cfg = (
         discord_cfg["approval_mentions"] if "approval_mentions" in discord_cfg
         else platform_extra_cfg.get("approval_mentions")
     )
-    if approval_mentions_cfg is not None and not os.getenv("DISCORD_APPROVAL_MENTIONS"):
-        os.environ["DISCORD_APPROVAL_MENTIONS"] = str(approval_mentions_cfg).lower()
+    if approval_mentions_cfg is not None:
+        leaf = "approval_mentions" if "approval_mentions" in discord_cfg else "extra.approval_mentions"
+        _write("DISCORD_APPROVAL_MENTIONS", str(approval_mentions_cfg).lower(), leaf, lambda: not os.getenv("DISCORD_APPROVAL_MENTIONS"))
     frc = discord_cfg.get("free_response_channels")
-    if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
-    if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
-        os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
-    if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
-        os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+        _write("DISCORD_FREE_RESPONSE_CHANNELS", str(frc), "free_response_channels", lambda: not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"))
+    if "auto_thread" in discord_cfg:
+        _write("DISCORD_AUTO_THREAD", str(discord_cfg["auto_thread"]).lower(), "auto_thread", lambda: not os.getenv("DISCORD_AUTO_THREAD"))
+    if "reactions" in discord_cfg:
+        _write("DISCORD_REACTIONS", str(discord_cfg["reactions"]).lower(), "reactions", lambda: not os.getenv("DISCORD_REACTIONS"))
     seeded_extra = {}
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)
     # ignored_channels: channels where bot never responds (even when mentioned)
     ic = discord_cfg.get("ignored_channels")
-    if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):
+    if ic is not None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
-        os.environ["DISCORD_IGNORED_CHANNELS"] = str(ic)
+        _write("DISCORD_IGNORED_CHANNELS", str(ic), "ignored_channels", lambda: not os.getenv("DISCORD_IGNORED_CHANNELS"))
     # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
     ac = discord_cfg.get("allowed_channels")
-    if ac is not None and not os.getenv("DISCORD_ALLOWED_CHANNELS"):
+    if ac is not None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
-        os.environ["DISCORD_ALLOWED_CHANNELS"] = str(ac)
+        _write("DISCORD_ALLOWED_CHANNELS", str(ac), "allowed_channels", lambda: not os.getenv("DISCORD_ALLOWED_CHANNELS"))
     # no_thread_channels: channels where bot responds directly without creating thread
     ntc = discord_cfg.get("no_thread_channels")
-    if ntc is not None and not os.getenv("DISCORD_NO_THREAD_CHANNELS"):
+    if ntc is not None:
         if isinstance(ntc, list):
             ntc = ",".join(str(v) for v in ntc)
-        os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+        _write("DISCORD_NO_THREAD_CHANNELS", str(ntc), "no_thread_channels", lambda: not os.getenv("DISCORD_NO_THREAD_CHANNELS"))
     # history_backfill: recover missed channel messages for shared sessions
     # when require_mention is active.  Fetches messages between bot turns
     # and prepends them to the user message for context.
-    if "history_backfill" in discord_cfg and not os.getenv("DISCORD_HISTORY_BACKFILL"):
-        os.environ["DISCORD_HISTORY_BACKFILL"] = str(discord_cfg["history_backfill"]).lower()
+    if "history_backfill" in discord_cfg:
+        _write("DISCORD_HISTORY_BACKFILL", str(discord_cfg["history_backfill"]).lower(), "history_backfill", lambda: not os.getenv("DISCORD_HISTORY_BACKFILL"))
     hbl = discord_cfg.get("history_backfill_limit")
-    if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
-        os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+    if hbl is not None:
+        _write("DISCORD_HISTORY_BACKFILL_LIMIT", str(hbl), "history_backfill_limit", lambda: not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"))
     # allow_mentions: granular control over what the bot can ping.
     # Safe defaults (no @everyone/roles) are applied in the adapter;
     # these YAML keys only override when set and let users opt back
@@ -9736,8 +9754,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             ("users", "DISCORD_ALLOW_MENTION_USERS"),
             ("replied_user", "DISCORD_ALLOW_MENTION_REPLIED_USER"),
         ):
-            if yaml_key in allow_mentions_cfg and not os.getenv(env_key):
-                os.environ[env_key] = str(allow_mentions_cfg[yaml_key]).lower()
+            if yaml_key in allow_mentions_cfg:
+                _write(env_key, str(allow_mentions_cfg[yaml_key]).lower(), f"allow_mentions.{yaml_key}", lambda env_key=env_key: not os.getenv(env_key))
     # reply_to_mode: top-level preferred, falls back to extra.reply_to_mode.
     # YAML 1.1 parses bare 'off' as boolean False — coerce to string "off".
     _discord_extra = discord_cfg.get("extra") if isinstance(discord_cfg.get("extra"), dict) else {}
@@ -9745,9 +9763,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         discord_cfg["reply_to_mode"] if "reply_to_mode" in discord_cfg
         else _discord_extra.get("reply_to_mode")
     )
-    if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
+    if _discord_rtm is not None:
         _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
-        os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str
+        _write("DISCORD_REPLY_TO_MODE", _rtm_str, "reply_to_mode" if "reply_to_mode" in discord_cfg else "extra.reply_to_mode", lambda: not os.getenv("DISCORD_REPLY_TO_MODE"))
     _websocket_extra_cfg = discord_cfg.get("extra")
     if not isinstance(_websocket_extra_cfg, dict):
         _websocket_extra_cfg = {}
@@ -9776,12 +9794,22 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     )
     for primary_key, legacy_key, env_key in _websocket_liveness_keys:
         value = _websocket_liveness_cfg.get(primary_key)
+        source_leaf = (
+            primary_key
+            if primary_key in discord_cfg
+            else f"extra.{primary_key}"
+        )
         if value is None and legacy_key:
             value = _websocket_liveness_cfg.get(legacy_key)
+            source_leaf = (
+                legacy_key
+                if legacy_key in discord_cfg
+                else f"extra.{legacy_key}"
+            )
         if value is not None:
             seeded_extra[primary_key] = value
-            if env_key and not os.getenv(env_key):
-                os.environ[env_key] = str(value)
+            if env_key:
+                _write(env_key, str(value), source_leaf, lambda env_key=env_key: not os.getenv(env_key))
     return seeded_extra or None
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5803,8 +5803,19 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
     feishu_cfg block from gateway/config.py::load_gateway_config() (allow_bots).
     Env vars take precedence over YAML. Returns None — flows through env.
     """
-    if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
-        os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "feishu"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    if "allow_bots" in feishu_cfg:
+        value = str(feishu_cfg["allow_bots"]).lower()
+        if yaml_env is not None:
+            yaml_env.set_env_from_yaml("FEISHU_ALLOW_BOTS", value, source_for("allow_bots"), predicate=lambda: not os.getenv("FEISHU_ALLOW_BOTS"))
+        elif not os.getenv("FEISHU_ALLOW_BOTS"):
+            os.environ["FEISHU_ALLOW_BOTS"] = value
     return None
 
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4916,38 +4916,47 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
     matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
     take precedence over YAML. Returns None — everything flows through env.
     """
-    if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
-        os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "matrix"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    if "require_mention" in matrix_cfg:
+        _write("MATRIX_REQUIRE_MENTION", str(matrix_cfg["require_mention"]).lower(), "require_mention", lambda: not os.getenv("MATRIX_REQUIRE_MENTION"))
     au = matrix_cfg.get("allowed_users")
-    if au is not None and not os.getenv("MATRIX_ALLOWED_USERS"):
+    if au is not None:
         if isinstance(au, list):
             au = ",".join(str(v) for v in au)
-        os.environ["MATRIX_ALLOWED_USERS"] = str(au)
+        _write("MATRIX_ALLOWED_USERS", str(au), "allowed_users", lambda: not os.getenv("MATRIX_ALLOWED_USERS"))
     frc = matrix_cfg.get("free_response_rooms")
-    if frc is not None and not os.getenv("MATRIX_FREE_RESPONSE_ROOMS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["MATRIX_FREE_RESPONSE_ROOMS"] = str(frc)
+        _write("MATRIX_FREE_RESPONSE_ROOMS", str(frc), "free_response_rooms", lambda: not os.getenv("MATRIX_FREE_RESPONSE_ROOMS"))
     ar = matrix_cfg.get("allowed_rooms")
-    if ar is not None and not os.getenv("MATRIX_ALLOWED_ROOMS"):
+    if ar is not None:
         if isinstance(ar, list):
             ar = ",".join(str(v) for v in ar)
-        os.environ["MATRIX_ALLOWED_ROOMS"] = str(ar)
+        _write("MATRIX_ALLOWED_ROOMS", str(ar), "allowed_rooms", lambda: not os.getenv("MATRIX_ALLOWED_ROOMS"))
     ignore_patterns = matrix_cfg.get("ignore_user_patterns")
-    if ignore_patterns is not None and not os.getenv("MATRIX_IGNORE_USER_PATTERNS"):
+    if ignore_patterns is not None:
         if isinstance(ignore_patterns, list):
             ignore_patterns = ",".join(str(v) for v in ignore_patterns)
-        os.environ["MATRIX_IGNORE_USER_PATTERNS"] = str(ignore_patterns)
-    if "process_notices" in matrix_cfg and not os.getenv("MATRIX_PROCESS_NOTICES"):
-        os.environ["MATRIX_PROCESS_NOTICES"] = str(matrix_cfg["process_notices"]).lower()
-    if "session_scope" in matrix_cfg and not os.getenv("MATRIX_SESSION_SCOPE"):
-        os.environ["MATRIX_SESSION_SCOPE"] = str(matrix_cfg["session_scope"]).lower()
-    if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
-        os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
-    if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
-        os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
-    if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
-        os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
+        _write("MATRIX_IGNORE_USER_PATTERNS", str(ignore_patterns), "ignore_user_patterns", lambda: not os.getenv("MATRIX_IGNORE_USER_PATTERNS"))
+    for key, env in (("process_notices", "MATRIX_PROCESS_NOTICES"), ("session_scope", "MATRIX_SESSION_SCOPE"), ("auto_thread", "MATRIX_AUTO_THREAD"), ("dm_mention_threads", "MATRIX_DM_MENTION_THREADS"), ("max_message_length", "MATRIX_MAX_MESSAGE_LENGTH")):
+        if key in matrix_cfg:
+            value = str(matrix_cfg[key]).lower() if key != "max_message_length" else str(matrix_cfg[key])
+            _write(env, value, key, lambda env=env: not os.getenv(env))
     return None
 
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1215,19 +1215,34 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     update.  Returns ``None`` because no extras are seeded into
     ``PlatformConfig.extra`` directly (everything flows through env).
     """
-    if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
-        os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "mattermost"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    if "require_mention" in mattermost_cfg:
+        _write("MATTERMOST_REQUIRE_MENTION", str(mattermost_cfg["require_mention"]).lower(), "require_mention", lambda: not os.getenv("MATTERMOST_REQUIRE_MENTION"))
     frc = mattermost_cfg.get("free_response_channels")
-    if frc is not None and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["MATTERMOST_FREE_RESPONSE_CHANNELS"] = str(frc)
+        _write("MATTERMOST_FREE_RESPONSE_CHANNELS", str(frc), "free_response_channels", lambda: not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"))
     # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
     ac = mattermost_cfg.get("allowed_channels")
-    if ac is not None and not os.getenv("MATTERMOST_ALLOWED_CHANNELS"):
+    if ac is not None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
-        os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+        _write("MATTERMOST_ALLOWED_CHANNELS", str(ac), "allowed_channels", lambda: not os.getenv("MATTERMOST_ALLOWED_CHANNELS"))
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -8975,56 +8975,64 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     survive a config.yaml update. Returns ``None`` because no extras are
     seeded into ``PlatformConfig.extra`` directly (everything flows through env).
     """
-    if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
-        os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
-    if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
-        os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
-    if "ignore_other_user_mentions" in slack_cfg and not os.getenv("SLACK_IGNORE_OTHER_USER_MENTIONS"):
-        os.environ["SLACK_IGNORE_OTHER_USER_MENTIONS"] = str(
-            slack_cfg["ignore_other_user_mentions"]
-        ).lower()
-    if "thread_require_mention" in slack_cfg and not os.getenv(
-        "SLACK_THREAD_REQUIRE_MENTION"
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "slack"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    for key, env in (
+        ("require_mention", "SLACK_REQUIRE_MENTION"),
+        ("strict_mention", "SLACK_STRICT_MENTION"),
+        ("ignore_other_user_mentions", "SLACK_IGNORE_OTHER_USER_MENTIONS"),
+        ("thread_require_mention", "SLACK_THREAD_REQUIRE_MENTION"),
+        ("allow_bots", "SLACK_ALLOW_BOTS"),
     ):
-        os.environ["SLACK_THREAD_REQUIRE_MENTION"] = str(
-            slack_cfg["thread_require_mention"]
-        ).lower()
-    if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
-        os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
+        if key in slack_cfg:
+            _write(env, str(slack_cfg[key]).lower(), key, lambda env=env: not os.getenv(env))
     frc = slack_cfg.get("free_response_channels")
-    if frc is not None and not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["SLACK_FREE_RESPONSE_CHANNELS"] = str(frc)
+        _write("SLACK_FREE_RESPONSE_CHANNELS", str(frc), "free_response_channels", lambda: not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"))
     rmc = slack_cfg.get("require_mention_channels")
-    if rmc is not None and not os.getenv("SLACK_REQUIRE_MENTION_CHANNELS"):
+    if rmc is not None:
         if isinstance(rmc, list):
             rmc = ",".join(str(v) for v in rmc)
-        os.environ["SLACK_REQUIRE_MENTION_CHANNELS"] = str(rmc)
-    if "reactions" in slack_cfg and not os.getenv("SLACK_REACTIONS"):
-        os.environ["SLACK_REACTIONS"] = str(slack_cfg["reactions"]).lower()
+        _write("SLACK_REQUIRE_MENTION_CHANNELS", str(rmc), "require_mention_channels", lambda: not os.getenv("SLACK_REQUIRE_MENTION_CHANNELS"))
+    if "reactions" in slack_cfg:
+        _write("SLACK_REACTIONS", str(slack_cfg["reactions"]).lower(), "reactions", lambda: not os.getenv("SLACK_REACTIONS"))
     rt = slack_cfg.get("reaction_triggers")
-    if rt is not None and not os.getenv("SLACK_REACTION_TRIGGERS"):
+    if rt is not None:
         if isinstance(rt, (list, tuple, set)):
             rt = ",".join(str(v) for v in rt)
-        os.environ["SLACK_REACTION_TRIGGERS"] = str(rt)
+        _write("SLACK_REACTION_TRIGGERS", str(rt), "reaction_triggers", lambda: not os.getenv("SLACK_REACTION_TRIGGERS"))
     rtt = slack_cfg.get("reaction_trigger_target")
-    if rtt is not None and not os.getenv("SLACK_REACTION_TRIGGER_TARGET"):
-        os.environ["SLACK_REACTION_TRIGGER_TARGET"] = str(rtt)
+    if rtt is not None:
+        _write("SLACK_REACTION_TRIGGER_TARGET", str(rtt), "reaction_trigger_target", lambda: not os.getenv("SLACK_REACTION_TRIGGER_TARGET"))
 
-    if "disable_dms" in slack_cfg and not os.getenv("SLACK_DISABLE_DMS"):
-        os.environ["SLACK_DISABLE_DMS"] = str(slack_cfg["disable_dms"]).lower()
+    if "disable_dms" in slack_cfg:
+        _write("SLACK_DISABLE_DMS", str(slack_cfg["disable_dms"]).lower(), "disable_dms", lambda: not os.getenv("SLACK_DISABLE_DMS"))
     ac = slack_cfg.get("allowed_channels")
-    if ac is not None and not os.getenv("SLACK_ALLOWED_CHANNELS"):
+    if ac is not None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
-        os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+        _write("SLACK_ALLOWED_CHANNELS", str(ac), "allowed_channels", lambda: not os.getenv("SLACK_ALLOWED_CHANNELS"))
     # ignored_channels: blacklist channels where Slack must never respond.
     ic = slack_cfg.get("ignored_channels")
-    if ic is not None and not os.getenv("SLACK_IGNORED_CHANNELS"):
+    if ic is not None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
-        os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
+        _write("SLACK_IGNORED_CHANNELS", str(ic), "ignored_channels", lambda: not os.getenv("SLACK_IGNORED_CHANNELS"))
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9905,76 +9905,101 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
     PlatformConfig.extra (disable_topic_auto_rename + runtime flags), or None.
     """
     import json as _json
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "telegram"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
     extras: dict = {}
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            source = "require_mention" if leaf == "__root__.require_mention" else source_for(leaf)
+            return yaml_env.set_env_from_yaml(name, value, source, predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
 
     if "disable_topic_auto_rename" in telegram_cfg:
         extras.setdefault("disable_topic_auto_rename", telegram_cfg["disable_topic_auto_rename"])
 
     _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
-    if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
-        os.environ["TELEGRAM_REQUIRE_MENTION"] = str(_effective_rm).lower()
-    if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
-        os.environ["TELEGRAM_MENTION_PATTERNS"] = _json.dumps(telegram_cfg["mention_patterns"])
-    if "exclusive_bot_mentions" in telegram_cfg and not os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS"):
-        os.environ["TELEGRAM_EXCLUSIVE_BOT_MENTIONS"] = str(telegram_cfg["exclusive_bot_mentions"]).lower()
-    if "allow_bots" in telegram_cfg and not os.getenv("TELEGRAM_ALLOW_BOTS"):
-        os.environ["TELEGRAM_ALLOW_BOTS"] = str(telegram_cfg["allow_bots"]).lower()
-    if "guest_mode" in telegram_cfg and not os.getenv("TELEGRAM_GUEST_MODE"):
-        os.environ["TELEGRAM_GUEST_MODE"] = str(telegram_cfg["guest_mode"]).lower()
-    if "observe_unmentioned_group_messages" in telegram_cfg and not os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
-        os.environ["TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] = str(telegram_cfg["observe_unmentioned_group_messages"]).lower()
+    if _effective_rm is not None:
+        leaf = "require_mention" if "require_mention" in telegram_cfg else "__root__.require_mention"
+        _write("TELEGRAM_REQUIRE_MENTION", str(_effective_rm).lower(), leaf, lambda: not os.getenv("TELEGRAM_REQUIRE_MENTION"))
+    for key, env in (
+        ("mention_patterns", "TELEGRAM_MENTION_PATTERNS"),
+        ("exclusive_bot_mentions", "TELEGRAM_EXCLUSIVE_BOT_MENTIONS"),
+        ("allow_bots", "TELEGRAM_ALLOW_BOTS"),
+        ("guest_mode", "TELEGRAM_GUEST_MODE"),
+        ("observe_unmentioned_group_messages", "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"),
+    ):
+        if key in telegram_cfg:
+            value = _json.dumps(telegram_cfg[key]) if key == "mention_patterns" else str(telegram_cfg[key]).lower()
+            _write(env, value, key, lambda env=env: not os.getenv(env))
     frc = telegram_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_CHATS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+        _write("TELEGRAM_FREE_RESPONSE_CHATS", str(frc), "free_response_chats", lambda: not os.getenv("TELEGRAM_FREE_RESPONSE_CHATS"))
     frt = telegram_cfg.get("free_response_topics")
-    if frt is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_TOPICS"):
+    if frt is not None:
         if isinstance(frt, list):
             frt = ",".join(str(v) for v in frt)
-        os.environ["TELEGRAM_FREE_RESPONSE_TOPICS"] = str(frt)
+        _write("TELEGRAM_FREE_RESPONSE_TOPICS", str(frt), "free_response_topics", lambda: not os.getenv("TELEGRAM_FREE_RESPONSE_TOPICS"))
     ac = telegram_cfg.get("allowed_chats")
-    if ac is not None and not os.getenv("TELEGRAM_ALLOWED_CHATS"):
+    if ac is not None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
-        os.environ["TELEGRAM_ALLOWED_CHATS"] = str(ac)
+        _write("TELEGRAM_ALLOWED_CHATS", str(ac), "allowed_chats", lambda: not os.getenv("TELEGRAM_ALLOWED_CHATS"))
     allowed_topics = telegram_cfg.get("allowed_topics")
-    if allowed_topics is not None and not os.getenv("TELEGRAM_ALLOWED_TOPICS"):
+    if allowed_topics is not None:
         if isinstance(allowed_topics, list):
             allowed_topics = ",".join(str(v) for v in allowed_topics)
-        os.environ["TELEGRAM_ALLOWED_TOPICS"] = str(allowed_topics)
+        _write("TELEGRAM_ALLOWED_TOPICS", str(allowed_topics), "allowed_topics", lambda: not os.getenv("TELEGRAM_ALLOWED_TOPICS"))
     ignored_threads = telegram_cfg.get("ignored_threads")
-    if ignored_threads is not None and not os.getenv("TELEGRAM_IGNORED_THREADS"):
+    if ignored_threads is not None:
         if isinstance(ignored_threads, list):
             ignored_threads = ",".join(str(v) for v in ignored_threads)
-        os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
-    if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
-        os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
-    if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
-        os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
+        _write("TELEGRAM_IGNORED_THREADS", str(ignored_threads), "ignored_threads", lambda: not os.getenv("TELEGRAM_IGNORED_THREADS"))
+    if "reactions" in telegram_cfg:
+        _write("TELEGRAM_REACTIONS", str(telegram_cfg["reactions"]).lower(), "reactions", lambda: not os.getenv("TELEGRAM_REACTIONS"))
+    if "proxy_url" in telegram_cfg:
+        _write("TELEGRAM_PROXY", str(telegram_cfg["proxy_url"]).strip(), "proxy_url", lambda: not os.getenv("TELEGRAM_PROXY"))
     _telegram_extra = telegram_cfg.get("extra") if isinstance(telegram_cfg.get("extra"), dict) else {}
     _telegram_rtm = (
         telegram_cfg["reply_to_mode"] if "reply_to_mode" in telegram_cfg
         else _telegram_extra.get("reply_to_mode")
     )
-    if _telegram_rtm is not None and not os.getenv("TELEGRAM_REPLY_TO_MODE"):
+    if _telegram_rtm is not None:
         _rtm_str = "off" if _telegram_rtm is False else str(_telegram_rtm).lower()
-        os.environ["TELEGRAM_REPLY_TO_MODE"] = _rtm_str
+        _write("TELEGRAM_REPLY_TO_MODE", _rtm_str, "reply_to_mode" if "reply_to_mode" in telegram_cfg else "extra.reply_to_mode", lambda: not os.getenv("TELEGRAM_REPLY_TO_MODE"))
     allowed_users = telegram_cfg.get("allow_from")
-    if allowed_users is not None and not os.getenv("TELEGRAM_ALLOWED_USERS"):
+    if allowed_users is not None:
         if isinstance(allowed_users, list):
             allowed_users = ",".join(str(v) for v in allowed_users)
-        os.environ["TELEGRAM_ALLOWED_USERS"] = str(allowed_users)
-    group_allowed_users = telegram_cfg.get("group_allow_from") or _telegram_extra.get("group_allow_from")
-    if group_allowed_users is not None and not os.getenv("TELEGRAM_GROUP_ALLOWED_USERS"):
+        _write("TELEGRAM_ALLOWED_USERS", str(allowed_users), "allow_from", lambda: not os.getenv("TELEGRAM_ALLOWED_USERS"))
+    group_allowed_users = telegram_cfg.get("group_allow_from")
+    group_allowed_users_leaf = "group_allow_from"
+    if not group_allowed_users:
+        group_allowed_users = _telegram_extra.get("group_allow_from")
+        group_allowed_users_leaf = "extra.group_allow_from"
+    if group_allowed_users is not None:
         if isinstance(group_allowed_users, list):
             group_allowed_users = ",".join(str(v) for v in group_allowed_users)
-        os.environ["TELEGRAM_GROUP_ALLOWED_USERS"] = str(group_allowed_users)
-    group_allowed_chats = telegram_cfg.get("group_allowed_chats") or _telegram_extra.get("group_allowed_chats")
-    if group_allowed_chats is not None and not os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS"):
+        _write("TELEGRAM_GROUP_ALLOWED_USERS", str(group_allowed_users), group_allowed_users_leaf, lambda: not os.getenv("TELEGRAM_GROUP_ALLOWED_USERS"))
+    group_allowed_chats = telegram_cfg.get("group_allowed_chats")
+    group_allowed_chats_leaf = "group_allowed_chats"
+    if not group_allowed_chats:
+        group_allowed_chats = _telegram_extra.get("group_allowed_chats")
+        group_allowed_chats_leaf = "extra.group_allowed_chats"
+    if group_allowed_chats is not None:
         if isinstance(group_allowed_chats, list):
             group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
-        os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
+        _write("TELEGRAM_GROUP_ALLOWED_CHATS", str(group_allowed_chats), group_allowed_chats_leaf, lambda: not os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS"))
     for _key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages", "free_response_topics"):
         if _key in telegram_cfg:
             extras.setdefault(_key, telegram_cfg[_key])

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1778,29 +1778,44 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
     take precedence over YAML. Returns None — everything flows through env.
     """
     import json as _json
-    if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
-        os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
-    if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
-        os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
+    from gateway.yaml_env import get_yaml_env_context
+
+    _context = get_yaml_env_context()
+    yaml_env = _context.load if _context else None
+    source_prefix = _context.source_prefix if _context else "whatsapp"
+    source_for = _context.source_for if _context else lambda leaf: f"{source_prefix}.{leaf}"
+
+    def _write(name, value, leaf, predicate):
+        if yaml_env is not None:
+            return yaml_env.set_env_from_yaml(name, value, source_for(leaf), predicate=predicate)
+        if predicate():
+            os.environ[name] = value
+            return True
+        return False
+
+    if "require_mention" in whatsapp_cfg:
+        _write("WHATSAPP_REQUIRE_MENTION", str(whatsapp_cfg["require_mention"]).lower(), "require_mention", lambda: not os.getenv("WHATSAPP_REQUIRE_MENTION"))
+    if "mention_patterns" in whatsapp_cfg:
+        _write("WHATSAPP_MENTION_PATTERNS", _json.dumps(whatsapp_cfg["mention_patterns"]), "mention_patterns", lambda: not os.getenv("WHATSAPP_MENTION_PATTERNS"))
     frc = whatsapp_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
+    if frc is not None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
-        os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
-    if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
-        os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
+        _write("WHATSAPP_FREE_RESPONSE_CHATS", str(frc), "free_response_chats", lambda: not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"))
+    if "dm_policy" in whatsapp_cfg:
+        _write("WHATSAPP_DM_POLICY", str(whatsapp_cfg["dm_policy"]).lower(), "dm_policy", lambda: not os.getenv("WHATSAPP_DM_POLICY"))
     af = whatsapp_cfg.get("allow_from")
-    if af is not None and not os.getenv("WHATSAPP_ALLOWED_USERS"):
+    if af is not None:
         if isinstance(af, list):
             af = ",".join(str(v) for v in af)
-        os.environ["WHATSAPP_ALLOWED_USERS"] = str(af)
-    if "group_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_GROUP_POLICY"):
-        os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
+        _write("WHATSAPP_ALLOWED_USERS", str(af), "allow_from", lambda: not os.getenv("WHATSAPP_ALLOWED_USERS"))
+    if "group_policy" in whatsapp_cfg:
+        _write("WHATSAPP_GROUP_POLICY", str(whatsapp_cfg["group_policy"]).lower(), "group_policy", lambda: not os.getenv("WHATSAPP_GROUP_POLICY"))
     gaf = whatsapp_cfg.get("group_allow_from")
-    if gaf is not None and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
+    if gaf is not None:
         if isinstance(gaf, list):
             gaf = ",".join(str(v) for v in gaf)
-        os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
+        _write("WHATSAPP_GROUP_ALLOWED_USERS", str(gaf), "group_allow_from", lambda: not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"))
     return None
 
 

--- a/tests/gateway/fixtures/issue-13582-telegram-self-restart.json
+++ b/tests/gateway/fixtures/issue-13582-telegram-self-restart.json
@@ -1,0 +1,13 @@
+{
+  "issue": 13582,
+  "host_os": "Windows 10",
+  "platform": "telegram",
+  "transport": "polling",
+  "multiplex_profiles": true,
+  "restart_command": "/restart",
+  "require_mention": true,
+  "initial_free_response_chats": ["-1001"],
+  "updated_free_response_chats": ["-1001", "-1002"],
+  "ordinary_message_chat": "-1002",
+  "observed_stale_gating_log": "ordinary message in the newly added group remained mention-gated"
+}

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1184,3 +1184,496 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestYamlEnvProvenance:
+    @pytest.fixture(autouse=True)
+    def _clear_yaml_env_records(self):
+        from gateway.yaml_env import clear_records
+
+        clear_records()
+        yield
+        clear_records()
+
+    def test_load_identity_guards_refresh_and_source(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+
+        monkeypatch.delenv("TEST_YAML_VALUE", raising=False)
+        load = YamlEnvLoad("gateway-config:/profile", lambda path: "managed-config")
+        assert load.set_env_from_yaml(
+            "TEST_YAML_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+        )
+        record = records_snapshot()["TEST_YAML_VALUE"]
+        assert record.owner == "gateway-config:/profile"
+        assert record.value == "A"
+        assert record.source == "managed-config:telegram.free_response_chats"
+
+    def test_successful_load_reconciles_removed_generated_writers(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw_home:
+            home = Path(raw_home) / ".hermes"
+            home.mkdir()
+            config_path = home / "config.yaml"
+            config_path.write_text(
+                "telegram:\n  free_response_chats:\n    - -1001\n",
+                encoding="utf-8",
+            )
+            monkeypatch.setenv("HERMES_HOME", str(home))
+            monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
+            load_gateway_config()
+            assert os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-1001"
+            config_path.write_text("telegram:\n  require_mention: true\n", encoding="utf-8")
+            load_gateway_config()
+            assert "TELEGRAM_FREE_RESPONSE_CHATS" not in os.environ
+
+        monkeypatch.delenv("TEST_YAML_VALUE", raising=False)
+        load = YamlEnvLoad("gateway-config:/profile")
+        load.set_env_from_yaml("TEST_YAML_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+        load2 = YamlEnvLoad("gateway-config:/profile")
+        load2.finish()
+        assert "TEST_YAML_VALUE" not in os.environ
+        assert "TEST_YAML_VALUE" not in records_snapshot()
+
+        os.environ["TEST_YAML_VALUE"] = "external"
+        load3 = YamlEnvLoad("gateway-config:/other")
+        load3.finish()
+        assert os.environ["TEST_YAML_VALUE"] == "external"
+
+    def test_incomplete_load_aborts_absence_cleanup(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+
+        monkeypatch.delenv("TEST_YAML_VALUE", raising=False)
+        first = YamlEnvLoad("gateway-config:/profile")
+        first.set_env_from_yaml("TEST_YAML_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+        second = YamlEnvLoad("gateway-config:/profile")
+        second.abort()
+        second.finish()
+        assert os.environ["TEST_YAML_VALUE"] == "A"
+        assert records_snapshot()["TEST_YAML_VALUE"].value == "A"
+
+    def test_plugin_discovery_failure_aborts_absence_cleanup(self, tmp_path, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, clear_records, records_snapshot
+        from hermes_cli import plugins
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("telegram: {}\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("TEST_YAML_VALUE", "A")
+        prior = YamlEnvLoad(f"gateway-config:{home.resolve()}")
+        prior.set_env_from_yaml(
+            "TEST_YAML_VALUE", "A", "test.value", predicate=lambda: True
+        )
+
+        monkeypatch.setattr(
+            plugins,
+            "discover_plugins",
+            lambda: (_ for _ in ()).throw(RuntimeError("discovery failed")),
+        )
+        load_gateway_config()
+
+        assert os.environ["TEST_YAML_VALUE"] == "A"
+        assert records_snapshot()["TEST_YAML_VALUE"].value == "A"
+        clear_records()
+
+    def test_yaml_env_writer_preserves_original_guard_semantics(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad
+
+        load = YamlEnvLoad("gateway-config:/guards")
+        monkeypatch.setenv("PRESENCE_VALUE", "")
+        assert not load.set_env_from_yaml("PRESENCE_VALUE", "new", "a", predicate=lambda: "PRESENCE_VALUE" not in os.environ)
+        monkeypatch.setenv("FALSY_VALUE", "")
+        assert load.set_env_from_yaml("FALSY_VALUE", "new", "b", predicate=lambda: not os.getenv("FALSY_VALUE"))
+        monkeypatch.setenv("BLANK_VALUE", "  ")
+        assert load.set_env_from_yaml("BLANK_VALUE", "new", "c", predicate=lambda: not os.environ.get("BLANK_VALUE", "").strip())
+
+    def test_same_owner_reload_refreshes_and_reconciles(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad
+
+        monkeypatch.delenv("TEST_YAML_VALUE", raising=False)
+        first = YamlEnvLoad("gateway-config:/profile")
+        first.set_env_from_yaml("TEST_YAML_VALUE", "A", "a", predicate=lambda: True)
+        second = YamlEnvLoad("gateway-config:/profile")
+        second.set_env_from_yaml("TEST_YAML_VALUE", "B", "b", predicate=lambda: False)
+        assert os.environ["TEST_YAML_VALUE"] == "B"
+        third = YamlEnvLoad("gateway-config:/profile")
+        third.finish()
+        assert "TEST_YAML_VALUE" not in os.environ
+
+    def test_profile_load_does_not_adopt_or_reconcile_other_owner_record(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+
+        monkeypatch.delenv("TEST_YAML_VALUE", raising=False)
+        first = YamlEnvLoad("gateway-config:/one")
+        first.set_env_from_yaml("TEST_YAML_VALUE", "A", "a", predicate=lambda: True)
+        second = YamlEnvLoad("gateway-config:/two")
+        second.set_env_from_yaml("TEST_YAML_VALUE", "B", "b", predicate=lambda: not os.getenv("TEST_YAML_VALUE"))
+        assert os.environ["TEST_YAML_VALUE"] == "A"
+        assert records_snapshot()["TEST_YAML_VALUE"].owner == "gateway-config:/one"
+
+    def test_equal_external_values_never_acquire_provenance(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot, without_yaml_generated_env
+
+        monkeypatch.setenv("TEST_YAML_VALUE", "same")
+        load = YamlEnvLoad("gateway-config:/equal")
+        load.set_env_from_yaml("TEST_YAML_VALUE", "same", "a", predicate=lambda: not os.getenv("TEST_YAML_VALUE"))
+        assert "TEST_YAML_VALUE" not in records_snapshot()
+        assert without_yaml_generated_env(dict(os.environ))["TEST_YAML_VALUE"] == "same"
+
+    def test_managed_source_selection_does_not_override_external_environment(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+
+        monkeypatch.setenv("TEST_YAML_VALUE", "external")
+        load = YamlEnvLoad("gateway-config:/managed", lambda path: "managed-config")
+        load.set_env_from_yaml("TEST_YAML_VALUE", "managed", "telegram.free_response_chats", predicate=lambda: not os.getenv("TEST_YAML_VALUE"))
+        assert os.environ["TEST_YAML_VALUE"] == "external"
+        assert "TEST_YAML_VALUE" not in records_snapshot()
+
+    def test_nested_platform_source_matches_effective_merge_precedence(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_scope
+        from gateway.yaml_env import records_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      free_response_chats: [user]\n",
+            encoding="utf-8",
+        )
+
+        managed_path = "platforms.telegram.free_response_chats"
+
+        def apply_overlay(config):
+            config = dict(config)
+            platforms = dict(config.get("platforms") or {})
+            platforms["telegram"] = {"free_response_chats": ["managed"]}
+            config["platforms"] = platforms
+            return config
+
+        monkeypatch.setattr(managed_scope, "apply_managed_overlay", apply_overlay)
+        monkeypatch.setattr(managed_scope, "managed_config_keys", lambda: {managed_path})
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "managed"
+        assert records_snapshot()["TELEGRAM_FREE_RESPONSE_CHATS"].source == (
+            "managed-config:platforms.telegram.free_response_chats"
+        )
+
+    def test_mixed_platform_blocks_resolve_source_per_leaf(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_scope
+        from gateway.yaml_env import records_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      free_response_chats: [user-nested]\n"
+            "platforms:\n"
+            "  telegram:\n"
+            "    require_mention: true\n"
+            "telegram:\n"
+            "  reply_to_mode: thread\n",
+            encoding="utf-8",
+        )
+
+        managed_path = "gateway.platforms.telegram.free_response_chats"
+
+        def apply_overlay(config):
+            config = dict(config)
+            gateway = dict(config.get("gateway") or {})
+            gateway_platforms = dict(gateway.get("platforms") or {})
+            telegram = dict(gateway_platforms.get("telegram") or {})
+            telegram["free_response_chats"] = ["managed"]
+            gateway_platforms["telegram"] = telegram
+            gateway["platforms"] = gateway_platforms
+            config["gateway"] = gateway
+            return config
+
+        monkeypatch.setattr(managed_scope, "apply_managed_overlay", apply_overlay)
+        monkeypatch.setattr(managed_scope, "managed_config_keys", lambda: {managed_path})
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        for name in (
+            "TELEGRAM_FREE_RESPONSE_CHATS",
+            "TELEGRAM_REQUIRE_MENTION",
+            "TELEGRAM_REPLY_TO_MODE",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        load_gateway_config()
+
+        records = records_snapshot()
+        assert records["TELEGRAM_FREE_RESPONSE_CHATS"].source == (
+            "managed-config:gateway.platforms.telegram.free_response_chats"
+        )
+        assert records["TELEGRAM_REQUIRE_MENTION"].source == (
+            "user-config:platforms.telegram.require_mention"
+        )
+        assert records["TELEGRAM_REPLY_TO_MODE"].source == (
+            "user-config:telegram.reply_to_mode"
+        )
+
+    def test_discord_websocket_liveness_extra_sources_resolve_per_leaf(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_scope
+        from gateway.yaml_env import records_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "platforms:\n"
+            "  discord:\n"
+            "    require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        managed_paths = {
+            "gateway.platforms.discord.extra.websocket_liveness_interval_seconds",
+            "gateway.platforms.discord.extra.websocket_liveness_failure_threshold",
+        }
+
+        def apply_overlay(config):
+            config = dict(config)
+            gateway = dict(config.get("gateway") or {})
+            gateway_platforms = dict(gateway.get("platforms") or {})
+            discord = dict(gateway_platforms.get("discord") or {})
+            discord["extra"] = {
+                **(discord.get("extra") or {}),
+                "websocket_liveness_interval_seconds": 11,
+                "websocket_liveness_failure_threshold": 8,
+            }
+            gateway_platforms["discord"] = discord
+            gateway["platforms"] = gateway_platforms
+            config["gateway"] = gateway
+            return config
+
+        monkeypatch.setattr(managed_scope, "apply_managed_overlay", apply_overlay)
+        monkeypatch.setattr(managed_scope, "managed_config_keys", lambda: managed_paths)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        for name in (
+            "HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS",
+            "HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        load_gateway_config()
+
+        records = records_snapshot()
+        assert records["HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS"].source == (
+            "managed-config:gateway.platforms.discord.extra.websocket_liveness_interval_seconds"
+        )
+        assert records["HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD"].source == (
+            "managed-config:gateway.platforms.discord.extra.websocket_liveness_failure_threshold"
+        )
+        assert records["DISCORD_REQUIRE_MENTION"].source == (
+            "user-config:platforms.discord.require_mention"
+        )
+
+    def test_telegram_group_extra_sources_resolve_per_leaf(self, tmp_path, monkeypatch):
+        from hermes_cli import managed_scope
+        from gateway.yaml_env import records_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        managed_paths = {
+            "gateway.platforms.telegram.extra.group_allow_from",
+            "gateway.platforms.telegram.extra.group_allowed_chats",
+        }
+
+        def apply_overlay(config):
+            config = dict(config)
+            gateway = dict(config.get("gateway") or {})
+            gateway_platforms = dict(gateway.get("platforms") or {})
+            telegram = dict(gateway_platforms.get("telegram") or {})
+            telegram["extra"] = {
+                **(telegram.get("extra") or {}),
+                "group_allow_from": ["alice"],
+                "group_allowed_chats": ["-1001"],
+            }
+            gateway_platforms["telegram"] = telegram
+            gateway["platforms"] = gateway_platforms
+            config["gateway"] = gateway
+            return config
+
+        monkeypatch.setattr(managed_scope, "apply_managed_overlay", apply_overlay)
+        monkeypatch.setattr(managed_scope, "managed_config_keys", lambda: managed_paths)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        for name in (
+            "TELEGRAM_GROUP_ALLOWED_USERS",
+            "TELEGRAM_GROUP_ALLOWED_CHATS",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        load_gateway_config()
+
+        records = records_snapshot()
+        assert records["TELEGRAM_GROUP_ALLOWED_USERS"].source == (
+            "managed-config:gateway.platforms.telegram.extra.group_allow_from"
+        )
+        assert records["TELEGRAM_GROUP_ALLOWED_CHATS"].source == (
+            "managed-config:gateway.platforms.telegram.extra.group_allowed_chats"
+        )
+        assert records["TELEGRAM_REQUIRE_MENTION"].source == (
+            "user-config:platforms.telegram.require_mention"
+        )
+
+    def test_external_overrides_remain_unmarked_under_all_sources(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot
+
+        for name, value in (("SHELL_VALUE", "shell"), ("SERVICE_VALUE", "service"), ("MANAGED_VALUE", "managed")):
+            monkeypatch.setenv(name, value)
+            load = YamlEnvLoad(f"gateway-config:/{name}")
+            load.set_env_from_yaml(name, value, name.lower(), predicate=lambda name=name: name not in os.environ)
+        assert all(name not in records_snapshot() for name in ("SHELL_VALUE", "SERVICE_VALUE", "MANAGED_VALUE"))
+
+    def test_sensitive_values_are_never_registered_or_scrubbed(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, records_snapshot, without_yaml_generated_env
+
+        monkeypatch.delenv("TEST_API_KEY", raising=False)
+        load = YamlEnvLoad("gateway-config:/secret")
+        assert not load.set_env_from_yaml("TEST_API_KEY", "secret", "api_key", predicate=lambda: True)
+        os.environ["TEST_API_KEY"] = "secret"
+        assert without_yaml_generated_env(dict(os.environ))["TEST_API_KEY"] == "secret"
+        assert "TEST_API_KEY" not in records_snapshot()
+
+    def test_legacy_unmarked_value_requires_clean_external_restart(self, monkeypatch):
+        from gateway.yaml_env import YamlEnvLoad, without_yaml_generated_env
+
+        monkeypatch.setenv("TEST_YAML_VALUE", "legacy")
+        load = YamlEnvLoad("gateway-config:/legacy")
+        load.finish()
+        assert without_yaml_generated_env(dict(os.environ))["TEST_YAML_VALUE"] == "legacy"
+
+    def test_all_nonsecret_platform_yaml_writers_route_with_exact_source(self, monkeypatch):
+        from gateway.yaml_env import (
+            YamlEnvLoad,
+            get_yaml_env_context,
+            records_snapshot,
+            yaml_env_context,
+        )
+        from plugins.platforms.buzz.adapter import _apply_yaml_config as buzz_apply
+        from plugins.platforms.dingtalk.adapter import _apply_yaml_config as dingtalk_apply
+        from plugins.platforms.discord.adapter import _apply_yaml_config as discord_apply
+        from plugins.platforms.feishu.adapter import _apply_yaml_config as feishu_apply
+        from plugins.platforms.matrix.adapter import _apply_yaml_config as matrix_apply
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config as mattermost_apply
+        from plugins.platforms.slack.adapter import _apply_yaml_config as slack_apply
+        from plugins.platforms.telegram.adapter import _apply_yaml_config as telegram_apply
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config as whatsapp_apply
+
+        cases = [
+            ("buzz", buzz_apply, {"extra": {"relay_url": "https://buzz"}}, "BUZZ_RELAY_URL", "extra.relay_url"),
+            ("dingtalk", dingtalk_apply, {"require_mention": True}, "DINGTALK_REQUIRE_MENTION", "require_mention"),
+            ("discord", discord_apply, {"require_mention": True}, "DISCORD_REQUIRE_MENTION", "require_mention"),
+            ("feishu", feishu_apply, {"allow_bots": True}, "FEISHU_ALLOW_BOTS", "allow_bots"),
+            ("matrix", matrix_apply, {"require_mention": True}, "MATRIX_REQUIRE_MENTION", "require_mention"),
+            ("mattermost", mattermost_apply, {"require_mention": True}, "MATTERMOST_REQUIRE_MENTION", "require_mention"),
+            ("slack", slack_apply, {"require_mention": True}, "SLACK_REQUIRE_MENTION", "require_mention"),
+            ("telegram", telegram_apply, {"free_response_chats": ["A", "B"]}, "TELEGRAM_FREE_RESPONSE_CHATS", "free_response_chats"),
+            ("whatsapp", whatsapp_apply, {"require_mention": True}, "WHATSAPP_REQUIRE_MENTION", "require_mention"),
+        ]
+        for platform, hook, platform_cfg, env_name, leaf in cases:
+            monkeypatch.delenv(env_name, raising=False)
+            load = YamlEnvLoad("gateway-config:/platform")
+            with yaml_env_context(load, f"platforms.{platform}"):
+                hook({}, platform_cfg)
+            context = get_yaml_env_context()
+            assert context is None
+            record = records_snapshot()[env_name]
+            assert record.source.endswith(f"platforms.{platform}.{leaf}")
+
+    def test_core_guarded_writers_route_through_yaml_env_load(self, tmp_path, monkeypatch):
+        from gateway.yaml_env import records_snapshot, clear_records
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "require_mention: true\nsignal:\n  require_mention: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
+        monkeypatch.delenv("SIGNAL_REQUIRE_MENTION", raising=False)
+        clear_records()
+        load_gateway_config()
+        assert {"TELEGRAM_REQUIRE_MENTION", "SIGNAL_REQUIRE_MENTION"} <= set(records_snapshot())
+
+
+def _run_yaml_env_proof(name, monkeypatch, tmp_path=None):
+    from gateway.yaml_env import clear_records
+
+    clear_records()
+    try:
+        target = getattr(TestYamlEnvProvenance(), name)
+        if tmp_path is None:
+            target(monkeypatch)
+        else:
+            target(tmp_path, monkeypatch)
+    finally:
+        clear_records()
+
+
+def test_successful_load_reconciles_removed_generated_writers(monkeypatch):
+    _run_yaml_env_proof("test_successful_load_reconciles_removed_generated_writers", monkeypatch)
+
+
+def test_incomplete_load_aborts_absence_cleanup(monkeypatch):
+    _run_yaml_env_proof("test_incomplete_load_aborts_absence_cleanup", monkeypatch)
+
+
+def test_all_nonsecret_platform_yaml_writers_route_with_exact_source(monkeypatch):
+    _run_yaml_env_proof("test_all_nonsecret_platform_yaml_writers_route_with_exact_source", monkeypatch)
+
+
+def test_core_guarded_writers_route_through_yaml_env_load(tmp_path, monkeypatch):
+    _run_yaml_env_proof("test_core_guarded_writers_route_through_yaml_env_load", monkeypatch, tmp_path)
+
+
+def test_yaml_env_writer_preserves_original_guard_semantics(monkeypatch):
+    _run_yaml_env_proof("test_yaml_env_writer_preserves_original_guard_semantics", monkeypatch)
+
+
+def test_managed_source_selection_does_not_override_external_environment(monkeypatch):
+    _run_yaml_env_proof("test_managed_source_selection_does_not_override_external_environment", monkeypatch)
+
+
+def test_equal_external_values_never_acquire_provenance(monkeypatch):
+    _run_yaml_env_proof("test_equal_external_values_never_acquire_provenance", monkeypatch)
+
+
+def test_same_owner_reload_refreshes_and_reconciles(monkeypatch):
+    _run_yaml_env_proof("test_same_owner_reload_refreshes_and_reconciles", monkeypatch)
+
+
+def test_profile_load_does_not_adopt_or_reconcile_other_owner_record(monkeypatch):
+    _run_yaml_env_proof("test_profile_load_does_not_adopt_or_reconcile_other_owner_record", monkeypatch)
+
+
+def test_mixed_platform_blocks_resolve_source_per_leaf(tmp_path, monkeypatch):
+    _run_yaml_env_proof("test_mixed_platform_blocks_resolve_source_per_leaf", monkeypatch, tmp_path)
+
+
+def test_external_overrides_remain_unmarked_under_all_sources(monkeypatch):
+    _run_yaml_env_proof("test_external_overrides_remain_unmarked_under_all_sources", monkeypatch)
+
+
+def test_sensitive_values_are_never_registered_or_scrubbed(monkeypatch):
+    _run_yaml_env_proof("test_sensitive_values_are_never_registered_or_scrubbed", monkeypatch)
+
+
+def test_legacy_unmarked_value_requires_clean_external_restart(monkeypatch):
+    _run_yaml_env_proof("test_legacy_unmarked_value_requires_clean_external_restart", monkeypatch)

--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -46,6 +46,7 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
             "HERMES_AGENT_TIMEOUT_WARNING",
             "HERMES_GATEWAY_BUSY_INPUT_MODE",
             "HERMES_GATEWAY_BUSY_TEXT_MODE",
+            "HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED",
             "HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT",
             "HERMES_TIMEZONE",
         ):
@@ -57,7 +58,11 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
     env = dict(initial_env)
     env["HERMES_HOME"] = str(hermes_home)
     # Keep PATH / PYTHONPATH so venv imports resolve.
-    for k in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME"):
+    for k in (
+        "PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME", "SystemRoot", "WINDIR",
+        "SYSTEMROOT", "SYSTEMDRIVE", "TEMP", "TMP", "USERPROFILE",
+        "APPDATA", "LOCALAPPDATA", "PATHEXT",
+    ):
         if k in os.environ and k not in env:
             env[k] = os.environ[k]
 
@@ -149,3 +154,25 @@ def test_env_platform_connect_timeout_wins_over_config(hermes_home: Path) -> Non
     )
 
     assert env.get("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT") == "120"
+
+
+def test_guarded_runner_bridges_route_through_yaml_env_load(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _write_config(home, gateway_cfg={"platform_connect_timeout": 90}, display_cfg={"busy_steer_ack_enabled": True})
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+    env = _run_gateway_import(home, {})
+    assert env["HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT"] == "90"
+    assert env["HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED"] == "True"
+
+
+def test_guarded_runner_bridges_preserve_empty_and_blank_semantics(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _write_config(home, gateway_cfg={"platform_connect_timeout": 90})
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "   ")
+    env = _run_gateway_import(home, {"HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT": "   "})
+    assert env["HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT"] == "90"

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -241,7 +241,7 @@ class TestApplyYamlConfigFnDispatch:
 
 
     def test_hook_exception_swallowed(self, tmp_path, monkeypatch):
-        """A misbehaving hook never aborts load_gateway_config()."""
+        """A misbehaving hook aborts reconciliation but doesn't abort loading."""
 
         def _bad_hook(yaml_cfg, platform_cfg):
             raise RuntimeError("plugin author bug")
@@ -249,9 +249,13 @@ class TestApplyYamlConfigFnDispatch:
         # Also register a well-behaved hook to ensure dispatch continues
         # iterating after a bad one.
         good_called = {"count": 0}
+        context_seen = {}
 
         def _good_hook(yaml_cfg, platform_cfg):
             good_called["count"] += 1
+            from gateway.yaml_env import get_yaml_env_context
+
+            context_seen["value"] = get_yaml_env_context()
             return None
 
         from gateway.platform_registry import platform_registry as _reg
@@ -279,11 +283,25 @@ class TestApplyYamlConfigFnDispatch:
             )
             monkeypatch.setenv("HERMES_HOME", str(home))
 
+            from gateway.yaml_env import YamlEnvLoad, clear_records, records_snapshot
+
+            monkeypatch.setenv("TEST_YAML_VALUE", "A")
+            prior = YamlEnvLoad(f"gateway-config:{home.resolve()}")
+            prior.set_env_from_yaml(
+                "TEST_YAML_VALUE", "A", "test.value", predicate=lambda: True
+            )
+
             # Must not raise.
             from gateway.config import load_gateway_config
             load_gateway_config()
 
             assert good_called["count"] == 1
+            assert context_seen["value"].source_prefix == "mygoodplat"
+            assert context_seen["value"].source_for("k") == "mygoodplat.k"
+            assert context_seen["value"].load.owner.startswith("gateway-config:")
+            assert os.environ["TEST_YAML_VALUE"] == "A"
+            assert records_snapshot()["TEST_YAML_VALUE"].value == "A"
+            clear_records()
         finally:
             _reg.unregister("mybadplat")
             _reg.unregister("mygoodplat")

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -235,6 +235,115 @@ async def test_windows_detached_restart_watcher_keeps_console_python(monkeypatch
     assert kwargs["creationflags"] == 0x08000200
 
 
+@pytest.mark.asyncio
+async def test_windows_detached_restart_uses_shared_restart_environment(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    runner, _adapter = make_restart_runner()
+    calls = []
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    monkeypatch.setenv("EXTERNAL_RESTART_VALUE", "external")
+    load = YamlEnvLoad("gateway-config:/restart")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    import hermes_cli._subprocess_compat as subprocess_compat
+    monkeypatch.setattr(subprocess_compat, "windows_detach_popen_kwargs", lambda: {})
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: calls.append(kwargs) or MagicMock())
+    await runner._launch_detached_restart_command()
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    assert calls[0]["env"]["EXTERNAL_RESTART_VALUE"] == "external"
+    clear_records()
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_retries_with_same_environment_after_spawn_error(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    runner, _adapter = make_restart_runner()
+    calls = []
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/restart-fallback")
+    load.set_env_from_yaml(
+        "GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+    )
+    import hermes_cli._subprocess_compat as subprocess_compat
+    monkeypatch.setattr(subprocess_compat, "windows_detach_popen_kwargs", lambda: {"creationflags": 1})
+    monkeypatch.setattr(subprocess_compat, "windows_detach_flags_without_breakaway", lambda: 2)
+
+    def fake_popen(cmd, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise OSError("breakaway denied")
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    await runner._launch_detached_restart_command()
+
+    assert len(calls) == 2
+    assert calls[0]["env"] == calls[1]["env"]
+    assert calls[1]["creationflags"] == 2
+    assert calls[1]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+@pytest.mark.asyncio
+async def test_posix_detached_restart_uses_setsid_when_available(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    runner, _adapter = make_restart_runner()
+    calls = []
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/setsid")
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/restart-setsid")
+    load.set_env_from_yaml(
+        "GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+    )
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: calls.append((cmd, kwargs)) or MagicMock())
+    await runner._launch_detached_restart_command()
+
+    assert calls[0][0][0] == "/usr/bin/setsid"
+    assert calls[0][1]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+@pytest.mark.asyncio
+async def test_posix_detached_restart_uses_shared_restart_environment(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    runner, _adapter = make_restart_runner()
+    calls = []
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/restart")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: calls.append(kwargs) or MagicMock())
+    await runner._launch_detached_restart_command()
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+def test_restart_filter_does_not_change_generic_subprocess_env(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+    from tools.environments.local import build_subprocess_env
+
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/generic")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    assert build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)["GENERATED_RESTART_VALUE"] == "A"
+    clear_records()
+
+
 # ── Shutdown notification tests ──────────────────────────────────────
 
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -882,3 +882,99 @@ def test_identity_freshness_does_not_depend_on_host_uptime(monkeypatch):
 
     adapter._note_bot_username("new_helper_bot")
     assert adapter._bot_identity_is_fresh() is True
+def test_external_allowlist_override_still_controls_message_gating(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FREE_RESPONSE_CHATS", "-1001")
+    adapter = _make_adapter(require_mention=True)
+    assert adapter._should_process_message(_group_message("hello", chat_id=-1001)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-1002)) is False
+
+
+def test_reporter_telegram_self_restart_refreshes_new_free_response_chat(tmp_path, monkeypatch):
+    import asyncio
+    import os
+    import subprocess
+    from pathlib import Path
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "issue-13582-telegram-self-restart.json").read_text(encoding="utf-8")
+    )
+    assert fixture["issue"] == 13582
+    assert fixture["host_os"] == "Windows 10"
+    assert fixture["platform"] == "telegram"
+    assert fixture["transport"] == "polling"
+    assert fixture["multiplex_profiles"] is True
+    assert fixture["restart_command"] == "/restart"
+    assert fixture["require_mention"] is True
+    assert fixture["updated_free_response_chats"] == ["-1001", "-1002"]
+    assert fixture["ordinary_message_chat"] in fixture["updated_free_response_chats"]
+    assert "mention-gated" in fixture["observed_stale_gating_log"]
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "telegram:\n"
+        f"  require_mention: {str(fixture['require_mention']).lower()}\n"
+        "  free_response_chats:\n"
+        + "".join(f"    - {chat}\n" for chat in fixture["initial_free_response_chats"]),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for env_name in (
+        "TELEGRAM_FREE_RESPONSE_CHATS",
+        "TELEGRAM_ALLOWED_CHATS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOWED_TOPICS",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    from gateway.config import Platform, load_gateway_config
+    try:
+        from gateway.yaml_env import clear_records
+        has_provenance = True
+    except ImportError:
+        clear_records = lambda: None
+        has_provenance = False
+    import gateway.run as gateway_run
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    clear_records()
+    first = load_gateway_config()
+    assert os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] == ",".join(fixture["initial_free_response_chats"])
+    config_path.write_text(
+        "telegram:\n"
+        f"  require_mention: {str(fixture['require_mention']).lower()}\n"
+        "  free_response_chats:\n"
+        + "".join(f"    - {chat}\n" for chat in fixture["updated_free_response_chats"]),
+        encoding="utf-8",
+    )
+    calls = []
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._detached_restart_helper_started = False
+    runner._restart_drain_timeout = 0.0
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    import hermes_cli._subprocess_compat as subprocess_compat
+    monkeypatch.setattr(subprocess_compat, "windows_detach_popen_kwargs", lambda: {})
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: calls.append(kwargs) or MagicMock())
+    asyncio.run(runner._launch_detached_restart_command())
+    child_env = calls[0]["env"]
+    if has_provenance:
+        assert child_env.get("TELEGRAM_FREE_RESPONSE_CHATS") is None
+    else:
+        assert child_env.get("TELEGRAM_FREE_RESPONSE_CHATS") == "-1001"
+    with patch.dict(os.environ, child_env, clear=True):
+        child = load_gateway_config()
+        assert os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] == ",".join(
+            fixture["updated_free_response_chats"]
+        )
+        adapter = TelegramAdapter(child.platforms[Platform.TELEGRAM])
+        adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+        assert adapter._telegram_free_response_chats() == set(
+            fixture["updated_free_response_chats"]
+        )
+        assert adapter._should_process_message(
+            _group_message("hello", chat_id=int(fixture["ordinary_message_chat"]))
+        ) is has_provenance
+    clear_records()

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -176,6 +176,65 @@ class TestHandleUpdateCommand:
         assert call_kwargs.get("start_new_session") is True
         assert "Starting Hermes update" in result
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("platform", "setsid_path"),
+        [("win32", "/usr/bin/setsid"), ("linux", "/usr/bin/setsid"), ("linux", None)],
+    )
+    async def test_update_replacement_spawn_uses_shared_restart_environment(
+        self, tmp_path, monkeypatch, platform, setsid_path
+    ):
+        from gateway.yaml_env import YamlEnvLoad, clear_records
+        import gateway.run as gateway_run
+
+        runner = _make_runner()
+        event = _make_event()
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        (fake_root / "gateway" / "run.py").touch()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        calls = []
+
+        def which(name):
+            if name == "hermes":
+                return "/usr/bin/hermes"
+            if name == "setsid":
+                return setsid_path
+            return None
+
+        monkeypatch.setattr(gateway_run.sys, "platform", platform)
+        monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+        monkeypatch.setenv("EXTERNAL_RESTART_VALUE", "external")
+        load = YamlEnvLoad("gateway-config:/update")
+        load.set_env_from_yaml(
+            "GENERATED_RESTART_VALUE",
+            "A",
+            "telegram.free_response_chats",
+            predicate=lambda: True,
+        )
+
+        def fake_popen(*args, **kwargs):
+            calls.append((args, kwargs))
+            return MagicMock()
+
+        try:
+            with patch("gateway.run._hermes_home", hermes_home), \
+                 patch("gateway.slash_commands.__file__", fake_file), \
+                 patch("shutil.which", side_effect=which), \
+                 patch("subprocess.Popen", side_effect=fake_popen):
+                await runner._handle_update_command(event)
+        finally:
+            clear_records()
+
+        assert calls
+        for _args, kwargs in calls:
+            assert kwargs["env"].get("GENERATED_RESTART_VALUE") is None
+            assert kwargs["env"]["EXTERNAL_RESTART_VALUE"] == "external"
+
 
 # ---------------------------------------------------------------------------
 # Platform allowlist gate

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -7,8 +7,20 @@ from types import SimpleNamespace
 
 import pytest
 
-pwd = pytest.importorskip("pwd")
-grp = pytest.importorskip("grp")
+try:
+    import pwd
+except ImportError:
+    class _UnavailablePwd:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: pytest.skip("pwd is unavailable on this platform")
+    pwd = _UnavailablePwd()
+try:
+    import grp
+except ImportError:
+    class _UnavailableGrp:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: pytest.skip("grp is unavailable on this platform")
+    grp = _UnavailableGrp()
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status
@@ -37,6 +49,88 @@ class TestUserSystemdPrivateSocketPreflight:
 
         assert gateway_cli._wait_for_user_dbus_socket(timeout=0.1) is True
         assert calls == ["env"]
+
+
+def test_update_restart_watcher_uses_shared_restart_environment(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    calls = []
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/watcher")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda cmd, **kwargs: calls.append(kwargs) or SimpleNamespace())
+    assert gateway_cli._spawn_gateway_restart_watcher(321, ["hermes", "gateway", "run"]) is True
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+def test_update_restart_watcher_retries_without_breakaway(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    calls = []
+    monkeypatch.setattr(gateway_cli.sys, "platform", "win32")
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/watcher-fallback")
+    load.set_env_from_yaml(
+        "GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+    )
+    monkeypatch.setattr(subprocess_compat, "windows_detach_popen_kwargs", lambda: {"creationflags": 1})
+    monkeypatch.setattr(subprocess_compat, "windows_detach_flags_without_breakaway", lambda: 2)
+
+    def fake_popen(cmd, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise OSError("breakaway denied")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", fake_popen)
+    assert gateway_cli._spawn_gateway_restart_watcher(321, ["hermes", "gateway", "run"]) is True
+    assert len(calls) == 2
+    assert calls[0]["env"] == calls[1]["env"]
+    assert calls[1]["creationflags"] == 2
+    assert calls[1]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+def test_update_restart_watcher_returns_false_when_both_spawns_fail(monkeypatch):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    monkeypatch.setattr(gateway_cli.sys, "platform", "win32")
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/watcher-error")
+    load.set_env_from_yaml(
+        "GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+    )
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda *a, **kw: (_ for _ in ()).throw(OSError("denied")))
+    assert gateway_cli._spawn_gateway_restart_watcher(321, ["hermes", "gateway", "run"]) is False
+    clear_records()
+
+
+def test_detached_launchd_fallback_uses_shared_restart_environment(monkeypatch, tmp_path):
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    home = tmp_path / ".hermes"
+    (home / "logs").mkdir(parents=True)
+    calls = []
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(gateway_cli, "_gateway_run_command", lambda: ["hermes", "gateway", "run"])
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/launchd")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda cmd, **kwargs: calls.append(kwargs) or SimpleNamespace())
+    assert gateway_cli._spawn_detached_gateway() is True
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
+
+
+def test_detached_launchd_fallback_reports_spawn_error(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "logs").mkdir(parents=True)
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(gateway_cli, "_gateway_run_command", lambda: ["hermes", "gateway", "run"])
+    monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda *a, **kw: (_ for _ in ()).throw(OSError("denied")))
+    assert gateway_cli._spawn_detached_gateway() is False
 
 
 class TestSystemdServiceRefresh:

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -24,7 +24,54 @@ def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
 
+def test_spawn_detached_uses_shared_restart_environment(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+    from gateway.yaml_env import YamlEnvLoad, clear_records
 
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_build_gateway_argv", lambda: (["python", "-m", "gateway"], str(tmp_path), {"HERMES_HOME": str(tmp_path)}))
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/windows")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+    monkeypatch.setattr(gateway_windows.subprocess, "Popen", lambda *args, **kwargs: calls.append(kwargs) or MagicMock(pid=42))
+    monkeypatch.setattr(gateway_windows, "windows_detach_flags", lambda: 0)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    assert gateway_windows._spawn_detached() == 42
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    assert calls[0]["env"]["HERMES_HOME"] == str(tmp_path)
+    clear_records()
+
+
+def test_spawn_detached_retries_without_breakaway(monkeypatch, tmp_path):
+    from unittest.mock import MagicMock
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_build_gateway_argv", lambda: (["python", "-m", "gateway"], str(tmp_path), {"HERMES_HOME": str(tmp_path)}))
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/windows-fallback")
+    load.set_env_from_yaml(
+        "GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True
+    )
+    monkeypatch.setattr(gateway_windows, "windows_detach_flags", lambda: 1)
+    monkeypatch.setattr(gateway_windows, "windows_detach_flags_without_breakaway", lambda: 2)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+
+    def fake_popen(*args, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise OSError("breakaway denied")
+        return MagicMock(pid=42)
+
+    monkeypatch.setattr(gateway_windows.subprocess, "Popen", fake_popen)
+    assert gateway_windows._spawn_detached() == 42
+    assert len(calls) == 2
+    assert calls[0]["env"] == calls[1]["env"]
+    assert calls[1]["creationflags"] == 2
+    assert calls[1]["env"].get("GENERATED_RESTART_VALUE") is None
+    clear_records()
 
 def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, tmp_path):
     """No pythonw / base-interpreter detour: the venv console python.exe is

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3518,3 +3518,28 @@ class TestDashboardComponentHealth:
         assert self.ws.DASHBOARD_HEALTH.snapshot()["status"] == "degraded"
 
 
+
+def test_dashboard_replacement_actions_use_restart_environment_only(monkeypatch, tmp_path):
+    from types import SimpleNamespace
+    from gateway.yaml_env import YamlEnvLoad, clear_records
+    import hermes_cli.web_server as web_server
+
+    calls = []
+    monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+    monkeypatch.setenv("GENERATED_RESTART_VALUE", "A")
+    load = YamlEnvLoad("gateway-config:/dashboard")
+    load.set_env_from_yaml("GENERATED_RESTART_VALUE", "A", "telegram.free_response_chats", predicate=lambda: True)
+
+    def fake_popen(cmd, **kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(pid=len(calls), poll=lambda: None)
+
+    monkeypatch.setattr(web_server.subprocess, "Popen", fake_popen)
+    web_server._spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+    web_server._spawn_hermes_action(["update"], "hermes-update")
+    web_server._spawn_hermes_action(["doctor"], "doctor")
+    assert calls[0]["env"].get("GENERATED_RESTART_VALUE") is None
+    assert calls[1]["env"].get("GENERATED_RESTART_VALUE") is None
+    assert calls[2]["env"]["GENERATED_RESTART_VALUE"] == "A"
+    assert all(call["env"]["HERMES_NONINTERACTIVE"] == "1" for call in calls)
+    clear_records()


### PR DESCRIPTION
## Summary

Hermes can leave a non-secret config value in the process environment after its YAML leaf or platform block is removed, and several self-restart paths can pass that value into the replacement gateway. The child then sees a pre-existing environment override and keeps stale behavior. In issue #13582, changing `telegram.free_response_chats` and restarting from Telegram left an ordinary message in the newly added group mention-gated.

This rebuild records provenance only after Hermes actually writes a non-secret environment value. Each complete config load tracks the keys supplied by its resolved source leaves, refreshes its own matching generated values, and removes a stale generated value only when the source disappeared and the live value still matches the record. Diverged and unmarked values survive.

One gateway restart-environment helper now prepares the replacement mapping used by the in-chat watcher, dashboard restart and update actions, CLI update watchers, the macOS detached fallback, and Windows direct restart. Ordinary subprocesses and service-manager restarts keep their existing environment paths.

Managed config still wins over user config when selecting the effective config leaf. It does not gain priority over an existing environment value. An external `.env`, shell, service, container, managed-environment, or external-secret value stays unmarked even when it is byte-equal to the selected user or managed config value.

An older gateway may already have an unmarked generated value. Its origin cannot be recovered safely, so an affected long-running installation needs one clean external stop/start after upgrading. Later same-process loads and self-restarts use the new provenance.

## Changes

- Add a non-secret config environment owner with explicit per-load begin, successful finish, abort, refresh, divergence, and source-removal transitions.
- Resolve the actual user or managed dotted config leaf structurally, then preserve each writer’s existing presence, falsy, or stripped-falsy environment guard.
- Route the two core bridges, nine platform hooks, and three guarded runner bridge classes through the shared owner without changing serializers, aliases, readers, extras, or secret handling.
- Add one replacement gateway environment seam and use it for in-chat Windows/POSIX restart watchers, dashboard restart/update actions, post-update/profile watchers, macOS detached fallback, and Windows direct start/restart.
- Add focused production-path coverage for removed keys and platform blocks, byte-equal external values, managed-source selection, every replacement spawn owner, ordinary subprocess preservation, Windows/POSIX restart behavior, and the reporter’s Telegram gate.

## Changed files

- `gateway/yaml_env.py`
- `gateway/config.py`
- `gateway/platform_registry.py`
- `gateway/run.py`
- `gateway/slash_commands.py`
- `hermes_cli/gateway.py`
- `hermes_cli/gateway_windows.py`
- `hermes_cli/web_server.py`
- `plugins/platforms/buzz/adapter.py`
- `plugins/platforms/dingtalk/adapter.py`
- `plugins/platforms/discord/adapter.py`
- `plugins/platforms/feishu/adapter.py`
- `plugins/platforms/matrix/adapter.py`
- `plugins/platforms/mattermost/adapter.py`
- `plugins/platforms/slack/adapter.py`
- `plugins/platforms/telegram/adapter.py`
- `plugins/platforms/whatsapp/adapter.py`
- `tests/gateway/fixtures/issue-13582-telegram-self-restart.json`
- `tests/gateway/test_config.py`
- `tests/gateway/test_config_env_bridge_authority.py`
- `tests/gateway/test_restart_drain.py`
- `tests/gateway/test_telegram_group_gating.py`
- `tests/gateway/test_update_command.py`
- `tests/hermes_cli/test_gateway_service.py`
- `tests/hermes_cli/test_gateway_windows.py`
- `tests/hermes_cli/test_web_server.py`

Validation recorded in `D:\Repos\.claude\pr-sweep\agent-PR-TARGET-13582-PROOF.md`: hidden CreateNoWindow runner, 60 focused tests, all passed, exit code 0; the file-level service run remains blocked by 34 pre-existing Windows-only service-test failures. The fixture reproduction passes with the updated chat `-1002`, and the platform registry test passes.

## Not in scope

This does not change generic subprocess environment construction, service-manager environment ownership, config-authoritative gateway bridges, adapter runtime reader precedence, secret provenance, or the managed-scope implementation.

Closes #13582
