### PR TITLE
install.sh: hint at root-owned npm cache when desktop npm install fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2281,6 +2281,16 @@ install_desktop() {
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
     ( cd "$INSTALL_DIR" && npm ci ) || ( cd "$INSTALL_DIR" && npm install ) || {
         log_error "Desktop workspace npm install failed"
+        # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
+        # ~/.npm, so this non-root install can't write the shared cache. npm hides
+        # it behind a confusing EEXIST / "File exists" message while the real errno
+        # is EACCES (-13). Point the user at the fix instead of a raw npm trace.
+        log_info "If the errors above mention EACCES / 'permission denied' / EEXIST while"
+        log_info "writing the npm cache, your ~/.npm likely holds root-owned files from an"
+        log_info "earlier 'sudo npm' or 'sudo npx'. Reclaim ownership and retry:"
+        log_info "  sudo chown -R \"\$(id -un)\" ~/.npm && npm cache verify"
+        log_info "Then re-run this installer, or build manually:"
+        log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
         return 1
     }
     log_success "Desktop workspace dependencies installed"


### PR DESCRIPTION
## Summary

When the desktop build can't install its workspace dependencies, `install_desktop` prints a single line — `Desktop workspace npm install failed` — and aborts. If the underlying npm failure is the (surprisingly common) root-owned cache problem, the user is left staring at a wall of npm output with no hint that it's a local permissions issue rather than a problem with the installer.

The trigger: `~/.npm` holds cache entries owned by `root`, left behind by an earlier `sudo npm` / `sudo npx`. A later non-root `npm install` then can't write those cache paths and fails. npm surfaces this as `EEXIST` / "File exists" with `errno -13`, which is actually `EACCES` (permission denied).

## What this changes

On the desktop-install failure path only, print a short, targeted hint pointing at the fix:

```
sudo chown -R "$(id -un)" ~/.npm && npm cache verify
```

…followed by the manual rebuild command. This mirrors the "Run manually: …" guidance already used elsewhere in the same function. No behavior change on success, and the stage stays a hard failure as intended.

## Why not just make the stage non-fatal?

The hard `return 1` is deliberate — see the comment above `install_desktop`: a silent skip produces a "complete" install with no app and a confusing launch-time error. This keeps that contract and only makes the failure self-explanatory.

## Notes

Scoped to the bash installer (`scripts/install.sh`), the path most users hit; `scripts/install.ps1` carries the same message and could get a parity hint in a follow-up. Verified with `bash -n`.
