### PR TITLE
fix(doctor): catch OSError when gh CLI is not executable

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1989,7 +1989,7 @@ def run_doctor(args):
                 capture_output=True, timeout=10,
             )
             return result.returncode == 0
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
             return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")


### PR DESCRIPTION
Fixes #39540

## Summary
The `_gh_authenticated()` function in `hermes_cli/doctor.py` only catches `FileNotFoundError` and `subprocess.TimeoutExpired`, but fails when `gh` exists as a non-executable file on the PATH (e.g. `gh.exe` on WSL).

## Change
- Broadened exception handler to catch `OSError` (parent of `PermissionError`)
- All `gh` failures now gracefully return `False` instead of crashing with a traceback

## Testing
Ran syntax check — code parses cleanly.