### PR TITLE
fix(desktop): re-sync composer draft on IME compositionend (CJK Send button)

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -568,16 +568,7 @@ export function ChatBar({
     }
   }, [trigger])
 
-  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
-    // During IME composition the DOM contains uncommitted preedit text
-    // mixed with real content.  Skip state writes — compositionend will
-    // deliver the finalized text via a clean input event.
-    if (composingRef.current) {
-      return
-    }
-
-    const editor = event.currentTarget
-
+  const syncDraftFromEditor = (editor: HTMLDivElement) => {
     if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
       editor.replaceChildren()
     }
@@ -590,6 +581,17 @@ export function ChatBar({
     }
 
     window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
+    // During IME composition the DOM contains uncommitted preedit text
+    // mixed with real content.  Skip state writes — compositionend re-syncs
+    // the finalized text via syncDraftFromEditor.
+    if (composingRef.current) {
+      return
+    }
+
+    syncDraftFromEditor(event.currentTarget)
   }
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
@@ -1227,8 +1229,13 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
-        onCompositionEnd={() => {
+        onCompositionEnd={event => {
+          // CJK IME commit: the input event carrying the finalized text often
+          // arrives while composingRef is still true and gets skipped above, so
+          // the composer payload (and Send button) never updates.  Re-sync the
+          // committed text here so Korean/Japanese/Chinese messages are sendable.
           composingRef.current = false
+          syncDraftFromEditor(event.currentTarget)
         }}
         onCompositionStart={() => {
           composingRef.current = true


### PR DESCRIPTION
## Problem

When composing text with a CJK IME (Korean / Japanese / Chinese), the desktop composer's **Send button never appears** — only the voice-conversation button is shown, and pressing Enter or clicking does not send the message. Latin input works fine.

### Root cause

`handleEditorInput` intentionally skips draft state writes while `composingRef.current` is `true`, to avoid capturing uncommitted IME preedit text:

```ts
if (composingRef.current) return
```

The comment says *"compositionend will deliver the finalized text via a clean input event."* But on Chromium/Electron the `input` event carrying the **finalized** composition text can fire while composition is still active (`isComposing` / `composingRef` still true), so it gets skipped. `onCompositionEnd` then only clears `composingRef` and never re-reads the editor:

```ts
onCompositionEnd={() => { composingRef.current = false }}
```

Result: the DOM contains the committed text (e.g. `안녕`) but the composer store is never updated, so `hasComposerPayload` stays `false` → `showVoicePrimary` stays `true` → the Send button is never rendered.

## Fix

Extract the draft-sync logic into `syncDraftFromEditor()` and call it from `onCompositionEnd` after clearing `composingRef`, so the committed text is captured and the Send button enables. No behavior change for Latin input.

## Verification

Reproduced and verified live via the Electron remote-debugging protocol (CDP), simulating the real IME event sequence on the running app:

| Step | Before fix | After fix |
|------|-----------|-----------|
| during composition | Send hidden | Send hidden (unchanged) |
| after `compositionend` | **Send still hidden (bug)** | **Send button appears** ✓ |

`tsc -b` and `vite build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)