### PR TITLE
fix(tui): preserve IME text before return submit

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,9 +32,7 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit ? ['pipe', 'ignore', 'ignore'] : 'pipe'
 
     const child = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,

--- a/ui-tui/src/__tests__/textInputReturnBurst.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnBurst.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { valueForReturnSubmit } from '../components/textInput.js'
+
+describe('valueForReturnSubmit', () => {
+  it('includes printable input that arrives in the same keypress as return', () => {
+    expect(valueForReturnSubmit('为什么打字上屏，', 8, '会丢失内容')).toEqual({
+      cursor: 13,
+      value: '为什么打字上屏，会丢失内容'
+    })
+  })
+
+  it('keeps IME commit text when it arrives in the same burst as return', () => {
+    expect(valueForReturnSubmit('为什么打字上屏，', 8, '会丢失内容\r')).toEqual({
+      cursor: 13,
+      value: '为什么打字上屏，会丢失内容'
+    })
+  })
+
+  it('leaves the draft unchanged when return carries no printable input', () => {
+    expect(valueForReturnSubmit('hello', 5, '')).toEqual({ cursor: 5, value: 'hello' })
+    expect(valueForReturnSubmit('hello', 5, '\r')).toEqual({ cursor: 5, value: 'hello' })
+    expect(valueForReturnSubmit('hello', 5, '\n')).toEqual({ cursor: 5, value: 'hello' })
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -123,6 +123,33 @@ export function applyPrintableInsert(
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
 
+export function valueForReturnSubmit(
+  value: string,
+  cursor: number,
+  input: string,
+  range?: { end: number; start: number } | null
+): TextInsertResult {
+  const pending = input.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+  if (!pending) {
+    return { cursor, value }
+  }
+
+  // Browser/xterm IME commits can arrive as one burst immediately followed by
+  // Return (for example "会丢失内容\r").  The Return keypath is already about to
+  // submit, but the committed text has not passed through the ordinary
+  // printable-input branch yet.  Preserve the printable prefix before the first
+  // newline so the visible, just-committed IME text is part of the submitted
+  // prompt instead of being silently dropped.
+  const [beforeReturn] = pending.split('\n', 1)
+
+  if (!beforeReturn) {
+    return { cursor, value }
+  }
+
+  return applyPrintableInsert(value, cursor, beforeReturn, range) ?? { cursor, value }
+}
+
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
     return true
@@ -968,13 +995,15 @@ export function TextInput({
       if (k.return) {
         flushKeyBurst()
 
+        const range = selRange()
+        const pending = valueForReturnSubmit(vRef.current, curRef.current, inp, range)
         const sequence = (event.keypress as { sequence?: string }).sequence
         const preserveBareLineFeed = shouldPreserveCtrlJNewline() && sequence === '\n'
 
         if (k.shift || k.ctrl || preserveBareLineFeed || (isMac ? isActionMod(k) : k.meta)) {
-          commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          commit(ins(pending.value, pending.cursor, '\n'), pending.cursor + 1)
         } else {
-          cbSubmit.current?.(vRef.current)
+          cbSubmit.current?.(pending.value)
         }
 
         return


### PR DESCRIPTION
## Summary
- Preserve printable IME commit text when xterm delivers it in the same input burst as Return.
- Submit the pending value from the Return keypath so Dashboard/TUI sends the visible draft instead of dropping the final segment.
- Add focused regression coverage for Return-burst inputs and fix the `execFileNoThrow` stdio tuple typing that blocked `ui-tui` type-check.

## Why
A browser/xterm IME flow can deliver finalized CJK text immediately followed by Return in one input burst, e.g. `会丢失内容\r`. The previous Return branch submitted `vRef.current` before the printable prefix had gone through the ordinary input path, so the prompt visible in the UI could be longer than the submitted prompt.

This is adjacent to #39246, but covers the "IME commit text + Return in the same burst should submit the visible draft" path rather than absorbing Enter as an IME-confirmation guard. Desktop IME syncing is left to #39435.

## Scope
This targets the `ui-tui` text input path used by the Dashboard chat's embedded TUI/xterm session. It does not touch the Electron Desktop composer (`apps/desktop/...`); the separate Desktop IME sync issue is covered by #39435.

## Test Plan
- [x] `git diff --cached --check`
- [x] Static scan of added lines for hardcoded secrets / shell injection / eval / pickle / SQL injection patterns
- [x] `npm run test --workspace ui-tui -- src/__tests__/textInputReturnBurst.test.ts`
- [x] `npm run type-check --workspace ui-tui`
- [x] `npm run build --workspace ui-tui`
- [x] Independent reviewer pass: no security concerns or logic errors

