### PR TITLE
fix(models): don't silently default Nous to the most expensive flagship

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1158,7 +1158,7 @@ _PROVIDER_ALIASES = {
 # non-interactive fallback when a profile sets ``provider: nous`` with no model
 # silently bills the most expensive model for traffic the user never opted into
 # (a missing default escalated to Opus and billed 863 requests before the user
-# noticed). Pin the silent default to the cheapest curated tier instead so a
+# noticed). Pin the silent default to a low-cost curated model instead so a
 # missing model can never escalate to the flagship.
 #
 # This is deliberately a fixed, side-effect-free default for the hot resolution
@@ -1167,7 +1167,7 @@ _PROVIDER_ALIASES = {
 # in hermes_cli/web_server.py and ``partition_nous_models_by_tier`` — which can
 # hit the Portal; this fallback must stay cheap and network-free.
 _PROVIDER_SILENT_DEFAULT_OVERRIDES: dict[str, str] = {
-    "nous": "nvidia/nemotron-3-super-120b-a12b",
+    "nous": "deepseek/deepseek-v4-flash",
 }
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1150,17 +1150,46 @@ _PROVIDER_ALIASES = {
 }
 
 
+# Cost-safe overrides for the *silent* auto-default
+# (``get_default_model_for_provider``). Most providers' curated lists lead with a
+# sensible default, but Nous Portal is a per-token *metered aggregator* whose
+# list is ordered best-/most-capable-first — entry [0] is the priciest flagship
+# (``anthropic/claude-opus-4.8``, $5/$25 per Mtok). Using that as the
+# non-interactive fallback when a profile sets ``provider: nous`` with no model
+# silently bills the most expensive model for traffic the user never opted into
+# (a missing default escalated to Opus and billed 863 requests before the user
+# noticed). Pin the silent default to the cheapest curated tier instead so a
+# missing model can never escalate to the flagship.
+#
+# This is deliberately a fixed, side-effect-free default for the hot resolution
+# path. The *interactive* default (GUI onboarding / ``hermes model``) uses the
+# richer free/paid-tier-aware resolver — see ``get_recommended_default_model``
+# in hermes_cli/web_server.py and ``partition_nous_models_by_tier`` — which can
+# hit the Portal; this fallback must stay cheap and network-free.
+_PROVIDER_SILENT_DEFAULT_OVERRIDES: dict[str, str] = {
+    "nous": "nvidia/nemotron-3-super-120b-a12b",
+}
+
+
 def get_default_model_for_provider(provider: str) -> str:
-    """Return the default model for a provider, or empty string if unknown.
+    """Return a cost-safe default model for a provider, or "" if unknown.
 
-    Uses the first entry in _PROVIDER_MODELS as the default.  This is the
-    model a user would be offered first in the ``hermes model`` picker.
+    Used as a NON-INTERACTIVE fallback when a provider is configured but no
+    model was ever selected (e.g. ``hermes auth add openai-codex`` without
+    ``hermes model``, or a profile that sets ``provider`` with no ``model``).
 
-    Used as a fallback when the user has configured a provider but never
-    selected a model (e.g. ``hermes auth add openai-codex`` without
-    ``hermes model``).
+    For most providers this is the first entry in ``_PROVIDER_MODELS`` — the
+    same model the ``hermes model`` picker offers first. For metered aggregators
+    whose curated list is ordered most-capable-first, that entry is also the
+    most EXPENSIVE one, so silently defaulting to it is a billing footgun. Such
+    providers carry an explicit low-cost override in
+    ``_PROVIDER_SILENT_DEFAULT_OVERRIDES``; a missing model must never
+    auto-escalate to the flagship.
     """
     models = _PROVIDER_MODELS.get(provider, [])
+    override = _PROVIDER_SILENT_DEFAULT_OVERRIDES.get(provider)
+    if override and override in models:
+        return override
     return models[0] if models else ""
 
 

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -30,6 +30,46 @@ class TestGetDefaultModelForProvider:
         # Custom providers don't have entries in _PROVIDER_MODELS
         assert get_default_model_for_provider("some-random-custom") == ""
 
+    def test_nous_silent_default_is_not_the_expensive_flagship(self):
+        """Nous Portal is a metered aggregator whose curated list is ordered
+        most-capable-first, so entry [0] is the priciest flagship
+        (anthropic/claude-opus-4.8). The silent fallback (provider set, no model)
+        must NOT escalate to it — otherwise an unconfigured profile silently
+        bills the most expensive model. Regression for the billing footgun.
+        """
+        from hermes_cli.models import (
+            _PROVIDER_MODELS,
+            _PROVIDER_SILENT_DEFAULT_OVERRIDES,
+            get_default_model_for_provider,
+        )
+
+        result = get_default_model_for_provider("nous")
+        assert result, "nous must resolve to a usable default model"
+        assert "opus" not in result.lower(), (
+            f"silent default escalated to an expensive flagship: {result!r}"
+        )
+        assert result != _PROVIDER_MODELS["nous"][0], (
+            "silent default must not be the most-capable/priciest catalog entry"
+        )
+        # The override must point at a model that actually exists in the catalog.
+        assert result == _PROVIDER_SILENT_DEFAULT_OVERRIDES["nous"]
+        assert result in _PROVIDER_MODELS["nous"]
+
+    def test_override_falls_back_to_catalog_when_missing(self):
+        """If an override model is no longer in the catalog, fall back to [0]
+        rather than returning a stale/absent id."""
+        from unittest.mock import patch
+
+        from hermes_cli import models as models_mod
+
+        with patch.dict(
+            models_mod._PROVIDER_SILENT_DEFAULT_OVERRIDES,
+            {"openai-codex": "does-not-exist-model"},
+            clear=False,
+        ):
+            result = models_mod.get_default_model_for_provider("openai-codex")
+            assert result == models_mod._PROVIDER_MODELS["openai-codex"][0]
+
 
 class TestGatewayEmptyModelFallback:
     """Test that _resolve_session_agent_runtime fills in empty model from provider catalog."""


### PR DESCRIPTION
## Summary
A profile that sets `provider: nous` with no model no longer silently bills the most expensive flagship. The non-interactive default for Nous is now pinned to a low-cost model (`deepseek/deepseek-v4-flash`) instead of catalog `[0]` (`anthropic/claude-opus-4.8`).

Salvage of #39669 by @xxxigm, with a follow-up changing the override target from the nvidia nemotron entry to deepseek-v4-flash.

## Root cause
When a provider is configured but no model was selected, the gateway/CLI fall back to `get_default_model_for_provider()` (`gateway/run.py`, `cli.py`, `gateway/platforms/feishu_comment.py`). That helper returned `_PROVIDER_MODELS[provider][0]`. The Nous list is ordered most-capable-first, so `[0]` is `anthropic/claude-opus-4.8` — a missing model silently escalated to the flagship and billed it (863 requests before the reporting user noticed).

## Changes
- `hermes_cli/models.py`: new `_PROVIDER_SILENT_DEFAULT_OVERRIDES` map (`nous → deepseek/deepseek-v4-flash`), guarded to fall back to catalog order if the id ever drops out of the curated list. Interactive picker (`hermes model` / GUI onboarding) unchanged — still uses the tier-aware resolver.
- `tests/test_empty_model_fallback.py`: regression tests — Nous silent default is not the expensive flagship and is not `_PROVIDER_MODELS["nous"][0]`; override falls back to catalog `[0]` when the override id is absent.

## Validation
| | Before | After |
|---|---|---|
| `get_default_model_for_provider("nous")` | `anthropic/claude-opus-4.8` | `deepseek/deepseek-v4-flash` |
| non-aggregator (`openai-codex`) | `gpt-5.5` | `gpt-5.5` (unchanged) |
| unknown provider | `""` | `""` (unchanged) |

`tests/test_empty_model_fallback.py` → 14/14 pass. E2E with real imports confirms the resolution path lands on deepseek-v4-flash, not opus.

Closes #39669.

## Infographic

![nous-silent-default-fix](https://v3b.fal.media/files/b/0a9d0f49/Sp6vnkSu37mB9wtnNX-TS_fAwcsc0I.png)
