### PR TITLE
fix(cli): target active venv during source update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8040,7 +8040,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_active_virtualenv_path())}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -8694,9 +8694,25 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _active_virtualenv_path() -> Path:
+    """Return the virtualenv that is running Hermes, falling back to venv/.
+
+    Source installs are not consistent about the environment directory name:
+    older managed installs used ``venv/`` while uv-based installs commonly use
+    ``.venv/``. During ``hermes update`` we must update the interpreter that is
+    actually launching Hermes, not a hardcoded sibling directory.
+    """
+    if sys.prefix != sys.base_prefix:
+        return Path(sys.prefix)
+    env_venv = os.environ.get("VIRTUAL_ENV")
+    if env_venv:
+        return Path(env_venv)
+    return PROJECT_ROOT / "venv"
+
+
 def _venv_scripts_dir() -> Path | None:
-    """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+    """Return the active venv Scripts/bin directory if it exists."""
+    venv_dir = _active_virtualenv_path()
     if not venv_dir.is_dir():
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
@@ -10557,7 +10573,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_active_virtualenv_path())}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -109,6 +109,47 @@ class TestCmdUpdatePip:
         assert "env" not in mock_run.call_args.kwargs
 
 
+class TestCmdUpdateSourceVirtualEnv:
+    """Source/git update dependency installs target the active interpreter venv."""
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_source_update_uses_sys_prefix_virtualenv_for_uv_install(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        """Regression for #39714: do not hardcode PROJECT_ROOT/venv.
+
+        uv-managed installs commonly run from PROJECT_ROOT/.venv. The update
+        path must export that active venv so `uv pip install -e .[...]` updates
+        the environment that actually launches Hermes.
+        """
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        active_venv = str(PROJECT_ROOT / ".venv")
+        monkeypatch.setattr(hm.sys, "prefix", active_venv)
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        captured_envs = []
+
+        def fake_install(_cmd, *, env=None, group="all"):
+            captured_envs.append(env)
+
+        with patch.object(hm, "_install_python_dependencies_with_optional_fallback", side_effect=fake_install), \
+             patch.object(hm, "_update_node_dependencies"), \
+             patch.object(hm, "_build_web_ui", return_value=True), \
+             patch.object(hm, "_refresh_active_lazy_features"), \
+             patch.object(hm, "_desktop_packaged_executable", return_value=None), \
+             patch.object(hm, "_desktop_dist_exists", return_value=False):
+            cmd_update(mock_args)
+
+        assert captured_envs
+        assert captured_envs[0]["VIRTUAL_ENV"] == active_venv
+        assert captured_envs[0]["VIRTUAL_ENV"] != str(PROJECT_ROOT / "venv")
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
## Summary
- Fixes `hermes update` source/git paths to export the active interpreter virtualenv instead of hardcoding `PROJECT_ROOT / "venv"`
- Reuses the active venv path for Windows shim/concurrent-instance detection
- Adds a regression test for uv-managed installs that run from `.venv`

Fixes #39714

## Test Plan
- `python -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py::TestCmdUpdateSourceVirtualEnv::test_source_update_uses_sys_prefix_virtualenv_for_uv_install -q`
- `python -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py::TestCmdUpdateSourceVirtualEnv tests/hermes_cli/test_cmd_update.py::TestCmdUpdatePip -q`
- `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py && git diff --check`

Note: On this Windows host, a broader update subset has existing platform-specific expectations around `git -c windows.appendAtomically=false` in a few tests; the new targeted regression and adjacent pip/source update tests pass.