### PR TITLE
fix(gateway): log silent file-delivery drops

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3016,6 +3016,17 @@ class BasePlatformAdapter(ABC):
             expanded = os.path.expanduser(raw)
             if os.path.isfile(expanded):
                 found.append((raw, expanded))
+            else:
+                # The reply mentions a deliverable-looking path that does not
+                # exist on disk, so it is silently dropped from native delivery.
+                # This is the most common reason a promised file never arrives
+                # (the model said "here's your file" but never wrote it, or
+                # referenced the wrong path). Log it so the gap is visible in
+                # gateway.log rather than vanishing without a trace.
+                logger.info(
+                    "Skipping bare file path in reply (no file on disk): %s",
+                    _log_safe_path(raw),
+                )
 
         # Deduplicate by expanded path, preserving discovery order
         seen: set = set()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4073,7 +4073,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send document: {e}")
+            logger.warning("[%s] Failed to send document: %s", self.name, e, exc_info=True)
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_video(
@@ -4120,7 +4120,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send video: {e}")
+            logger.warning("[%s] Failed to send video: %s", self.name, e, exc_info=True)
             return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
 
     async def send_image(


### PR DESCRIPTION
## Summary
File-delivery drops over messaging platforms are now visible in `gateway.log` instead of vanishing silently — the most common reason a "here's your file" reply never actually attaches anything.

## Changes
- `gateway/platforms/base.py` `extract_local_files`: when the reply references a deliverable-looking path that fails `os.path.isfile()`, log it at INFO (`Skipping bare file path in reply (no file on disk): ...`) instead of dropping it without a trace. Fires only on found-but-rejected candidates — plain text and in-code paths stay silent.
- `gateway/platforms/telegram.py` `send_document` / `send_video`: convert `print(...)` exception handlers to `logger.warning(..., exc_info=True)`. `print` writes to stdout, which `hermes logs` never captures, so outbound upload failures (oversized files, Bot API rejections) were invisible.

The other guard layer (`filter_media_delivery_paths` / `filter_local_delivery_paths` → `validate_media_delivery_path`) already logs unsafe-path rejections, so no change there.

## Validation
| Case | Behavior |
|---|---|
| Real file on disk | delivered, silent (no log noise) |
| Reply references nonexistent `.md` path | dropped **and** logged at INFO |
| Plain text, no path | silent |
| Path inside code block | ignored, not logged |

E2E with real imports confirmed all four; `tests/gateway/test_media_extraction.py` (9) + telegram picker/approval/slash-confirm suites pass under the hermetic per-test runner.

## Infographic

![log-silent-file-delivery-drops](https://v3b.fal.media/files/b/0a9d1181/8FyenrE9oiDtB3D0ks_0i_muXtejun.png)
