### PR TITLE
fix: ignore Codex agent message deltas

### DIFF
--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -66,6 +66,14 @@ class ProjectionResult:
     final_text: Optional[str] = None  # Set when an agentMessage completes
 
 
+_IGNORED_NOTIFICATION_METHODS = frozenset({
+    # Codex streams assistant text here before later sending the authoritative
+    # item/completed agentMessage. Treat the delta as display-only so memory /
+    # transcript projection does not duplicate partial assistant content.
+    "item/agentMessage/delta",
+})
+
+
 class CodexEventProjector:
     """Stateful projector consuming Codex notifications in arrival order.
 
@@ -85,6 +93,9 @@ class CodexEventProjector:
         # (`item/<type>/outputDelta`, `item/<type>/delta`) are display-only and
         # don't enter the messages list — same way Hermes already only writes
         # the assistant message after the streaming completion event.
+        if method in _IGNORED_NOTIFICATION_METHODS:
+            return ProjectionResult()
+
         if method != "item/completed":
             return ProjectionResult()
 

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -60,6 +60,19 @@ class TestProjectionInvariants:
             assert r.is_tool_iteration is False
             assert r.final_text is None
 
+    def test_agent_message_delta_is_explicitly_ignored(self) -> None:
+        p = CodexEventProjector()
+        r = p.project({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "delta": "partial text",
+                "item": {"type": "agentMessage", "id": "m1", "text": "partial text"},
+            },
+        })
+        assert r.messages == []
+        assert r.final_text is None
+        assert r.is_tool_iteration is False
+
     def test_turn_started_and_completed_are_silent(self) -> None:
         p = CodexEventProjector()
         for method in ("turn/started", "turn/completed", "thread/started"):


### PR DESCRIPTION
## Summary
- Explicitly treat Codex `item/agentMessage/delta` notifications as display-only in the event projector
- Add a regression test ensuring agent message deltas do not create projected messages, final text, or tool iterations

## Test Plan
- `pytest -o addopts='' tests/agent/transports/test_codex_event_projector.py`
- `git diff --check`