### PR TITLE
feat(cli): show prompt cache hit rate in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3591,6 +3591,27 @@ class HermesCLI:
             return "class:status-bar-warn"
         return "class:status-bar-good"
 
+    def _cache_hit_rate(self, snapshot: dict, precision: int = 1) -> "tuple[float, str] | None":
+        """Return (cache_pct, formatted_label) or None if no cache data.
+
+        Centralises the cache-hit-rate computation so both the plain-text
+        status bar and the prompt-toolkit fragment path share one formula.
+        """
+        cache_read = snapshot.get("session_cache_read_tokens", 0)
+        prompt_total = snapshot.get("session_prompt_tokens", 0)
+        if cache_read > 0 and prompt_total > 0:
+            cache_pct = cache_read / prompt_total * 100
+            return cache_pct, f"◎ {cache_pct:.{precision}f}%"
+        return None
+
+    def _cache_hit_rate_style(self, cache_pct: float) -> str:
+        """Style for cache hit rate — higher is better (opposite of context %)."""
+        if cache_pct >= 70:
+            return "class:status-bar-good"
+        if cache_pct >= 40:
+            return "class:status-bar-warn"
+        return "class:status-bar-bad"
+
     @staticmethod
     def _compression_count_style(count: int) -> str:
         """Return a style class reflecting context compression pressure."""
@@ -3942,6 +3963,9 @@ class HermesCLI:
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                cache = self._cache_hit_rate(snapshot, precision=0)
+                if cache:
+                    parts.append(cache[1])
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3965,6 +3989,9 @@ class HermesCLI:
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            cache = self._cache_hit_rate(snapshot)
+            if cache:
+                parts.append(cache[1])
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -4021,6 +4048,10 @@ class HermesCLI:
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    cache = self._cache_hit_rate(snapshot, precision=0)
+                    if cache:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((self._cache_hit_rate_style(cache[0]), cache[1]))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -4060,6 +4091,10 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    cache = self._cache_hit_rate(snapshot)
+                    if cache:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((self._cache_hit_rate_style(cache[0]), cache[1]))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -676,3 +676,107 @@ class TestStatusBarWidthSource:
         mock_get_app.assert_not_called()
         mock_shutil.assert_not_called()
         assert len(text) > 0
+
+
+class TestCacheHitRate:
+    def test_cache_hit_rate_shown_in_wide_terminal(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=7600,
+            cache_write_tokens=0,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "◎ 76.0%" in text
+
+    def test_cache_hit_rate_shown_in_narrow_terminal(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=5000,
+            cache_write_tokens=0,
+        )
+
+        text = cli_obj._build_status_bar_text(width=60)
+
+        assert "◎ 50%" in text
+
+    def test_cache_hit_rate_hidden_when_zero(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "◎" not in text
+
+    def test_cache_hit_rate_hidden_when_no_data(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "◎" not in text
+
+    def test_cache_hit_rate_one_decimal(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=7620,
+            cache_write_tokens=0,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "◎ 76.2%" in text
+
+    def test_cache_hit_rate_with_anthropic_style_cache(self):
+        """Anthropic has both cache_read and cache_write"""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=5000,
+            cache_write_tokens=2000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        # cache_read / prompt_tokens = 5000 / 10000 = 50%
+        assert "◎ 50.0%" in text


### PR DESCRIPTION
## What does this PR do?

Add a `◎ XX.X%` indicator to the CLI status bar showing the prompt cache hit rate (`cache_read_tokens / prompt_tokens`). This helps users monitor how effectively their provider's prompt caching is working in real-time.

## Related Issue

Fixes #39761

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: Added `_cache_hit_rate()` helper and `_cache_hit_rate_style()` method. Cache hit rate display in `_build_status_bar_text()` and `_get_status_bar_fragments()`.
- `tests/cli/test_cli_status_bar.py`: Added 6 test cases for cache hit rate display

## How to Test

1. Start a new hermes session with a provider that supports prompt caching (xiaomi, OpenAI, Anthropic, DeepSeek)
2. Send a message — cache hit rate won't appear yet (first message has no cache)
3. Send a second message — now `◎ XX.X%` appears as the system prompt + first message are cached
4. Verify color coding: green (≥70%), yellow (40-70%), red (<40%)
5. Verify narrow terminals show integer precision, wide terminals show one decimal
6. Run `pytest tests/cli/test_cli_status_bar.py -v` to verify all tests pass

## Note on Provider Switching

When switching providers mid-session (e.g., `/model deepseek`), the agent is rebuilt and cache statistics reset. The cache hit rate will reappear after the **second message** with the new provider — this is expected behavior since server-side prefix caching needs at least one prior message to cache.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Wide terminal:   ⚕ mimo-v2.5 │ 12K/200K │ 6% │ ◎ 76.2% │ 3m20s
Narrow terminal: ⚕ mimo · 6% · ◎ 76% · 3m20s
```

Color coding:
- ≥70%: Green (good cache utilization)
- 40-70%: Yellow (moderate)
- <40%: Red (poor)