### PR TITLE
fix(plugins): normalize activation aliases (#18005)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import noninteractive_git_env
@@ -261,10 +261,19 @@ def _repo_name_from_url(url: str) -> str:
     return name
 
 
+def _manifest_file(plugin_dir: Path) -> Optional[Path]:
+    """Return the preferred manifest file in *plugin_dir*, if any."""
+    for filename in ("plugin.yaml", "plugin.yml"):
+        manifest_file = plugin_dir / filename
+        if manifest_file.exists():
+            return manifest_file
+    return None
+
+
 def _read_manifest(plugin_dir: Path) -> dict:
-    """Read plugin.yaml and return the parsed dict, or empty dict."""
-    manifest_file = plugin_dir / "plugin.yaml"
-    if not manifest_file.exists():
+    """Read the preferred plugin manifest and return the parsed dict."""
+    manifest_file = _manifest_file(plugin_dir)
+    if manifest_file is None:
         return {}
     try:
         import yaml
@@ -272,7 +281,7 @@ def _read_manifest(plugin_dir: Path) -> dict:
         with open(manifest_file, encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except Exception as e:
-        logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
+        logger.warning("Failed to read %s in %s: %s", manifest_file.name, plugin_dir, e)
         return {}
 
 
@@ -535,8 +544,7 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
 
         shutil.move(str(tmp_target), str(target))
 
-    has_yaml = (target / "plugin.yaml").exists() or (target / "plugin.yml").exists()
-    if not has_yaml and not (target / "__init__.py").exists():
+    if _manifest_file(target) is None and not (target / "__init__.py").exists():
         logger.warning(
             "%s has no plugin.yaml / __init__.py; may not be a valid plugin",
             plugin_name,
@@ -590,9 +598,7 @@ def cmd_install(
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    if not (target / "plugin.yaml").exists() and not (target / "plugin.yml").exists() and not (
-        target / "__init__.py"
-    ).exists():
+    if _manifest_file(target) is None and not (target / "__init__.py").exists():
         console.print(
             f"[yellow]Warning:[/yellow] {installed_name} doesn't contain plugin.yaml "
             f"or __init__.py. It may not be a valid Hermes plugin.",
@@ -616,12 +622,15 @@ def cmd_install(
             should_enable = False
 
     if should_enable:
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+        result = _set_plugin_activation(installed_name, enable=True)
+        if result is None and _manifest_file(target) is None:
+            _persist_unresolved_install_activation(installed_name)
+        elif result is None or result.blocked:
+            console.print(
+                f"[red]Plugin '{installed_name}' could not be enabled because "
+                "its activation alias is ambiguous.[/red]"
+            )
+            sys.exit(1)
         console.print(
             f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
         )
@@ -744,9 +753,19 @@ def ensure_basic_auth_plugin_enabled_in_config(cfg: dict) -> bool:
         return False
     if not (set(disabled) & _BASIC_AUTH_PLUGIN_KEYS):
         return False
-    plugins_cfg["disabled"] = sorted(
-        set(disabled) - _BASIC_AUTH_PLUGIN_KEYS
+    enabled = plugins_cfg.get("enabled", [])
+    enabled_set = set(enabled) if isinstance(enabled, list) else set()
+    update = _normalize_plugin_activation(
+        "dashboard_auth/basic",
+        enabled_set,
+        set(disabled),
+        enable=True,
     )
+    if update is None or update.blocked:
+        return False
+    if update.disabled == set(disabled):
+        return False
+    plugins_cfg["disabled"] = sorted(update.disabled)
     return True
 
 
@@ -790,40 +809,153 @@ def _resolve_plugin_key(name: str) -> Optional[str]:
     ``disable`` write the same key that ``PluginManager`` matches against —
     nested category plugins (e.g. ``observability/nemo_relay``) included.
     """
-    entries = _discover_all_plugins()
-    # 1. Exact match on canonical key or manifest name — always unambiguous.
+    resolved = _resolve_plugin_entry(name)
+    return resolved[5] if resolved is not None else None
+
+
+def _plugin_loader_aliases(entry: tuple) -> set[str]:
+    """Return the aliases recognized by the runtime loader."""
+    manifest_name, _version, _description, _source, _directory, key = entry
+    return {alias for alias in (key, manifest_name) if alias}
+
+
+def _plugin_legacy_aliases(entry: tuple) -> set[str]:
+    """Return directory and leaf aliases accepted by the CLI resolver."""
+    _manifest_name, _version, _description, _source, directory, key = entry
+    aliases = {key.rsplit("/", 1)[-1]}
+    if isinstance(directory, Path):
+        aliases.add(directory.name)
+    return {alias for alias in aliases if alias}
+
+
+def _resolve_plugin_entry(name: str, entries: Optional[list] = None) -> Optional[tuple]:
+    """Resolve *name* to one discovered entry, or refuse an ambiguous alias."""
+    if entries is None:
+        entries = _discover_all_plugins()
+
+    # Canonical keys and manifest names are authoritative. This also handles a
+    # canonical key that happens to equal another plugin's legacy alias.
     for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return entry[5]
-    # 2. Fall back to a bare leaf-name match (e.g. "nemo_relay" ->
-    #    "observability/nemo_relay"), but only when it resolves to exactly one
-    #    plugin so we never silently pick the wrong same-named nested plugin.
-    leaf_matches = [entry[5] for entry in entries if name == entry[5].split("/")[-1]]
-    if len(leaf_matches) == 1:
-        return leaf_matches[0]
-    return None
+        if name == entry[5]:
+            return entry
+    for entry in entries:
+        if name == entry[0]:
+            return entry
+
+    matches = [entry for entry in entries if name in _plugin_legacy_aliases(entry)]
+    keys = {entry[5] for entry in matches}
+    if len(keys) != 1:
+        return None
+    return next(entry for entry in matches if entry[5] in keys)
 
 
-def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
+def _resolve_plugin_key_and_source(
+    name: str, entries: Optional[list] = None,
+) -> Optional[tuple]:
     """Resolve *name* to ``(canonical_key, source)`` or ``None`` if no match.
 
     Mirrors :func:`_resolve_plugin_key`'s normalization but also returns the
     plugin's source (``"bundled"``, ``"user"``, ``"project"``, ...) so the
     enable path can tell whether a built-in-override consent prompt is needed.
     """
-    entries = _discover_all_plugins()
-    for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return (entry[5], entry[3])
-    leaf_matches = [
-        (entry[5], entry[3]) for entry in entries
-        if name == entry[5].split("/")[-1]
-    ]
-    if len(leaf_matches) == 1:
-        return leaf_matches[0]
-    return None
+    resolved = _resolve_plugin_entry(name, entries=entries)
+    return (resolved[5], resolved[3]) if resolved is not None else None
+
+
+class _PluginActivationUpdate(NamedTuple):
+    key: str
+    enabled: set
+    disabled: set
+    blocked: bool
+
+
+class _PluginActivationResult(NamedTuple):
+    key: str
+    changed: bool
+    blocked: bool
+
+
+def _normalize_plugin_activation(
+    name: str,
+    enabled: set,
+    disabled: set,
+    *,
+    enable: bool,
+    entries: Optional[list] = None,
+) -> Optional[_PluginActivationUpdate]:
+    """Compute canonical activation state without writing configuration."""
+    if entries is None:
+        entries = _discover_all_plugins()
+    entry = _resolve_plugin_entry(name, entries=entries)
+    if entry is None:
+        return None
+
+    key = entry[5]
+    loader_aliases = _plugin_loader_aliases(entry)
+    owners: dict[str, set[str]] = {}
+    for candidate in entries:
+        for alias in _plugin_loader_aliases(candidate):
+            owners.setdefault(alias, set()).add(candidate[5])
+    unique_loader_aliases = {
+        alias for alias in loader_aliases if owners.get(alias) == {key}
+    }
+
+    # PluginManager gates on the canonical key and manifest name. Preserve an
+    # ambiguous deny alias because removing it could enable a sibling too.
+    blocked = enable and any(
+        alias in disabled and alias not in unique_loader_aliases
+        for alias in loader_aliases
+    )
+    if blocked:
+        return _PluginActivationUpdate(key, set(enabled), set(disabled), True)
+
+    new_enabled = set(enabled)
+    new_disabled = set(disabled)
+    new_enabled.difference_update(unique_loader_aliases)
+    new_disabled.difference_update(unique_loader_aliases)
+    if enable:
+        new_enabled.add(key)
+    else:
+        new_disabled.add(key)
+    return _PluginActivationUpdate(key, new_enabled, new_disabled, False)
+
+
+def _set_plugin_activation(
+    name: str, *, enable: bool, entries: Optional[list] = None,
+) -> Optional[_PluginActivationResult]:
+    """Normalize one activation request and persist only canonical state."""
+    current_enabled = _get_enabled_set()
+    current_disabled = _get_disabled_set()
+    update = _normalize_plugin_activation(
+        name,
+        current_enabled,
+        current_disabled,
+        enable=enable,
+        entries=entries,
+    )
+    if update is None:
+        return None
+    if update.blocked:
+        return _PluginActivationResult(update.key, False, True)
+
+    changed = (
+        update.enabled != current_enabled
+        or update.disabled != current_disabled
+    )
+    if changed:
+        _save_enabled_set(update.enabled)
+        _save_disabled_set(update.disabled)
+    return _PluginActivationResult(update.key, changed, False)
+
+
+def _persist_unresolved_install_activation(name: str) -> None:
+    """Keep manifestless installs compatible with the legacy installer path."""
+    enabled = _get_enabled_set()
+    disabled = _get_disabled_set()
+    enabled.add(name)
+    disabled.discard(name)
+    _save_enabled_set(enabled)
+    _save_disabled_set(disabled)
 
 
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
@@ -867,31 +999,18 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         sys.exit(1)
     key, source = resolved
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
+    result = _set_plugin_activation(key, enable=True)
+    if result is None:
+        console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
+        sys.exit(1)
+    if result.blocked:
+        console.print(
+            f"[red]Cannot enable '{key}': an ambiguous disabled alias would "
+            "also affect another plugin.[/red]"
+        )
+        sys.exit(1)
 
-    already_enabled = key in enabled and key not in disabled
-
-    if not already_enabled:
-        enabled.add(key)
-        disabled.discard(key)
-        # Drop every alias of this plugin from the disabled list so an
-        # explicit disable under a different form can't keep it off. The
-        # loader's disable check matches on BOTH the canonical key
-        # (``web/firecrawl``) AND the manifest name (``web-firecrawl``);
-        # a stale entry under either form makes "explicit disable wins"
-        # (plugins.py) silently veto this enable. Discard the key, its
-        # bare leaf, and the manifest name. (#40190 follow-up.)
-        bare = key.split("/")[-1]
-        if bare != key:
-            disabled.discard(bare)
-        for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key)
-            if entry[5] == key:
-                disabled.discard(entry[0])
-                break
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+    if result.changed:
         console.print(
             f"[green]✓[/green] Plugin [bold]{key}[/bold] enabled. "
             "Takes effect on next session."
@@ -957,26 +1076,17 @@ def cmd_disable(name: str) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-
-    if key not in enabled and key in disabled:
+    result = _set_plugin_activation(key, enable=False)
+    if result is None:
+        console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
+        sys.exit(1)
+    if result.changed:
+        console.print(
+            f"[yellow]\u2298[/yellow] Plugin [bold]{key}[/bold] disabled. "
+            "Takes effect on next session."
+        )
+    else:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
-        return
-
-    enabled.discard(key)
-    # Drop any legacy bare-name entry from the allow-list too, so a stale
-    # bare name can't keep a nested plugin loading after an explicit disable.
-    bare = key.split("/")[-1]
-    if bare != key:
-        enabled.discard(bare)
-    disabled.add(key)
-    _save_enabled_set(enabled)
-    _save_disabled_set(disabled)
-    console.print(
-        f"[yellow]\u2298[/yellow] Plugin [bold]{key}[/bold] disabled. "
-        "Takes effect on next session."
-    )
 
 
 def _plugin_exists(name: str) -> bool:
@@ -989,10 +1099,8 @@ def _read_manifest_info(d: Path, prefix: str):
 
     Returns None if no manifest file exists.
     """
-    manifest_file = d / "plugin.yaml"
-    if not manifest_file.exists():
-        manifest_file = d / "plugin.yml"
-    if not manifest_file.exists():
+    manifest_file = _manifest_file(d)
+    if manifest_file is None:
         return None
     try:
         import yaml
@@ -1428,14 +1536,14 @@ def cmd_toggle() -> None:
     try:
         import curses
         _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                          disabled_set, categories, console)
+                          disabled_set, categories, console, entries=entries)
     except ImportError:
         _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                                disabled_set, categories, console)
+                                disabled_set, categories, console, entries=entries)
 
 
 def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                      disabled, categories, console):
+                      disabled, categories, console, *, entries=None):
     """Custom curses screen with checkboxes + category action rows."""
     from hermes_cli.curses_ui import flush_stdin
 
@@ -1655,26 +1763,26 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     curses.wrapper(_draw)
     flush_stdin()
 
-    # Persist by canonical key. Unchecked plugins are written to the
-    # disabled-list so they stay off even if a future plugin auto-enables
-    # itself — but we ONLY ever write the canonical key (never the bare
-    # manifest name), so the disabled-list can't drift out of sync with
-    # what ``cmd_enable`` clears or what PluginManager gates on (#40190).
-    new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
-    for i, key in enumerate(plugin_keys):
-        bare = key.split("/")[-1]
-        if i in chosen:
-            new_enabled.add(key)
-            new_disabled.discard(key)
-            # Drop any stale legacy bare-leaf disable so re-enabling here
-            # fully clears the plugin from the disabled-list.
-            if bare != key:
-                new_disabled.discard(bare)
-        else:
-            new_disabled.add(key)
-
+    # Normalize each requested transition against the same alias ownership
+    # rules as the direct CLI and dashboard writers.
+    if entries is None:
+        entries = _discover_all_plugins()
     prev_enabled = _get_enabled_set()
+    new_enabled: set = set(prev_enabled)
+    new_disabled: set = set(disabled)
+    for i, key in enumerate(plugin_keys):
+        update = _normalize_plugin_activation(
+            key,
+            new_enabled,
+            new_disabled,
+            enable=i in chosen,
+            entries=entries,
+        )
+        if update is None or update.blocked:
+            continue
+        new_enabled = update.enabled
+        new_disabled = update.disabled
+
     enabled_changed = new_enabled != prev_enabled
     disabled_changed = new_disabled != disabled
 
@@ -1682,8 +1790,8 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
         _save_enabled_set(new_enabled)
         _save_disabled_set(new_disabled)
         console.print(
-            f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
-            f"{len(plugin_keys) - len(new_enabled)} disabled."
+            f"\n[green]\u2713[/green] General plugins: {len(chosen)} enabled, "
+            f"{len(plugin_keys) - len(chosen)} disabled."
         )
     elif n_plugins > 0:
         console.print("\n[dim]General plugins unchanged.[/dim]")
@@ -1702,7 +1810,7 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
 
 
 def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                            disabled, categories, console):
+                            disabled, categories, console, *, entries=None):
     """Text-based fallback for the composite plugins UI."""
     from hermes_cli.colors import Colors, color
 
@@ -1730,21 +1838,23 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 return
             print()
 
-        # Persist by canonical key only — never the bare manifest name — so
-        # the disabled-list stays aligned with cmd_enable / PluginManager
-        # (#40190).
-        new_enabled: set = set()
+        if entries is None:
+            entries = _discover_all_plugins()
+        prev_enabled = _get_enabled_set()
+        new_enabled: set = set(prev_enabled)
         new_disabled: set = set(disabled)
         for i, key in enumerate(plugin_keys):
-            bare = key.split("/")[-1]
-            if i in chosen:
-                new_enabled.add(key)
-                new_disabled.discard(key)
-                if bare != key:
-                    new_disabled.discard(bare)
-            else:
-                new_disabled.add(key)
-        prev_enabled = _get_enabled_set()
+            update = _normalize_plugin_activation(
+                key,
+                new_enabled,
+                new_disabled,
+                enable=i in chosen,
+                entries=entries,
+            )
+            if update is None or update.blocked:
+                continue
+            new_enabled = update.enabled
+            new_disabled = update.disabled
         if new_enabled != prev_enabled or new_disabled != disabled:
             _save_enabled_set(new_enabled)
             _save_disabled_set(new_disabled)
@@ -1794,12 +1904,17 @@ def dashboard_install_plugin(
 
     missing_env = _missing_requires_env_names(installed_manifest)
     if enable:
-        en = _get_enabled_set()
-        dis = _get_disabled_set()
-        en.add(installed_name)
-        dis.discard(installed_name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
+        result = _set_plugin_activation(installed_name, enable=True)
+        if result is None and _manifest_file(target) is None:
+            _persist_unresolved_install_activation(installed_name)
+        elif result is None or result.blocked:
+            return {
+                "ok": False,
+                "error": (
+                    f"Plugin '{installed_name}' could not be enabled because "
+                    "its activation alias is ambiguous."
+                ),
+            }
 
     hint: str | None = None
     ap = target / "after-install.md"
@@ -1816,7 +1931,7 @@ def dashboard_install_plugin(
     }
 
 
-def _get_plugin_toolset_key(name: str) -> Optional[str]:
+def _get_plugin_toolset_key(name: str, entries: Optional[list] = None) -> Optional[str]:
     """Return the toolset key a plugin registers its tools under, or None.
 
     Queries the live tool registry — the plugin must already be loaded.
@@ -1834,40 +1949,52 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
         discover_plugins()  # idempotent — ensures plugins are loaded
         manager = get_plugin_manager()
         for _key, loaded in manager._plugins.items():
-            if loaded.manifest.name == name or _key == name:
+            manifest = loaded.manifest
+            if (
+                manifest.name == name
+                or getattr(manifest, "key", "") == name
+                or _key == name
+            ):
                 for tool_name in loaded.tools_registered:
                     entry = registry.get_entry(tool_name)
                     if entry and entry.toolset:
                         return entry.toolset
-                break
     except Exception:
         pass
 
     # Fallback: read provides_tools from manifest on disk and query registry
     try:
         from hermes_cli.plugins import get_bundled_plugins_dir
+        candidates: list[Path] = []
+        resolved = _resolve_plugin_entry(name, entries=entries)
+        if resolved is not None and isinstance(resolved[4], Path):
+            candidates.append(resolved[4])
         for base in (get_bundled_plugins_dir(), _plugins_dir()):
             if not base.is_dir():
                 continue
             candidate = base / name
-            if candidate.is_dir():
-                manifest = _read_manifest(candidate)
-                for tool_name in manifest.get("provides_tools") or []:
-                    entry = registry.get_entry(tool_name)
-                    if entry and entry.toolset:
-                        return entry.toolset
+            if candidate.is_dir() and candidate not in candidates:
+                candidates.append(candidate)
+        for candidate in candidates:
+            manifest = _read_manifest(candidate)
+            for tool_name in manifest.get("provides_tools") or []:
+                entry = registry.get_entry(tool_name)
+                if entry and entry.toolset:
+                    return entry.toolset
     except Exception:
         pass
 
     return None
 
 
-def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
+def _toggle_plugin_toolset(
+    name: str, *, enable: bool, entries: Optional[list] = None,
+) -> None:
     """Add or remove a plugin's toolset from platform_toolsets for all platforms.
 
     Only acts if the plugin actually provides tools (has a toolset key).
     """
-    toolset_key = _get_plugin_toolset_key(name)
+    toolset_key = _get_plugin_toolset_key(name, entries=entries)
     if not toolset_key:
         return
 
@@ -1906,31 +2033,25 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     For plugins that provide tools (toolsets), also toggles the toolset in
     ``platform_toolsets`` so the agent actually sees the tools in sessions.
     """
-    if not _plugin_exists(name):
+    entries = _discover_all_plugins()
+    resolved = _resolve_plugin_key_and_source(name, entries=entries)
+    if resolved is None:
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
-
-    en = _get_enabled_set()
-    dis = _get_disabled_set()
-
-    if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
-
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
-
-    en.discard(name)
-    dis.add(name)
-    _save_enabled_set(en)
-    _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
+    key, _source = resolved
+    result = _set_plugin_activation(key, enable=enabled, entries=entries)
+    if result is None:
+        return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
+    if result.blocked:
+        return {
+            "ok": False,
+            "error": (
+                f"Plugin '{name}' could not be enabled because its activation "
+                "alias is ambiguous."
+            ),
+        }
+    if result.changed:
+        _toggle_plugin_toolset(key, enable=enabled, entries=entries)
+    return {"ok": True, "name": name, "unchanged": not result.changed}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1897,13 +1897,13 @@ def _run_post_setup(post_setup_key: str):
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).
         try:
-            from hermes_cli.plugins_cmd import _get_enabled_set, _save_enabled_set
-            enabled = _get_enabled_set()
-            if "observability/langfuse" in enabled or "langfuse" in enabled:
+            from hermes_cli.plugins_cmd import _set_plugin_activation
+            result = _set_plugin_activation("observability/langfuse", enable=True)
+            if result is None or result.blocked:
+                raise RuntimeError("an ambiguous activation alias would affect another plugin")
+            if not result.changed:
                 _print_success("    Plugin observability/langfuse already enabled")
             else:
-                enabled.add("observability/langfuse")
-                _save_enabled_set(enabled)
                 _print_success("    Plugin observability/langfuse enabled")
         except Exception as exc:
             _print_warning(f"    Could not enable plugin automatically: {exc}")

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -244,3 +244,31 @@ class TestBundledPluginAssetGate:
                 resp = test_client.get("/dashboard-plugins/goodbundled/dist/index.js")
                 assert resp.status_code == 200
 
+
+def test_dashboard_disable_then_cli_enable_clears_legacy_deny_residue(
+    monkeypatch, tmp_path,
+):
+    """A fresh loader must see the plugin after cross-surface activation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+
+    from hermes_cli.config import save_config
+    from hermes_cli.plugins import PluginManager
+    from hermes_cli.plugins_cmd import (
+        _get_disabled_set,
+        cmd_enable,
+        dashboard_set_agent_plugin_enabled,
+    )
+
+    save_config({"plugins": {"enabled": ["web/exa"], "disabled": []}})
+    with patch("hermes_cli.plugins_cmd._toggle_plugin_toolset"):
+        result = dashboard_set_agent_plugin_enabled("web-exa", enabled=False)
+    assert result["ok"] is True
+
+    cmd_enable("web/exa", allow_tool_override=False)
+
+    assert _get_disabled_set() == set()
+    manager = PluginManager()
+    manager.discover_and_load()
+    assert manager._plugins["web/exa"].enabled is True
+

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -200,6 +201,17 @@ class TestReadManifest:
         result = _read_manifest(tmp_path)
         assert result == {}
 
+    def test_plugin_yml_is_read_when_yaml_is_absent(self, tmp_path):
+        (tmp_path / "plugin.yml").write_text("name: declared-name\n")
+
+        assert _read_manifest(tmp_path) == {"name": "declared-name"}
+
+    def test_plugin_yaml_takes_precedence_over_plugin_yml(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text("name: yaml-name\n")
+        (tmp_path / "plugin.yml").write_text("name: yml-name\n")
+
+        assert _read_manifest(tmp_path) == {"name": "yaml-name"}
+
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 
@@ -222,6 +234,195 @@ class TestCmdInstall:
         with pytest.raises(SystemExit) as exc_info:
             cmd_install("invalid")
         assert exc_info.value.code == 1
+
+    def test_install_auto_enable_normalizes_distinct_canonical_key(self, tmp_path):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        target = tmp_path / "category" / "canonical-key"
+        target.mkdir(parents=True)
+        (target / "plugin.yml").write_text("name: declared-name\n")
+        entry = (
+            "declared-name", "", "", "user", target, "category/canonical-key",
+        )
+
+        with patch(
+            "hermes_cli.plugins_cmd._resolve_git_url",
+            return_value=("https://example.test/plugin.git", None),
+        ), patch(
+            "hermes_cli.plugins_cmd._install_plugin_core",
+            return_value=(target, {"name": "declared-name"}, "declared-name"),
+        ), patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[entry]), patch(
+            "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
+        ), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set",
+            return_value={"declared-name", "checkout"},
+        ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+            "hermes_cli.plugins_cmd._save_disabled_set"
+        ) as save_disabled, patch(
+            "hermes_cli.plugins_cmd._prompt_plugin_env_vars"
+        ), patch("hermes_cli.plugins_cmd._display_after_install"):
+            cmd_install("owner/repo", enable=True)
+
+        assert save_enabled.call_args[0][0] == {"category/canonical-key"}
+        assert save_disabled.call_args[0][0] == {"checkout"}
+
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins.discover_plugins")
+    @patch("hermes_cli.plugins.get_plugin_manager")
+    @patch("tools.registry.registry")
+    def test_toolset_fallback_uses_discovered_directory_after_disabled_entry(
+        self,
+        mock_registry,
+        mock_manager,
+        mock_discover,
+        mock_bundled_dir,
+        mock_plugins_dir,
+        mock_discover_all_plugins,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import _get_plugin_toolset_key
+
+        target = tmp_path / "ping_island"
+        target.mkdir()
+        (target / "plugin.yml").write_text(
+            "name: ping-island\nprovides_tools:\n  - ping_tool\n",
+            encoding="utf-8",
+        )
+        entry = ("ping-island", "", "", "user", target, "ping-island")
+        mock_discover_all_plugins.return_value = [entry]
+        mock_manager.return_value = SimpleNamespace(
+            _plugins={
+                "ping-island": SimpleNamespace(
+                    manifest=SimpleNamespace(name="ping-island", key="ping-island"),
+                    tools_registered=[],
+                )
+            }
+        )
+        mock_bundled_dir.return_value = tmp_path / "bundled"
+        mock_plugins_dir.return_value = tmp_path / "plugins"
+        mock_registry.get_entry.return_value = SimpleNamespace(toolset="ping-island")
+
+        assert _get_plugin_toolset_key("ping-island") == "ping-island"
+
+    def test_dashboard_install_auto_enable_normalizes_distinct_canonical_key(self, tmp_path):
+        from hermes_cli.plugins_cmd import dashboard_install_plugin
+
+        target = tmp_path / "category" / "canonical-key"
+        target.mkdir(parents=True)
+        (target / "plugin.yml").write_text("name: declared-name\n")
+        entry = (
+            "declared-name", "", "", "user", target, "category/canonical-key",
+        )
+
+        with patch(
+            "hermes_cli.plugins_cmd._resolve_git_url",
+            return_value=("https://example.test/plugin.git", None),
+        ), patch(
+            "hermes_cli.plugins_cmd._install_plugin_core",
+            return_value=(target, {"name": "declared-name"}, "declared-name"),
+        ), patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[entry]), patch(
+            "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
+        ), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set",
+            return_value={"declared-name", "checkout"},
+        ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+            "hermes_cli.plugins_cmd._save_disabled_set"
+        ) as save_disabled:
+            result = dashboard_install_plugin("owner/repo", force=False, enable=True)
+
+        assert result["ok"] is True
+        assert save_enabled.call_args[0][0] == {"category/canonical-key"}
+        assert save_disabled.call_args[0][0] == {"checkout"}
+
+    def test_install_manifestless_auto_enable_keeps_legacy_success(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        target = tmp_path / "manifestless"
+        target.mkdir()
+
+        with patch(
+            "hermes_cli.plugins_cmd._resolve_git_url",
+            return_value=("https://example.test/plugin.git", None),
+        ), patch(
+            "hermes_cli.plugins_cmd._install_plugin_core",
+            return_value=(target, {}, "manifestless"),
+        ), patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[]), patch(
+            "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
+        ), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value={"manifestless"}
+        ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+            "hermes_cli.plugins_cmd._save_disabled_set"
+        ) as save_disabled, patch(
+            "hermes_cli.plugins_cmd._prompt_plugin_env_vars"
+        ), patch("hermes_cli.plugins_cmd._display_after_install"):
+            cmd_install("owner/repo", enable=True)
+
+        assert save_enabled.call_args[0][0] == {"manifestless"}
+        assert save_disabled.call_args[0][0] == set()
+        assert "Plugin manifestless enabled." in capsys.readouterr().out
+
+    def test_dashboard_install_manifestless_auto_enable_keeps_legacy_success(self, tmp_path):
+        from hermes_cli.plugins_cmd import dashboard_install_plugin
+
+        target = tmp_path / "manifestless"
+        target.mkdir()
+
+        with patch(
+            "hermes_cli.plugins_cmd._resolve_git_url",
+            return_value=("https://example.test/plugin.git", None),
+        ), patch(
+            "hermes_cli.plugins_cmd._install_plugin_core",
+            return_value=(target, {}, "manifestless"),
+        ), patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[]), patch(
+            "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
+        ), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value={"manifestless"}
+        ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+            "hermes_cli.plugins_cmd._save_disabled_set"
+        ) as save_disabled:
+            result = dashboard_install_plugin("owner/repo", force=False, enable=True)
+
+        assert result["ok"] is True
+        assert save_enabled.call_args[0][0] == {"manifestless"}
+        assert save_disabled.call_args[0][0] == set()
+
+    def test_install_rejects_ambiguous_manifest_alias(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        target = tmp_path / "category" / "shared"
+        sibling = tmp_path / "other" / "sibling"
+        target.mkdir(parents=True)
+        sibling.mkdir(parents=True)
+        (target / "plugin.yml").write_text("name: shared\n")
+        entries = [
+            ("shared", "", "", "user", target, "category/shared"),
+            ("shared", "", "", "user", sibling, "other/sibling"),
+        ]
+
+        with patch(
+            "hermes_cli.plugins_cmd._resolve_git_url",
+            return_value=("https://example.test/plugin.git", None),
+        ), patch(
+            "hermes_cli.plugins_cmd._install_plugin_core",
+            return_value=(target, {"name": "shared"}, "shared"),
+        ), patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=entries), patch(
+            "hermes_cli.plugins_cmd._get_enabled_set", return_value=set()
+        ), patch(
+            "hermes_cli.plugins_cmd._get_disabled_set", return_value={"shared"}
+        ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+            "hermes_cli.plugins_cmd._save_disabled_set"
+        ) as save_disabled, patch("hermes_cli.plugins_cmd._prompt_plugin_env_vars"), patch(
+            "hermes_cli.plugins_cmd._display_after_install"
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_install("owner/repo", enable=True)
+
+        assert exc_info.value.code == 1
+        assert "activation alias is ambiguous" in capsys.readouterr().out
+        save_enabled.assert_not_called()
+        save_disabled.assert_not_called()
 
     @patch("hermes_cli.plugins_cmd._display_after_install")
     @patch("hermes_cli.plugins_cmd.shutil.move")

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -77,6 +77,31 @@ class TestResolvePluginKey:
         assert _resolve_plugin_key("openai") is None
         assert _resolve_plugin_key("image_gen/openai") == "image_gen/openai"
 
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_exact_manifest_name_precedes_ambiguous_leaf(self, mock_entries, tmp_path):
+        from hermes_cli.plugins_cmd import _resolve_plugin_key
+
+        mock_entries.return_value = [
+            (
+                "openai",
+                "",
+                "",
+                "bundled",
+                tmp_path / "image_gen" / "openai",
+                "image_gen/openai",
+            ),
+            (
+                "other-openai",
+                "",
+                "",
+                "bundled",
+                tmp_path / "model-providers" / "openai",
+                "model-providers/openai",
+            ),
+        ]
+
+        assert _resolve_plugin_key("openai") == "image_gen/openai"
+
 
 # ---------------------------------------------------------------------------
 # cmd_enable / cmd_disable — write the canonical key
@@ -134,6 +159,126 @@ class TestEnableDisableNested:
         cmd_enable("disk-cleanup", allow_tool_override=False)
         saved = mock_save_en.call_args[0][0]
         assert "disk-cleanup" in saved
+
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"web-exa"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"web/exa"})
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_enable_repairs_dashboard_alias_residue(
+        self, mock_entries, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        entry = (
+            "web-exa", "", "", "bundled", tmp_path / "web" / "exa", "web/exa",
+        )
+        mock_entries.return_value = [entry]
+
+        cmd_enable("web/exa", allow_tool_override=False)
+
+        assert mock_save_en.call_args[0][0] == {"web/exa"}
+        assert mock_save_dis.call_args[0][0] == set()
+
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"nous"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_loader_alias_cleanup_ignores_legacy_alias_collision(
+        self, mock_entries, mock_en, mock_dis, mock_save_en, mock_save_dis, tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        mock_entries.return_value = [
+            (
+                "nous", "", "", "bundled",
+                tmp_path / "dashboard_auth" / "nous", "dashboard_auth/nous",
+            ),
+            (
+                "nous-provider", "", "", "user",
+                tmp_path / "model-providers" / "nous", "model-providers/nous",
+            ),
+        ]
+
+        cmd_enable("dashboard_auth/nous", allow_tool_override=False)
+
+        assert mock_save_en.call_args[0][0] == {"dashboard_auth/nous"}
+        assert mock_save_dis.call_args[0][0] == set()
+
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"shared"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"one/plugin"})
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_enable_preserves_ambiguous_deny_alias(
+        self, mock_entries, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        mock_entries.return_value = [
+            ("shared", "", "", "user", tmp_path / "one" / "plugin", "one/plugin"),
+            ("shared", "", "", "user", tmp_path / "two" / "plugin", "two/plugin"),
+        ]
+
+        with pytest.raises(SystemExit):
+            cmd_enable("one/plugin", allow_tool_override=False)
+
+        mock_save_en.assert_not_called()
+        mock_save_dis.assert_not_called()
+
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_directory_alias_resolves_only_when_unique(self, mock_entries, tmp_path):
+        from hermes_cli.plugins_cmd import _resolve_plugin_key
+
+        mock_entries.return_value = [
+            ("declared-name", "", "", "user", tmp_path / "directory-name", "declared-name"),
+        ]
+
+        assert _resolve_plugin_key("directory-name") == "declared-name"
+
+
+class TestBasicAuthConfig:
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_basic_auth_removes_unique_bundled_aliases(self, mock_entries, tmp_path):
+        from hermes_cli.plugins_cmd import ensure_basic_auth_plugin_enabled_in_config
+
+        mock_entries.return_value = [
+            (
+                "basic",
+                "",
+                "",
+                "bundled",
+                tmp_path / "dashboard_auth" / "basic",
+                "dashboard_auth/basic",
+            ),
+        ]
+        config = {"plugins": {"disabled": ["basic", "dashboard_auth/basic"]}}
+
+        assert ensure_basic_auth_plugin_enabled_in_config(config) is True
+        assert config["plugins"]["disabled"] == []
+
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_basic_auth_preserves_ambiguous_sibling_alias(self, mock_entries, tmp_path):
+        from hermes_cli.plugins_cmd import ensure_basic_auth_plugin_enabled_in_config
+
+        mock_entries.return_value = [
+            (
+                "basic",
+                "",
+                "",
+                "bundled",
+                tmp_path / "dashboard_auth" / "basic",
+                "dashboard_auth/basic",
+            ),
+            ("basic", "", "", "user", tmp_path / "basic", "basic"),
+        ]
+        config = {"plugins": {"disabled": ["basic"]}}
+
+        assert ensure_basic_auth_plugin_enabled_in_config(config) is False
+        assert config["plugins"]["disabled"] == ["basic"]
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +342,58 @@ class TestEnableToolOverrideConsent:
         mock_set_flag.assert_not_called()
 
 
+class TestDashboardPluginActivation:
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"web-exa"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"web/exa"})
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_dashboard_enable_clears_stale_deny_alias(
+        self, mock_entries, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_toggle, tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+        mock_entries.return_value = [
+            ("web-exa", "", "", "bundled", tmp_path / "web" / "exa", "web/exa"),
+        ]
+
+        result = dashboard_set_agent_plugin_enabled("web-exa", enabled=True)
+
+        assert result == {"ok": True, "name": "web-exa", "unchanged": False}
+        assert mock_save_en.call_args[0][0] == {"web/exa"}
+        assert mock_save_dis.call_args[0][0] == set()
+        mock_toggle.assert_called_once_with(
+            "web/exa", enable=True, entries=mock_entries.return_value,
+        )
+
+    @patch("hermes_cli.plugins_cmd._toggle_plugin_toolset")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"web/exa"})
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    def test_dashboard_disable_writes_canonical_key(
+        self, mock_entries, mock_en, mock_dis, mock_save_en, mock_save_dis,
+        mock_toggle, tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+        mock_entries.return_value = [
+            ("web-exa", "", "", "bundled", tmp_path / "web" / "exa", "web/exa"),
+        ]
+
+        result = dashboard_set_agent_plugin_enabled("web-exa", enabled=False)
+
+        assert result["ok"] is True
+        assert mock_save_en.call_args[0][0] == set()
+        assert mock_save_dis.call_args[0][0] == {"web/exa"}
+        mock_toggle.assert_called_once_with(
+            "web/exa", enable=False, entries=mock_entries.return_value,
+        )
+
+
 class TestCompositeMenuWritesCanonicalKey:
     """#40190 follow-up: the interactive `hermes plugins` menu must persist
     the CANONICAL KEY (``web/firecrawl``), never the bare manifest name
@@ -230,4 +427,51 @@ class TestCompositeMenuWritesCanonicalKey:
         saved_dis = mock_save_dis.call_args[0][0]
         assert "web/firecrawl" in saved_dis      # canonical key persisted
         assert "web-firecrawl" not in saved_dis   # never the bare name
+
+    @patch("hermes_cli.curses_ui.flush_stdin")
+    @patch("hermes_cli.plugins_cmd._discover_all_plugins")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch(
+        "hermes_cli.plugins_cmd._get_enabled_set",
+        return_value={"canonical-key", "removed-thing"},
+    )
+    def test_curses_persistence_clears_stale_alias(
+        self,
+        mock_en,
+        mock_save_en,
+        mock_save_dis,
+        mock_entries,
+        mock_flush,
+        tmp_path,
+        capsys,
+    ):
+        from hermes_cli.plugins_cmd import _run_composite_ui
+        from rich.console import Console
+
+        mock_entries.return_value = [
+            (
+                "declared-name", "", "", "user", tmp_path / "canonical-key", "canonical-key",
+            ),
+        ]
+
+        class FakeCurses:
+            @staticmethod
+            def wrapper(callback):
+                return None
+
+        _run_composite_ui(
+            FakeCurses(),
+            ["canonical-key"],
+            ["declared-name"],
+            {0},
+            {"declared-name"},
+            [],
+            Console(),
+        )
+
+        assert mock_save_en.call_args[0][0] == {"canonical-key", "removed-thing"}
+        assert mock_save_dis.call_args[0][0] == set()
+        mock_entries.assert_called_once_with()
+        assert "General plugins: 1 enabled, 0 disabled." in capsys.readouterr().out
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -166,6 +166,37 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "terminal" not in saved_toolsets
 
 
+def test_langfuse_post_setup_repairs_stale_deny_alias(tmp_path):
+    entry = (
+        "langfuse",
+        "",
+        "",
+        "bundled",
+        tmp_path / "observability" / "langfuse",
+        "observability/langfuse",
+    )
+
+    with patch(
+        "hermes_cli.plugins_cmd._discover_all_plugins",
+        return_value=[entry],
+    ), patch(
+        "hermes_cli.plugins_cmd._get_enabled_set",
+        return_value={"observability/langfuse"},
+    ), patch(
+        "hermes_cli.plugins_cmd._get_disabled_set",
+        return_value={"langfuse"},
+    ), patch("hermes_cli.plugins_cmd._save_enabled_set") as save_enabled, patch(
+        "hermes_cli.plugins_cmd._save_disabled_set"
+    ) as save_disabled, patch(
+        "hermes_cli.tools_config._pip_install"
+    ) as pip_install:
+        pip_install.return_value.returncode = 0
+        _run_post_setup("langfuse")
+
+    assert save_enabled.call_args[0][0] == {"observability/langfuse"}
+    assert save_disabled.call_args[0][0] == set()
+
+
 
 
 


### PR DESCRIPTION
## Summary

Plugin activation could persist different spellings through the CLI, dashboard, installers, and setup helpers. A dashboard disable by manifest name could leave a deny entry that a later canonical CLI enable did not clear, so the CLI reported success while a fresh process still skipped the plugin.

All activation writers now resolve to one canonical plugin key before changing configuration. Exact canonical keys and manifest names retain precedence, while ambiguous directory and leaf aliases fail without changing either plugin. The shared mutation also repairs legacy aliases only when the runtime loader can attribute them to that plugin.

Fixes #18005.

## Changes

- `hermes_cli/plugins_cmd.py`: centralize manifest selection, canonical resolution, activation-state normalization, installer activation, Basic Auth setup, composite toggles, and dashboard toolset lookup.
- `hermes_cli/tools_config.py`: route Langfuse post-setup through the same canonical activation path.
- `tests/hermes_cli/test_plugins_cmd.py`: cover canonical, manifestless, ambiguous, and flat directory install paths.
- `tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py`: cover resolver precedence, legacy deny cleanup, Basic Auth, composite menus, and dashboard toolset lookup.
- `tests/hermes_cli/test_plugin_runtime_disable_gate.py`: cover dashboard disable followed by canonical CLI enable in a fresh loader.
- `tests/hermes_cli/test_tools_config.py`: cover Langfuse legacy deny cleanup.

## Validation

| Scenario | Before | After |
|---|---|---|
| Dashboard disable by `web-exa`, then CLI enable by `web/exa` | Stale deny alias survived | Fresh loader activates `web/exa` |
| Exact manifest name with a colliding directory or leaf alias | Could be rejected as ambiguous | Exact manifest name resolves first |
| Legacy deny alias owned only by a directory or leaf collision | Canonical enable could remain blocked | Loader-recognized alias cleanup proceeds safely |
| Basic Auth with a same-named sibling plugin | Could clear the sibling deny alias | Ambiguous sibling deny entry stays intact |
| Composite plugin menu | Repeated discovery for every row and stale summary counts | One discovery snapshot and selected-row counts |
| `plugin.yml` or manifestless install | Activation paths could report a failed completed install | Canonical installs normalize state, manifestless installs retain legacy success |

## Test plan

- `python -m pytest tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py tests/hermes_cli/test_plugin_runtime_disable_gate.py tests/hermes_cli/test_tools_config.py -v --timeout=0` — 98 passed
- `ruff check hermes_cli/plugins_cmd.py hermes_cli/tools_config.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py tests/hermes_cli/test_plugin_runtime_disable_gate.py tests/hermes_cli/test_tools_config.py`

## Not in scope

The runtime loader retains compatibility with existing canonical and manifest-name configuration. This change does not migrate historical config entries.
