### PR TITLE
fix(langfuse): surface reasoning_content in traces (#29482)

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -530,10 +530,18 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
     return serialized
 
 
+def _extract_assistant_reasoning(message: Any) -> Any:
+    for field in ("reasoning", "reasoning_content", "reasoning_details"):
+        value = getattr(message, field, None)
+        if value is not None:
+            return _safe_value(value)
+    return None
+
+
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     return {
         "content": _safe_value(getattr(message, "content", None)),
-        "reasoning": _safe_value(getattr(message, "reasoning", None)),
+        "reasoning": _extract_assistant_reasoning(message),
         "tool_calls": _serialize_tool_calls(getattr(message, "tool_calls", None)),
     }
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -710,6 +711,62 @@ class TestRequestMessageCoercion:
             user_message="u",
         ) == [{"role": "user", "content": "h"}]
         assert mod._coerce_request_messages(user_message="u") == [{"role": "user", "content": "u"}]
+
+
+class TestAssistantMessageSerialization:
+    def test_serialize_assistant_message_prefers_reasoning(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(
+            content="answer",
+            reasoning="primary reasoning",
+            reasoning_content="fallback reasoning",
+            reasoning_details=[{"type": "summary", "text": "structured reasoning"}],
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == "primary reasoning"
+
+    def test_serialize_assistant_message_uses_reasoning_content_when_reasoning_absent(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(
+            content="answer",
+            reasoning=None,
+            reasoning_content="provider scratchpad",
+            reasoning_details=[{"type": "summary", "text": "structured reasoning"}],
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == "provider scratchpad"
+
+    def test_serialize_assistant_message_uses_structured_reasoning_details(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        reasoning_details = [
+            {"type": "summary", "text": "checked tools"},
+            {"type": "encrypted_content", "encrypted_content": b"opaque"},
+        ]
+        message = SimpleNamespace(
+            content="answer",
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=reasoning_details,
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == [
+            {"type": "summary", "text": "checked tools"},
+            {"type": "encrypted_content", "encrypted_content": {"type": "bytes", "len": 6}},
+        ]
+
+    def test_serialize_assistant_message_without_reasoning_fields_sets_none(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(content="answer")
+
+        assert mod._serialize_assistant_message(message)["reasoning"] is None
 
 
 class TestToolCallOutputBackfill:


### PR DESCRIPTION
## Summary

Langfuse assistant-message serialization only reads `message.reasoning`. Reasoning models and adapters can expose reasoning under `reasoning_content` or structured `reasoning_details`, which makes Langfuse traces show `reasoning: None` despite available reasoning data.

This PR adds a small reasoning extraction helper and uses it during assistant-message serialization.

## Changes

- `plugins/observability/langfuse/__init__.py`: serialize reasoning from `reasoning`, `reasoning_content`, or `reasoning_details`.
- Tests: add Langfuse serialization coverage for alternate reasoning fields.

## Validation

- `python -m pytest tests -k langfuse -v --timeout=0`
- `python -m pytest tests/ -v --timeout=60`

## Upstream

Closes #29482.
Reported by @swanhtet1992.
