### PR TITLE
feat(gateway): add Nutanix answer verifier gate

### DIFF
--- a/gateway/nutanix_answer_shadow.py
+++ b/gateway/nutanix_answer_shadow.py
@@ -1,0 +1,378 @@
+"""Shadow-mode post-answer verification for Nutanix RAG answers.
+
+This module is intentionally small and optional: failures must never block or
+mutate delivery. It only extracts Hermes/NX-Shield RAG tool output from the
+current turn, runs the external Nutanix answer verifier, and writes a local JSON
+report for later review.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from hermes_constants import get_hermes_home
+
+RAG_TOOL_NAMES = {
+    "hermes_master_search",
+    "mcp_nutanix_rag_search_hermes_master_search",
+    "mcp_nutanix_rag_search_canary_hermes_master_search",
+}
+DEFAULT_RAG_ROOT = get_hermes_home() / "rag" / "nutanix"
+PASS_VERDICTS = {"PASS", "PASS_WITH_WARNINGS"}
+REVISION_VERDICTS = {"REWRITE_REQUIRED"}
+FAIL_CLOSED_VERDICTS = {"FAIL_CLOSED"}
+DeliveryAction = Literal["send_original", "request_revision", "send_evidence_fallback", "unchanged"]
+
+
+def _safe_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except Exception:
+        return str(value)
+
+
+def _parse_tool_arguments(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _tool_name_and_args(call: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    fn = call.get("function") if isinstance(call, dict) else None
+    if isinstance(fn, dict):
+        return str(fn.get("name") or ""), _parse_tool_arguments(fn.get("arguments"))
+    return str(call.get("name") or ""), _parse_tool_arguments(call.get("arguments"))
+
+
+def _iter_tool_calls(raw: Any) -> list[dict[str, Any]]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except Exception:
+            return []
+    if not isinstance(raw, list):
+        return []
+    return [call for call in raw if isinstance(call, dict)]
+
+
+def _strip_tool_output_query_echo(text: str) -> str:
+    lines = []
+    for line in str(text or "").splitlines():
+        if line.strip().lower().startswith("query:"):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def extract_rag_evidence(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Extract current-turn RAG MCP tool outputs as verifier evidence rows."""
+    calls_by_id: dict[str, tuple[str, dict[str, Any]]] = {}
+    evidence: list[dict[str, str]] = []
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant":
+            for call in _iter_tool_calls(msg.get("tool_calls")):
+                call_id = str(call.get("id") or "")
+                tool_name, args = _tool_name_and_args(call)
+                if call_id and tool_name in RAG_TOOL_NAMES:
+                    calls_by_id[call_id] = (tool_name, args)
+            continue
+
+        if msg.get("role") not in {"tool", "function"}:
+            continue
+
+        tool_name = str(msg.get("name") or msg.get("tool_name") or "")
+        args: dict[str, Any] = {}
+        call_id = str(msg.get("tool_call_id") or "")
+        if call_id in calls_by_id:
+            tool_name, args = calls_by_id[call_id]
+
+        if tool_name not in RAG_TOOL_NAMES:
+            continue
+
+        text = _strip_tool_output_query_echo(_safe_str(msg.get("content"))).strip()
+        if not text:
+            continue
+        query = _safe_str(args.get("query")).strip()
+        row = {
+            "source": f"mcp_tool:{tool_name}",
+            "tool_name": tool_name,
+            "query": query,
+            "text": text,
+        }
+        if "[OFFICIAL_PORTAL]" in text or "official_nutanix_portal" in text.lower():
+            row["source_authority"] = "official_nutanix_portal"
+        evidence.append(row)
+
+    return evidence
+
+
+def default_shadow_audit_dir() -> Path:
+    configured = os.environ.get("NUTANIX_ANSWER_VERIFIER_AUDIT_DIR", "").strip()
+    if configured:
+        return Path(configured)
+    rag_root = Path(os.environ.get("HERMES_NUTANIX_RAG_ROOT", str(DEFAULT_RAG_ROOT)))
+    day = datetime.now().strftime("%Y%m%d")
+    return rag_root / "audits" / "answer_verifier_shadow" / day
+
+
+def _load_default_verifier() -> Callable[..., dict[str, Any]]:
+    rag_root = Path(os.environ.get("HERMES_NUTANIX_RAG_ROOT", str(DEFAULT_RAG_ROOT)))
+    src = rag_root / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    module = importlib.import_module("nx_rag.answer_verifier")
+    return module.verify_answer
+
+
+def _report_name(session_id: str, query: str) -> str:
+    ts = datetime.now().strftime("%Y%m%dT%H%M%S%z")
+    digest = hashlib.sha256(f"{session_id}\n{query}".encode("utf-8")).hexdigest()[:12]
+    safe_session = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in session_id)[:80]
+    return f"{ts}_{safe_session or 'session'}_{digest}.json"
+
+
+def enforcement_enabled_from_config(config: dict[str, Any] | None = None) -> bool:
+    """Resolve the disabled-by-default enforcement gate.
+
+    Env ``NUTANIX_ANSWER_VERIFIER_ENFORCE`` wins. Config path is
+    ``rag.answer_verification.enforce_enabled``. This helper is intentionally
+    separate from shadow mode so shadow reporting can stay on while delivery
+    enforcement remains off.
+    """
+    raw_env = os.environ.get("NUTANIX_ANSWER_VERIFIER_ENFORCE")
+    if raw_env is not None:
+        return raw_env.strip().lower() in {"1", "true", "yes", "on"}
+    cfg = config or {}
+    try:
+        rag = cfg.get("rag") if isinstance(cfg, dict) else None
+        av = rag.get("answer_verification") if isinstance(rag, dict) else None
+        return bool(av.get("enforce_enabled")) if isinstance(av, dict) else False
+    except Exception:
+        return False
+
+
+def build_evidence_fallback(query: str, evidence: list[dict[str, Any]], verification: dict[str, Any] | None = None) -> str:
+    """Build a conservative fallback answer from evidence metadata/text snippets.
+
+    This avoids asserting unsupported claims. It is only a candidate fallback for
+    future enforcement mode; the current gateway path does not send it.
+    """
+    lines = [
+        "I could not verify the drafted answer strongly enough against the retrieved Nutanix evidence.",
+        "Here is the safest evidence-bound summary instead:",
+    ]
+    if query:
+        lines.append(f"- Query: {query}")
+    for idx, row in enumerate(evidence[:3], start=1):
+        source = _safe_str(row.get("source") or row.get("doc_id") or row.get("tool_name") or "Nutanix RAG evidence")
+        text = re.sub(r"\s+", " ", _safe_str(row.get("text"))).strip()
+        snippet = text[:300] + ("…" if len(text) > 300 else "")
+        lines.append(f"- Evidence {idx}: {source}")
+        if snippet:
+            lines.append(f"  - {snippet}")
+    issues = []
+    if isinstance(verification, dict):
+        issues = [str(item) for item in verification.get("issues") or [] if str(item)]
+    if issues:
+        lines.append("- Verification issues:")
+        for issue in issues[:5]:
+            lines.append(f"  - {issue}")
+    return "\n".join(lines)
+
+
+def build_revision_request_prompt(
+    *,
+    query: str,
+    draft_answer: str,
+    evidence: list[dict[str, Any]],
+    verification: dict[str, Any] | None,
+) -> str:
+    """Build a bounded prompt for a single verifier-driven answer revision.
+
+    The prompt is pure data: callers may use it to run exactly one additional
+    model turn, then must verify the revised answer again before delivery. Keep
+    evidence snippets short to avoid leaking unrelated retrieval text or causing
+    the revision step to drift beyond current-turn evidence.
+    """
+    lines = [
+        "Revise the Nutanix answer using only the retrieved evidence and verifier feedback below.",
+        "Do not introduce new claims, assumptions, or external sources.",
+        "If the evidence does not support a claim, remove it or state the limitation.",
+        "Return only the revised user-facing answer.",
+        "",
+    ]
+    if query:
+        lines.extend(["User query:", query.strip(), ""])
+    if draft_answer:
+        lines.extend(["Draft answer to revise:", draft_answer.strip(), ""])
+    issues: list[str] = []
+    warnings: list[str] = []
+    verdict = "UNKNOWN"
+    if isinstance(verification, dict):
+        verdict = _safe_str(verification.get("verdict") or "UNKNOWN") or "UNKNOWN"
+        issues = [_safe_str(item).strip() for item in verification.get("issues") or [] if _safe_str(item).strip()]
+        warnings = [_safe_str(item).strip() for item in verification.get("warnings") or [] if _safe_str(item).strip()]
+    lines.extend(["Verifier result:", f"- Verdict: {verdict}"])
+    if issues:
+        lines.append("- Issues:")
+        for issue in issues[:5]:
+            lines.append(f"  - {issue}")
+    if warnings:
+        lines.append("- Warnings:")
+        for warning in warnings[:5]:
+            lines.append(f"  - {warning}")
+    lines.append("")
+    lines.append("Retrieved evidence, limited to top 3 rows:")
+    for idx, row in enumerate(evidence[:3], start=1):
+        source = _safe_str(row.get("source") or row.get("doc_id") or row.get("tool_name") or "Nutanix RAG evidence")
+        text = re.sub(r"\s+", " ", _safe_str(row.get("text"))).strip()
+        snippet = text[:500] + ("…" if len(text) > 500 else "")
+        lines.append(f"- Evidence {idx}: {source}")
+        if snippet:
+            lines.append(f"  - {snippet}")
+    return "\n".join(lines).strip()
+
+
+def decide_delivery_action(
+    *,
+    enforce_enabled: bool,
+    verification: dict[str, Any] | None,
+    query: str,
+    evidence: list[dict[str, Any]],
+    revision_attempted: bool = False,
+    draft_answer: str = "",
+) -> dict[str, Any]:
+    """Return a delivery decision for future verifier enforcement.
+
+    This is pure decision logic and has no side effects. The current production
+    gateway still uses shadow mode only unless explicit wiring enables it later.
+    """
+    if not enforce_enabled:
+        return {"action": "unchanged", "reason": "enforcement_disabled"}
+    if not isinstance(verification, dict):
+        return {
+            "action": "send_evidence_fallback",
+            "reason": "missing_verification_report",
+            "fallback_answer": build_evidence_fallback(query, evidence, verification),
+        }
+    verdict = str(verification.get("verdict") or "UNKNOWN")
+    if verdict in PASS_VERDICTS:
+        return {"action": "send_original", "reason": f"verdict_{verdict.lower()}", "verdict": verdict}
+    if verdict in REVISION_VERDICTS and not revision_attempted:
+        return {
+            "action": "request_revision",
+            "reason": "rewrite_required_before_delivery",
+            "verdict": verdict,
+            "issues": verification.get("issues", []),
+            "warnings": verification.get("warnings", []),
+            "revision_prompt": build_revision_request_prompt(
+                query=query,
+                draft_answer=draft_answer,
+                evidence=evidence,
+                verification=verification,
+            ),
+        }
+    return {
+        "action": "send_evidence_fallback",
+        "reason": "fail_closed_or_revision_exhausted",
+        "verdict": verdict,
+        "fallback_answer": build_evidence_fallback(query, evidence, verification),
+    }
+
+
+def maybe_run_shadow_verification(
+    *,
+    enabled: bool,
+    query: str,
+    answer: str,
+    messages: list[dict[str, Any]],
+    identity: str,
+    audit_dir: str | Path | None = None,
+    session_id: str = "",
+    platform: str = "",
+    chat_id: str = "",
+    verifier: Callable[..., dict[str, Any]] | None = None,
+) -> str | None:
+    """Run verifier in shadow mode and write a report.
+
+    Returns the report path when a report is written. Returns ``None`` when the
+    feature is disabled, there is no answer, or no RAG evidence exists. Raises no
+    deliberate delivery-affecting exceptions; callers should still wrap this in a
+    best-effort try/except at the delivery boundary.
+    """
+    if not enabled or not (answer or "").strip():
+        return None
+
+    evidence = extract_rag_evidence(messages)
+    if not evidence:
+        return None
+
+    verifier = verifier or _load_default_verifier()
+    verification = verifier(
+        query=query or (evidence[-1].get("query") or ""),
+        answer=answer,
+        evidence=evidence,
+        identity=identity or "hermes",
+    )
+    verdict = str(verification.get("verdict") or "UNKNOWN") if isinstance(verification, dict) else "UNKNOWN"
+
+    out_dir = Path(audit_dir) if audit_dir is not None else default_shadow_audit_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = out_dir / _report_name(session_id, query or evidence[-1].get("query", ""))
+
+    report = {
+        "schema_version": 1,
+        "mode": "shadow",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "platform": platform,
+        "chat_id": chat_id,
+        "identity": identity or "hermes",
+        "query": query,
+        "answer": answer,
+        "evidence_count": len(evidence),
+        "evidence": evidence,
+        "verdict": verdict,
+        "verification": verification,
+        "delivery_action": "unchanged",
+    }
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+    return str(report_path)
+
+
+def shadow_enabled_from_config(config: dict[str, Any] | None = None) -> bool:
+    """Resolve the shadow-mode gate from env or config.
+
+    Env ``NUTANIX_ANSWER_VERIFIER_SHADOW`` wins. Config path is
+    ``rag.answer_verification.shadow_enabled``.
+    """
+    raw_env = os.environ.get("NUTANIX_ANSWER_VERIFIER_SHADOW")
+    if raw_env is not None:
+        return raw_env.strip().lower() in {"1", "true", "yes", "on"}
+    cfg = config or {}
+    try:
+        rag = cfg.get("rag") if isinstance(cfg, dict) else None
+        av = rag.get("answer_verification") if isinstance(rag, dict) else None
+        return bool(av.get("shadow_enabled")) if isinstance(av, dict) else False
+    except Exception:
+        return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Awaitable, Callable, Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -55,6 +55,12 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.nutanix_answer_shadow import (
+    decide_delivery_action as _nutanix_decide_delivery_action,
+    enforcement_enabled_from_config as _nutanix_enforcement_enabled_from_config,
+    maybe_run_shadow_verification as _nutanix_shadow_maybe_run,
+    shadow_enabled_from_config as _nutanix_shadow_enabled_from_config,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -317,6 +323,252 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text
+
+
+def _read_nutanix_shadow_report(report_path: str | None) -> dict[str, Any] | None:
+    if not report_path:
+        return None
+    try:
+        return json.loads(Path(report_path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Nutanix answer verifier report read failed: %s", exc)
+        return None
+
+
+def _nutanix_answer_identity() -> str:
+    raw = (
+        os.environ.get("NX_AGENT_IDENTITY")
+        or os.environ.get("NUTANIX_RAG_IDENTITY")
+        or os.environ.get("HERMES_PROFILE")
+        or ""
+    ).strip().lower().replace("-", "_")
+    if raw in {"nx_shield", "nxshield"}:
+        return "nx_shield"
+    return raw or "hermes"
+
+
+def _nutanix_max_regenerations_from_config(config: dict[str, Any] | None) -> int:
+    raw_env = os.environ.get("NUTANIX_ANSWER_VERIFIER_MAX_REGENERATIONS")
+    if raw_env is not None:
+        try:
+            return max(0, min(1, int(str(raw_env).strip())))
+        except (TypeError, ValueError):
+            return 0
+    cfg = config or {}
+    try:
+        rag = cfg.get("rag") if isinstance(cfg, dict) else None
+        av = rag.get("answer_verification") if isinstance(rag, dict) else None
+        if isinstance(av, dict):
+            return max(0, min(1, int(av.get("max_regenerations", 0))))
+    except (TypeError, ValueError):
+        return 0
+    except Exception:
+        return 0
+    return 0
+
+
+def _run_nutanix_answer_verifier_gate(
+    *,
+    config: dict[str, Any] | None,
+    query: str,
+    answer: str,
+    messages: list[dict[str, Any]],
+    source: Any,
+    session_id: str,
+) -> dict[str, Any]:
+    """Run optional Nutanix answer verification at the gateway boundary.
+
+    Shadow mode always leaves delivery unchanged. If enforcement is explicitly
+    enabled, this call-site uses a fallback-only policy: unsafe or missing
+    verification sends conservative evidence fallback rather than attempting an
+    unimplemented regenerate loop inside the gateway.
+    """
+    result: dict[str, Any] = {
+        "delivery_response": answer,
+        "delivery_action": "unchanged",
+        "shadow_report_path": None,
+    }
+    try:
+        shadow_enabled = _nutanix_shadow_enabled_from_config(config)
+        enforce_enabled = _nutanix_enforcement_enabled_from_config(config)
+        if not shadow_enabled and not enforce_enabled:
+            return result
+        platform = getattr(getattr(source, "platform", ""), "value", getattr(source, "platform", ""))
+        report_path = _nutanix_shadow_maybe_run(
+            enabled=bool(shadow_enabled or enforce_enabled),
+            query=query,
+            answer=answer,
+            messages=messages or [],
+            identity=_nutanix_answer_identity(),
+            session_id=session_id,
+            platform=str(platform or ""),
+            chat_id=str(getattr(source, "chat_id", "") or ""),
+        )
+        result["shadow_report_path"] = report_path
+        if report_path:
+            logger.info("Nutanix answer verifier shadow report written: %s", report_path)
+        if not enforce_enabled:
+            return result
+        if not report_path:
+            result["delivery_reason"] = "no_rag_evidence_report"
+            logger.info(
+                "Nutanix answer verifier produced no report: reason=no_rag_evidence_report "
+                "shadow_enabled=%s enforce_enabled=%s message_count=%s",
+                shadow_enabled,
+                enforce_enabled,
+                len(messages or []),
+            )
+            return result
+        report = _read_nutanix_shadow_report(report_path)
+        max_regenerations = _nutanix_max_regenerations_from_config(config)
+        revision_attempted = max_regenerations <= 0
+        decision = _nutanix_decide_delivery_action(
+            enforce_enabled=True,
+            verification=(report or {}).get("verification") if isinstance(report, dict) else None,
+            query=query,
+            evidence=(report or {}).get("evidence", []) if isinstance(report, dict) else [],
+            revision_attempted=revision_attempted,
+            draft_answer=answer,
+        )
+        result["delivery_action"] = decision.get("action", "unchanged")
+        result["delivery_reason"] = decision.get("reason", "")
+        if decision.get("revision_prompt"):
+            result["revision_prompt"] = str(decision.get("revision_prompt") or "")
+        if decision.get("action") == "send_evidence_fallback" and decision.get("fallback_answer"):
+            result["delivery_response"] = str(decision["fallback_answer"])
+        return result
+    except Exception as exc:
+        logger.info(
+            "Nutanix answer verifier gateway gate skipped after error: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        logger.debug("Nutanix answer verifier gateway gate traceback", exc_info=True)
+        return result
+
+
+async def _run_nutanix_answer_verifier_gate_with_revision(
+    *,
+    config: dict[str, Any] | None,
+    query: str,
+    answer: str,
+    messages: list[dict[str, Any]],
+    source: Any,
+    session_id: str,
+    revision_runner: Callable[[str], Awaitable[dict[str, Any] | str]] | None = None,
+) -> dict[str, Any]:
+    """Run Nutanix verifier with at most one injected revision attempt.
+
+    The live gateway can keep ``max_regenerations`` at 0 for fallback-only
+    behavior. When explicitly set to 1 and a ``revision_runner`` is provided,
+    this wrapper verifies the draft, asks for exactly one revision on
+    ``REWRITE_REQUIRED``, verifies the revised answer against the same current
+    turn RAG evidence, then either sends the revised answer or fail-closes to an
+    evidence fallback.
+    """
+    first = _run_nutanix_answer_verifier_gate(
+        config=config,
+        query=query,
+        answer=answer,
+        messages=messages,
+        source=source,
+        session_id=session_id,
+    )
+    if first.get("delivery_action") != "request_revision":
+        return first
+
+    if _nutanix_max_regenerations_from_config(config) <= 0 or revision_runner is None:
+        first["delivery_action"] = "send_evidence_fallback"
+        first["delivery_reason"] = "revision_requested_but_runner_unavailable"
+        report = _read_nutanix_shadow_report(first.get("shadow_report_path"))
+        decision = _nutanix_decide_delivery_action(
+            enforce_enabled=True,
+            verification=(report or {}).get("verification") if isinstance(report, dict) else None,
+            query=query,
+            evidence=(report or {}).get("evidence", []) if isinstance(report, dict) else [],
+            revision_attempted=True,
+            draft_answer=answer,
+        )
+        if decision.get("fallback_answer"):
+            first["delivery_response"] = str(decision["fallback_answer"])
+        return first
+
+    revision_prompt = str(first.get("revision_prompt") or "").strip()
+    if not revision_prompt:
+        first["delivery_action"] = "send_evidence_fallback"
+        first["delivery_reason"] = "missing_revision_prompt"
+        return first
+
+    try:
+        revision_result = await asyncio.wait_for(revision_runner(revision_prompt), timeout=120)
+    except Exception as exc:
+        logger.info(
+            "Nutanix answer verifier revision attempt failed: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        first["delivery_action"] = "send_evidence_fallback"
+        first["delivery_reason"] = "revision_runner_failed"
+        report = _read_nutanix_shadow_report(first.get("shadow_report_path"))
+        decision = _nutanix_decide_delivery_action(
+            enforce_enabled=True,
+            verification=(report or {}).get("verification") if isinstance(report, dict) else None,
+            query=query,
+            evidence=(report or {}).get("evidence", []) if isinstance(report, dict) else [],
+            revision_attempted=True,
+            draft_answer=answer,
+        )
+        if decision.get("fallback_answer"):
+            first["delivery_response"] = str(decision["fallback_answer"])
+        return first
+
+    if isinstance(revision_result, dict):
+        revised_answer = str(revision_result.get("final_response") or revision_result.get("delivery_response") or "").strip()
+    else:
+        revised_answer = str(revision_result or "").strip()
+    if not revised_answer:
+        first["delivery_action"] = "send_evidence_fallback"
+        first["delivery_reason"] = "empty_revision_response"
+        return first
+
+    try:
+        platform = getattr(getattr(source, "platform", ""), "value", getattr(source, "platform", ""))
+        revised_report_path = _nutanix_shadow_maybe_run(
+            enabled=True,
+            query=query,
+            answer=revised_answer,
+            messages=messages or [],
+            identity=_nutanix_answer_identity(),
+            session_id=f"{session_id}_revision",
+            platform=str(platform or ""),
+            chat_id=str(getattr(source, "chat_id", "") or ""),
+        )
+    except Exception as exc:
+        logger.info(
+            "Nutanix answer verifier revised-answer report failed: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        revised_report_path = None
+
+    revised_report = _read_nutanix_shadow_report(revised_report_path)
+    decision = _nutanix_decide_delivery_action(
+        enforce_enabled=True,
+        verification=(revised_report or {}).get("verification") if isinstance(revised_report, dict) else None,
+        query=query,
+        evidence=(revised_report or {}).get("evidence", []) if isinstance(revised_report, dict) else [],
+        revision_attempted=True,
+        draft_answer=revised_answer,
+    )
+    result = dict(first)
+    result["revision_report_path"] = revised_report_path
+    result["delivery_action"] = decision.get("action", "unchanged")
+    result["delivery_reason"] = decision.get("reason", "")
+    if decision.get("action") == "send_original":
+        result["delivery_response"] = revised_answer
+    elif decision.get("action") == "send_evidence_fallback" and decision.get("fallback_answer"):
+        result["delivery_response"] = str(decision["fallback_answer"])
+    return result
 
 
 async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
@@ -3034,16 +3286,13 @@ class GatewayRunner:
         """Load ephemeral prefill messages from config or env var.
         
         Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
-        the top-level prefill_messages_file key in ~/.hermes/config.yaml.
-        agent.prefill_messages_file is accepted as a legacy fallback.
+        the prefill_messages_file key in ~/.hermes/config.yaml.
         Relative paths are resolved from ~/.hermes/.
         """
         file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
             cfg = _load_gateway_runtime_config()
             file_path = str(cfg.get("prefill_messages_file", "") or "")
-            if not file_path:
-                file_path = str(cfg_get(cfg, "agent", "prefill_messages_file", default="") or "")
         if not file_path:
             return []
         path = Path(file_path).expanduser()
@@ -3807,7 +4056,6 @@ class GatewayRunner:
                     "on_session_finalize",
                     session_id=getattr(agent, "session_id", None),
                     platform="gateway",
-                    reason="shutdown",
                 )
             except Exception:
                 pass
@@ -4156,7 +4404,7 @@ class GatewayRunner:
         {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
     )
 
-    def _schedule_resume_pending_sessions(self, platform=None) -> int:
+    def _schedule_resume_pending_sessions(self) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
@@ -4169,15 +4417,7 @@ class GatewayRunner:
         Adapters that are not yet ready (adapter missing from
         ``self.adapters``) are skipped silently; their sessions stay
         ``resume_pending`` and will auto-resume on the next real user
-        message, or when the platform reconnects — the reconnect watcher
-        calls this again scoped to that ``platform``.
-
-        ``platform`` (a ``Platform``) restricts the pass to sessions that
-        originated on that platform.  The reconnect path passes it so a
-        platform coming back online retries only its own sessions and never
-        re-touches another platform's in-flight recoveries.  Sessions whose
-        agent is already running are skipped regardless, so a session
-        scheduled at startup is never resumed a second time.
+        message, or on the next gateway startup.
         """
         window = _auto_continue_freshness_window()
         try:
@@ -4189,7 +4429,6 @@ class GatewayRunner:
                     and not entry.suspended
                     and entry.origin is not None
                     and entry.resume_reason in self._AUTO_RESUME_REASONS
-                    and (platform is None or entry.origin.platform == platform)
                 ]
         except Exception as exc:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
@@ -4200,11 +4439,6 @@ class GatewayRunner:
         for entry in candidates:
             marker = entry.last_resume_marked_at or entry.updated_at
             if marker is not None and (now - marker).total_seconds() > window:
-                continue
-
-            # Already being resumed (e.g. scheduled at startup and still
-            # in-flight) — don't synthesize a second continuation turn.
-            if entry.session_key in self._running_agents:
                 continue
 
             source = entry.origin
@@ -5054,7 +5288,6 @@ class GatewayRunner:
                                 "on_session_finalize",
                                 session_id=entry.session_id,
                                 platform=_platform,
-                                reason="session_expired",
                             )
                         except Exception:
                             pass
@@ -5402,12 +5635,10 @@ class GatewayRunner:
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
+                                h = payload_summary.strip().splitlines()[0][:200]
                                 handoff = f"\n{h}"
                             elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
+                                r = task.result.strip().splitlines()[0][:160]
                                 handoff = f"\n{r}"
                             msg = (
                                 f"✔ {tag}Kanban {sub['task_id']} done"
@@ -5755,14 +5986,7 @@ class GatewayRunner:
             logger.warning("kanban dispatcher: kanban_db not importable; dispatcher disabled")
             return
 
-        try:
-            interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
-        except (ValueError, TypeError):
-            logger.warning(
-                "kanban dispatcher: invalid dispatch_interval_seconds=%r, using default 60",
-                kanban_cfg.get("dispatch_interval_seconds"),
-            )
-            interval = 60.0
+        interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
         # Read max_spawn config to limit concurrent kanban tasks
@@ -6295,21 +6519,6 @@ class GatewayRunner:
                             await build_channel_directory(self.adapters)
                         except Exception:
                             pass
-
-                        # A platform that was offline at gateway startup never
-                        # got its restart-interrupted sessions auto-resumed —
-                        # the startup pass skips sessions whose adapter isn't
-                        # connected yet. Now that it's back, retry the
-                        # auto-resume scoped to this platform so recovery
-                        # doesn't silently wait for a manual user message.
-                        try:
-                            self._schedule_resume_pending_sessions(platform=platform)
-                        except Exception:
-                            logger.debug(
-                                "resume-pending reschedule after %s reconnect failed",
-                                platform.value,
-                                exc_info=True,
-                            )
                     # Check if the failure is non-retryable
                     elif adapter.has_fatal_error and not adapter.fatal_error_retryable:
                         self._update_platform_runtime_status(
@@ -6987,38 +7196,6 @@ class GatewayRunner:
             return False
         return bool(getattr(adapter, "enforces_own_access_policy", False))
 
-    def _adapter_dm_policy(self, platform: Optional[Platform]) -> str:
-        """Best-effort read of an own-policy adapter's effective DM policy.
-
-        Returns the lowercased ``dm_policy`` (``"open"`` / ``"allowlist"`` /
-        ``"disabled"`` / ``"pairing"``) for *platform*, or ``""`` when unknown.
-        Prefers the live adapter's resolved ``_dm_policy`` — which already folds
-        in both ``config.extra`` and the ``<PLATFORM>_DM_POLICY`` env var (the
-        env var is not always bridged back into ``config.extra``) — and falls
-        back to ``config.extra`` for bare runners built without a live adapter.
-
-        Used by ``_is_user_authorized`` to carve ``dm_policy: pairing`` out of
-        the adapter-trust shortcut: in pairing mode the adapter forwards the DM
-        so the gateway can run its pairing handshake, so "reached the gateway"
-        must not be read as "authorized".
-        """
-        if not platform:
-            return ""
-        adapters = getattr(self, "adapters", None) or {}
-        adapter = adapters.get(platform)
-        policy = getattr(adapter, "_dm_policy", None) if adapter is not None else None
-        if policy is None:
-            config = getattr(self, "config", None)
-            platform_cfg = (
-                config.platforms.get(platform)
-                if config is not None and hasattr(config, "platforms")
-                else None
-            )
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
-            if isinstance(extra, dict):
-                policy = extra.get("dm_policy")
-        return str(policy or "").strip().lower()
-
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -7166,20 +7343,7 @@ class GatewayRunner:
             # env-only default-deny below, which would silently break
             # `dm_policy: open` and config-only allowlists. (#34515)
             if self._adapter_enforces_own_access_policy(source.platform):
-                # Exception: `dm_policy: pairing` does NOT authorize at intake.
-                # The adapter forwards the DM precisely so the gateway can run
-                # its pairing handshake (issue a code, consult the pairing
-                # store). The pairing-store approval check above already ran and
-                # returned False for this sender, so blanket-trusting the
-                # adapter here would silently turn pairing mode into open
-                # access. Fall through to default-deny so the unpaired sender is
-                # offered a pairing code instead. (Pairing is DM-only; group
-                # traffic keeps the adapter-trust path.)
-                if not (
-                    source.chat_type == "dm"
-                    and self._adapter_dm_policy(source.platform) == "pairing"
-                ):
-                    return True
+                return True
             # No allowlists configured -- check global allow-all flag
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
@@ -8524,14 +8688,18 @@ class GatewayRunner:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            # If _run_agent replaced the sentinel with a real agent and
+            # then cleaned it up, this is a no-op.  If we exited early
+            # (exception, command fallthrough, etc.) the sentinel must
+            # not linger or the session would be permanently locked out.
+            if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
+                self._release_running_agent_state(_quick_key)
+            else:
+                # Agent path already cleaned _running_agents; make sure
+                # the paired metadata dicts are gone too.
+                self._running_agents_ts.pop(_quick_key, None)
+                if hasattr(self, "_busy_ack_ts"):
+                    self._busy_ack_ts.pop(_quick_key, None)
 
     async def _prepare_inbound_message_text(
         self,
@@ -9532,6 +9700,42 @@ class GatewayRunner:
                 agent_result, response, history_len=len(history),
             )
             response = _sanitize_gateway_final_response(source.platform, response)
+            async def _nutanix_revision_runner(prompt: str) -> dict[str, Any]:
+                revision_context = (
+                    context_prompt
+                    + "\n\n[System note: This is a verifier-driven answer revision. "
+                    + "Answer only the original user question, using the supplied retrieved evidence and verifier feedback. "
+                    + "Do not call tools unless the prompt explicitly requires fresh evidence.]"
+                )
+                return await self._run_agent(
+                    prompt,
+                    revision_context,
+                    [],
+                    source,
+                    session_entry.session_id,
+                    session_key=session_key,
+                    run_generation=run_generation,
+                    event_message_id=None,
+                    channel_prompt=None,
+                )
+
+            _nutanix_verifier_gate = await _run_nutanix_answer_verifier_gate_with_revision(
+                config=_load_gateway_config(),
+                query=message_text,
+                answer=response,
+                messages=agent_messages,
+                source=source,
+                session_id=session_entry.session_id,
+                revision_runner=_nutanix_revision_runner,
+            )
+            response = _nutanix_verifier_gate.get("delivery_response", response)
+            if _nutanix_verifier_gate.get("delivery_action") not in {None, "unchanged"}:
+                logger.info(
+                    "Nutanix answer verifier delivery action: %s reason=%s report=%s",
+                    _nutanix_verifier_gate.get("delivery_action"),
+                    _nutanix_verifier_gate.get("delivery_reason", ""),
+                    _nutanix_verifier_gate.get("shadow_report_path"),
+                )
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
@@ -10028,12 +10232,6 @@ class GatewayRunner:
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
-        # Evict the running-agent slot now that the generation is bumped. The
-        # in-flight run's own guarded release (run_generation=old) will return
-        # False and leave its dead agent behind; clearing here keeps the slot
-        # from becoming a zombie that silently drops all later messages (#28686).
-        # Idempotent, so the run's finally calling it again is harmless.
-        self._release_running_agent_state(session_key)
 
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
@@ -10085,19 +10283,12 @@ class GatewayRunner:
         # previous conversation must not survive the reset.
         self._clear_session_boundary_security_state(session_key)
 
-        _old_sid = old_entry.session_id if old_entry else None
-
         # Fire plugin on_session_finalize hook (session boundary)
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _invoke_hook(
-                "on_session_finalize",
-                session_id=_old_sid,
-                platform=source.platform.value if source.platform else "",
-                reason="new_session",
-                old_session_id=_old_sid,
-                new_session_id=new_entry.session_id if new_entry else None,
-            )
+            _old_sid = old_entry.session_id if old_entry else None
+            _invoke_hook("on_session_finalize", session_id=_old_sid,
+                         platform=source.platform.value if source.platform else "")
         except Exception:
             pass
 
@@ -10166,14 +10357,8 @@ class GatewayRunner:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _new_sid = new_entry.session_id if new_entry else None
-            _invoke_hook(
-                "on_session_reset",
-                session_id=_new_sid,
-                platform=source.platform.value if source.platform else "",
-                reason="new_session",
-                old_session_id=_old_sid,
-                new_session_id=_new_sid,
-            )
+            _invoke_hook("on_session_reset", session_id=_new_sid,
+                         platform=source.platform.value if source.platform else "")
         except Exception:
             pass
 
@@ -13956,17 +14141,12 @@ class GatewayRunner:
 
         parent_session_id = current_entry.session_id
 
-        # Create the new session with parent link.
-        # Persist a stable ``_branched_from`` marker in model_config so
-        # list_sessions_rich() keeps the branch visible in /resume and
-        # /sessions even after the parent is reopened and re-ended with a
-        # different end_reason (e.g. tui_shutdown overwriting 'branched').
+        # Create the new session with parent link
         try:
             self._session_db.create_session(
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
-                model_config={"_branched_from": parent_session_id},
                 parent_session_id=parent_session_id,
             )
         except Exception as e:
@@ -15149,15 +15329,10 @@ class GatewayRunner:
 
         if not adapter or not chat_id:
             logger.warning("Update watcher: cannot resolve adapter/chat_id, falling back to completion-only")
-            # Fall back to completion-only: wait for the exit code and send the
-            # final notification. _send_update_notification re-resolves the
-            # adapter on every call, so when the target platform is still
-            # reconnecting it returns False and keeps the markers. Keep polling
-            # until it actually delivers (returns True) instead of giving up
-            # after the first completion check — otherwise a platform that
-            # reconnects a few seconds after completion never gets notified.
+            # Fall back to old behavior: wait for exit code and send final notification
             while (pending_path.exists() or claimed_path.exists()) and loop.time() < deadline:
-                if exit_code_path.exists() and await self._send_update_notification():
+                if exit_code_path.exists():
+                    await self._send_update_notification()
                     return
                 await asyncio.sleep(poll_interval)
             if (pending_path.exists() or claimed_path.exists()) and not exit_code_path.exists():
@@ -15370,24 +15545,6 @@ class GatewayRunner:
             # Resolve adapter
             platform = Platform(platform_str)
             adapter = self.adapters.get(platform)
-
-            if not adapter and chat_id:
-                # The update finished, but the target platform has not
-                # reconnected yet (common right after the restart that
-                # `hermes update` triggers). Treating "adapter missing" as a
-                # definitive skip would delete the markers and silently lose the
-                # completion notification — the user never learns whether the
-                # update succeeded or timed out. Preserve the markers instead so
-                # a later retry (the watcher poll loop, or the next gateway
-                # startup) can deliver the result once the adapter is back.
-                logger.info(
-                    "Update notification deferred: %s adapter not connected yet",
-                    platform_str,
-                )
-                cleanup = False
-                active_pending_path = pending_path
-                claimed_path.replace(pending_path)
-                return False
 
             if adapter and chat_id:
                 metadata = self._thread_metadata_for_target(
@@ -17024,47 +17181,6 @@ class GatewayRunner:
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
 
-        # ── Discord voice "verbal ack before tool calls" ────────────────
-        # When the bot is in a voice channel with the continuous mixer
-        # installed (discord.voice_fx.enabled), speak a short phrase ("let me
-        # look into that") over the ambient idle bed on the FIRST tool call of
-        # the turn.  Fires from tool_start_callback (independent of the
-        # tool-progress text gate), at most once per turn.  No-op on every
-        # other platform / when not in a voice channel.
-        _voice_ack_fired = [False]
-        _voice_ack_guild: List[Optional[int]] = [None]
-        if source.platform == Platform.DISCORD:
-            _va = self.adapters.get(Platform.DISCORD)
-            # source.chat_id is the linked text channel; resolve the guild whose
-            # voice connection is bound to it (mirrors DiscordAdapter.play_tts).
-            _vtc = getattr(_va, "_voice_text_channels", None)
-            if isinstance(_vtc, dict) and hasattr(_va, "voice_mixer_active"):
-                for _gid, _tc in _vtc.items():
-                    if str(_tc) == str(source.chat_id) and _va.voice_mixer_active(_gid):
-                        _voice_ack_guild[0] = _gid
-                        break
-        _voice_ack_loop = asyncio.get_running_loop()
-
-        def voice_ack_callback(call_id, tool_name, args):
-            """tool_start_callback: speak a one-time ack in the voice channel."""
-            if _voice_ack_fired[0] or _voice_ack_guild[0] is None:
-                return
-            if not _run_still_current():
-                return
-            _voice_ack_fired[0] = True
-            _adapter = self.adapters.get(Platform.DISCORD)
-            if _adapter is None or not hasattr(_adapter, "play_ack_in_voice"):
-                return
-            try:
-                safe_schedule_threadsafe(
-                    _adapter.play_ack_in_voice(_voice_ack_guild[0]),
-                    _voice_ack_loop,
-                    logger=logger,
-                    log_message="voice ack scheduling error",
-                )
-            except Exception as _ack_err:
-                logger.debug("voice ack schedule failed: %s", _ack_err)
-
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
         # ``display.platforms.<platform>.cleanup_progress: true``, message IDs
@@ -17875,11 +17991,6 @@ class GatewayRunner:
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
-            # Discord voice verbal-ack hook (fires once per turn on first tool
-            # call; armed only when in a voice channel with the mixer running).
-            agent.tool_start_callback = (
-                voice_ack_callback if _voice_ack_guild[0] is not None else None
-            )
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
@@ -19374,7 +19485,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     tick_count = 0
     while not stop_event.is_set():
         try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
+            cron_tick(verbose=False, adapters=adapters, loop=loop)
         except Exception as e:
             logger.debug("Cron tick error: %s", e)
 

--- a/tests/gateway/test_nutanix_answer_shadow.py
+++ b/tests/gateway/test_nutanix_answer_shadow.py
@@ -1,0 +1,543 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from gateway.nutanix_answer_shadow import (
+    build_evidence_fallback,
+    build_revision_request_prompt,
+    decide_delivery_action,
+    enforcement_enabled_from_config,
+    extract_rag_evidence,
+    maybe_run_shadow_verification,
+)
+
+
+def test_extract_rag_evidence_from_mcp_tool_messages():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "hermes_master_search",
+                        "arguments": '{"query":"Security Advisory 0048"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "[EXACT-ID] [OFFICIAL_PORTAL] Security Advisory 0048 covers CVE-2026-43500.",
+        },
+    ]
+
+    evidence = extract_rag_evidence(messages)
+
+    assert evidence == [
+        {
+            "source": "mcp_tool:hermes_master_search",
+            "tool_name": "hermes_master_search",
+            "query": "Security Advisory 0048",
+            "text": "[EXACT-ID] [OFFICIAL_PORTAL] Security Advisory 0048 covers CVE-2026-43500.",
+            "source_authority": "official_nutanix_portal",
+        }
+    ]
+
+
+def test_extract_rag_evidence_from_gateway_registered_mcp_tool_name():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "mcp_nutanix_rag_search_hermes_master_search",
+                        "arguments": '{"query":"Prism Central VM HA migrate node failure"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": (
+                "[OFFICIAL_PORTAL] Prism Central supports high availability by "
+                "migrating and restarting the PCVM from a failed node to another node."
+            ),
+        },
+    ]
+
+    evidence = extract_rag_evidence(messages)
+
+    assert len(evidence) == 1
+    assert evidence[0]["tool_name"] == "mcp_nutanix_rag_search_hermes_master_search"
+    assert evidence[0]["query"] == "Prism Central VM HA migrate node failure"
+    assert evidence[0]["source_authority"] == "official_nutanix_portal"
+
+
+def test_extract_rag_evidence_from_gateway_tool_name_without_assistant_pairing():
+    messages = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "tool_name": "mcp_nutanix_rag_search_hermes_master_search",
+            "content": "[OFFICIAL_PORTAL] Prism Central scale-out requires a deployment container mounted on hypervisor hosts.",
+        }
+    ]
+
+    evidence = extract_rag_evidence(messages)
+
+    assert len(evidence) == 1
+    assert evidence[0]["tool_name"] == "mcp_nutanix_rag_search_hermes_master_search"
+    assert evidence[0]["query"] == ""
+    assert evidence[0]["source_authority"] == "official_nutanix_portal"
+
+
+def test_extract_rag_evidence_from_json_string_tool_calls():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": json.dumps(
+                [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "mcp_nutanix_rag_search_hermes_master_search",
+                            "arguments": '{"query":"Prism Central scale-out single cluster"}',
+                        },
+                    }
+                ]
+            ),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "tool_name": "mcp_nutanix_rag_search_hermes_master_search",
+            "content": "[OFFICIAL_PORTAL] The container used for deployment is mounted on hypervisor hosts.",
+        },
+    ]
+
+    evidence = extract_rag_evidence(messages)
+
+    assert len(evidence) == 1
+    assert evidence[0]["query"] == "Prism Central scale-out single cluster"
+
+
+def test_shadow_verification_writes_report_without_changing_answer(tmp_path):
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "hermes_master_search",
+                        "arguments": '{"query":"Security Advisory 0048"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "Security Advisory 0048 covers CVE-2026-43500.",
+        },
+    ]
+
+    def fake_verifier(query, answer, evidence, identity):
+        assert query == "Security Advisory 0048"
+        assert answer == "Security Advisory 0048 covers CVE-2026-43500."
+        assert evidence[0]["text"] == "Security Advisory 0048 covers CVE-2026-43500."
+        assert identity == "nx_shield"
+        return {
+            "verdict": "PASS",
+            "query_class": "security_advisory",
+            "claim_results": [],
+            "issues": [],
+            "warnings": [],
+        }
+
+    report_path = maybe_run_shadow_verification(
+        enabled=True,
+        query="Security Advisory 0048",
+        answer="Security Advisory 0048 covers CVE-2026-43500.",
+        messages=messages,
+        identity="nx_shield",
+        audit_dir=tmp_path,
+        session_id="sid-1",
+        platform="telegram",
+        chat_id="chat-1",
+        verifier=fake_verifier,
+    )
+
+    assert report_path is not None
+    report = json.loads(Path(report_path).read_text())
+    assert report["mode"] == "shadow"
+    assert report["verdict"] == "PASS"
+    assert report["identity"] == "nx_shield"
+    assert report["delivery_action"] == "unchanged"
+    assert report["evidence_count"] == 1
+    assert report["evidence"][0]["source"] == "mcp_tool:hermes_master_search"
+
+
+def test_shadow_verification_skips_when_no_rag_evidence(tmp_path):
+    report_path = maybe_run_shadow_verification(
+        enabled=True,
+        query="hello",
+        answer="hello back",
+        messages=[{"role": "assistant", "content": "hello back"}],
+        identity="hermes",
+        audit_dir=tmp_path,
+        session_id="sid-1",
+        platform="telegram",
+        chat_id="chat-1",
+        verifier=lambda **_: {"verdict": "PASS"},
+    )
+
+    assert report_path is None
+    assert not list(tmp_path.glob("*.json"))
+
+def test_enforcement_gate_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("NUTANIX_ANSWER_VERIFIER_ENFORCE", raising=False)
+    assert enforcement_enabled_from_config({}) is False
+    assert enforcement_enabled_from_config({"rag": {"answer_verification": {"enforce_enabled": True}}}) is True
+
+
+def test_enforcement_gate_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("NUTANIX_ANSWER_VERIFIER_ENFORCE", "false")
+    assert enforcement_enabled_from_config({"rag": {"answer_verification": {"enforce_enabled": True}}}) is False
+    monkeypatch.setenv("NUTANIX_ANSWER_VERIFIER_ENFORCE", "true")
+    assert enforcement_enabled_from_config({}) is True
+
+
+def test_decide_delivery_action_keeps_shadow_only_unchanged():
+    decision = decide_delivery_action(
+        enforce_enabled=False,
+        verification={"verdict": "FAIL_CLOSED"},
+        query="Security Advisory 0048",
+        evidence=[{"text": "evidence"}],
+    )
+    assert decision == {"action": "unchanged", "reason": "enforcement_disabled"}
+
+
+def test_decide_delivery_action_sends_original_for_pass():
+    decision = decide_delivery_action(
+        enforce_enabled=True,
+        verification={"verdict": "PASS"},
+        query="Security Advisory 0048",
+        evidence=[{"text": "evidence"}],
+    )
+    assert decision["action"] == "send_original"
+
+
+def test_decide_delivery_action_requests_revision_once_for_rewrite_required():
+    decision = decide_delivery_action(
+        enforce_enabled=True,
+        verification={"verdict": "REWRITE_REQUIRED", "issues": ["unsupported claim"]},
+        query="Security Advisory 0048",
+        evidence=[{"text": "evidence"}],
+        revision_attempted=False,
+        draft_answer="Unsupported draft.",
+    )
+    assert decision["action"] == "request_revision"
+    assert decision["issues"] == ["unsupported claim"]
+    assert "revision_prompt" in decision
+    assert "Unsupported draft." in decision["revision_prompt"]
+    assert "unsupported claim" in decision["revision_prompt"]
+
+
+def test_build_revision_request_prompt_limits_evidence_and_instructs_reverify_safe_revision():
+    evidence = [{"source": f"source-{i}", "text": "row text " * 80} for i in range(5)]
+    prompt = build_revision_request_prompt(
+        query="Is 25Gb always required?",
+        draft_answer="25Gb is always required and 10Gb is never acceptable.",
+        evidence=evidence,
+        verification={"verdict": "REWRITE_REQUIRED", "issues": ["absolute claim lacks direct support"], "warnings": ["thin evidence"]},
+    )
+
+    assert "using only the retrieved evidence" in prompt
+    assert "Return only the revised user-facing answer" in prompt
+    assert "25Gb is always required" in prompt
+    assert "absolute claim lacks direct support" in prompt
+    assert "thin evidence" in prompt
+    assert "source-0" in prompt
+    assert "source-2" in prompt
+    assert "source-3" not in prompt
+    assert len(prompt) < 3500
+
+
+def test_decide_delivery_action_falls_back_after_revision_or_fail_closed():
+    evidence = [{"source": "KB-021613", "text": "KB-21613 says AssignIp task fails on unmanaged subnets."}]
+    decision = decide_delivery_action(
+        enforce_enabled=True,
+        verification={"verdict": "FAIL_CLOSED", "issues": ["restricted evidence"]},
+        query="KB-21613",
+        evidence=evidence,
+        revision_attempted=True,
+    )
+    assert decision["action"] == "send_evidence_fallback"
+    assert "KB-21613" in decision["fallback_answer"]
+    assert "restricted evidence" in decision["fallback_answer"]
+
+
+def test_build_evidence_fallback_limits_to_three_evidence_rows():
+    evidence = [{"source": f"source-{i}", "text": "text"} for i in range(5)]
+    fallback = build_evidence_fallback("query", evidence)
+    assert "source-0" in fallback
+    assert "source-2" in fallback
+    assert "source-3" not in fallback
+
+
+
+def test_gateway_shadow_gate_invokes_shadow_runner_when_enabled(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    calls = []
+
+    def fake_enabled(config):
+        assert config == {"rag": {"answer_verification": {"shadow_enabled": True}}}
+        return True
+
+    def fake_enforcement(config):
+        return False
+
+    def fake_shadow_runner(**kwargs):
+        calls.append(kwargs)
+        return str(tmp_path / "shadow.json")
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", fake_enabled)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", fake_enforcement)
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", fake_shadow_runner)
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = gateway_run._run_nutanix_answer_verifier_gate(
+        config={"rag": {"answer_verification": {"shadow_enabled": True}}},
+        query="Security Advisory 0048",
+        answer="Security Advisory 0048 covers CVE-2026-43500.",
+        messages=[{"role": "assistant", "content": "x"}],
+        source=source,
+        session_id="sid-1",
+    )
+
+    assert result["delivery_response"] == "Security Advisory 0048 covers CVE-2026-43500."
+    assert result["shadow_report_path"].endswith("shadow.json")
+    assert calls[0]["enabled"] is True
+    assert calls[0]["identity"] == "hermes"
+    assert calls[0]["platform"] == "discord"
+    assert calls[0]["chat_id"] == "chat-1"
+
+
+def test_gateway_enforcement_gate_fallback_only_replaces_response(monkeypatch):
+    import gateway.run as gateway_run
+
+    def fake_enabled(config):
+        return True
+
+    def fake_enforcement(config):
+        return True
+
+    def fake_shadow_runner(**kwargs):
+        path = "/tmp/verifier-report.json"
+        return path
+
+    def fake_decide(**kwargs):
+        assert kwargs["enforce_enabled"] is True
+        assert kwargs["revision_attempted"] is True
+        return {
+            "action": "send_evidence_fallback",
+            "reason": "fail_closed_or_revision_exhausted",
+            "fallback_answer": "safe fallback",
+        }
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", fake_enabled)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", fake_enforcement)
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", fake_shadow_runner)
+    monkeypatch.setattr(gateway_run, "_nutanix_decide_delivery_action", fake_decide)
+    monkeypatch.setattr(gateway_run, "_read_nutanix_shadow_report", lambda _path: {"verification": {"verdict": "REWRITE_REQUIRED"}, "evidence": [{"text": "evidence"}]})
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = gateway_run._run_nutanix_answer_verifier_gate(
+        config={"rag": {"answer_verification": {"shadow_enabled": True, "enforce_enabled": True}}},
+        query="Networking query",
+        answer="25Gb is always required and 10Gb is never acceptable.",
+        messages=[{"role": "assistant", "content": "x"}],
+        source=source,
+        session_id="sid-1",
+    )
+
+    assert result["delivery_response"] == "safe fallback"
+    assert result["delivery_action"] == "send_evidence_fallback"
+
+
+def test_gateway_enforcement_gate_requests_revision_when_max_regeneration_enabled(monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", lambda **_kwargs: "/tmp/verifier-report.json")
+    monkeypatch.setattr(gateway_run, "_read_nutanix_shadow_report", lambda _path: {"verification": {"verdict": "REWRITE_REQUIRED"}, "evidence": [{"text": "evidence"}]})
+
+    def fake_decide(**kwargs):
+        assert kwargs["revision_attempted"] is False
+        assert kwargs["draft_answer"] == "unsupported draft"
+        return {"action": "request_revision", "reason": "rewrite_required_before_delivery", "revision_prompt": "revise now"}
+
+    monkeypatch.setattr(gateway_run, "_nutanix_decide_delivery_action", fake_decide)
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = gateway_run._run_nutanix_answer_verifier_gate(
+        config={"rag": {"answer_verification": {"shadow_enabled": True, "enforce_enabled": True, "max_regenerations": 1}}},
+        query="query",
+        answer="unsupported draft",
+        messages=[{"role": "assistant", "content": "x"}],
+        source=source,
+        session_id="sid-1",
+    )
+
+    assert result["delivery_action"] == "request_revision"
+    assert result["revision_prompt"] == "revise now"
+
+
+@pytest.mark.asyncio
+async def test_gateway_revision_wrapper_sends_revised_answer_after_reverify_pass(monkeypatch):
+    import gateway.run as gateway_run
+
+    calls = {"shadow": 0, "runner": 0}
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", lambda _config: True)
+
+    def fake_shadow_runner(**kwargs):
+        calls["shadow"] += 1
+        assert kwargs["session_id"] in {"sid-1", "sid-1_revision"}
+        return f"/tmp/verifier-report-{calls['shadow']}.json"
+
+    def fake_read(path):
+        if str(path).endswith("-1.json"):
+            return {"verification": {"verdict": "REWRITE_REQUIRED"}, "evidence": [{"text": "evidence"}]}
+        return {"verification": {"verdict": "PASS"}, "evidence": [{"text": "evidence"}]}
+
+    def fake_decide(**kwargs):
+        verdict = kwargs["verification"]["verdict"]
+        if verdict == "REWRITE_REQUIRED":
+            assert kwargs["revision_attempted"] is False
+            return {"action": "request_revision", "reason": "rewrite_required_before_delivery", "revision_prompt": "revise now"}
+        assert kwargs["revision_attempted"] is True
+        return {"action": "send_original", "reason": "verdict_pass", "verdict": "PASS"}
+
+    async def fake_revision_runner(prompt):
+        calls["runner"] += 1
+        assert prompt == "revise now"
+        return {"final_response": "revised safe answer"}
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", fake_shadow_runner)
+    monkeypatch.setattr(gateway_run, "_read_nutanix_shadow_report", fake_read)
+    monkeypatch.setattr(gateway_run, "_nutanix_decide_delivery_action", fake_decide)
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = await gateway_run._run_nutanix_answer_verifier_gate_with_revision(
+        config={"rag": {"answer_verification": {"shadow_enabled": True, "enforce_enabled": True, "max_regenerations": 1}}},
+        query="query",
+        answer="unsupported draft",
+        messages=[{"role": "assistant", "content": "x"}],
+        source=source,
+        session_id="sid-1",
+        revision_runner=fake_revision_runner,
+    )
+
+    assert calls == {"shadow": 2, "runner": 1}
+    assert result["delivery_action"] == "send_original"
+    assert result["delivery_response"] == "revised safe answer"
+    assert result["revision_report_path"] == "/tmp/verifier-report-2.json"
+
+
+@pytest.mark.asyncio
+async def test_gateway_revision_wrapper_falls_back_when_revised_answer_fails(monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", lambda **_kwargs: "/tmp/verifier-report.json")
+    monkeypatch.setattr(gateway_run, "_read_nutanix_shadow_report", lambda _path: {"verification": {"verdict": "REWRITE_REQUIRED"}, "evidence": [{"text": "evidence"}]})
+
+    def fake_decide(**kwargs):
+        if kwargs["revision_attempted"] is False:
+            return {"action": "request_revision", "reason": "rewrite_required_before_delivery", "revision_prompt": "revise now"}
+        return {"action": "send_evidence_fallback", "reason": "fail_closed_or_revision_exhausted", "fallback_answer": "safe fallback"}
+
+    async def fake_revision_runner(_prompt):
+        return "still unsupported"
+
+    monkeypatch.setattr(gateway_run, "_nutanix_decide_delivery_action", fake_decide)
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = await gateway_run._run_nutanix_answer_verifier_gate_with_revision(
+        config={"rag": {"answer_verification": {"shadow_enabled": True, "enforce_enabled": True, "max_regenerations": 1}}},
+        query="query",
+        answer="unsupported draft",
+        messages=[{"role": "assistant", "content": "x"}],
+        source=source,
+        session_id="sid-1",
+        revision_runner=fake_revision_runner,
+    )
+
+    assert result["delivery_action"] == "send_evidence_fallback"
+    assert result["delivery_response"] == "safe fallback"
+
+
+def test_extract_rag_evidence_strips_query_echo_from_tool_output():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "hermes_master_search",
+                        "arguments": '{"query":"Is 25Gb always required and is 10Gb never acceptable?"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "  [v4] backend=v4_hybrid_rrf identity=nx_shield\n\nQuery: Is 25Gb always required and is 10Gb never acceptable?\n\n[SOURCE: SEMANTIC CONTEXT]\n[1] Official guide says use appropriate network design.",
+        },
+    ]
+
+    evidence = extract_rag_evidence(messages)
+
+    assert "Query: Is 25Gb always required" not in evidence[0]["text"]
+    assert "[1] Official guide says use appropriate network design." in evidence[0]["text"]
+
+
+def test_gateway_enforcement_gate_leaves_non_rag_turns_unchanged(monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_enforcement_enabled_from_config", lambda _config: True)
+    monkeypatch.setattr(gateway_run, "_nutanix_shadow_maybe_run", lambda **_kwargs: None)
+
+    source = type("Source", (), {"platform": "discord", "chat_id": "chat-1"})()
+    result = gateway_run._run_nutanix_answer_verifier_gate(
+        config={"rag": {"answer_verification": {"shadow_enabled": True, "enforce_enabled": True}}},
+        query="hello",
+        answer="hello back",
+        messages=[{"role": "assistant", "content": "hello back"}],
+        source=source,
+        session_id="sid-1",
+    )
+
+    assert result["delivery_response"] == "hello back"
+    assert result["delivery_action"] == "unchanged"
+    assert result["delivery_reason"] == "no_rag_evidence_report"


### PR DESCRIPTION
## Summary
- Adds a Nutanix answer verifier shadow/enforcement gate for gateway final responses.
- Supports fallback-only enforcement and a scoped regenerate-once path with re-verification.
- Adds focused tests for PASS, REWRITE_REQUIRED, fallback, evidence extraction, profile-aware identity, and max-regeneration behavior.

## Test plan
- `PYTHONPATH=. python -m pytest tests/gateway/test_nutanix_answer_shadow.py -q`
- `python -m py_compile gateway/run.py gateway/nutanix_answer_shadow.py tests/gateway/test_nutanix_answer_shadow.py`

## Notes
- Defaults preserve existing behavior unless profile config/env enables Nutanix verifier gates.
- Paths use profile-aware Hermes home helpers where applicable.
