### PR TITLE
Decouple cron-ticker liveness from tick execution (gateway heartbeat thread)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -235,6 +235,68 @@ def _get_lock_paths() -> tuple[Path, Path]:
     return lock_dir, lock_dir / ".tick.lock"
 
 
+def _get_heartbeat_path() -> Path:
+    """Resolve the gateway heartbeat file path.
+
+    Distinct from ``.tick.lock``: ``.tick.lock`` mtime means "a tick actually
+    ran"; ``.gateway.heartbeat`` mtime means "the gateway event loop is alive".
+    Keeping them separate lets the health monitor tell a long-running cron job
+    (tick lock held, but gateway healthy) apart from a real gateway hang.
+    """
+    return _get_hermes_home() / "cron" / ".gateway.heartbeat"
+
+
+def heartbeat_loop(stop_event, alive_check, interval: float = 30.0, heartbeat_path=None) -> None:
+    """Bump the gateway heartbeat file mtime every ``interval`` seconds.
+
+    Runs in a dedicated daemon thread started by the gateway. Decouples the
+    gateway-liveness signal from ``tick()`` execution: even while a long
+    sequential cron job monopolises the cron-ticker thread (holding the
+    ``.tick.lock`` ``flock`` for ~26 min), this loop keeps ``.gateway.heartbeat``
+    fresh so the health monitor does not false-alarm "cron tick stopped".
+
+    Safety requirement: each bump is gated on ``alive_check()`` — a
+    callable returning True only when the gateway event loop is provably
+    responsive. If the loop is hung, ``alive_check()`` returns False and we STOP
+    bumping, so the monitor still detects the real outage. An unconditional,
+    always-on bump would permanently disable the health monitor and is forbidden.
+
+    Args:
+        stop_event: ``threading.Event`` set on gateway shutdown to exit promptly.
+        alive_check: zero-arg callable -> bool gating each bump on real
+            event-loop liveness (see gateway ``_gateway_alive``).
+        interval: seconds between bump attempts (default 30s; 1/10 of the
+            health monitor's 300s staleness threshold).
+    """
+    # Resolve the heartbeat path ONCE. Prefer the caller-supplied path: the
+    # gateway resolves it on the MAIN thread (clean Hermes home) before any tick
+    # job can transiently mutate the process-global ``_hermes_home`` in the
+    # ticker thread. Falling back to _get_heartbeat_path() here is only for
+    # direct/test callers that have no concurrent ticker.
+    hb_path = Path(heartbeat_path) if heartbeat_path is not None else _get_heartbeat_path()
+    try:
+        hb_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.debug("Heartbeat dir create failed (non-fatal): %s", e)
+    logger.info("Gateway heartbeat loop started (interval=%.0fs, file=%s)", interval, hb_path)
+    while not stop_event.is_set():
+        try:
+            # Re-check stop_event AFTER the (possibly blocking) liveness probe so
+            # a shutdown landing mid-probe does not produce a post-shutdown bump.
+            if alive_check() and not stop_event.is_set():
+                # Path-based mtime bump — independent of the fcntl LOCK_EX that
+                # tick() holds on .tick.lock (different file/inode), so it works
+                # mid-tick.
+                hb_path.touch(exist_ok=True)
+                os.utime(hb_path, None)
+        except OSError as e:
+            logger.debug("Heartbeat bump failed (non-fatal): %s", e)
+        except Exception as e:  # never let the heartbeat thread die silently
+            logger.debug("Heartbeat loop unexpected error (non-fatal): %s", e)
+        stop_event.wait(interval)
+    logger.info("Gateway heartbeat loop stopped")
+
+
 @contextmanager
 def _job_profile_context(job_id: str, profile: Optional[str]):
     """Temporarily run a job under a specific Hermes profile.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15920,6 +15920,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Start background cron ticker so scheduled jobs fire automatically.
     # Pass the event loop so cron delivery can use live adapters (E2EE support).
     cron_stop = threading.Event()
+    # Resolve the heartbeat file path on THIS (main) thread, BEFORE the
+    # cron ticker starts and could transiently mutate the process-global Hermes
+    # home in its own thread. Passed explicitly to the heartbeat loop below.
+    from cron.scheduler import _get_heartbeat_path as _get_hb_path
+    _hb_path = _get_hb_path()
     cron_thread = threading.Thread(
         target=_start_cron_ticker,
         args=(cron_stop,),
@@ -15928,6 +15933,35 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
+
+    # Gateway heartbeat — decouples the liveness signal from cron tick.
+    # Gated on _gateway_alive(): if the event loop is hung the probe never
+    # returns and the heartbeat stops, so a real outage still trips the monitor.
+    _hb_loop = asyncio.get_running_loop()
+    _HEARTBEAT_PROBE_TIMEOUT = 10.0  # seconds to wait for the loop to run a probe
+
+    def _gateway_alive() -> bool:
+        if cron_stop.is_set():
+            return False
+        if _hb_loop is None or not _hb_loop.is_running():
+            return False
+        probe = threading.Event()
+        try:
+            _hb_loop.call_soon_threadsafe(probe.set)
+        except RuntimeError:
+            return False
+        return probe.wait(_HEARTBEAT_PROBE_TIMEOUT)
+
+    from cron.scheduler import heartbeat_loop as _cron_heartbeat_loop
+    hb_stop = threading.Event()
+    hb_thread = threading.Thread(
+        target=_cron_heartbeat_loop,
+        args=(hb_stop, _gateway_alive),
+        kwargs={"interval": 30.0, "heartbeat_path": _hb_path},
+        daemon=True,
+        name="cron-heartbeat",
+    )
+    hb_thread.start()
     
     # Wait for shutdown
     await runner.wait_for_shutdown()
@@ -15940,6 +15974,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Stop cron ticker cleanly
     cron_stop.set()
     cron_thread.join(timeout=5)
+
+    # Stop gateway heartbeat thread
+    hb_stop.set()
+    hb_thread.join(timeout=5)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/tests/cron/test_heartbeat_loop.py
+++ b/tests/cron/test_heartbeat_loop.py
@@ -1,0 +1,123 @@
+"""Tests for cron.scheduler.heartbeat_loop (gateway-liveness heartbeat).
+
+Covers:
+  - heartbeat stays fresh while a long job holds the .tick.lock flock
+    (the liveness signal is decoupled from tick execution)
+  - alive_check() False -> file is never created/bumped (a hung event loop
+    must NOT keep the heartbeat alive, or real outages would be masked)
+  - stop_event.set() -> loop exits promptly
+  - bump is a path-based touch + os.utime; file is auto-created
+  - an explicit heartbeat_path wins over the process-global Hermes home
+    (race-safe when a tick job transiently mutates the global)
+"""
+
+from __future__ import annotations
+
+import fcntl
+import threading
+import time
+from pathlib import Path
+
+import cron.scheduler as sched
+
+
+def _run_loop(home: Path, alive, interval=0.05, heartbeat_path=None):
+    """Start heartbeat_loop bound to `home` in a thread; return (stop, thread)."""
+    sched._hermes_home = home  # monkeypatch hook honored by _get_hermes_home()
+    stop = threading.Event()
+    kwargs = {"interval": interval}
+    if heartbeat_path is not None:
+        kwargs["heartbeat_path"] = heartbeat_path
+    t = threading.Thread(
+        target=sched.heartbeat_loop,
+        args=(stop, alive),
+        kwargs=kwargs,
+        daemon=True,
+        name="test-heartbeat",
+    )
+    t.start()
+    return stop, t
+
+
+def test_bumps_while_tick_lock_held(tmp_path):
+    """Heartbeat stays fresh even while a long job holds the tick flock."""
+    home = tmp_path
+    hb = home / "cron" / ".gateway.heartbeat"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    # Simulate a long sequential job: hold an exclusive flock on .tick.lock
+    # in THIS thread for the whole test.
+    lock_fd = open(home / "cron" / ".tick.lock", "w")
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    stop, t = _run_loop(home, lambda: True)
+    try:
+        time.sleep(0.4)  # several 0.05s cycles
+        assert hb.exists(), "heartbeat file should be created"
+        m1 = hb.stat().st_mtime
+        time.sleep(0.4)
+        m2 = hb.stat().st_mtime
+        assert m2 >= m1, "heartbeat mtime should advance while job blocks"
+        assert time.time() - m2 < 2.0, "heartbeat must be fresh despite tick lock held"
+    finally:
+        stop.set()
+        t.join(timeout=2)
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        lock_fd.close()
+
+
+def test_no_bump_when_not_alive(tmp_path):
+    """alive_check() False => file must never be created/bumped."""
+    home = tmp_path
+    hb = home / "cron" / ".gateway.heartbeat"
+    stop, t = _run_loop(home, lambda: False)
+    try:
+        time.sleep(0.4)
+        assert not hb.exists(), (
+            "heartbeat must NOT be bumped when alive_check is False"
+        )
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+
+def test_stops_promptly_on_stop_event(tmp_path):
+    stop, t = _run_loop(tmp_path, lambda: True, interval=5.0)
+    time.sleep(0.2)
+    stop.set()
+    t.join(timeout=2)
+    assert not t.is_alive(), "heartbeat_loop should exit promptly on stop_event"
+
+
+def test_path_based_autocreate(tmp_path):
+    home = tmp_path
+    hb = home / "cron" / ".gateway.heartbeat"
+    assert not hb.exists()
+    stop, t = _run_loop(home, lambda: True)
+    try:
+        time.sleep(0.3)
+        assert hb.exists(), "heartbeat file auto-created via touch(exist_ok)"
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+
+def test_explicit_path_honored_over_global(tmp_path):
+    """Explicit heartbeat_path wins over the (mutable) global Hermes home.
+
+    Simulates the cross-thread race: the global _hermes_home points at a WRONG
+    profile, but the gateway passed an explicit path resolved on the main
+    thread. The bump must land at the explicit path, never the global one.
+    """
+    good = tmp_path / "good"
+    wrong = tmp_path / "wrong"
+    good.mkdir()
+    wrong.mkdir()
+    good_hb = good / "cron" / ".gateway.heartbeat"
+    wrong_hb = wrong / "cron" / ".gateway.heartbeat"
+    stop, t = _run_loop(wrong, lambda: True, heartbeat_path=good_hb)
+    try:
+        time.sleep(0.3)
+        assert good_hb.exists(), "bump must land at the explicit path"
+        assert not wrong_hb.exists(), "bump must NOT use the mutated global home"
+    finally:
+        stop.set()
+        t.join(timeout=2)


### PR DESCRIPTION
## Problem

`cron/scheduler.py::tick()` runs on a single in-process background thread
(`gateway/run.py::_start_cron_ticker`, 60s interval). It acquires
`fcntl.flock(LOCK_EX)` on `<HERMES_HOME>/cron/.tick.lock` and **holds it for the
entire tick**, and `tick()` runs `workdir`/`profile` jobs **sequentially**
(intended invariant — those jobs mutate process-global `_hermes_home`/`os.environ`).

When a sequential job is long-running (e.g. a multi-minute browser+LLM pipeline),
the ticker thread is monopolised for that whole duration. Consequences:

- The next 60s tick fails `LOCK_NB` and returns early → `.tick.lock` mtime freezes.
- Any external liveness monitor keyed on `.tick.lock` mtime false-alarms
  "cron stopped" even though the gateway is perfectly healthy and the job is
  progressing normally.

The freeze is **not** a throughput bug (long sequential execution is by design).
The only real defect is that the **liveness signal is coupled to the work thread**.

## Fix

A dedicated daemon thread bumps a **separate** `<HERMES_HOME>/cron/.gateway.heartbeat`
file mtime every 30s, independent of `tick()`:

- `cron/scheduler.py`: add `_get_heartbeat_path()` and `heartbeat_loop(stop_event, alive_check, interval=30)`.
  The bump is a path-based `touch` + `os.utime` — unaffected by the `flock` held
  on the *different* `.tick.lock` inode, so it stays fresh mid-tick.
- `gateway/run.py`: start the heartbeat thread next to the cron ticker and stop
  it on shutdown. The bump is gated on `_gateway_alive()`, which actively probes
  the event loop with `loop.call_soon_threadsafe(event.set)` + `event.wait(timeout)`
  — if the loop is genuinely hung the probe never returns, the heartbeat stops,
  and the monitor correctly fires.

`.tick.lock` keeps its original meaning ("a tick actually ran"), so tick deadlocks
remain detectable; `.gateway.heartbeat` answers the distinct question "is the
gateway event loop alive?".

## Why a separate file (not reusing `.tick.lock`)

Reusing `.tick.lock` for the heartbeat would conflate two signals — a healthy
event loop with a stuck/deadlocked cron tick would then be indistinguishable.
A distinct file preserves both diagnostics.

## Invariants preserved

- `tick()` lock acquisition/release and the sequential/parallel job partition are
  **unchanged** (byte-for-byte).
- The heartbeat **never** bumps unconditionally — the `_gateway_alive()` gate is a
  hard requirement, otherwise an always-on heartbeat would permanently mask real
  outages from the health monitor.

## Tests

Unit test covers: heartbeat stays fresh while a long job holds the tick lock;
`alive_check()==False` ⇒ no bump (hung-loop gate); prompt exit on `stop_event`;
path-based auto-create.

## Notes for adopters

External monitors should treat `.gateway.heartbeat` as the gateway-liveness
signal and `.tick.lock` as the tick-progress signal: a stale `.tick.lock` with a
fresh `.gateway.heartbeat` means a long job is in progress (no alarm).
