### PR TITLE
fix(desktop): dismiss file preview tabs when switching conversations (#39657)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
@@ -4,12 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
 import {
+  $filePreviewTabs,
   $previewTarget,
   clearSessionPreviewRegistry,
   type PreviewTarget,
-  registerSessionPreview
+  registerSessionPreview,
+  setCurrentSessionPreviewTarget
 } from '@/store/preview'
-import { $currentCwd, $messages } from '@/store/session'
+import { $activeSessionId, $currentCwd, $messages, $selectedStoredSessionId } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
 import { usePreviewRouting } from './use-preview-routing'
@@ -37,8 +39,15 @@ function previewTarget(source: string): PreviewTarget {
 
 let handleEvent: (event: RpcEvent) => void = () => undefined
 
-function PreviewRoutingHarness({ onEvent }: { onEvent: (handler: (event: RpcEvent) => void) => void }) {
-  const activeSessionIdRef = useRef<string | null>('session-1')
+function PreviewRoutingHarness({
+  onEvent,
+  routedSessionId = 'session-1'
+}: {
+  onEvent: (handler: (event: RpcEvent) => void) => void
+  routedSessionId?: string
+}) {
+  const activeSessionIdRef = useRef<string | null>(routedSessionId)
+  activeSessionIdRef.current = routedSessionId
 
   const routing = usePreviewRouting({
     activeSessionIdRef,
@@ -46,7 +55,7 @@ function PreviewRoutingHarness({ onEvent }: { onEvent: (handler: (event: RpcEven
     currentCwd: '/work',
     currentView: 'chat',
     requestGateway: vi.fn(),
-    routedSessionId: 'session-1',
+    routedSessionId,
     selectedStoredSessionId: null
   })
 
@@ -62,6 +71,8 @@ describe('usePreviewRouting', () => {
     $currentCwd.set('/work')
     $messages.set([])
     $previewTarget.set(null)
+    $activeSessionId.set('session-1')
+    $selectedStoredSessionId.set(null)
     clearSessionPreviewRegistry()
     handleEvent = () => undefined
     window.localStorage.clear()
@@ -78,6 +89,9 @@ describe('usePreviewRouting', () => {
     cleanup()
     $messages.set([])
     $previewTarget.set(null)
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $filePreviewTabs.set([])
     vi.restoreAllMocks()
     clearSessionPreviewRegistry()
     window.localStorage.clear()
@@ -98,6 +112,79 @@ describe('usePreviewRouting', () => {
     await waitFor(() => {
       expect($previewTarget.get()).toEqual({ ...target, renderMode: 'preview' })
     })
+  })
+
+  it('dismisses a file preview tab when switching to another conversation', async () => {
+    const file = previewTarget('/work/attachment.png')
+
+    // Opened while session-1 is active → tagged with session-1.
+    setCurrentSessionPreviewTarget(file, 'manual')
+    expect($filePreviewTabs.get()).toHaveLength(1)
+
+    const { rerender } = render(
+      <PreviewRoutingHarness
+        onEvent={handler => {
+          handleEvent = handler
+        }}
+        routedSessionId="session-1"
+      />
+    )
+
+    // The file belongs to session-1, so it survives while that conversation is active.
+    expect($filePreviewTabs.get()).toHaveLength(1)
+
+    // Switching conversations moves both the active session and the route.
+    act(() => {
+      $activeSessionId.set('session-2')
+    })
+    rerender(
+      <PreviewRoutingHarness
+        onEvent={handler => {
+          handleEvent = handler
+        }}
+        routedSessionId="session-2"
+      />
+    )
+
+    await waitFor(() => {
+      expect($filePreviewTabs.get()).toEqual([])
+    })
+  })
+
+  it('keeps a tab scoped to the routed session when the runtime session store diverges', async () => {
+    const file = previewTarget('/work/attachment.png')
+
+    // Opened while session-1 is active → tagged with session-1.
+    setCurrentSessionPreviewTarget(file, 'manual')
+    expect($filePreviewTabs.get()[0]?.sessionId).toBe('session-1')
+
+    // A distinct live preview for session-1 lets us observe that the effect
+    // routes to session-1 (not the diverged runtime session-2).
+    const livePreview = previewTarget('/work/live.html')
+    registerSessionPreview('session-1', livePreview, 'tool-result')
+
+    // The runtime `$activeSessionId` store advances to session-2, but the hook
+    // is still routing to session-1 (routedSessionId). Scoping the sync to a
+    // re-derived current id (which reads the session-2 store) would wrongly drop
+    // the session-1 tab we are still viewing; scoping to the routed id keeps it.
+    act(() => {
+      $activeSessionId.set('session-2')
+    })
+    render(
+      <PreviewRoutingHarness
+        onEvent={handler => {
+          handleEvent = handler
+        }}
+        routedSessionId="session-1"
+      />
+    )
+
+    // The effect ran and routed to session-1's live preview...
+    await waitFor(() => {
+      expect($previewTarget.get()).toEqual({ ...livePreview, renderMode: 'preview' })
+    })
+    // ...and the session-1 file tab was kept, not dropped by the stale runtime id.
+    expect($filePreviewTabs.get()).toHaveLength(1)
   })
 
   it('does not infer previews from assistant prose', async () => {

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -12,7 +12,8 @@ import {
   progressPreviewServerRestart,
   requestPreviewReload,
   setCurrentSessionPreviewTarget,
-  setPreviewTarget
+  setPreviewTarget,
+  syncFilePreviewTabsForSession
 } from '@/store/preview'
 import { $currentCwd } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
@@ -63,6 +64,8 @@ export function usePreviewRouting({
 
       return
     }
+
+    syncFilePreviewTabsForSession(previewSessionId)
 
     const record = getSessionPreviewRecord(previewSessionId)
 

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -12,11 +12,13 @@ import {
   beginPreviewServerRestart,
   clearSessionPreviewRegistry,
   closeActiveRightRailTab,
+  decodeFilePreviewTabs,
   dismissPreviewTarget,
   getSessionPreviewRecord,
   type PreviewTarget,
   progressPreviewServerRestart,
-  setCurrentSessionPreviewTarget
+  setCurrentSessionPreviewTarget,
+  syncFilePreviewTabsForSession
 } from './preview'
 import { $activeSessionId, $selectedStoredSessionId } from './session'
 
@@ -134,5 +136,69 @@ describe('preview store', () => {
     expect($filePreviewTarget.get()).toBeNull()
     expect($rightRailActiveTabId.get()).toBe(RIGHT_RAIL_PREVIEW_TAB_ID)
     expect($previewTarget.get()).toEqual(withRenderMode(live, 'preview'))
+  })
+
+  it('drops file preview tabs from other sessions when the routed session changes', () => {
+    const file = previewTarget('/work/file.html')
+
+    setCurrentSessionPreviewTarget(file, 'manual')
+
+    expect($filePreviewTabs.get()).toHaveLength(1)
+    expect($filePreviewTabs.get()[0]?.sessionId).toBe('session-1')
+    expect($rightRailActiveTabId.get()).toBe(`file:${file.url}`)
+
+    // Routing to a conversation that does not contain the attachment must
+    // dismiss the leaked file tab and fall back to the live preview tab.
+    syncFilePreviewTabsForSession('session-2')
+
+    expect($filePreviewTabs.get()).toEqual([])
+    expect($rightRailActiveTabId.get()).toBe(RIGHT_RAIL_PREVIEW_TAB_ID)
+  })
+
+  it('keeps file preview tabs when re-syncing the same session', () => {
+    const file = previewTarget('/work/file.html')
+
+    setCurrentSessionPreviewTarget(file, 'manual')
+
+    // The routing effect re-runs on every registry update within the same
+    // session, so syncing the unchanged session must be a no-op.
+    syncFilePreviewTabsForSession('session-1')
+
+    expect($filePreviewTabs.get()).toHaveLength(1)
+    expect($rightRailActiveTabId.get()).toBe(`file:${file.url}`)
+  })
+
+  it('filters file tabs by the session id it is given', () => {
+    const file = previewTarget('/work/file.html')
+
+    setCurrentSessionPreviewTarget(file, 'manual')
+    expect($filePreviewTabs.get()[0]?.sessionId).toBe('session-1')
+
+    // The function scopes purely by its argument — the caller (the routing
+    // effect) is responsible for passing the session it is routing to. Syncing
+    // against a non-matching id drops the tab.
+    syncFilePreviewTabsForSession('session-1')
+    expect($filePreviewTabs.get()).toHaveLength(1)
+
+    syncFilePreviewTabsForSession('other-session')
+    expect($filePreviewTabs.get()).toEqual([])
+  })
+
+  it('drops legacy and blank-session persisted file tabs on decode', () => {
+    const scoped = {
+      id: 'file:///work/new.html',
+      sessionId: 'session-1',
+      target: previewTarget('/work/new.html')
+    }
+
+    // A pre-scoping row carries no sessionId, and a blank sessionId is just as
+    // unattributable — neither can be scoped to a conversation, so decode must
+    // reject both rather than surface an unscoped tab.
+    const legacy = { id: 'file:///work/old.html', target: previewTarget('/work/old.html') }
+    const blank = { id: 'file:///work/blank.html', sessionId: '', target: previewTarget('/work/blank.html') }
+
+    const decoded = decodeFilePreviewTabs(JSON.stringify([scoped, legacy, blank]))
+
+    expect(decoded).toEqual([scoped])
   })
 })

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -57,6 +57,7 @@ type SessionPreviewRegistry = Record<string, SessionPreviewRecord[]>
 
 export interface FilePreviewTab {
   id: `file:${string}`
+  sessionId: string
   target: PreviewTarget
 }
 
@@ -66,15 +67,21 @@ const MAX_RECORDS_PER_SESSION = 1
 const MAX_SESSIONS = 120
 
 export const $previewTarget = atom<PreviewTarget | null>(null)
+
 // Persisted so open file-preview tabs survive a relaunch; content is re-read
 // from each target's path/url on demand. Invalid rows are dropped on load and
 // inline image bytes (megabytes) are stripped on save, mirroring the registry.
-export const $filePreviewTabs = persistentAtom<FilePreviewTab[]>(TABS_STORAGE_KEY, [], {
-  decode: raw => {
-    const parsed = JSON.parse(raw) as unknown
+// Exported so the persisted-tab contract can be regression-tested directly:
+// legacy rows written before file tabs were session-scoped ({ id, target }, no
+// `sessionId`) must be dropped rather than surfaced as unscoped tabs.
+export function decodeFilePreviewTabs(raw: string): FilePreviewTab[] {
+  const parsed = JSON.parse(raw) as unknown
 
-    return Array.isArray(parsed) ? parsed.filter(isFilePreviewTab) : []
-  },
+  return Array.isArray(parsed) ? parsed.filter(isFilePreviewTab) : []
+}
+
+export const $filePreviewTabs = persistentAtom<FilePreviewTab[]>(TABS_STORAGE_KEY, [], {
+  decode: decodeFilePreviewTabs,
   encode: tabs => JSON.stringify(tabs, (key, value) => (key === 'dataUrl' ? undefined : value))
 })
 
@@ -151,11 +158,11 @@ export function filePreviewTabId(target: PreviewTarget): `file:${string}` {
   return `file:${target.url}`
 }
 
-function openFilePreviewTarget(target: PreviewTarget) {
+function openFilePreviewTarget(sessionId: string, target: PreviewTarget) {
   const id = filePreviewTabId(target)
   const current = $filePreviewTabs.get()
   const index = current.findIndex(tab => tab.id === id)
-  const tab: FilePreviewTab = { id, target }
+  const tab: FilePreviewTab = { id, sessionId, target }
 
   $filePreviewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
   setPaneOpen(PREVIEW_PANE_ID, true)
@@ -176,12 +183,12 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
   return { ...target, renderMode: isFilePreviewSource(source) ? 'source' : 'preview' }
 }
 
-function tryOpenFilePreview(target: PreviewTarget, source: PreviewRecordSource): boolean {
+function tryOpenFilePreview(sessionId: string, target: PreviewTarget, source: PreviewRecordSource): boolean {
   if (target.kind !== 'file' || !isFilePreviewSource(source)) {
     return false
   }
 
-  openFilePreviewTarget(previewTargetForSource(target, source))
+  openFilePreviewTarget(sessionId, previewTargetForSource(target, source))
 
   return true
 }
@@ -208,7 +215,17 @@ function isFilePreviewTab(value: unknown): value is FilePreviewTab {
 
   const r = value as Record<string, unknown>
 
-  return typeof r.id === 'string' && r.id.startsWith('file:') && isPreviewTarget(r.target)
+  // `sessionId` was added when file tabs became session-scoped. Legacy rows
+  // ({ id, target }) predate it, and a blank id carries no conversation
+  // identity either — neither can be scoped to a session, so reject both here
+  // instead of loading a tab that would leak into the wrong conversation.
+  return (
+    typeof r.id === 'string' &&
+    r.id.startsWith('file:') &&
+    typeof r.sessionId === 'string' &&
+    r.sessionId.length > 0 &&
+    isPreviewTarget(r.target)
+  )
 }
 
 function isPreviewRecord(value: unknown): value is SessionPreviewRecord {
@@ -348,7 +365,7 @@ export function setSessionPreviewTarget(
   source: PreviewRecordSource,
   rawTarget = target.source
 ): SessionPreviewRecord | null {
-  if (tryOpenFilePreview(target, source)) {
+  if (tryOpenFilePreview(sessionId?.trim() || '', target, source)) {
     return null
   }
 
@@ -541,6 +558,38 @@ export function closeRightRailTabsToRight(tabId: RightRailTabId) {
 
   for (const id of order.slice(index + 1)) {
     closeRightRailTab(id)
+  }
+}
+
+/**
+ * Scope the open file preview tabs to a conversation. File previews are opened
+ * against whichever session was current at the time, so switching to another
+ * conversation must drop tabs that belong elsewhere — the file is not part of
+ * the new conversation.
+ *
+ * Callers pass the session identity they are routing to. The session-routing
+ * effect derives that id as `selectedStoredSessionId || routedSessionId ||
+ * activeSessionIdRef.current`, which can lead the runtime `$activeSessionId`
+ * mid-switch; syncing against the caller's resolved id (rather than
+ * re-deriving `currentPreviewSessionId()` here) keeps the filter aligned with
+ * the session whose preview is being restored. Re-syncing with the same id the
+ * tabs are tagged with is a no-op, so the effect can call this on every render
+ * without clobbering same-session tabs.
+ */
+export function syncFilePreviewTabsForSession(sessionId: string) {
+  const current = $filePreviewTabs.get()
+  const next = current.filter(tab => tab.sessionId === sessionId)
+
+  if (next.length === current.length) {
+    return
+  }
+
+  $filePreviewTabs.set(next)
+
+  const activeTabId = $rightRailActiveTabId.get()
+
+  if (activeTabId.startsWith('file:') && !next.some(tab => tab.id === activeTabId)) {
+    selectRightRailTab(next[0]?.id ?? RIGHT_RAIL_PREVIEW_TAB_ID)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the **cross-conversation persistence** half of #39657: opening an image/file preview in one conversation left the preview tab visible after switching to a different conversation that does not contain that attachment.

## Related Issue

Addresses #39657 (the persistence issue). The top-right **overlap** with the window controls reported in the same issue is a separate titlebar/layout concern and is intentionally left as a follow-up — see Scope below.

## Root cause

File preview tabs live in `$filePreviewTabs` (`apps/desktop/src/store/preview.ts`), a flat global atom whose `FilePreviewTab` records carried no session association. The live preview (`$previewTarget`) is already re-scoped per session — `usePreviewRouting`'s effect reads the per-session `$sessionPreviewRegistry` on every session change and resets the target. But `$filePreviewTabs` was never touched on a session change, so a file tab opened in session A stayed mounted when you switched to session B.

Clicking an image/file attachment routes through `setCurrentSessionPreviewTarget(..., 'manual', ...)` → `tryOpenFilePreview` → `$filePreviewTabs`, which is exactly the leaking path.

## Fix

- Tag each `FilePreviewTab` with the `sessionId` it was opened under (threaded through `tryOpenFilePreview`/`openFilePreviewTarget` from the `sessionId` the caller already passes).
- Add `syncFilePreviewTabsForSession(sessionId)`: keeps only tabs belonging to the given session, and re-selects the live-preview tab if the active file tab was dropped. Re-syncing the current session is a **no-op**, so it's safe to call on every render.
- `usePreviewRouting`'s session effect now calls it alongside the existing `$previewTarget` reset — clearing other-session tabs on a real session switch, without clobbering same-session tabs when the effect re-runs on registry updates.

Net production change is ~8 lines of logic; no new dependencies, no behavior change for the same-session case.

## How to Test

1. Open the Desktop app, open a conversation that has an image/file attachment.
2. Click the attachment to open its preview tab (top-right rail).
3. Switch to a different conversation that does **not** contain that attachment.
4. **Before:** the file preview tab persists. **After:** the tab is dismissed and the rail falls back to the live-preview tab.

Automated coverage (`npm run test:ui`, run from `apps/desktop`):
- `store/preview.test.ts` — drops other-session tabs on switch; keeps same-session tabs on re-sync.
- `app/session/hooks/use-preview-routing.test.tsx` — file tab is dismissed when the routed session changes. This test **fails without the effect-level call**, so it pins the regression.

All preview/routing tests green; `tsc -b` and `eslint` clean. (Pre-existing unrelated failures in `model-settings`/`toolset`/`skills`/`streaming`/`pane-shell` suites reproduce on a clean `main` checkout too.)

## Scope — intentionally not changed

- **Top-right overlap (the other half of #39657).** The preview tab bar visually colliding with the window controls is a titlebar/z-index layout problem (`app/shell` `--titlebar-tools-right`/`--titlebar-tools-width` reservations), not a state bug. It needs a packaged Desktop build to repro and verify a CSS fix with before/after evidence, so it's deliberately out of scope here to keep this PR a small, fully unit-tested state fix. Happy to follow up with a dedicated layout PR.
- Live preview (`$previewTarget`) behavior is unchanged — it was already correctly per-session.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)