### PR TITLE
fix(gateway): terminate typing indicator before executing post-delive…

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4438,13 +4438,6 @@ class BasePlatformAdapter(ABC):
                 )
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
-            if callable(_post_cb):
-                try:
-                    _post_result = _post_cb()
-                    if inspect.isawaitable(_post_result):
-                        await _post_result
-                except Exception:
-                    pass
             # Stop typing indicator
             await _stop_typing_task()
             # Also cancel any platform-level persistent typing tasks (e.g. Discord)
@@ -4454,6 +4447,14 @@ class BasePlatformAdapter(ABC):
                     await self.stop_typing(event.source.chat_id)
             except Exception:
                 pass
+
+            if callable(_post_cb):
+                try:
+                    _post_result = _post_cb()
+                    if inspect.isawaitable(_post_result):
+                        await _post_result
+                except Exception:
+                    pass
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
             await self._flush_text_debounce_now(session_key)


### PR DESCRIPTION
## What does this PR do?

Currently, the gateway adapter stops the typing indicator task after all post-delivery callbacks (such as background conversation review) are fully executed. 

This causes the "typing..." indicator to linger for several seconds (or even minutes due to client-side UI glitches) after the bot has already sent the final message, which confuses the user.

This approach resolves the issue by swapping the execution order: terminating the typing indicator immediately after the response is sent, before starting any background post-delivery callbacks.


## Related Issue

Fixes #


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- `gateway/platforms/base.py`: Swapped the execution order of typing task termination (`_stop_typing_task`) and post-delivery callback execution (`_post_cb`) in `_process_message_background`.


## How to Test

1. Run a Telegram or Discord bot session.
2. Send a message to the bot.
3. Observe that the "typing..." status bubble disappears immediately after the bot sends the final message, rather than staying active while the background review (`bg-review`) is running.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A