### PR TITLE
fix(security): redact Google OAuth token prefixes (ya29., 1//) in secret scrubber

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,8 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    r"ya29\.[A-Za-z0-9_-]{20,}",        # Google OAuth 2.0 access token
+    r"1//[A-Za-z0-9_-]{20,}",           # Google OAuth 2.0 refresh token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -45,6 +45,23 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("AIzaSyB-abc123def456ghi789jklmno012345")
         assert "abc123def456" not in result
 
+    def test_google_oauth_access_token(self):
+        # Bare Google OAuth access token in tool output (no JSON key adjacency)
+        token = "ya29." + "a1b2c3d4e5" * 4  # 40 contiguous token chars
+        result = redact_sensitive_text(f"got token {token}")
+        assert "a1b2c3d4e5" * 4 not in result
+        assert "..." in result
+
+    def test_google_oauth_refresh_token(self):
+        token = "1//" + "0gAbCdEf_-" * 4  # url-safe base64, 40 chars
+        result = redact_sensitive_text(f"refresh={token}")
+        assert "0gAbCdEf" not in result
+
+    def test_google_oauth_short_non_token_unchanged(self):
+        # Negative: a short "1//foo" must NOT be redacted (no false positive)
+        text = "see path 1//foo for details"
+        assert redact_sensitive_text(text) == text
+
     def test_perplexity_key(self):
         result = redact_sensitive_text("pplx-abcdef123456789012345")
         assert "abcdef12345" not in result


### PR DESCRIPTION
## This is a sibling follow-up to commit 5613dfea9 (`fix(security): redact xAI (Grok) API keys in logs`)

- 5613dfea9 and the surrounding hardening family added per-provider credential prefixes to `agent/redact.py::_PREFIX_PATTERNS` (sk-, ghp_, AIza, xai-, syt_, gAAAA, …).
- That family did NOT cover Google OAuth 2.0 tokens — access tokens (`ya29.`) and refresh tokens (`1//`). They appear throughout the repo's own auth fixtures yet are only masked when adjacent to a JSON secret key; a **bare** token echoed into tool output or logs persists verbatim.
- This PR adds the two missing prefix patterns so bare Google OAuth tokens are redacted the same way every other provider's are.

## What does this PR do?

Extends the secret scrubber's known-prefix denylist to cover Google OAuth 2.0 access (`ya29.`) and refresh (`1//`) tokens. Without this, `security.redact_secrets` (on by default) misses bare Google tokens in tool output / logs because they had no prefix entry and only matched via `_JSON_KEY_NAMES` adjacency.

This addresses gap #2 of #39654. Gap #1 (extending redaction to the `state.db` persistence layer) is a separate structural change and is intentionally left out of this surgical PR.

## Related Issue

Fixes #39654

## Type of Change

- [x] Bug fix / hardening (non-breaking change which fixes an issue)

## Changes Made

- `agent/redact.py`: added `ya29\.[A-Za-z0-9_-]{20,}` (access) and `1//[A-Za-z0-9_-]{20,}` (refresh) to `_PREFIX_PATTERNS`. The `{20,}` tail length avoids false positives on short non-token strings (e.g. a literal `1//foo` path); real Google tokens are >100 chars. The dot in `ya29\.` is escaped so the literal-prefix pre-screen (`_extract_literal_prefix`) correctly derives `ya29`/`1//` substrings with no false negatives.
- `tests/agent/test_redact.py`: added `test_google_oauth_access_token`, `test_google_oauth_refresh_token`, and a negative `test_google_oauth_short_non_token_unchanged` to `TestKnownPrefixes`.

> Audited siblings: confirmed every other provider in `_PREFIX_PATTERNS` already has a prefix entry; Google OAuth was the lone uncovered token family present in the repo's auth fixtures. No further widening needed.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_redact.py -v
```

## Checklist

### Code
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation & Housekeeping
- [x] My changes generate no new warnings
- [x] No AI-attribution added