### PR TITLE
fix(cli): require explicit setup before treating env keys as configured

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -665,12 +665,14 @@ def _has_any_provider_configured() -> bool:
     for pconfig in PROVIDER_REGISTRY.values():
         if pconfig.auth_type == "api_key":
             provider_env_vars.update(pconfig.api_key_env_vars)
-    if any(os.getenv(v) for v in provider_env_vars):
+    # Env-detected keys only count once Hermes has been explicitly set up
+    # — same precedent as the Claude Code path below. See #38471.
+    if _has_hermes_config and any(os.getenv(v) for v in provider_env_vars):
         return True
 
     # Check .env file for keys
     env_file = get_env_path()
-    if env_file.exists():
+    if _has_hermes_config and env_file.exists():
         try:
             for line in env_file.read_text(encoding="utf-8").splitlines():
                 line = line.strip()

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -692,22 +692,67 @@ class TestRuntimeProviderResolution:
 class TestHasAnyProviderConfigured:
 
     def test_glm_key_counts(self, monkeypatch, tmp_path):
+        import yaml
         from hermes_cli import config as config_module
         monkeypatch.setenv("GLM_API_KEY", "test-key")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.dump({"model": {"default": "my-configured-model"}})
+        )
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is True
 
     def test_minimax_key_counts(self, monkeypatch, tmp_path):
+        import yaml
         from hermes_cli import config as config_module
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.dump({"model": {"default": "my-configured-model"}})
+        )
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is True
+
+    def test_stale_env_key_without_hermes_config_does_not_skip_onboarding(
+        self, monkeypatch, tmp_path
+    ):
+        """Regression test for #38471."""
+        from hermes_cli import config as config_module
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-stale-key-from-some-other-tool")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
+        monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("hermes_cli.copilot_auth.resolve_copilot_token", lambda: ("", ""))
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda _pid: {})
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None,
+        )
+        from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is False
+
+    def test_stale_env_key_with_hermes_config_counts(self, monkeypatch, tmp_path):
+        import yaml
+        from hermes_cli import config as config_module
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-user-key-from-onboarding")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.dump({"model": {"default": "anthropic/claude-opus-4.6", "provider": "openrouter"}})
+        )
+        monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
+        monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is True
 


### PR DESCRIPTION
## What does this PR do?

`_has_any_provider_configured()` currently treats the presence of any provider env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) as proof that Hermes is already set up, and skips onboarding accordingly. That assumption is wrong when the env var belongs to some other tool — Hermes boots straight into the chat, the model picker surfaces `openai-api/*` rows from the stale key, every send returns 401, and the user is given no in-app affordance to recover.

The fix gates the env-var and `.env` paths on the same `_has_hermes_config` signal that the Claude Code OAuth path already uses (a few lines below in the same function). After the fix, env vars only count as "configured" once the user has explicitly completed setup. A stale key from another tool no longer bypasses onboarding; once the user picks a provider in the wizard, their explicit choice is what's used.

## Related Issue

Fixes #38471

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_has_any_provider_configured()` now requires
  `_has_hermes_config` before treating env-detected provider keys or `.env` entries as "configured".
- `tests/hermes_cli/test_api_key_providers.py`:
  - Updated `test_glm_key_counts` and `test_minimax_key_counts` to write an explicit Hermes config alongside the env key (both still pass).
  - Added `test_stale_env_key_without_hermes_config_does_not_skip_onboarding`
    — the #38471 regression, asserts False.
  - Added `test_stale_env_key_with_hermes_config_counts` — counterpart, asserts True once setup has been completed.

## How to Test

1. On a clean Windows install (no `~/.hermes/config.yaml`), set a leftover `OPENAI_API_KEY` at machine scope: `[System.Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "FAKE", "Machine")`
2. Launch Hermes Desktop.
   - Before this fix: app jumps straight to chat, picker shows `openai-api/*` rows, sending fails with 401.
   - With this fix: onboarding overlay appears as expected; the user picks a provider, finishes setup, and gets a working chat.
3. `pytest tests/hermes_cli/test_api_key_providers.py::TestHasAnyProviderConfigured -q`
   — 11 passed.
