### PR TITLE
fix(memory): extract clean declarative facts instead of raw messages in holographic auto_extract (#22907)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -357,14 +357,19 @@ class HolographicMemoryProvider(MemoryProvider):
     # -- Auto-extraction (on_session_end) ------------------------------------
 
     def _auto_extract_facts(self, messages: list) -> None:
+        """Extract structured facts from user messages at session end.
+
+        Instead of dumping raw messages verbatim (the old behavior that caused
+        #22907), this extracts the matching portion and wraps it as a clean
+        declarative statement. Only extracts from messages that match clear
+        preference/decision patterns, and deduplicates against existing facts.
+        """
         _PREF_PATTERNS = [
-            re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
-        ]
-        _DECISION_PATTERNS = [
-            re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
-            re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            (re.compile(r'\bI\s+prefer\s+(.+?)(?:\s+(?:over|instead of|rather than)\s+(.+?))?(?:\.|!|$)', re.IGNORECASE), "pref"),
+            (re.compile(r'\bI\s+(?:always|never|usually)\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "habit"),
+            (re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+(\w+)\s+is\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "pref"),
+            (re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+?)(?:\.|!|$)', re.IGNORECASE), "decision"),
+            (re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "project"),
         ]
 
         extracted = 0
@@ -375,23 +380,43 @@ class HolographicMemoryProvider(MemoryProvider):
             if not isinstance(content, str) or len(content) < 10:
                 continue
 
-            for pattern in _PREF_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="user_pref")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
+            for pattern, kind in _PREF_PATTERNS:
+                m = pattern.search(content)
+                if not m:
+                    continue
 
-            for pattern in _DECISION_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="project")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
+                # Build a clean declarative fact from the captured groups
+                groups = [g.strip().rstrip('.,;!') for g in m.groups() if g]
+                if not groups:
+                    continue
+
+                if kind == "pref" and len(groups) >= 2 and " over " in content[m.start():m.end()].lower():
+                    fact_text = f"prefers {groups[0]} over {groups[1]}"
+                elif kind == "pref":
+                    fact_text = f"prefers {groups[0]}"
+                elif kind == "habit":
+                    habit_word = "always" if "always" in content[m.start():m.end()].lower() else ("never" if "never" in content[m.start():m.end()].lower() else "usually")
+                    fact_text = f"{habit_word} {groups[0]}"
+                elif kind == "decision":
+                    fact_text = f"decided to {groups[0]}"
+                elif kind == "project":
+                    fact_text = f"project requires {groups[0]}"
+                else:
+                    fact_text = groups[0]
+
+                # Cap length to avoid storing entire conversations
+                if len(fact_text) > 200:
+                    fact_text = fact_text[:200]
+
+                category_map = {"pref": "user_pref", "habit": "user_pref", "decision": "project", "project": "project"}
+                cat = category_map.get(kind, "general")
+
+                try:
+                    self._store.add_fact(fact_text, category=cat)
+                    extracted += 1
+                except Exception:
+                    pass
+                break  # one fact per message max
 
         if extracted:
             logger.info("Auto-extracted %d facts from conversation", extracted)

--- a/tests/plugins/memory/test_auto_extract.py
+++ b/tests/plugins/memory/test_auto_extract.py
@@ -1,0 +1,109 @@
+"""Tests for holographic memory auto_extract structured facts (#22907).
+
+The old regex patterns matched "I like / I want / I need" and dumped the
+entire user message verbatim as a fact. "I like that, sounds good" became
+a stored fact.
+
+The fix removes noisy patterns and extracts clean declarative statements
+from captured groups.
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    db = str(tmp_path / "test_memory.db")
+    return MemoryStore(db_path=db, default_trust=0.5, hrr_dim=128)
+
+
+class TestAutoExtract:
+    """auto_extract should produce clean declarative facts, not raw messages."""
+
+    def _make_provider(self, store):
+        from plugins.memory.holographic import HolographicMemoryProvider
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = store
+        provider._config = {"auto_extract": True}
+        return provider
+
+    def test_preference_extraction(self, store):
+        """'I prefer dark mode' should extract 'prefers dark mode'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I prefer dark mode over light mode"}
+        ])
+        facts = store.list_facts(category="user_pref")
+        assert any("dark mode" in f["content"] for f in facts)
+        # Should NOT contain the raw message
+        assert not any("over light mode" not in f["content"] and "I prefer" in f["content"] for f in facts)
+
+    def test_no_raw_message_dump(self, store):
+        """'I like that, sounds good' should NOT be stored as a fact."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I like that, sounds good"}
+        ])
+        facts = store.list_facts()
+        # "I like" no longer matches — we removed "like" from the pattern
+        assert not any("I like that" in f["content"] for f in facts)
+
+    def test_decision_extraction(self, store):
+        """'We decided to use PostgreSQL' should extract 'decided to use PostgreSQL'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "We decided to use PostgreSQL for the backend"}
+        ])
+        facts = store.list_facts(category="project")
+        assert any("PostgreSQL" in f["content"] for f in facts)
+        assert any(f["content"].startswith("decided to") for f in facts)
+
+    def test_habit_extraction(self, store):
+        """'I always check git status' should extract 'always check git status'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I always check git status before committing"}
+        ])
+        facts = store.list_facts(category="user_pref")
+        assert any("always check git status" in f["content"] for f in facts)
+
+    def test_assistant_messages_ignored(self, store):
+        """Assistant messages should not produce facts."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "assistant", "content": "I prefer to use structured outputs"}
+        ])
+        facts = store.list_facts()
+        assert len(facts) == 0
+
+    def test_short_messages_ignored(self, store):
+        """Messages under 10 chars should be skipped."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I like"}
+        ])
+        facts = store.list_facts()
+        assert len(facts) == 0
+
+    def test_one_fact_per_message(self, store):
+        """A single message should produce at most one fact."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I prefer Rust. We decided to use Rust. I always use Rust."}
+        ])
+        facts = store.list_facts(category="user_pref")
+        # Should produce at most 1 fact for this message (first match wins)
+        assert len([f for f in facts if "Rust" in f["content"]]) <= 1
+
+    def test_fact_length_capped(self, store):
+        """Extracted facts should not exceed 200 characters."""
+        provider = self._make_provider(store)
+        long_pref = "x" * 300
+        provider._auto_extract_facts([
+            {"role": "user", "content": f"I prefer {long_pref}"}
+        ])
+        facts = store.list_facts()
+        for f in facts:
+            assert len(f["content"]) <= 200


### PR DESCRIPTION
Fixes #22907

The old regex patterns (I like/love/want/need) matched common phrases and dumped the entire user message verbatim as a fact. "I like that, sounds good" became a stored fact.

**Fix:** Removed noisy like/love/want/need patterns. Remaining patterns extract captured groups into clean declarative statements: "prefers dark mode over light mode" instead of "I prefer dark mode over light mode, can you set it up?". 200 char cap, one fact per message, assistant messages skipped.

**Tests:** 8 tests — preference extraction, no raw dumps, decisions, habits, assistant messages ignored, short messages skipped, one fact per message, 200-char length cap.

This was originally part of #23221 — split into focused single-fix PRs for easier review.