### PR TITLE
feat(browser): read proxy from browser.proxy config

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2007,7 +2007,20 @@ def _run_browser_command(
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
 
-        # Inject --no-sandbox when needed (issue #15765):
+        # Inject browser proxy from config (browser.proxy) if not already set
+        # via environment variable.  Supports http://, https://, socks5://, etc.
+        if not browser_env.get("AGENT_BROWSER_PROXY"):
+            try:
+                from hermes_cli.config import read_raw_config
+                _cfg = read_raw_config()
+                _proxy = cfg_get(_cfg, "browser", "proxy")
+                if _proxy:
+                    browser_env["AGENT_BROWSER_PROXY"] = str(_proxy)
+                    logger.debug("browser: injected proxy from config: %s", _proxy)
+            except Exception as e:
+                logger.debug("Could not read browser.proxy from config: %s", e)
+
+        # Inject --no-sandbox when needed
         # - Running as root: Chromium always refuses to start without it
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"


### PR DESCRIPTION
## Summary

Adds support for configuring browser proxy via `config.yaml` instead of requiring system environment variables.

The browser tool now reads the `browser.proxy` config key and injects it as `AGENT_BROWSER_PROXY` environment variable for the agent-browser subprocess.

## Problem

Users in restricted networks (e.g., China) need to use a proxy to access sites like Google. Previously, the only way to configure browser proxy was:
1. Set `AGENT_BROWSER_PROXY` as a system/user environment variable
2. Set `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` env vars

This required:
- Modifying Windows registry or system environment variables
- Restarting the gateway from a NEW cmd window (env vars not inherited from .env)
- No way to change proxy without system-level changes

## Solution

Read `browser.proxy` from config.yaml and inject it into the subprocess environment. This allows:

```bash
hermes config set browser.proxy socks5://127.0.0.1:30172
hermes gateway restart
```

## Precedence

Environment variables take precedence over config (existing behavior preserved):
- If `AGENT_BROWSER_PROXY` is already set in the environment → use it
- Otherwise → read from `browser.proxy` config

## Testing

- Verified with Google.com through SOCKS5 proxy on Windows
- Config: `browser.proxy: socks5://127.0.0.1:30172`
- Agent-browser successfully connects through proxy
