### PR TITLE
fix(runtime): close dashboard plugin and Langfuse gaps

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -165,6 +165,7 @@
     "asar": true,
     "afterSign": "scripts/notarize.cjs",
     "asarUnpack": [
+      "dist/**",
       "**/*.node",
       "**/prebuilds/**"
     ],

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -725,7 +725,47 @@ def _plugin_exists(name: str) -> bool:
             or (candidate / "plugin.yml").exists()
         ):
             return True
+        # Category plugins use path-derived keys such as
+        # ``observability/langfuse`` (the same key shape used by
+        # PluginManager.discover_and_load).  Keep the CLI/dashboard provider
+        # inventory aligned with the runtime loader instead of only checking
+        # flat ``plugins/<name>/`` directories.
+        try:
+            nested = _sanitize_plugin_name(name, repo_plugins, allow_subdir=True)
+        except ValueError:
+            nested = None
+        if nested and nested.is_dir() and (
+            (nested / "plugin.yaml").exists()
+            or (nested / "plugin.yml").exists()
+        ):
+            return True
     return False
+
+
+def _iter_plugin_manifest_dirs(base: Path, source: str):
+    """Yield ``(lookup_key, dir)`` for flat and category plugin manifests.
+
+    This mirrors the two-level layout supported by ``PluginManager``:
+    ``plugins/disk-cleanup/plugin.yaml`` and
+    ``plugins/observability/langfuse/plugin.yaml``.  Memory/context/model
+    provider directories keep their dedicated discovery paths.
+    """
+    if not base.is_dir():
+        return
+    skip_top = {"memory", "context_engine", "model-providers"}
+    for child in sorted(base.iterdir()):
+        if not child.is_dir():
+            continue
+        if source == "bundled" and child.name in skip_top:
+            continue
+        if (child / "plugin.yaml").exists() or (child / "plugin.yml").exists():
+            yield child.name, child
+            continue
+        for nested in sorted(child.iterdir()):
+            if not nested.is_dir():
+                continue
+            if (nested / "plugin.yaml").exists() or (nested / "plugin.yml").exists():
+                yield f"{child.name}/{nested.name}", nested
 
 
 def _discover_all_plugins() -> list:
@@ -741,43 +781,36 @@ def _discover_all_plugins() -> list:
     except ImportError:
         yaml = None
 
-    seen: dict = {}  # name -> (name, version, description, source, path)
+    seen: dict = {}  # lookup key -> (key, version, description, source, path)
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
+    # Bundled/user plugin manifests, including category layouts such as
+    # ``observability/langfuse``.  The lookup key intentionally matches the
+    # runtime PluginManager key so ``hermes plugins list`` and the dashboard
+    # hub do not drift from what actually loads.
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            if not d.is_dir():
-                continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
-                continue
+        for lookup_key, d in _iter_plugin_manifest_dirs(base, source):
             manifest_file = d / "plugin.yaml"
             if not manifest_file.exists():
                 manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
-                continue
-            name = d.name
             version = ""
             description = ""
             if yaml:
                 try:
                     with open(manifest_file, encoding="utf-8") as f:
                         manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
                     version = manifest.get("version", "")
                     description = manifest.get("description", "")
                 except Exception:
                     pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
+            # User plugins override bundled on lookup-key collision.
+            if lookup_key in seen and source == "bundled":
                 continue
             src_label = source
             if source == "user" and (d / ".git").exists():
                 src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+            seen[lookup_key] = (lookup_key, version, description, src_label, d)
     return list(seen.values())
 
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -227,7 +227,30 @@ def _trace_key(task_id: str, session_id: str) -> str:
     return f"thread:{threading.get_ident()}"
 
 
-def _truncate_text(value: str, max_chars: int) -> str:
+def _is_base64_data_uri(value: str) -> bool:
+    prefix = value[:200].lower()
+    return prefix.startswith("data:") and ";base64," in prefix
+
+
+def _redact_data_uri(value: str) -> dict[str, Any]:
+    header = value.split(",", 1)[0] if "," in value else "data:"
+    media_type = header[5:].split(";", 1)[0] if header.startswith("data:") else ""
+    return {
+        "type": "data_uri",
+        "media_type": media_type or None,
+        "omitted": True,
+        "length": len(value),
+    }
+
+
+def _truncate_text(value: str, max_chars: int) -> Any:
+    # Langfuse SDK treats data:*;base64 strings as media and attempts to
+    # decode them. Truncating those strings produces invalid base64 and noisy
+    # "Error parsing base64 data URI" logs. Observability only needs metadata,
+    # not raw image/audio payloads, so redact the whole data URI before it
+    # reaches the SDK.
+    if _is_base64_data_uri(value):
+        return _redact_data_uri(value)
     if len(value) <= max_chars:
         return value
     return value[:max_chars] + f"... [truncated {len(value) - max_chars} chars]"

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -393,6 +393,17 @@ class TestCmdRemove:
 class TestCmdList:
     """Test the list command."""
 
+    def test_discover_all_plugins_includes_category_plugin_keys(self):
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        names = {entry[0] for entry in _discover_all_plugins()}
+        assert "observability/langfuse" in names
+
+    def test_plugin_exists_accepts_category_plugin_key(self):
+        from hermes_cli.plugins_cmd import _plugin_exists
+
+        assert _plugin_exists("observability/langfuse") is True
+
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_list_empty_plugins_dir(self, mock_plugins_dir):
         from hermes_cli.plugins_cmd import cmd_list

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -171,6 +171,40 @@ class TestHooksInert:
         mod.on_post_tool_call(tool_name="read_file", args={}, result="ok", task_id="t", session_id="s")
 
 
+class TestPayloadSanitization:
+    def test_safe_value_redacts_base64_data_uri_instead_of_truncating(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        import importlib
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        payload = "data:image/png;base64," + ("a" * 20000)
+        result = mod._safe_value(payload)
+
+        assert result == {
+            "type": "data_uri",
+            "media_type": "image/png",
+            "omitted": True,
+            "length": len(payload),
+        }
+
+    def test_serialize_messages_redacts_data_uri_parts(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        import importlib
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        payload = "data:image/jpeg;base64," + ("b" * 20000)
+        serialized = mod._serialize_messages([
+            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": payload}}]}
+        ])
+
+        assert serialized[0]["content"][0]["image_url"]["url"] == {
+            "type": "data_uri",
+            "media_type": "image/jpeg",
+            "omitted": True,
+            "length": len(payload),
+        }
+
+
 # ---------------------------------------------------------------------------
 # Placeholder-credential guard (#23823).
 #

--- a/tests/test_desktop_packaging.py
+++ b/tests/test_desktop_packaging.py
@@ -1,0 +1,17 @@
+"""Regression guards for the packaged Hermes Desktop bundle config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_dist_is_unpacked_for_python_backend():
+    package_json = json.loads(
+        (REPO_ROOT / "apps" / "desktop" / "package.json").read_text(encoding="utf-8")
+    )
+    asar_unpack = package_json.get("build", {}).get("asarUnpack", [])
+    assert "dist/**" in asar_unpack

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -976,9 +976,20 @@ def skill_view(
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name).
+            # like "foundations/runtime/explore-codebase" called by bare name),
+            # plus frontmatter `name:` lookup. `skills_list()` exposes the
+            # frontmatter name, so `skill_view(name)` must accept it too even
+            # when the on-disk directory is a shorter category/alias.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
+                    _record(found_skill_md.parent, found_skill_md)
+                    continue
+                try:
+                    fm_content = found_skill_md.read_text(encoding="utf-8")
+                    fm, _ = _parse_frontmatter(fm_content)
+                except Exception:
+                    fm = {}
+                if fm.get("name") == name:
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.


### PR DESCRIPTION
## Summary
- Unpack Desktop `dist/**` so the Python dashboard backend can serve the packaged web bundle outside `app.asar`.
- Make plugin CLI/dashboard discovery include category-nested bundled plugins such as `observability/langfuse`.
- Redact base64 data URIs in the Langfuse plugin instead of truncating them into invalid base64 payloads.
- Allow `skill_view` resolution by frontmatter `name` when the directory name differs from the skill name.

## Test Plan
- `venv/bin/python -m pytest tests/test_desktop_packaging.py tests/hermes_cli/test_plugins_cmd.py tests/plugins/test_langfuse_plugin.py -q`
- Local Desktop smoke:
  - `GET http://127.0.0.1:9120/` returns 200 and `<title>Hermes</title>`
  - `/api/memory` reports `active=hindsight`
  - `/api/dashboard/plugins/hub` includes `observability/langfuse`, `disk-cleanup`, and `security-guidance` with `runtime_status=enabled`

## Notes
This PR overlaps with #39093 on the Desktop `dist/**` packaging guard, but adds the runtime/plugin-hub and Langfuse data URI regressions from the same local diagnosis.
