### PR TITLE
test(honcho): keep dynamic context out of system prompt (#13631)

### DIFF
--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -195,6 +195,45 @@ class TestMemoryManager:
         result = mgr.build_system_prompt()
         assert result == "Has content"
 
+    def test_system_prompt_and_prefetch_keep_honcho_context_separate(self):
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("honcho")
+        p._prompt_block = "# Honcho Memory\nActive (hybrid mode)."
+        p._prefetch_result = (
+            "## Session Summary\nfresh session\n\n"
+            "## User Representation\nfresh peer\n\n"
+            "dialectic: current turn synthesis"
+        )
+        mgr.add_provider(p)
+
+        system_prompt = mgr.build_system_prompt()
+        prefetch = mgr.prefetch_all("query")
+
+        assert "Honcho Memory" in system_prompt
+        assert "Session Summary" not in system_prompt
+        assert "User Representation" not in system_prompt
+        assert "current turn synthesis" not in system_prompt
+        assert "Session Summary" in prefetch
+        assert "User Representation" in prefetch
+        assert "current turn synthesis" in prefetch
+
+    def test_real_honcho_system_prompt_is_static(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        provider._config = object()
+        provider._recall_mode = "hybrid"
+
+        system_prompt = provider.system_prompt_block()
+
+        assert "Honcho Memory" in system_prompt
+        assert "Active (hybrid mode)." in system_prompt
+        assert "Session Summary" not in system_prompt
+        assert "User Representation" not in system_prompt
+        assert "User Peer Card" not in system_prompt
+        assert "AI Self-Representation" not in system_prompt
+        assert "AI Identity Card" not in system_prompt
+
     def test_prefetch_merges_results(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -3,7 +3,23 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.system_prompt import build_system_prompt_parts
+from agent.system_prompt import build_system_prompt, build_system_prompt_parts
+
+
+class HonchoLikeMemoryManager:
+    def __init__(self):
+        self.prefetch_called = False
+
+    def build_system_prompt(self):
+        return "# Honcho Memory\nActive (hybrid mode)."
+
+    def prefetch_all(self, query, *, session_id=""):
+        self.prefetch_called = True
+        return (
+            "## Session Summary\nfresh session\n\n"
+            "## User Representation\nfresh peer\n\n"
+            "dialectic: current turn synthesis"
+        )
 
 
 def _make_agent(**overrides):
@@ -99,3 +115,26 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestHonchoPromptCacheBoundary:
+    def test_dynamic_honcho_context_stays_out_of_cached_prompt(self):
+        memory_manager = HonchoLikeMemoryManager()
+        agent = _make_agent(
+            skip_context_files=True,
+            _memory_manager=memory_manager,
+        )
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+        ):
+            prompt = build_system_prompt(agent)
+
+        assert "Honcho Memory" in prompt
+        assert "Active (hybrid mode)." in prompt
+        assert "Session Summary" not in prompt
+        assert "User Representation" not in prompt
+        assert "current turn synthesis" not in prompt
+        assert memory_manager.prefetch_called is False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7314,23 +7314,33 @@ class TestMemoryProviderTurnStart:
         """Source-level check: prefetch context stays out of cached system prompt."""
         import inspect
         from agent.conversation_loop import run_conversation as _rc
-        src = inspect.getsource(_rc)
+        from agent.turn_context import build_turn_context as _btc
 
-        idx_prefetch = src.index(
-            "_ext_prefetch_cache = agent._memory_manager.prefetch_all"
+        prologue_src = inspect.getsource(_btc)
+        loop_src = inspect.getsource(_rc)
+
+        idx_turn_prefetch = prologue_src.index(
+            'ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""'
         )
-        idx_api_messages = src.index("api_messages = []")
-        idx_current_user_guard = src.index(
+        idx_turn_return = prologue_src.index("return TurnContext(")
+        assert idx_turn_prefetch < idx_turn_return
+
+        idx_api_messages = loop_src.index("api_messages = []")
+        idx_current_user_guard = loop_src.index(
             'if idx == current_turn_user_idx and msg.get("role") == "user":'
         )
-        idx_fence = src.index("build_memory_context_block(_ext_prefetch_cache)")
-        idx_user_append = src.index(
+        idx_fence = loop_src.index("build_memory_context_block(_ext_prefetch_cache)")
+        idx_user_append = loop_src.index(
             'api_msg["content"] = _base + "\\n\\n" + "\\n\\n".join(_injections)'
         )
 
-        assert idx_prefetch < idx_api_messages < idx_current_user_guard
         assert idx_current_user_guard < idx_fence < idx_user_append
 
-        prefetch_to_user_append = src[idx_prefetch:idx_user_append]
+        injection_window = loop_src[idx_api_messages:idx_user_append]
+        assert "_ext_prefetch_cache = _ctx.ext_prefetch_cache" in loop_src
+        assert "_cached_system_prompt" not in injection_window
+        assert "_build_system_prompt" not in injection_window
+
+        prefetch_to_user_append = prologue_src[idx_turn_prefetch:] + injection_window
         assert "_cached_system_prompt" not in prefetch_to_user_append
         assert "_build_system_prompt" not in prefetch_to_user_append

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7309,3 +7309,28 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+    def test_prefetch_context_is_injected_into_current_user_message(self):
+        """Source-level check: prefetch context stays out of cached system prompt."""
+        import inspect
+        from agent.conversation_loop import run_conversation as _rc
+        src = inspect.getsource(_rc)
+
+        idx_prefetch = src.index(
+            "_ext_prefetch_cache = agent._memory_manager.prefetch_all"
+        )
+        idx_api_messages = src.index("api_messages = []")
+        idx_current_user_guard = src.index(
+            'if idx == current_turn_user_idx and msg.get("role") == "user":'
+        )
+        idx_fence = src.index("build_memory_context_block(_ext_prefetch_cache)")
+        idx_user_append = src.index(
+            'api_msg["content"] = _base + "\\n\\n" + "\\n\\n".join(_injections)'
+        )
+
+        assert idx_prefetch < idx_api_messages < idx_current_user_guard
+        assert idx_current_user_guard < idx_fence < idx_user_append
+
+        prefetch_to_user_append = src[idx_prefetch:idx_user_append]
+        assert "_cached_system_prompt" not in prefetch_to_user_append
+        assert "_build_system_prompt" not in prefetch_to_user_append


### PR DESCRIPTION
## Summary

Honcho auto context is now cache-safe on current main: the provider's system prompt path emits only static mode guidance, while refreshed session summaries, peer representations, cards, and dialectic output ride through `prefetch()` into the current user message. this is exactly the class of regression that is easy to reintroduce because `MemoryManager.build_system_prompt()` and `MemoryManager.prefetch_all()` sit next to each other and both return text blocks. These tests pin the boundary so refreshed Honcho context cannot slip back into `_cached_system_prompt` and break prefix-cache reuse.

## Changes

- `tests/agent/test_system_prompt.py`: add a regression test proving dynamic Honcho-style prefetch text is absent from the fully assembled cached prompt, and that prompt assembly does not call `prefetch_all()`. (~+40 lines)
- `tests/agent/test_memory_provider.py`: add a MemoryManager contract test that separates provider `system_prompt_block()` output from dynamic `prefetch()` output, plus a real Honcho provider test that keeps live context sections out of `system_prompt_block()`. (~+39 lines)
- `tests/run_agent/test_run_agent.py`: add a source-level guard that `prefetch_all()` output is fenced and appended only to the current user message, without mutating `_cached_system_prompt`. (~+23 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| Honcho static mode header | enters cached system prompt | enters cached system prompt |
| Honcho session summary / peer representation / dialectic context | could regress into cached system prompt without a direct guard | excluded by regression tests |
| Honcho dynamic recall | available through `prefetch_all()` for current-turn injection | available through `prefetch_all()` for current-turn injection |

## Test plan

- `python -m pytest tests\agent\test_system_prompt.py tests\agent\test_memory_provider.py tests\run_agent\test_run_agent.py::TestMemoryProviderTurnStart::test_prefetch_context_is_injected_into_current_user_message -v --timeout=0`: 86 passed
- `python -m pytest tests/ -v --timeout=60 --timeout-method=thread`: Not run locally; CI is the source of truth.

## Upstream

Closes #13631.
Reported by @0xAlcibiades.
