### PR TITLE
fix(memory): warn when numpy is missing in holographic memory (#17350)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -180,6 +180,20 @@ class HolographicMemoryProvider(MemoryProvider):
         )
         self._session_id = session_id
 
+        # Warn if numpy is missing — HRR operations silently disabled (#17350)
+        try:
+            from . import holographic as _hrr
+            self._hrr_available = _hrr._HAS_NUMPY
+        except ImportError:
+            self._hrr_available = False
+
+        if not self._hrr_available:
+            logger.warning(
+                "Holographic memory: numpy not found. HRR vector operations disabled. "
+                "Only FTS5 keyword search will be available. "
+                "Install numpy to enable compositional retrieval (probe/reason/contradict)."
+            )
+
     def system_prompt_block(self) -> str:
         if not self._store:
             return ""
@@ -189,18 +203,29 @@ class HolographicMemoryProvider(MemoryProvider):
             ).fetchone()[0]
         except Exception:
             total = 0
+
+        hrr_status = ""
+        if not self._hrr_available:
+            hrr_status = (
+                "\nWARNING: numpy not installed — HRR vector operations disabled. "
+                "Only keyword search works. probe/reason/contradict will use FTS5 fallback. "
+                "Install numpy for full compositional retrieval."
+            )
+
         if total == 0:
             return (
                 "# Holographic Memory\n"
                 "Active. Empty fact store — proactively add facts the user would expect you to remember.\n"
                 "Use fact_store(action='add') to store durable structured facts about people, projects, preferences, decisions.\n"
                 "Use fact_feedback to rate facts after using them (trains trust scores)."
+                + hrr_status
             )
         return (
             f"# Holographic Memory\n"
             f"Active. {total} facts stored with entity resolution and trust scoring.\n"
             f"Use fact_store to search, probe entities, reason across entities, or add facts.\n"
             f"Use fact_feedback to rate facts after using them (trains trust scores)."
+            + hrr_status
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:

--- a/tests/plugins/memory/test_numpy_warning.py
+++ b/tests/plugins/memory/test_numpy_warning.py
@@ -1,0 +1,54 @@
+"""Tests for holographic memory numpy degradation warning (#17350).
+
+When numpy is missing, HRR operations silently fell back to FTS5-only.
+No warning was logged and hermes doctor couldn't detect it.
+"""
+
+import logging
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+class TestNumpyWarning:
+    """Holographic memory should warn when numpy is unavailable."""
+
+    def test_system_prompt_with_numpy(self):
+        """With numpy available, system prompt should not show warning."""
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = MagicMock()
+        provider._hrr_available = True
+        provider._store._conn.execute.return_value.fetchone.return_value = (5,)
+
+        prompt = provider.system_prompt_block()
+        assert "WARNING" not in prompt
+        assert "5 facts" in prompt
+
+    def test_system_prompt_without_numpy(self):
+        """Without numpy, system prompt should show degradation warning."""
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = MagicMock()
+        provider._hrr_available = False
+        provider._store._conn.execute.return_value.fetchone.return_value = (3,)
+
+        prompt = provider.system_prompt_block()
+        assert "WARNING" in prompt
+        assert "numpy" in prompt
+        assert "3 facts" in prompt
+
+    def test_init_warns_without_numpy(self, caplog):
+        """initialize() should log a warning when numpy is missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            provider = HolographicMemoryProvider(config={
+                "db_path": os.path.join(tmp, "test.db"),
+            })
+            with patch("plugins.memory.holographic.holographic._HAS_NUMPY", False):
+                with caplog.at_level(logging.WARNING, logger="plugins.memory.holographic"):
+                    provider.initialize("test-session")
+                assert hasattr(provider, "_hrr_available")
+                assert not provider._hrr_available
+                assert any("numpy not found" in r.message for r in caplog.records)


### PR DESCRIPTION
Fixes #17350

When numpy was not installed, HRR vector operations silently fell back to FTS5-only. No warning was logged and hermes doctor couldn't detect it. Users had no idea probe/reason/contradict were degraded.

**Fix:** `initialize()` logs a WARNING. `system_prompt_block()` includes a visible WARNING in the prompt so both the agent and user know HRR vector operations are disabled.

**Tests:** 3 tests — system prompt without numpy shows WARNING, with numpy hides it, init logs warning.

This was originally part of #23221 — split into focused single-fix PRs for easier review.