### PR TITLE
fix(agent): relax repeated hermes-agent skill loading guidance (#20721)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -143,8 +143,10 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. The `hermes-agent` skill is available for additional workflow "
-    "guidance, but treat the docs as the source of truth when the two differ."
+    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+    "for additional guidance and proven workflows. If that same skill is already "
+    "loaded for the current task or thread, reuse its instructions instead of "
+    "loading it again. Treat the docs as the source of truth when the two differ."
 )
 
 MEMORY_GUIDANCE = (
@@ -1666,17 +1668,24 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills\n"
-            "Before replying, scan the skills below and load a skill when its specialized "
-            "instructions are needed for the task. If a relevant skill was already loaded "
-            "for this task or thread, reuse that context instead of loading it again. "
-            "Skills contain specialized knowledge, API endpoints, tool-specific commands, "
-            "proven workflows, and the user's preferred conventions for tasks like code "
-            "review, planning, and testing.\n"
-            "For Hermes Agent configuration, setup, troubleshooting, or feature work, prefer "
-            "the `hermes-agent` skill when current docs or workflow details are needed. "
-            "It covers commands such as `hermes config set ...`, `hermes tools`, and "
-            "`hermes setup`.\n"
+            "## Skills (mandatory)\n"
+            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+            "If that same relevant skill is already loaded for the current task or thread, reuse "
+            "its instructions instead of loading it again. "
+            "Err on the side of loading — it is always better to have context you don't need "
+            "than to miss critical steps, pitfalls, or established workflows. "
+            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+            "and proven workflows that outperform general-purpose approaches. Load the skill "
+            "even if you think you could handle the task with basic tools like web_search or terminal. "
+            "Skills also encode the user's preferred approach, conventions, and quality standards "
+            "for tasks like code review, planning, and testing — load them even for tasks you "
+            "already know how to do, because the skill defines how it should be done here.\n"
+            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
+            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
@@ -1684,7 +1693,9 @@ def build_skills_system_prompt(
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>"
+            "</available_skills>\n"
+            "\n"
+            "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
         )
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -143,9 +143,8 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
+    "information. The `hermes-agent` skill is available for additional workflow "
+    "guidance, but treat the docs as the source of truth when the two differ."
 )
 
 MEMORY_GUIDANCE = (
@@ -1667,22 +1666,17 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+            "## Skills\n"
+            "Before replying, scan the skills below and load a skill when its specialized "
+            "instructions are needed for the task. If a relevant skill was already loaded "
+            "for this task or thread, reuse that context instead of loading it again. "
+            "Skills contain specialized knowledge, API endpoints, tool-specific commands, "
+            "proven workflows, and the user's preferred conventions for tasks like code "
+            "review, planning, and testing.\n"
+            "For Hermes Agent configuration, setup, troubleshooting, or feature work, prefer "
+            "the `hermes-agent` skill when current docs or workflow details are needed. "
+            "It covers commands such as `hermes config set ...`, `hermes tools`, and "
+            "`hermes setup`.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
@@ -1690,9 +1684,7 @@ def build_skills_system_prompt(
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "</available_skills>"
             + hidden_note
         )
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -415,7 +415,7 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
-    def test_skills_prompt_avoids_hard_load_mandates(self, monkeypatch, tmp_path):
+    def test_skills_prompt_requires_relevant_skill_loading(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         skills_dir = tmp_path / "skills" / "coding" / "python-debug"
         skills_dir.mkdir(parents=True)
@@ -425,13 +425,13 @@ class TestBuildSkillsSystemPrompt:
 
         result = build_skills_system_prompt()
 
-        assert "MUST load" not in result
-        assert "Err on the side of loading" not in result
-        assert "load the `hermes-agent` skill first" not in result
-        assert (
-            "Only proceed without loading a skill if genuinely none are relevant"
-            not in result
-        )
+        assert "## Skills (mandatory)" in result
+        assert "matches or is even partially relevant" in result
+        assert "MUST load it with skill_view(name)" in result
+        assert "Err on the side of loading" in result
+        assert "If that same relevant skill is already loaded" in result
+        assert "load the `hermes-agent` skill first" in result
+        assert "Only proceed without loading a skill if genuinely none are relevant" in result
 
     def test_skills_prompt_preserves_index_and_hermes_hint(
         self, monkeypatch, tmp_path
@@ -447,11 +447,9 @@ class TestBuildSkillsSystemPrompt:
 
         assert "<available_skills>" in result
         assert "- hermes-agent: Hermes Agent workflow help" in result
-        assert (
-            "For Hermes Agent configuration, setup, troubleshooting, or feature work"
-            in result
-        )
-        assert "reuse that context instead of loading it again" in result
+        assert "load the `hermes-agent` skill first" in result
+        assert "If that same relevant skill is already loaded" in result
+        assert "Only proceed without loading a skill if genuinely none are relevant" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -415,6 +415,44 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_skills_prompt_avoids_hard_load_mandates(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "MUST load" not in result
+        assert "Err on the side of loading" not in result
+        assert "load the `hermes-agent` skill first" not in result
+        assert (
+            "Only proceed without loading a skill if genuinely none are relevant"
+            not in result
+        )
+
+    def test_skills_prompt_preserves_index_and_hermes_hint(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "core" / "hermes-agent"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: Hermes Agent workflow help\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "<available_skills>" in result
+        assert "- hermes-agent: Hermes Agent workflow help" in result
+        assert (
+            "For Hermes Agent configuration, setup, troubleshooting, or feature work"
+            in result
+        )
+        assert "reuse that context instead of loading it again" in result
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"
@@ -1644,5 +1682,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -67,6 +67,16 @@ def _stable_prompt(agent):
         return build_system_prompt_parts(agent)["stable"]
 
 
+class TestHermesAgentHelpGuidance:
+    def test_stable_prompt_keeps_direct_skill_pointer_without_skills_tools(self):
+        stable = _stable_prompt(_make_agent())
+
+        assert "https://hermes-agent.nousresearch.com/docs" in stable
+        assert "skill_view(name='hermes-agent')" in stable
+        assert "docs as the source of truth when the two differ" in stable
+        assert "If that same skill is already loaded for the current task or thread" in stable
+
+
 def _init_code_repo(path):
     """A git repo that actually holds code — the coding posture requires a source
     file (or manifest), not a bare ``.git`` (a prose/notes repo stays general)."""


### PR DESCRIPTION
## Summary

The skills prompt needs two separate rules. Relevant or partially relevant skills still need to be loaded so the model gets the right workflow instructions, but the same skill should not be loaded again when the current task or thread already has that context. The current branch blurred those decisions together, which weakened the relevance threshold and also removed the direct Hermes help pointer from the assembled system prompt.

This restores the original relevance policy, keeps the direct `hermes-agent` skill pointer and docs precedence, and narrows the duplicate-load exception to the same skill already present in the current task or thread. It also adds assembled-prompt coverage for the standalone `HERMES_AGENT_HELP_GUIDANCE` block so the live system prompt is tested, not just the indexed skills helper.

## Changes

- `agent/prompt_builder.py`: restore mandatory relevance guidance in `build_skills_system_prompt()` and restore the direct `skill_view(name='hermes-agent')` pointer in `HERMES_AGENT_HELP_GUIDANCE` while allowing same-skill reuse in the current task or thread.
- `tests/agent/test_prompt_builder.py`: replace the regression assertions that expected softer loading language with assertions that the relevance rule, Hermes-first guidance, and same-skill reuse exception stay present.
- `tests/agent/test_system_prompt.py`: add stable assembled-prompt coverage for the standalone Hermes help block with no generated skills index in play.

## Validation

| Scenario | Before | After |
|---|---|---|
| partially relevant skill in index | prompt said the model `MUST load` it | prompt still says the model must load it, unless that same skill is already loaded for the current task or thread |
| Hermes task after `hermes-agent` was already loaded | prompt still pushed another load | prompt reuses the existing `hermes-agent` context for the current task or thread |
| standalone Hermes help block in the assembled system prompt | not directly tested | direct skill pointer, docs precedence, and reuse exception are covered through `build_system_prompt_parts()` |
| no relevant skill | prompt allowed proceeding only when none were relevant | unchanged |

## Test plan

- `python -m pytest tests/agent/test_prompt_builder.py -k "skills_prompt" -v --timeout=0` - 2 passed
- `python -m pytest tests/agent/test_system_prompt.py -v --timeout=0` - 6 passed
- `python -m pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -v --timeout=0` - 165 passed, 1 skipped

## Not in scope

This does not relax skill relevance, remove the Hermes docs pointer, change skill discovery, or change prompt assembly outside the two affected skill-guidance surfaces.

## Upstream

Closes #20721.
Reported by @Nek-12.
