### PR TITLE
fix(auxiliary): rebuild closed cached clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6561,6 +6561,28 @@ def neuter_async_httpx_del() -> None:
         pass  # Graceful degradation if the SDK changes its internals
 
 
+def _client_is_closed(client: Any) -> bool:
+    """Best-effort check for cached sync clients with closed transports."""
+    candidates = [
+        client,
+        getattr(client, "_client", None),
+        getattr(client, "client", None),
+        getattr(client, "_real_client", None),
+    ]
+    real_client = getattr(client, "_real_client", None)
+    if real_client is not None:
+        candidates.extend([
+            getattr(real_client, "_client", None),
+            getattr(real_client, "client", None),
+        ])
+    for obj in candidates:
+        if obj is None:
+            continue
+        if getattr(obj, "is_closed", False) is True:
+            return True
+    return False
+
+
 def _force_close_async_httpx(client: Any) -> None:
     """Mark the httpx AsyncClient inside an AsyncOpenAI client as closed.
 
@@ -6721,8 +6743,11 @@ def _get_cached_client(
                 _force_close_async_httpx(cached_client)
                 del _client_cache[cache_key]
             else:
-                effective = _compat_model(cached_client, model, cached_default)
-                return cached_client, effective
+                if _client_is_closed(cached_client):
+                    del _client_cache[cache_key]
+                else:
+                    effective = _compat_model(cached_client, model, cached_default)
+                    return cached_client, effective
     # Build outside the lock.
     # For pool-backed api_key providers, derive the active API key from the
     # pool entry rather than from env vars.  resolve_api_key_provider_credentials

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6578,7 +6578,7 @@ def _client_is_closed(client: Any) -> bool:
     for obj in candidates:
         if obj is None:
             continue
-        if getattr(obj, "is_closed", False) is True:
+        if bool(getattr(obj, "is_closed", False)):
             return True
     return False
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6578,7 +6578,8 @@ def _client_is_closed(client: Any) -> bool:
     for obj in candidates:
         if obj is None:
             continue
-        if bool(getattr(obj, "is_closed", False)):
+        closed = getattr(obj, "is_closed", False)
+        if isinstance(closed, bool) and closed:
             return True
     return False
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3355,6 +3355,41 @@ class TestAuxiliaryClientPoisonedCacheEviction:
 
 
 
+    def test_get_cached_client_rebuilds_closed_sync_client(self):
+        """A cached sync client with a closed transport must not be reused."""
+        from agent.auxiliary_client import (
+            _client_cache, _client_cache_key, _client_cache_lock, _get_cached_client,
+        )
+
+        closed_client = SimpleNamespace(
+            _client=SimpleNamespace(is_closed=True),
+            base_url="https://openrouter.ai/api/v1",
+        )
+        fresh_client = SimpleNamespace(
+            _client=SimpleNamespace(is_closed=False),
+            base_url="https://openrouter.ai/api/v1",
+        )
+        cache_key = _client_cache_key("openrouter", async_mode=False)
+
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (closed_client, "openrouter/model", None)
+
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fresh_client, "openrouter/model"),
+            ) as resolve_mock:
+                client, model = _get_cached_client("openrouter")
+
+            assert client is fresh_client
+            assert model == "openrouter/model"
+            resolve_mock.assert_called_once()
+            assert _client_cache[cache_key][0] is fresh_client
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
     def test_evict_cached_client_instance_walks_async_wrapper(self):
         """async_mode is part of the cache key so sync and async share the same
         underlying OpenAI client across two distinct cache entries. A single


### PR DESCRIPTION
## Summary
- evict cached auxiliary sync clients once their underlying HTTP client is closed
- handle closed-client detection without treating mock attributes as closed clients
- add regression coverage for cache reuse/rebuild behavior

## Tests
- `.venv/bin/python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_crossloop_client_cache.py -q`
