### PR TITLE
fix(update): make ensure_uv() survive the update boundary (no first-run crash)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -51,15 +51,50 @@ def resolve_uv() -> Optional[str]:
     return None
 
 
-def ensure_uv() -> Optional[str]:
+class _UvResult(str):
+    """``ensure_uv()`` return value that survives an update boundary.
+
+    ``ensure_uv()``'s arity has flipped between a single path string and a
+    ``(path, fresh_bootstrap)`` tuple across releases. ``hermes update`` runs
+    the call site from the *old*, already-imported ``hermes_cli.main`` against
+    this *freshly pulled* module, so the two can disagree on how many values
+    ``ensure_uv()`` returns — which crashed the first update with
+    ``ValueError: not enough values to unpack (expected 2, got 1)`` for installs
+    parked on a 2-tuple release. This wrapper answers to both conventions:
+
+        uv_bin = ensure_uv()         # behaves as the path str ("" when absent)
+        uv_bin, fresh = ensure_uv()  # unpacks as (path|None, fresh_bootstrap)
+
+    Missing uv is the empty string (falsy) instead of ``None`` so legacy
+    2-target call sites can still unpack a failure without raising, while
+    ``if not uv_bin`` keeps working for single-value callers.
+    """
+
+    fresh_bootstrap: bool
+
+    def __new__(cls, path: Optional[str], fresh: bool = False) -> "_UvResult":
+        self = super().__new__(cls, path or "")
+        self.fresh_bootstrap = fresh
+        return self
+
+    def __iter__(self):
+        # Tuple-unpacking hook for legacy ``uv_bin, fresh = ensure_uv()`` sites.
+        # First element mirrors the historical contract: the path string, or
+        # ``None`` when uv is unavailable.
+        return iter(((str(self) or None), self.fresh_bootstrap))
+
+
+def ensure_uv() -> "_UvResult":
     """Return the managed uv path, installing it first if necessary.
 
-    On failure returns ``None`` (never raises) so callers can fall
-    back to pip gracefully.
+    Returns a :class:`_UvResult` (a ``str`` subclass) that is both usable
+    directly as the path and unpackable as ``(path, fresh_bootstrap)`` for
+    older call sites. On failure the result is falsy (``""``) — never raises —
+    so callers can fall back to pip gracefully.
     """
     existing = resolve_uv()
     if existing:
-        return existing
+        return _UvResult(existing)
 
     target = managed_uv_path()
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -71,7 +106,7 @@ def ensure_uv() -> Optional[str]:
     except Exception as exc:
         logger.warning("Managed uv install failed: %s", exc)
         print(f"  ✗ Failed to install managed uv: {exc}")
-        return None
+        return _UvResult(None)
 
     # Verify
     result = resolve_uv()
@@ -85,7 +120,7 @@ def ensure_uv() -> Optional[str]:
         print(f"  ✓ Managed uv installed ({version})")
     else:
         print("  ✗ Managed uv install appeared to succeed but binary not found")
-    return result
+    return _UvResult(result)
 
 
 def update_managed_uv() -> Optional[str]:

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -58,9 +58,13 @@ class _UvResult(str):
     ``(path, fresh_bootstrap)`` tuple across releases. ``hermes update`` runs
     the call site from the *old*, already-imported ``hermes_cli.main`` against
     this *freshly pulled* module, so the two can disagree on how many values
-    ``ensure_uv()`` returns — which crashed the first update with
-    ``ValueError: not enough values to unpack (expected 2, got 1)`` for installs
-    parked on a 2-tuple release. This wrapper answers to both conventions:
+    ``ensure_uv()`` returns. An install parked on a 2-tuple release runs
+    ``uv_bin, fresh_bootstrap = ensure_uv()`` against the single-value module
+    and crashes the first update: the returned path is a plain ``str``, which is
+    itself iterable, so the 2-target unpack walks its characters and raises
+    ``ValueError: too many values to unpack (expected 2)`` (and on the failure
+    path the ``None`` return raises ``TypeError: cannot unpack non-iterable
+    NoneType``). This wrapper answers to both conventions:
 
         uv_bin = ensure_uv()         # behaves as the path str ("" when absent)
         uv_bin, fresh = ensure_uv()  # unpacks as (path|None, fresh_bootstrap)

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -92,12 +92,51 @@ class TestEnsureUv:
             assert path == str(tmp_path / "bin" / "uv")
             mock_install.assert_called_once()
 
-    def test_install_failure_returns_none(self, tmp_path):
+    def test_install_failure_returns_falsy(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
             from hermes_cli.managed_uv import ensure_uv
             path = ensure_uv()
-            assert path is None
+            # Failure is a falsy sentinel (not None) so legacy 2-target call
+            # sites can still unpack it without raising — see
+            # TestEnsureUvUpdateBoundary for why.
+            assert not path
+
+
+class TestEnsureUvUpdateBoundary:
+    """``ensure_uv()`` must answer to both the single-value and the legacy
+    ``(path, fresh_bootstrap)`` call conventions.
+
+    ``hermes update`` runs the call site from the old, already-imported
+    ``hermes_cli.main`` against the freshly pulled ``managed_uv``. When the two
+    disagree on ``ensure_uv()``'s arity the first update crashed with a
+    ``ValueError`` (root cause behind PR #39763). The result must therefore be
+    usable as a bare path *and* unpackable as a 2-tuple, in success and failure.
+    """
+
+    def test_success_usable_as_single_value(self, tmp_path):
+        _make_executable(tmp_path / "bin" / "uv")
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            from hermes_cli.managed_uv import ensure_uv
+            uv_bin = ensure_uv()
+            assert uv_bin == str(tmp_path / "bin" / "uv")
+            assert bool(uv_bin) is True
+
+    def test_success_unpacks_as_legacy_two_tuple(self, tmp_path):
+        _make_executable(tmp_path / "bin" / "uv")
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+            from hermes_cli.managed_uv import ensure_uv
+            uv_bin, fresh = ensure_uv()  # old: uv_bin, fresh_bootstrap = ensure_uv()
+            assert uv_bin == str(tmp_path / "bin" / "uv")
+            assert fresh is False
+
+    def test_failure_unpacks_without_raising(self, tmp_path):
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
+            from hermes_cli.managed_uv import ensure_uv
+            uv_bin, fresh = ensure_uv()
+            assert uv_bin is None
+            assert fresh is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -108,10 +108,14 @@ class TestEnsureUvUpdateBoundary:
     ``(path, fresh_bootstrap)`` call conventions.
 
     ``hermes update`` runs the call site from the old, already-imported
-    ``hermes_cli.main`` against the freshly pulled ``managed_uv``. When the two
-    disagree on ``ensure_uv()``'s arity the first update crashed with a
-    ``ValueError`` (root cause behind PR #39763). The result must therefore be
-    usable as a bare path *and* unpackable as a 2-tuple, in success and failure.
+    ``hermes_cli.main`` against the freshly pulled ``managed_uv``. A release
+    parked on a ``(path, fresh)`` tuple runs ``uv_bin, fresh = ensure_uv()``
+    against the single-value module; the path is an iterable ``str`` so the
+    2-target unpack walked its characters and raised
+    ``ValueError: too many values to unpack (expected 2)`` (root cause behind
+    PR #39763), or ``TypeError`` on the ``None`` failure path. The result must
+    therefore be usable as a bare path *and* unpackable as a 2-tuple, in both
+    the success and failure cases.
     """
 
     def test_success_usable_as_single_value(self, tmp_path):


### PR DESCRIPTION
## Summary

This is a standalone fix for the reported first-update crash. `managed_uv` is only ever **lazily** imported in the update path, so `hermes update` binds the **freshly pulled** module while the *call site* is still the old, already-imported `_cmd_update_impl`. `ensure_uv()`'s return arity churned across that boundary, and the old call site crashes consuming the new module — *before* any post-dep-install hand-off (e.g. #39763) could run. Because this fix ships in the pulled-in module (the callee), it protects the **first** update for the parked population.

## Root cause

`ensure_uv()`'s return arity flipped:

- `4df280d51` — `ensure_uv() -> Tuple[Optional[str], bool]`; callers became `uv_bin, fresh_bootstrap = ensure_uv()`.
- `fb853a178` ("scrap rebuild venv") — reverted to `ensure_uv() -> Optional[str]`; callers became `uv_bin = ensure_uv()`.

An install parked between those two runs the old 2-target unpack against the new single-value module:

```python
uv_bin, fresh_bootstrap = ensure_uv()   # old call site (in memory)
```

The new `ensure_uv()` returns a bare path **string**, which is itself iterable, so the 2-target unpack walks its characters → `ValueError: too many values to unpack (expected 2)` (exactly the reported string). On the failure path the `None` return raises `TypeError: cannot unpack non-iterable NoneType`. This sits in the dependency-install step, so it kills the update before any subprocess hand-off could take over; the second `hermes update` only "fixed itself" because by then call site and module were both new.

## Fix

Return a `_UvResult` (a `str` subclass) that answers to **both** call conventions:

```python
uv_bin = ensure_uv()         # behaves as the path str ("" when absent)
uv_bin, fresh = ensure_uv()  # unpacks as (path|None, fresh_bootstrap)
```

- Subclasses `str`, so every existing single-value caller and `==`/`if uv_bin` check is unchanged.
- `__iter__` yields exactly `(path|None, fresh_bootstrap)` for legacy 2-target unpacking (overriding str's char-iteration, which is the trap).
- Missing uv is `""` (falsy) instead of `None`, so a *failure* still unpacks without raising while `if not uv_bin` keeps working.
- `fresh_bootstrap` is always `False` — the `rebuild_venv` path it gated was intentionally scrapped in `fb853a178`, so legacy callers correctly skip it.

Compatible in both directions, so it can't re-break if the arity flips again.

## How likely are other cases?

Low on current `main`, but the pattern is structural. I scanned the entire post-pull path of `_cmd_update_impl` for positional unpacks of a call result. The only two are:

- `syntax_ok, failing_path, syntax_error = _validate_critical_files_syntax(...)` — defined in `main.py` itself (startup-loaded; old/old consistent).
- `current_ver, latest_ver = check_config_version()` — from `hermes_cli.config`, which **is** imported at startup, so it binds the old in-memory module and is immune to fresh-from-disk drift.

Every other lazily-imported (fresh) post-pull helper — `sync_skills`, `seed_profile_skills`, `restore_cron_jobs_if_emptied`, the gateway-restart functions — returns a dict or is consumed by single-assignment/attribute access, which tolerates arity drift, and most are `try`-wrapped. `ensure_uv` was the one genuinely exposed site (lazy + fresh + positional unpack + churned arity) and sat in one of the few un-`try`-wrapped regions, which is why it was fatal. The trap re-arms whenever someone adds a lazily-imported `a, b = f()` to the update path or changes the arity of an existing one — hence the regression test below.

## Tests / verification

`scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_uv_tool_update.py` → **90 passed**. New `TestEnsureUvUpdateBoundary` encodes the cross-boundary contract.

**1. Crash + fix repro** — loads the unpatched `origin/main` module and the patched module, runs the real legacy `uv_bin, fresh_bootstrap = ensure_uv()` against both:

```
=== UNPATCHED-origin/main ===
  [FAIL] success / 2-tuple unpack: raised ValueError: too many values to unpack (expected 2)
  [PASS] success / single-value: value='.../bin/uv' truthy=True
  [FAIL] failure / 2-tuple unpack: raised TypeError: cannot unpack non-iterable NoneType object

=== PATCHED-PR#39780 ===
  [PASS] success / 2-tuple unpack: uv_bin='.../bin/uv' fresh=False
  [PASS] success / single-value: value='.../bin/uv' truthy=True
  [PASS] failure / 2-tuple unpack: uv_bin=None fresh=False
```

The unpatched module reproduces the exact reported error; the patched module passes all four.

**2. End-to-end "it works" check** — runs the **verbatim** parked dep-install branch (`HEAD~200`) against the patched module and asserts behavior, not just the absence of an exception:

```
=== parked + uv present (the common case) ===
  [PASS] ran without raising
  [PASS] uv installer invoked with real binary: [(['.../bin/uv','pip'], 'all')]
  [PASS] rebuild_venv correctly skipped
  [PASS] pip fallback NOT taken

=== parked + uv missing, install fails (degraded) ===
  [PASS] ran without raising
  [PASS] gracefully fell back to pip
```

So the parked first `hermes update` actually **completes and installs deps via uv** — it doesn't merely avoid the error. (The parked branch also `import`s `rebuild_venv` from `managed_uv`, so that stub must stay on disk or the import alone would crash; it does.)

## Relationship to #39763

Independent. #39763 re-runs post-pull steps in a fresh subprocess *after* dependency install — it neither catches this crash (which is *inside* dep-install) nor fixes the transition update onto its own commit. This PR is the actual fix for the reported bug and does not depend on #39763.