### PR TITLE
fix(skills): make loading guidance targeted

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1246,17 +1246,19 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
+            "## Skills (targeted, mandatory when triggered)\n"
+            "Before replying, scan the skills below. Load a skill with skill_view(name) only "
+            "when its trigger or description materially matches the task, a requested workflow, "
+            "or a prerequisite you must satisfy. Prefer the most specific applicable skill(s); "
+            "do not load broad or mega-skills just because they are loosely related. If a "
+            "meta-skill matches, load that lightweight routing skill first, then load only the "
+            "targeted subordinate skills it says are needed. Avoid context bloat: more skill "
+            "text is not automatically better.\n"
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "and proven workflows that outperform general-purpose approaches. Use them when "
+            "they change what you would do, define a required convention, or cover a non-trivial "
+            "workflow. Do not load a skill for trivial tasks or routine tool use unless the skill "
+            "description clearly makes it mandatory for that task.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -1271,7 +1273,7 @@ def build_skills_system_prompt(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "Proceed without loading a skill when none materially match the task."
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -265,6 +265,26 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_skills_guidance_requires_targeted_loading(self, monkeypatch, tmp_path):
+        """Prompt should prevent context-bloating loads of loosely related skills."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "targeted, mandatory when triggered" in result
+        assert "materially matches the task" in result
+        assert "do not load broad or mega-skills" in result
+        assert "meta-skill" in result
+        assert "context bloat" in result
+        assert "Err on the side of loading" not in result
+        assert "even partially relevant" not in result
+        assert "context you don't need" not in result
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -86,9 +86,10 @@ would do or plan to do without actually doing it.
 - GitHub: alice-dev
 
 # Layer 7: Skills index
-## Skills (mandatory)
-Before replying, scan the skills below. If one clearly matches
-your task, load it with skill_view(name) and follow its instructions.
+## Skills (targeted, mandatory when triggered)
+Before replying, scan the skills below. Load a skill only when its trigger
+or description materially matches the task. Prefer specific skills and
+lightweight meta-skills over broad context-bloating skill bundles.
 ...
 <available_skills>
   software-development:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/prompt-assembly.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/prompt-assembly.md
@@ -86,9 +86,10 @@ would do or plan to do without actually doing it.
 - GitHub: alice-dev
 
 # Layer 7: Skills index
-## Skills (mandatory)
-Before replying, scan the skills below. If one clearly matches
-your task, load it with skill_view(name) and follow its instructions.
+## Skills (targeted, mandatory when triggered)
+Before replying, scan the skills below. Load a skill only when its trigger
+or description materially matches the task. Prefer specific skills and
+lightweight meta-skills over broad context-bloating skill bundles.
 ...
 <available_skills>
   software-development:


### PR DESCRIPTION
## Summary
- narrows mandatory skill guidance to materially matching skills
- discourages broad/mega-skill loading when loosely related
- updates prompt assembly docs and regression coverage

## Test Plan
- venv/bin/python -m pytest -o addopts='' tests/agent/test_prompt_builder.py -q