### PR TITLE
feat: allow safe recursive deletion of cache dirs

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -863,6 +863,39 @@ code_execution:
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================
+# Approval Prompts
+# =============================================================================
+# Controls how Hermes handles commands classified as dangerous.
+#
+# mode:
+#   manual - always prompt the user (default)
+#   smart  - use an auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
+#   off    - skip all approval prompts (equivalent to --yolo)
+#
+# safe_delete_roots allows literal child `rm` targets under disposable roots to
+# skip approval. safe_delete_dir_names allows recursive deletion of literal cache
+# directory basenames from any parent. Deleting roots, traversal, globs, shell
+# expansion, compound commands, and mixed safe/unsafe targets remain gated.
+approvals:
+  mode: "manual"
+  timeout: 60
+  cron_mode: "deny"  # Cron jobs deny dangerous commands by default.
+  safe_delete_roots:
+    - "/tmp"
+    - "/private/tmp"
+  safe_delete_dir_names:
+    - "__pycache__"
+    - ".pytest_cache"
+    - ".mypy_cache"
+    - ".ruff_cache"
+    - ".pyre"
+    - ".pytype"
+    - ".tox"
+    - ".nox"
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1907,6 +1907,23 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # Absolute roots where literal child rm targets may skip approval.
+        # This is for disposable sandboxes such as /tmp; deleting the root
+        # itself, globs, traversal, and shell-expanded targets stay gated.
+        "safe_delete_roots": ["/tmp", "/private/tmp"],
+        # Literal cache directory basenames where recursive rm may skip
+        # approval from any parent path. Only exact basenames are allowed;
+        # traversal, globs, shell expansion, and mixed unsafe targets stay gated.
+        "safe_delete_dir_names": [
+            "__pycache__",
+            ".pytest_cache",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".pyre",
+            ".pytype",
+            ".tox",
+            ".nox",
+        ],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -53,7 +53,7 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
     def test_rm_recursive_long_flag(self):
-        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /tmp/stuff")
+        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /home/user/stuff")
         assert is_dangerous is True
         assert key is not None
         assert "delete" in desc.lower()
@@ -231,7 +231,7 @@ class TestRmRecursiveFlagVariants:
         assert "recursive" in desc.lower() or "delete" in desc.lower()
 
     def test_rm_rf(self):
-        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/test")
+        dangerous, key, desc = detect_dangerous_command("rm -rf /home/user/test")
         assert dangerous is True
         assert key is not None
 
@@ -259,6 +259,137 @@ class TestRmRecursiveFlagVariants:
         dangerous, key, desc = detect_dangerous_command("sudo rm -rf /tmp")
         assert dangerous is True
         assert key is not None
+
+
+class TestScopedSafeDeleteRoots:
+    """Scoped sandbox cleanup should avoid prompts without broad rm bypasses."""
+
+    def test_default_tmp_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm /tmp/hermes-output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_tmp_recursive_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm /workfolder/output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_recursive_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run-123/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_safe_root_itself_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_glob_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/*")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_traversal_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/../etc")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_sibling_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder2/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_multiple_targets_require_every_target_scoped(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_shell_expansion_target_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/$RUN_ID")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_compound_safe_then_dangerous_rm_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run; rm -rf /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+
+class TestSafeDeleteDirNames:
+    """Known cache directories can be removed recursively without prompts."""
+
+    def test_default_pycache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_nested_pycache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf pkg/__pycache__")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_pytest_cache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf .pytest_cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_cache_basename_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_dir_names": [".custom_cache"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf build/.custom_cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_dynamic_cache_target_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf $CACHE_DIR")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_traversal_to_safe_basename_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf pkg/../__pycache__")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_mixed_safe_dir_name_and_unsafe_target_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__ /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_glob_inside_safe_dir_name_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__/*")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
 
 
 class TestMultilineBypass:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -11,7 +11,9 @@ This module is the single source of truth for the dangerous command system:
 import contextvars
 import logging
 import os
+import posixpath
 import re
+import shlex
 import sys
 import threading
 import time
@@ -540,15 +542,179 @@ def _normalize_command_for_detection(command: str) -> str:
     return command
 
 
+_DEFAULT_SAFE_DELETE_ROOTS = ("/tmp", "/private/tmp")
+_DEFAULT_SAFE_DELETE_DIR_NAMES = (
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pyre",
+    ".pytype",
+    ".tox",
+    ".nox",
+)
+_DELETE_TARGET_UNSAFE_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}")
+
+
+def _configured_safe_delete_roots() -> tuple[str, ...]:
+    """Return absolute roots where scoped rm targets can skip approvals."""
+    roots: list[str] = list(_DEFAULT_SAFE_DELETE_ROOTS)
+    configured = _get_approval_config().get("safe_delete_roots", [])
+    if isinstance(configured, str):
+        configured = [configured]
+    elif not isinstance(configured, (list, tuple, set)):
+        configured = []
+
+    for root in configured:
+        roots.append(str(root))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        root = root.strip()
+        if not root.startswith("/"):
+            continue
+        root = posixpath.normpath(root)
+        if root in {"/", "."} or root in seen:
+            continue
+        normalized.append(root)
+        seen.add(root)
+    return tuple(normalized)
+
+
+def _configured_safe_delete_dir_names() -> tuple[str, ...]:
+    """Return literal directory basenames where recursive rm can skip approvals."""
+    names: list[str] = list(_DEFAULT_SAFE_DELETE_DIR_NAMES)
+    configured = _get_approval_config().get("safe_delete_dir_names", [])
+    if isinstance(configured, str):
+        configured = [configured]
+    elif not isinstance(configured, (list, tuple, set)):
+        configured = []
+
+    for name in configured:
+        names.append(str(name))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        name = name.strip()
+        if not name or name in {".", ".."} or "/" in name or name in seen:
+            continue
+        if any(marker in name for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+            continue
+        normalized.append(name)
+        seen.add(name)
+    return tuple(normalized)
+
+
+def _contains_shell_separator(command: str) -> bool:
+    """Conservatively reject compound commands from scoped delete bypasses."""
+    return any(sep in command for sep in ("\n", "&&", "||", ";", "|"))
+
+
+def _rm_tokens(command: str) -> list[str]:
+    if _contains_shell_separator(command):
+        return []
+    try:
+        tokens = shlex.split(command.strip(), posix=True)
+    except ValueError:
+        return []
+    return tokens if tokens and tokens[0] == "rm" else []
+
+
+def _rm_flag_is_recursive(flag: str) -> bool:
+    if flag == "--recursive":
+        return True
+    if flag.startswith("--"):
+        return False
+    return "r" in flag[1:] or "R" in flag[1:]
+
+
+def _rm_targets(command: str, require_recursive: bool) -> list[str]:
+    tokens = _rm_tokens(command)
+    if not tokens:
+        return []
+
+    flags: list[str] = []
+    targets: list[str] = []
+    after_double_dash = False
+    for token in tokens[1:]:
+        if after_double_dash:
+            targets.append(token)
+        elif token == "--":
+            after_double_dash = True
+        elif token.startswith("-") and token != "-":
+            flags.append(token)
+        else:
+            targets.append(token)
+
+    if require_recursive and not any(_rm_flag_is_recursive(flag) for flag in flags):
+        return []
+    return targets
+
+
+def _is_scoped_safe_delete_target(target: str) -> bool:
+    """True only for literal child paths under configured safe delete roots."""
+    if any(marker in target for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+        return False
+    if not target.startswith("/"):
+        return False
+
+    normalized = posixpath.normpath(target)
+    if normalized != target.rstrip("/"):
+        return False
+
+    for root in _configured_safe_delete_roots():
+        prefix = root + "/"
+        if not normalized.startswith(prefix):
+            continue
+        rest = normalized[len(prefix):]
+        first_component = rest.split("/", 1)[0]
+        return bool(first_component) and first_component not in {".", ".."}
+    return False
+
+
+def _is_safe_delete_dir_name_target(target: str) -> bool:
+    """True only for literal paths whose basename is an allowed cache dir."""
+    if any(marker in target for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+        return False
+
+    normalized = posixpath.normpath(target)
+    if normalized != target.rstrip("/"):
+        return False
+
+    basename = posixpath.basename(normalized)
+    return basename in _configured_safe_delete_dir_names()
+
+
+def _is_allowed_root_delete(command: str) -> bool:
+    """Allow non-recursive rm of literal children under safe delete roots."""
+    targets = _rm_targets(command, require_recursive=False)
+    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+
+
+def _is_allowed_recursive_delete(command: str) -> bool:
+    """Allow scoped recursive cleanup while keeping broad rm -r gated."""
+    targets = _rm_targets(command, require_recursive=True)
+    return bool(targets) and all(
+        _is_scoped_safe_delete_target(t) or _is_safe_delete_dir_name_target(t)
+        for t in targets
+    )
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = _normalize_command_for_detection(command).lower()
+    command_normalized = _normalize_command_for_detection(command)
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-        if pattern_re.search(command_lower):
+        if pattern_re.search(command_normalized):
+            if description == "delete in root path" and _is_allowed_root_delete(command_normalized):
+                continue
+            if description.startswith("recursive delete") and _is_allowed_recursive_delete(command_normalized):
+                continue
             pattern_key = description
             return (True, pattern_key, description)
     return (False, None, None)


### PR DESCRIPTION
## What does this PR do?

Allows low-risk cleanup commands to skip dangerous-command approval only when every `rm` target is provably scoped to a disposable path or known cache-directory basename.

This solves approval friction for common sandbox/cache cleanup like `/tmp/hermes-run/...` and `__pycache__` while keeping broad or ambiguous recursive deletion gated. The implementation parses simple `rm` commands with `shlex`, rejects compound commands, shell expansion, globs, traversal, root deletion, and mixed safe/unsafe target lists, and documents the new config keys in `cli-config.yaml.example`.

## Related Issue

No issue linked. Duplicate search performed:
- `safe delete roots rm approval repo:NousResearch/hermes-agent` -> no matching issues.
- `safe delete dir names rm approval repo:NousResearch/hermes-agent` -> no relevant duplicate; one broad docs/i18n issue matched unrelated text.
- `safe recursive deletion cache dirs repo:NousResearch/hermes-agent` -> only this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py` adds safe delete root and cache-dir basename checks for literal `rm` targets.
- `hermes_cli/config.py` adds default `approvals.safe_delete_roots` and `approvals.safe_delete_dir_names` config values.
- `cli-config.yaml.example` documents the new approval config keys and defaults.
- `tests/tools/test_approval.py` covers safe paths, unsafe roots, globs, traversal, shell expansion, compound commands, and mixed safe/unsafe target lists.

## How to Test

1. Run `UV_LINK_MODE=copy uv run --extra dev python -m pytest tests/tools/test_approval.py -q`.
2. Run `UV_LINK_MODE=copy uv run --extra dev python -m py_compile tools/approval.py hermes_cli/config.py tests/tools/test_approval.py`.
3. Run `UV_LINK_MODE=copy uv run --extra dev python scripts/check-windows-footguns.py --diff upstream/main`.
4. Run `git diff --check upstream/main...HEAD -- cli-config.yaml.example tools/approval.py hermes_cli/config.py tests/tools/test_approval.py && git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no tool schema or LLM-facing tool description changes

## Screenshots / Logs

Verification after the checklist doc update:

- `UV_LINK_MODE=copy uv run --extra dev python -m pytest tests/tools/test_approval.py -q` -> 222 passed.
- `UV_LINK_MODE=copy uv run --extra dev python -m py_compile tools/approval.py hermes_cli/config.py tests/tools/test_approval.py` -> passed.
- `UV_LINK_MODE=copy uv run --extra dev python scripts/check-windows-footguns.py --diff upstream/main` -> no Windows footguns found in 3 scanned files.
- `git diff --check upstream/main...HEAD -- cli-config.yaml.example tools/approval.py hermes_cli/config.py tests/tools/test_approval.py && git diff --check` -> passed.

Not run: full `pytest tests/ -q`.
