### PR TITLE
fix(terminal): bridge docker_extra_args from config.yaml (#39615)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -605,6 +605,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -927,6 +927,7 @@ if _config_path.exists():
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5956,6 +5956,7 @@ def set_config_value(key: str, value: str):
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "terminal.docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "terminal.docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+        "terminal.docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "terminal.docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
         "terminal.docker_env": "TERMINAL_DOCKER_ENV",
         # JSON-valued keys (terminal_tool parses these via json.loads). The user

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -295,3 +295,23 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_docker_extra_args_is_bridged_everywhere():
+    """Regression pin for ``terminal.docker_extra_args`` being silently ignored.
+
+    ``terminal.docker_extra_args`` in config.yaml specifies extra flags passed
+    verbatim to ``docker run``.  The key was present in the default config
+    schema (``hermes_cli/config.py``) and consumed by terminal_tool (via
+    ``_get_env_config`` → ``TERMINAL_DOCKER_EXTRA_ARGS`` →
+    ``_create_environment`` → ``DockerEnvironment(extra_args=...)``), but
+    never bridged from config.yaml to env vars in cli.py's env_mappings,
+    gateway/run.py's _terminal_env_map, or set_config_value's
+    _config_to_env_sync.  So ``terminal.docker_extra_args: '["--network=host"]'``
+    in config.yaml silently did nothing — the flags only took effect when set
+    via the TERMINAL_DOCKER_EXTRA_ARGS env var directly.  Issue #39615.
+    """
+    assert "docker_extra_args" in _cli_env_map_keys()
+    assert "docker_extra_args" in _gateway_env_map_keys()
+    assert "docker_extra_args" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_EXTRA_ARGS" in _terminal_tool_env_var_names()


### PR DESCRIPTION
## What

Fixes #39615 by bridging `terminal.docker_extra_args` from `config.yaml` into the `TERMINAL_DOCKER_EXTRA_ARGS` environment variable everywhere Hermes already bridges Docker terminal settings:

- CLI startup config loading (`cli.py`)
- gateway startup config loading (`gateway/run.py`)
- `hermes config set terminal.docker_extra_args ...` env sync (`hermes_cli/config.py`)

Without this, `docker_extra_args` was defined in the default config schema and consumed by the Docker terminal backend, but values set in `config.yaml` were silently ignored unless users also set `TERMINAL_DOCKER_EXTRA_ARGS` directly.

## Why

`terminal_tool` reads Docker runtime options from `TERMINAL_*` env vars. The sibling settings (`docker_env`, `docker_volumes`, `docker_forward_env`, `docker_run_as_host_user`, etc.) already had bridge entries, but `docker_extra_args` was missing from three bridge tables. This made config.yaml values like:

```yaml
terminal:
  docker_extra_args: '["--network=hermes-net","--dns=172.16.18.1"]'
```

never reach the Docker run argument builder.

## Tests

Focused regression suite:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_terminal_config_env_sync.py -v -o "addopts=" --tb=short
```

Result: `10 passed in 1.10s`.

Red/green proof captured by the automation: the new regression test fails on upstream/main because `docker_extra_args` is missing from the bridge maps, then passes after adding the three bridge entries.

## Duplicate / competitor check

Before publication, the automation checked open PRs by issue number and distinctive topic keywords (`docker_extra_args terminal config`) and found no focused competing open PRs.

Auto-published by Moonsong via Path B automated pipeline.
