### PR TITLE
fix(security): allow scoped safe recursive deletes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -919,8 +919,9 @@ code_execution:
 #   off    — skip all approval prompts (equivalent to --yolo)
 #
 # safe_delete_roots allows literal child `rm` targets under disposable roots to
-# skip approval. Deleting the root itself, traversal, globs, shell expansion,
-# compound commands, and mixed safe/unsafe target lists remain approval-gated.
+# skip approval. safe_delete_dir_names allows recursive deletion of literal cache
+# directory basenames from any parent. Deleting roots, traversal, globs, shell
+# expansion, compound commands, and mixed safe/unsafe targets remain gated.
 approvals:
   mode: "manual"
   timeout: 60
@@ -928,6 +929,15 @@ approvals:
   safe_delete_roots:
     - "/tmp"
     - "/private/tmp"
+  safe_delete_dir_names:
+    - "__pycache__"
+    - ".pytest_cache"
+    - ".mypy_cache"
+    - ".ruff_cache"
+    - ".pyre"
+    - ".pytype"
+    - ".tox"
+    - ".nox"
   mcp_reload_confirm: true
   destructive_slash_confirm: true
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -909,6 +909,29 @@ code_execution:
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================
+# Approval Prompts
+# =============================================================================
+# Controls how Hermes handles commands classified as dangerous.
+#
+# mode:
+#   manual — always prompt the user (default)
+#   smart  — use an auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
+#   off    — skip all approval prompts (equivalent to --yolo)
+#
+# safe_delete_roots allows literal child `rm` targets under disposable roots to
+# skip approval. Deleting the root itself, traversal, globs, shell expansion,
+# compound commands, and mixed safe/unsafe target lists remain approval-gated.
+approvals:
+  mode: "manual"
+  timeout: 60
+  cron_mode: "deny"  # Cron jobs deny dangerous commands by default.
+  safe_delete_roots:
+    - "/tmp"
+    - "/private/tmp"
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2011,10 +2011,23 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
-        # Absolute roots where literal child rm targets can skip approval.
+        # Absolute roots where literal child rm targets may skip approval.
         # This is for disposable sandboxes such as /tmp; deleting the root
         # itself, globs, traversal, and shell-expanded targets stay gated.
         "safe_delete_roots": ["/tmp", "/private/tmp"],
+        # Literal cache directory basenames where recursive rm may skip
+        # approval from any parent path. Only exact basenames are allowed;
+        # traversal, globs, shell expansion, and mixed unsafe targets stay gated.
+        "safe_delete_dir_names": [
+            "__pycache__",
+            ".pytest_cache",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".pyre",
+            ".pytype",
+            ".tox",
+            ".nox",
+        ],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2011,6 +2011,10 @@ DEFAULT_CONFIG = {
         "mode": "manual",
         "timeout": 60,
         "cron_mode": "deny",
+        # Absolute roots where literal child rm targets can skip approval.
+        # This is for disposable sandboxes such as /tmp; deleting the root
+        # itself, globs, traversal, and shell-expanded targets stay gated.
+        "safe_delete_roots": ["/tmp", "/private/tmp"],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -54,7 +54,7 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
     def test_rm_recursive_long_flag(self):
-        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /workspace/stuff")
+        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /home/user/stuff")
         assert is_dangerous is True
         assert key is not None
         assert "delete" in desc.lower()
@@ -232,7 +232,7 @@ class TestRmRecursiveFlagVariants:
         assert "recursive" in desc.lower() or "delete" in desc.lower()
 
     def test_rm_rf(self):
-        dangerous, key, desc = detect_dangerous_command("rm -rf /workspace/test")
+        dangerous, key, desc = detect_dangerous_command("rm -rf /home/user/test")
         assert dangerous is True
         assert key is not None
 
@@ -335,6 +335,59 @@ class TestScopedSafeDeleteRoots:
 
     def test_compound_safe_then_dangerous_rm_stays_gated(self):
         dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run; rm -rf /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+
+class TestSafeDeleteDirNames:
+    """Known cache directories can be removed recursively without prompts."""
+
+    def test_default_pycache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_nested_pycache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf pkg/__pycache__")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_pytest_cache_basename_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf .pytest_cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_cache_basename_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_dir_names": [".custom_cache"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf build/.custom_cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_dynamic_cache_target_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf $CACHE_DIR")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_traversal_to_safe_basename_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf pkg/../__pycache__")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_mixed_safe_dir_name_and_unsafe_target_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__ /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_glob_inside_safe_dir_name_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf __pycache__/*")
         assert dangerous is True
         assert key is not None
         assert "delete" in desc.lower()

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -54,7 +54,7 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
     def test_rm_recursive_long_flag(self):
-        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /tmp/stuff")
+        is_dangerous, key, desc = detect_dangerous_command("rm --recursive /workspace/stuff")
         assert is_dangerous is True
         assert key is not None
         assert "delete" in desc.lower()
@@ -232,7 +232,7 @@ class TestRmRecursiveFlagVariants:
         assert "recursive" in desc.lower() or "delete" in desc.lower()
 
     def test_rm_rf(self):
-        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/test")
+        dangerous, key, desc = detect_dangerous_command("rm -rf /workspace/test")
         assert dangerous is True
         assert key is not None
 
@@ -260,6 +260,84 @@ class TestRmRecursiveFlagVariants:
         dangerous, key, desc = detect_dangerous_command("sudo rm -rf /tmp")
         assert dangerous is True
         assert key is not None
+
+
+class TestScopedSafeDeleteRoots:
+    """Scoped sandbox cleanup should avoid prompts without broad rm bypasses."""
+
+    def test_default_tmp_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm /tmp/hermes-output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_default_tmp_recursive_child_rm_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm /workfolder/output.txt")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_configured_workfolder_recursive_child_rm_is_safe(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run-123/cache")
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_safe_root_itself_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_glob_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/*")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_traversal_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/../etc")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_safe_root_sibling_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder2/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_multiple_targets_require_every_target_scoped(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/run /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_shell_expansion_target_stays_gated(self):
+        with mock_patch("tools.approval._get_approval_config", return_value={"safe_delete_roots": ["/workfolder"]}):
+            dangerous, key, desc = detect_dangerous_command("rm -rf /workfolder/$RUN_ID")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
+
+    def test_compound_safe_then_dangerous_rm_stays_gated(self):
+        dangerous, key, desc = detect_dangerous_command("rm -rf /tmp/hermes-run; rm -rf /workspace/run")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in desc.lower()
 
 
 class TestMultilineBypass:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -11,7 +11,9 @@ This module is the single source of truth for the dangerous command system:
 import contextvars
 import logging
 import os
+import posixpath
 import re
+import shlex
 import sys
 import threading
 import time
@@ -591,15 +593,128 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
     return command
 
 
+_DEFAULT_SAFE_DELETE_ROOTS = ("/tmp", "/private/tmp")
+_DELETE_TARGET_UNSAFE_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}")
+
+
+def _configured_safe_delete_roots() -> tuple[str, ...]:
+    """Return absolute roots where scoped rm targets can skip approvals."""
+    roots = list(_DEFAULT_SAFE_DELETE_ROOTS)
+    configured = _get_approval_config().get("safe_delete_roots", [])
+    if isinstance(configured, str):
+        configured = [configured]
+    elif not isinstance(configured, (list, tuple, set)):
+        configured = []
+
+    for root in configured:
+        roots.append(str(root))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        root = root.strip()
+        if not root.startswith("/"):
+            continue
+        root = posixpath.normpath(root)
+        if root in {"/", "."} or root in seen:
+            continue
+        normalized.append(root)
+        seen.add(root)
+    return tuple(normalized)
+
+
+def _contains_shell_separator(command: str) -> bool:
+    """Conservatively reject compound commands from scoped delete bypasses."""
+    return any(sep in command for sep in ("\n", "&&", "||", ";", "|"))
+
+
+def _rm_tokens(command: str) -> list[str]:
+    if _contains_shell_separator(command):
+        return []
+    try:
+        tokens = shlex.split(command.strip(), posix=True)
+    except ValueError:
+        return []
+    return tokens if tokens and tokens[0] == "rm" else []
+
+
+def _rm_flag_is_recursive(flag: str) -> bool:
+    if flag == "--recursive":
+        return True
+    if flag.startswith("--"):
+        return False
+    return "r" in flag[1:] or "R" in flag[1:]
+
+
+def _rm_targets(command: str, require_recursive: bool) -> list[str]:
+    tokens = _rm_tokens(command)
+    if not tokens:
+        return []
+
+    flags: list[str] = []
+    targets: list[str] = []
+    after_double_dash = False
+    for token in tokens[1:]:
+        if after_double_dash:
+            targets.append(token)
+        elif token == "--":
+            after_double_dash = True
+        elif token.startswith("-") and token != "-":
+            flags.append(token)
+        else:
+            targets.append(token)
+
+    if require_recursive and not any(_rm_flag_is_recursive(flag) for flag in flags):
+        return []
+    return targets
+
+
+def _is_scoped_safe_delete_target(target: str) -> bool:
+    """True only for literal child paths under configured safe delete roots."""
+    if any(marker in target for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+        return False
+    if not target.startswith("/"):
+        return False
+
+    normalized = posixpath.normpath(target)
+    if normalized != target.rstrip("/"):
+        return False
+
+    for root in _configured_safe_delete_roots():
+        prefix = root + "/"
+        if not normalized.startswith(prefix):
+            continue
+        rest = normalized[len(prefix):]
+        first_component = rest.split("/", 1)[0]
+        return bool(first_component) and first_component not in {".", ".."}
+    return False
+
+
+def _is_allowed_root_delete(command: str) -> bool:
+    """Allow non-recursive rm of literal children under safe delete roots."""
+    targets = _rm_targets(command, require_recursive=False)
+    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+
+
+def _is_allowed_recursive_delete(command: str) -> bool:
+    """Allow scoped recursive cleanup while keeping broad rm -r gated."""
+    targets = _rm_targets(command, require_recursive=True)
+    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = _normalize_command_for_detection(command).lower()
+    command_normalized = _normalize_command_for_detection(command)
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-        if pattern_re.search(command_lower):
+        if pattern_re.search(command_normalized):
+            if description == "delete in root path" and _is_allowed_root_delete(command_normalized):
+                continue
+            if description.startswith("recursive delete") and _is_allowed_recursive_delete(command_normalized):
+                continue
             pattern_key = description
             return (True, pattern_key, description)
     return (False, None, None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -594,12 +594,22 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
 
 
 _DEFAULT_SAFE_DELETE_ROOTS = ("/tmp", "/private/tmp")
+_DEFAULT_SAFE_DELETE_DIR_NAMES = (
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pyre",
+    ".pytype",
+    ".tox",
+    ".nox",
+)
 _DELETE_TARGET_UNSAFE_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}")
 
 
 def _configured_safe_delete_roots() -> tuple[str, ...]:
     """Return absolute roots where scoped rm targets can skip approvals."""
-    roots = list(_DEFAULT_SAFE_DELETE_ROOTS)
+    roots: list[str] = list(_DEFAULT_SAFE_DELETE_ROOTS)
     configured = _get_approval_config().get("safe_delete_roots", [])
     if isinstance(configured, str):
         configured = [configured]
@@ -620,6 +630,31 @@ def _configured_safe_delete_roots() -> tuple[str, ...]:
             continue
         normalized.append(root)
         seen.add(root)
+    return tuple(normalized)
+
+
+def _configured_safe_delete_dir_names() -> tuple[str, ...]:
+    """Return literal directory basenames where recursive rm can skip approvals."""
+    names: list[str] = list(_DEFAULT_SAFE_DELETE_DIR_NAMES)
+    configured = _get_approval_config().get("safe_delete_dir_names", [])
+    if isinstance(configured, str):
+        configured = [configured]
+    elif not isinstance(configured, (list, tuple, set)):
+        configured = []
+
+    for name in configured:
+        names.append(str(name))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        name = name.strip()
+        if not name or name in {".", ".."} or "/" in name or name in seen:
+            continue
+        if any(marker in name for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+            continue
+        normalized.append(name)
+        seen.add(name)
     return tuple(normalized)
 
 
@@ -690,6 +725,19 @@ def _is_scoped_safe_delete_target(target: str) -> bool:
     return False
 
 
+def _is_safe_delete_dir_name_target(target: str) -> bool:
+    """True only for literal paths whose basename is an allowed cache dir."""
+    if any(marker in target for marker in _DELETE_TARGET_UNSAFE_MARKERS):
+        return False
+
+    normalized = posixpath.normpath(target)
+    if normalized != target.rstrip("/"):
+        return False
+
+    basename = posixpath.basename(normalized)
+    return basename in _configured_safe_delete_dir_names()
+
+
 def _is_allowed_root_delete(command: str) -> bool:
     """Allow non-recursive rm of literal children under safe delete roots."""
     targets = _rm_targets(command, require_recursive=False)
@@ -699,7 +747,10 @@ def _is_allowed_root_delete(command: str) -> bool:
 def _is_allowed_recursive_delete(command: str) -> bool:
     """Allow scoped recursive cleanup while keeping broad rm -r gated."""
     targets = _rm_targets(command, require_recursive=True)
-    return bool(targets) and all(_is_scoped_safe_delete_target(t) for t in targets)
+    return bool(targets) and all(
+        _is_scoped_safe_delete_target(t) or _is_safe_delete_dir_name_target(t)
+        for t in targets
+    )
 
 
 def detect_dangerous_command(command: str) -> tuple:


### PR DESCRIPTION
## Summary
- add configurable safe-delete roots for approval policy
- allow recursive deletion of configured cache/temp directories without weakening arbitrary `rm -rf` protection
- document the approval config and cover the safe/unsafe cases in approval tests

## Tests
- `.venv/bin/python -m pytest tests/tools/test_approval.py -q`
