### PR TITLE
fix(version): suppress false 'commits behind' warning on detached HEAD (tag checkout)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -191,8 +191,34 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _is_on_release_tag(repo_dir: Path) -> bool:
+    """True only when HEAD is detached *and* pinned exactly to a git tag.
+
+    Deliberately narrower than "any detached HEAD": an arbitrary detached
+    commit (e.g. mid-bisect, or a checked-out SHA that isn't a tag) still
+    wants the normal behind-count comparison. Only an exact tag checkout —
+    the "I installed a tagged release" case from #39771 — should be
+    reported as up to date.
+    """
+    # A successful symbolic-ref means HEAD is on a branch, not detached.
+    on_branch = _git_stdout(["symbolic-ref", "-q", "HEAD"], cwd=repo_dir)
+    if on_branch:
+        return False
+    tag = _git_stdout(["describe", "--tags", "--exact-match", "HEAD"], cwd=repo_dir)
+    return bool(tag)
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
+    if _is_on_release_tag(repo_dir):
+        # Detached HEAD on a release tag — "commits behind origin/main" is
+        # meaningless here, the user intentionally checked out a tagged
+        # release rather than tracking a branch. Placed ahead of every
+        # comparison path below (official SSH remote, shallow clone, and
+        # full-clone rev-list) so none of them can override it with a
+        # misleading behind-count. See #39771.
+        return 0
+
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -154,7 +154,18 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         )
     except Exception:
         pass  # Offline or timeout — use stale refs, that's fine
-
+# Detached HEAD (e.g. tag checkout) — not on a branch, so
+    # "commits behind origin/main" is misleading. Suppress the warning.
+    try:
+        sym = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if sym.returncode != 0:
+            return 0
+    except Exception:
+        pass
     try:
         result = subprocess.run(
             ["git", "rev-list", "--count", "HEAD..origin/main"],

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -93,8 +93,8 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    # origin probe + is-shallow probe + git fetch + git rev-list
-    assert mock_run.call_count == 4
+    # symbolic-ref probe (tag guard) + origin probe + is-shallow probe + git fetch + git rev-list
+    assert mock_run.call_count == 5
 
 
 def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
@@ -109,6 +109,8 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=0, stdout="refs/heads/main\n")
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="git@github.com:NousResearch/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "HEAD"]:
@@ -148,6 +150,8 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=0, stdout="refs/heads/main\n")
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
@@ -179,6 +183,8 @@ def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):
     (repo_dir / ".git").mkdir()
 
     def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=0, stdout="refs/heads/main\n")
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
@@ -206,6 +212,8 @@ def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
     (repo_dir / ".git").mkdir()
 
     def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=0, stdout="refs/heads/main\n")
         if cmd == ["git", "remote", "get-url", "origin"]:
             return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
         if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
@@ -220,6 +228,118 @@ def test_check_via_local_git_full_clone_keeps_exact_count(tmp_path):
         result = banner._check_via_local_git(repo_dir)
 
     assert result == 7
+
+
+def test_check_via_local_git_release_tag_reports_up_to_date(tmp_path):
+    """Detached HEAD pinned exactly to a release tag reports up to date (0).
+
+    Regression for #39771: `hermes version` incorrectly showed "N commits
+    behind" after `git checkout <tag>`. The guard must short-circuit before
+    any origin comparison runs.
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=1, stdout="")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "HEAD"]:
+            return MagicMock(returncode=0, stdout="v2026.5.29.2\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
+
+
+def test_check_via_local_git_older_release_tag_reports_up_to_date(tmp_path):
+    """An older tag (not just the latest) still counts as a valid release checkout.
+
+    The guard checks "is HEAD exactly a tag", not "is HEAD the newest tag" —
+    hermes has no way to know intent beyond "this is a tagged release".
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=1, stdout="")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "HEAD"]:
+            return MagicMock(returncode=0, stdout="v2025.1.1\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
+
+
+def test_check_via_local_git_detached_non_tag_still_counts(tmp_path):
+    """A detached HEAD that is NOT on a tag (e.g. a bisect/arbitrary SHA)
+    must NOT get the free pass — it should fall through to the normal
+    behind-count comparison, same as a full clone on a branch.
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=1, stdout="")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "HEAD"]:
+            return MagicMock(returncode=128, stdout="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="12\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 12
+
+
+def test_check_via_local_git_branch_checkout_skips_tag_guard(tmp_path):
+    """A normal branch checkout (not detached) must never even ask about tags."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "symbolic-ref", "-q", "HEAD"]:
+            return MagicMock(returncode=0, stdout="refs/heads/main\n")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "HEAD"]:
+            raise AssertionError("must not check for a tag when HEAD is on a branch")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -93,7 +93,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git fetch + git rev-list
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #39771

## What does this PR do?
When a user checks out a release tag (detached HEAD), `hermes version` 
incorrectly reports "N commits behind — run 'hermes update'" because 
`_check_via_local_git()` always compares `HEAD..origin/main`.

On a detached HEAD, this comparison is meaningless — the user is on a 
tagged release, not a branch. The fix adds a `git symbolic-ref` check 
before the commit count: if HEAD is detached, return 0 (up to date) 
instead of a misleading behind-count.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `hermes_cli/banner.py`: added detached HEAD guard in 
  `_check_via_local_git()` — returns 0 when not on a branch

## How to Test
1. `git checkout v2026.5.29.2` (or any tag)
2. Run `hermes version`
3. Should not show "commits behind" warning

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] Tested on: Windows 10