### PR TITLE
fix(docker): use China-accessible image addresses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
+FROM ghcr.nju.edu.cn/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
 # Node 22 LTS source stage. Debian trixie's bundled nodejs is pinned to 20.x
 # which reached EOL in April 2026 — we copy node + npm + corepack from the
 # upstream node:22 image instead so we can stay on a supported LTS without
@@ -6,8 +6,8 @@ FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df228
 # so the produced binary links against glibc 2.36, which runs cleanly on
 # our Debian 13 (trixie, glibc 2.41) runtime.  Bumping to a new Node major
 # is a one-line ARG change; see #4977.
-FROM node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732 AS node_source
-FROM debian:13.4
+FROM m.daocloud.io/docker.io/library/node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732 AS node_source
+FROM m.daocloud.io/docker.io/library/debian:13.4
 
 # Disable Python stdout buffering to ensure logs are printed immediately
 ENV PYTHONUNBUFFERED=1
@@ -23,7 +23,11 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # replaces tini with s6-overlay's /init (PID 1 = s6-svscan), which reaps
 # zombies non-blockingly on SIGCHLD and additionally supervises the main
 # hermes process, the dashboard, and per-profile gateways.
-RUN apt-get update && \
+RUN sed -i \
+        -e 's|http://deb.debian.org/debian-security|http://mirrors.tuna.tsinghua.edu.cn/debian-security|g' \
+        -e 's|http://deb.debian.org/debian|http://mirrors.tuna.tsinghua.edu.cn/debian|g' \
+        /etc/apt/sources.list.d/debian.sources && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
@@ -128,6 +132,12 @@ COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/
 # runtime `npm install` that then failed with EACCES.  Keeping the env
 # guards against a future regression if the source npm version changes.
 ENV npm_config_install_links=false
+ENV npm_config_registry=https://registry.npmmirror.com \
+    npm_config_replace_registry_host=npmjs \
+    npm_config_fetch_retries=5 \
+    npm_config_fetch_retry_maxtimeout=120000 \
+    UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple \
+    PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -11,7 +11,7 @@
 #
 services:
   gateway:
-    image: nousresearch/hermes-agent:latest
+    image: m.daocloud.io/docker.io/nousresearch/hermes-agent:latest
     container_name: hermes
     restart: unless-stopped
     volumes:
@@ -22,7 +22,7 @@ services:
     command: ["gateway", "run"]
 
   dashboard:
-    image: nousresearch/hermes-agent:latest
+    image: m.daocloud.io/docker.io/nousresearch/hermes-agent:latest
     container_name: hermes-dashboard
     restart: unless-stopped
     depends_on:

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -116,7 +116,7 @@ TERMINAL_TOOL_DEFINITION = {
 
 def create_environment(
     env_type: str = "local",
-    image: str = "python:3.11-slim",
+    image: str = "m.daocloud.io/docker.io/library/python:3.11-slim",
     cwd: str = "/tmp",
     timeout: int = 60,
     **kwargs
@@ -166,7 +166,7 @@ class MiniSWERunner:
         base_url: str = None,
         api_key: str = None,
         env_type: str = "local",
-        image: str = "python:3.11-slim",
+        image: str = "m.daocloud.io/docker.io/library/python:3.11-slim",
         cwd: str = "/tmp",
         max_iterations: int = 15,
         command_timeout: int = 60,
@@ -641,7 +641,7 @@ def main(
     base_url: str = None,
     api_key: str = None,
     env: str = "local",
-    image: str = "python:3.11-slim",
+    image: str = "m.daocloud.io/docker.io/library/python:3.11-slim",
     cwd: str = "/tmp",
     max_iterations: int = 15,
     timeout: int = 60,


### PR DESCRIPTION
## Summary
- Replace Dockerfile base image references with China-accessible mirror addresses while preserving pinned digests.
- Point Windows compose image references at a directly pullable China-accessible image address.
- Use China-accessible default Docker image for mini_swe_runner Docker environments.
- Configure Dockerfile build-time apt/npm/uv/pip sources for mainland China network reliability.

## Verification
- `docker info` shows no daemon `registry-mirrors` active.
- `docker manifest inspect` succeeds for the direct mirror image addresses.
- `docker compose -f docker-compose.windows.yml config` succeeds.
- `docker build -t hermes-agent:cn-mirror-smoke .` completed and produced image `sha256:e83a1d2b673cb392f1c2df8539a82351f533b5b5ab97845794b60c79a3dfeb96` in the pre-rebase verification; a follow-up build on the rebased branch progressed through apt/npm/playwright/uv install with the mirrored sources before being stopped to avoid a long redundant export.
- Smoke test on built image: `/opt/hermes/.venv/bin/hermes --version` reported Hermes Agent v0.15.1.
