### PR TITLE
gemini_native: route Palantir Foundry /google proxy through GeminiNativeClient

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1296,7 +1296,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
-    if agent.provider == "gemini":
+    if agent.provider == "gemini" or "/api/v2/llm/proxy/google" in str(client_kwargs.get("base_url", "") or "").lower():
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
         base_url = str(client_kwargs.get("base_url", "") or "")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1430,7 +1430,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             if model is None:
                 continue  # skip provider if we don't know a valid aux model
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
-            if provider_id == "gemini":
+            if provider_id == "gemini" or "/api/v2/llm/proxy/google" in (base_url or "").lower():
                 from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
                 if is_native_gemini_base_url(base_url):
@@ -1467,7 +1467,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if model is None:
             continue  # skip provider if we don't know a valid aux model
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
-        if provider_id == "gemini":
+        if provider_id == "gemini" or "/api/v2/llm/proxy/google" in (base_url or "").lower():
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
@@ -3749,12 +3749,12 @@ def resolve_provider_client(
         default_model = _get_aux_model_for_provider(provider)
         final_model = _normalize_resolved_model(model or default_model, provider)
 
-        if provider == "gemini":
+        if provider == "gemini" or "/api/v2/llm/proxy/google" in (base_url or "").lower():
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
                 client = GeminiNativeClient(api_key=api_key, base_url=base_url)
-                logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+                logger.debug("resolve_provider_client: %s (%s) [gemini-native]", provider, final_model)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))
 

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -35,10 +35,23 @@ DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
 
 def is_native_gemini_base_url(base_url: str) -> bool:
-    """Return True when the endpoint speaks Gemini's native REST API."""
+    """Return True when the endpoint speaks Gemini's native REST API.
+
+    Recognizes:
+    - Google AI Studio: ``generativelanguage.googleapis.com/v1beta``
+      (default; the ``/openai`` compat suffix is excluded.)
+    - Palantir Foundry LLM proxy: any host with the path segment
+      ``/api/v2/llm/proxy/google/v1`` (Foundry forwards the native
+      ``models/{rid}:generateContent`` shape verbatim to Vertex/Gemini).
+    """
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
+    # Palantir Foundry LLM proxy - native Gemini shape, just behind a Bearer token.
+    # Keeping this case before the googleapis.com check keeps both paths working
+    # if a downstream caller proxies via a custom Foundry domain.
+    if "/api/v2/llm/proxy/google/v1" in normalized:
+        return True
     if "generativelanguage.googleapis.com" not in normalized:
         return False
     return not normalized.endswith("/openai")
@@ -851,9 +864,15 @@ class GeminiNativeClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "x-goog-api-key": self.api_key,
             "User-Agent": "hermes-agent (gemini-native)",
         }
+        # Palantir Foundry LLM proxy expects ``Authorization: Bearer <token>``;
+        # Google AI Studio expects ``x-goog-api-key: <key>``. We branch on the
+        # base_url shape so the same adapter can talk to both surfaces.
+        if "/api/v2/llm/proxy/google" in (self.base_url or "").lower():
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        else:
+            headers["x-goog-api-key"] = self.api_key
         headers.update(self._default_headers)
         return headers
 


### PR DESCRIPTION
## What

Adds routing for the **Google/Gemini surface** of the Palantir Foundry LLM
proxy (`/api/v2/llm/proxy/google/v1`). The Anthropic and OpenAI surfaces are
already supported (via `api_mode: anthropic_messages` / `chat_completions`),
but a custom provider pointed at the Google surface was never recognized as
Gemini-native, so requests fell through to the OpenAI-shaped path and either
404'd or got coerced into the wrong wire format.

## Concrete repro

A `providers:` entry in `config.yaml` pointed at the Foundry Google surface:

```yaml
providers:
  palantir-gemini:
    api: https://<tenant>.<region>.palantirfoundry.co.uk/api/v2/llm/proxy/google/v1
    key_env: PALANTIR_TOKEN
    api_mode: chat_completions      # no gemini api_mode exists
    default_model: ri.language-model-service..language-model.gemini-3-1-pro
```

Before this change a chat turn against `palantir-gemini` was dispatched as
OpenAI-wire (`POST /v1/chat/completions` against a `/google/v1` base) →
404, or coerced into Anthropic shape → `unrecognizedProperty=...`. The
proxy actually speaks the native Gemini REST shape
(`models/{rid}:generateContent`), so it should go through `GeminiNativeClient`.

## Root cause

The Gemini-native dispatch was keyed on `provider == "gemini"` /
`provider_id == "gemini"` only. A `custom:<name>` / `providers:` entry that
happens to point at a Gemini-speaking proxy never matched, so it never
reached `GeminiNativeClient`. The brand label on the provider id is the
wrong signal — the **base_url** is what decides the wire.

## Fix

Three changes, all gated on the proxy URL so native Google AI Studio
behaviour is untouched:

- `is_native_gemini_base_url()`: also return True for any host carrying the
  path segment `/api/v2/llm/proxy/google/v1`. Foundry forwards the native
  `models/{rid}:generateContent` shape verbatim to Vertex/Gemini, so the
  same adapter logic applies. The `generativelanguage.googleapis.com` path
  (and its `/openai` compat-suffix exclusion) is unchanged.
- `GeminiNativeClient._headers()`: send `Authorization: Bearer <token>` for
  the Foundry proxy surface, keep `x-goog-api-key: <key>` for Google AI
  Studio. Branch on `base_url` so one adapter talks to both surfaces.
- Three dispatch sites (`auxiliary_client._resolve_api_key_provider` — the
  pooled and non-pooled arms — and `resolve_provider_client`) now also route
  to `GeminiNativeClient` when the base_url is a Palantir google proxy, not
  only when the provider id equals `gemini`. Each site still calls
  `is_native_gemini_base_url(base_url)` as the inner guard, so a
  mis-configured base_url can't accidentally route.

No new config field, no schema change — this reuses the existing
`providers:` mechanism and the existing `GeminiNativeClient`.

## Verification

Verified live in a fresh CLI session against a real Foundry tenant:
`gemini-3.1-pro` and `gemini-3.5-flash` behind a `palantir-gemini` provider
both complete a round-trip (model returns text, `finishReason` present).
Native Google AI Studio Gemini still resolves via the unchanged
`x-goog-api-key` path.

```python
from agent.gemini_native_adapter import is_native_gemini_base_url
assert is_native_gemini_base_url("https://generativelanguage.googleapis.com/v1beta")
assert is_native_gemini_base_url("https://t.r.palantirfoundry.co.uk/api/v2/llm/proxy/google/v1")
assert not is_native_gemini_base_url("https://t.r.palantirfoundry.co.uk/api/v2/llm/proxy/openai/v1")
```

## Test status

No existing tests touched. The change is additive (an extra `or` clause on
each dispatch guard plus a header branch). Pre-existing unrelated Pyright
`str | None` warnings in the touched files are untouched by this PR.
