### PR TITLE
Add Mission Control lane dashboard

### DIFF
--- a/hermes_cli/mission_control_autonomy.py
+++ b/hermes_cli/mission_control_autonomy.py
@@ -1,0 +1,370 @@
+"""Inert policy primitives for future Mission Control autonomous lane running.
+
+This module is data-only decision support. Callers must supply observed repo
+state and requested tool metadata; the helpers here do not inspect the machine,
+load transcripts, persist state, wire runtime behavior, or execute tool calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class LaneState(str, Enum):
+    ACTIVE = "active"
+    BLOCKED = "blocked"
+    STOPPED = "stopped"
+    COMPLETE = "complete"
+
+
+class ApprovalTier(str, Enum):
+    READ_ONLY = "read_only"
+    CODE_TEST = "code_test"
+    ELEVATED = "elevated"
+    FORBIDDEN = "forbidden"
+
+
+@dataclass(frozen=True)
+class EvidenceCardModel:
+    kind: str
+    title: str
+    summary: str
+    limitations: tuple[str, ...] = ()
+    trusted_for_execution: bool = False
+    inert_context_only: bool = True
+    authorizing: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", str(self.kind))
+        object.__setattr__(self, "title", str(self.title))
+        object.__setattr__(self, "summary", str(self.summary))
+        object.__setattr__(self, "limitations", _tuple_of_text(self.limitations))
+        object.__setattr__(self, "trusted_for_execution", False)
+        object.__setattr__(self, "inert_context_only", True)
+        object.__setattr__(self, "authorizing", False)
+
+
+@dataclass(frozen=True)
+class TaskControlEnvelopeModel:
+    active_lane: str
+    mode: str
+    lane_state: LaneState
+    approval_tier: ApprovalTier
+    repo_path: str
+    branch: str
+    allowed_actions: tuple[str, ...] = ()
+    forbidden_actions: tuple[str, ...] = ()
+    allowed_files: tuple[str, ...] = ()
+    forbidden_files: tuple[str, ...] = ()
+    allowed_start_gate_dirty_files: tuple[str, ...] = ()
+    focused_test_files: tuple[str, ...] = ()
+    stop_condition: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "active_lane", str(self.active_lane))
+        object.__setattr__(self, "mode", str(self.mode))
+        object.__setattr__(self, "lane_state", LaneState(self.lane_state))
+        object.__setattr__(self, "approval_tier", ApprovalTier(self.approval_tier))
+        object.__setattr__(self, "repo_path", str(self.repo_path))
+        object.__setattr__(self, "branch", str(self.branch))
+        object.__setattr__(self, "allowed_actions", _tuple_of_text(self.allowed_actions))
+        object.__setattr__(self, "forbidden_actions", _tuple_of_text(self.forbidden_actions))
+        object.__setattr__(self, "allowed_files", _tuple_of_text(self.allowed_files))
+        object.__setattr__(self, "forbidden_files", _tuple_of_text(self.forbidden_files))
+        object.__setattr__(
+            self,
+            "allowed_start_gate_dirty_files",
+            _tuple_of_text(self.allowed_start_gate_dirty_files),
+        )
+        object.__setattr__(self, "focused_test_files", _tuple_of_text(self.focused_test_files))
+        object.__setattr__(self, "stop_condition", str(self.stop_condition))
+
+
+@dataclass(frozen=True)
+class ToolRequest:
+    tool_name: str
+    action: str
+    target_files: tuple[str, ...] = ()
+    writes: bool = False
+    executes: bool = False
+    uses_network: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tool_name", str(self.tool_name))
+        object.__setattr__(self, "action", str(self.action))
+        object.__setattr__(self, "target_files", _tuple_of_text(self.target_files))
+        object.__setattr__(self, "writes", bool(self.writes))
+        object.__setattr__(self, "executes", bool(self.executes))
+        object.__setattr__(self, "uses_network", bool(self.uses_network))
+
+
+@dataclass(frozen=True)
+class GuardDecision:
+    allowed: bool
+    approval_tier: ApprovalTier
+    reason: str
+    violations: tuple[str, ...] = ()
+    evidence_cards: tuple[EvidenceCardModel, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "approval_tier", ApprovalTier(self.approval_tier))
+        object.__setattr__(self, "reason", str(self.reason))
+        object.__setattr__(self, "violations", _tuple_of_text(self.violations))
+        object.__setattr__(self, "evidence_cards", tuple(self.evidence_cards))
+
+
+def task_control_envelope_model_from_record(record: dict[str, Any]) -> TaskControlEnvelopeModel:
+    """Convert a stored Mission Control envelope record into an inert policy model.
+
+    The record is treated as opaque stored data. This helper does not resolve
+    paths, inspect git state, load transcripts, execute tools, or authorize
+    future action.
+    """
+    lane_lock = _dict(record.get("lane_lock"))
+    repo_context = _dict(record.get("repo_context"))
+    metadata = _dict(record.get("metadata"))
+    return TaskControlEnvelopeModel(
+        active_lane=_text(lane_lock.get("active_lane"), _text(record.get("title"), "No active lane")),
+        mode=_text(record.get("mode"), "unknown"),
+        lane_state=_lane_state(record.get("status")),
+        approval_tier=_approval_tier(metadata.get("approval_tier")),
+        repo_path=_text(repo_context.get("path")),
+        branch=_text(repo_context.get("branch")),
+        allowed_actions=_string_tuple(record.get("allowed_actions")),
+        forbidden_actions=_string_tuple(record.get("forbidden_actions")),
+        allowed_files=_string_tuple(metadata.get("allowed_files")),
+        forbidden_files=_string_tuple(metadata.get("forbidden_files")),
+        allowed_start_gate_dirty_files=_string_tuple(
+            metadata.get("allowed_start_gate_dirty_files")
+        ),
+        focused_test_files=_string_tuple(metadata.get("focused_test_files")),
+        stop_condition=_text(metadata.get("stop_condition")),
+    )
+
+
+def task_control_envelope_model_summary(model: TaskControlEnvelopeModel) -> dict[str, Any]:
+    return {
+        "active_lane": model.active_lane,
+        "mode": model.mode,
+        "lane_state": model.lane_state.value,
+        "approval_tier": model.approval_tier.value,
+        "repo_path": model.repo_path,
+        "branch": model.branch,
+        "allowed_actions": list(model.allowed_actions),
+        "forbidden_actions": list(model.forbidden_actions),
+        "allowed_files": list(model.allowed_files),
+        "forbidden_files": list(model.forbidden_files),
+        "allowed_start_gate_dirty_files": list(model.allowed_start_gate_dirty_files),
+        "focused_test_files": list(model.focused_test_files),
+        "stop_condition": model.stop_condition,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+
+
+def summarize_guard_decision(decision: GuardDecision | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(decision, dict):
+        allowed = bool(decision.get("allowed"))
+        approval_tier = _approval_tier(decision.get("approval_tier"))
+        reason = _text(decision.get("reason"), "unknown")
+        violations = _string_tuple(decision.get("violations"))
+    else:
+        allowed = decision.allowed
+        approval_tier = decision.approval_tier
+        reason = decision.reason
+        violations = decision.violations
+    return {
+        "allowed": allowed,
+        "approval_tier": approval_tier.value,
+        "reason": reason,
+        "violations": list(violations),
+        "execution_enabled": False,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+
+
+def next_action_decision_summary(
+    envelope: TaskControlEnvelopeModel | None,
+    start_gate_decision: GuardDecision | dict[str, Any] | None,
+) -> dict[str, Any]:
+    decision = (
+        summarize_guard_decision(start_gate_decision)
+        if start_gate_decision is not None
+        else summarize_guard_decision(
+            GuardDecision(
+                allowed=False,
+                approval_tier=ApprovalTier.FORBIDDEN,
+                reason="no_start_gate_decision",
+            )
+        )
+    )
+    if envelope is None:
+        kind = "forbidden"
+        label = "Forbidden"
+        reason = "no_task_control_envelope"
+    elif not decision["allowed"] or envelope.approval_tier is ApprovalTier.FORBIDDEN:
+        kind = "forbidden"
+        label = "Forbidden"
+        reason = decision["reason"]
+    elif envelope.approval_tier is ApprovalTier.READ_ONLY:
+        kind = "auto"
+        label = "Auto read-only"
+        reason = "read_only_lane_after_start_gate"
+    else:
+        kind = "one_click_approval"
+        label = "One-click approval required"
+        reason = "approval_required_for_non_read_only_lane"
+    return {
+        "kind": kind,
+        "label": label,
+        "reason": reason,
+        "execution_enabled": False,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+
+
+def validate_start_gate(
+    envelope: TaskControlEnvelopeModel,
+    *,
+    repo_path: str,
+    branch: str,
+    dirty_files: tuple[str, ...] = (),
+) -> GuardDecision:
+    violations: list[str] = []
+    observed_dirty = _tuple_of_text(dirty_files)
+    allowed_dirty = set(envelope.allowed_start_gate_dirty_files)
+
+    if envelope.lane_state is not LaneState.ACTIVE:
+        violations.append(f"lane_not_active:{envelope.lane_state.value}")
+    if str(repo_path) != envelope.repo_path:
+        violations.append("repo_path_mismatch")
+    if str(branch) != envelope.branch:
+        violations.append("branch_mismatch")
+    for dirty_file in observed_dirty:
+        if dirty_file not in allowed_dirty:
+            violations.append(f"unexpected_dirty_file:{dirty_file}")
+
+    allowed = not violations
+    reason = "start_gate_passed" if allowed else "start_gate_blocked"
+    return GuardDecision(
+        allowed=allowed,
+        approval_tier=envelope.approval_tier if allowed else ApprovalTier.FORBIDDEN,
+        reason=reason,
+        violations=tuple(violations),
+        evidence_cards=(
+            EvidenceCardModel(
+                kind="start_gate",
+                title="Autonomous lane runner start gate",
+                summary=reason,
+                limitations=("caller_supplied_state_only",),
+            ),
+        ),
+    )
+
+
+def decide_tool_request(
+    envelope: TaskControlEnvelopeModel,
+    request: ToolRequest,
+) -> GuardDecision:
+    violations: list[str] = []
+
+    if envelope.lane_state is not LaneState.ACTIVE:
+        violations.append(f"lane_not_active:{envelope.lane_state.value}")
+
+    forbidden_actions = set(envelope.forbidden_actions)
+    allowed_actions = set(envelope.allowed_actions)
+    if request.action in forbidden_actions:
+        violations.append(f"forbidden_action:{request.action}")
+    elif request.action not in allowed_actions:
+        violations.append(f"action_not_allowed:{request.action}")
+
+    if request.uses_network:
+        violations.append("network_not_allowed")
+
+    if request.writes:
+        allowed_files = set(envelope.allowed_files)
+        forbidden_files = set(envelope.forbidden_files)
+        for target_file in request.target_files:
+            if target_file in forbidden_files:
+                violations.append(f"forbidden_file:{target_file}")
+            elif target_file not in allowed_files:
+                violations.append(f"write_outside_allowed_files:{target_file}")
+
+    if request.action == "run_focused_tests":
+        focused_files = set(envelope.focused_test_files)
+        for target_file in request.target_files:
+            if target_file not in focused_files:
+                violations.append(f"test_outside_focused_scope:{target_file}")
+
+    allowed = not violations
+    reason = "tool_request_allowed" if allowed else "tool_request_blocked"
+    return GuardDecision(
+        allowed=allowed,
+        approval_tier=envelope.approval_tier if allowed else ApprovalTier.FORBIDDEN,
+        reason=reason,
+        violations=tuple(violations),
+        evidence_cards=(
+            EvidenceCardModel(
+                kind="tool_policy",
+                title=f"Tool request: {request.tool_name}",
+                summary=reason,
+                limitations=("decision_only_no_execution",),
+            ),
+        ),
+    )
+
+
+def _tuple_of_text(values: tuple[str, ...]) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    return tuple(str(value) for value in values)
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text or fallback
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item) for item in value if isinstance(item, str))
+
+
+def _lane_state(value: Any) -> LaneState:
+    text = _text(value, "stopped")
+    if text == "completed":
+        return LaneState.COMPLETE
+    if text == "archived":
+        return LaneState.STOPPED
+    try:
+        return LaneState(text)
+    except ValueError:
+        return LaneState.STOPPED
+
+
+def _approval_tier(value: Any) -> ApprovalTier:
+    text = _text(value, "forbidden").lower().replace("-", "_").replace("/", "_")
+    text = "_".join(part for part in text.split() if part)
+    aliases = {
+        "read_only": ApprovalTier.READ_ONLY,
+        "read_only_only": ApprovalTier.READ_ONLY,
+        "readonly": ApprovalTier.READ_ONLY,
+        "code_test": ApprovalTier.CODE_TEST,
+        "code_test_only": ApprovalTier.CODE_TEST,
+        "code_testing": ApprovalTier.CODE_TEST,
+        "code": ApprovalTier.CODE_TEST,
+        "elevated": ApprovalTier.ELEVATED,
+        "forbidden": ApprovalTier.FORBIDDEN,
+    }
+    return aliases.get(text, ApprovalTier.FORBIDDEN)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -64,7 +64,7 @@ from gateway.status import get_running_pid, read_runtime_status
 from utils import env_var_enabled
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+    from fastapi import FastAPI, File, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
@@ -76,7 +76,7 @@ except ImportError:
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tool.dashboard", prompt=False)
-        from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+        from fastapi import FastAPI, File, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
@@ -5414,6 +5414,1083 @@ class CronJobCreate(BaseModel):
 
 class CronJobUpdate(BaseModel):
     updates: dict
+
+
+class ApprovalCreate(BaseModel):
+    title: str
+    project: str
+    profile: str = "default"
+    risk_label: str
+    proposed_action: str
+    target: str
+    preview: str
+    reason: str
+    rollback_or_verification: str
+    created_by: str = "dashboard"
+    expires_at: Optional[str] = None
+    source_surface: Optional[str] = None
+    source_ref: Optional[str] = None
+    conversation_excerpt: Optional[str] = None
+    related_paths: Optional[List[str]] = None
+
+
+class ApprovalDecision(BaseModel):
+    decided_by: str
+    decision_note: Optional[str] = None
+
+
+def _model_dump(body: BaseModel) -> Dict[str, Any]:
+    if hasattr(body, "model_dump"):
+        return body.model_dump(exclude_none=True)  # type: ignore[attr-defined]
+    return body.dict(exclude_none=True)
+
+
+def _approval_store():
+    from hermes_cli.ops_approvals import ApprovalStore
+    return ApprovalStore()
+
+
+def _approval_error(exc: Exception) -> HTTPException:
+    detail = str(exc) or "Invalid approval request"
+    status = 404 if "not found" in detail.lower() else 400
+    return HTTPException(status_code=status, detail=detail)
+
+
+@app.get("/api/ops/approvals")
+async def list_ops_approvals():
+    try:
+        return _approval_store().list()
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals")
+async def create_ops_approval(body: ApprovalCreate):
+    try:
+        return _approval_store().create(_model_dump(body))
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/propose")
+async def propose_ops_approval(body: ApprovalCreate):
+    try:
+        return _approval_store().propose_from_context(_model_dump(body))
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/approvals/audit")
+async def list_ops_approval_audit(approval_id: Optional[str] = None):
+    try:
+        return _approval_store().audit_events(approval_id)
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/approvals/summary")
+async def summarize_ops_approvals():
+    try:
+        return _approval_store().summary()
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/actions")
+async def get_ops_action_registry_status():
+    try:
+        from hermes_cli.ops_actions import action_registry_status
+
+        return action_registry_status()
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/memory-status")
+async def get_ops_memory_status():
+    try:
+        from hermes_cli.ops_memory_status import read_ops_memory_status
+
+        return read_ops_memory_status()
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/social-platform-status")
+async def get_ops_social_platform_status(response: Response):
+    try:
+        from hermes_cli.ops_social_status import read_social_platform_status
+
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        return read_social_platform_status()
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/ops/social-platform-status/history")
+async def get_ops_social_platform_status_history(response: Response, limit: int = 8):
+    try:
+        from hermes_cli.ops_social_status import read_social_platform_history
+
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        return read_social_platform_history(limit=limit)
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/social-platform-status")
+async def update_ops_social_platform_status(payload: Dict[str, Any]):
+    try:
+        from hermes_cli.ops_social_status import write_manual_social_platform_status
+
+        return write_manual_social_platform_status(payload)
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/actions/{action_name}/dry-run")
+async def dry_run_ops_approval_action(approval_id: str, action_name: str):
+    try:
+        from hermes_cli.ops_actions import dry_run_action
+
+        store = _approval_store()
+        approval = store.get(approval_id)
+        return dry_run_action(action_name, approval)
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/actions/{action_name}/execute")
+async def execute_ops_approval_action(approval_id: str, action_name: str):
+    try:
+        from hermes_cli.ops_actions import execute_read_only_status_probe
+
+        store = _approval_store()
+        approval = store.get(approval_id)
+
+        def _audit(event: str, item: Dict[str, Any], actor: str) -> None:
+            store.append_audit_event(event, dict(item), actor=actor, note=action_name)
+
+        return execute_read_only_status_probe(
+            action_name,
+            approval,
+            audit=_audit,
+            actor="dashboard",
+        )
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/approve")
+async def approve_ops_approval(approval_id: str, body: ApprovalDecision):
+    try:
+        return _approval_store().decide(
+            approval_id,
+            "approved",
+            decided_by=body.decided_by,
+            decision_note=body.decision_note,
+        )
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/reject")
+async def reject_ops_approval(approval_id: str, body: ApprovalDecision):
+    try:
+        return _approval_store().decide(
+            approval_id,
+            "rejected",
+            decided_by=body.decided_by,
+            decision_note=body.decision_note,
+        )
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/clarify")
+async def clarify_ops_approval(approval_id: str, body: ApprovalDecision):
+    try:
+        return _approval_store().decide(
+            approval_id,
+            "clarification_requested",
+            decided_by=body.decided_by,
+            decision_note=body.decision_note,
+        )
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.post("/api/ops/approvals/{approval_id}/snooze")
+async def snooze_ops_approval(approval_id: str, body: ApprovalDecision):
+    try:
+        return _approval_store().decide(
+            approval_id,
+            "snoozed",
+            decided_by=body.decided_by,
+            decision_note=body.decision_note,
+        )
+    except Exception as exc:
+        raise _approval_error(exc) from exc
+
+
+@app.get("/api/mission-control/project-status")
+async def get_mission_control_project_status():
+    from hermes_cli.mission_control import project_status
+
+    return project_status()
+
+
+@app.get("/api/mission-control/open-tasks")
+async def get_mission_control_open_tasks():
+    from hermes_cli.mission_control import open_tasks
+
+    return open_tasks()
+
+
+@app.get("/api/mission-control/latest-worker-results")
+async def get_mission_control_latest_worker_results():
+    from hermes_cli.mission_control import latest_worker_results
+
+    return latest_worker_results()
+
+
+@app.get("/api/mission-control/repo-status")
+async def get_mission_control_repo_status():
+    from hermes_cli.mission_control import repo_status
+
+    return repo_status()
+
+
+@app.get("/api/mission-control/approval-gates")
+async def get_mission_control_approval_gates():
+    from hermes_cli.mission_control import approval_gates
+
+    return approval_gates()
+
+
+@app.get("/api/mission-control/recent-audit-log")
+async def get_mission_control_recent_audit_log():
+    from hermes_cli.mission_control import recent_audit_log
+
+    return recent_audit_log()
+
+
+@app.get("/api/mission-control/active-envelope")
+async def get_mission_control_active_envelope():
+    from hermes_cli.mission_control_task_control_envelopes import active_task_control_envelope_selection
+
+    selection = active_task_control_envelope_selection()
+    envelope = selection.get("task_control_envelope")
+    if envelope:
+        selected_from_count = int(selection.get("selected_from_count") or 0)
+        repo_context = envelope.get("repo_context") or {}
+        lane_lock = envelope.get("lane_lock") if isinstance(envelope.get("lane_lock"), dict) else {}
+        return {
+            "exists": True,
+            "active_lane": lane_lock.get("active_lane"),
+            "active_mode": envelope.get("mode"),
+            "execution_boundary": "persisted_envelope_inert_non_authorizing",
+            "allowed_actions": envelope.get("allowed_actions", []),
+            "forbidden_actions": envelope.get("forbidden_actions", []),
+            "checkpoint": envelope.get("checkpoint"),
+            "repo_state": {
+                "status": repo_context.get("dirty_state", "not_probed"),
+                "source": repo_context.get("source", "unknown"),
+            },
+            "evidence": {
+                "count": selected_from_count,
+                "links": [],
+            },
+            "data_source": "persisted_task_control_envelope",
+            "task_control_envelope": {
+                "id": envelope.get("id"),
+                "schema": envelope.get("schema"),
+                "status": envelope.get("status"),
+                "title": envelope.get("title"),
+                "mode": envelope.get("mode"),
+                "mode_label": envelope.get("mode_label", ""),
+                "created_at": envelope.get("created_at"),
+                "updated_at": envelope.get("updated_at"),
+                "trusted_for_execution": False,
+                "inert_context_only": True,
+                "vocabulary_version": "g1",
+            },
+            "selection": {
+                "selected_from_count": selected_from_count,
+                "ambiguous": selected_from_count > 1,
+                "selection_reason": "newest_active_updated_at",
+            },
+            "trusted_for_execution": False,
+            "inert_context_only": True,
+        }
+    return {
+        "exists": False,
+        "active_lane": None,
+        "active_mode": None,
+        "execution_boundary": "no_active_authorization",
+        "allowed_actions": [],
+        "forbidden_actions": [],
+        "checkpoint": None,
+        "repo_state": {
+            "status": "unknown",
+            "source": "not_probed",
+        },
+        "evidence": {
+            "count": 0,
+            "links": [],
+        },
+        "data_source": "no_persisted_envelope",
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+
+
+def _read_json_records(directory: Path, pattern: str) -> list[dict[str, Any]]:
+    if not directory.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in sorted(directory.glob(pattern)):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(data, dict):
+            records.append(data)
+    return records
+
+
+def _first_text(value: Any, fallback: str) -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text or fallback
+
+
+def _safe_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def _token_estimates(envelope: dict[str, Any] | None, evidence: list[dict[str, Any]]) -> dict[str, Any]:
+    metadata = envelope.get("metadata") if isinstance(envelope, dict) else {}
+    budget = {}
+    if isinstance(metadata, dict):
+        budget = (
+            metadata.get("context_budget")
+            or metadata.get("token_context_budget")
+            or metadata.get("token_budget")
+        )
+    if not isinstance(budget, dict):
+        budget = {}
+    estimated_input = budget.get("estimated_input_tokens", budget.get("input_estimate"))
+    estimated_output = budget.get("estimated_output_tokens", budget.get("output_estimate"))
+    if not isinstance(estimated_input, int):
+        estimated_input = min(12000, 1200 + sum(len(str(card.get("summary") or "")) for card in evidence))
+    if not isinstance(estimated_output, int):
+        estimated_output = 1800
+    return {
+        "estimated_input_tokens": estimated_input,
+        "estimated_output_tokens": estimated_output,
+        "remaining_context_window": _first_text(budget.get("remaining_context_window"), "unknown"),
+        "show_token_estimates": True,
+        "conservation_behavior": "summary_first_details_on_demand_no_transcript_load",
+    }
+
+
+def _mission_control_state_dir(name: str) -> Path:
+    return Path(get_hermes_home()) / "state" / "mission-control" / name
+
+
+def _lane_policy_read_model(envelope: dict[str, Any] | None) -> dict[str, Any]:
+    from hermes_cli.mission_control_autonomy import (
+        ApprovalTier,
+        GuardDecision,
+        next_action_decision_summary,
+        summarize_guard_decision,
+        task_control_envelope_model_from_record,
+        task_control_envelope_model_summary,
+        validate_start_gate,
+    )
+
+    if not envelope:
+        start_gate = GuardDecision(
+            allowed=False,
+            approval_tier=ApprovalTier.FORBIDDEN,
+            reason="no_task_control_envelope",
+        )
+        return {
+            "policy_model": None,
+            "start_gate": summarize_guard_decision(start_gate),
+            "next_action": next_action_decision_summary(None, start_gate),
+        }
+
+    model = task_control_envelope_model_from_record(envelope)
+    metadata = envelope.get("metadata") if isinstance(envelope.get("metadata"), dict) else {}
+    start_gate_dirty_files = _safe_string_list(metadata.get("start_gate_dirty_files"))
+    start_gate = validate_start_gate(
+        model,
+        repo_path=model.repo_path,
+        branch=model.branch,
+        dirty_files=tuple(start_gate_dirty_files),
+    )
+    return {
+        "policy_model": task_control_envelope_model_summary(model),
+        "start_gate": summarize_guard_decision(start_gate),
+        "next_action": next_action_decision_summary(model, start_gate),
+    }
+
+
+def _active_lane_dashboard_payload() -> dict[str, Any]:
+    envelopes = [
+        record
+        for record in _read_json_records(_mission_control_state_dir("task-control-envelopes"), "envelope_*.json")
+        if record.get("status") == "active"
+    ]
+    envelopes.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+    envelope = envelopes[0] if envelopes else None
+    lane_lock = envelope.get("lane_lock") if isinstance(envelope, dict) and isinstance(envelope.get("lane_lock"), dict) else {}
+    repo_context = envelope.get("repo_context") if isinstance(envelope, dict) and isinstance(envelope.get("repo_context"), dict) else {}
+    metadata = envelope.get("metadata") if isinstance(envelope, dict) and isinstance(envelope.get("metadata"), dict) else {}
+
+    slices = [
+        record
+        for record in _read_json_records(_mission_control_state_dir("approval-slices"), "slice_*.json")
+        if record.get("status") == "active"
+    ]
+    slices.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+    latest_slice = slices[0] if slices else None
+
+    evidence_cards = _read_json_records(_mission_control_state_dir("evidence-cards"), "card_*.json")
+    evidence_cards.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
+    evidence_summaries = [
+        {
+            "id": card.get("id"),
+            "kind": card.get("kind"),
+            "title": card.get("title"),
+            "summary": card.get("summary"),
+            "source": card.get("source", ""),
+            "created_at": card.get("created_at"),
+            "trusted_for_execution": False,
+            "inert_context_only": True,
+            "authorizing": False,
+        }
+        for card in evidence_cards[:5]
+    ]
+
+    allowed_actions = _safe_string_list((envelope or {}).get("allowed_actions"))
+    forbidden_actions = _safe_string_list((envelope or {}).get("forbidden_actions"))
+    checkpoint = None
+    checkpoints = _safe_string_list((envelope or {}).get("checkpoints"))
+    if checkpoints:
+        checkpoint = checkpoints[0]
+
+    start_gate_status = _first_text(metadata.get("start_gate_status"), "unknown")
+    next_action = _first_text(
+        metadata.get("next_recommended_action"),
+        "Attach a Task Control Envelope before starting lane work.",
+    )
+    quarantine_warning = _first_text(
+        metadata.get("quarantine_warning"),
+        "No parent scans or quarantined path access are allowed from this dashboard.",
+    )
+    policy_read_model = _lane_policy_read_model(envelope)
+
+    return {
+        "mode": "local_read_only",
+        "active_lane": {
+            "label": _first_text(lane_lock.get("active_lane"), "No active lane"),
+            "mode": (envelope or {}).get("mode"),
+            "status": (envelope or {}).get("status", "none"),
+            "source": "persisted_task_control_envelope" if envelope else "no_persisted_envelope",
+        },
+        "task_control_envelope": {
+            "exists": envelope is not None,
+            "id": (envelope or {}).get("id"),
+            "summary": (envelope or {}).get("title"),
+            "mode_label": (envelope or {}).get("mode_label", ""),
+            "checkpoint": checkpoint,
+            "selected_from_count": len(envelopes),
+            "policy_model": policy_read_model["policy_model"],
+            "trusted_for_execution": False,
+            "inert_context_only": True,
+        },
+        "approval_tier": {
+            "label": _first_text(metadata.get("approval_tier"), "No approval slice" if not latest_slice else "approval slice active"),
+            "active_slice_count": len(slices),
+            "latest_slice_id": (latest_slice or {}).get("id"),
+            "latest_slice_title": (latest_slice or {}).get("title"),
+        },
+        "allowed_actions": allowed_actions,
+        "forbidden_actions": forbidden_actions,
+        "start_gate": {
+            "status": start_gate_status,
+            "source": _first_text(repo_context.get("source"), "not_probed"),
+            "repo_state": _first_text(repo_context.get("dirty_state"), "unknown"),
+        },
+        "guard_decisions": {
+            "start_gate": policy_read_model["start_gate"],
+        },
+        "evidence": {
+            "count": len(evidence_cards),
+            "summaries": evidence_summaries,
+            "details_on_demand": True,
+        },
+        "next_action": policy_read_model["next_action"],
+        "next_recommended_action": next_action,
+        "token_context_budget": _token_estimates(envelope, evidence_cards),
+        "safety": {
+            "quarantine_parent_scan_warning": quarantine_warning,
+            "parent_scan_performed": False,
+            "quarantined_path_accessed": False,
+            "transcript_loaded": False,
+            "execution_controls": False,
+            "runner_integration": False,
+            "tool_interception": False,
+        },
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+
+
+@app.get("/api/mission-control/lane-dashboard")
+async def get_mission_control_lane_dashboard():
+    return _active_lane_dashboard_payload()
+
+
+@app.get("/api/mission-control/artifacts")
+async def get_mission_control_artifacts(kind: str | None = None, status: str | None = None):
+    from hermes_cli.mission_control_artifacts import list_artifacts
+
+    return list_artifacts(kind=kind, status=status)
+
+
+def _mission_control_packet_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control import MissionControlPacketError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Packet not found")
+    if isinstance(exc, MissionControlPacketError):
+        if str(exc) == "Invalid packet id":
+            return HTTPException(status_code=404, detail="Packet not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Mission Control packet error")
+
+
+def _project_room_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control_project_rooms import ProjectRoomError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Project Room item not found")
+    if isinstance(exc, OverflowError):
+        return HTTPException(status_code=413, detail=str(exc))
+    if isinstance(exc, ProjectRoomError):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Project Rooms error")
+
+
+def _mission_briefs_enabled() -> bool:
+    config = load_config()
+    return cfg_get(config, "dashboard", "mission_briefs_enabled", default=False) is True
+
+
+def _require_mission_briefs_enabled() -> None:
+    if not _mission_briefs_enabled():
+        raise HTTPException(status_code=404, detail="Mission Briefs disabled")
+
+
+def _goal_contracts_enabled() -> bool:
+    config = load_config()
+    return cfg_get(config, "dashboard", "goal_contracts_enabled", default=False) is True
+
+
+def _require_goal_contracts_enabled() -> None:
+    if not _goal_contracts_enabled():
+        raise HTTPException(status_code=404, detail="Goal Contracts disabled")
+
+
+def _approval_slices_enabled() -> bool:
+    config = load_config()
+    return cfg_get(config, "dashboard", "approval_slices_enabled", default=False) is True
+
+
+def _require_approval_slices_enabled() -> None:
+    if not _approval_slices_enabled():
+        raise HTTPException(status_code=404, detail="Approval Slices disabled")
+
+
+def _task_control_envelopes_enabled() -> bool:
+    config = load_config()
+    return cfg_get(config, "dashboard", "task_control_envelopes_enabled", default=False) is True
+
+
+def _require_task_control_envelopes_enabled() -> None:
+    if not _task_control_envelopes_enabled():
+        raise HTTPException(status_code=404, detail="Task Control Envelopes disabled")
+
+
+def _evidence_cards_enabled() -> bool:
+    config = load_config()
+    return cfg_get(config, "dashboard", "evidence_cards_enabled", default=False) is True
+
+
+def _require_evidence_cards_enabled() -> None:
+    if not _evidence_cards_enabled():
+        raise HTTPException(status_code=404, detail="Evidence Cards disabled")
+
+
+def _mission_brief_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_briefs import MissionBriefError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Mission Brief not found")
+    if isinstance(exc, MissionBriefError):
+        if str(exc) == "Invalid brief id":
+            return HTTPException(status_code=404, detail="Mission Brief not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Mission Brief error")
+
+
+def _goal_contract_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control_goal_contracts import GoalContractError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Goal Contract not found")
+    if isinstance(exc, GoalContractError):
+        if str(exc) == "Invalid contract id":
+            return HTTPException(status_code=404, detail="Goal Contract not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Goal Contract error")
+
+
+def _approval_slice_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control_approval_slices import ApprovalSliceError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Approval Slice not found")
+    if isinstance(exc, ApprovalSliceError):
+        if str(exc) == "Invalid approval slice id":
+            return HTTPException(status_code=404, detail="Approval Slice not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Approval Slice error")
+
+
+def _task_control_envelope_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control_task_control_envelopes import TaskControlEnvelopeError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Task Control Envelope not found")
+    if isinstance(exc, TaskControlEnvelopeError):
+        if str(exc) == "Invalid task control envelope id":
+            return HTTPException(status_code=404, detail="Task Control Envelope not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Task Control Envelope error")
+
+
+def _evidence_card_error(exc: Exception) -> HTTPException:
+    from hermes_cli.mission_control_evidence_cards import EvidenceCardError
+
+    if isinstance(exc, FileNotFoundError):
+        return HTTPException(status_code=404, detail="Evidence Card not found")
+    if isinstance(exc, EvidenceCardError):
+        if str(exc) == "Invalid evidence card id":
+            return HTTPException(status_code=404, detail="Evidence Card not found")
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Evidence Card error")
+
+
+@app.get("/api/mission-control/packets")
+async def get_mission_control_packets():
+    from hermes_cli.mission_control import list_packets
+
+    return list_packets()
+
+
+@app.get("/api/mission-control/packets/{packet_id}")
+async def get_mission_control_packet(packet_id: str):
+    from hermes_cli.mission_control import get_packet
+
+    try:
+        return get_packet(packet_id)
+    except Exception as exc:
+        raise _mission_control_packet_error(exc) from exc
+
+
+@app.post("/api/mission-control/packets/codex-prompt")
+async def post_mission_control_codex_prompt_packet(body: Dict[str, Any]):
+    from hermes_cli.mission_control import (
+        create_rejection_audit,
+        save_next_codex_prompt,
+    )
+
+    try:
+        packet = save_next_codex_prompt(dict(body))
+        return {"packet": packet}
+    except Exception as exc:
+        create_rejection_audit(dict(body), str(exc), packet_kind="codex_prompt")
+        raise _mission_control_packet_error(exc) from exc
+
+
+@app.post("/api/mission-control/packets/worker-result")
+async def post_mission_control_worker_result_packet(body: Dict[str, Any]):
+    from hermes_cli.mission_control import (
+        create_rejection_audit,
+        import_worker_result,
+    )
+
+    try:
+        packet = import_worker_result(dict(body))
+        return {"packet": packet}
+    except Exception as exc:
+        create_rejection_audit(dict(body), str(exc), packet_kind="worker_result")
+        raise _mission_control_packet_error(exc) from exc
+
+
+@app.post("/api/mission-control/packets/block-flag")
+async def post_mission_control_block_flag_packet(body: Dict[str, Any]):
+    from hermes_cli.mission_control import (
+        create_rejection_audit,
+        set_block_flag,
+    )
+
+    try:
+        packet = set_block_flag(dict(body))
+        return {"packet": packet}
+    except Exception as exc:
+        create_rejection_audit(dict(body), str(exc), packet_kind="block_flag")
+        raise _mission_control_packet_error(exc) from exc
+
+
+@app.get("/api/mission-control/mission-briefs")
+async def get_mission_briefs():
+    _require_mission_briefs_enabled()
+    from hermes_cli.mission_briefs import list_briefs
+
+    return list_briefs()
+
+
+@app.post("/api/mission-control/mission-briefs")
+async def post_mission_brief(body: Dict[str, Any]):
+    _require_mission_briefs_enabled()
+    from hermes_cli.mission_briefs import create_brief
+
+    try:
+        return {"brief": create_brief(dict(body))}
+    except Exception as exc:
+        raise _mission_brief_error(exc) from exc
+
+
+@app.get("/api/mission-control/mission-briefs/{brief_id}")
+async def get_mission_brief(brief_id: str):
+    _require_mission_briefs_enabled()
+    from hermes_cli.mission_briefs import get_brief
+
+    try:
+        return get_brief(brief_id)
+    except Exception as exc:
+        raise _mission_brief_error(exc) from exc
+
+
+@app.put("/api/mission-control/mission-briefs/{brief_id}")
+async def put_mission_brief(brief_id: str, body: Dict[str, Any]):
+    _require_mission_briefs_enabled()
+    from hermes_cli.mission_briefs import update_brief
+
+    try:
+        return update_brief(brief_id, dict(body))
+    except Exception as exc:
+        raise _mission_brief_error(exc) from exc
+
+
+@app.delete("/api/mission-control/mission-briefs/{brief_id}")
+async def delete_mission_brief(brief_id: str):
+    _require_mission_briefs_enabled()
+    from hermes_cli.mission_briefs import archive_brief
+
+    try:
+        return archive_brief(brief_id)
+    except Exception as exc:
+        raise _mission_brief_error(exc) from exc
+
+
+@app.get("/api/mission-control/goal-contracts")
+async def get_goal_contracts():
+    _require_goal_contracts_enabled()
+    from hermes_cli.mission_control_goal_contracts import list_contracts
+
+    return list_contracts()
+
+
+@app.post("/api/mission-control/goal-contracts")
+async def post_goal_contract(body: Dict[str, Any]):
+    _require_goal_contracts_enabled()
+    from hermes_cli.mission_control_goal_contracts import create_contract
+
+    try:
+        return {"contract": create_contract(dict(body))}
+    except Exception as exc:
+        raise _goal_contract_error(exc) from exc
+
+
+@app.get("/api/mission-control/goal-contracts/{contract_id}")
+async def get_goal_contract(contract_id: str):
+    _require_goal_contracts_enabled()
+    from hermes_cli.mission_control_goal_contracts import get_contract
+
+    try:
+        return get_contract(contract_id)
+    except Exception as exc:
+        raise _goal_contract_error(exc) from exc
+
+
+@app.put("/api/mission-control/goal-contracts/{contract_id}")
+async def put_goal_contract(contract_id: str, body: Dict[str, Any]):
+    _require_goal_contracts_enabled()
+    from hermes_cli.mission_control_goal_contracts import update_contract
+
+    try:
+        return update_contract(contract_id, dict(body))
+    except Exception as exc:
+        raise _goal_contract_error(exc) from exc
+
+
+@app.delete("/api/mission-control/goal-contracts/{contract_id}")
+async def delete_goal_contract(contract_id: str):
+    _require_goal_contracts_enabled()
+    from hermes_cli.mission_control_goal_contracts import archive_contract
+
+    try:
+        return archive_contract(contract_id)
+    except Exception as exc:
+        raise _goal_contract_error(exc) from exc
+
+
+@app.get("/api/mission-control/approval-slices")
+async def get_approval_slices(include_inactive: bool = False):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import list_approval_slices
+
+    return list_approval_slices(include_inactive=include_inactive)
+
+
+@app.post("/api/mission-control/approval-slices")
+async def post_approval_slice(body: Dict[str, Any]):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import create_approval_slice
+
+    try:
+        return {"approval_slice": create_approval_slice(dict(body))}
+    except Exception as exc:
+        raise _approval_slice_error(exc) from exc
+
+
+@app.get("/api/mission-control/approval-slices/{slice_id}")
+async def get_approval_slice(slice_id: str):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import get_approval_slice as read_approval_slice
+
+    try:
+        return read_approval_slice(slice_id)
+    except Exception as exc:
+        raise _approval_slice_error(exc) from exc
+
+
+@app.post("/api/mission-control/approval-slices/{slice_id}/revoke")
+async def revoke_approval_slice(slice_id: str):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import transition_approval_slice
+
+    try:
+        return transition_approval_slice(slice_id, "revoked")
+    except Exception as exc:
+        raise _approval_slice_error(exc) from exc
+
+
+@app.post("/api/mission-control/approval-slices/{slice_id}/expire")
+async def expire_approval_slice(slice_id: str):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import transition_approval_slice
+
+    try:
+        return transition_approval_slice(slice_id, "expired")
+    except Exception as exc:
+        raise _approval_slice_error(exc) from exc
+
+
+@app.post("/api/mission-control/approval-slices/{slice_id}/complete")
+async def complete_approval_slice(slice_id: str):
+    _require_approval_slices_enabled()
+    from hermes_cli.mission_control_approval_slices import transition_approval_slice
+
+    try:
+        return transition_approval_slice(slice_id, "completed")
+    except Exception as exc:
+        raise _approval_slice_error(exc) from exc
+
+
+@app.get("/api/mission-control/task-control-envelopes")
+async def get_task_control_envelopes(include_inactive: bool = False):
+    _require_task_control_envelopes_enabled()
+    from hermes_cli.mission_control_task_control_envelopes import list_task_control_envelopes
+
+    return list_task_control_envelopes(include_inactive=include_inactive)
+
+
+@app.post("/api/mission-control/task-control-envelopes")
+async def post_task_control_envelope(body: Dict[str, Any]):
+    _require_task_control_envelopes_enabled()
+    from hermes_cli.mission_control_task_control_envelopes import create_task_control_envelope
+
+    try:
+        return {"task_control_envelope": create_task_control_envelope(dict(body))}
+    except Exception as exc:
+        raise _task_control_envelope_error(exc) from exc
+
+
+@app.get("/api/mission-control/task-control-envelopes/{envelope_id}")
+async def get_task_control_envelope(envelope_id: str):
+    _require_task_control_envelopes_enabled()
+    from hermes_cli.mission_control_task_control_envelopes import (
+        get_task_control_envelope as read_task_control_envelope,
+    )
+
+    try:
+        return read_task_control_envelope(envelope_id)
+    except Exception as exc:
+        raise _task_control_envelope_error(exc) from exc
+
+
+@app.post("/api/mission-control/task-control-envelopes/{envelope_id}/complete")
+async def complete_task_control_envelope(envelope_id: str):
+    _require_task_control_envelopes_enabled()
+    from hermes_cli.mission_control_task_control_envelopes import transition_task_control_envelope
+
+    try:
+        return transition_task_control_envelope(envelope_id, "completed")
+    except Exception as exc:
+        raise _task_control_envelope_error(exc) from exc
+
+
+@app.post("/api/mission-control/task-control-envelopes/{envelope_id}/archive")
+async def archive_task_control_envelope(envelope_id: str):
+    _require_task_control_envelopes_enabled()
+    from hermes_cli.mission_control_task_control_envelopes import transition_task_control_envelope
+
+    try:
+        return transition_task_control_envelope(envelope_id, "archived")
+    except Exception as exc:
+        raise _task_control_envelope_error(exc) from exc
+
+
+@app.get("/api/mission-control/evidence-cards")
+async def get_evidence_cards():
+    _require_evidence_cards_enabled()
+    from hermes_cli.mission_control_evidence_cards import list_cards
+
+    return list_cards()
+
+
+@app.post("/api/mission-control/evidence-cards")
+async def post_evidence_card(body: Dict[str, Any]):
+    _require_evidence_cards_enabled()
+    from hermes_cli.mission_control_evidence_cards import create_card
+
+    try:
+        return {"card": create_card(dict(body))}
+    except Exception as exc:
+        raise _evidence_card_error(exc) from exc
+
+
+@app.get("/api/mission-control/evidence-cards/{card_id}")
+async def get_evidence_card(card_id: str):
+    _require_evidence_cards_enabled()
+    from hermes_cli.mission_control_evidence_cards import get_card
+
+    try:
+        return get_card(card_id)
+    except Exception as exc:
+        raise _evidence_card_error(exc) from exc
+
+
+@app.get("/api/mission-control/project-rooms")
+async def get_project_rooms():
+    from hermes_cli.mission_control_project_rooms import list_rooms
+
+    return list_rooms()
+
+
+@app.post("/api/mission-control/project-rooms")
+async def post_project_room(body: Dict[str, Any]):
+    from hermes_cli.mission_control_project_rooms import create_room
+
+    try:
+        return {"room": create_room(dict(body))}
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
+
+
+@app.get("/api/mission-control/project-rooms/{room_id}/messages")
+async def get_project_room_messages(room_id: str):
+    from hermes_cli.mission_control_project_rooms import list_messages
+
+    try:
+        return list_messages(room_id)
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
+
+
+@app.post("/api/mission-control/project-rooms/{room_id}/messages")
+async def post_project_room_message(room_id: str, body: Dict[str, Any]):
+    from hermes_cli.mission_control_project_rooms import add_message
+
+    try:
+        return {"message": add_message(room_id, dict(body))}
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
+
+
+@app.post("/api/mission-control/project-rooms/{room_id}/attachments")
+async def post_project_room_attachment(room_id: str, file: UploadFile = File(...)):
+    from hermes_cli.mission_control_project_rooms import add_attachment
+
+    try:
+        content = await file.read()
+        attachment = add_attachment(
+            room_id,
+            filename=file.filename or "",
+            mime_type=file.content_type or "application/octet-stream",
+            content=content,
+        )
+        return {"attachment": attachment}
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
+    finally:
+        await file.close()
+
+
+@app.get("/api/mission-control/project-rooms/{room_id}/attachments/{attachment_id}")
+async def get_project_room_attachment(room_id: str, attachment_id: str):
+    from hermes_cli.mission_control_project_rooms import get_attachment
+
+    try:
+        return {"attachment": get_attachment(room_id, attachment_id)}
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
+
+
+@app.get("/api/mission-control/project-rooms/{room_id}/attachments/{attachment_id}/download")
+async def download_project_room_attachment(room_id: str, attachment_id: str):
+    from hermes_cli.mission_control_project_rooms import attachment_file_path
+
+    try:
+        path, attachment = attachment_file_path(room_id, attachment_id)
+        return FileResponse(
+            path,
+            media_type=str(attachment.get("mime_type") or "application/octet-stream"),
+            filename=str(attachment.get("original_filename") or path.name),
+        )
+    except Exception as exc:
+        raise _project_room_error(exc) from exc
 
 
 _CRON_PROFILE_LOCK = threading.RLock()

--- a/tests/hermes_cli/test_mission_control_autonomy.py
+++ b/tests/hermes_cli/test_mission_control_autonomy.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+
+ALLOWED_WEBSITE_GENERATED = (
+    "website/static/api/skills-meta.json",
+    "website/static/api/skills.json",
+)
+
+
+def _envelope(**overrides):
+    from hermes_cli.mission_control_autonomy import (
+        ApprovalTier,
+        LaneState,
+        TaskControlEnvelopeModel,
+    )
+
+    payload = {
+        "active_lane": "autonomous lane runner MVP implementation",
+        "mode": "code/test only",
+        "lane_state": LaneState.ACTIVE,
+        "approval_tier": ApprovalTier.CODE_TEST,
+        "repo_path": "/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        "branch": "mission-control-os-stateful-foundation",
+        "allowed_actions": ("read_files", "edit_files", "run_focused_tests", "py_compile", "diff_check", "secret_scan"),
+        "forbidden_actions": ("network", "subprocess", "dashboard_wiring", "production_wiring", "commit"),
+        "allowed_files": (
+            "hermes_cli/mission_control_autonomy.py",
+            "tests/hermes_cli/test_mission_control_autonomy.py",
+        ),
+        "allowed_start_gate_dirty_files": ALLOWED_WEBSITE_GENERATED,
+        "focused_test_files": ("tests/hermes_cli/test_mission_control_autonomy.py",),
+        "stop_condition": "stop before commit",
+    }
+    payload.update(overrides)
+    return TaskControlEnvelopeModel(**payload)
+
+
+def test_start_gate_allows_only_expected_repo_branch_and_allowed_dirty_files():
+    from hermes_cli.mission_control_autonomy import validate_start_gate
+
+    decision = validate_start_gate(
+        _envelope(),
+        repo_path="/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        branch="mission-control-os-stateful-foundation",
+        dirty_files=ALLOWED_WEBSITE_GENERATED,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "start_gate_passed"
+    assert decision.approval_tier.value == "code_test"
+    assert decision.violations == ()
+    assert decision.evidence_cards[0].kind == "start_gate"
+    assert decision.evidence_cards[0].inert_context_only is True
+    assert decision.evidence_cards[0].authorizing is False
+
+
+def test_start_gate_denies_unexpected_dirty_files_without_touching_filesystem():
+    from hermes_cli.mission_control_autonomy import validate_start_gate
+
+    decision = validate_start_gate(
+        _envelope(),
+        repo_path="/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        branch="mission-control-os-stateful-foundation",
+        dirty_files=ALLOWED_WEBSITE_GENERATED + ("hermes_cli/web_server.py",),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "start_gate_blocked"
+    assert decision.violations == ("unexpected_dirty_file:hermes_cli/web_server.py",)
+
+
+def test_start_gate_denies_wrong_repo_or_branch():
+    from hermes_cli.mission_control_autonomy import validate_start_gate
+
+    wrong_repo = validate_start_gate(
+        _envelope(),
+        repo_path="/tmp/other",
+        branch="mission-control-os-stateful-foundation",
+        dirty_files=(),
+    )
+    wrong_branch = validate_start_gate(
+        _envelope(),
+        repo_path="/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        branch="other",
+        dirty_files=(),
+    )
+
+    assert wrong_repo.allowed is False
+    assert wrong_repo.violations == ("repo_path_mismatch",)
+    assert wrong_branch.allowed is False
+    assert wrong_branch.violations == ("branch_mismatch",)
+
+
+def test_tool_decision_allows_scoped_edit_and_focused_validation_requests():
+    from hermes_cli.mission_control_autonomy import ToolRequest, decide_tool_request
+
+    edit_decision = decide_tool_request(
+        _envelope(),
+        ToolRequest(
+            tool_name="apply_patch",
+            action="edit_files",
+            target_files=("hermes_cli/mission_control_autonomy.py",),
+            writes=True,
+        ),
+    )
+    test_decision = decide_tool_request(
+        _envelope(),
+        ToolRequest(
+            tool_name="pytest",
+            action="run_focused_tests",
+            target_files=("tests/hermes_cli/test_mission_control_autonomy.py",),
+            executes=True,
+        ),
+    )
+
+    assert edit_decision.allowed is True
+    assert edit_decision.reason == "tool_request_allowed"
+    assert test_decision.allowed is True
+    assert test_decision.reason == "tool_request_allowed"
+
+
+def test_tool_decision_denies_forbidden_actions_and_out_of_scope_files():
+    from hermes_cli.mission_control_autonomy import ToolRequest, decide_tool_request
+
+    deploy = decide_tool_request(
+        _envelope(),
+        ToolRequest(tool_name="deploy", action="deploy", executes=True),
+    )
+    production_wiring = decide_tool_request(
+        _envelope(),
+        ToolRequest(
+            tool_name="apply_patch",
+            action="production_wiring",
+            target_files=("run_agent.py",),
+            writes=True,
+        ),
+    )
+    outside_file = decide_tool_request(
+        _envelope(),
+        ToolRequest(
+            tool_name="apply_patch",
+            action="edit_files",
+            target_files=("hermes_cli/web_server.py",),
+            writes=True,
+        ),
+    )
+
+    assert deploy.allowed is False
+    assert deploy.violations == ("action_not_allowed:deploy",)
+    assert production_wiring.allowed is False
+    assert production_wiring.violations == (
+        "forbidden_action:production_wiring",
+        "write_outside_allowed_files:run_agent.py",
+    )
+    assert outside_file.allowed is False
+    assert outside_file.violations == ("write_outside_allowed_files:hermes_cli/web_server.py",)
+
+
+def test_tool_decision_denies_network_and_unfocused_tests():
+    from hermes_cli.mission_control_autonomy import ToolRequest, decide_tool_request
+
+    network = decide_tool_request(
+        _envelope(),
+        ToolRequest(tool_name="curl", action="network", uses_network=True),
+    )
+    broad_tests = decide_tool_request(
+        _envelope(),
+        ToolRequest(
+            tool_name="pytest",
+            action="run_focused_tests",
+            target_files=("tests/hermes_cli/test_mission_control.py",),
+            executes=True,
+        ),
+    )
+
+    assert network.allowed is False
+    assert network.violations == ("forbidden_action:network", "network_not_allowed")
+    assert broad_tests.allowed is False
+    assert broad_tests.violations == (
+        "test_outside_focused_scope:tests/hermes_cli/test_mission_control.py",
+    )
+
+
+def test_autonomy_models_are_frozen_dataclasses_and_module_has_no_runtime_wiring_symbols():
+    from hermes_cli import mission_control_autonomy as autonomy
+
+    for model in (
+        autonomy.TaskControlEnvelopeModel,
+        autonomy.ToolRequest,
+        autonomy.GuardDecision,
+        autonomy.EvidenceCardModel,
+    ):
+        assert dataclasses.is_dataclass(model)
+        assert model.__dataclass_params__.frozen is True
+
+    source = Path("hermes_cli/mission_control_autonomy.py").read_text(encoding="utf-8")
+    forbidden_symbols = {
+        "subprocess",
+        "urllib",
+        "requests",
+        "httpx",
+        "socket",
+        "Path(",
+        ".read_text",
+        ".write_text",
+        "FastAPI",
+        "APIRouter",
+        "add_api_route",
+        "run_agent",
+        "handle_function_call",
+    }
+    for symbol in forbidden_symbols:
+        assert symbol not in source
+
+
+def test_stored_task_control_envelope_converts_to_inert_policy_model():
+    from hermes_cli.mission_control_autonomy import (
+        ApprovalTier,
+        LaneState,
+        task_control_envelope_model_from_record,
+    )
+
+    model = task_control_envelope_model_from_record(
+        {
+            "status": "active",
+            "title": "Fallback lane",
+            "mode": "implement-slice",
+            "allowed_actions": ["read_files", "edit_files", "run_focused_tests"],
+            "forbidden_actions": ["deploy", "restart_service"],
+            "repo_context": {
+                "path": "/repo",
+                "branch": "feature-branch",
+            },
+            "lane_lock": {"active_lane": "Hermes OS autonomy read-model wiring"},
+            "metadata": {
+                "approval_tier": "code/test only",
+                "allowed_files": ["hermes_cli/mission_control_autonomy.py"],
+                "forbidden_files": ["website/static/api/skills.json"],
+                "allowed_start_gate_dirty_files": ["website/static/api/skills.json"],
+                "focused_test_files": ["tests/hermes_cli/test_mission_control_autonomy.py"],
+                "stop_condition": "stop before commit",
+            },
+        }
+    )
+
+    assert model.active_lane == "Hermes OS autonomy read-model wiring"
+    assert model.mode == "implement-slice"
+    assert model.lane_state is LaneState.ACTIVE
+    assert model.approval_tier is ApprovalTier.CODE_TEST
+    assert model.repo_path == "/repo"
+    assert model.branch == "feature-branch"
+    assert model.allowed_actions == ("read_files", "edit_files", "run_focused_tests")
+    assert model.forbidden_actions == ("deploy", "restart_service")
+    assert model.allowed_files == ("hermes_cli/mission_control_autonomy.py",)
+    assert model.forbidden_files == ("website/static/api/skills.json",)
+    assert model.allowed_start_gate_dirty_files == ("website/static/api/skills.json",)
+    assert model.focused_test_files == ("tests/hermes_cli/test_mission_control_autonomy.py",)
+    assert model.stop_condition == "stop before commit"
+
+
+def test_policy_read_summaries_are_decision_only_and_classify_next_action():
+    from hermes_cli.mission_control_autonomy import (
+        ApprovalTier,
+        ToolRequest,
+        decide_tool_request,
+        next_action_decision_summary,
+        summarize_guard_decision,
+        task_control_envelope_model_from_record,
+        validate_start_gate,
+    )
+
+    model = task_control_envelope_model_from_record(
+        {
+            "status": "active",
+            "title": "Read-only lane",
+            "mode": "inspection-only",
+            "allowed_actions": ["read_files"],
+            "forbidden_actions": ["deploy"],
+            "repo_context": {"path": "/repo", "branch": "main"},
+            "metadata": {"approval_tier": "read_only"},
+        }
+    )
+    start_gate = validate_start_gate(model, repo_path="/repo", branch="main", dirty_files=())
+    guard_summary = summarize_guard_decision(start_gate)
+
+    assert guard_summary == {
+        "allowed": True,
+        "approval_tier": "read_only",
+        "reason": "start_gate_passed",
+        "violations": [],
+        "execution_enabled": False,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+    assert next_action_decision_summary(model, start_gate)["kind"] == "auto"
+
+    code_model = dataclasses.replace(model, approval_tier=ApprovalTier.CODE_TEST)
+    code_start_gate = validate_start_gate(code_model, repo_path="/repo", branch="main", dirty_files=())
+    assert next_action_decision_summary(code_model, code_start_gate)["kind"] == "one_click_approval"
+
+    blocked = summarize_guard_decision(
+        validate_start_gate(code_model, repo_path="/repo", branch="wrong", dirty_files=())
+    )
+    assert blocked["allowed"] is False
+    assert blocked["approval_tier"] == "forbidden"
+    assert next_action_decision_summary(code_model, blocked)["kind"] == "forbidden"
+
+    tool_summary = summarize_guard_decision(
+        decide_tool_request(
+            code_model,
+            ToolRequest(tool_name="deploy", action="deploy", executes=True),
+        )
+    )
+    assert tool_summary["allowed"] is False
+    assert tool_summary["execution_enabled"] is False

--- a/tests/hermes_cli/test_mission_control_lane_dashboard_api.py
+++ b/tests/hermes_cli/test_mission_control_lane_dashboard_api.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture()
+def dashboard_client(_isolate_hermes_home, monkeypatch):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli import web_server
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {"dashboard": {"approval_slices_enabled": True, "evidence_cards_enabled": True}},
+    )
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def _envelope_payload(**overrides):
+    payload = {
+        "title": "Hermes OS lane dashboard MVP",
+        "mode": "implement-slice",
+        "mode_label": "Code/test only",
+        "allowed_actions": ["inspect_repo", "read_files", "search_files", "edit_files", "run_focused_tests", "run_build", "run_lint"],
+        "forbidden_actions": ["deploy", "restart_service", "push", "open_pr", "external_network", "touch_secrets", "destructive_git"],
+        "checkpoints": ["stop_after_validation_report", "stop_on_unrelated_dirty_files"],
+        "checkpoint_requirements": ["stop_on_scope_expansion", "stop_on_restart_or_deploy_needed"],
+        "repo_context": {
+            "path": "/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+            "branch": "mission-control-os-stateful-foundation",
+            "head": "7399c9785",
+            "dirty_state": "only excluded generated website files",
+            "source": "OR1C Start Gate",
+        },
+        "lane_lock": {"active_lane": "Hermes OS lane dashboard MVP"},
+        "relationships": {"source_thread": "discord://thread/mission-control-os"},
+        "source": "manual_command",
+        "raw_user_approval": "Build read-only dashboard stub only.",
+        "metadata": {
+            "approval_tier": "code/test only",
+            "start_gate_status": "pass",
+            "next_recommended_action": "Review read-only MVP and commit after Travis approval.",
+            "context_budget": {"input_estimate": 9000, "output_estimate": 2500, "remaining_context_window": "moderate"},
+            "quarantine_warning": "No parent scans or quarantined path access allowed.",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _slice_payload(**overrides):
+    payload = {
+        "title": "Read-only dashboard approval slice",
+        "repo_path": "/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        "allowed_paths": ["hermes_cli/web_server.py", "web/src/components/MissionControlLaneDashboard.tsx"],
+        "forbidden_paths": ["gateway/run.py", "website/static/api/skills.json"],
+        "expected_locality": "current repo only",
+        "allowed_actions": ["inspect_repo", "read_files", "search_files", "edit_files", "run_focused_tests"],
+        "forbidden_actions": ["deploy", "restart_service", "push", "open_pr"],
+        "stop_condition": "stop_after_validation_report",
+        "checkpoint": "stop_after_validation_report",
+        "created_by": "Travis",
+        "created_from": "manual_command",
+        "raw_user_approval": "Code/test only; stop before commit.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _card_payload(**overrides):
+    payload = {
+        "kind": "validation",
+        "title": "Focused dashboard validation",
+        "summary": "Focused backend and frontend validation planned for lane dashboard MVP.",
+        "details": "Details are inert evidence data only.",
+        "structured_payload": {"command": "pytest focused", "exit_code": 0},
+        "limitations": ["No broad tests requested."],
+        "redaction_notes": ["No raw transcript content included."],
+        "source": "operator_supplied",
+        "created_by": "dashboard-test",
+        "created_from": "operator_supplied",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _mission_control_state_dir(name: str):
+    from hermes_constants import get_hermes_home
+
+    path = get_hermes_home() / "state" / "mission-control" / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_record(name: str, record_id: str, payload: dict) -> dict:
+    path = _mission_control_state_dir(name) / f"{record_id}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def _create_task_control_envelope(payload: dict) -> dict:
+    created_at = datetime.now(timezone.utc).isoformat()
+    envelope = {
+        **payload,
+        "id": "envelope_20260605T000000Z_000000000001",
+        "schema": "mission-control.task-control-envelope.v1",
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+    return _write_record("task-control-envelopes", envelope["id"], envelope)
+
+
+def _create_approval_slice(payload: dict) -> dict:
+    created_at = datetime.now(timezone.utc).isoformat()
+    approval_slice = {
+        **payload,
+        "id": "slice_20260605T000000Z_000000000001",
+        "status": "active",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+    return _write_record("approval-slices", approval_slice["id"], approval_slice)
+
+
+def _create_card(payload: dict, *, index: int) -> dict:
+    created_at = (datetime.now(timezone.utc) + timedelta(seconds=index)).isoformat()
+    card = {
+        **payload,
+        "id": f"card_20260605T00000{index}Z_00000000000{index}",
+        "schema": "mission-control.evidence-card.v1",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+        "authorizing": False,
+    }
+    return _write_record("evidence-cards", card["id"], card)
+
+
+def test_lane_dashboard_requires_dashboard_token(_isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app
+
+    client = TestClient(app)
+    assert client.get("/api/mission-control/lane-dashboard").status_code == 401
+
+
+def test_lane_dashboard_is_not_public():
+    from hermes_cli.web_server import _PUBLIC_API_PATHS
+
+    assert "/api/mission-control/lane-dashboard" not in _PUBLIC_API_PATHS
+
+
+def test_lane_dashboard_returns_empty_inert_read_model(dashboard_client):
+    resp = dashboard_client.get("/api/mission-control/lane-dashboard")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "local_read_only"
+    assert body["active_lane"]["label"] == "No active lane"
+    assert body["task_control_envelope"]["exists"] is False
+    assert body["approval_tier"]["label"] == "No approval slice"
+    assert body["start_gate"]["status"] == "unknown"
+    assert body["evidence"]["summaries"] == []
+    assert body["next_recommended_action"] == "Attach a Task Control Envelope before starting lane work."
+    assert body["token_context_budget"]["show_token_estimates"] is True
+    assert body["safety"]["quarantine_parent_scan_warning"]
+    assert body["safety"]["transcript_loaded"] is False
+    assert body["safety"]["execution_controls"] is False
+    assert body["trusted_for_execution"] is False
+    assert body["inert_context_only"] is True
+
+
+def test_lane_dashboard_summarizes_envelope_slice_and_evidence_without_runtime_access(dashboard_client, monkeypatch):
+    import subprocess
+    from pathlib import Path
+
+    import model_tools
+    envelope = _create_task_control_envelope(_envelope_payload())
+    approval_slice = _create_approval_slice(_slice_payload())
+    _create_card(
+        _card_payload(title="Start Gate", summary="OR1C Start Gate passed with only excluded generated website files."),
+        index=1,
+    )
+    _create_card(
+        _card_payload(kind="secret_scan", title="Added-line secret scan", summary="No hardcoded secrets found in added lines."),
+        index=2,
+    )
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("lane dashboard must not execute commands or call tools")
+
+    original_stat = Path.stat
+
+    def guarded_stat(self, *args, **kwargs):
+        if str(self) == "/tmp/lane-dashboard-must-not-stat":
+            raise AssertionError("lane dashboard must not stat opaque paths")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    monkeypatch.setattr(subprocess, "Popen", fail_if_called)
+    monkeypatch.setattr(model_tools, "handle_function_call", fail_if_called)
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+
+    resp = dashboard_client.get("/api/mission-control/lane-dashboard")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["active_lane"] == {
+        "label": "Hermes OS lane dashboard MVP",
+        "mode": "implement-slice",
+        "status": "active",
+        "source": "persisted_task_control_envelope",
+    }
+    assert body["task_control_envelope"]["id"] == envelope["id"]
+    assert body["task_control_envelope"]["summary"] == "Hermes OS lane dashboard MVP"
+    assert body["approval_tier"]["label"] == "code/test only"
+    assert body["approval_tier"]["active_slice_count"] == 1
+    assert body["approval_tier"]["latest_slice_id"] == approval_slice["id"]
+    assert body["start_gate"] == {
+        "status": "pass",
+        "source": "OR1C Start Gate",
+        "repo_state": "only excluded generated website files",
+    }
+    assert body["task_control_envelope"]["policy_model"] == {
+        "active_lane": "Hermes OS lane dashboard MVP",
+        "mode": "implement-slice",
+        "lane_state": "active",
+        "approval_tier": "code_test",
+        "repo_path": "/home/jenny/.hermes/hermes-context-routing-e1d-integration",
+        "branch": "mission-control-os-stateful-foundation",
+        "allowed_actions": _envelope_payload()["allowed_actions"],
+        "forbidden_actions": _envelope_payload()["forbidden_actions"],
+        "allowed_files": [],
+        "forbidden_files": [],
+        "allowed_start_gate_dirty_files": [],
+        "focused_test_files": [],
+        "stop_condition": "",
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+    assert body["guard_decisions"]["start_gate"] == {
+        "allowed": True,
+        "approval_tier": "code_test",
+        "reason": "start_gate_passed",
+        "violations": [],
+        "execution_enabled": False,
+        "trusted_for_execution": False,
+        "inert_context_only": True,
+    }
+    assert body["next_action"]["kind"] == "one_click_approval"
+    assert body["next_action"]["execution_enabled"] is False
+    assert body["allowed_actions"] == _envelope_payload()["allowed_actions"]
+    assert body["forbidden_actions"] == _envelope_payload()["forbidden_actions"]
+    assert body["evidence"]["count"] == 2
+    assert [item["title"] for item in body["evidence"]["summaries"]] == ["Added-line secret scan", "Start Gate"]
+    assert body["evidence"]["details_on_demand"] is True
+    assert body["token_context_budget"]["estimated_input_tokens"] == 9000
+    assert body["token_context_budget"]["estimated_output_tokens"] == 2500
+    assert body["safety"]["parent_scan_performed"] is False
+    assert body["safety"]["quarantined_path_accessed"] is False
+    assert body["safety"]["transcript_loaded"] is False
+    assert body["safety"]["execution_controls"] is False
+
+
+def test_lane_dashboard_exposes_no_mutation_methods():
+    from hermes_cli.web_server import app
+
+    methods = {
+        method
+        for route in app.routes
+        if getattr(route, "path", None) == "/api/mission-control/lane-dashboard"
+        for method in getattr(route, "methods", set())
+    }
+
+    assert methods == {"GET"}

--- a/tests/hermes_cli/test_mission_control_lane_dashboard_ui.py
+++ b/tests/hermes_cli/test_mission_control_lane_dashboard_ui.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PANEL_TSX = ROOT / "web" / "src" / "components" / "MissionControlLaneDashboard.tsx"
+API_TS = ROOT / "web" / "src" / "lib" / "api.ts"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_lane_dashboard_component_renders_required_read_only_sections():
+    source = _read(PANEL_TSX)
+
+    for phrase in (
+        "Mission Control Lane Dashboard",
+        "Active lane",
+        "Task Control Envelope",
+        "Approval tier",
+        "Allowed actions",
+        "Forbidden actions",
+        "Start Gate",
+        "Guard decision",
+        "Next action type",
+        "Evidence summaries",
+        "Next recommended action",
+        "Token/context budget",
+        "Quarantine / parent-scan warning",
+        "Read-only API/UI only",
+        "trusted_for_execution=false",
+        "inert_context_only=true",
+    ):
+        assert phrase in source
+
+
+def test_lane_dashboard_keeps_evidence_details_on_demand():
+    source = _read(PANEL_TSX)
+
+    assert "<details" in source
+    assert "Evidence details are collapsed until requested." in source
+    assert "details_on_demand" in source
+
+
+def test_lane_dashboard_omits_transcript_and_execution_controls():
+    source = _read(PANEL_TSX)
+
+    for label in (
+        ">Run<",
+        ">Execute<",
+        ">Deploy<",
+        ">Restart<",
+        ">Merge<",
+        ">Commit<",
+        ">Push<",
+        ">Approve<",
+        ">Load transcript<",
+        ">Scan parent<",
+        ">Open quarantine<",
+    ):
+        assert label not in source
+
+    for token in (
+        "<button",
+        "<form",
+        "<input",
+        "<select",
+        "<textarea",
+        "onClick",
+        "executeOpsApprovalAction",
+        "dryRunOpsApprovalAction",
+        "getSessionMessages",
+        "getSessionLatestDescendant",
+        "window.location",
+        "nextAction",
+    ):
+        assert token not in source
+
+
+def test_lane_dashboard_uses_get_only_client_helper():
+    source = _read(PANEL_TSX)
+    api_source = _read(API_TS)
+
+    assert "api.getMissionControlLaneDashboard()" in source
+    assert "getMissionControlLaneDashboard: () =>" in api_source
+    assert 'fetchJSON<MissionControlLaneDashboardResponse>("/api/mission-control/lane-dashboard", { cache: "no-store" })' in api_source
+
+    for token in ("fetch(", "XMLHttpRequest", "method:", "POST", "PUT", "PATCH", "DELETE"):
+        assert token not in source
+
+
+def test_lane_dashboard_exports_mountable_component():
+    source = _read(PANEL_TSX)
+
+    assert "export function MissionControlLaneDashboard()" in source
+    assert "return <DashboardContent data={data} />" in source

--- a/web/src/components/MissionControlLaneDashboard.tsx
+++ b/web/src/components/MissionControlLaneDashboard.tsx
@@ -1,0 +1,261 @@
+import { CheckCircle2, ClipboardList, Gauge, LockKeyhole, ShieldAlert } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Card, CardContent } from "@nous-research/ui/ui/components/card";
+import { api, type MissionControlLaneDashboardResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const panel = "rounded-xl border border-[#284848] bg-black/30 p-4";
+const labelClass = "text-xs font-semibold uppercase tracking-[0.08em] text-text-secondary";
+
+function listText(values?: string[] | null): string {
+  if (!values?.length) return "None declared";
+  return values.join(", ");
+}
+
+function textValue(value?: string | number | boolean | null): string {
+  if (value === null || value === undefined || value === "") return "-";
+  return String(value);
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-2">
+      <div className={labelClass}>{label}</div>
+      <div className="mt-1 break-words text-sm font-semibold text-text-primary">{value}</div>
+    </div>
+  );
+}
+
+function decisionText(values?: string[] | null): string {
+  if (!values?.length) return "No violations";
+  return values.join(", ");
+}
+
+function Section({
+  title,
+  children,
+  tone,
+}: {
+  title: string;
+  children: ReactNode;
+  tone?: string;
+}) {
+  return (
+    <section className={cn(panel, tone)}>
+      <div className="mb-3 text-sm font-semibold uppercase tracking-[0.08em] text-emerald-100/90">{title}</div>
+      {children}
+    </section>
+  );
+}
+
+function InertState({ title, copy }: { title: string; copy: string }) {
+  return (
+    <Card className="font-readable-ui border-[#264545] bg-[#071717]/90">
+      <CardContent className="p-5">
+        <div className="text-base font-semibold text-text-primary">{title}</div>
+        <div className="mt-1 text-sm leading-6 text-text-secondary">{copy}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DashboardContent({ data }: { data: MissionControlLaneDashboardResponse }) {
+  return (
+    <Card className="font-readable-ui border-[#264545] bg-[#071717]/90 shadow-[0_0_0_1px_rgba(47,214,161,0.04),0_18px_60px_rgba(0,0,0,0.28)]">
+      <CardContent className="space-y-5 p-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-midground">
+              <ClipboardList className="h-5 w-5" />
+              <h2 className="text-xl font-semibold text-text-primary">Mission Control Lane Dashboard</h2>
+            </div>
+            <div className="mt-1 text-sm leading-6 text-text-secondary">
+              Read-only API/UI only. Compact lane status without runner integration, tool interception, transcript loading, execution controls, parent scans, or quarantined path access.
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge tone="outline" className="border-amber-400/35 bg-amber-500/10 text-amber-100">
+              {data.mode}
+            </Badge>
+            <Badge tone="outline" className="border-red-400/35 bg-red-500/10 text-red-100">
+              trusted_for_execution=false
+            </Badge>
+            <Badge tone="outline" className="border-emerald-400/35 bg-emerald-500/10 text-emerald-100">
+              inert_context_only=true
+            </Badge>
+          </div>
+        </div>
+
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <Metric label="Active lane" value={data.active_lane.label} />
+          <Metric label="Approval tier" value={data.approval_tier.label} />
+          <Metric label="Start Gate" value={`${data.start_gate.status} · ${data.start_gate.repo_state}`} />
+          <Metric label="Next action type" value={data.next_action.label} />
+          <Metric label="Evidence summaries" value={`${data.evidence.count} recorded`} />
+        </section>
+
+        <div className="grid gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+          <Section title="Task Control Envelope">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Metric label="Envelope" value={data.task_control_envelope.exists ? textValue(data.task_control_envelope.summary) : "No active envelope"} />
+              <Metric label="Mode" value={textValue(data.active_lane.mode)} />
+              <Metric label="Checkpoint" value={textValue(data.task_control_envelope.checkpoint)} />
+              <Metric label="Selected records" value={textValue(data.task_control_envelope.selected_from_count)} />
+            </div>
+          </Section>
+
+          <Section title="Quarantine / parent-scan warning" tone="border-amber-400/25 bg-amber-500/10">
+            <div className="flex gap-3 text-sm leading-6 text-amber-100">
+              <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>{data.safety.quarantine_parent_scan_warning}</div>
+            </div>
+          </Section>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <Section title="Allowed actions">
+            <div className="break-words text-sm leading-6 text-text-secondary">{listText(data.allowed_actions)}</div>
+          </Section>
+          <Section title="Forbidden actions">
+            <div className="break-words text-sm leading-6 text-text-secondary">{listText(data.forbidden_actions)}</div>
+          </Section>
+        </div>
+
+        <Section title="Guard decision">
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            <Metric label="Start gate" value={data.guard_decisions.start_gate.allowed ? "Allowed" : "Forbidden"} />
+            <Metric label="Reason" value={data.guard_decisions.start_gate.reason} />
+            <Metric label="Approval model" value={data.guard_decisions.start_gate.approval_tier} />
+            <Metric label="Execution enabled" value={String(data.guard_decisions.start_gate.execution_enabled)} />
+          </div>
+          <div className="mt-2 rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-sm leading-6 text-text-secondary">
+            {decisionText(data.guard_decisions.start_gate.violations)}
+          </div>
+        </Section>
+
+        <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <Section title="Evidence summaries">
+            <div className="space-y-2">
+              {data.evidence.summaries.length === 0 && (
+                <div className="rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-sm text-text-secondary">
+                  No evidence summaries attached.
+                </div>
+              )}
+              {data.evidence.summaries.map((item) => (
+                <details key={item.id || item.title} className="rounded-lg border border-white/10 bg-black/25 px-3 py-2 text-sm text-text-secondary">
+                  <summary className="cursor-default list-none font-semibold text-text-primary">
+                    {textValue(item.title)} <span className="font-normal text-text-secondary">· {textValue(item.kind)}</span>
+                  </summary>
+                  <div className="mt-2 leading-6">
+                    <div>{textValue(item.summary)}</div>
+                    <div className="mt-1 text-xs text-text-tertiary">Evidence details are collapsed until requested.</div>
+                  </div>
+                </details>
+              ))}
+              {data.evidence.details_on_demand && (
+                <div className="flex items-center gap-2 text-xs text-text-tertiary">
+                  <LockKeyhole className="h-3.5 w-3.5" />
+                  Evidence details only on demand.
+                </div>
+              )}
+            </div>
+          </Section>
+
+          <Section title="Token/context budget">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Metric label="Input estimate" value={`${data.token_context_budget.estimated_input_tokens.toLocaleString()} tokens`} />
+              <Metric label="Output estimate" value={`${data.token_context_budget.estimated_output_tokens.toLocaleString()} tokens`} />
+              <Metric label="Context" value={data.token_context_budget.remaining_context_window} />
+              <Metric label="Token estimates" value={data.token_context_budget.show_token_estimates ? "Shown" : "Hidden"} />
+            </div>
+            <div className="mt-3 flex items-start gap-2 rounded-lg border border-emerald-400/20 bg-emerald-500/10 px-3 py-2 text-sm leading-6 text-emerald-100">
+              <Gauge className="mt-1 h-4 w-4 shrink-0" />
+              <div>{data.token_context_budget.conservation_behavior}</div>
+            </div>
+          </Section>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]">
+          <Section title="Next recommended action">
+            <div className="flex gap-3 text-sm leading-6 text-text-secondary">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-200" />
+              <div>{data.next_recommended_action}</div>
+            </div>
+          </Section>
+          <Section title="Safety posture">
+            <div className="grid gap-2 text-sm text-text-secondary">
+              <Metric label="Transcript loaded" value={String(data.safety.transcript_loaded)} />
+              <Metric label="Execution controls" value={String(data.safety.execution_controls)} />
+              <Metric label="Runner integration" value={String(data.safety.runner_integration)} />
+              <Metric label="Tool interception" value={String(data.safety.tool_interception)} />
+            </div>
+          </Section>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MissionControlLaneDashboard() {
+  const [data, setData] = useState<MissionControlLaneDashboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    api.getMissionControlLaneDashboard()
+      .then((response) => {
+        if (cancelled) return;
+        setData(response);
+        setError(null);
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : "Lane dashboard could not be loaded.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <InertState title="Loading lane dashboard." copy="Mission Control lane state is being read without enabling actions." />;
+  }
+
+  if (error) {
+    return (
+      <InertState
+        title="Lane dashboard could not be loaded."
+        copy={`Read-only surface remains inert. ${error}`}
+      />
+    );
+  }
+
+  if (!data) {
+    return (
+      <InertState
+        title="No lane dashboard state."
+        copy="No Mission Control lane dashboard payload was returned."
+      />
+    );
+  }
+
+  if (data.safety.parent_scan_performed || data.safety.quarantined_path_accessed) {
+    return (
+      <InertState
+        title="Lane dashboard safety warning."
+        copy="Read model reported forbidden parent-scan or quarantined-path access."
+      />
+    );
+  }
+
+  return <DashboardContent data={data} />;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -386,6 +386,8 @@ export const api = {
       body: JSON.stringify({ key }),
     });
   },
+  getMissionControlLaneDashboard: () =>
+    fetchJSON<MissionControlLaneDashboardResponse>("/api/mission-control/lane-dashboard", { cache: "no-store" }),
 
   // Cron jobs
   getCronJobs: (profile = "all") =>
@@ -1492,6 +1494,643 @@ export interface ModelsAnalyticsResponse {
     total_api_calls: number;
   };
   period_days: number;
+}
+
+export interface OpsApproval {
+  id: string;
+  created_at: string;
+  created_by: string;
+  project: string;
+  profile: string;
+  risk_label: string;
+  title: string;
+  proposed_action: string;
+  target: string;
+  preview: string;
+  reason: string;
+  rollback_or_verification: string;
+  blocked_until_approved: boolean;
+  status: "pending" | "approved" | "rejected" | "expired" | "clarification_requested" | "snoozed";
+  expires_at: string;
+  decided_at?: string | null;
+  decided_by?: string | null;
+  decision_note?: string | null;
+  execution_allowed: boolean;
+  execution_result?: unknown;
+  generated_command?: string | null;
+  proposal_kind?: "manual" | "gated_action" | string;
+  source_surface?: string | null;
+  source_ref?: string | null;
+  conversation_excerpt?: string | null;
+  related_paths?: string[];
+}
+
+export interface OpsApprovalCreate {
+  title: string;
+  project: string;
+  profile?: string;
+  risk_label: string;
+  proposed_action: string;
+  target: string;
+  preview: string;
+  reason: string;
+  rollback_or_verification: string;
+  created_by?: string;
+  expires_at?: string;
+  source_surface?: string;
+  source_ref?: string;
+  conversation_excerpt?: string;
+  related_paths?: string[];
+}
+
+export interface OpsApprovalDecision {
+  decided_by: string;
+  decision_note?: string;
+}
+
+export interface OpsApprovalAuditEvent {
+  event: string;
+  approval_id?: string | null;
+  status?: string | null;
+  actor?: string | null;
+  note?: string | null;
+  timestamp: string;
+}
+
+export interface OpsApprovalSummary {
+  pending_count: number;
+  total_count: number;
+  blocked_execution: boolean;
+  pending: OpsApproval[];
+  review_text: string;
+}
+
+export interface OpsActionDryRun {
+  ok: boolean;
+  reason: string;
+  approval_id?: string | null;
+  action: {
+    name: string;
+    title: string;
+    description: string;
+    risk_label: string;
+    verification: string;
+  };
+  config: {
+    allowed: boolean;
+    reason: string;
+    execution_enabled: boolean;
+    allowed_actions: string[];
+  };
+  approval: {
+    approval_ok: boolean;
+    reason: string;
+  };
+  execution_allowed: false;
+  would_execute: false;
+  message: string;
+}
+
+export interface OpsActionRegistryStatus {
+  execution_enabled: boolean;
+  allowed_actions: string[];
+  actions: Array<OpsActionDryRun["action"] & {
+    configured_allowed: boolean;
+    executable: boolean;
+    mutation_scope: "audit_log_only" | "none";
+  }>;
+  blocked_action_classes: string[];
+  message: string;
+}
+
+export interface OpsMemoryFileStatus {
+  target: "memory" | "user" | string;
+  filename: string;
+  path: string;
+  exists: boolean;
+  enabled: boolean;
+  chars: number;
+  limit: number;
+  percent_used: number;
+  entries: number;
+  duplicate_entries: number;
+  status: "ok" | "warning" | "critical" | "missing" | "disabled" | string;
+}
+
+export interface OpsMemoryStatus {
+  ok: boolean;
+  mode: "local_read_only";
+  profile_home: string;
+  provider: string;
+  memory_enabled: boolean;
+  user_profile_enabled: boolean;
+  updated_at: string;
+  status: "ok" | "warning" | "critical" | "missing" | "disabled" | string;
+  total_chars: number;
+  total_limit: number;
+  total_percent_used: number;
+  warning?: string | null;
+  files: OpsMemoryFileStatus[];
+}
+
+export interface OpsSocialPlatformStatusItem {
+  platform: string;
+  published: string;
+  scheduled: string;
+  issues_private: string;
+  readiness: string;
+  source: string;
+  status: string;
+  last_checked_at?: string | null;
+}
+
+export interface OpsSocialPlatformStatus {
+  ok: boolean;
+  mode: "local_read_only";
+  path: string;
+  updated_at?: string | null;
+  warning?: string | null;
+  source?: string | null;
+  platforms: OpsSocialPlatformStatusItem[];
+}
+
+export interface OpsSocialPlatformStatusUpdate {
+  source?: string;
+  updated_at?: string;
+  platforms: Array<Partial<OpsSocialPlatformStatusItem> & { platform: string }>;
+}
+
+export interface OpsSocialPlatformHistoryEvent {
+  timestamp?: string | null;
+  source?: string | null;
+  mode?: string;
+  platform_count?: number;
+  status_counts?: Record<string, number>;
+  platforms?: Array<Partial<OpsSocialPlatformStatusItem> & { platform?: string | null }>;
+}
+
+export interface OpsSocialPlatformHistory {
+  ok: boolean;
+  mode: "local_read_only";
+  path: string;
+  warning?: string | null;
+  events: OpsSocialPlatformHistoryEvent[];
+}
+
+export type MissionControlPacketKind = "codex_prompt" | "worker_result" | "operator_note" | "block_flag";
+export type MissionControlPacketStatus = "draft" | "queued" | "imported" | "reviewed" | "archived";
+
+export interface MissionControlPacketSummary {
+  id: string;
+  kind: MissionControlPacketKind;
+  project: string;
+  title: string;
+  status: MissionControlPacketStatus;
+  dry_run: boolean;
+  review_required: boolean;
+  trusted_for_execution: boolean;
+  author?: string;
+  created_at: string;
+  updated_at: string;
+  redacted_payload_preview?: string;
+  warnings: string[];
+}
+
+export interface MissionControlPacket {
+  id: string;
+  kind: MissionControlPacketKind;
+  project: string;
+  title: string;
+  payload: Record<string, unknown> & {
+    prompt?: string;
+    worker_result?: string;
+    parsed_metadata?: Record<string, unknown>;
+    flag?: string;
+    reason?: string;
+    advisory_only?: boolean;
+  };
+  redacted_payload_preview: string;
+  source_refs: string[];
+  approval_gates: unknown[];
+  dry_run: boolean;
+  review_required: boolean;
+  trusted_for_execution: boolean;
+  status: MissionControlPacketStatus;
+  author: string;
+  created_at: string;
+  updated_at: string;
+  warnings: string[];
+}
+
+export interface MissionControlPacketListResponse {
+  generated_at: string;
+  source: string;
+  source_refs: string[];
+  items: MissionControlPacketSummary[];
+  warnings: string[];
+}
+
+export interface MissionControlPacketDetailResponse {
+  generated_at: string;
+  source: string;
+  source_refs: string[];
+  packet: MissionControlPacket;
+  warnings: string[];
+}
+
+export interface MissionControlPacketCreateResponse {
+  packet: MissionControlPacket;
+}
+
+export interface MissionControlArtifact {
+  source_type: string;
+  record_id: string;
+  title: string;
+  project: string;
+  status: string;
+  kind: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  archived_at?: string | null;
+  counts: Record<string, number>;
+  linked_ids: Record<string, string[]>;
+  source_ref_count: number;
+  flags: Record<string, unknown>;
+  warnings: string[];
+  trusted_for_execution: false;
+  inert_context_only: true;
+  untrusted: true;
+}
+
+export interface MissionControlArtifactListResponse {
+  generated_at: string;
+  source: string;
+  items: MissionControlArtifact[];
+  warnings: string[];
+}
+
+export interface MissionControlActiveEnvelopeMetadata {
+  id?: string | null;
+  schema?: string | null;
+  status?: string | null;
+  title?: string | null;
+  mode?: string | null;
+  mode_label?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  trusted_for_execution: false;
+  inert_context_only: true;
+  vocabulary_version?: string | null;
+}
+
+export interface MissionControlActiveEnvelopeResponse {
+  exists: boolean;
+  active_lane?: string | null;
+  active_mode?: string | null;
+  execution_boundary: string;
+  allowed_actions: string[];
+  forbidden_actions: string[];
+  checkpoint?: string | null;
+  repo_state: {
+    status?: string | null;
+    source?: string | null;
+  };
+  evidence: {
+    count: number;
+    links: string[];
+  };
+  data_source: string;
+  task_control_envelope?: MissionControlActiveEnvelopeMetadata;
+  selection?: {
+    selected_from_count: number;
+    ambiguous: boolean;
+    selection_reason: string;
+  };
+  trusted_for_execution: false;
+  inert_context_only: true;
+}
+
+export interface MissionControlLaneEvidenceSummary {
+  id?: string | null;
+  kind?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  source?: string | null;
+  created_at?: string | null;
+  trusted_for_execution: false;
+  inert_context_only: true;
+  authorizing: false;
+}
+
+export interface MissionControlLaneDashboardResponse {
+  mode: "local_read_only";
+  active_lane: {
+    label: string;
+    mode?: string | null;
+    status: string;
+    source: string;
+  };
+  task_control_envelope: {
+    exists: boolean;
+    id?: string | null;
+    summary?: string | null;
+    mode_label?: string | null;
+    checkpoint?: string | null;
+    selected_from_count: number;
+    policy_model?: {
+      active_lane: string;
+      mode: string;
+      lane_state: string;
+      approval_tier: string;
+      repo_path: string;
+      branch: string;
+      allowed_actions: string[];
+      forbidden_actions: string[];
+      allowed_files: string[];
+      forbidden_files: string[];
+      allowed_start_gate_dirty_files: string[];
+      focused_test_files: string[];
+      stop_condition: string;
+      trusted_for_execution: false;
+      inert_context_only: true;
+    } | null;
+    trusted_for_execution: false;
+    inert_context_only: true;
+  };
+  approval_tier: {
+    label: string;
+    active_slice_count: number;
+    latest_slice_id?: string | null;
+    latest_slice_title?: string | null;
+  };
+  allowed_actions: string[];
+  forbidden_actions: string[];
+  start_gate: {
+    status: string;
+    source: string;
+    repo_state: string;
+  };
+  guard_decisions: {
+    start_gate: {
+      allowed: boolean;
+      approval_tier: string;
+      reason: string;
+      violations: string[];
+      execution_enabled: false;
+      trusted_for_execution: false;
+      inert_context_only: true;
+    };
+  };
+  evidence: {
+    count: number;
+    summaries: MissionControlLaneEvidenceSummary[];
+    details_on_demand: boolean;
+  };
+  next_action: {
+    kind: "auto" | "one_click_approval" | "forbidden";
+    label: string;
+    reason: string;
+    execution_enabled: false;
+    trusted_for_execution: false;
+    inert_context_only: true;
+  };
+  next_recommended_action: string;
+  token_context_budget: {
+    estimated_input_tokens: number;
+    estimated_output_tokens: number;
+    remaining_context_window: string;
+    show_token_estimates: true;
+    conservation_behavior: string;
+  };
+  safety: {
+    quarantine_parent_scan_warning: string;
+    parent_scan_performed: false;
+    quarantined_path_accessed: false;
+    transcript_loaded: false;
+    execution_controls: false;
+    runner_integration: false;
+    tool_interception: false;
+  };
+  trusted_for_execution: false;
+  inert_context_only: true;
+}
+
+export type ApprovalSliceStatus = "active" | "revoked" | "expired" | "completed";
+
+export interface ApprovalSliceSummary {
+  id: string;
+  status: ApprovalSliceStatus;
+  title: string;
+  repo_path?: string | null;
+  allowed_actions: string[];
+  forbidden_actions: string[];
+  stop_condition?: string | null;
+  checkpoint?: string | null;
+  linked_goal_contract_id?: string | null;
+  created_by?: string | null;
+  created_from?: string | null;
+  created_at: string;
+  updated_at: string;
+  revoked_at?: string | null;
+  expired_at?: string | null;
+  completed_at?: string | null;
+  trusted_for_execution: false;
+  inert_context_only: true;
+}
+
+export interface ApprovalSlicesResponse {
+  items: ApprovalSliceSummary[];
+  warnings: string[];
+}
+
+export interface MissionControlCodexPromptPacketCreate {
+  project: string;
+  title: string;
+  prompt: string;
+  source_refs?: string[];
+  author?: string;
+}
+
+export interface MissionControlWorkerResultPacketCreate {
+  project: string;
+  title: string;
+  worker_result: string;
+  source_refs?: string[];
+  author?: string;
+}
+
+export interface MissionControlBlockFlagPacketCreate {
+  project: string;
+  title: string;
+  flag: "pause_future_outreach" | "block_all_sends" | "pause_cron_triggered_outreach" | "disable_launch_actions";
+  reason: string;
+  source_refs?: string[];
+  author?: string;
+}
+
+export interface MissionBrief {
+  id: string;
+  title: string;
+  summary: string;
+  references: string[];
+  status: "active" | "archived";
+  author: string;
+  created_at: string;
+  updated_at: string;
+  archived_at?: string | null;
+  trusted_for_execution: false;
+  inert_context_only: true;
+}
+
+export interface MissionBriefSummary {
+  id: string;
+  title: string;
+  summary: string;
+  status: "active" | "archived";
+  reference_count: number;
+  created_at: string;
+  updated_at: string;
+  archived_at?: string | null;
+  trusted_for_execution: false;
+  inert_context_only: true;
+}
+
+export interface MissionBriefListResponse {
+  items: MissionBriefSummary[];
+  warnings: string[];
+}
+
+export interface MissionBriefDetailResponse {
+  brief: MissionBrief;
+}
+
+export interface MissionBriefCreate {
+  title: string;
+  summary?: string;
+  references?: string[];
+  author?: string;
+}
+
+export type MissionBriefUpdate = Partial<MissionBriefCreate>;
+
+export interface MissionBriefCreateResponse {
+  brief: MissionBrief;
+}
+
+export interface ProjectRoom {
+  id: string;
+  slug: string;
+  title: string;
+  project_key: string;
+  description: string;
+  trusted_for_execution: false;
+  inert_context_only: true;
+  created_at: string;
+  updated_at: string;
+  message_count: number;
+  attachment_count: number;
+}
+
+export interface ProjectRoomsResponse {
+  generated_at: string;
+  source: string;
+  source_refs: string[];
+  rooms: ProjectRoom[];
+  warnings: string[];
+}
+
+export interface ProjectRoomCreate {
+  title: string;
+  project_key?: string;
+  description?: string;
+}
+
+export interface ProjectRoomCreateResponse {
+  room: ProjectRoom;
+}
+
+export interface ProjectRoomMessage {
+  id: string;
+  room_id: string;
+  author: string;
+  role: string;
+  content_type: string;
+  content_text: string;
+  source_refs: string[];
+  linked_packet_ids: string[];
+  trusted_for_execution: false;
+  inert_context_only: true;
+  created_at: string;
+}
+
+export interface ProjectRoomMessagesResponse {
+  generated_at: string;
+  source: string;
+  room: ProjectRoom;
+  messages: ProjectRoomMessage[];
+  warnings: string[];
+}
+
+export interface ProjectRoomMessageCreate {
+  author?: string;
+  role?: string;
+  content_type?: string;
+  content_text: string;
+  source_refs?: string[];
+  linked_packet_ids?: string[];
+  trusted_for_execution?: boolean;
+}
+
+export interface ProjectRoomMessageCreateResponse {
+  message: ProjectRoomMessage;
+}
+
+export interface ProjectRoomAttachment {
+  id: string;
+  room_id: string;
+  original_filename: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  trusted_for_execution: false;
+  inert_context_only: true;
+  created_at: string;
+}
+
+export interface ProjectRoomAttachmentCreateResponse {
+  attachment: ProjectRoomAttachment;
+}
+
+export interface ProjectRoomAttachmentResponse {
+  attachment: ProjectRoomAttachment;
+}
+
+export interface OpsActionExecute {
+  ok: boolean;
+  executed: true;
+  approval_id?: string | null;
+  action: OpsActionDryRun["action"];
+  approval: {
+    allowed: boolean;
+    would_execute: false;
+    execution_allowed: false;
+    reason: string;
+    approval_id?: string | null;
+  };
+  mutation_scope: "audit_log_only";
+  result: {
+    timestamp: string;
+    gateway_running?: boolean | null;
+    gateway_state?: string | null;
+    gateway_pid?: number | string | null;
+    gateway_platform_count: number;
+    gateway_updated_at?: string | null;
+    gateway_exit_reason?: string | null;
+    action_execution_enabled: boolean;
+    allowed_actions: string[];
+    approval_status?: string | null;
+  };
+  message: string;
 }
 
 export interface CronJob {


### PR DESCRIPTION
## Summary
- Add Mission Control lane policy read model support
- Add Mission Control dashboard/API coverage for lane policy state
- Rebuilt from current `main` to replace conflicting PR #39689

## Validation
- `npm --prefix web run build`
- `scripts/run_tests.sh tests/hermes_cli/test_mission_control_autonomy.py tests/hermes_cli/test_mission_control_lane_dashboard_api.py tests/hermes_cli/test_mission_control_lane_dashboard_ui.py`
- `git diff --check`
- `git diff --cached --check`

Supersedes #39689.
