### PR TITLE
fix(windows): resolve Git Bash relative to git.exe on PATH

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1073,6 +1073,16 @@ function findGitBash() {
     candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
   }
 
+  // Try locating relative to git.exe on PATH (covers custom installation paths)
+  const gitPath = findOnPath('git')
+  if (gitPath) {
+    const gitDir = path.dirname(gitPath)
+    candidates.push(path.join(gitDir, '..', 'bin', 'bash.exe'))
+    candidates.push(path.join(gitDir, '..', 'usr', 'bin', 'bash.exe'))
+    candidates.push(path.join(gitDir, 'bin', 'bash.exe'))
+    candidates.push(path.join(gitDir, 'usr', 'bin', 'bash.exe'))
+  }
+
   // Standard Git for Windows install locations.
   candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
   candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -273,6 +273,18 @@ def _find_bash() -> str:
     if found:
         return found
 
+    git_path = shutil.which("git")
+    if git_path:
+        git_dir = os.path.dirname(git_path)
+        for candidate in (
+            os.path.join(git_dir, "..", "bin", "bash.exe"),
+            os.path.join(git_dir, "..", "usr", "bin", "bash.exe"),
+            os.path.join(git_dir, "bin", "bash.exe"),
+            os.path.join(git_dir, "usr", "bin", "bash.exe"),
+        ):
+            if os.path.isfile(candidate):
+                return candidate
+
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),


### PR DESCRIPTION
### Problem
On Windows, when Git is installed in a custom directory (e.g. `D:\Git`), the standard installer adds `...\Git\cmd` to the system `PATH` to expose `git.exe`, but does not add `...\Git\bin` (where `bash.exe` resides). 

Currently, both the Electron desktop main process (`findGitBash`) and the Python agent (`_find_bash`) only probe standard hardcoded paths (e.g. `C:\Program Files\Git`) and look for `bash` directly on the `PATH`. This causes the desktop app boot to fail for users with custom Git installations.

### Solution
If `git` is already on the user's `PATH`, we can resolve its location and check relative paths to locate `bash.exe`. This resolves the detection issue for any custom Git installation path without requiring registry checks or manual system `PATH` manipulation.

### Changes
1. **Desktop Wrapper (`apps/desktop/electron/main.cjs`)**: Added check inside `findGitBash()` to resolve path of `git.exe` on `PATH` and probe relative candidate paths for `bash.exe`.
2. **Local Environment (`tools/environments/local.py`)**: Added the same relative path check inside `_find_bash()`.