### PR TITLE
fix(cli): resolve active venv directory dynamically instead of hardcoding "venv"

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2313,7 +2313,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
     detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / (".venv" if (PROJECT_ROOT / ".venv").is_dir() else "venv"))
 
     path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
@@ -3020,7 +3020,7 @@ def generate_launchd_plist() -> str:
     # the systemd unit), then capture the user's full shell PATH so every
     # user-installed tool (node, ffmpeg, …) is reachable.
     detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / (".venv" if (PROJECT_ROOT / ".venv").is_dir() else "venv"))
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7994,7 +7994,7 @@ def _update_via_zip(args):
                     break
 
         # Copy updated files over existing installation, preserving venv/node_modules/.git
-        preserve = {"venv", "node_modules", ".git", ".env"}
+        preserve = {"venv", ".venv", "node_modules", ".git", ".env"}
         update_count = 0
         for item in os.listdir(extracted):
             if item in preserve:
@@ -8040,7 +8040,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_resolve_venv_dir())}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -8694,9 +8694,35 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _resolve_venv_dir() -> Path:
+    """Resolve the active venv directory, checking both '.venv' and 'venv'.
+
+    Preference order: ``sys.prefix`` (if inside a venv) → ``VIRTUAL_ENV``
+    env-var → first existing directory among ``.venv`` / ``venv`` under
+    ``PROJECT_ROOT``.  Falls back to ``PROJECT_ROOT / "venv"`` when nothing
+    is found so callers always get a usable Path.
+    """
+    # 1. If we're already running inside a venv, use it directly.
+    if sys.prefix != sys.base_prefix:
+        return Path(sys.prefix)
+    # 2. Honour the VIRTUAL_ENV environment variable.
+    venv_env = os.environ.get("VIRTUAL_ENV")
+    if venv_env:
+        p = Path(venv_env)
+        if p.is_dir():
+            return p
+    # 3. Probe both candidate directory names.
+    for name in (".venv", "venv"):
+        p = PROJECT_ROOT / name
+        if p.is_dir():
+            return p
+    # 4. Nothing found — return the conventional default.
+    return PROJECT_ROOT / "venv"
+
+
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+    venv_dir = _resolve_venv_dir()
     if not venv_dir.is_dir():
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
@@ -10557,7 +10583,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_resolve_venv_dir())}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)


### PR DESCRIPTION
## Fixes #39714

### Problem

On uv-based installs, `hermes update` installs Python dependencies into a hardcoded `PROJECT_ROOT/venv` directory, but the CLI launcher and running processes actually use `PROJECT_ROOT/.venv` (created by the uv installer). This creates two side-by-side virtualenvs — the active `.venv` silently drifts out of date.

The same hardcoded path exists in:
- ZIP update preserve set — `.venv` is **not preserved**, so it gets wiped during update
- ZIP update dependency reinstall — `VIRTUAL_ENV` set to wrong path
- `_venv_scripts_dir()` — concurrent-instance safety check skipped
- Git-pull dependency reinstall — `VIRTUAL_ENV` set to wrong path
- `gateway.py` systemd/launchd fallbacks

### Fix

Add `_resolve_venv_dir()` helper in `hermes_cli/main.py` that resolves the active venv by checking:
1. `sys.prefix` (if running inside a venv)
2. `VIRTUAL_ENV` environment variable
3. Both `.venv` and `venv` under `PROJECT_ROOT`
4. Falls back to `PROJECT_ROOT/venv`

Replace all 4 hardcoded `PROJECT_ROOT/"venv"` references with `_resolve_venv_dir()`. Add `.venv` to the ZIP update preserve set. Fix `gateway.py` fallbacks to also check `.venv`.
