### PR TITLE
fix(desktop): reconcile composer draft on compositionend for IME reliability

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1229,6 +1229,21 @@ export function ChatBar({
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={() => {
           composingRef.current = false
+
+          // Reconcile the draft from the editor DOM immediately.
+          // With some IMEs (macOS Vietnamese Telex, Windows Japanese, etc.)
+          // the trailing `input` event after `compositionend` is not reliably
+          // delivered, which means the final composed text would never be
+          // written to the draft if we only rely on handleEditorInput.
+          // By reading the DOM here we guarantee the finalized text lands.
+          const editor = editorRef.current
+          if (editor) {
+            const next = composerPlainText(editor)
+            if (next !== draftRef.current) {
+              draftRef.current = next
+              aui.composer().setText(next)
+            }
+          }
         }}
         onCompositionStart={() => {
           composingRef.current = true
@@ -1284,6 +1299,18 @@ export function ChatBar({
 
             if (composingRef.current) {
               return
+            }
+
+            // Defensive reconcile: enter may race compositionend, so
+            // read the editor DOM one more time to ensure the draft
+            // reflects the latest composed text.
+            const editorSubmit = editorRef.current
+            if (editorSubmit) {
+              const nextSubmit = composerPlainText(editorSubmit)
+              if (nextSubmit !== draftRef.current) {
+                draftRef.current = nextSubmit
+                aui.composer().setText(nextSubmit)
+              }
             }
 
             submitDraft()


### PR DESCRIPTION
## Summary

macOS Vietnamese Telex (and similar East Asian IMEs with per-syllable composition) do not reliably fire a trailing `input` event after `compositionend`. The `handleEditorInput` handler early-returns while `composingRef.current` is true (correct — avoids reading preedit text), but `onCompositionEnd` only cleared the flag and never re-read the DOM, so the final composed characters/tone marks were silently dropped.

## Changes

### 1. `onCompositionEnd` — reconcile draft from DOM (primary fix)

After clearing `composingRef.current`, immediately read the editor DOM with `composerPlainText(editor)` and sync it to the draft via `aui.composer().setText()`. This guarantees the finalized composed text lands in the draft even when the trailing `input` event is not delivered (as happens with macOS Vietnamese Telex).

### 2. `onSubmit` — defensive reconcile before `submitDraft()`

Re-read the editor DOM one more time before submitting, so that if Enter races with composition end, the draft is still fresh.

## Testing

No macOS hardware available to test directly, but the fix follows the exact same pattern already used throughout this file for draft reconciliation (`draftRef.current = composerPlainText(editor); aui.composer().setText(draftRef.current)` at lines 614-615, 498-500, etc.). The change is additive (27 insertions, 0 deletions) and cannot regress non-IME input paths.

## Related

- Fixes #39636
- #39620 — Japanese IME composition broken in Desktop composer (Windows). Same file, same root cause.
- #39025 — Windows Chinese: rich composer draft stays stale.