### PR TITLE
docs: remove --include-desktop install instructions

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -24,12 +24,6 @@
 
 ### Install with Hermes (recommended)
 
-Add `--include-desktop` to the [one-line installer](../../README.md#quick-install) and it sets up the agent and builds the desktop app in one go:
-
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --include-desktop
-```
-
 Already have the Hermes CLI? Just run:
 
 ```bash

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,11 +12,6 @@ Get Hermes Agent up and running in under two minutes!
 ### With the Hermes Desktop installer on macOS or Windows (recommended)
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) from our website and run it.
 
-### With the Hermes Desktop installer on Linux:
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh --include-desktop | bash
-```
-
 ### Without Hermes Desktop:
 For a command-line only install without Hermes Desktop, run:
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -50,10 +50,6 @@ Pick the row that matches your goal:
 ### With the Hermes Desktop installer on macOS or Windows (recommended)
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) from our website and run it.
 
-### With the Hermes Desktop installer on Linux:
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh --include-desktop | bash
-```
 ### Without Hermes Desktop:
 For a command-line only install without Hermes Desktop, run:
 

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -67,12 +67,6 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
 
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) from our website and run it.
 
-### Linux
-
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh --include-desktop | bash
-```
-
 ### Without Hermes Desktop:
 
 For a command-line only install without Hermes Desktop, run:


### PR DESCRIPTION
## Summary
Removes every `--include-desktop` reference from the user-facing documentation.

## Changes
- `apps/desktop/README.md`: drop the `--include-desktop` curl block; `hermes desktop` is the primary install-with-Hermes path
- `website/docs/getting-started/quickstart.md`: drop the redundant "Hermes Desktop installer on Linux" block
- `website/docs/getting-started/installation.md`: same — drop the Linux `--include-desktop` block
- `website/docs/index.mdx`: same — drop the Linux `--include-desktop` block

The `--include-desktop` flag itself remains in `scripts/install.sh` and the Tauri bootstrap installer — only the docs that advertised it are removed. The website installer covers macOS/Windows desktop; the CLI-only curl covers Linux.

## Validation
- `grep -rn 'include-desktop' website/docs apps/desktop/README.md` → 0 hits in any markdown/mdx doc
- No internal anchor links referenced the removed subsections
- Rebased onto current `main` (was 97 commits behind); conflicts resolved in favor of main's structure

## Infographic
![docs-remove-include-desktop](https://v3b.fal.media/files/b/0a9d1156/TKN1aT1egj5LsHOOrKX0B_LpdfmfT1.png)
