### PR TITLE
fix(config): migrate stale HERMES_DASHBOARD_SESSION_TOKEN from .env (v30)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2520,7 +2520,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 29,
+    "_config_version": 30,
 }
 
 # =============================================================================
@@ -4808,6 +4808,17 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             save_config(config)
             if not quiet:
                 print("  ✓ Renamed write_mode → write_approval (boolean gate)")
+
+    # ── Version 29 → 30: clear HERMES_DASHBOARD_SESSION_TOKEN from .env ──
+    # Remote mode now uses username/password auth; local mode auto-generates tokens per boot.
+    if current_ver < 30:
+        try:
+            removed = remove_env_value("HERMES_DASHBOARD_SESSION_TOKEN")
+            if removed and not quiet:
+                print("  ✓ Removed HERMES_DASHBOARD_SESSION_TOKEN from .env (no longer used)")
+        except Exception as exc:
+            if not quiet:
+                print(f"  ⚠ Failed to remove HERMES_DASHBOARD_SESSION_TOKEN from .env: {exc}")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")


### PR DESCRIPTION
## What does this PR do?

Automatically removes stale `HERMES_DASHBOARD_SESSION_TOKEN` from `~/.hermes/.env` during config migration (version 30). The previous docs recommended pinning this token for remote mode; current docs use username/password auth. Users who set up remote mode under the old docs still have a stale pinned token that breaks Desktop LOCAL mode: the Desktop app generates a fresh random token per boot, then `python-dotenv` with `override=True` clobbers it with the stale pinned one, causing immediate 401 auth failures and a boot loop.

This fix removes the root cause (the legacy `.env` entry) rather than adding runtime workarounds to `env_loader.py`.

## Related Issue

Fixes #38575

Supersedes #38586 (runtime token preservation approach gated on `HERMES_DASHBOARD_TUI == "1"`, never set in production)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`:
  - Bumped `_config_version` 29 → 30
  - Added migration block `if current_ver < 30:` that unconditionally calls `remove_env_value("HERMES_DASHBOARD_SESSION_TOKEN")`
  - Uses `remove_env_value()` instead of `save_env_value(key, "")` to fully delete the key (not leave an empty string)
  - Emits warning on failure instead of silently swallowing exceptions

## How to Test

1. Add `HERMES_DASHBOARD_SESSION_TOKEN=*** to `~/.hermes/.env`
2. Run `hermes update` (or any command that triggers config migration)
3. Verify `HERMES_DASHBOARD_SESSION_TOKEN` is removed from `.env`
4. Verify `hermes desktop` (local mode) starts without 401 errors

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(config):`)
- [x] I searched existing PRs — this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've added tests for my changes — **no tests added** (follows exact same pattern as existing `ANTHROPIC_TOKEN` migration which also has no dedicated tests; migration logic is implicitly exercised by every `hermes update` call)
- [x] I've tested on my platform: Ubuntu 24.04
- [x] N/A — no docs update needed (removes legacy behavior, not adds new)
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — no tool behavior changes
