### PR TITLE
fix(environments): reconcile stale daytona sandboxes on startup (#28807)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -612,11 +612,12 @@ def load_cli_config() -> Dict[str, Any]:
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",
         "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-        "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-        "modal_image": "TERMINAL_MODAL_IMAGE",
-        "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-        # SSH config
-        "ssh_host": "TERMINAL_SSH_HOST",
+            "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+            "modal_image": "TERMINAL_MODAL_IMAGE",
+            "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+            "daytona_orphan_reaper": "TERMINAL_DAYTONA_ORPHAN_REAPER",
+            # SSH config
+            "ssh_host": "TERMINAL_SSH_HOST",
         "ssh_user": "TERMINAL_SSH_USER",
         "ssh_port": "TERMINAL_SSH_PORT",
         "ssh_key": "TERMINAL_SSH_KEY",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1457,6 +1457,7 @@ if _config_path.exists():
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+                "daytona_orphan_reaper": "TERMINAL_DAYTONA_ORPHAN_REAPER",
                 "ssh_host": "TERMINAL_SSH_HOST",
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1149,6 +1149,7 @@ DEFAULT_CONFIG = {
         "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
         "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+        "daytona_orphan_reaper": True,
         # Container resource limits (docker, singularity, modal, daytona — ignored for local/ssh)
         "container_cpu": 1,
         "container_memory": 5120,       # MB (default 5GB)
@@ -6718,6 +6719,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
     "modal_image": "TERMINAL_MODAL_IMAGE",
     "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "daytona_orphan_reaper": "TERMINAL_DAYTONA_ORPHAN_REAPER",
     "ssh_host": "TERMINAL_SSH_HOST",
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -1,5 +1,6 @@
 """Unit tests for the Daytona cloud sandbox environment backend."""
 
+from datetime import datetime, timedelta, timezone
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -19,6 +20,8 @@ def _make_sandbox(sandbox_id="sb-123", state="started"):
     sb = MagicMock()
     sb.id = sandbox_id
     sb.state = state
+    sb.name = f"hermes-{sandbox_id}"
+    sb.labels = {}
     sb.process.exec.return_value = _make_exec_response()
     return sb
 
@@ -37,7 +40,9 @@ def _patch_daytona_imports(monkeypatch):
 
     daytona_mod = _types.ModuleType("daytona")
     daytona_mod.Daytona = MagicMock
-    daytona_mod.CreateSandboxFromImageParams = MagicMock
+    daytona_mod.CreateSandboxFromImageParams = MagicMock(
+        name="CreateSandboxFromImageParams"
+    )
     daytona_mod.DaytonaError = type("DaytonaError", (Exception,), {})
     daytona_mod.Resources = MagicMock(name="Resources")
     daytona_mod.SandboxState = _SandboxState
@@ -142,45 +147,81 @@ class TestCwdResolution:
 # ---------------------------------------------------------------------------
 
 class TestPersistence:
-    def test_persistent_resumes_via_get(self, make_env):
+    def test_persistent_resumes_same_profile_and_refreshes_owner(self, make_env):
         existing = _make_sandbox(sandbox_id="sb-existing")
+        existing.labels = {
+            "hermes_task_id": "mytask",
+            "hermes_profile": "default",
+            "hermes_owner_pid": "99999",
+        }
         existing.process.exec.return_value = _make_exec_response(result="/root")
-        env = make_env(get_side_effect=lambda name: existing, persistent=True,
+        env = make_env(list_return=iter([existing]), persistent=True,
                        task_id="mytask")
         existing.start.assert_called_once()
-        env._mock_client.get.assert_called_once_with("hermes-mytask")
+        env._mock_client.list.assert_called_once_with(
+            labels={"hermes_task_id": "mytask", "hermes_profile": "default"},
+            limit=1,
+        )
+        existing.set_labels.assert_called_once()
+        assert existing.set_labels.call_args.args[0]["hermes_owner_pid"].isdigit()
         env._mock_client.create.assert_not_called()
 
-    def test_persistent_resumes_legacy_via_list(self, make_env, daytona_sdk):
+    def test_persistent_does_not_reuse_profileless_legacy_sandbox(self, make_env):
         legacy = _make_sandbox(sandbox_id="sb-legacy")
         legacy.process.exec.return_value = _make_exec_response(result="/root")
-        env = make_env(
-            get_side_effect=daytona_sdk.DaytonaError("not found"),
-            list_return=iter([legacy]),
-            persistent=True,
-            task_id="mytask",
-        )
-        legacy.start.assert_called_once()
+        env = make_env(list_return=iter([legacy]), persistent=True, task_id="mytask")
+        legacy.start.assert_not_called()
+        env._mock_client.create.assert_called_once()
         env._mock_client.list.assert_called_once_with(
-            labels={"hermes_task_id": "mytask"}, limit=1)
-        env._mock_client.create.assert_not_called()
+            labels={"hermes_task_id": "mytask", "hermes_profile": "default"},
+            limit=1,
+        )
+
+    def test_persistent_does_not_reuse_cross_profile_sandbox(self, make_env):
+        other = _make_sandbox(sandbox_id="sb-other-profile")
+        other.labels = {
+            "hermes_task_id": "mytask",
+            "hermes_profile": "other",
+            "hermes_owner_pid": "99999",
+        }
+        env = make_env(list_return=iter([other]), persistent=True, task_id="mytask")
+        other.start.assert_not_called()
+        env._mock_client.create.assert_called_once()
 
     def test_persistent_creates_new_when_none_found(self, make_env, daytona_sdk):
+        env = make_env(persistent=True, task_id="mytask")
+        env._mock_client.create.assert_called_once()
+        params = daytona_sdk.CreateSandboxFromImageParams.call_args.kwargs
+        assert params["name"].startswith("hermes-")
+        assert params["name"] != "hermes-mytask"
+        env._mock_client.list.assert_called_with(
+            labels={"hermes_task_id": "mytask", "hermes_profile": "default"},
+            limit=1,
+        )
+
+    def test_created_sandbox_gets_profile_and_owner_labels(
+        self, make_env, daytona_sdk, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "tools.environments.daytona._get_active_profile_name",
+            lambda: "research",
+        )
         env = make_env(
             get_side_effect=daytona_sdk.DaytonaError("not found"),
             persistent=True,
             task_id="mytask",
         )
-        env._mock_client.create.assert_called_once()
-        # Verify the name and labels were passed to CreateSandboxFromImageParams
-        # by checking get() was called with the right sandbox name
-        env._mock_client.get.assert_called_with("hermes-mytask")
+        labels = daytona_sdk.CreateSandboxFromImageParams.call_args.kwargs["labels"]
+        assert labels["hermes_task_id"] == "mytask"
+        assert labels["hermes_profile"] == "research"
+        assert labels["hermes_owner_pid"].isdigit()
         env._mock_client.list.assert_called_with(
-            labels={"hermes_task_id": "mytask"}, limit=1)
+            labels={"hermes_task_id": "mytask", "hermes_profile": "research"},
+            limit=1,
+        )
 
     def test_non_persistent_skips_lookup(self, make_env):
         env = make_env(persistent=False)
-        env._mock_client.get.assert_not_called()
         env._mock_client.list.assert_not_called()
         env._mock_client.create.assert_called_once()
 
@@ -440,3 +481,178 @@ class TestSyncSafety:
         assert "; touch" not in mkdir_cmd.replace(
             "'/root/.hermes/skills/evil; touch /tmp/daytona-owned'", ""
         )
+
+
+# ---------------------------------------------------------------------------
+# Orphan reaper
+# ---------------------------------------------------------------------------
+
+class TestOrphanReaper:
+    def _stale_sandbox(self, task_id="oldtask", profile="default", state="started"):
+        sb = _make_sandbox(sandbox_id=f"sb-{task_id}", state=state)
+        sb.name = f"hermes-{task_id}"
+        sb.labels = {
+            "hermes_task_id": task_id,
+            "hermes_profile": profile,
+            "hermes_owner_pid": "12345",
+        }
+        sb.created_at = datetime.now(timezone.utc) - timedelta(seconds=1000)
+        return sb
+
+    def test_reaper_stops_matching_stale_sandbox(self, monkeypatch):
+        from tools.environments import daytona
+
+        stale = self._stale_sandbox()
+        client = MagicMock()
+        client.list.return_value = iter([stale])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: False)
+
+        stopped = daytona.reap_orphan_sandboxes(
+            max_age_seconds=600,
+            current_task_id="current",
+            profile_filter="default",
+            daytona_client=client,
+        )
+
+        assert stopped == 1
+        stale.stop.assert_called_once()
+
+    def test_reaper_skips_current_task_sandbox(self, monkeypatch):
+        from tools.environments import daytona
+
+        current = self._stale_sandbox(task_id="current")
+        client = MagicMock()
+        client.list.return_value = iter([current])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: False)
+
+        stopped = daytona.reap_orphan_sandboxes(
+            max_age_seconds=600,
+            current_task_id="current",
+            profile_filter="default",
+            daytona_client=client,
+        )
+
+        assert stopped == 0
+        current.stop.assert_not_called()
+
+    def test_reaper_skips_recent_sandbox(self, monkeypatch):
+        from tools.environments import daytona
+
+        recent = self._stale_sandbox()
+        recent.created_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+        client = MagicMock()
+        client.list.return_value = iter([recent])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: False)
+
+        stopped = daytona.reap_orphan_sandboxes(
+            max_age_seconds=600,
+            current_task_id="current",
+            profile_filter="default",
+            daytona_client=client,
+        )
+
+        assert stopped == 0
+        recent.stop.assert_not_called()
+
+    def test_reaper_skips_live_owner(self, monkeypatch):
+        from tools.environments import daytona
+
+        active = self._stale_sandbox()
+        client = MagicMock()
+        client.list.return_value = iter([active])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: True)
+
+        stopped = daytona.reap_orphan_sandboxes(
+            max_age_seconds=600,
+            current_task_id="current",
+            profile_filter="default",
+            daytona_client=client,
+        )
+
+        assert stopped == 0
+        active.stop.assert_not_called()
+
+    @pytest.mark.parametrize("owner_pid", [None, "bad", "0", "-1"])
+    def test_reaper_skips_incomplete_owner_metadata(self, owner_pid):
+        from tools.environments import daytona
+
+        stale = self._stale_sandbox()
+        if owner_pid is None:
+            stale.labels.pop("hermes_owner_pid")
+        else:
+            stale.labels["hermes_owner_pid"] = owner_pid
+        client = MagicMock()
+        client.list.return_value = iter([stale])
+        assert daytona.reap_orphan_sandboxes(
+            max_age_seconds=600, current_task_id="current",
+            profile_filter="default", daytona_client=client,
+        ) == 0
+        stale.stop.assert_not_called()
+
+    @pytest.mark.parametrize("profile", [None, "other"])
+    def test_reaper_skips_missing_or_mismatched_profile(self, monkeypatch, profile):
+        from tools.environments import daytona
+
+        stale = self._stale_sandbox(profile=profile or "default")
+        if profile is None:
+            stale.labels.pop("hermes_profile")
+        client = MagicMock()
+        client.list.return_value = iter([stale])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: False)
+
+        assert daytona.reap_orphan_sandboxes(
+            max_age_seconds=600, current_task_id="current",
+            profile_filter="default", daytona_client=client,
+        ) == 0
+        stale.stop.assert_not_called()
+
+    def test_reaper_skips_unknown_pid_state(self, monkeypatch):
+        from tools.environments import daytona
+
+        stale = self._stale_sandbox()
+        client = MagicMock()
+        client.list.return_value = iter([stale])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: None)
+
+        assert daytona.reap_orphan_sandboxes(
+            max_age_seconds=600, current_task_id="current",
+            profile_filter="default", daytona_client=client,
+        ) == 0
+        stale.stop.assert_not_called()
+
+    def test_reaper_skips_missing_task_id(self, monkeypatch):
+        from tools.environments import daytona
+
+        stale = self._stale_sandbox()
+        stale.labels.pop("hermes_task_id")
+        client = MagicMock()
+        client.list.return_value = iter([stale])
+        monkeypatch.setattr(daytona, "_pid_is_alive", lambda pid: False)
+
+        assert daytona.reap_orphan_sandboxes(
+            max_age_seconds=600, current_task_id="current",
+            profile_filter="default", daytona_client=client,
+        ) == 0
+        stale.stop.assert_not_called()
+
+    def test_reaper_requires_profile_filter(self):
+        from tools.environments import daytona
+
+        client = MagicMock()
+        assert daytona.reap_orphan_sandboxes(daytona_client=client) == 0
+        client.list.assert_not_called()
+
+    def test_reaper_swallows_sdk_failures(self):
+        from tools.environments import daytona
+
+        client = MagicMock()
+        client.list.side_effect = RuntimeError("sdk down")
+
+        stopped = daytona.reap_orphan_sandboxes(
+            max_age_seconds=600,
+            current_task_id="current",
+            profile_filter="default",
+            daytona_client=client,
+        )
+
+        assert stopped == 0

--- a/tests/tools/test_daytona_orphan_reaper_integration.py
+++ b/tests/tools/test_daytona_orphan_reaper_integration.py
@@ -1,0 +1,110 @@
+"""Integration tests for Daytona orphan-reaper wiring in terminal_tool."""
+
+from unittest.mock import patch
+
+import tools.terminal_tool as terminal_tool
+
+
+def _reset_reaper_gate():
+    terminal_tool._daytona_orphan_reaper_ran = False
+
+
+def test_maybe_reap_runs_once_per_process(monkeypatch):
+    _reset_reaper_gate()
+    call_count = {"reap": 0}
+
+    def _fake_reap(**kwargs):
+        call_count["reap"] += 1
+        return 0
+
+    with patch("tools.environments.daytona.reap_orphan_sandboxes", _fake_reap):
+        config = {"daytona_orphan_reaper": True}
+        terminal_tool._maybe_reap_daytona_orphans(config, "current")
+        terminal_tool._maybe_reap_daytona_orphans(config, "current")
+        terminal_tool._maybe_reap_daytona_orphans(config, "current")
+
+    assert call_count["reap"] == 1
+
+
+def test_maybe_reap_respects_disable_flag(monkeypatch):
+    _reset_reaper_gate()
+    call_count = {"reap": 0}
+
+    def _fake_reap(**kwargs):
+        call_count["reap"] += 1
+        return 0
+
+    with patch("tools.environments.daytona.reap_orphan_sandboxes", _fake_reap):
+        terminal_tool._maybe_reap_daytona_orphans(
+            {"daytona_orphan_reaper": False},
+            "current",
+        )
+
+    assert call_count["reap"] == 0
+    assert terminal_tool._daytona_orphan_reaper_ran is False
+
+
+def test_maybe_reap_passes_current_task_profile_and_age(monkeypatch):
+    _reset_reaper_gate()
+    captured_args = {}
+
+    def _fake_reap(**kwargs):
+        captured_args.update(kwargs)
+        return 0
+
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "300")
+    with patch("tools.environments.daytona.reap_orphan_sandboxes", _fake_reap), \
+         patch("tools.environments.daytona._get_active_profile_name", return_value="research"):
+        terminal_tool._maybe_reap_daytona_orphans(
+            {"daytona_orphan_reaper": True},
+            "current",
+        )
+
+    assert captured_args["max_age_seconds"] == 600
+    assert captured_args["current_task_id"] == "current"
+    assert captured_args["profile_filter"] == "research"
+
+
+def test_maybe_reap_swallows_exceptions(monkeypatch):
+    _reset_reaper_gate()
+
+    def _exploding_reap(**kwargs):
+        raise RuntimeError("sdk down")
+
+    with patch("tools.environments.daytona.reap_orphan_sandboxes", _exploding_reap):
+        terminal_tool._maybe_reap_daytona_orphans(
+            {"daytona_orphan_reaper": True},
+            "current",
+        )
+
+
+def test_create_environment_runs_daytona_reaper_before_constructor(monkeypatch):
+    _reset_reaper_gate()
+    events = []
+
+    class FakeDaytonaEnvironment:
+        def __init__(self, **kwargs):
+            events.append(("create", kwargs["task_id"]))
+
+    def _fake_reap(config, task_id):
+        events.append(("reap", task_id, config["daytona_orphan_reaper"]))
+
+    monkeypatch.setattr(terminal_tool, "_maybe_reap_daytona_orphans", _fake_reap)
+    monkeypatch.setattr(
+        "tools.environments.daytona.DaytonaEnvironment",
+        FakeDaytonaEnvironment,
+    )
+
+    terminal_tool._create_environment(
+        env_type="daytona",
+        image="test-image",
+        cwd="/home/daytona",
+        timeout=60,
+        container_config={"daytona_orphan_reaper": True},
+        task_id="current",
+    )
+
+    assert events == [
+        ("reap", "current", True),
+        ("create", "current"),
+    ]

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -290,6 +290,16 @@ def test_docker_orphan_reaper_is_bridged_everywhere():
     assert "TERMINAL_DOCKER_ORPHAN_REAPER" in _terminal_tool_env_var_names()
 
 
+def test_daytona_orphan_reaper_is_bridged_everywhere(monkeypatch):
+    assert "daytona_orphan_reaper" in _cli_env_map_keys()
+    assert "daytona_orphan_reaper" in _gateway_env_map_keys()
+    assert "daytona_orphan_reaper" in _save_config_env_sync_keys()
+    assert "TERMINAL_DAYTONA_ORPHAN_REAPER" in _terminal_tool_env_var_names()
+    monkeypatch.setenv("TERMINAL_DAYTONA_ORPHAN_REAPER", "false")
+    from tools.terminal_tool import _get_env_config
+    assert _get_env_config()["daytona_orphan_reaper"] is False
+
+
 def test_docker_volumes_is_bridged_everywhere():
     """Regression pin for ``terminal.docker_volumes`` being silently dropped by
     ``hermes config set``.

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -10,7 +10,9 @@ import math
 import os
 import shlex
 import threading
-from pathlib import Path
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
 
 from tools.environments.base import (
     BaseEnvironment,
@@ -25,6 +27,169 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _get_active_profile_name() -> str:
+    """Return the active Hermes profile name, or ``"default"`` on any error."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _sandbox_attr(sandbox, *names):
+    for name in names:
+        value = getattr(sandbox, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _sandbox_labels(sandbox) -> dict:
+    labels = _sandbox_attr(sandbox, "labels", "metadata")
+    return labels if isinstance(labels, dict) else {}
+
+
+def _sandbox_name(sandbox) -> str:
+    return str(_sandbox_attr(sandbox, "name", "sandbox_name") or "")
+
+
+def _sandbox_state(sandbox) -> str:
+    state = _sandbox_attr(sandbox, "state", "status")
+    value = getattr(state, "value", state)
+    return str(value or "").lower()
+
+
+def _sandbox_task_id(sandbox) -> str | None:
+    labels = _sandbox_labels(sandbox)
+    task_id = labels.get("hermes_task_id")
+    return str(task_id) if task_id else None
+
+
+def _parse_daytona_time(value) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, (int, float)):
+        dt = datetime.fromtimestamp(value, timezone.utc)
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _sandbox_age_seconds(sandbox, now: datetime) -> float | None:
+    for attr in ("last_active_at", "updated_at", "created_at", "createdAt"):
+        dt = _parse_daytona_time(_sandbox_attr(sandbox, attr))
+        if dt is not None:
+            return (now - dt).total_seconds()
+    return None
+
+
+def _pid_is_alive(pid: object) -> bool | None:
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid_int <= 0:
+        return None
+    try:
+        import psutil  # type: ignore
+
+        return bool(psutil.pid_exists(pid_int))
+    except Exception:
+        return None
+
+
+def reap_orphan_sandboxes(
+    *,
+    max_age_seconds: int = 600,
+    current_task_id: str | None = None,
+    profile_filter: str | None = None,
+    daytona_client=None,
+) -> int:
+    """Stop stale Hermes-created Daytona sandboxes from prior processes.
+
+    Daytona persistent cleanup normally stops the active sandbox to preserve
+    its filesystem. The startup reaper uses the same non-destructive action
+    for old sandboxes because Daytona metadata does not reliably distinguish
+    persistent from disposable sandboxes after process death. Sandboxes without
+    any usable age metadata are left alone.
+    """
+    try:
+        if daytona_client is None:
+            from daytona import Daytona
+
+            daytona_client = Daytona()
+    except Exception as e:
+        logger.debug("Daytona orphan reaper could not initialize SDK: %s", e)
+        return 0
+
+    if not profile_filter:
+        return 0
+    list_kwargs = {"labels": {"hermes_profile": profile_filter}, "limit": 100}
+
+    candidates = []
+    try:
+        try:
+            results = daytona_client.list(**list_kwargs)
+        except TypeError:
+            results = daytona_client.list(labels=list_kwargs["labels"])
+        candidates.extend(results)
+    except Exception as e:
+        logger.debug("Daytona orphan reaper list failed: %s", e)
+
+    now = datetime.now(timezone.utc)
+    stopped = 0
+    for sandbox in candidates:
+        labels = _sandbox_labels(sandbox)
+        task_id = _sandbox_task_id(sandbox)
+        sandbox_profile = labels.get("hermes_profile")
+        owner_pid = labels.get("hermes_owner_pid")
+        if not task_id or not sandbox_profile or not owner_pid:
+            continue
+        if sandbox_profile != profile_filter:
+            continue
+        if current_task_id and task_id == current_task_id:
+            continue
+
+        age = _sandbox_age_seconds(sandbox, now)
+        if age is None or age < max_age_seconds:
+            continue
+
+        owner_alive = _pid_is_alive(owner_pid)
+        if owner_alive is not False:
+            continue
+
+        state = _sandbox_state(sandbox)
+        if state and state in {"stopped", "archived"}:
+            continue
+
+        try:
+            sandbox.stop()
+            stopped += 1
+            logger.info(
+                "Daytona orphan reaper stopped sandbox %s for task %s",
+                _sandbox_attr(sandbox, "id") or _sandbox_name(sandbox) or "<unknown>",
+                task_id or "<unknown>",
+            )
+        except Exception as e:
+            logger.debug("Daytona orphan reaper stop failed: %s", e)
+    return stopped
 
 
 class DaytonaEnvironment(BaseEnvironment):
@@ -61,7 +226,6 @@ class DaytonaEnvironment(BaseEnvironment):
         from daytona import (
             Daytona,
             CreateSandboxFromImageParams,
-            DaytonaError,
             Resources,
             SandboxState,
         )
@@ -83,38 +247,38 @@ class DaytonaEnvironment(BaseEnvironment):
             disk_gib = 10
         resources = Resources(cpu=cpu, memory=memory_gib, disk=disk_gib)
 
-        labels = {"hermes_task_id": task_id}
-        sandbox_name = f"hermes-{task_id}"
+        profile = _get_active_profile_name()
+        labels = {
+            "hermes_task_id": task_id,
+            "hermes_profile": profile,
+            "hermes_owner_pid": str(os.getpid()),
+        }
+        sandbox_name = f"hermes-{uuid.uuid4().hex[:12]}"
 
         if self._persistent:
             try:
-                self._sandbox = self._daytona.get(sandbox_name)
-                self._sandbox.start()
-                logger.info("Daytona: resumed sandbox %s for task %s",
-                            self._sandbox.id, task_id)
-            except DaytonaError:
-                self._sandbox = None
-            except Exception as e:
-                logger.warning("Daytona: failed to resume sandbox for task %s: %s",
-                               task_id, e)
-                self._sandbox = None
-
-            if self._sandbox is None:
-                try:
-                    # Daytona SDK >=0.108.0 uses cursor-based pagination and
-                    # list() returns an iterator. Offset-based pagination
-                    # (page=1) is removed on June 10, 2026.
-                    results = self._daytona.list(labels=labels, limit=1)
-                    legacy = next(iter(results), None)
-                    if legacy is not None:
-                        self._sandbox = legacy
-                        self._sandbox.start()
-                        logger.info("Daytona: resumed legacy sandbox %s for task %s",
-                                    self._sandbox.id, task_id)
-                except Exception as e:
-                    logger.debug("Daytona: no legacy sandbox found for task %s: %s",
-                                 task_id, e)
+                # Daytona SDK >=0.108.0 uses cursor-based pagination and
+                # list() returns an iterator. Offset-based pagination (page=1)
+                # is removed on June 10, 2026.
+                results = self._daytona.list(
+                    labels={"hermes_task_id": task_id, "hermes_profile": profile},
+                    limit=1,
+                )
+                self._sandbox = next(iter(results), None)
+                if self._sandbox is not None and (
+                    _sandbox_labels(self._sandbox).get("hermes_task_id") != task_id
+                    or _sandbox_labels(self._sandbox).get("hermes_profile") != profile
+                ):
                     self._sandbox = None
+                if self._sandbox is not None:
+                    self._sandbox.set_labels(labels)
+                    self._sandbox.start()
+                    logger.info("Daytona: resumed sandbox %s for task %s",
+                                self._sandbox.id, task_id)
+            except Exception as e:
+                logger.debug("Daytona: no reusable sandbox found for task %s: %s",
+                             task_id, e)
+                self._sandbox = None
 
         if self._sandbox is None:
             self._sandbox = self._daytona.create(
@@ -153,7 +317,7 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _daytona_upload(self, host_path: str, remote_path: str) -> None:
         """Upload a single file via Daytona SDK."""
-        parent = str(Path(remote_path).parent)
+        parent = str(PurePosixPath(remote_path).parent)
         self._sandbox.process.exec(quoted_mkdir_command([parent]))
         self._sandbox.fs.upload_file(host_path, remote_path)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -992,6 +992,8 @@ _cleanup_running = False
 # calls for parallel subagents won't re-trigger the sweep.
 _docker_orphan_reaper_ran = False
 _docker_orphan_reaper_lock = threading.Lock()
+_daytona_orphan_reaper_ran = False
+_daytona_orphan_reaper_lock = threading.Lock()
 
 
 def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
@@ -1057,6 +1059,50 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
     except Exception as e:
         # Never fail the env-creation path because of a janitor problem.
         logger.debug("Docker orphan reaper raised: %s", e)
+
+
+def _maybe_reap_daytona_orphans(
+    container_config: Dict[str, Any],
+    current_task_id: str,
+) -> None:
+    """Run the Daytona orphan reaper once per process, if enabled."""
+    global _daytona_orphan_reaper_ran
+    if not container_config.get("daytona_orphan_reaper", True):
+        return
+    if _daytona_orphan_reaper_ran:
+        return
+    with _daytona_orphan_reaper_lock:
+        if _daytona_orphan_reaper_ran:
+            return
+        _daytona_orphan_reaper_ran = True
+
+    try:
+        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+    except (TypeError, ValueError):
+        lifetime = 300
+    lifetime = max(60, lifetime)
+    max_age = lifetime * 2
+
+    try:
+        from tools.environments.daytona import (
+            reap_orphan_sandboxes, _get_active_profile_name,
+        )
+    except ImportError:
+        return
+    try:
+        profile = _get_active_profile_name()
+        stopped = reap_orphan_sandboxes(
+            max_age_seconds=max_age,
+            current_task_id=current_task_id,
+            profile_filter=profile,
+        )
+        if stopped:
+            logger.info(
+                "Daytona orphan reaper stopped %d stale sandbox(es) for profile %s",
+                stopped, profile,
+            )
+    except Exception as e:
+        logger.debug("Daytona orphan reaper raised: %s", e)
 
 
 # Per-task environment overrides registry.
@@ -1375,6 +1421,9 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_orphan_reaper": os.getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
+        "daytona_orphan_reaper": os.getenv(
+            "TERMINAL_DAYTONA_ORPHAN_REAPER", "true"
+        ).lower() in {"true", "1", "yes"},
     }
 
 
@@ -1514,6 +1563,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     elif env_type == "daytona":
         # Lazy import so daytona SDK is only required when backend is selected.
         from tools.environments.daytona import DaytonaEnvironment as _DaytonaEnvironment
+        _maybe_reap_daytona_orphans(cc, task_id)
         return _DaytonaEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=int(cpu), memory=memory, disk=disk,
@@ -2214,6 +2264,7 @@ def terminal_tool(
                                 "docker_network": config.get("docker_network", True),
                                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+                                "daytona_orphan_reaper": config.get("daytona_orphan_reaper", True),
                             }
 
                         local_config = None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -213,6 +213,7 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `TERMINAL_SINGULARITY_IMAGE` | Singularity image or `.sif` path |
 | `TERMINAL_MODAL_IMAGE` | Modal container image |
 | `TERMINAL_DAYTONA_IMAGE` | Daytona sandbox image |
+| `TERMINAL_DAYTONA_ORPHAN_REAPER` | Override `terminal.daytona_orphan_reaper` to enable or disable the once-per-process stale-sandbox sweep |
 | `TERMINAL_TIMEOUT` | Command timeout in seconds |
 | `TERMINAL_LIFETIME_SECONDS` | Max lifetime for terminal sessions in seconds |
 | `TERMINAL_CWD` | Deprecated direct override for gateway/cron terminal sessions. Prefer `terminal.cwd` in `config.yaml`; CLI still uses the launch directory. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -362,11 +362,14 @@ terminal:
   container_memory: 5120           # MB → converted to GiB
   container_disk: 10240            # MB → converted to GiB (max 10 GiB)
   container_persistent: true       # Stop/resume instead of delete
+  daytona_orphan_reaper: true      # Reconcile stale sandboxes at startup
 ```
 
 **Required:** `DAYTONA_API_KEY` environment variable.
 
-**Persistence:** When enabled, sandboxes are stopped (not deleted) on cleanup and resumed on next session. Sandbox names follow the pattern `hermes-{task_id}`.
+**Persistence:** When enabled, sandboxes are stopped (not deleted) on cleanup and resumed on next session. Reuse is scoped to the exact Hermes profile and task labels, and resumed sandboxes receive fresh owner labels before they start. New sandbox names are unique; labels are the canonical identity.
+
+**Startup reconciliation:** Once per Python process, Hermes checks sandboxes in the active profile that are older than `2 × terminal.lifetime_seconds` with a 60-second minimum. It stops a sandbox only when its profile, task ID, and positive owner PID labels are complete and that PID is definitively dead. The current task, recent sandboxes, stopped or archived sandboxes, live owners, unknown PID states, SDK errors, and unreadable metadata are left untouched. The action is stop, never delete, so the persistent filesystem remains available. Profileless legacy sandboxes aren't reused or reaped. Set `terminal.daytona_orphan_reaper: false` to disable the sweep.
 
 **Disk limit:** Daytona enforces a 10 GiB maximum. Requests above this are capped with a warning.
 


### PR DESCRIPTION
## Summary

Docker terminal environments already had a best-effort once-per-process orphan reaper for stale containers left behind by crashed Hermes processes. Daytona sandboxes were labeled and reused, but there was no equivalent reconciliation pass, so orphaned cloud sandboxes could persist indefinitely after gateway restarts.

The fix adds conservative Daytona stale-sandbox reconciliation and wires it into Daytona environment creation with the same fail-open behavior used by Docker. The reaper is now ownership-aware: it requires exact profile and task labels, a valid positive owner PID, enough age, and a definitive dead-PID result before it stops anything. Persistent reuse is also scoped to the exact profile plus task labels, refreshes owner metadata before restart, and uses unique provider-side names for new sandboxes.

## Changes

- `tools/environments/daytona.py`: add conservative stale-sandbox reconciliation, require complete ownership metadata before stopping, scope persistent reuse to exact profile plus task labels, refresh owner labels on reused sandboxes, and switch new sandbox names to unique IDs.
- `tools/terminal_tool.py`: run the Daytona reaper once per process before Daytona environment creation and keep the existing environment override path.
- `cli.py`, `gateway/run.py`, and `hermes_cli/config.py`: add the `terminal.daytona_orphan_reaper` config default and bridge it through the CLI, gateway, and `hermes config set` environment sync.
- `tests/tools/test_daytona_environment.py`, `tests/tools/test_daytona_orphan_reaper_integration.py`, and `tests/tools/test_terminal_config_env_sync.py`: cover fail-closed owner checks, profile-safe reuse, once-per-process wiring, and config propagation.
- `website/docs/reference/environment-variables.md` and `website/docs/user-guide/configuration.md`: document the config toggle, ownership requirements, age threshold, and stop-not-delete behavior.

## Validation

- `python -m pytest tests/tools/test_daytona_environment.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_daytona_orphan_reaper_integration.py -q` - 59 passed.
- `git diff --check`
- Full suite not run locally; CI is the source of truth.

## Test plan

Run `python -m pytest tests/tools/test_daytona_environment.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_daytona_orphan_reaper_integration.py -q`.

## Upstream

Closes #28807.
Reported by @rileydev.
