### PR TITLE
fix(cron): isolate profile job scheduler home

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -224,7 +224,20 @@ _hermes_home: Path | None = None
 
 
 def _get_hermes_home() -> Path:
-    """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
+    """Resolve Hermes home dynamically while preserving test monkeypatch hooks.
+
+    Context-local profile overrides must win over the legacy module-level
+    test hook.  The hook is process-global, so using it for per-job profile
+    switching can leak a profile job's home into unrelated parallel jobs.
+    """
+    try:
+        from hermes_constants import get_hermes_home_override
+
+        override = get_hermes_home_override()
+        if override:
+            return Path(override)
+    except Exception:
+        pass
     return _hermes_home or get_hermes_home()
 
 
@@ -241,10 +254,10 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
 
     Cron jobs are stored and scheduled by the profile running the scheduler, but
     an individual job can opt into a different runtime profile. While active,
-    the scheduler's test/override hook and a context-local Hermes home override
-    both point at the resolved profile directory so _get_hermes_home(),
-    .env/config loading, script resolution, AIAgent construction, and downstream
-    get_hermes_home() callers agree on the same home.
+    a context-local Hermes home override points at the resolved profile
+    directory so _get_hermes_home(), .env/config loading, script resolution,
+    AIAgent construction, and downstream get_hermes_home() callers agree on
+    the same home without mutating scheduler-global path state.
 
     Some existing provider/config paths still load profile .env values through
     os.environ, so profile jobs also snapshot and restore the process
@@ -256,8 +269,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         yield None
         return
 
-    global _hermes_home
-    prior_override = _hermes_home
     env_snapshot = os.environ.copy()
 
     from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
@@ -278,7 +289,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     override_token = None
     try:
         override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
         logger.info(
             "Job '%s': using Hermes profile '%s' (%s)",
             job_id,
@@ -287,7 +297,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         )
         yield normalized_profile
     finally:
-        _hermes_home = prior_override
         if override_token is not None:
             reset_hermes_home_override(override_token)
         # Delta-based restore: remove added keys, restore changed keys.
@@ -2084,8 +2093,8 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         # Partition due jobs: jobs with a per-job workdir and/or profile touch
         # process-global runtime state inside run_job. Workdir jobs temporarily
         # set os.environ["TERMINAL_CWD"]; profile jobs use a context-local
-        # Hermes home override, scheduler _hermes_home hook, and temporary
-        # profile .env load into os.environ with snapshot/restore. They MUST run
+        # Hermes home override plus temporary profile .env load into os.environ
+        # with snapshot/restore. They MUST run
         # sequentially to avoid corrupting each other. Jobs without either field
         # stay parallel-safe.
         sequential_jobs = [

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2402,6 +2402,96 @@ class TestParallelTick:
         assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
         assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
 
+    def test_profile_job_does_not_leak_script_home_to_parallel_profileless_job(self, tmp_path, monkeypatch):
+        """A profile job running in the sequential pool must not retarget a
+        simultaneous profile-less script job in the parallel pool.
+
+        Regression for mixed-profile scheduler ticks: a job stored by the
+        scheduler profile with ``profile=None`` should resolve its relative
+        script under that scheduler profile, even while a different
+        ``profile=linearops`` job is active.
+        """
+        import threading
+
+        from cron import scheduler
+
+        scheduler._shutdown_parallel_pool()
+        scheduler._running_job_ids.clear()
+        monkeypatch.delenv("HERMES_CRON_MAX_PARALLEL", raising=False)
+
+        root = tmp_path / ".hermes"
+        mister_home = root / "profiles" / "mister"
+        linearops_home = root / "profiles" / "linearops"
+        (mister_home / "scripts").mkdir(parents=True)
+        (linearops_home / "scripts").mkdir(parents=True)
+        (mister_home / "scripts" / "mister-only.sh").write_text(
+            "#!/usr/bin/env bash\necho mister-home-ok\n",
+            encoding="utf-8",
+        )
+        (linearops_home / "scripts" / "linearops-slow.sh").write_text(
+            "#!/usr/bin/env bash\necho linearops-ok\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(mister_home))
+
+        profile_context_entered = threading.Event()
+        release_profile_job = threading.Event()
+        original_run_script = scheduler._run_job_script
+
+        def coordinated_run_script(script_path):
+            active_home = scheduler._get_hermes_home().resolve()
+            if script_path == "linearops-slow.sh":
+                assert active_home == linearops_home.resolve()
+                profile_context_entered.set()
+                assert release_profile_job.wait(5), "profile-less script never ran"
+                return True, "linearops-ok"
+            if script_path == "mister-only.sh":
+                assert profile_context_entered.wait(5), "profile job never entered profile context"
+                try:
+                    return original_run_script(script_path)
+                finally:
+                    release_profile_job.set()
+            return original_run_script(script_path)
+
+        jobs = [
+            {
+                "id": "linearops-job",
+                "name": "linearops",
+                "deliver": "local",
+                "profile": "linearops",
+                "no_agent": True,
+                "script": "linearops-slow.sh",
+            },
+            {
+                "id": "mister-job",
+                "name": "mister",
+                "deliver": "local",
+                "profile": None,
+                "no_agent": True,
+                "script": "mister-only.sh",
+            },
+        ]
+
+        try:
+            with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+                 patch("cron.scheduler.advance_next_run"), \
+                 patch("cron.scheduler._run_job_script", side_effect=coordinated_run_script), \
+                 patch("cron.scheduler.save_job_output", return_value="/tmp/out.md") as save_mock, \
+                 patch("cron.scheduler._deliver_result", return_value=None), \
+                 patch("cron.scheduler.mark_job_run") as mark_mock:
+                result = scheduler.tick(verbose=False)
+        finally:
+            release_profile_job.set()
+            scheduler._shutdown_parallel_pool()
+            scheduler._running_job_ids.clear()
+
+        assert result == 2
+        saved_docs = {call.args[0]: call.args[1] for call in save_mock.call_args_list}
+        assert "mister-home-ok" in saved_docs["mister-job"]
+        assert "Script not found" not in saved_docs["mister-job"]
+        mark_status = {call.args[0]: call.args[1] for call in mark_mock.call_args_list}
+        assert mark_status == {"linearops-job": True, "mister-job": True}
+
     def test_max_parallel_env_var(self, monkeypatch):
         """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
         monkeypatch.setenv("HERMES_CRON_MAX_PARALLEL", "1")


### PR DESCRIPTION
## Summary
- Stop profile-scoped cron jobs from mutating the scheduler-global `_hermes_home` override.
- Resolve cron homes through the context-local Hermes home override, so `profile=None` jobs keep using the scheduler profile while mixed-profile jobs run in the sequential pool.
- Add a regression test where a `profile=linearops` script job overlaps a profile-less Mister script job.

## Test Plan
- `python3 -m pytest tests/cron/test_scheduler.py::TestParallelTick::test_profile_job_does_not_leak_script_home_to_parallel_profileless_job -q -o 'addopts='`
- `python3 -m pytest tests/cron/test_cron_profile.py -q -o 'addopts='`
- `python3 -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
- `python3 -m pytest tests/cron -q -o 'addopts='`

## Linear
- MIS-240
