### PR TITLE
fix(gateway): pass session_db to hygiene agent for proper session rotation (#39704)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9248,6 +9248,7 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=self._session_db,
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None


### PR DESCRIPTION
Fixes #39704. When Gateway Session Hygiene creates a temporary AIAgent for compression, it didn't pass the session_db parameter, causing _compress_context to skip session rotation. This meant compressed messages overwrote the original transcript in the same session, permanently deleting the originals. The fix passes session_db=self._session_db to the hygiene agent so compression can properly rotate to a new session, preserving the original messages.