### PR TITLE
feat(gateway): show todo progress details in progress bubbles

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -262,6 +262,91 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     return preview
 
 
+def format_todo_result_for_progress(result: str, *, max_items: int = 12, max_content_len: int = 88) -> str | None:
+    """Render a todo tool JSON result as a compact gateway progress block."""
+    data = safe_json_loads(result, default={})
+    if not isinstance(data, dict):
+        return None
+
+    todos = data.get("todos")
+    if not isinstance(todos, list):
+        return None
+
+    summary_raw = data.get("summary")
+    summary = summary_raw if isinstance(summary_raw, dict) else {}
+
+    def _count(key: str, default: int = 0) -> int:
+        try:
+            return int(summary.get(key, default) or 0)
+        except (TypeError, ValueError):
+            return default
+
+    def _truncate(text: str, max_len: int) -> str:
+        if max_len <= 0 or len(text) <= max_len:
+            return text
+        if max_len <= 3:
+            return text[:max_len]
+        return text[:max_len - 3] + "..."
+
+    def _code_text(text: str) -> str:
+        # Keep user-controlled task text from terminating the markdown fence.
+        return _truncate(_oneline(text).replace("```", "`\u200b``"), max_content_len)
+
+    total = _count("total", len(todos))
+    pending = _count("pending")
+    in_progress = _count("in_progress")
+    completed = _count("completed")
+    cancelled = _count("cancelled")
+
+    summary_parts = [f"{total} total"]
+    if in_progress:
+        summary_parts.append(f"{in_progress} doing")
+    if pending:
+        summary_parts.append(f"{pending} todo")
+    if completed:
+        summary_parts.append(f"{completed} done")
+    if cancelled:
+        summary_parts.append(f"{cancelled} cancelled")
+
+    header = f"📋 tasks: {' · '.join(summary_parts)}"
+    if not todos:
+        return header
+
+    markers = {
+        "in_progress": "▸",
+        "pending": "○",
+        "completed": "✓",
+        "cancelled": "✕",
+    }
+    labels = {
+        "in_progress": "doing",
+        "pending": "todo",
+        "completed": "done",
+        "cancelled": "cancelled",
+    }
+
+    code_lines: list[str] = []
+    shown = 0
+    valid_items = [item for item in todos if isinstance(item, dict)]
+    for item in valid_items:
+        if shown >= max_items:
+            break
+        content = _code_text(str(item.get("content") or "(no description)"))
+        status = str(item.get("status") or "pending").strip().lower()
+        marker = markers.get(status, "?")
+        label = labels.get(status, status or "unknown")
+        code_lines.append(f"{marker} {label:<9} {content}")
+        shown += 1
+
+    remaining = len(valid_items) - shown
+    if remaining > 0:
+        code_lines.append(f"… +{remaining} more")
+
+    if not code_lines:
+        return header
+    return f"{header}\n```text\n" + "\n".join(code_lines) + "\n```"
+
+
 # =========================================================================
 # Inline diff previews for write actions
 # =========================================================================

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17057,31 +17057,46 @@ class GatewayRunner:
             # /verbose.  We only fire when (a) the user hasn't seen the hint
             # before and (b) /verbose is actually usable on this platform
             # (gateway gate must be open).  The CLI has its own trigger.
-            if event_type == "tool.completed" and not long_tool_hint_fired[0]:
-                try:
-                    duration = kwargs.get("duration") or 0
-                    if duration >= _LONG_TOOL_THRESHOLD_S and progress_mode == "all":
-                        from agent.onboarding import (
-                            TOOL_PROGRESS_FLAG,
-                            is_seen,
-                            mark_seen,
-                            tool_progress_hint_gateway,
-                        )
-                        _cfg = _load_gateway_config()
-                        gate_on = is_truthy_value(
-                            cfg_get(_cfg, "display", "tool_progress_command"),
-                            default=False,
-                        )
-                        if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
-                            long_tool_hint_fired[0] = True
-                            progress_queue.put(tool_progress_hint_gateway())
-                            mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
-                except Exception as _hint_err:
-                    logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+            if event_type == "tool.completed":
+                if not long_tool_hint_fired[0]:
+                    try:
+                        duration = kwargs.get("duration") or 0
+                        if duration >= _LONG_TOOL_THRESHOLD_S and progress_mode == "all":
+                            from agent.onboarding import (
+                                TOOL_PROGRESS_FLAG,
+                                is_seen,
+                                mark_seen,
+                                tool_progress_hint_gateway,
+                            )
+                            _cfg = _load_gateway_config()
+                            gate_on = is_truthy_value(
+                                cfg_get(_cfg, "display", "tool_progress_command"),
+                                default=False,
+                            )
+                            if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
+                                long_tool_hint_fired[0] = True
+                                progress_queue.put(tool_progress_hint_gateway())
+                                mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
+                    except Exception as _hint_err:
+                        logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+
+                if tool_name == "todo" and not kwargs.get("is_error"):
+                    try:
+                        from agent.display import format_todo_result_for_progress
+                        todo_progress = format_todo_result_for_progress(kwargs.get("result") or "")
+                        if todo_progress:
+                            # Replace the transient todo started preview (for
+                            # example `📋 todo: "updating 2 task(s)"`) with the
+                            # final status block in the same editable progress
+                            # bubble. Match by prefix so parallel tool-start
+                            # lines queued after todo are not overwritten.
+                            progress_queue.put(("__replace_last_matching__", "📋 todo", todo_progress))
+                    except Exception as _todo_err:
+                        logger.debug("todo progress formatting failed: %s", _todo_err)
                 return
 
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Only act on tool.started events (ignore reasoning.available, etc.)
             if event_type not in {"tool.started",}:
                 return
 
@@ -17354,6 +17369,20 @@ class GatewayRunner:
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__replace_last_matching__":
+                        _, prefix, replacement = raw
+                        msg = str(replacement)
+                        replace_idx = None
+                        for idx in range(len(progress_lines) - 1, -1, -1):
+                            if str(progress_lines[idx]).startswith(str(prefix)):
+                                replace_idx = idx
+                                break
+                        if replace_idx is not None:
+                            progress_lines[replace_idx] = msg
+                        else:
+                            progress_lines.append(msg)
+                        last_progress_msg[0] = msg
+                        repeat_count[0] = 0
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
                         # the current tool-progress bubble so the next tool
@@ -17369,7 +17398,7 @@ class GatewayRunner:
                         repeat_count[0] = 0
                         continue
                     else:
-                        msg = raw
+                        msg = str(raw)
                         progress_lines.append(msg)
 
                     if await _roll_progress_overflow_if_needed():
@@ -17386,11 +17415,11 @@ class GatewayRunner:
                     _now = time.monotonic()
                     _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
                     if _remaining > 0:
-                        # Wait out the throttle interval, then loop back to
-                        # drain any additional queued messages before sending
-                        # a single batched edit.
+                        # Wait out the throttle interval, then deliver the
+                        # latest accumulated lines.  Do not loop back here:
+                        # if this was the final tool event, there may be no
+                        # later queue item to trigger the edit.
                         await asyncio.sleep(_remaining)
-                        continue
 
                     if not _run_still_current():
                         return
@@ -17476,6 +17505,18 @@ class GatewayRunner:
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                     await _roll_progress_overflow_if_needed()
+                            elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__replace_last_matching__":
+                                _, prefix, replacement = raw
+                                replace_idx = None
+                                for idx in range(len(progress_lines) - 1, -1, -1):
+                                    if str(progress_lines[idx]).startswith(str(prefix)):
+                                        replace_idx = idx
+                                        break
+                                if replace_idx is not None:
+                                    progress_lines[replace_idx] = str(replacement)
+                                else:
+                                    progress_lines.append(str(replacement))
+                                await _roll_progress_overflow_if_needed()
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
@@ -17492,7 +17533,7 @@ class GatewayRunner:
                                 last_progress_msg[0] = None
                                 repeat_count[0] = 0
                             else:
-                                progress_lines.append(raw)
+                                progress_lines.append(str(raw))
                                 await _roll_progress_overflow_if_needed()
                         except Exception:
                             break

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1446,6 +1446,7 @@ AUTHOR_MAP = {
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
+    "qlskssk@gmail.com": "Soju06",
 }
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -8,6 +8,7 @@ from agent.display import (
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
+    format_todo_result_for_progress,
     get_cute_tool_message,
     set_tool_preview_max_len,
     _render_inline_unified_diff,
@@ -109,6 +110,81 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+
+class TestFormatTodoResultForProgress:
+    def test_formats_summary_and_status_lines(self):
+        result = json.dumps({
+            "todos": [
+                {"id": "1", "content": "Inspect gateway todo progress", "status": "in_progress"},
+                {"id": "2", "content": "Add formatter tests", "status": "pending"},
+                {"id": "3", "content": "Verify focused suite", "status": "completed"},
+                {"id": "4", "content": "Discard stale approach", "status": "cancelled"},
+            ],
+            "summary": {
+                "total": 4,
+                "pending": 1,
+                "in_progress": 1,
+                "completed": 1,
+                "cancelled": 1,
+            },
+        })
+
+        line = format_todo_result_for_progress(result)
+
+        assert line is not None
+        assert line.startswith("📋 tasks: 4 total")
+        assert "1 doing" in line
+        assert "1 todo" in line
+        assert "1 done" in line
+        assert "1 cancelled" in line
+        assert "```text" in line
+        assert line.endswith("\n```")
+        assert "▸ doing" in line
+        assert "Inspect gateway todo progress" in line
+        assert "○ todo" in line
+        assert "Add formatter tests" in line
+        assert "✓ done" in line
+        assert "Verify focused suite" in line
+        assert "✕ cancelled" in line
+        assert "Discard stale approach" in line
+
+    def test_returns_none_for_non_todo_json(self):
+        assert format_todo_result_for_progress('{"ok": true}') is None
+        assert format_todo_result_for_progress('not json') is None
+
+    def test_truncates_long_lists(self):
+        result = json.dumps({
+            "todos": [
+                {"id": str(i), "content": f"Task {i}", "status": "pending"}
+                for i in range(3)
+            ],
+            "summary": {"total": 3, "pending": 3, "in_progress": 0, "completed": 0, "cancelled": 0},
+        })
+
+        line = format_todo_result_for_progress(result, max_items=2)
+
+        assert line is not None
+        assert "○ todo" in line
+        assert "Task 0" in line
+        assert "Task 1" in line
+        assert "Task 2" not in line
+        assert "… +1 more" in line
+
+    def test_escapes_task_code_fences_inside_markdown_block(self):
+        result = json.dumps({
+            "todos": [
+                {"id": "1", "content": "Do not break ``` fences", "status": "pending"},
+            ],
+            "summary": {"total": "bad", "pending": 1},
+        })
+
+        line = format_todo_result_for_progress(result)
+
+        assert line is not None
+        assert line.count("```") == 2
+        assert "`\u200b`` fences" in line
+        assert "1 todo" in line
 
 
 class TestCuteToolMessagePreviewLength:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -144,6 +144,43 @@ class FakeAgent:
         }
 
 
+class TodoProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        assert cb is not None
+        cb("tool.started", "todo", "planning 2 task(s)", {
+            "todos": [
+                {"id": "1", "content": "Inspect code", "status": "in_progress"},
+                {"id": "2", "content": "Run tests", "status": "pending"},
+            ],
+        })
+        cb("tool.started", "terminal", "pytest focused suite", {})
+        time.sleep(0.35)
+        cb(
+            "tool.completed",
+            "todo",
+            None,
+            None,
+            duration=0.1,
+            is_error=False,
+            result=(
+                '{"todos":[{"id":"1","content":"Inspect code","status":"in_progress"},'
+                '{"id":"2","content":"Run tests","status":"pending"}],'
+                '"summary":{"total":2,"pending":1,"in_progress":1,"completed":0,"cancelled":0}}'
+            ),
+        )
+        time.sleep(1.7)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -243,6 +280,60 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_renders_todo_completed_result(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TodoProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.todo_tool  # noqa: F401 - register todo emoji for this fake-agent test
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-todo",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert '📋 todo: "planning 2 task(s)"' in adapter.sent[0]["content"]
+    assert adapter.edits
+    final_progress = adapter.edits[-1]["content"]
+    assert '📋 todo: "planning 2 task(s)"' not in final_progress
+    assert final_progress.startswith("📋 tasks: 2 total")
+    assert "1 doing" in final_progress
+    assert "1 todo" in final_progress
+    assert "```text" in final_progress
+    assert "\n```\n💻 terminal" in final_progress
+    assert "▸ doing" in final_progress
+    assert "Inspect code" in final_progress
+    assert "○ todo" in final_progress
+    assert "Run tests" in final_progress
+    assert '💻 terminal: "pytest focused suite"' in final_progress
+    assert final_progress.index("📋 tasks:") < final_progress.index('💻 terminal: "pytest focused suite"')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Render todo tool results as rich progress details in gateway progress bubbles, so Discord and other editable platforms show individual task statuses instead of only item counts.

Also ensures throttled progress edits flush the final accumulated lines when no later tool event arrives — previously the last batch of progress updates could be silently dropped.

## Changes

| File | Description |
|---|---|
| `agent/display.py` | Add `format_todo_result_for_progress()` — renders todo JSON result as a compact progress block with status icons (✓/▸/○/✗) and truncated content |
| `gateway/run.py` | Integrate todo progress rendering into gateway progress bubbles + fix throttled edit flush for final accumulated lines |
| `tests/agent/test_display.py` | Unit tests for `format_todo_result_for_progress()` |
| `tests/gateway/test_run_progress_topics.py` | Integration tests for gateway progress topic rendering |

## Screenshots

### Many tasks (20 items, truncated with "+N more")
![todo-progress-many](https://i.imgur.com/AMZQ2w1.png)

### Mixed status (done/doing/todo)
![todo-progress-mixed](https://i.imgur.com/6D8bELH.png)

## Details

- Status icons: `✓` done, `▸` doing, `○` todo, `✗` cancelled
- Truncates long item content at 88 chars
- Caps visible items at 12, shows `… +N more` for overflow
- Header line: `📋 tasks: N total · X doing · Y todo · Z done`
- Graceful fallback: returns `None` (existing behavior) when result is missing or malformed
