### PR TITLE
fix(tui): re-emit session.info after MCP discovery to fix stale branding

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -246,6 +246,13 @@ def main():
             try:
                 from tools.mcp_tool import discover_mcp_tools
                 discover_mcp_tools()
+                # Re-emit session.info after MCP discovery so TUI branding
+                # shows accurate status instead of stale 'failed' (issue #37159).
+                try:
+                    from tui_gateway.server import _refresh_mcp_status_for_all_sessions
+                    _refresh_mcp_status_for_all_sessions()
+                except Exception:
+                    pass
             except Exception:
                 logger.warning(
                     "Background MCP tool discovery failed", exc_info=True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -117,6 +117,21 @@ except Exception:
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
 
 _sessions: dict[str, dict] = {}
+
+
+def _refresh_mcp_status_for_all_sessions() -> None:
+   """Re-emit session.info for all active sessions after MCP discovery.
+
+   Called after discover_mcp_tools() completes so the TUI branding shows
+   accurate MCP server status instead of stale "failed" (issue #37159).
+   """
+   for sid, sess in list(_sessions.items()):
+       agent = sess.get("agent")
+       if agent is not None:
+           try:
+               _emit("session.info", sid, _session_info(agent))
+           except Exception:
+               pass
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}


### PR DESCRIPTION
TUI branding shows all MCP servers as failed on startup — session.info emitted before discover_mcp_tools() completes (issue #37159).

Fix: after discover_mcp_tools() completes, call _refresh_mcp_status_for_all_sessions().

Fixes #37159