### PR TITLE
fix(security): strip HERMES_SESSION_KEY from subprocess env

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -177,6 +177,7 @@ class TestProviderEnvBlocklist:
             "EMAIL_PASSWORD": "email-secret",
             "FIRECRAWL_API_KEY": "fc-secret",
             "HERMES_DASHBOARD_SESSION_TOKEN": "dashboard-session-secret",
+            "HERMES_SESSION_KEY": "hermes-session-secret",
             "BROWSERBASE_PROJECT_ID": "bb-project",
             "ELEVENLABS_API_KEY": "el-secret",
             "GITHUB_TOKEN": "ghp_secret",
@@ -191,6 +192,24 @@ class TestProviderEnvBlocklist:
 
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
+
+    def test_hermes_session_key_is_stripped(self):
+        """HERMES_SESSION_KEY is the Hermes-internal session / approval-binding
+        credential. It must not leak into terminal/execute_code subprocesses —
+        a child that reads it can borrow the live session's approval scope
+        (borrowed-credential escalation).
+
+        Sibling follow-up to commit 3278b423d, which stripped the dashboard
+        session token (HERMES_DASHBOARD_SESSION_TOKEN) but left this adjacent
+        Hermes session credential inheritable.
+        """
+        result_env = _run_with_env(extra_os_env={
+            "HERMES_SESSION_KEY": "hermes-session-secret",
+        })
+
+        assert "HERMES_SESSION_KEY" not in result_env, (
+            "HERMES_SESSION_KEY leaked into subprocess env"
+        )
 
     def test_safe_vars_are_preserved(self):
         """Standard env vars (PATH, HOME, USER) must still be passed through."""
@@ -364,6 +383,7 @@ class TestBlocklistCoverage:
             "EMAIL_HOME_ADDRESS",
             "EMAIL_HOME_ADDRESS_NAME",
             "HERMES_DASHBOARD_SESSION_TOKEN",
+            "HERMES_SESSION_KEY",
             "GATEWAY_ALLOWED_USERS",
             "GH_TOKEN",
             "GITHUB_APP_ID",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -176,6 +176,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "EMAIL_HOME_ADDRESS",
         "EMAIL_HOME_ADDRESS_NAME",
         "HERMES_DASHBOARD_SESSION_TOKEN",
+        "HERMES_SESSION_KEY",
         "GATEWAY_ALLOWED_USERS",
         "GH_TOKEN",
         "GITHUB_APP_ID",


### PR DESCRIPTION
## This is a sibling follow-up to commit 3278b423d

`3278b423d` (*fix(dashboard): strip session token from subprocess env*) hardened `tools/environments/local.py::_build_provider_env_blocklist()`:

- **What it covered:** added `HERMES_DASHBOARD_SESSION_TOKEN` to the subprocess-env blocklist so the dashboard session token no longer inherits into agent-spawned shells / PTYs / background processes.
- **What it did NOT touch:** the adjacent Hermes-internal session credential `HERMES_SESSION_KEY` — the session / approval-binding key written to `os.environ` by the gateway, the TUI slash worker, and ACP per-session binding.
- **What this PR adds:** the same one-line blocklist entry for `HERMES_SESSION_KEY`, closing the sibling leak in the exact same code path.

## What does this PR do?

Adds `HERMES_SESSION_KEY` to `_build_provider_env_blocklist()` so it is stripped from every subprocess environment the agent spawns (`_sanitize_subprocess_env` / `_make_run_env`).

`HERMES_SESSION_KEY` is the Hermes-internal session / approval-binding credential (resolved by `tools/approval.py`, consumed by `tools/terminal_tool.py` and the ACP per-session binding). It is **not** in the static blocklist, **not** in `hermes_cli/config.py` `OPTIONAL_ENV_VARS` (so the dynamic credential/tool/messaging sweep does not cover it), and **not** passthrough-allowed. It therefore propagated into shells, PTYs, and background processes spawned by the agent. A subprocess that reads `HERMES_SESSION_KEY` can borrow the live session's approval scope / authorization binding — a borrowed-credential escalation. This is the same leak class commit `3278b423d` closed for the dashboard session token.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/environments/local.py`: added `"HERMES_SESSION_KEY"` to the `blocked.update({...})` literal in `_build_provider_env_blocklist()`, adjacent to `HERMES_DASHBOARD_SESSION_TOKEN` (keeps the Hermes-internal session credentials grouped). +1 production LOC.
- `tests/tools/test_local_env_blocklist.py`: mirrored the parent commit's two-site coverage — added `HERMES_SESSION_KEY` to the `leaked_vars` dict in `test_tool_and_gateway_vars_are_stripped` and to the `extras` set in `test_gateway_runtime_vars_are_in_blocklist`; added a focused `test_hermes_session_key_is_stripped` regression asserting the var does not appear in the sanitized subprocess env.

## How to Test

1. Run the focused suite: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_local_env_blocklist.py -v` — 23 passed.
2. Regression guard (red/green): revert the single production line (`"HERMES_SESSION_KEY",`) and re-run — `test_hermes_session_key_is_stripped`, `test_tool_and_gateway_vars_are_stripped`, and `test_gateway_runtime_vars_are_in_blocklist` all FAIL with a `HERMES_SESSION_KEY leaked into subprocess env` / extras-subset message. Restore the line → all pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused file: `tests/tools/test_local_env_blocklist.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (env-var blocklist is platform-independent set membership)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A