### PR TITLE
Fix holographic FTS search for slash-containing queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
 
+try:
+    from .store import build_fts_queries
+except ImportError:
+    from store import build_fts_queries  # type: ignore[no-redef]
+
 
 class FactRetriever:
     """Multi-strategy fact retrieval with trust-weighted scoring."""
@@ -491,19 +496,20 @@ class FactRetriever:
         with rank scoring. Normalizes FTS5 rank to [0, 1] range.
         """
         conn = self.store._conn
+        fts_queries = build_fts_queries(query)
+        if not fts_queries:
+            return []
 
         # Build query - FTS5 rank is negative (lower = better match)
         # We need to join facts_fts with facts to get all columns
-        params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        category_params: list = []
 
         if category:
             where_clauses.append("f.category = ?")
-            params.append(category)
+            category_params.append(category)
 
         where_clauses.append("f.trust_score >= ?")
-        params.append(min_trust)
 
         where_sql = " AND ".join(where_clauses)
 
@@ -515,13 +521,16 @@ class FactRetriever:
             ORDER BY facts_fts.rank
             LIMIT ?
         """
-        params.append(limit)
-
-        try:
-            rows = conn.execute(sql, params).fetchall()
-        except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
-            return []
+        rows = []
+        for fts_query in fts_queries:
+            params: list = [fts_query, *category_params, min_trust, limit]
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            except Exception:
+                # FTS5 MATCH can fail on malformed queries — try the broader fallback.
+                rows = []
+            if rows:
+                break
 
         if not rows:
             return []

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -89,10 +89,46 @@ _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
 )
+_RE_FTS_SAFE     = re.compile(r'^[\w\s]+$', re.UNICODE)
+_RE_FTS_TOKEN    = re.compile(r'\w+', re.UNICODE)
 
 
 def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
+
+
+def sanitize_fts_query(query: str) -> str:
+    """Normalize natural-language queries into a safe FTS5 MATCH string."""
+    query = (query or "").strip()
+    if not query:
+        return ""
+    if _RE_FTS_SAFE.fullmatch(query):
+        return query
+
+    ordered_tokens: list[str] = []
+    seen: set[str] = set()
+    for token in _RE_FTS_TOKEN.findall(query):
+        folded = token.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        ordered_tokens.append(token)
+    return " ".join(ordered_tokens)
+
+
+def build_fts_queries(query: str) -> list[str]:
+    """Return narrow-then-broad FTS5 queries for natural-language input."""
+    fts_query = sanitize_fts_query(query)
+    if not fts_query:
+        return []
+
+    queries = [fts_query]
+    tokens = fts_query.split()
+    if len(tokens) > 1:
+        or_query = " OR ".join(tokens)
+        if or_query not in queries:
+            queries.append(or_query)
+    return queries
 
 
 class MemoryStore:
@@ -201,16 +237,15 @@ class MemoryStore:
         descending. Also increments retrieval_count for matched facts.
         """
         with self._lock:
-            query = query.strip()
-            if not query:
+            fts_queries = build_fts_queries(query)
+            if not fts_queries:
                 return []
 
-            params: list = [query, min_trust]
             category_clause = ""
+            category_params: list = []
             if category is not None:
                 category_clause = "AND f.category = ?"
-                params.append(category)
-            params.append(limit)
+                category_params.append(category)
 
             sql = f"""
                 SELECT f.fact_id, f.content, f.category, f.tags,
@@ -225,7 +260,12 @@ class MemoryStore:
                 LIMIT ?
             """
 
-            rows = self._conn.execute(sql, params).fetchall()
+            rows = []
+            for fts_query in fts_queries:
+                params: list = [fts_query, min_trust, *category_params, limit]
+                rows = self._conn.execute(sql, params).fetchall()
+                if rows:
+                    break
             results = [self._row_to_dict(r) for r in rows]
 
             if results:

--- a/tests/plugins/memory/test_holographic_provider.py
+++ b/tests/plugins/memory/test_holographic_provider.py
@@ -1,0 +1,70 @@
+import json
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_store_search_facts_sanitizes_slash_query(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db")
+    try:
+        store.add_fact(
+            "Claude/Codex handoff lives in the gateway/WebUI notes.",
+            category="general",
+        )
+
+        results = store.search_facts("Claude/Codex", limit=5)
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Claude/Codex handoff lives in the gateway/WebUI notes."
+    finally:
+        store.close()
+
+
+def test_retriever_search_uses_or_fallback_for_sanitized_slash_query(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db")
+    try:
+        store.add_fact("Gateway restart SOP for Claude agents.", category="general")
+        retriever = FactRetriever(store)
+
+        results = retriever.search("gateway/WebUI restart SOP", limit=5)
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Gateway restart SOP for Claude agents."
+    finally:
+        store.close()
+
+
+def test_fact_store_search_handles_slash_queries_end_to_end(tmp_path):
+    provider = HolographicMemoryProvider(
+        {
+            "db_path": str(tmp_path / "memory_store.db"),
+            "default_trust": 0.5,
+            "min_trust_threshold": 0.3,
+        }
+    )
+    provider.initialize("session-1")
+    try:
+        provider.handle_tool_call(
+            "fact_store",
+            {
+                "action": "add",
+                "content": "gateway restart SOP for Claude agents",
+                "category": "general",
+            },
+        )
+
+        raw = provider.handle_tool_call(
+            "fact_store",
+            {
+                "action": "search",
+                "query": "gateway/WebUI restart SOP",
+                "limit": 5,
+            },
+        )
+
+        payload = json.loads(raw)
+        assert payload["count"] == 1
+        assert payload["results"][0]["content"] == "gateway restart SOP for Claude agents"
+    finally:
+        provider.shutdown()


### PR DESCRIPTION
## Summary

Fix `plugins/memory/holographic` searches when natural-language queries contain FTS5 special characters such as `/`.

## Problem

`fact_store(action="search")` feeds the raw user query directly into SQLite FTS5 `MATCH`.
Queries like `Claude/Codex` or `gateway/WebUI` can therefore:

- raise `fts5: syntax error near "/"`, or
- produce zero FTS candidates before the existing Jaccard/HRR reranking ever runs.

That makes the holographic search path brittle for normal natural-language queries containing separators.

## Root cause

The FTS stage assumed the query was already a valid FTS5 expression, but `fact_store(search)` accepts arbitrary natural-language input.

## Fix

- Normalize natural-language queries into safe FTS tokens before calling `MATCH`.
- Reuse the same normalization logic in both `MemoryStore.search_facts()` and `FactRetriever._fts_candidates()`.
- Try a narrow sanitized query first.
- If that returns no rows, retry with an `OR`-joined fallback to widen the candidate set.
- Keep the existing Jaccard + HRR reranking behavior unchanged once candidates are found.

## Before / After

Before:
- `Claude/Codex` could fail with an FTS5 syntax error.
- Multi-token queries with separators could also bottom out at 0 FTS candidates.

After:
- Slash-containing natural-language queries are converted into safe FTS input.
- Zero-hit narrow searches get a broader `OR` fallback.
- Existing reranking remains the same once FTS returns candidates.

## Tests

Added focused regression coverage for:

- `MemoryStore.search_facts("Claude/Codex")`
- `FactRetriever.search("gateway/WebUI restart SOP")`
- end-to-end `fact_store(action="search")` with slash-containing input