### PR TITLE
fix(banner): remove redundant dim modifier from toolset and skill category labels

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -624,7 +624,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                     colored_names.append(f"[{text}]{name}[/]")
             tools_str = ", ".join(colored_names)
 
-        right_lines.append(f"[dim {dim}]{toolset}:[/] {tools_str}")
+        right_lines.append(f"[{dim}]{toolset}:[/] {tools_str}")
 
     if remaining_toolsets > 0:
         right_lines.append(f"[dim {dim}](and {remaining_toolsets} more toolsets...)[/]")
@@ -671,7 +671,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                 skills_str = ", ".join(skill_names)
             if len(skills_str) > 50:
                 skills_str = skills_str[:47] + "..."
-            right_lines.append(f"[dim {dim}]{category}:[/] [{text}]{skills_str}[/]")
+            right_lines.append(f"[{dim}]{category}:[/] [{text}]{skills_str}[/]")
     else:
         right_lines.append(f"[dim {dim}]No skills installed[/]")
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -167,3 +167,40 @@ def test_build_welcome_banner_disabled_mcp_shows_disabled_not_failed():
     assert "broken" in output
     assert "failed" in output
 
+
+
+def test_category_labels_use_banner_dim_without_dim_modifier():
+    """Toolset and skill-category labels must use banner_dim color only.
+
+    Redundant ``dim`` modifier was removed in fix/banner-dim-double-dimming.
+    This test guards against regression.
+    """
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            return_value=(["web"], []),
+        ),
+        patch.object(
+            banner,
+            "get_available_skills",
+            return_value={"creative": ["comfyui", "pixel-art"]},
+        ),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(record=True, force_terminal=True, color_system="truecolor", width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=[{"function": {"name": "web_search"}}],
+            get_toolset_for_tool=lambda n: "web",
+        )
+    markup = console.export_text()
+    # Labels must appear in output
+    assert "web:" in markup
+    assert "creative:" in markup
+    # Redundant dim modifier must NOT appear in the markup source
+    rendered = console.export_text(styles=False)
+    assert "dim dim" not in rendered


### PR DESCRIPTION
## What does this PR do?

Toolset and skill category labels in the startup banner were rendered with `[dim {color}]`, which applies Rich's `dim` modifier on top of an already-muted `banner_dim` color. This causes double-dimming: on skins where `banner_dim` is already dark (`#475569` for light mode, `#444444` for github-dark), the extra `dim` modifier makes category labels nearly invisible — appearing grey/washed-out while tool names render normally.

Fix: use `[{color}]` directly for toolset and skill category labels so they render at the intended muted-but-readable brightness across all skins.

## Related Issue

Fixes #39675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py` line 627: `[dim {dim}]{toolset}:` → `[{dim}]{toolset}:`
- `hermes_cli/banner.py` line 674: `[dim {dim}]{category}:` → `[{dim}]{category}:`

## How to Test

1. Set skin to light mode or github-dark: `hermes config set skin light`
2. Start hermes and observe the startup banner
3. Tool and skill category labels should now be visible with muted-but-readable color instead of nearly invisible grey

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q -k banner` — 52 passed
- [x] I've tested on my platform: WSL2 Ubuntu 24.04

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python/Rich markup)
- [x] I've updated tool descriptions/schemas — N/A