### PR TITLE
fix(desktop): show send button for committed IME text (Chinese/Japanese/Korean)

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
+++ b/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent, render } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+// Faithful mirror of index.tsx's composer text wiring for IME input, driven
+// through REAL DOM composition + input events on a contentEditable.
+//
+// Regression repro for #39614: typing committed multi-character IME text (e.g.
+// Chinese "你好") used to leave the send button hidden. The input events fired
+// during composition carry uncommitted preedit text and are intentionally
+// skipped; Chromium then does NOT reliably emit a trailing input event after
+// compositionend on Windows IMEs, so the finalized text never reached composer
+// state and `hasPayload` stayed false until an unrelated edit forced a sync.
+// The fix flushes the live DOM text in onCompositionEnd.
+function Harness({ onPayload }: { onPayload: (hasPayload: boolean) => void }) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const composingRef = useRef(false)
+  const draftRef = useRef('')
+  const [draft, setDraft] = useState('')
+
+  const flushEditorToDraft = (editor: HTMLDivElement) => {
+    const next = editor.textContent ?? ''
+
+    if (next !== draftRef.current) {
+      draftRef.current = next
+      setDraft(next)
+    }
+  }
+
+  onPayload(draft.trim().length > 0)
+
+  return (
+    <div
+      contentEditable
+      data-testid="editor"
+      onCompositionEnd={event => {
+        composingRef.current = false
+        flushEditorToDraft(event.currentTarget)
+      }}
+      onCompositionStart={() => {
+        composingRef.current = true
+      }}
+      onInput={event => {
+        if (composingRef.current) {
+          return
+        }
+
+        flushEditorToDraft(event.currentTarget)
+      }}
+      ref={editorRef}
+      suppressContentEditableWarning
+    />
+  )
+}
+
+describe('composer IME composition — send button visibility (#39614)', () => {
+  it('shows the send button after committing CJK text without a trailing edit', async () => {
+    let hasPayload = false
+    const { getByTestId } = render(<Harness onPayload={p => (hasPayload = p)} />)
+    const editor = getByTestId('editor')
+
+    // Compose "你好" the way a Windows Chinese IME does: compositionstart, then
+    // input events carrying uncommitted preedit text, then compositionend with
+    // the committed text already in the DOM — and crucially NO input event
+    // afterwards.
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = '你'
+      fireEvent.input(editor)
+      editor.textContent = '你好'
+      fireEvent.input(editor)
+      fireEvent.compositionEnd(editor)
+    })
+
+    // Before the fix this was false (button hidden) until a further edit.
+    expect(hasPayload).toBe(true)
+    expect(editor.textContent).toBe('你好')
+  })
+
+  it('also covers Japanese/Korean and any IME-composed script', async () => {
+    let hasPayload = false
+    const { getByTestId } = render(<Harness onPayload={p => (hasPayload = p)} />)
+    const editor = getByTestId('editor')
+
+    for (const committed of ['こんにちは', '안녕하세요']) {
+      await act(async () => {
+        fireEvent.compositionStart(editor)
+        editor.textContent = committed
+        fireEvent.input(editor)
+        fireEvent.compositionEnd(editor)
+      })
+
+      expect(hasPayload).toBe(true)
+
+      // Clear for the next script.
+      await act(async () => {
+        editor.textContent = ''
+        fireEvent.input(editor)
+      })
+      expect(hasPayload).toBe(false)
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -568,16 +568,10 @@ export function ChatBar({
     }
   }, [trigger])
 
-  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
-    // During IME composition the DOM contains uncommitted preedit text
-    // mixed with real content.  Skip state writes — compositionend will
-    // deliver the finalized text via a clean input event.
-    if (composingRef.current) {
-      return
-    }
-
-    const editor = event.currentTarget
-
+  // Pull the live contentEditable text into draftRef + the AUI composer state
+  // (which drives `hasComposerPayload` → the send button). Shared by the input
+  // and compositionend paths so committed IME text reaches state through either.
+  const flushEditorToDraft = (editor: HTMLDivElement) => {
     if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
       editor.replaceChildren()
     }
@@ -590,6 +584,17 @@ export function ChatBar({
     }
 
     window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
+    // During IME composition the DOM contains uncommitted preedit text
+    // mixed with real content.  Skip state writes — compositionend flushes
+    // the finalized text (see onCompositionEnd).
+    if (composingRef.current) {
+      return
+    }
+
+    flushEditorToDraft(event.currentTarget)
   }
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
@@ -1227,8 +1232,17 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
-        onCompositionEnd={() => {
+        onCompositionEnd={event => {
           composingRef.current = false
+
+          // The input events fired *during* composition were skipped (they
+          // carried uncommitted preedit text), and Chromium does NOT reliably
+          // emit a trailing input event after compositionend on Windows IMEs.
+          // Without flushing here, committed multi-character IME input (e.g.
+          // Chinese "你好", Japanese, Korean) never reaches composer state, so
+          // `hasComposerPayload` stays false and the send button stays hidden
+          // until an unrelated edit forces a sync (#39614).
+          flushEditorToDraft(event.currentTarget)
         }}
         onCompositionStart={() => {
           composingRef.current = true


### PR DESCRIPTION
## Summary

Fixes #39614. Typing committed multi-character IME text (e.g. Chinese `你好`) left the **send button hidden** until an unrelated edit. It only appeared after deleting a character (e.g. leaving `你`), which matches the report exactly.

This is **not Chinese-specific** — it affects any text entered through an IME composition session: Chinese (Pinyin/Zhuyin), Japanese (Kana→Kanji), Korean (Hangul), and other IME-composed scripts. ASCII input like `hello` is unaffected because it never goes through a composition session.

## Root cause

The composer's send button visibility is driven by `hasComposerPayload`, which reads the AUI composer state (`composer.text`).

- `onInput` intentionally **skips state writes while `composingRef` is true** (during composition the DOM holds uncommitted preedit text).
- The code assumed a trailing `input` event would fire **after** `compositionend` to deliver the finalized text. Chromium (Electron renderer) does **not** reliably emit that trailing input event on Windows IMEs.
- Result: the committed text lands in the DOM but never reaches composer state, so `hasComposerPayload` stays `false` and the button stays hidden. Pressing Backspace fires a non-composition `input` that finally syncs state — hence "delete a char and it appears."

## Fix

Flush the live editor text into composer state in `onCompositionEnd`. The per-keystroke sync logic is extracted into `flushEditorToDraft(editor)` and shared by both the `input` and `compositionend` paths, so committed IME text reaches state through whichever event the platform delivers. As a side effect this also makes Enter send committed IME text immediately, since `draft` is now correct on commit.

## Test plan

- [x] `tsc -b` passes (desktop)
- [x] Lint clean on changed files
- [x] Added `ime-composition-dom-repro.test.tsx`: drives real DOM `compositionstart` → `input` (preedit) → `compositionend` with **no trailing input event** and asserts the payload (send button) becomes visible for Chinese `你好`, Japanese `こんにちは`, and Korean `안녕하세요`.
- [ ] Manual: on Windows desktop, type `你好` via a Chinese IME and confirm the send button appears without further edits.

> Note: the new test follows the existing `slash-nav-dom-repro.test.tsx` pattern and runs under `vitest --environment jsdom` in CI.