### PR TITLE
fix(background-review): whitelist dynamic memory-provider tools

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -463,6 +463,17 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # Dynamic memory-provider tools (e.g. Honcho's honcho_* set) are
+            # injected by the active MemoryManager at AIAgent init time, not by
+            # any static toolset definition. The review fork inherits the same
+            # provider configuration, so whitelist those tool names too without
+            # widening beyond the parent's live memory tool surface.
+            _memory_manager = getattr(agent, "_memory_manager", None)
+            if _memory_manager is not None:
+                try:
+                    review_whitelist.update(_memory_manager.get_all_tool_names())
+                except Exception:
+                    pass
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1029,6 +1029,17 @@ def _run_review_fork(
     _track_review_fork(agent, st.review_agent, register=True)
     from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist
     review_whitelist, configured_extra_tools = _review_tool_whitelist(st.review_agent, task_cfg, review_memory)
+    # Dynamic memory-provider tools (e.g. Honcho's honcho_* set) are injected
+    # by the active MemoryManager at AIAgent init time, not by any static
+    # toolset definition. The review fork inherits the same provider
+    # configuration, so whitelist those tool names too without widening beyond
+    # the parent's live memory tool surface.
+    _memory_manager = getattr(agent, "_memory_manager", None)
+    if _memory_manager is not None:
+        try:
+            review_whitelist |= set(_memory_manager.get_all_tool_names())
+        except Exception:
+            pass
     extra_list = ", ".join(sorted(configured_extra_tools))
     deny_extra = f" Configured extra tools also allowed: {extra_list}." if configured_extra_tools else ""
     prompt_extra = f" Exception — these configured tools are also allowed: {extra_list}." if configured_extra_tools else ""

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -135,6 +135,45 @@ def test_background_review_installs_thread_local_whitelist():
     assert "execute_code" not in whitelist
 
 
+def test_background_review_whitelist_includes_dynamic_memory_provider_tools():
+    """Dynamic memory-provider tools must be whitelisted alongside static toolsets."""
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        captured["deny_msg_fmt"] = deny_msg_fmt
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    class _MemoryManagerStub:
+        def get_all_tool_names(self):
+            return {"honcho_profile", "honcho_search", "honcho_context"}
+
+    agent._memory_manager = _MemoryManagerStub()
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
+    whitelist = captured["whitelist"]
+    assert "honcho_profile" in whitelist
+    assert "honcho_search" in whitelist
+    assert "honcho_context" in whitelist
+
+
 def test_background_review_agent_tools_are_limited():
     """Verify the resolved memory+skills toolsets only contain memory and skill tools.
 

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -187,6 +187,45 @@ def test_read_file_registers_background_review_read_mark(tmp_path):
         reset_current_write_origin(token)
 
 
+def test_background_review_whitelist_includes_dynamic_memory_provider_tools():
+    """Dynamic memory-provider tools must be whitelisted alongside static toolsets."""
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        captured["deny_msg_fmt"] = deny_msg_fmt
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    class _MemoryManagerStub:
+        def get_all_tool_names(self):
+            return {"honcho_profile", "honcho_search", "honcho_context"}
+
+    agent._memory_manager = _MemoryManagerStub()
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
+    whitelist = captured["whitelist"]
+    assert "honcho_profile" in whitelist
+    assert "honcho_search" in whitelist
+    assert "honcho_context" in whitelist
+
+
 def test_read_file_outside_review_does_not_mark(tmp_path):
     """Foreground reads must not populate the review-fork read set."""
     from tools.file_tools import read_file_tool


### PR DESCRIPTION
## What does this PR do?

Fixes background review for dynamic memory-provider tools. The review thread previously built its runtime whitelist from the static `memory` and `skills` toolsets only, which excluded tools injected at runtime by memory providers such as Honcho (`honcho_profile`, `honcho_search`, `honcho_context`, etc.). As a result, background reviews inherited those tools in the schema but then denied them at dispatch time.

This PR keeps the existing static whitelist and extends it with tool names reported by the parent agent’s active `MemoryManager`. That preserves the safety boundary while allowing the review fork to call the same memory-provider tools already present in the parent agent’s live tool surface.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/background_review.py` so the background review whitelist starts from the static `memory` and `skills` toolsets, then unions in dynamic tool names from `agent._memory_manager.get_all_tool_names()`.
- Kept the whitelist scoped to the parent agent’s active memory-provider surface instead of broadening background review access to unrelated tools.
- Added regression coverage in `tests/run_agent/test_background_review_toolset_restriction.py` for dynamically injected memory-provider tools, including Honcho-style `honcho_*` names.

## How to Test

1. Check out `fix-background-review-memory-tools`.
2. Run:
   ```bash
   scripts/run_tests.sh tests/run_agent/test_background_review_toolset_restriction.py
   ```
3. Confirm the regression passes: dynamically injected memory-provider tools are whitelisted for background review, while non-memory tools remain denied.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```bash
scripts/run_tests.sh tests/run_agent/test_background_review_toolset_restriction.py
```

Passed: `1 files, 4 tests passed, 0 failed`.
