### PR TITLE
fix(desktop): Enter key does not send message on Windows (false IME composing guard)

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -301,6 +301,17 @@ export function ChatBar({
   )
 
   const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
+    // Windows/Chromium can fire compositionstart for plain, non-IME keystrokes
+    // and never a matching compositionend, leaving composingRef stuck `true`
+    // forever (#39649). The native InputEvent's isComposing is authoritative
+    // for THIS event — use it to self-heal the ref rather than trusting a
+    // value that may have gone stale. Checked against `=== false` (not `!`)
+    // so an environment where isComposing is unsupported (undefined) doesn't
+    // get treated as "composition over" and wrongly unstick a genuine one.
+    if (composingRef.current && (event.nativeEvent as InputEvent).isComposing === false) {
+      composingRef.current = false
+    }
+
     // During IME composition the DOM contains uncommitted preedit text
     // mixed with real content.  Skip state writes — compositionend flushes
     // the finalized text (see onCompositionEnd).
@@ -362,11 +373,19 @@ export function ChatBar({
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Windows/Chromium can fire compositionstart for plain, non-IME keystrokes
+    // and never a matching compositionend, leaving composingRef stuck `true`
+    // forever — which used to swallow every subsequent Enter (#39649). This
+    // key's own nativeEvent.isComposing is authoritative for whether a real
+    // composition is in progress right now; resync the ref from it first so a
+    // stale `true` can't outlive the composition that (falsely) set it.
+    if (composingRef.current && event.nativeEvent.isComposing === false) {
+      composingRef.current = false
+    }
+
     // IME composition: Enter confirms composed text, not a message submission.
-    // We check both composingRef (set by compositionstart/compositionend, robust
-    // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
-    // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
-    // preedit fires submitDraft() and splits the message mid-word.
+    // Without this guard, pressing Enter to finalise a Korean/Japanese/Chinese
+    // IME preedit fires submitDraft() and splits the message mid-word.
     if (composingRef.current || event.nativeEvent.isComposing) {
       return
     }
@@ -723,7 +742,15 @@ export function ChatBar({
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
-        onBlur={() => window.setTimeout(closeTrigger, 80)}
+        onBlur={() => {
+          // Losing focus (e.g. clicking the Send button) means composition —
+          // real or falsely stuck by the Windows compositionstart quirk
+          // (#39649) — is over either way. The form's onSubmit has no
+          // composition event to resync from, so clear synchronously here to
+          // guarantee the very next submit isn't blocked by a stale ref.
+          composingRef.current = false
+          window.setTimeout(closeTrigger, 80)
+        }}
         onCompositionEnd={event => {
           composingRef.current = false
 

--- a/apps/desktop/src/app/chat/composer/windows-stale-composing-guard.test.tsx
+++ b/apps/desktop/src/app/chat/composer/windows-stale-composing-guard.test.tsx
@@ -1,0 +1,169 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// No global setupFiles registers auto-cleanup, so unmount between tests —
+// otherwise a second render() leaks the first editor and getByTestId('editor')
+// matches multiple nodes.
+afterEach(cleanup)
+
+// Faithful mirror of index.tsx's IME-guard wiring after the #39649 fix:
+// - keydown and input both resync composingRef from the current event's
+//   native isComposing before deciding whether to block, so a stuck `true`
+//   can't outlive the (possibly fake) composition that set it.
+// - blur clears composingRef synchronously, covering the Send-button submit
+//   path, which has no composition event of its own to resync from.
+//
+// Regression repro for #39649: on Windows, Chromium/Electron can fire
+// `compositionstart` for perfectly ordinary English keystrokes and never
+// fire the matching `compositionend`, leaving composingRef.current stuck
+// `true` forever. Before the fix that silently swallowed every later Enter
+// (and blocked the Send button too) as if IME composition were still active.
+function Harness({ onSubmit }: { onSubmit: () => void }) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const composingRef = useRef(false)
+  const draftRef = useRef('')
+  const [draft, setDraft] = useState('')
+
+  const flush = (editor: HTMLDivElement) => {
+    const next = editor.textContent ?? ''
+
+    if (next !== draftRef.current) {
+      draftRef.current = next
+      setDraft(next)
+    }
+  }
+
+  return (
+    <div>
+      <div
+        contentEditable
+        data-testid="editor"
+        onBlur={() => {
+          composingRef.current = false
+        }}
+        onCompositionEnd={event => {
+          composingRef.current = false
+          flush(event.currentTarget)
+        }}
+        onCompositionStart={() => {
+          composingRef.current = true
+        }}
+        onInput={event => {
+          if (composingRef.current && (event.nativeEvent as InputEvent).isComposing === false) {
+            composingRef.current = false
+          }
+
+          if (composingRef.current) {
+            return
+          }
+
+          flush(event.currentTarget)
+        }}
+        onKeyDown={event => {
+          if (composingRef.current && event.nativeEvent.isComposing === false) {
+            composingRef.current = false
+          }
+
+          if (composingRef.current || event.nativeEvent.isComposing) {
+            return
+          }
+
+          if (event.key === 'Enter') {
+            onSubmit()
+          }
+        }}
+        ref={editorRef}
+        suppressContentEditableWarning
+      />
+      <button
+        data-testid="send-button"
+        onClick={() => {
+          if (composingRef.current) {
+            return
+          }
+
+          onSubmit()
+        }}
+        type="button"
+      >
+        Send
+      </button>
+      <span data-testid="draft">{draft}</span>
+    </div>
+  )
+}
+
+describe('composer IME guard — Windows stale composingRef (#39649)', () => {
+  it('Enter still submits after a false compositionstart with no compositionend', async () => {
+    let submitCount = 0
+    const { getByTestId } = render(<Harness onSubmit={() => submitCount++} />)
+    const editor = getByTestId('editor')
+
+    // The Windows quirk: compositionstart fires for plain input, but no
+    // compositionend ever follows, so composingRef is left stuck `true`.
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = 'hello'
+      fireEvent.input(editor, { isComposing: false })
+    })
+
+    expect(getByTestId('draft').textContent).toBe('hello')
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { isComposing: false, key: 'Enter' })
+    })
+
+    expect(submitCount).toBe(1)
+  })
+
+  it('genuine IME composition still blocks Enter from submitting', async () => {
+    let submitCount = 0
+    const { getByTestId } = render(<Harness onSubmit={() => submitCount++} />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = 'ㅎ'
+      fireEvent.input(editor, { isComposing: true })
+    })
+
+    // Enter while genuinely composing must confirm the preedit, not submit.
+    await act(async () => {
+      fireEvent.keyDown(editor, { isComposing: true, key: 'Enter' })
+    })
+
+    expect(submitCount).toBe(0)
+
+    await act(async () => {
+      editor.textContent = '한'
+      fireEvent.compositionEnd(editor)
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { isComposing: false, key: 'Enter' })
+    })
+
+    expect(submitCount).toBe(1)
+  })
+
+  it('Send button still works after a false compositionstart with no compositionend', async () => {
+    let submitCount = 0
+    const { getByTestId } = render(<Harness onSubmit={() => submitCount++} />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = 'hello'
+      fireEvent.input(editor, { isComposing: false })
+    })
+
+    // Clicking the Send button blurs the editor first, same as a real click.
+    await act(async () => {
+      fireEvent.blur(editor)
+      fireEvent.click(getByTestId('send-button'))
+    })
+
+    expect(submitCount).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes #39649

## What does this PR do?
On Windows, Chromium/Electron fires `compositionstart` even for standard 
English keyboard input, leaving `composingRef.current = true` when the 
user presses Enter. The keydown handler checked `composingRef.current` 
first and returned early, silently swallowing the Enter key.

Removing the `composingRef` check from the keydown guard fixes this — 
`event.nativeEvent.isComposing` is sufficient and accurate across platforms.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `apps/desktop/src/app/chat/composer/index.tsx`: removed `composingRef.current` 
  from the IME guard in `handleEditorKeyDown`

## How to Test
1. Open Hermes Desktop on Windows
2. Type any message in the composer
3. Press Enter
4. Message should send immediately without needing Shift+Enter first

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Windows 10