### PR TITLE
fix(file-ops): fix unreachable rg/grep error guard in search methods

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2042,8 +2042,8 @@ class ShellFileOperations(FileOperations):
         result = self._exec(cmd, timeout=60)
         
         # rg exit codes: 0=matches found, 1=no matches, 2=error
-        if result.exit_code == 2 and not result.stdout.strip():
-            error_msg = result.stderr.strip() if hasattr(result, 'stderr') and result.stderr else "Search error"
+        if result.exit_code == 2:
+            error_msg = result.stdout.strip() or "Search error"
             return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
         
         # Parse results based on output mode
@@ -2142,8 +2142,8 @@ class ShellFileOperations(FileOperations):
         result = self._exec(cmd, timeout=60)
         
         # grep exit codes: 0=matches found, 1=no matches, 2=error
-        if result.exit_code == 2 and not result.stdout.strip():
-            error_msg = result.stderr.strip() if hasattr(result, 'stderr') and result.stderr else "Search error"
+        if result.exit_code == 2:
+            error_msg = result.stdout.strip() or "Search error"
             return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
         
         if output_mode == "files_only":


### PR DESCRIPTION
## What does this PR do?

Fixes an unreachable error guard in `_search_with_rg()` and `_search_with_grep()` that prevented search errors from being reported correctly.

## Type of Change
- [x] Bug fix

## Changes Made

`_exec()` captures command output in `stdout` only (via `stderr=subprocess.STDOUT`). When `rg` or `grep` exits with code 2 (error), diagnostic messages appear in `stdout`. The original guard:

```python
if result.exit_code == 2 and not result.stdout.strip():
    error_msg = result.stderr.strip() if hasattr(result, 'stderr') and result.stderr else "Search error"
```

Had two bugs:
1. `not result.stdout.strip()` was always `False` when rg/grep errored — the error text IS in stdout, so the branch never fired. Error text was parsed as file paths or match lines instead.
2. `hasattr(result, 'stderr')` is dead code — `ExecuteResult` has no `stderr` field.

Fix:

```python
if result.exit_code == 2:
    error_msg = result.stdout.strip() or "Search error"
```

Affects both `_search_with_rg` (L2045) and `_search_with_grep` (L2145).

## Root Cause
Same stdout/stderr pattern as #39366 — `_exec()` merges stderr into stdout but the error handling code assumed they were separate.

## How to Test
Trigger a search with an invalid regex or unreadable path. Before this fix the error was silently parsed as results. After: `SearchResult.error` is populated correctly.

## Checklist
- [x] Single focused change
- [x] No unrelated modifications