### PR TITLE
fix(cron): contain timed-out cron workers (#18004)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2013,7 +2013,11 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                         return False  # someone holds a fresh claim
                 except Exception:
                     pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
+            job["fire_claim"] = {
+                "at": now.isoformat(),
+                "by": _machine_id(),
+                "incarnation": uuid.uuid4().hex,
+            }
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
@@ -2022,6 +2026,24 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             save_jobs(jobs)
             return True
         return False
+
+
+def heartbeat_fire_claim(job_id: str, *, expected_incarnation: str) -> bool:
+    """Refresh one matching external-fire claim while its worker remains live."""
+    if not expected_incarnation:
+        return False
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            claim = job.get("fire_claim")
+            if not isinstance(claim, dict) or claim.get("incarnation") != expected_incarnation:
+                return False
+            claim["at"] = _hermes_now().isoformat()
+            save_jobs(jobs)
+            return True
+    return False
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2480,10 +2480,12 @@ def _run_job_script_with_claim_heartbeat(
         heartbeat_thread.start()
     except Exception:
         logger.debug(
-            "Job '%s': could not start script run_claim heartbeat",
+            "Job '%s': could not start script claim heartbeat",
             job_id,
             exc_info=True,
         )
+        if fire_claim_incarnation:
+            return False, "Script execution skipped: external fire-claim heartbeat could not start"
         return _run_job_script(script_path, workdir=workdir)
 
     try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -281,7 +281,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_fire_claim,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -326,6 +334,59 @@ _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
 _running_lock = threading.Lock()
+
+
+class _RunningJobLease(str):
+    """An exact-once transfer of one job's existing local admission."""
+
+    def __new__(cls, job_id: str):
+        lease = super().__new__(cls, job_id)
+        lease.job_id = job_id
+        lease._released = False
+        lease._release_lock = threading.Lock()
+        lease._waiting_for_worker_exit = False
+        return lease
+
+    def retain_while_worker_lives(self) -> None:
+        """Keep shutdown terminalization out of a timed-out worker's join."""
+        with self._release_lock:
+            if not self._released:
+                self._waiting_for_worker_exit = True
+
+    def worker_exited(self) -> None:
+        """Allow the existing terminal path to own the completed worker."""
+        with self._release_lock:
+            self._waiting_for_worker_exit = False
+
+    def waits_for_worker_exit(self) -> bool:
+        with self._release_lock:
+            return self._waiting_for_worker_exit
+
+    def release(self) -> None:
+        with self._release_lock:
+            if self._released:
+                return
+            self._released = True
+        with _running_lock:
+            _running_job_ids.discard(self.job_id)
+
+
+class _DeferredCronAgentTeardown(list):
+    """Carry the shared lease through run_job without another lifecycle owner."""
+
+    def __init__(self, running_lease: _RunningJobLease):
+        super().__init__()
+        self.running_lease = running_lease
+
+
+def _acquire_running_job_lease(job_id: str) -> Optional[_RunningJobLease]:
+    """Acquire the scheduler's one local admission slot for ``job_id``."""
+    with _running_lock:
+        if job_id in _running_job_ids:
+            return None
+        lease = _RunningJobLease(job_id)
+        _running_job_ids.add(lease)
+    return lease
 
 # Job IDs the gateway shutdown path force-killed the tool subprocess of
 # while still in ``_running_job_ids`` (see ``mark_running_jobs_interrupted``
@@ -381,7 +442,15 @@ def mark_running_jobs_interrupted(reason: str) -> list:
     Returns the list of job IDs marked, for the caller to log.
     """
     with _running_lock:
-        job_ids = list(_running_job_ids)
+        active_jobs = list(_running_job_ids)
+        job_ids = [
+            str(job_id)
+            for job_id in active_jobs
+            if not (
+                isinstance(job_id, _RunningJobLease)
+                and job_id.waits_for_worker_exit()
+            )
+        ]
         _interrupted_job_ids.update(job_ids)
     marked = []
     for job_id in job_ids:
@@ -2341,26 +2410,36 @@ def _run_job_script(
 def _run_job_script_with_claim_heartbeat(
     job: dict, script_path: str, workdir: Optional[str] = None,
 ) -> tuple[bool, str]:
-    """Run a cron script while keeping its owned one-shot claim fresh.
+    """Run a cron script while keeping its owned durable claims fresh.
 
     Script execution is synchronous and may legitimately outlive the stale
-    claim TTL.  Without a concurrent heartbeat, another scheduler process can
-    mistake the live run for a dead owner and dispatch the same one-shot again.
-    Recurring jobs and unclaimed/manual runs have no durable one-shot claim and
-    therefore use the ordinary script path without starting a thread.
+    claim TTL. Without a concurrent heartbeat, another scheduler process can
+    mistake the live run for a dead owner and dispatch the same fire again.
+    Recurring jobs and unclaimed/manual runs have no durable claim and therefore
+    use the ordinary script path without starting a thread.
 
-    The claim owner is captured from the dispatched job and never re-read from
-    storage.  ``heartbeat_run_claim`` compares that stable owner before every
-    refresh, so a stale runner cannot extend a replacement owner's claim.
+    Claim identities are captured from the dispatched job and never re-read
+    from storage. ``heartbeat_run_claim`` and ``heartbeat_fire_claim`` compare
+    their stable owner or incarnation before every refresh, so a stale runner
+    cannot extend a replacement owner's claim.
     """
     schedule = job.get("schedule")
-    claim = job.get("run_claim")
-    owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
-    if not (
+    run_claim = job.get("run_claim")
+    run_claim_owner = (
+        str(run_claim.get("by") or "") if isinstance(run_claim, dict) else ""
+    )
+    has_run_claim = (
         isinstance(schedule, dict)
         and schedule.get("kind") == "once"
-        and owner
-    ):
+        and bool(run_claim_owner)
+    )
+    fire_claim = job.get("fire_claim")
+    fire_claim_incarnation = (
+        str(fire_claim.get("incarnation") or "")
+        if isinstance(fire_claim, dict)
+        else ""
+    )
+    if not has_run_claim and not fire_claim_incarnation:
         return _run_job_script(script_path, workdir=workdir)
 
     job_id = str(job.get("id") or "")
@@ -2369,14 +2448,27 @@ def _run_job_script_with_claim_heartbeat(
 
     def _heartbeat_loop() -> None:
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
-            try:
-                heartbeat_run_claim(job_id, expected_owner=owner)
-            except Exception:
-                logger.debug(
-                    "Job '%s': script run_claim heartbeat failed",
-                    job_id,
-                    exc_info=True,
-                )
+            if has_run_claim:
+                try:
+                    heartbeat_run_claim(job_id, expected_owner=run_claim_owner)
+                except Exception:
+                    logger.debug(
+                        "Job '%s': script run_claim heartbeat failed",
+                        job_id,
+                        exc_info=True,
+                    )
+            if fire_claim_incarnation:
+                try:
+                    heartbeat_fire_claim(
+                        job_id,
+                        expected_incarnation=fire_claim_incarnation,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Job '%s': script fire_claim heartbeat failed",
+                        job_id,
+                        exc_info=True,
+                    )
 
     heartbeat_thread = threading.Thread(
         target=heartbeat_context.run,
@@ -3098,12 +3190,6 @@ def run_job(
     # checks _SESSION_CWD first, so gateway sessions with no override see
     # their own cwd, not the cron's workdir (#69396).
 
-    # Snapshot the current env value BEFORE acquiring the lock so the finally
-    # below can always restore it, even if an exception fires before we set the
-    # override inside the try.  This read can't leak the lock (it precedes the
-    # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
-    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
-
     _holds_cwd_write = _job_workdir is not None
     if _holds_cwd_write:
         _terminal_cwd_lock.acquire_write()
@@ -3115,7 +3201,9 @@ def run_job(
     # statement raises.  A leaked writer would deadlock the whole scheduler
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
+    _prior_terminal_cwd = "_UNSET_"
     try:
+        _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3544,22 +3632,38 @@ def run_job(
         _run_claim_owner = (
             str(_run_claim.get("by") or "") if isinstance(_run_claim, dict) else ""
         )
+        _fire_claim = job.get("fire_claim")
+        _fire_claim_incarnation = (
+            str(_fire_claim.get("incarnation") or "")
+            if isinstance(_fire_claim, dict) else ""
+        )
         _last_claim_heartbeat = time.monotonic()
 
-        def _heartbeat_run_claim_if_due():
+        def _heartbeat_claims_if_due():
             nonlocal _last_claim_heartbeat
-            if not _is_oneshot or not _run_claim_owner:
+            if not _run_claim_owner and not _fire_claim_incarnation:
                 return
             _mono = time.monotonic()
             if _mono - _last_claim_heartbeat < _RUN_CLAIM_HEARTBEAT_SECONDS:
                 return
             _last_claim_heartbeat = _mono
-            try:
-                heartbeat_run_claim(job_id, expected_owner=_run_claim_owner)
-            except Exception:
-                logger.debug(
-                    "Job '%s': run_claim heartbeat failed", job_name, exc_info=True
-                )
+            if _is_oneshot and _run_claim_owner:
+                try:
+                    heartbeat_run_claim(job_id, expected_owner=_run_claim_owner)
+                except Exception:
+                    logger.debug(
+                        "Job '%s': run_claim heartbeat failed", job_name, exc_info=True
+                    )
+            if _fire_claim_incarnation:
+                try:
+                    heartbeat_fire_claim(
+                        job_id,
+                        expected_incarnation=_fire_claim_incarnation,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Job '%s': fire_claim heartbeat failed", job_name, exc_info=True
+                    )
 
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
@@ -3570,9 +3674,9 @@ def run_job(
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot:
+                # Unlimited — no inactivity watchdog, but any durable claim
+                # still needs its heartbeat, so poll instead of blocking.
+                if _is_oneshot or _fire_claim_incarnation:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
@@ -3581,7 +3685,7 @@ def run_job(
                         if done:
                             result = _cron_future.result()
                             break
-                        _heartbeat_run_claim_if_due()
+                        _heartbeat_claims_if_due()
                 else:
                     result = _cron_future.result()
             else:
@@ -3593,7 +3697,7 @@ def run_job(
                     if done:
                         result = _cron_future.result()
                         break
-                    _heartbeat_run_claim_if_due()
+                    _heartbeat_claims_if_due()
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -3605,11 +3709,9 @@ def run_job(
                     if _idle_secs >= _cron_inactivity_limit:
                         _inactivity_timeout = True
                         break
-        except Exception:
-            _cron_pool.shutdown(wait=False, cancel_futures=True)
+        except BaseException:
+            _cron_pool.shutdown(wait=True, cancel_futures=True)
             raise
-        finally:
-            _cron_pool.shutdown(wait=False, cancel_futures=True)
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.
@@ -3632,13 +3734,37 @@ def run_job(
                 _last_desc, _iter_n, _iter_max,
                 _cur_tool or "none",
             )
-            if hasattr(agent, "interrupt"):
-                agent.interrupt("Cron job timed out (inactivity)")
+            _running_lease = getattr(defer_agent_teardown, "running_lease", None)
+            if _running_lease is not None:
+                _running_lease.retain_while_worker_lives()
+            try:
+                if hasattr(agent, "interrupt"):
+                    try:
+                        agent.interrupt("Cron job timed out (inactivity)")
+                    except Exception:
+                        logger.debug("Job '%s': cooperative interrupt failed", job_name, exc_info=True)
+                while True:
+                    done, _ = concurrent.futures.wait(
+                        {_cron_future}, timeout=_POLL_INTERVAL,
+                    )
+                    if done:
+                        try:
+                            _cron_future.result()
+                        except BaseException:
+                            pass
+                        break
+                    _heartbeat_claims_if_due()
+            finally:
+                if _running_lease is not None:
+                    _running_lease.worker_exited()
+            _cron_pool.shutdown(wait=True, cancel_futures=True)
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
                 f"— last activity: {_last_desc}"
             )
+
+        _cron_pool.shutdown(wait=True, cancel_futures=True)
 
         # Guard against non-dict returns from run_conversation under error conditions
         if not isinstance(result, dict):
@@ -3875,7 +4001,14 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+def run_one_job(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    lease: Optional[_RunningJobLease] = None,
+) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
@@ -3890,9 +4023,17 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
-    execution_id = job.get("execution_id")
-    if not execution_id:
-        execution_id = create_execution(job["id"], source="direct")["id"]
+    lease = lease or _acquire_running_job_lease(job["id"])
+    if lease is None:
+        logger.info("Job '%s' already running — skipping", job.get("name", job["id"]))
+        return False
+    try:
+        execution_id = job.get("execution_id")
+        if not execution_id:
+            execution_id = create_execution(job["id"], source="direct")["id"]
+    except BaseException:
+        lease.release()
+        raise
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -3940,7 +4081,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # list makes run_job hand the agent back instead, and we tear it down
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
-        _deferred_agents: list = []
+        _deferred_agents = _DeferredCronAgentTeardown(lease)
         try:
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents
@@ -4076,6 +4217,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         if not isinstance(e, Exception):
             raise
         return False
+    finally:
+        lease.release()
 
 
 def _notify_provider_jobs_changed() -> None:
@@ -4186,12 +4329,18 @@ def tick(
                 _max_workers if _max_workers else "unbounded",
             )
 
-        def _process_job(job: dict) -> bool:
+        def _process_job(job: dict, lease: _RunningJobLease) -> bool:
             """Run one due job end-to-end. Thin wrapper around the shared
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            return run_one_job(
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+                lease=lease,
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
@@ -4224,29 +4373,27 @@ def tick(
                     job.get("name", job_id),
                 )
                 return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                    return None
-                _running_job_ids.add(job_id)
+            lease = _acquire_running_job_lease(job_id)
+            if lease is None:
+                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                return None
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
+            try:
+                execution = create_execution(job_id, source="builtin")
+            except BaseException:
+                lease.release()
+                raise
             dispatched_job = dict(job, execution_id=execution["id"])
             _ctx = contextvars.copy_context()
 
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
-                try:
-                    return ctx.run(_process_job, j)
-                finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
+            def _run_one(j=dispatched_job, ctx=_ctx, run_lease=lease):
+                return ctx.run(_process_job, j, run_lease)
 
             try:
-                return pool.submit(_run_and_release)
+                return pool.submit(_run_one)
             except Exception as submit_err:
-                with _running_lock:
-                    _running_job_ids.discard(job_id)
+                lease.release()
                 finish_execution(
                     execution["id"],
                     success=False,

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -102,15 +102,21 @@ class CronScheduler(ABC):
         """
         from cron.jobs import claim_job_for_fire, get_job
         from cron.executions import create_execution
-        from cron.scheduler import run_one_job
+        from cron.scheduler import _acquire_running_job_lease, run_one_job
 
-        if not claim_job_for_fire(job_id):
-            return False  # another machine already claimed this fire
-        job = get_job(job_id)
-        if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        job["execution_id"] = create_execution(job_id, source=self.name)["id"]
-        return run_one_job(job, adapters=adapters, loop=loop)
+        lease = _acquire_running_job_lease(job_id)
+        if lease is None:
+            return False
+        try:
+            if not claim_job_for_fire(job_id):
+                return False  # another machine already claimed this fire
+            job = get_job(job_id)
+            if job is None:
+                return False  # job removed (e.g. repeat-N exhausted) between arm and fire
+            job["execution_id"] = create_execution(job_id, source=self.name)["id"]
+            return run_one_job(job, adapters=adapters, loop=loop, lease=lease)
+        finally:
+            lease.release()
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -7,6 +7,8 @@ claim for a given fire. Single-machine deployments always win (unaffected).
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.
 """
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 
@@ -58,3 +60,47 @@ def test_mark_job_run_clears_claim(temp_home):
     assert get_job(jid).get("fire_claim") is None
     # …and the re-armed recurring job is claimable again.
     assert claim_job_for_fire(jid) is True
+
+
+def test_matching_fire_claim_heartbeat_refreshes_only_its_incarnation(temp_home, monkeypatch):
+    from cron.jobs import (
+        claim_job_for_fire,
+        create_job,
+        get_job,
+        heartbeat_fire_claim,
+        load_jobs,
+        save_jobs,
+    )
+
+    now = [datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)]
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now[0])
+
+    job = create_job(prompt="x", schedule="every 5m", name="heartbeat")
+    job_id = job["id"]
+    assert claim_job_for_fire(job_id) is True
+    claim = get_job(job_id)["fire_claim"]
+    incarnation = claim["incarnation"]
+    original_at = claim["at"]
+
+    now[0] += timedelta(seconds=240)
+    assert heartbeat_fire_claim(job_id, expected_incarnation=incarnation) is True
+    refreshed_claim = get_job(job_id)["fire_claim"]
+    assert refreshed_claim["at"] != original_at
+    assert refreshed_claim["incarnation"] == incarnation
+
+    # The original fire is more than five minutes old, but the matching
+    # heartbeat keeps this exact worker's claim from being reclaimed.
+    now[0] += timedelta(seconds=61)
+    assert claim_job_for_fire(job_id) is False
+
+    assert heartbeat_fire_claim(job_id, expected_incarnation="different") is False
+
+    jobs = load_jobs()
+    jobs[0]["fire_claim"] = {"at": original_at, "by": "legacy"}
+    save_jobs(jobs)
+    assert heartbeat_fire_claim(job_id, expected_incarnation=incarnation) is False
+
+    jobs = load_jobs()
+    jobs[0]["fire_claim"] = "malformed"
+    save_jobs(jobs)
+    assert heartbeat_fire_claim(job_id, expected_incarnation=incarnation) is False

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -9,10 +9,14 @@ Tests cover:
 """
 
 import concurrent.futures
+import contextvars
+import itertools
 import os
 import sys
+import threading
 import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 
 # Ensure project root is importable
@@ -224,6 +228,123 @@ class TestInactivityTimeout:
         # Should NOT have timed out — bare agent has no get_activity_summary
         assert not _inactivity_timeout
         assert result["final_response"] == "no activity tracker"
+
+    def test_timeout_keeps_terminal_lifecycle_open_until_nested_worker_exits(self, tmp_path, monkeypatch):
+        """A timed-out agent stays admitted until its submitted worker exits."""
+        import cron.scheduler as scheduler
+
+        started = threading.Event()
+        interrupted = threading.Event()
+        release = threading.Event()
+        terminalized = threading.Event()
+        terminal = []
+        mark_calls = []
+        fire_heartbeats = []
+        profile_seen = []
+        from hermes_constants import (
+            get_hermes_home_override,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        profile_home = tmp_path / "profile"
+        profile_token = set_hermes_home_override(profile_home)
+
+        class EventControlledAgent:
+            def get_activity_summary(self):
+                return {
+                    "last_activity_desc": "tool_call",
+                    "seconds_since_activity": 1,
+                    "api_call_count": 1,
+                    "max_iterations": 90,
+                }
+
+            def interrupt(self, _message):
+                interrupted.set()
+
+            def run_conversation(self, _prompt):
+                profile_seen.append(get_hermes_home_override())
+                started.set()
+                assert release.wait(timeout=5)
+                return {"final_response": "late success", "messages": []}
+
+            def close(self):
+                terminal.append("teardown")
+
+        def immediate_poll(futures, timeout):
+            done = {future for future in futures if future.done()}
+            return done, set(futures) - done
+
+        agent = EventControlledAgent()
+        fake_db = MagicMock()
+        fake_db.close.side_effect = lambda: terminal.append("db-close")
+        monkeypatch.setattr(scheduler.concurrent.futures, "wait", immediate_poll)
+        clock = itertools.count(start=0, step=61)
+        monkeypatch.setattr(scheduler.time, "monotonic", lambda: next(clock))
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0.1")
+        monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+        monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+        monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: terminal.append("save"))
+        monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: terminal.append("deliver"))
+        def mark(*args, **kwargs):
+            mark_calls.append((args, kwargs))
+            terminal.append("mark")
+            terminalized.set()
+
+        monkeypatch.setattr(scheduler, "mark_job_run", mark)
+        monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: terminal.append("finish"))
+        monkeypatch.setattr(
+            scheduler,
+            "heartbeat_fire_claim",
+            lambda job_id, *, expected_incarnation: fire_heartbeats.append((job_id, expected_incarnation)) or True,
+        )
+
+        result = []
+        run_context = contextvars.copy_context()
+        thread = threading.Thread(
+            target=lambda: run_context.run(
+                lambda: result.append(
+                    scheduler.run_one_job({
+                        "id": "timeout-job",
+                        "name": "timeout",
+                        "prompt": "go",
+                        "execution_id": "e1",
+                        "fire_claim": {"incarnation": "fire-incarnation"},
+                    })
+                )
+            ),
+        )
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             }), \
+             patch("run_agent.AIAgent", return_value=agent):
+            thread.start()
+            assert started.wait(timeout=5)
+            assert interrupted.wait(timeout=5)
+            try:
+                assert not terminalized.wait(timeout=0.2)
+                assert thread.is_alive()
+                assert fire_heartbeats
+            finally:
+                release.set()
+            thread.join(timeout=5)
+        reset_hermes_home_override(profile_token)
+
+        assert not thread.is_alive()
+        assert result == [True]
+        assert terminal == ["db-close", "save", "deliver", "teardown", "mark", "finish"]
+        assert len(mark_calls) == 1
+        assert mark_calls[0][0][1] is False
+        assert "idle for" in mark_calls[0][0][2]
+        assert profile_seen == [str(profile_home)]
+        assert all(heartbeat == ("timeout-job", "fire-incarnation") for heartbeat in fire_heartbeats)
 
 
 class TestSysPathOrdering:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 
@@ -225,6 +226,39 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     assert events[0] == ("running", "exec-3")
     assert events[-1][0:2] == ("finish", "exec-3")
     assert events[-1][2]["success"] is True
+
+
+def test_live_run_keeps_ledger_running_until_worker_release(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    import cron.scheduler as scheduler
+
+    record = executions.create_execution("live-ledger", source="direct")
+    started = threading.Event()
+    release = threading.Event()
+
+    def run_job(job, *, defer_agent_teardown=None):
+        started.set()
+        assert release.wait(timeout=5)
+        return True, "output", "response", None
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "run_job", run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    worker = threading.Thread(
+        target=lambda: scheduler.run_one_job({"id": "live-ledger", "execution_id": record["id"]}),
+    )
+    worker.start()
+    assert started.wait(timeout=5)
+    assert executions.latest_execution("live-ledger")["status"] == "running"
+    assert worker.is_alive()
+    release.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert executions.latest_execution("live-ledger")["status"] == "completed"
 
 
 def test_provider_start_recovers_interrupted_records_before_tick(monkeypatch):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -66,6 +66,22 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_direct_run_one_job_rejects_an_existing_lease_before_execution(monkeypatch):
+    lease = s._acquire_running_job_lease("j2-duplicate")
+    assert lease is not None
+    try:
+        created = []
+        monkeypatch.setattr(
+            s,
+            "create_execution",
+            lambda *_args, **_kwargs: created.append("execution"),
+        )
+        assert s.run_one_job({"id": "j2-duplicate", "name": "t"}) is False
+        assert not created
+    finally:
+        lease.release()
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1246,6 +1246,21 @@ class TestParallelTick:
         assert len(ends) == 2
         assert max(starts) < min(ends), f"Jobs not concurrent: {call_order}"
 
+    def test_tick_rejects_existing_lease_before_creating_execution(self):
+        import cron.scheduler as scheduler
+
+        lease = scheduler._acquire_running_job_lease("tick-overlap")
+        assert lease is not None
+        try:
+            created = []
+            with patch("cron.scheduler.get_due_jobs", return_value=[{"id": "tick-overlap", "name": "t"}]), \
+                 patch("cron.scheduler.advance_next_run"), \
+                 patch("cron.scheduler.create_execution", side_effect=lambda *_args, **_kwargs: created.append(True)):
+                assert scheduler.tick(verbose=False, sync=False) == 0
+            assert not created
+        finally:
+            lease.release()
+
     def test_parallel_jobs_isolated_contextvars(self):
         """Each job's ContextVars must be isolated — no cross-contamination."""
         from gateway.session_context import get_session_env

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -253,6 +253,22 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     assert ran == ["j1"]
 
 
+def test_fire_due_rejects_local_overlap_before_creating_a_fire_claim(monkeypatch):
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    lease = sched._acquire_running_job_lease("j1-overlap")
+    assert lease is not None
+    try:
+        claimed = []
+        monkeypatch.setattr(jobs, "claim_job_for_fire", lambda job_id: claimed.append(job_id) or True)
+        assert InProcessCronScheduler().fire_due("j1-overlap") is False
+        assert not claimed
+    finally:
+        lease.release()
+
+
 # ── F2a: ticker liveness — survival, heartbeat, honest status (#32612, #32895) ──
 
 

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -244,6 +244,77 @@ def test_externally_fired_script_refreshes_its_matching_fire_claim(
     assert refreshed_claim["at"] != original_claim["at"]
 
 
+@pytest.mark.parametrize("no_agent", [True, False], ids=("no-agent", "pre-agent"))
+def test_externally_claimed_script_does_not_run_without_heartbeat(
+    tmp_path, monkeypatch, no_agent,
+):
+    """A failed fire-claim heartbeat startup rejects both script entry paths."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    job = {
+        "id": "externally-claimed-script",
+        "name": "externally claimed script",
+        "prompt": "inspect the script output",
+        "script": "watchdog.py",
+        "no_agent": no_agent,
+        "schedule": {"kind": "interval", "seconds": 600},
+    }
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([job])
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed_job = jobs.get_job(job["id"])
+        original_claim = dict(claimed_job["fire_claim"])
+
+    script_runs = []
+    prerun_results = []
+    real_thread_start = threading.Thread.start
+
+    def _fail_script_heartbeat_start(thread):
+        if thread.name == "cron-script-claim-heartbeat":
+            raise RuntimeError("heartbeat startup failed")
+        return real_thread_start(thread)
+
+    def _unexpected_script(*_args, **_kwargs):
+        script_runs.append(True)
+        raise AssertionError("externally claimed script ran without a heartbeat")
+
+    monkeypatch.setattr(threading.Thread, "start", _fail_script_heartbeat_start)
+    monkeypatch.setattr(scheduler, "_run_job_script", _unexpected_script)
+    if not no_agent:
+        def _capture_failed_prerun(_job, *, prerun_script):
+            prerun_results.append(prerun_script)
+            return None
+
+        monkeypatch.setattr(scheduler, "_build_job_prompt", _capture_failed_prerun)
+
+    with (
+        jobs.use_cron_store(profile_home),
+        patch("hermes_state.SessionDB", return_value=MagicMock()),
+    ):
+        success, _doc, _response, error = scheduler.run_job(claimed_job)
+        stored_claim = jobs.get_job(job["id"])["fire_claim"]
+
+    assert script_runs == []
+    assert stored_claim == original_claim
+    if no_agent:
+        assert success is False
+        assert error == (
+            "Script execution skipped: external fire-claim heartbeat could not start"
+        )
+    else:
+        assert success is True
+        assert error is None
+        assert prerun_results == [
+            (
+                False,
+                "Script execution skipped: external fire-claim heartbeat could not start",
+            )
+        ]
+
+
 def test_script_heartbeat_does_not_refresh_a_replaced_fire_claim(tmp_path, monkeypatch):
     """A stale externally fired script cannot extend a later incarnation."""
     import cron.jobs as jobs

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -1,6 +1,7 @@
 """Regression coverage for one-shot claims during blocking cron scripts."""
 
 from datetime import datetime, timedelta, timezone
+import itertools
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -163,3 +164,222 @@ def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
             "at": replacement_timestamp,
             "by": "replacement-owner",
         }
+
+
+@pytest.mark.parametrize(
+    ("no_agent", "script_output"),
+    [
+        (True, "watchdog complete"),
+        (False, '{"wakeAgent": false}'),
+    ],
+    ids=("script-only-job", "pre-agent-script"),
+)
+def test_externally_fired_script_refreshes_its_matching_fire_claim(
+    tmp_path, monkeypatch, no_agent, script_output,
+):
+    """Both script paths keep only their externally won fire live."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    original_time = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+    current_time = [original_time]
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: current_time[0])
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+
+    job = {
+        "id": "externally-fired-script",
+        "name": "externally fired script",
+        "prompt": "inspect the script output",
+        "script": "watchdog.py",
+        "no_agent": no_agent,
+        "schedule": {"kind": "interval", "seconds": 600},
+        "next_run_at": original_time.isoformat(),
+        "enabled": True,
+    }
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([job])
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed_job = jobs.get_job(job["id"])
+        original_claim = dict(claimed_job["fire_claim"])
+
+    heartbeat_seen = threading.Event()
+    competing_fire = {}
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_incarnation: str) -> bool:
+        current_time[0] = original_time + timedelta(seconds=240)
+        updated = real_heartbeat(
+            job_id,
+            expected_incarnation=expected_incarnation,
+        )
+        current_time[0] = original_time + timedelta(seconds=301)
+        competing_fire["claimed"] = jobs.claim_job_for_fire(job_id)
+        heartbeat_seen.set()
+        return updated
+
+    def _unexpected_run_claim_heartbeat(*_args, **_kwargs):
+        raise AssertionError("recurring external scripts must not heartbeat run_claim")
+
+    def _blocking_script(_script_path: str, **_kwargs) -> tuple[bool, str]:
+        assert heartbeat_seen.wait(timeout=2), "fire_claim was not refreshed"
+        return True, script_output
+
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", _unexpected_run_claim_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_job_script", _blocking_script)
+
+    with (
+        jobs.use_cron_store(profile_home),
+        patch("hermes_state.SessionDB", return_value=MagicMock()),
+    ):
+        success, _doc, _response, error = scheduler.run_job(claimed_job)
+        refreshed_claim = jobs.get_job(job["id"])["fire_claim"]
+
+    assert success is True
+    assert error is None
+    assert competing_fire == {"claimed": False}
+    assert refreshed_claim["incarnation"] == original_claim["incarnation"]
+    assert refreshed_claim["at"] != original_claim["at"]
+
+
+def test_script_heartbeat_does_not_refresh_a_replaced_fire_claim(tmp_path, monkeypatch):
+    """A stale externally fired script cannot extend a later incarnation."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    job = {
+        "id": "reclaimed-fire-script",
+        "script": "watchdog.py",
+        "schedule": {"kind": "interval", "seconds": 600},
+        "fire_claim": {
+            "at": "2026-07-12T12:00:00+00:00",
+            "by": "original-owner",
+            "incarnation": "original-incarnation",
+        },
+    }
+    replacement_claim = {
+        "at": "2026-07-12T12:00:30+00:00",
+        "by": "replacement-owner",
+        "incarnation": "replacement-incarnation",
+    }
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([{**job, "fire_claim": replacement_claim}])
+
+    heartbeat_seen = threading.Event()
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_incarnation: str) -> bool:
+        updated = real_heartbeat(
+            job_id,
+            expected_incarnation=expected_incarnation,
+        )
+        heartbeat_seen.set()
+        return updated
+
+    def _blocking_script(_script_path: str, **_kwargs) -> tuple[bool, str]:
+        assert heartbeat_seen.wait(timeout=2)
+        return True, "done"
+
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_job_script", _blocking_script)
+
+    with jobs.use_cron_store(profile_home):
+        assert scheduler._run_job_script_with_claim_heartbeat(job, "watchdog.py") == (
+            True,
+            "done",
+        )
+        assert jobs.get_job(job["id"])["fire_claim"] == replacement_claim
+
+
+def test_unlimited_external_agent_keeps_its_fire_claim_after_pre_agent_script(
+    tmp_path, monkeypatch,
+):
+    """A pre-agent script hands its external claim heartbeat to the agent monitor."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    original_time = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+    current_time = [original_time]
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: current_time[0])
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+
+    def immediate_poll(futures, timeout):
+        done = {future for future in futures if future.done()}
+        return done, set(futures) - done
+
+    clock = itertools.count(start=0, step=61)
+    monkeypatch.setattr(scheduler.concurrent.futures, "wait", immediate_poll)
+    monkeypatch.setattr(scheduler.time, "monotonic", lambda: next(clock))
+
+    job = {
+        "id": "unlimited-external-agent",
+        "name": "unlimited external agent",
+        "prompt": "inspect the script output",
+        "script": "watchdog.py",
+        "schedule": {"kind": "interval", "seconds": 600},
+        "next_run_at": original_time.isoformat(),
+        "enabled": True,
+    }
+    with jobs.use_cron_store(profile_home):
+        jobs.save_jobs([job])
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed_job = jobs.get_job(job["id"])
+        original_claim = dict(claimed_job["fire_claim"])
+
+    heartbeat_seen = threading.Event()
+    competing_fire = {}
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_incarnation: str) -> bool:
+        current_time[0] = original_time + timedelta(seconds=240)
+        updated = real_heartbeat(
+            job_id,
+            expected_incarnation=expected_incarnation,
+        )
+        current_time[0] = original_time + timedelta(seconds=301)
+        competing_fire["claimed"] = jobs.claim_job_for_fire(job_id)
+        heartbeat_seen.set()
+        return updated
+
+    class HeartbeatControlledAgent:
+        def run_conversation(self, _prompt):
+            assert heartbeat_seen.wait(timeout=2), "agent monitor did not refresh fire_claim"
+            return {"final_response": "done", "messages": []}
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_run_job_script", lambda *_args, **_kwargs: (True, "context"))
+
+    with (
+        jobs.use_cron_store(profile_home),
+        patch("cron.scheduler._hermes_home", profile_home),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=MagicMock()),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        }),
+        patch("run_agent.AIAgent", return_value=HeartbeatControlledAgent()),
+    ):
+        success, _doc, _response, error = scheduler.run_job(claimed_job)
+        refreshed_claim = jobs.get_job(job["id"])["fire_claim"]
+
+    assert success is True
+    assert error is None
+    assert competing_fire == {"claimed": False}
+    assert refreshed_claim["incarnation"] == original_claim["incarnation"]
+    assert refreshed_claim["at"] != original_claim["at"]

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -11,7 +11,10 @@ Covers the cron/scheduler.py primitives directly:
     result AFTER its tool was already killed out from under it
 """
 
-from unittest.mock import patch
+import contextvars
+import itertools
+import threading
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -111,6 +114,127 @@ class TestMarkRunningJobsInterrupted:
             marked = sched.mark_running_jobs_interrupted("shutdown")
 
         assert marked == ["job-2"]
+
+    def test_keeps_timed_out_live_worker_claims_until_its_real_run_exits(
+        self, tmp_path, monkeypatch,
+    ):
+        """Gateway shutdown leaves a timeout join to its existing terminal path."""
+        import cron.jobs as jobs
+        import cron.scheduler as sched
+
+        started = threading.Event()
+        interrupted = threading.Event()
+        release = threading.Event()
+        marks = []
+        shutdown_marks = []
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        stored_job = jobs.create_job(
+            prompt="go",
+            schedule="every 5m",
+            name="timed-out external fire",
+        )
+        job_id = stored_job["id"]
+        assert jobs.claim_job_for_fire(job_id) is True
+        jobs_data = jobs.load_jobs()
+        jobs_data[0]["run_claim"] = {
+            "at": jobs_data[0]["fire_claim"]["at"],
+            "by": "one-shot-owner",
+        }
+        jobs.save_jobs(jobs_data)
+        job = jobs.get_job(job_id)
+        original_fire_claim = dict(job["fire_claim"])
+        original_run_claim = dict(job["run_claim"])
+
+        class EventControlledAgent:
+            def get_activity_summary(self):
+                return {
+                    "last_activity_desc": "tool_call",
+                    "seconds_since_activity": 1,
+                    "api_call_count": 1,
+                    "max_iterations": 90,
+                }
+
+            def interrupt(self, _message):
+                shutdown_marks.append(
+                    sched.mark_running_jobs_interrupted("gateway shutdown")
+                )
+                interrupted.set()
+
+            def run_conversation(self, _prompt):
+                started.set()
+                assert release.wait(timeout=5)
+                return {"final_response": "late success", "messages": []}
+
+            def close(self):
+                return None
+
+        def immediate_poll(futures, timeout):
+            done = {future for future in futures if future.done()}
+            return done, set(futures) - done
+
+        real_mark = jobs.mark_job_run
+
+        def observed_mark(*args, **kwargs):
+            marks.append((args, kwargs))
+            return real_mark(*args, **kwargs)
+
+        monkeypatch.setattr(sched.concurrent.futures, "wait", immediate_poll)
+        clock = itertools.count(start=0, step=61)
+        monkeypatch.setattr(sched.time, "monotonic", lambda: next(clock))
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0.1")
+        monkeypatch.setattr(sched, "claim_dispatch", lambda _job_id: True)
+        monkeypatch.setattr(sched, "save_job_output", lambda *_args: None)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(sched, "mark_job_run", observed_mark)
+
+        result = []
+        worker_context = contextvars.copy_context()
+        worker = threading.Thread(
+            target=lambda: worker_context.run(
+                lambda: result.append(sched.run_one_job(job))
+            ),
+        )
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=MagicMock()), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             }), \
+             patch("run_agent.AIAgent", return_value=EventControlledAgent()):
+            worker.start()
+            assert started.wait(timeout=5)
+            assert interrupted.wait(timeout=5)
+            try:
+                assert shutdown_marks == [[]]
+                assert marks == []
+                assert job_id in sched.get_running_job_ids()
+                assert job_id not in sched._interrupted_job_ids
+                persisted = jobs.get_job(job_id)
+                assert (
+                    persisted["fire_claim"]["incarnation"]
+                    == original_fire_claim["incarnation"]
+                )
+                assert persisted["run_claim"] == original_run_claim
+            finally:
+                release.set()
+            worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert result == [True]
+        assert len(marks) == 1
+        assert marks[0][0][0] == job_id
+        assert marks[0][0][1] is False
+        assert "idle for" in marks[0][0][2]
+        persisted = jobs.get_job(job_id)
+        assert persisted["fire_claim"] is None
+        assert persisted["run_claim"] is None
+        assert job_id not in sched.get_running_job_ids()
 
 
 class TestIsInterrupted:

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -10,6 +10,7 @@ jobs as readers (concurrent with each other, excluded from a writer's run).
 These tests assert that contract.
 """
 
+import os
 import threading
 
 
@@ -189,3 +190,93 @@ def test_run_job_releases_cwd_lock_when_body_raises(tmp_path):
     t.start()
     assert acquired.wait(timeout=5), "writer lock was leaked by run_job on exception"
     t.join(timeout=5)
+
+
+def test_queued_writer_snapshots_terminal_cwd_after_its_lock_acquires(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock, patch
+    import cron.scheduler as sched
+
+    workdir_a = tmp_path / "a"
+    workdir_b = tmp_path / "b"
+    workdir_a.mkdir()
+    workdir_b.mkdir()
+    original = "scheduler-cwd"
+    monkeypatch.setenv("TERMINAL_CWD", original)
+    a_started = threading.Event()
+    b_waiting = threading.Event()
+    release_a = threading.Event()
+    base_lock = sched._ReadWriteLock()
+
+    class ObservedLock:
+        def acquire_write(self):
+            if threading.current_thread().name == "writer-b":
+                b_waiting.set()
+            base_lock.acquire_write()
+
+        def release_write(self):
+            base_lock.release_write()
+
+        def acquire_read(self):
+            base_lock.acquire_read()
+
+        def release_read(self):
+            base_lock.release_read()
+
+    class Agent:
+        def __init__(self, started=None, release=None):
+            self.started = started
+            self.release = release
+
+        def run_conversation(self, _prompt):
+            if self.started is not None:
+                self.started.set()
+            if self.release is not None:
+                assert self.release.wait(timeout=5)
+            return {"final_response": "done"}
+
+        def close(self):
+            return None
+
+    agent_a = Agent(a_started, release_a)
+    agent_b = Agent()
+    monkeypatch.setattr(sched, "_terminal_cwd_lock", ObservedLock())
+    runtime = {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+    patches = [
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=MagicMock()),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime),
+        patch("run_agent.AIAgent", side_effect=[agent_a, agent_b]),
+    ]
+    with patch("cron.scheduler.save_job_output", return_value=None), \
+         patch("cron.scheduler._deliver_result", return_value=None), \
+         patch("cron.scheduler.mark_job_run"), \
+         patch("cron.scheduler.claim_dispatch", return_value=True):
+        with __import__("contextlib").ExitStack() as stack:
+            for item in patches:
+                stack.enter_context(item)
+            writer_a = threading.Thread(
+                target=lambda: sched.run_job({"id": "a", "name": "a", "prompt": "a", "workdir": str(workdir_a)}),
+                name="writer-a",
+            )
+            writer_b = threading.Thread(
+                target=lambda: sched.run_job({"id": "b", "name": "b", "prompt": "b", "workdir": str(workdir_b)}),
+                name="writer-b",
+            )
+            writer_a.start()
+            assert a_started.wait(timeout=5)
+            writer_b.start()
+            assert b_waiting.wait(timeout=5)
+            release_a.set()
+            writer_a.join(timeout=5)
+            writer_b.join(timeout=5)
+
+    assert not writer_a.is_alive() and not writer_b.is_alive()
+    assert os.environ["TERMINAL_CWD"] == original

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -42,6 +42,19 @@ class TestCronjobRunExecutesImmediately:
         assert res["success"] is False
         m_run.assert_not_called()
 
+    def test_execute_job_now_rejects_local_overlap_before_claim(self):
+        from cron.scheduler import _acquire_running_job_lease
+
+        lease = _acquire_running_job_lease("job-run-1")
+        assert lease is not None
+        try:
+            with patch("tools.cronjob_tools.claim_job_for_fire") as m_claim:
+                res = _execute_job_now(dict(_JOB))
+            assert res["claimed"] is False
+            m_claim.assert_not_called()
+        finally:
+            lease.release()
+
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
         with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -582,8 +582,17 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    lease = None
     try:
-        from cron.scheduler import run_one_job
+        from cron.scheduler import _acquire_running_job_lease, run_one_job
+
+        lease = _acquire_running_job_lease(job_id)
+        if lease is None:
+            return {
+                "claimed": False,
+                "success": False,
+                "error": "Job is already running locally; not run again.",
+            }
 
         # At-most-once claim: bail without running if a tick/other fire owns it.
         if not claim_job_for_fire(job_id):
@@ -600,9 +609,16 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
                 reason = "Job is already being fired by the scheduler; not run again."
             return {"claimed": False, "success": False, "error": reason}
 
+        job = get_job(job_id)
+        if job is None:
+            return {
+                "claimed": False,
+                "success": False,
+                "error": "Job no longer exists; nothing to run.",
+            }
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
+        processed = run_one_job(job, lease=lease)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
         return {
@@ -618,6 +634,9 @@ def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
         except Exception:
             pass
         return {"claimed": True, "success": False, "error": str(e)}
+    finally:
+        if lease is not None:
+            lease.release()
 
 
 def cronjob(


### PR DESCRIPTION
## Summary

Cron inactivity could mark an attempt failed while its nested agent worker still executed. That allowed output, job state, durable execution history, local admission, and process-global cwd cleanup to describe a completed attempt before the worker had stopped.

The timeout path now requests cooperative interruption and retains the active attempt until the submitted worker exits. The existing terminal lifecycle then records the saved timeout once. Built-in ticks, external fires, manual runs, and direct callers share one local admission lease, while matching external fire claims remain live for long-running agent and script work.

## Changes

- `cron/scheduler.py`: joins timed-out workers before terminal handling, preserves the active lease through cleanup, protects shutdown behavior, and snapshots `TERMINAL_CWD` under its lock.
- `cron/jobs.py`: adds matching-incarnation fire-claim refresh for live externally fired work.
- `cron/scheduler_provider.py` and `tools/cronjob_tools.py`: acquire local admission before durable fire claims.
- Focused cron tests: cover timed workers, late success, provider and tool ingress, claim liveness, shutdown, script heartbeat failure, profile context, and queued cwd writers.

## Validation

| Scenario | Before | After |
| --- | --- | --- |
| Timed-out worker ignores interruption | Terminal state could be recorded while the worker was live. | Terminal handling waits for worker exit and retains the active attempt. |
| Same job enters through another local path | Admission order differed by caller. | One scheduler lease prevents local overlap. |
| External agent or script outlives its initial fire-claim TTL | Another replica could reclaim the job. | Only the matching live claim is refreshed until completion. |
| Gateway shuts down during a timed-out worker | Shutdown could clear claims before worker exit. | The live worker retains ownership until it completes. |
| Queued workdir writer | It could restore a stale cwd snapshot. | Snapshot and restore both occur under the writer lock. |

## Test plan

- `python -m py_compile cron/scheduler.py cron/jobs.py cron/scheduler_provider.py tools/cronjob_tools.py`
- `python -m pytest tests/cron/test_claim_job_for_fire.py tests/cron/test_cron_inactivity_timeout.py tests/cron/test_execution_ledger.py tests/cron/test_run_one_job.py tests/cron/test_scheduler.py tests/cron/test_scheduler_provider.py tests/cron/test_script_claim_heartbeat.py tests/cron/test_shutdown_interrupt.py tests/cron/test_terminal_cwd_lock.py tests/tools/test_cronjob_run_immediate.py -v --timeout=0`

## Not in scope

Python cannot forcibly terminate an arbitrary running thread or external side effect. A supervised process boundary would be required for immediate hard cancellation.

## Upstream

Closes #18004.
