### PR TITLE
fix(gateway): randomize fallback api session ids (#7484)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1268,6 +1268,13 @@ def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
+def _make_normalized_request_fingerprint(payload: Dict[str, Any]) -> str:
+    from hashlib import sha256
+
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return sha256(encoded.encode("utf-8")).hexdigest()
+
+
 _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
@@ -5432,18 +5439,32 @@ class APIServerAdapter(BasePlatformAdapter):
         idempotency_key = request.headers.get("Idempotency-Key")
         idempotency_scope = self._idempotency_scope(request, "responses")
         if idempotency_key and idempotency_scope is not None:
-            fp = _make_request_fingerprint(
-                body,
-                keys=[
-                    "input",
-                    "instructions",
-                    "previous_response_id",
-                    "conversation",
-                    "model",
-                    "provider",
-                    "model_options",
-                    "tools",
-                ],
+            model_options = agent_overrides.get("model_options")
+            service_tier = _request_service_tier(model_options)
+            request_options = {
+                "reasoning_config": _request_reasoning_config(model_options),
+                "service_tier": None if service_tier is _REQUEST_OPTION_MISSING else service_tier,
+            }
+            route_identity = {
+                "source": "model_routes" if route else "global",
+                "model": route.get("model") if isinstance(route, dict) else None,
+                "provider": route.get("provider") if isinstance(route, dict) else None,
+            }
+            fp = _make_normalized_request_fingerprint(
+                {
+                    "user_message": user_message,
+                    "conversation_history": conversation_history,
+                    "instructions": instructions,
+                    "truncation": "auto" if body.get("truncation") == "auto" else "none",
+                    "request_options": request_options,
+                    "route": route_identity,
+                    "requested_model": agent_overrides.get("requested_model"),
+                    "requested_provider": agent_overrides.get("requested_provider"),
+                    "previous_response_id": previous_response_id,
+                    "conversation": conversation,
+                    "store": store,
+                    "tools": body.get("tools"),
+                }
             )
             try:
                 result, usage = await self._idempotency_cache.get_or_set(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1275,6 +1275,14 @@ def _make_normalized_request_fingerprint(payload: Dict[str, Any]) -> str:
     return sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _make_fingerprint_digest(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or not value:
+        return None
+    return hashlib.sha256(
+        b"hermes-api-idempotency-route-value-v1\0" + value.encode("utf-8")
+    ).hexdigest()
+
+
 _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
@@ -5446,9 +5454,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 "service_tier": None if service_tier is _REQUEST_OPTION_MISSING else service_tier,
             }
             route_identity = {
+                "alias": _clean_request_string(body.get("model")) if route else None,
                 "source": "model_routes" if route else "global",
                 "model": route.get("model") if isinstance(route, dict) else None,
                 "provider": route.get("provider") if isinstance(route, dict) else None,
+                "api_key_digest": _make_fingerprint_digest(route.get("api_key"))
+                if isinstance(route, dict)
+                else None,
+                "base_url_digest": _make_fingerprint_digest(route.get("base_url"))
+                if isinstance(route, dict)
+                else None,
             }
             fp = _make_normalized_request_fingerprint(
                 {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1212,7 +1212,7 @@ class _IdempotencyCache:
     def __init__(self, max_items: int = 1000, ttl_seconds: int = 300):
         from collections import OrderedDict
         self._store = OrderedDict()
-        self._inflight: Dict[tuple[str, str], "asyncio.Task[Any]"] = {}
+        self._inflight: Dict[tuple[tuple[str, ...], str, str], "asyncio.Task[Any]"] = {}
         self._ttl = ttl_seconds
         self._max = max_items
 
@@ -1224,19 +1224,29 @@ class _IdempotencyCache:
         while len(self._store) > self._max:
             self._store.popitem(last=False)
 
-    async def get_or_set(self, key: str, fingerprint: str, compute_coro):
+    async def get_or_set(
+        self,
+        scope: Optional[tuple[str, ...]],
+        key: str,
+        fingerprint: str,
+        compute_coro,
+    ):
+        if scope is None:
+            return await compute_coro()
+
         self._purge()
-        item = self._store.get(key)
+        store_key = (scope, key)
+        item = self._store.get(store_key)
         if item and item["fp"] == fingerprint:
             return item["resp"]
 
-        inflight_key = (key, fingerprint)
+        inflight_key = (scope, key, fingerprint)
         task = self._inflight.get(inflight_key)
         if task is None:
             async def _compute_and_store():
                 resp = await compute_coro()
                 import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+                self._store[store_key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
                 self._purge()
                 return resp
 
@@ -1252,31 +1262,10 @@ class _IdempotencyCache:
         return await asyncio.shield(task)
 
 
-_idem_cache = _IdempotencyCache()
-
-
 def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
     return sha256(repr(subset).encode("utf-8")).hexdigest()
-
-
-def _derive_chat_session_id(
-    system_prompt: Optional[str],
-    first_user_message: str,
-) -> str:
-    """Derive a stable session ID from the conversation's first user message.
-
-    OpenAI-compatible frontends (Open WebUI, LibreChat, etc.) send the full
-    conversation history with every request.  The system prompt and first user
-    message are constant across all turns of the same conversation, so hashing
-    them produces a deterministic session ID that lets the API server reuse
-    the same Hermes session (and therefore the same Docker container sandbox
-    directory) across turns.
-    """
-    seed = f"{system_prompt or ''}\n{first_user_message}"
-    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
-    return f"api-{digest}"
 
 
 _CRON_AVAILABLE = False
@@ -1436,6 +1425,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._idempotency_cache = _IdempotencyCache()
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
         # server requests; "*" is the process-wide fallback), mirroring
@@ -1774,6 +1764,44 @@ class APIServerAdapter(BasePlatformAdapter):
                 type(exc).__name__,
             )
             return ""
+
+    @staticmethod
+    def _idempotency_header_scope(
+        request: "web.Request", header_name: str
+    ) -> tuple[str, str]:
+        if header_name not in request.headers:
+            return "absent", ""
+        return "present", request.headers.get(header_name, "").strip()
+
+    def _idempotency_scope(
+        self, request: "web.Request", endpoint: str
+    ) -> Optional[tuple[str, ...]]:
+        """Build the non-secret logical scope for an authenticated retry."""
+        expected_key = self._expected_api_key()
+        if not expected_key:
+            return None
+
+        profile = _api_request_profile.get()
+        normalized_profile = (profile or "default").strip() or "default"
+        credential_digest = hashlib.sha256(
+            b"hermes-api-idempotency-credential-v1\0"
+            + expected_key.encode("utf-8")
+        ).hexdigest()
+        session_id_state, session_id_value = self._idempotency_header_scope(
+            request, "X-Hermes-Session-Id"
+        )
+        session_key_state, session_key_value = self._idempotency_header_scope(
+            request, "X-Hermes-Session-Key"
+        )
+        return (
+            endpoint,
+            normalized_profile,
+            f"credential:{credential_digest}",
+            f"session-id:{session_id_state}",
+            session_id_value,
+            f"session-key:{session_key_state}",
+            session_key_value,
+        )
 
     def _check_auth(self, request: "web.Request") -> Optional["web.Response"]:
         """
@@ -4139,16 +4167,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []
         else:
-            # Derive a stable session ID from the conversation fingerprint so
-            # that consecutive messages from the same Open WebUI (or similar)
-            # conversation map to the same Hermes session.  The first user
-            # message + system prompt are constant across all turns.
-            first_user = ""
-            for cm in conversation_messages:
-                if cm.get("role") == "user":
-                    first_user = cm.get("content", "")
-                    break
-            session_id = _derive_chat_session_id(system_prompt, first_user)
+            session_id = f"api-{uuid.uuid4().hex}"
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
@@ -4283,13 +4302,16 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
-        if idempotency_key:
+        idempotency_scope = self._idempotency_scope(request, "chat_completions")
+        if idempotency_key and idempotency_scope is not None:
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await self._idempotency_cache.get_or_set(
+                    idempotency_scope, idempotency_key, fp, _compute_completion
+                )
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
@@ -5408,7 +5430,8 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
-        if idempotency_key:
+        idempotency_scope = self._idempotency_scope(request, "responses")
+        if idempotency_key and idempotency_scope is not None:
             fp = _make_request_fingerprint(
                 body,
                 keys=[
@@ -5423,7 +5446,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 ],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+                result, usage = await self._idempotency_cache.get_or_set(
+                    idempotency_scope, idempotency_key, fp, _compute_response
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
@@ -6316,6 +6341,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     return (
                         {
                             "final_response": f"⚠️ Provider authentication failed: {exc}",
+                            "session_id": session_id,
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -31,7 +31,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
-    _derive_chat_session_id,
+    _ProviderAuthResolutionError,
     _hermes_version,
     _redact_api_error_text,
     _request_agent_overrides,
@@ -124,6 +124,7 @@ class TestIdempotencyCache:
     @pytest.mark.asyncio
     async def test_concurrent_same_key_and_fingerprint_runs_once(self):
         cache = _IdempotencyCache()
+        scope = ("chat_completions", "default", "credential:digest", "session-id:absent", "", "session-key:absent", "")
         gate = asyncio.Event()
         started = asyncio.Event()
         calls = 0
@@ -135,8 +136,8 @@ class TestIdempotencyCache:
             await gate.wait()
             return ("response", {"total_tokens": 1})
 
-        first = asyncio.create_task(cache.get_or_set("idem-key", "fp-1", compute))
-        second = asyncio.create_task(cache.get_or_set("idem-key", "fp-1", compute))
+        first = asyncio.create_task(cache.get_or_set(scope, "idem-key", "fp-1", compute))
+        second = asyncio.create_task(cache.get_or_set(scope, "idem-key", "fp-1", compute))
 
         await started.wait()
         assert calls == 1
@@ -145,6 +146,60 @@ class TestIdempotencyCache:
         first_result, second_result = await asyncio.gather(first, second)
 
         assert first_result == second_result == ("response", {"total_tokens": 1})
+
+    @pytest.mark.asyncio
+    async def test_completed_entries_partition_by_scope_and_fingerprint(self):
+        cache = _IdempotencyCache()
+        calls = []
+
+        async def compute(label):
+            calls.append(label)
+            return label
+
+        scope_a = ("chat_completions", "default", "credential:a", "session-id:absent", "", "session-key:absent", "")
+        scope_b = ("chat_completions", "default", "credential:b", "session-id:absent", "", "session-key:absent", "")
+        assert await cache.get_or_set(scope_a, "same-key", "same-body", lambda: compute("a1")) == "a1"
+        assert await cache.get_or_set(scope_a, "same-key", "same-body", lambda: compute("a2")) == "a1"
+        assert await cache.get_or_set(scope_b, "same-key", "same-body", lambda: compute("b1")) == "b1"
+        assert await cache.get_or_set(scope_a, "same-key", "other-body", lambda: compute("a2")) == "a2"
+        assert calls == ["a1", "b1", "a2"]
+
+    @pytest.mark.asyncio
+    async def test_inflight_entries_partition_by_scope(self):
+        cache = _IdempotencyCache()
+        gate = asyncio.Event()
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            await gate.wait()
+            return calls
+
+        scope_a = ("chat_completions", "default", "credential:a", "session-id:absent", "", "session-key:absent", "")
+        scope_b = ("responses", "default", "credential:a", "session-id:absent", "", "session-key:absent", "")
+        tasks = [
+            asyncio.create_task(cache.get_or_set(scope_a, "same-key", "same-body", compute)),
+            asyncio.create_task(cache.get_or_set(scope_a, "same-key", "same-body", compute)),
+            asyncio.create_task(cache.get_or_set(scope_b, "same-key", "same-body", compute)),
+        ]
+        await asyncio.sleep(0.01)
+        assert calls == 2
+        gate.set()
+        assert await asyncio.gather(*tasks) == [2, 2, 2]
+
+    @pytest.mark.asyncio
+    async def test_none_scope_bypasses_cache(self):
+        cache = _IdempotencyCache()
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            return calls
+
+        assert await cache.get_or_set(None, "same-key", "same-body", compute) == 1
+        assert await cache.get_or_set(None, "same-key", "same-body", compute) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -983,6 +1038,118 @@ class TestChatCompletionsEndpoint:
             data = await resp.json()
             assert "messages" in data["error"]["message"]
 
+    @pytest.mark.asyncio
+    async def test_same_scope_idempotency_replays_generated_session_identity(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        calls = []
+
+        async def run_agent(**kwargs):
+            calls.append(kwargs["session_id"])
+            return (
+                {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "retry-1"},
+                    json=body,
+                )
+                retry = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "retry-1"},
+                    json=body,
+                )
+
+        assert first.status == retry.status == 200
+        assert mock_run.call_count == 1
+        assert first.headers["X-Hermes-Session-Id"] == retry.headers["X-Hermes-Session-Id"] == calls[0]
+
+    @pytest.mark.asyncio
+    async def test_provider_auth_failure_replay_preserves_session_identity(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        auth_failure = _ProviderAuthResolutionError("provider unavailable")
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=auth_failure) as create_agent:
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "auth-failure-retry"}
+                first = await cli.post("/v1/chat/completions", headers=headers, json=body)
+                retry = await cli.post("/v1/chat/completions", headers=headers, json=body)
+                first_data = await first.json()
+                retry_data = await retry.json()
+
+        assert first.status == retry.status == 200
+        assert create_agent.call_count == 1
+        assert first_data["choices"] == retry_data["choices"]
+        assert first.headers["X-Hermes-Session-Id"] == retry.headers["X-Hermes-Session-Id"]
+        assert first.headers["X-Hermes-Session-Id"].startswith("api-")
+
+    @pytest.mark.asyncio
+    async def test_idempotency_partitions_each_session_header_coordinate(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+
+        async def run_agent(**kwargs):
+            return (
+                {"final_response": kwargs["session_id"], "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                common = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "partitioned"}
+                await cli.post("/v1/chat/completions", headers=common, json=body)
+                await cli.post(
+                    "/v1/chat/completions",
+                    headers={**common, "X-Hermes-Session-Key": "memory-a"},
+                    json=body,
+                )
+                await cli.post(
+                    "/v1/chat/completions",
+                    headers={**common, "X-Hermes-Session-Id": "explicit-a"},
+                    json=body,
+                )
+                await cli.post(
+                    "/v1/chat/completions",
+                    headers={**common, "X-Hermes-Session-Key": "memory-b"},
+                    json=body,
+                )
+
+        assert mock_run.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_no_auth_idempotency_key_bypasses_cache(self, adapter):
+        app = _create_app(adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        session_ids = []
+
+        async def run_agent(**kwargs):
+            session_ids.append(kwargs["session_id"])
+            return (
+                {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                for _ in range(2):
+                    response = await cli.post(
+                        "/v1/chat/completions",
+                        headers={"Idempotency-Key": "unauthenticated"},
+                        json=body,
+                    )
+                    assert response.status == 200
+
+        assert mock_run.call_count == 2
+        assert session_ids[0] != session_ids[1]
+
 
     @pytest.mark.asyncio
     async def test_chat_completions_stream_passes_request_model_provider_options(self, adapter):
@@ -1019,6 +1186,45 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_streaming_no_header_requests_keep_fresh_ids_and_skip_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        }
+        session_ids = []
+
+        async def run_agent(**kwargs):
+            session_ids.append(kwargs["session_id"])
+            callback = kwargs.get("stream_delta_callback")
+            if callback:
+                callback("ok")
+            return (
+                {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                responses = [
+                    await cli.post(
+                        "/v1/chat/completions",
+                        headers={
+                            "Authorization": "Bearer sk-secret",
+                            "Idempotency-Key": "stream-retry",
+                        },
+                        json=body,
+                    )
+                    for _ in range(2)
+                ]
+
+        assert all(response.status == 200 for response in responses)
+        assert mock_run.call_count == 2
+        assert session_ids[0] != session_ids[1]
+        assert responses[0].headers["X-Hermes-Session-Id"] != responses[1].headers["X-Hermes-Session-Id"]
 
 
     @pytest.mark.asyncio
@@ -1293,22 +1499,55 @@ class TestChatCompletionsEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# _derive_chat_session_id unit tests
+# Fresh no-header Chat Completions identities
 # ---------------------------------------------------------------------------
 
 
-class TestDeriveChatSessionId:
-    def test_deterministic(self):
-        """Same inputs always produce the same session ID."""
-        a = _derive_chat_session_id("sys", "hello")
-        b = _derive_chat_session_id("sys", "hello")
-        assert a == b
+class TestFreshChatSessionIdentity:
+    @pytest.mark.asyncio
+    async def test_identical_no_header_requests_receive_distinct_uuid4_sessions(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        session_ids = []
 
+        async def run_agent(**kwargs):
+            session_ids.append(kwargs["session_id"])
+            return (
+                {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
 
-    def test_different_system_prompt(self):
-        a = _derive_chat_session_id("You are a pirate.", "Hello")
-        b = _derive_chat_session_id("You are a robot.", "Hello")
-        assert a != b
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent):
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+                second = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json=body,
+                )
+
+        assert first.status == second.status == 200
+        assert len(session_ids) == 2
+        assert session_ids[0] != session_ids[1]
+        for session_id, response in zip(session_ids, (first, second)):
+            assert session_id.startswith("api-")
+            assert uuid.UUID(session_id[4:]).version == 4
+            assert response.headers["X-Hermes-Session-Id"] == session_id
+
+    def test_authenticated_scope_contains_only_a_digest_of_the_api_key(self, auth_adapter):
+        request = types.SimpleNamespace(
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        scope = auth_adapter._idempotency_scope(request, "chat_completions")
+        assert scope is not None
+        assert "sk-secret" not in repr(scope)
+        assert scope[0] == "chat_completions"
+        assert scope[1] == "default"
+        assert scope[2].startswith("credential:")
 
 
 # ---------------------------------------------------------------------------
@@ -1349,6 +1588,101 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+    @pytest.mark.asyncio
+    async def test_same_scope_idempotency_replays_responses_result(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "input": "hello", "store": False}
+
+        async def run_agent(**kwargs):
+            return (
+                {"final_response": "stable", "session_id": "responses-session", "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                first = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "responses-retry"},
+                    json=body,
+                )
+                retry = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "responses-retry"},
+                    json=body,
+                )
+                first_data = await first.json()
+                retry_data = await retry.json()
+
+        assert first.status == retry.status == 200
+        assert mock_run.call_count == 1
+        assert first_data["output"] == retry_data["output"]
+        assert retry.headers["X-Hermes-Session-Id"] == "responses-session"
+
+    @pytest.mark.asyncio
+    async def test_provider_auth_failure_replay_preserves_responses_session_identity(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "input": "hello", "store": False}
+        auth_failure = _ProviderAuthResolutionError("provider unavailable")
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=auth_failure) as create_agent:
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "auth-failure-responses"}
+                first = await cli.post("/v1/responses", headers=headers, json=body)
+                retry = await cli.post("/v1/responses", headers=headers, json=body)
+                first_data = await first.json()
+                retry_data = await retry.json()
+
+        assert first.status == retry.status == 200
+        assert create_agent.call_count == 1
+        assert first_data["output"] == retry_data["output"]
+        assert first.headers["X-Hermes-Session-Id"] == retry.headers["X-Hermes-Session-Id"]
+        assert first.headers["X-Hermes-Session-Id"]
+
+    @pytest.mark.asyncio
+    async def test_endpoint_and_adapter_namespaces_partition_idempotency(self, auth_adapter):
+        other_adapter = _make_adapter(api_key="sk-secret")
+        chat_app = _create_app(auth_adapter)
+        responses_app = _create_app(auth_adapter)
+        other_app = _create_app(other_adapter)
+        chat_body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+        responses_body = {"model": "hermes-agent", "input": "hello", "store": False}
+
+        async def chat_run(**kwargs):
+            return (
+                {"final_response": "chat", "session_id": "chat-session", "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async def responses_run(**kwargs):
+            return (
+                {"final_response": "responses", "session_id": "responses-session", "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with (
+            TestClient(TestServer(chat_app)) as chat_cli,
+            TestClient(TestServer(responses_app)) as responses_cli,
+            TestClient(TestServer(other_app)) as other_cli,
+        ):
+            with (
+                patch.object(auth_adapter, "_run_agent", side_effect=chat_run) as chat_mock,
+                patch.object(other_adapter, "_run_agent", side_effect=responses_run) as other_mock,
+                patch("gateway.platforms.api_server._make_request_fingerprint", return_value="same-fp"),
+            ):
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "shared-key"}
+                chat_response = await chat_cli.post("/v1/chat/completions", headers=headers, json=chat_body)
+                response_result = await responses_cli.post("/v1/responses", headers=headers, json=responses_body)
+                other_result = await other_cli.post("/v1/responses", headers=headers, json=responses_body)
+                response_data = await response_result.json()
+                other_data = await other_result.json()
+
+        assert chat_response.status == response_result.status == other_result.status == 200
+        assert chat_mock.call_count == 2
+        assert other_mock.call_count == 1
+        assert response_data["output"][0]["content"][0]["text"] == "chat"
+        assert other_data["output"][0]["content"][0]["text"] == "responses"
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1724,6 +1724,51 @@ class TestResponsesEndpoint:
         assert first.status == second.status == 200
         assert mock_run.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_responses_idempotency_partitions_route_credentials(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        auth_adapter._model_routes = {
+            "shared-route": {
+                "model": "provider/model",
+                "provider": "openrouter",
+                "api_key": "route-secret-a",
+                "base_url": "https://route-a.example/v1",
+            }
+        }
+
+        async def run_agent(**kwargs):
+            return (
+                {"final_response": "ok", "session_id": "responses-session", "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "route-retry"}
+                first = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={"model": "shared-route", "input": "hello", "store": False},
+                )
+                auth_adapter._model_routes["shared-route"] = {
+                    "model": "provider/model",
+                    "provider": "openrouter",
+                    "api_key": "route-secret-b",
+                    "base_url": "https://route-b.example/v1",
+                }
+                second = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={"model": "shared-route", "input": "hello", "store": False},
+                )
+
+        assert first.status == second.status == 200
+        assert mock_run.call_count == 2
+        assert [call.kwargs["route"]["base_url"] for call in mock_run.call_args_list] == [
+            "https://route-a.example/v1",
+            "https://route-b.example/v1",
+        ]
+
 
     @pytest.mark.asyncio
     async def test_provider_auth_failure_replay_preserves_responses_session_identity(self, auth_adapter):
@@ -3338,4 +3383,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1695,6 +1695,10 @@ class TestResponsesEndpoint:
 
         assert first.status == second.status == 200
         assert mock_run.call_count == 2
+        assert [call.kwargs["conversation_history"] for call in mock_run.call_args_list] == [
+            [{"role": "user", "content": "prior"}],
+            [{"role": "user", "content": "prior"}],
+        ]
 
     @pytest.mark.asyncio
     async def test_responses_idempotency_normalizes_equivalent_input_forms(self, auth_adapter):
@@ -1820,6 +1824,10 @@ class TestResponsesEndpoint:
                 patch.object(auth_adapter, "_run_agent", side_effect=chat_run) as chat_mock,
                 patch.object(other_adapter, "_run_agent", side_effect=responses_run) as other_mock,
                 patch("gateway.platforms.api_server._make_request_fingerprint", return_value="same-fp"),
+                patch(
+                    "gateway.platforms.api_server._make_normalized_request_fingerprint",
+                    return_value="same-fp",
+                ),
             ):
                 headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "shared-key"}
                 chat_response = await chat_cli.post("/v1/chat/completions", headers=headers, json=chat_body)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1621,6 +1621,111 @@ class TestResponsesEndpoint:
         assert retry.headers["X-Hermes-Session-Id"] == "responses-session"
 
     @pytest.mark.asyncio
+    async def test_responses_idempotency_partitions_normalized_conversation_history(self, auth_adapter):
+        app = _create_app(auth_adapter)
+
+        async def run_agent(**kwargs):
+            history_value = kwargs["conversation_history"][0]["content"]
+            return (
+                {"final_response": history_value, "session_id": "responses-session", "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "history-retry"}
+                first = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                        "conversation_history": [{"role": "user", "content": "secret-A"}],
+                        "store": False,
+                    },
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                        "conversation_history": [{"role": "user", "content": "secret-B"}],
+                        "store": False,
+                    },
+                )
+                first_data = await first.json()
+                second_data = await second.json()
+
+        assert first.status == second.status == 200
+        assert mock_run.call_count == 2
+        assert [call.kwargs["conversation_history"] for call in mock_run.call_args_list] == [
+            [{"role": "user", "content": "secret-A"}],
+            [{"role": "user", "content": "secret-B"}],
+        ]
+        assert first_data["output"][0]["content"][0]["text"] == "secret-A"
+        assert second_data["output"][0]["content"][0]["text"] == "secret-B"
+
+    @pytest.mark.asyncio
+    async def test_responses_idempotency_partitions_truncation_mode(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "input": "hello", "store": False}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "session_id": "responses-session", "messages": []},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "truncation-retry"}
+                first = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={**body, "conversation_history": [{"role": "user", "content": "prior"}]},
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={
+                        **body,
+                        "conversation_history": [{"role": "user", "content": "prior"}],
+                        "truncation": "auto",
+                    },
+                )
+
+        assert first.status == second.status == 200
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_responses_idempotency_normalizes_equivalent_input_forms(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "stable", "session_id": "responses-session", "messages": []},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "input-form-retry"}
+                first = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={"model": "hermes-agent", "input": "hello", "store": False},
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={
+                        "model": "hermes-agent",
+                        "input": [{"role": "user", "content": "hello"}],
+                        "store": False,
+                    },
+                )
+
+        assert first.status == second.status == 200
+        assert mock_run.call_count == 1
+
+
+    @pytest.mark.asyncio
     async def test_provider_auth_failure_replay_preserves_responses_session_identity(self, auth_adapter):
         app = _create_app(auth_adapter)
         body = {"model": "hermes-agent", "input": "hello", "store": False}
@@ -1932,6 +2037,40 @@ class TestResponsesEndpoint:
 
 
 class TestResponsesStreaming:
+
+    @pytest.mark.asyncio
+    async def test_authenticated_streaming_idempotency_requests_execute_independently(self, auth_adapter):
+        app = _create_app(auth_adapter)
+
+        async def run_agent(**kwargs):
+            return (
+                {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        async def write_sse(**kwargs):
+            await kwargs["agent_task"]
+            return web.Response(status=200, text="ok")
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run,
+                patch.object(auth_adapter, "_write_sse_responses", side_effect=write_sse),
+            ):
+                headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "stream-retry"}
+                first = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={"model": "hermes-agent", "input": "hello", "stream": True},
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    headers=headers,
+                    json={"model": "hermes-agent", "input": "hello", "stream": True},
+                )
+
+        assert first.status == second.status == 200
+        assert mock_run.call_count == 2
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -182,7 +182,7 @@ async def test_profile_aliases_and_credentials_partition_adapter_idempotency(
     )()
     monkeypatch.setattr(
         "hermes_cli.profiles.profiles_to_serve",
-        lambda multiplex: [("default", tmp_path), ("worker", worker_home)],
+        lambda multiplex, profile_allowlist=None: [("default", tmp_path), ("worker", worker_home)],
     )
     monkeypatch.setattr(
         "hermes_cli.profiles.get_profile_dir",
@@ -226,5 +226,4 @@ async def test_profile_aliases_and_credentials_partition_adapter_idempotency(
     assert mock_run.call_count == 2
     assert first.headers["X-Hermes-Session-Id"] == default_alias.headers["X-Hermes-Session-Id"]
     assert worker.headers["X-Hermes-Session-Id"] != first.headers["X-Hermes-Session-Id"]
-
 

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -161,3 +161,70 @@ async def test_profile_middleware_binds_auth_before_handler(
         assert (await accepted.json())["profile"] == "worker"
 
 
+@pytest.mark.asyncio
+async def test_profile_aliases_and_credentials_partition_adapter_idempotency(
+    adapter, tmp_path, monkeypatch
+):
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from gateway.config import GatewayConfig
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    profile_key = "w" * 32
+    default_key = "d" * 32
+    (worker_home / ".env").write_text(
+        f"API_SERVER_KEY={profile_key}\n", encoding="utf-8"
+    )
+    adapter._api_key = default_key
+    adapter.gateway_runner = type(
+        "_Runner", (), {"config": GatewayConfig(multiplex_profiles=True)}
+    )()
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", tmp_path), ("worker", worker_home)],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: tmp_path if name == "default" else worker_home,
+    )
+    ss.set_multiplex_active(True)
+
+    async def run_agent(**kwargs):
+        return (
+            {"final_response": "ok", "session_id": kwargs["session_id"], "messages": []},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/p/{profile}/v1/chat/completions", adapter._handle_chat_completions)
+    body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]}
+
+    async with TestClient(TestServer(app)) as client:
+        from unittest.mock import patch
+
+        with patch.object(adapter, "_run_agent", side_effect=run_agent) as mock_run:
+            default_headers = {
+                "Authorization": f"Bearer {default_key}",
+                "Idempotency-Key": "profile-key",
+            }
+            first = await client.post("/v1/chat/completions", headers=default_headers, json=body)
+            default_alias = await client.post(
+                "/p/default/v1/chat/completions", headers=default_headers, json=body
+            )
+            worker = await client.post(
+                "/p/worker/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {profile_key}",
+                    "Idempotency-Key": "profile-key",
+                },
+                json=body,
+            )
+
+    assert first.status == default_alias.status == worker.status == 200
+    assert mock_run.call_count == 2
+    assert first.headers["X-Hermes-Session-Id"] == default_alias.headers["X-Hermes-Session-Id"]
+    assert worker.headers["X-Hermes-Session-Id"] != first.headers["X-Hermes-Session-Id"]
+
+


### PR DESCRIPTION
## Summary

`/v1/chat/completions` derived no-header session IDs from the system prompt and first user message. Unrelated chats with the same opener therefore shared a predictable transcript and sandbox identity.

The API server also treated an `Idempotency-Key` as process-wide authority. A cached result could cross profiles, credentials, session headers, adapter instances, or the Chat Completions and Responses endpoints, carrying the first request's effective session ID with it. Responses retries could additionally replay across different normalized conversation histories, truncation modes, or routed upstream identities.

This rebuild gives ordinary no-header chat requests a fresh UUID-backed session ID. Authenticated retries replay their original agent result and session ID only when endpoint, profile, credential, adapter, session-header state, and effective normalized agent context match. Route-specific upstream credentials and endpoints participate through non-secret digests. Clients that need SessionDB and sandbox continuity continue to authenticate and send the returned `X-Hermes-Session-Id`; full-history clients can keep sending their transcript in the request body. `X-Hermes-Session-Key` remains an independent long-term-memory scope.

Fixes #7484.

## Changes

- `gateway/platforms/api_server.py`: replace prompt-derived no-header Chat Completions IDs with fresh UUID4-backed `api-` IDs.
- `gateway/platforms/api_server.py`: keep idempotency ownership adapter-local and partition completed and in-flight entries by endpoint, normalized profile, credential digest, explicit session-header coordinates, and canonical normalized Responses context.
- `gateway/platforms/api_server.py`: include normalized history, truncation mode, effective request options, route identity, and non-secret route-value digests in Responses fingerprints.
- `tests/gateway/test_api_server.py`: cover fresh identities, same-scope retries, endpoint/header/adapter partitions, normalized history and truncation isolation, equivalent input forms, route-credential isolation, authenticated streaming bypass, unauthenticated bypass, and provider-auth replay identity.
- `tests/gateway/test_api_server_multiplex_secret_scope.py`: cover profile-alias and profile-credential isolation through the real middleware.

## Validation

| Scenario | Before | After |
|---|---|---|
| Identical no-header chat requests | Shared a prompt-derived session ID | Receive distinct UUID-backed session IDs |
| Same authenticated idempotency retry | Could replay across unrelated identity scopes | Replays only the cached agent result and session ID inside the exact normalized scope |
| Distinct session headers, profiles, credentials, adapters, or endpoints | Could share an idempotency result | Compute independently |
| Distinct Responses histories, truncation modes, or routed upstream identities | Could replay the first request's result | Compute independently |
| Explicit `X-Hermes-Session-Id` continuation | Loads persisted history after authentication | Unchanged |
| No API key on manually wired adapters | Could use the shared idempotency cache | Bypasses caching and runs independently |

## Test plan

- `python -m pytest tests/gateway/test_api_server.py -k "idempotency or truncation_auto_preserves_non_leading_compaction_summary" -v` — 16 passed
- `python -m pytest tests/gateway/test_api_server.py -k "provider_auth_failure_replay_preserves_responses_session_identity or same_scope_idempotency_replays_responses_result" -v` — 2 passed
- `python -m pytest tests/gateway/test_api_server_multiplex_secret_scope.py -v` — 4 passed
- `ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py` — passed
