### PR TITLE
feat: optionally mention Discord approval owners

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -729,6 +729,7 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   approval_mentions: false         # Mention numeric allowed users on approval prompts (default: false)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1945,6 +1945,10 @@ DEFAULT_CONFIG = {
         # real memory cost. Default 32 MiB matches the historical hardcoded
         # cap. Set to 0 for no cap. Env override: DISCORD_MAX_ATTACHMENT_BYTES.
         "max_attachment_bytes": 33554432,
+        # When True, Discord approval prompts mention numeric allowed users so
+        # owners notice approval requests in shared channels/threads. Env override:
+        # DISCORD_APPROVAL_MENTIONS. Default false avoids surprise pings.
+        "approval_mentions": False,
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and
@@ -3252,6 +3256,13 @@ OPTIONAL_ENV_VARS = {
     "DISCORD_REPLY_TO_MODE": {
         "description": "Discord reply threading mode: 'off' (no reply references), 'first' (reply on first message only, default), 'all' (reply on every chunk)",
         "prompt": "Discord reply mode (off/first/all)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "DISCORD_APPROVAL_MENTIONS": {
+        "description": "Mention numeric DISCORD_ALLOWED_USERS in Discord command approval prompts (true/false)",
+        "prompt": "Mention allowed users in Discord approval prompts? (true/false)",
         "url": None,
         "password": False,
         "category": "messaging",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -143,6 +143,13 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"true", "1", "yes", "on"}
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -195,10 +202,7 @@ def _build_allowed_mentions():
         return None
 
     def _b(name: str, default: bool) -> bool:
-        raw = os.getenv(name, "").strip().lower()
-        if not raw:
-            return default
-        return raw in {"true", "1", "yes", "on"}
+        return _env_bool(name, default)
 
     return discord.AllowedMentions(
         everyone=_b("DISCORD_ALLOW_MENTION_EVERYONE", False),
@@ -4429,6 +4433,15 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return None
 
+    def _approval_mention_content(self) -> Optional[str]:
+        """Return user mentions for approval prompts when explicitly enabled."""
+        if not _env_bool("DISCORD_APPROVAL_MENTIONS", False):
+            return None
+        user_ids = sorted(uid for uid in self._allowed_user_ids if str(uid).isdigit())
+        if not user_ids:
+            return None
+        return " ".join(f"<@{uid}>" for uid in user_ids)
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -4469,7 +4482,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            send_kwargs = {"embed": embed, "view": view}
+            mention_content = self._approval_mention_content()
+            if mention_content:
+                send_kwargs["content"] = mention_content
+                allowed_mentions_cls = getattr(discord, "AllowedMentions", None)
+                if allowed_mentions_cls is not None:
+                    send_kwargs["allowed_mentions"] = allowed_mentions_cls(
+                        users=True,
+                        roles=False,
+                        everyone=False,
+                        replied_user=False,
+                    )
+
+            msg = await channel.send(**send_kwargs)
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 
@@ -6646,6 +6672,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(allowed_users_cfg, list):
             allowed_users_cfg = ",".join(str(v) for v in allowed_users_cfg)
         os.environ["DISCORD_ALLOWED_USERS"] = str(allowed_users_cfg)
+    approval_mentions_cfg = (
+        discord_cfg["approval_mentions"] if "approval_mentions" in discord_cfg
+        else platform_extra_cfg.get("approval_mentions")
+    )
+    if approval_mentions_cfg is not None and not os.getenv("DISCORD_APPROVAL_MENTIONS"):
+        os.environ["DISCORD_APPROVAL_MENTIONS"] = str(approval_mentions_cfg).lower()
     frc = discord_cfg.get("free_response_channels")
     if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
         if isinstance(frc, list):

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -1,0 +1,81 @@
+"""Discord approval prompts can opt into owner mentions."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.platforms.discord.adapter import (
+    DiscordAdapter,
+    _apply_yaml_config,
+)
+
+
+class _FakeChannel:
+    def __init__(self):
+        self.sent_kwargs = None
+
+    async def send(self, **kwargs):
+        self.sent_kwargs = kwargs
+        return SimpleNamespace(id=12345)
+
+
+class _FakeClient:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get_channel(self, channel_id):
+        return self.channel
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_mentions_allowed_users_when_enabled(monkeypatch):
+    monkeypatch.setenv("DISCORD_APPROVAL_MENTIONS", "true")
+    channel = _FakeChannel()
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = _FakeClient(channel)
+    adapter._allowed_user_ids = {"222", "111", "alice"}
+    adapter._allowed_role_ids = set()
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+        description="dangerous command",
+    )
+
+    assert result.success is True
+    assert channel.sent_kwargs["content"] == "<@111> <@222>"
+    assert "allowed_mentions" in channel.sent_kwargs
+    assert channel.sent_kwargs["embed"].title.endswith("Command Approval Required")
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_does_not_mention_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_APPROVAL_MENTIONS", raising=False)
+    channel = _FakeChannel()
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = _FakeClient(channel)
+    adapter._allowed_user_ids = {"111"}
+    adapter._allowed_role_ids = set()
+
+    result = await adapter.send_exec_approval(
+        chat_id="99",
+        command="make check",
+        session_key="session-1",
+    )
+
+    assert result.success is True
+    assert "content" not in channel.sent_kwargs
+    assert "allowed_mentions" not in channel.sent_kwargs
+
+
+def test_yaml_config_bridges_approval_mentions_to_env(monkeypatch):
+    monkeypatch.delenv("DISCORD_APPROVAL_MENTIONS", raising=False)
+
+    _apply_yaml_config(
+        {"discord": {"approval_mentions": True}},
+        {"approval_mentions": True},
+    )
+
+    assert os.environ["DISCORD_APPROVAL_MENTIONS"] == "true"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Discord approval prompt mention feature for operators who want approval owners to be notified in shared Discord channels or threads.

When `discord.approval_mentions` or `DISCORD_APPROVAL_MENTIONS=true` is enabled, Discord dangerous-command approval prompts prepend mentions for numeric `DISCORD_ALLOWED_USERS`. The feature is default-off, ignores non-numeric allowed-user entries, and sends per-message `AllowedMentions` that permit user mentions only while blocking roles, `@everyone`, and replied-user pings.

## Related Issue

No issue linked. Duplicate/overlap search performed:
- `Discord approval mentions allowed users repo:NousResearch/hermes-agent` found this PR plus related open PR #21528.
- #21528 mentions the original requester for approval prompts; this PR mentions configured approval owners from `DISCORD_ALLOWED_USERS`, so it is related but not the same UX/control surface.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py` adds default-off approval mention rendering and user-only `AllowedMentions` for approval prompts.
- `plugins/platforms/discord/adapter.py` bridges YAML config to `DISCORD_APPROVAL_MENTIONS` without overriding an explicit env var.
- `hermes_cli/config.py` adds the `discord.approval_mentions` default and `DISCORD_APPROVAL_MENTIONS` env metadata.
- `cli-config.yaml.example` documents the new Discord setting.
- `tests/gateway/test_discord_approval_mentions.py` covers enabled mentions, default-off behavior, and YAML-to-env bridging.

## How to Test

1. Run `UV_LINK_MODE=copy uv run --extra dev --extra messaging python -m pytest tests/gateway/test_discord_approval_mentions.py tests/gateway/test_discord_component_auth.py tests/gateway/test_discord_send.py -q`.
2. Run `UV_LINK_MODE=copy uv run --extra dev --extra messaging python -m py_compile plugins/platforms/discord/adapter.py hermes_cli/config.py tests/gateway/test_discord_approval_mentions.py`.
3. Run `UV_LINK_MODE=copy uv run --extra dev --extra messaging python scripts/check-windows-footguns.py --diff upstream/main`.
4. Run `git diff --check upstream/main...HEAD -- cli-config.yaml.example plugins/platforms/discord/adapter.py hermes_cli/config.py tests/gateway/test_discord_approval_mentions.py && git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no tool schema or LLM-facing tool description changes

## Screenshots / Logs

Verification after the checklist doc update:

- `UV_LINK_MODE=copy uv run --extra dev --extra messaging python -m pytest tests/gateway/test_discord_approval_mentions.py tests/gateway/test_discord_component_auth.py tests/gateway/test_discord_send.py -q` -> 40 passed.
- `UV_LINK_MODE=copy uv run --extra dev --extra messaging python -m py_compile plugins/platforms/discord/adapter.py hermes_cli/config.py tests/gateway/test_discord_approval_mentions.py` -> passed.
- `UV_LINK_MODE=copy uv run --extra dev --extra messaging python scripts/check-windows-footguns.py --diff upstream/main` -> no Windows footguns found in 3 scanned files.
- `git diff --check upstream/main...HEAD -- cli-config.yaml.example plugins/platforms/discord/adapter.py hermes_cli/config.py tests/gateway/test_discord_approval_mentions.py && git diff --check` -> passed.

Not run: full `pytest tests/ -q`.
