### PR TITLE
fix(cron): redact sensitive text in LLM error path before delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1898,6 +1898,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
+        # Redact secrets from error messages before delivery to user chat.
+        # Provider errors can contain API key fragments, bearer tokens, or
+        # endpoint URLs with embedded credentials (COD-301).
+        try:
+            from agent.redact import redact_sensitive_text
+            error_msg = redact_sensitive_text(error_msg)
+        except Exception:
+            pass
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
         
         output = f"""# Cron Job: {job_name} (FAILED)


### PR DESCRIPTION
## What

When an LLM-backed cron job fails, the exception message was formatted and delivered verbatim to the user's chat (Telegram, Discord, etc.) and persisted in plaintext in `jobs.json`. Provider error messages can contain API key fragments, bearer tokens, or endpoint URLs with embedded credentials.

## How

Apply `redact_sensitive_text()` to `error_msg` immediately after construction, before it flows into the user-delivered output markdown and the return value. Matches the existing pattern at lines 1019–1024 in the `no_agent` script path.

## Scope

- `cron/scheduler.py`: +8 lines (redaction step + comment)
- No signature changes, no new dependencies

## Risk

Low. Purely additive defensive measure. If redaction fails, the `try/except` silently falls through and the original error message is used — identical to current behavior.

Fixes COD-301.