### PR TITLE
fix(gateway): prevent session hygiene compression from overwriting original transcript

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -534,6 +534,22 @@ def compress_context(
             agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+    else:
+        # _session_db is None — still rotate the session_id so the caller
+        # (gateway hygiene) can distinguish old vs new transcripts and
+        # avoid overwriting the original session's messages.
+        old_session_id = agent.session_id
+        agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        try:
+            from gateway.session_context import set_current_session_id
+
+            set_current_session_id(agent.session_id)
+        except Exception:
+            os.environ["HERMES_SESSION_ID"] = agent.session_id
+        logger.info(
+            "Session hygiene: rotated session_id %s → %s (no session DB)",
+            old_session_id, agent.session_id,
+        )
 
     # Notify the context engine that the session_id rotated because of
     # compression (not a fresh /new). Plugin engines (e.g. hermes-lcm) use

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9273,10 +9273,19 @@ class GatewayRunner:
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                    else:
+                                        # _session_db was None so no session rotation
+                                        # occurred.  Do NOT overwrite the original
+                                        # transcript — the compressed messages are
+                                        # used in-memory only for this turn.
+                                        logger.info(
+                                            "Session hygiene: compression applied "
+                                            "in-memory (no session DB — original "
+                                            "transcript preserved)"
+                                        )
                                     # Reset stored token count — transcript was rewritten
                                     session_entry.last_prompt_tokens = 0
                                     history = _compressed


### PR DESCRIPTION
## Fixes #39704

### Problem

When Gateway Session Hygiene triggers compression and the temporary `AIAgent` has `_session_db=None`, the original session's messages are permanently overwritten with compressed ones. This is a **data loss** bug — the uncompressed transcript is gone forever.

**Root cause**: Two code paths interact incorrectly:

1. `agent/conversation_compression.py:501` — `_compress_context` gates the entire session-rotation block on `if agent._session_db:`. When it's `None`, no new session is created and `session_id` remains unchanged.

2. `gateway/run.py:9277` — `rewrite_transcript()` executes **unconditionally**, outside the `if _hyg_new_sid != session_entry.session_id` block. When no rotation occurred, it overwrites the original session's messages.

### Fix

**`gateway/run.py`**: Move `rewrite_transcript()` inside the session-rotation `if` block so it only runs when a new session was actually created. Add a log message in the `else` branch for the no-rotation case.

**`agent/conversation_compression.py`**: Add an `else` branch after the `if agent._session_db:` block that still rotates `session_id` even without a session DB. This ensures the gateway's existing `if _hyg_new_sid != session_entry.session_id` check works correctly, and the context engine notification fires with the correct `old_session_id`.

### Verification

- With `_session_db` available: behavior unchanged — old session preserved, new session gets compressed messages
- With `_session_db=None`: session_id rotates, `rewrite_transcript` is NOT called, original transcript preserved, compressed messages used in-memory only
