### PR TITLE
fix(kanban): confirm corrupt boards before backoff (#33486)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -940,13 +940,12 @@ class GatewayKanbanWatchersMixin:
         HEALTH_WINDOW = 6
         bad_ticks = 0
         last_warn_at = 0
-        # Avoid hot-looping corrupt-looking board DBs, but do not suppress
+        # Avoid hot-looping confirmed corrupt board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
         # surface as "database disk image is malformed" for one tick.
-        CORRUPT_BOARD_RETRY_AFTER_SECONDS = 300
-        disabled_corrupt_boards: dict[
-            str, tuple[tuple[str, int | None, int | None], float]
-        ] = {}
+        CORRUPT_BOARD_INITIAL_BACKOFF_SECONDS = 30.0
+        CORRUPT_BOARD_MAX_BACKOFF_SECONDS = 900.0
+        disabled_corrupt_boards: dict[str, dict[str, Any]] = {}
 
         def _board_db_fingerprint(slug: str) -> tuple[str, int | None, int | None]:
             path = _kb.kanban_db_path(slug)
@@ -972,6 +971,91 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
+        def _readonly_sqlite_uri(path: Path) -> str:
+            try:
+                resolved = path.expanduser().resolve()
+            except Exception:
+                resolved = path
+            try:
+                uri = resolved.as_uri()
+            except ValueError:
+                uri = f"file:{resolved}"
+            separator = "&" if "?" in uri else "?"
+            return f"{uri}{separator}mode=ro"
+
+        def _confirm_corruption(slug: str, exc: Exception) -> bool:
+            """Confirm a corrupt-looking dispatch error without mutating the DB."""
+            try:
+                path = _kb.kanban_db_path(slug)
+                conn = sqlite3.connect(_readonly_sqlite_uri(path), uri=True)
+            except Exception as probe_exc:
+                return _is_corrupt_board_db_error(probe_exc)
+            try:
+                rows = conn.execute("PRAGMA quick_check").fetchall()
+            except Exception as probe_exc:
+                return _is_corrupt_board_db_error(probe_exc)
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            for row in rows:
+                if not row:
+                    continue
+                if str(row[0]).strip().lower() != "ok":
+                    return True
+            return False
+
+        def _record_confirmed_corrupt_board(
+            slug: str, fingerprint: tuple[str, int | None, int | None]
+        ) -> float:
+            previous = disabled_corrupt_boards.get(slug)
+            if previous and previous.get("fingerprint") == fingerprint:
+                previous_backoff = float(
+                    previous.get(
+                        "backoff_seconds", CORRUPT_BOARD_INITIAL_BACKOFF_SECONDS
+                    )
+                )
+                backoff_seconds = min(
+                    previous_backoff * 2.0, CORRUPT_BOARD_MAX_BACKOFF_SECONDS
+                )
+            else:
+                backoff_seconds = CORRUPT_BOARD_INITIAL_BACKOFF_SECONDS
+            disabled_corrupt_boards[slug] = {
+                "fingerprint": fingerprint,
+                "disabled_until_ts": time.monotonic() + backoff_seconds,
+                "backoff_seconds": backoff_seconds,
+            }
+            return backoff_seconds
+
+        def _handle_corrupt_board_error(
+            slug: str,
+            fingerprint: tuple[str, int | None, int | None],
+            exc: Exception,
+        ) -> bool:
+            if not _is_corrupt_board_db_error(exc):
+                return False
+            if not _confirm_corruption(slug, exc):
+                logger.warning(
+                    "kanban dispatcher: board %s database %s raised a "
+                    "corrupt-looking error, but read-only quick_check passed; "
+                    "retrying on the next dispatcher tick",
+                    slug,
+                    fingerprint[0],
+                )
+                return True
+            backoff_seconds = _record_confirmed_corrupt_board(slug, fingerprint)
+            logger.error(
+                "kanban dispatcher: board %s database %s is not a valid "
+                "SQLite database; pausing dispatch for this board for %.0fs "
+                "or until the file changes. Move or restore the file, "
+                "then run `hermes kanban init` if you need a fresh board.",
+                slug,
+                fingerprint[0],
+                backoff_seconds,
+            )
+            return True
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -985,26 +1069,31 @@ class GatewayKanbanWatchersMixin:
             fingerprint = _board_db_fingerprint(slug)
             disabled_entry = disabled_corrupt_boards.get(slug)
             if disabled_entry is not None:
-                disabled_fingerprint, disabled_at = disabled_entry
-                age = time.monotonic() - disabled_at
-                if (
-                    disabled_fingerprint == fingerprint
-                    and age < CORRUPT_BOARD_RETRY_AFTER_SECONDS
-                ):
+                disabled_fingerprint = disabled_entry.get("fingerprint")
+                disabled_until_ts = float(
+                    disabled_entry.get("disabled_until_ts", 0.0) or 0.0
+                )
+                backoff_seconds = float(
+                    disabled_entry.get(
+                        "backoff_seconds", CORRUPT_BOARD_INITIAL_BACKOFF_SECONDS
+                    )
+                )
+                now = time.monotonic()
+                if disabled_fingerprint == fingerprint and now < disabled_until_ts:
                     return None
                 if disabled_fingerprint == fingerprint:
                     logger.info(
                         "kanban dispatcher: board %s database fingerprint unchanged "
-                        "after %.0fs quarantine; retrying dispatch",
+                        "after %.0fs corrupt-board backoff; retrying dispatch",
                         slug,
-                        age,
+                        backoff_seconds,
                     )
                 else:
                     logger.info(
                         "kanban dispatcher: board %s database changed; retrying dispatch",
                         slug,
                     )
-                disabled_corrupt_boards.pop(slug, None)
+                    disabled_corrupt_boards.pop(slug, None)
             try:
                 conn = _kb.connect(board=slug)
                 # `connect()` runs the schema + idempotent migration on
@@ -1013,7 +1102,7 @@ class GatewayKanbanWatchersMixin:
                 # re-ran the migration on a second connection, racing
                 # the first. See the matching comment in
                 # `_kanban_notifier_watcher` and issue #21378.
-                return _kb.dispatch_once(
+                result = _kb.dispatch_once(
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
@@ -1023,33 +1112,15 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                 )
+                disabled_corrupt_boards.pop(slug, None)
+                return result
             except sqlite3.DatabaseError as exc:
-                if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                if _handle_corrupt_board_error(slug, fingerprint, exc):
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             except Exception as exc:
-                if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                if _handle_corrupt_board_error(slug, fingerprint, exc):
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3673,7 +3673,7 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
 def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     monkeypatch, tmp_path, caplog, corrupt_exc
 ):
-    """Corrupt board DBs log one actionable error and stop retrying per tick."""
+    """Corrupt board DBs log one actionable error and back off per tick."""
     import asyncio
     import logging
     import sqlite3
@@ -3694,6 +3694,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )
@@ -3722,13 +3723,6 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         raise sqlite3.DatabaseError("file is not a database")
 
     async def _to_thread(fn, *args, **kwargs):
-        # PR salvage (#32857 commit 7): the dispatcher now reaps zombies at
-        # the top of each tick via ``asyncio.to_thread(_kb.reap_worker_zombies)``
-        # BEFORE the per-board tick work. Each tick now issues 3 ``to_thread``
-        # calls (reaper + ``_tick_once`` + ``_ready_nonempty``) instead of 2,
-        # so this counter must reach 6 to allow the same 2 dispatch ticks the
-        # pre-reaper test expected at 4. Connect counts in the assertion below
-        # are unchanged.
         calls["to_thread"] += 1
         result = fn(*args, **kwargs)
         if calls["to_thread"] >= 6:
@@ -3754,19 +3748,16 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kb.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # First tick connect (dispatch) + one swallowed health-probe connect
+    # per tick. The second dispatch tick skips the dispatch connect because
+    # the corrupt board fingerprint is disabled.
+    assert calls["connect"] == 3
 
 
-def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
+def test_gateway_dispatcher_retries_corrupt_board_after_backoff(
     monkeypatch, tmp_path, caplog
 ):
-    """A corrupt-looking board is retried after the quarantine TTL expires."""
+    """A confirmed corrupt board is retried after the backoff expires."""
     import asyncio
     import inspect
     import logging
@@ -3788,6 +3779,7 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )
@@ -3804,16 +3796,19 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
 
     real_monotonic = time.monotonic
-    time_values = iter([1000.0, 1001.0, 1301.0, 1301.0])
+    time_values = iter([1000.0, 1030.0, 1030.0])
 
     def _monotonic_for_gateway_dispatcher():
         caller = inspect.currentframe().f_back  # type: ignore[union-attr]
         code = caller.f_code if caller is not None else None
         filename = code.co_filename if code is not None else ""
-        # The kanban dispatcher/notifier watcher loops were extracted from
-        # gateway/run.py into gateway/kanban_watchers.py (god-file Phase 3),
-        # so accept either filename for the time-travel mock.
-        if filename.endswith("gateway/run.py") or filename.endswith("gateway/kanban_watchers.py"):
+        function_name = code.co_name if code is not None else ""
+        if filename.replace("\\", "/").endswith(
+            "gateway/kanban_watchers.py"
+        ) and function_name in {
+            "_record_confirmed_corrupt_board",
+            "_tick_once_for_board",
+        }:
             return next(time_values, 1301.0)
         return real_monotonic()
 
@@ -3826,10 +3821,15 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
         raise sqlite3.DatabaseError("file is not a database")
 
     async def _to_thread(fn, *args, **kwargs):
+        name = getattr(fn, "__name__", "")
+        if name == "reap_worker_zombies":
+            return []
+        if name == "_ready_nonempty":
+            return False
         result = fn(*args, **kwargs)
-        if getattr(fn, "__name__", "") == "_tick_once":
+        if name == "_tick_once":
             calls["tick"] += 1
-            if calls["tick"] >= 3:
+            if calls["tick"] >= 2:
                 runner._running = False
         return result
 
@@ -3850,8 +3850,8 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
 
     messages = [record.getMessage() for record in caplog.records]
     assert sum("not a valid SQLite database" in msg for msg in messages) == 2
-    assert any("database fingerprint unchanged" in msg for msg in messages)
-    assert calls["tick"] == 3
+    assert any("after 30s corrupt-board backoff" in msg for msg in messages)
+    assert calls["tick"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_dispatcher_resilience.py
+++ b/tests/hermes_cli/test_kanban_dispatcher_resilience.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import sqlite3
+import time
+from types import SimpleNamespace
+
+
+class _DummyConn:
+    def close(self) -> None:
+        pass
+
+
+def _install_gateway_dispatcher_harness(
+    monkeypatch,
+    tmp_path,
+    *,
+    dispatch_once,
+    stop_after_ticks: int,
+    monotonic_values: list[float] | None = None,
+    after_tick=None,
+):
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    db_path = tmp_path / "kanban.db"
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    calls = {"ticks": 0}
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(_kb, "read_board_metadata", lambda slug: {"slug": slug})
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: db_path)
+    monkeypatch.setattr(_kb, "connect", lambda *args, **kwargs: _DummyConn())
+    monkeypatch.setattr(_kb, "dispatch_once", dispatch_once)
+
+    async def _to_thread(fn, *args, **kwargs):
+        name = getattr(fn, "__name__", "")
+        if name == "reap_worker_zombies":
+            return []
+        if name == "_ready_nonempty":
+            return False
+        result = fn(*args, **kwargs)
+        if name == "_tick_once":
+            calls["ticks"] += 1
+            if after_tick is not None:
+                after_tick(calls["ticks"])
+            if calls["ticks"] >= stop_after_ticks:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    if monotonic_values is not None:
+        values = iter(monotonic_values)
+        fallback = monotonic_values[-1]
+        real_monotonic = time.monotonic
+
+        def _monotonic_for_gateway_dispatcher():
+            caller = inspect.currentframe().f_back  # type: ignore[union-attr]
+            code = caller.f_code if caller is not None else None
+            filename = code.co_filename if code is not None else ""
+            function_name = code.co_name if code is not None else ""
+            if filename.replace("\\", "/").endswith(
+                "gateway/kanban_watchers.py"
+            ) and function_name in {
+                "_record_confirmed_corrupt_board",
+                "_tick_once_for_board",
+            }:
+                return next(values, fallback)
+            return real_monotonic()
+
+        monkeypatch.setattr(
+            "gateway.kanban_watchers.time.monotonic",
+            _monotonic_for_gateway_dispatcher,
+        )
+
+    return runner, db_path, calls
+
+
+def _run_watcher(runner) -> None:
+    asyncio.run(asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3.0))
+
+
+def test_gateway_dispatcher_quick_check_ok_does_not_latch(
+    monkeypatch, tmp_path, caplog
+):
+    dispatch_calls = {"count": 0}
+
+    def _dispatch_once(*args, **kwargs):
+        dispatch_calls["count"] += 1
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    runner, db_path, calls = _install_gateway_dispatcher_harness(
+        monkeypatch,
+        tmp_path,
+        dispatch_once=_dispatch_once,
+        stop_after_ticks=2,
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE marker(id INTEGER)")
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        _run_watcher(runner)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert calls["ticks"] == 2
+    assert dispatch_calls["count"] == 2
+    assert not any("not a valid SQLite database" in msg for msg in messages)
+    assert sum("read-only quick_check passed" in msg for msg in messages) == 2
+
+
+def test_gateway_dispatcher_confirmed_corruption_doubles_backoff(
+    monkeypatch, tmp_path, caplog
+):
+    dispatch_calls = {"count": 0}
+
+    def _dispatch_once(*args, **kwargs):
+        dispatch_calls["count"] += 1
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    runner, db_path, calls = _install_gateway_dispatcher_harness(
+        monkeypatch,
+        tmp_path,
+        dispatch_once=_dispatch_once,
+        stop_after_ticks=3,
+        monotonic_values=[1000.0, 1029.0, 1030.0, 1030.0],
+    )
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _run_watcher(runner)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert calls["ticks"] == 3
+    assert dispatch_calls["count"] == 2
+    assert any("for 30s" in msg for msg in messages)
+    assert any("for 60s" in msg for msg in messages)
+    assert any("after 30s corrupt-board backoff" in msg for msg in messages)
+
+
+def test_gateway_dispatcher_fingerprint_change_retries_and_resets_backoff(
+    monkeypatch, tmp_path, caplog
+):
+    dispatch_calls = {"count": 0}
+
+    def _dispatch_once(*args, **kwargs):
+        dispatch_calls["count"] += 1
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    def _after_tick(tick: int) -> None:
+        if tick == 1:
+            db_path.write_text("not sqlite but changed", encoding="utf-8")
+
+    runner, db_path, calls = _install_gateway_dispatcher_harness(
+        monkeypatch,
+        tmp_path,
+        dispatch_once=_dispatch_once,
+        stop_after_ticks=2,
+        monotonic_values=[1000.0, 1001.0, 1001.0],
+        after_tick=_after_tick,
+    )
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _run_watcher(runner)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert calls["ticks"] == 2
+    assert dispatch_calls["count"] == 2
+    assert sum("for 30s" in msg for msg in messages) == 2
+    assert not any("for 60s" in msg for msg in messages)
+    assert any("database changed; retrying dispatch" in msg for msg in messages)
+
+
+def test_gateway_dispatcher_success_clears_disabled_board_state(
+    monkeypatch, tmp_path, caplog
+):
+    dispatch_calls = {"count": 0}
+
+    def _dispatch_once(*args, **kwargs):
+        dispatch_calls["count"] += 1
+        if dispatch_calls["count"] in {1, 3}:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return SimpleNamespace(spawned=[])
+
+    runner, db_path, calls = _install_gateway_dispatcher_harness(
+        monkeypatch,
+        tmp_path,
+        dispatch_once=_dispatch_once,
+        stop_after_ticks=3,
+        monotonic_values=[1000.0, 1030.0, 1031.0],
+    )
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _run_watcher(runner)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert calls["ticks"] == 3
+    assert dispatch_calls["count"] == 3
+    assert sum("for 30s" in msg for msg in messages) == 2
+    assert not any("for 60s" in msg for msg in messages)


### PR DESCRIPTION
## Summary

The gateway kanban dispatcher already avoids hot-looping corrupt-looking board databases, but the current guard backs off every matching SQLite error on a flat five-minute timer. That still penalizes transient open races that look like corruption for one tick and does not preserve the exponential retry behavior from the deferred PR #32857 commit.

This rebuilds the deferred quick_check and exponential-backoff behavior on top of the current fingerprint-change retry logic. The dispatcher confirms corruption with a read-only `PRAGMA quick_check` probe before latching, backs off confirmed same-fingerprint corruption from 30 seconds up to a capped delay, retries immediately when the file fingerprint changes, and clears the board state after a successful dispatch.

Credit: @steveonjava designed the original quick_check and exponential-backoff change in PR #32857 commit `fefb4617d`; @donovan-yohan added the current flat-timer quarantine and fingerprint-change foundation in c94ad8981.

## Changes

- `gateway/run.py`: replace the flat corrupt-board quarantine timer with confirmed-corruption exponential backoff while preserving fingerprint-change retry semantics.
- `tests/hermes_cli/test_kanban_core_functionality.py`: update the existing gateway dispatcher corrupt-board quarantine test for the new backoff behavior.
- `tests/hermes_cli/test_kanban_dispatcher_resilience.py`: add focused dispatcher resilience tests for quick_check transient suppression, repeated confirmed-corruption backoff, fingerprint-change retry, and success-state clearing.

## Validation

| Scenario | Before | After |
|---|---|---|
| corrupt-looking exception, `PRAGMA quick_check` returns `ok` | board is quarantined for 300 seconds | latch is skipped and the next normal tick can retry |
| repeated same-fingerprint confirmed corruption | retry every 300 seconds | retry uses exponential backoff from 30 seconds to the selected cap |
| board file fingerprint changes | retry immediately | retry immediately, unchanged |
| dispatch later succeeds | no explicit state reset needed for flat tuple state | disabled-board state is cleared |

## Test plan

- `python -m pytest tests\hermes_cli\test_kanban_core_functionality.py -k "gateway_dispatcher" -v --timeout=0` - 6 passed, 161 deselected
- `python -m pytest tests\hermes_cli\test_kanban_dispatcher_resilience.py -v --timeout=0` - 4 passed
- `python -m pytest tests\hermes_cli\test_kanban_core_functionality.py tests\hermes_cli\test_kanban_dispatcher_resilience.py -v --timeout=0` - 2 failed, 168 passed, 1 skipped, failures are existing unrelated `kanban_db` tests: `test_list_profiles_on_disk` and `test_detect_crashed_workers_protocol_violation_auto_blocks`
- `python -m pytest tests/ -v --timeout=60` - failed with the same two unrelated tests above

## Not in scope

This does not change `hermes_cli/kanban_db.py` corruption backup semantics. The gateway probe is only a latch-confirmation step before dispatcher backoff.

## Upstream

Closes #33486.
Reported by @kshitijk4poor.
