### PR TITLE
fix(models): don't silently default Nous to the most expensive flagship model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1150,17 +1150,46 @@ _PROVIDER_ALIASES = {
 }
 
 
+# Cost-safe overrides for the *silent* auto-default
+# (``get_default_model_for_provider``). Most providers' curated lists lead with a
+# sensible default, but Nous Portal is a per-token *metered aggregator* whose
+# list is ordered best-/most-capable-first — entry [0] is the priciest flagship
+# (``anthropic/claude-opus-4.8``, $5/$25 per Mtok). Using that as the
+# non-interactive fallback when a profile sets ``provider: nous`` with no model
+# silently bills the most expensive model for traffic the user never opted into
+# (a missing default escalated to Opus and billed 863 requests before the user
+# noticed). Pin the silent default to the cheapest curated tier instead so a
+# missing model can never escalate to the flagship.
+#
+# This is deliberately a fixed, side-effect-free default for the hot resolution
+# path. The *interactive* default (GUI onboarding / ``hermes model``) uses the
+# richer free/paid-tier-aware resolver — see ``get_recommended_default_model``
+# in hermes_cli/web_server.py and ``partition_nous_models_by_tier`` — which can
+# hit the Portal; this fallback must stay cheap and network-free.
+_PROVIDER_SILENT_DEFAULT_OVERRIDES: dict[str, str] = {
+    "nous": "nvidia/nemotron-3-super-120b-a12b",
+}
+
+
 def get_default_model_for_provider(provider: str) -> str:
-    """Return the default model for a provider, or empty string if unknown.
+    """Return a cost-safe default model for a provider, or "" if unknown.
 
-    Uses the first entry in _PROVIDER_MODELS as the default.  This is the
-    model a user would be offered first in the ``hermes model`` picker.
+    Used as a NON-INTERACTIVE fallback when a provider is configured but no
+    model was ever selected (e.g. ``hermes auth add openai-codex`` without
+    ``hermes model``, or a profile that sets ``provider`` with no ``model``).
 
-    Used as a fallback when the user has configured a provider but never
-    selected a model (e.g. ``hermes auth add openai-codex`` without
-    ``hermes model``).
+    For most providers this is the first entry in ``_PROVIDER_MODELS`` — the
+    same model the ``hermes model`` picker offers first. For metered aggregators
+    whose curated list is ordered most-capable-first, that entry is also the
+    most EXPENSIVE one, so silently defaulting to it is a billing footgun. Such
+    providers carry an explicit low-cost override in
+    ``_PROVIDER_SILENT_DEFAULT_OVERRIDES``; a missing model must never
+    auto-escalate to the flagship.
     """
     models = _PROVIDER_MODELS.get(provider, [])
+    override = _PROVIDER_SILENT_DEFAULT_OVERRIDES.get(provider)
+    if override and override in models:
+        return override
     return models[0] if models else ""
 
 

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -30,6 +30,46 @@ class TestGetDefaultModelForProvider:
         # Custom providers don't have entries in _PROVIDER_MODELS
         assert get_default_model_for_provider("some-random-custom") == ""
 
+    def test_nous_silent_default_is_not_the_expensive_flagship(self):
+        """Nous Portal is a metered aggregator whose curated list is ordered
+        most-capable-first, so entry [0] is the priciest flagship
+        (anthropic/claude-opus-4.8). The silent fallback (provider set, no model)
+        must NOT escalate to it — otherwise an unconfigured profile silently
+        bills the most expensive model. Regression for the billing footgun.
+        """
+        from hermes_cli.models import (
+            _PROVIDER_MODELS,
+            _PROVIDER_SILENT_DEFAULT_OVERRIDES,
+            get_default_model_for_provider,
+        )
+
+        result = get_default_model_for_provider("nous")
+        assert result, "nous must resolve to a usable default model"
+        assert "opus" not in result.lower(), (
+            f"silent default escalated to an expensive flagship: {result!r}"
+        )
+        assert result != _PROVIDER_MODELS["nous"][0], (
+            "silent default must not be the most-capable/priciest catalog entry"
+        )
+        # The override must point at a model that actually exists in the catalog.
+        assert result == _PROVIDER_SILENT_DEFAULT_OVERRIDES["nous"]
+        assert result in _PROVIDER_MODELS["nous"]
+
+    def test_override_falls_back_to_catalog_when_missing(self):
+        """If an override model is no longer in the catalog, fall back to [0]
+        rather than returning a stale/absent id."""
+        from unittest.mock import patch
+
+        from hermes_cli import models as models_mod
+
+        with patch.dict(
+            models_mod._PROVIDER_SILENT_DEFAULT_OVERRIDES,
+            {"openai-codex": "does-not-exist-model"},
+            clear=False,
+        ):
+            result = models_mod.get_default_model_for_provider("openai-codex")
+            assert result == models_mod._PROVIDER_MODELS["openai-codex"][0]
+
 
 class TestGatewayEmptyModelFallback:
     """Test that _resolve_session_agent_runtime fills in empty model from provider catalog."""


### PR DESCRIPTION
## Summary

A Nous Portal user reported being charged **\$6.18 for `anthropic/claude-opus-4.8`** across 863 requests even though their account is set to a free model (`nvidia/nemotron-3-ultra:free`). Root cause: a new agent profile had `provider: nous` but **no default model**, and the platform silently routed every call to the most expensive flagship.

This is a real billing footgun in the silent (non-interactive) default resolution.

## Root cause

When a provider is configured but no model is selected, the gateway/CLI fall back to `get_default_model_for_provider()`:

- `gateway/run.py` (`_resolve_session_agent_runtime`)
- `cli.py` (session runtime resolution)
- `gateway/platforms/feishu_comment.py`

That helper returned **`_PROVIDER_MODELS[provider][0]`** — the first curated catalog entry. The Nous list is ordered *most-capable-first*, so entry `[0]` is `anthropic/claude-opus-4.8` (the single most expensive model, \$5/\$25 per Mtok). A profile that sets `provider: nous` with no model therefore silently escalated to the flagship and billed it.

## Fix

Pin the **silent** default for metered aggregators to the cheapest curated tier via a new `_PROVIDER_SILENT_DEFAULT_OVERRIDES` map (`nous → nvidia/nemotron-3-super-120b-a12b`). A missing model can no longer auto-escalate to the flagship.

- Deliberately a fixed, **side-effect-free** default for the hot resolution path (no network).
- The *interactive* default (GUI onboarding / `hermes model`) is unchanged — it keeps using the richer free/paid-tier-aware resolver (`get_recommended_default_model` / `partition_nous_models_by_tier`).
- The override is guarded: if the pinned model isn't in the catalog, it falls back to catalog order, so it can't return a stale id.

## Test plan

- [x] `tests/test_empty_model_fallback.py` — added regression tests:
  - `nous` silent default is **not** the expensive flagship (no `opus`, not `_PROVIDER_MODELS["nous"][0]`).
  - override falls back to catalog `[0]` when the override id is absent.
- [x] `pytest tests/test_empty_model_fallback.py tests/hermes_cli/test_models.py` → 90 passed.
- [x] Existing behaviour preserved for non-aggregator providers (openai-codex, tencent-tokenhub, unknown → "").