### PR TITLE
fix(session): reconcile rich list message counts

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1677,7 +1677,10 @@ class SessionDB:
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
         if min_message_count > 0:
-            where_clauses.append("s.message_count >= ?")
+            where_clauses.append(
+                "MAX(COALESCE(s.message_count, 0), "
+                "(SELECT COUNT(*) FROM messages mc WHERE mc.session_id = s.id)) >= ?"
+            )
             params.append(min_message_count)
         if archived_only:
             where_clauses.append("s.archived = 1")
@@ -1751,6 +1754,7 @@ class SessionDB:
                     GROUP BY root_id
                 )
                 SELECT s.*,
+                    (SELECT COUNT(*) FROM messages mc WHERE mc.session_id = s.id) AS _actual_message_count,
                     COALESCE(
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
@@ -1775,6 +1779,7 @@ class SessionDB:
         else:
             query = f"""
                 SELECT s.*,
+                    (SELECT COUNT(*) FROM messages mc WHERE mc.session_id = s.id) AS _actual_message_count,
                     COALESCE(
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
@@ -1798,6 +1803,12 @@ class SessionDB:
         sessions = []
         for row in rows:
             s = dict(row)
+            actual_count = s.pop("_actual_message_count", None)
+            if actual_count is not None:
+                s["message_count"] = max(
+                    int(s.get("message_count") or 0),
+                    int(actual_count or 0),
+                )
             # Build the preview from the raw substring
             raw = s.pop("_preview_raw", "").strip()
             if raw:
@@ -1852,6 +1863,7 @@ class SessionDB:
         """
         query = """
             SELECT s.*,
+                (SELECT COUNT(*) FROM messages mc WHERE mc.session_id = s.id) AS _actual_message_count,
                 COALESCE(
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m
@@ -1872,6 +1884,12 @@ class SessionDB:
         if not row:
             return None
         s = dict(row)
+        actual_count = s.pop("_actual_message_count", None)
+        if actual_count is not None:
+            s["message_count"] = max(
+                int(s.get("message_count") or 0),
+                int(actual_count or 0),
+            )
         raw = s.pop("_preview_raw", "").strip()
         if raw:
             text = raw[:60]
@@ -3221,7 +3239,10 @@ class SessionDB:
             where_clauses.append("s.source = ?")
             params.append(source)
         if min_message_count > 0:
-            where_clauses.append("s.message_count >= ?")
+            where_clauses.append(
+                "MAX(COALESCE(s.message_count, 0), "
+                "(SELECT COUNT(*) FROM messages mc WHERE mc.session_id = s.id)) >= ?"
+            )
             params.append(min_message_count)
         if archived_only:
             where_clauses.append("s.archived = 1")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2864,13 +2864,35 @@ class TestCompressionChainProjection:
         # root1's tip must be tip1 (via mid1), not delegate1.
         assert db.get_compression_tip("root1") == "tip1"
 
+    def test_list_reconciles_stale_zero_message_count_from_messages_table(self, db):
+        """Regression for #39734: list/browse must not expose a persisted
+        prompt as a zero-message session when the cached sessions.message_count
+        is stale.
+        """
+        db.create_session("stale_count", "cli")
+        db.append_message("stale_count", "user", "recover this prompt")
+        db._conn.execute(
+            "UPDATE sessions SET message_count = 0 WHERE id = ?",
+            ("stale_count",),
+        )
+        db._conn.commit()
+
+        row = next(
+            s for s in db.list_sessions_rich(source="cli", limit=20)
+            if s["id"] == "stale_count"
+        )
+
+        assert row["message_count"] == 1
+        assert row["preview"].startswith("recover this prompt")
+
     def test_list_surfaces_tip_for_compressed_root(self, db):
         """The list must show the tip's id/message_count/preview in place of
         the root row, so users can see and resume the live conversation.
         """
         import time as _time
+
         self._build_compression_chain(db, _time.time() - 3600)
-        # Add an uncompressed root for comparison.
+
         db.create_session("solo", "cli")
         db.append_message("solo", "user", "standalone")
         db._conn.commit()


### PR DESCRIPTION
## Summary
- Reconcile `list_sessions_rich()` message counts with the actual persisted rows in `messages` so a stale `sessions.message_count = 0` cache does not surface an existing prompt as a zero-message session.
- Apply the same reconciled threshold to `min_message_count` filtering / `session_count()` so browse/list totals stay consistent.
- Add a regression test for #39734 that forces a stale zero cached count after persisting a user prompt.

Fixes #39734

## Test Plan
- `python -m py_compile hermes_state.py tests/test_hermes_state.py`
- `python -m pytest -o addopts='' tests/test_hermes_state.py::TestCompressionChainProjection tests/tools/test_session_search.py::TestBrowseShape -q`

Result: `12 passed`

## Notes
- Per CONTRIBUTING/AGENTS guidance I first tried `scripts/run_tests.sh`, but this checkout has no `.venv` or `venv`, so the wrapper reports: `error: no virtualenv found ...`. I used the current Python interpreter with `-o addopts=''` for the focused regression tests.
- On this Windows/Conda host, broader curses browse tests are blocked by missing `_curses`; the session state/session_search tests related to this fix pass.
