### PR TITLE
feat: add /review skill for AI-powered code review

### DIFF
--- a/skills/software-development/review/SKILL.md
+++ b/skills/software-development/review/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: review
-description: >
-  AI-powered code review via /review. Analyzes staged changes (default),
-  unstaged changes, specific files, or the current PR branch. Produces
-  structured feedback with severity levels using existing tools.
+description: Inspect code diffs, files, or PR branches.
 version: 1.0.0
-author: Hermes Agent
+author: Rishabh Bhandari (@RishabhKodes) + Hermes Agent
 license: MIT
 metadata:
   hermes:
@@ -13,183 +10,151 @@ metadata:
     related_skills: [requesting-code-review, github-code-review, test-driven-development]
 ---
 
-# Code Review
+# Code Review Skill
 
-On-demand code review. Analyzes diffs or files and returns structured feedback
-organized by severity: critical issues, warnings, suggestions, and positives.
+Use this skill for quick, conversational review of local code changes. It reviews
+staged diffs, unstaged diffs, a single file, or the current branch against
+`main`, then returns findings grouped by severity. It does not post GitHub
+comments, run subagents, or auto-fix code.
 
-## Invocation
+## When to Use
 
-```
-/review              — review staged changes (git diff --cached)
-/review unstaged     — review working-tree changes (git diff)
-/review <file>       — review a specific file in full
-/review pr           — review all commits on the current branch vs main
-```
+- The user invokes `/review` with no arguments to review staged changes.
+- The user invokes `/review unstaged` to review working-tree changes.
+- The user invokes `/review <path>` to review one file.
+- The user invokes `/review pr` to review the current branch against `main`.
+- The user asks for a lightweight review of their own local work.
 
-## Step 1 — Determine the review target
+Use `requesting-code-review` instead when the user wants a heavier pre-commit
+pipeline with static checks, an independent reviewer subagent, and auto-fix
+loops. Use `github-code-review` instead when the user wants comments posted on a
+remote GitHub PR.
 
-Parse the user instruction to select one of four modes:
+## Prerequisites
 
-| Instruction        | Mode     | Diff command                          |
-|--------------------|----------|---------------------------------------|
-| (empty)            | staged   | `git diff --cached`                   |
-| `unstaged`         | unstaged | `git diff`                            |
-| a file path        | file     | `read_file` on the path               |
-| `pr`               | pr       | `git diff main...HEAD`                |
+- Diff-based modes require a git repository and `git` available through
+  `terminal`.
+- File mode requires the target file to be readable through `read_file`.
+- For broad or multi-file reviews, load `references/review-checklist.md` with
+  `skill_view` if you need the full review checklist.
 
-If the mode is `staged` and `git diff --cached` is empty, check `git diff`.
-If that is also empty, tell the user there are no changes to review and stop.
+## How to Run
 
-For `pr` mode, also run:
-```bash
-git log main..HEAD --oneline
-git diff main...HEAD --stat
-```
-
-## Step 2 — Gather context
-
-### For diff-based modes (staged, unstaged, pr)
-
-1. Get the stat summary first to understand scope:
-```bash
-git diff --cached --stat   # or git diff --stat / git diff main...HEAD --stat
+```text
+/review
+/review unstaged
+/review path/to/file.py
+/review pr
 ```
 
-2. If the diff exceeds 500 lines, review file-by-file:
-```bash
-git diff --cached --name-only
-# then for each file:
-git diff --cached -- path/to/file.py
-```
+Treat text after `/review` as the target selector:
 
-3. For each changed file, use `read_file` to see surrounding context when the
-   diff alone is ambiguous. A diff shows what changed; the full file shows
-   whether the change is correct.
+| User input | Target | Primary context |
+|------------|--------|-----------------|
+| empty | staged changes | `git diff --cached` |
+| `unstaged` | working-tree changes | `git diff` |
+| file path | one file | `read_file` |
+| `pr` | branch vs main | `git diff main...HEAD` |
 
-### For file mode
+If staged mode has no staged diff, check `git diff`. If both diffs are empty,
+report that there are no changes to review and stop.
 
-Use `read_file` on the target path. If the file is in a git repo, also run:
-```bash
-git log --oneline -5 -- path/to/file
-```
+## Quick Reference
 
-## Step 3 — Scan for common problems
+- Use `terminal` for git commands.
+- Use `read_file` when a diff lacks enough surrounding context.
+- Use `search_files` to look for debug artifacts, conflict markers, or related
+  call sites when the diff suggests a broader issue.
+- Use `skill_view` to load `references/review-checklist.md` during larger
+  reviews.
+- Keep findings concrete: every issue needs a file path and line number when
+  available.
 
-Run these checks on the diff output (skip for file mode):
+## Procedure
 
-```bash
-# Debug artifacts left behind
-git diff --cached | grep -n "print(\|console\.log\|debugger\|binding\.pry"
+1. Determine the target.
+   - Empty instruction: staged changes.
+   - `unstaged`: working-tree changes.
+   - `pr`: current branch compared with `main`.
+   - Anything else: treat it as a file path.
 
-# Credentials or secrets
-git diff --cached | grep -in "password\|secret\|api_key\|token.*=.*['\"]"
+2. Gather a scope summary.
+   - For staged mode, run `git diff --cached --stat`.
+   - For unstaged mode, run `git diff --stat`.
+   - For PR mode, run `git log main..HEAD --oneline` and
+     `git diff main...HEAD --stat`.
+   - For file mode, read the file with `read_file`.
 
-# Merge conflict markers
-git diff --cached | grep -n "<<<<<<\|>>>>>>\|======="
+3. Gather review context.
+   - For diff modes, read the relevant diff with `terminal`.
+   - If a diff is large, list changed files first and review one file at a time.
+   - Use `read_file` for changed files when the diff alone is ambiguous.
+   - Use `search_files` for related definitions, call sites, conflict markers,
+     or suspicious debug artifacts.
 
-# TODO/FIXME/HACK markers (informational, not blocking)
-git diff --cached | grep -n "TODO\|FIXME\|HACK\|XXX"
-```
+4. Review for material issues.
+   - Correctness: broken behavior, missed edge cases, bad error handling.
+   - Security: secrets, unsafe input handling, injection, traversal, auth gaps.
+   - Logic and data flow: wrong conditions, bad state ordering, async mistakes.
+   - Code quality: unnecessary complexity, unclear naming, misplaced
+     abstractions, duplicated logic.
+   - Testing: missing tests for new behavior or tests that do not assert the
+     behavior they claim to cover.
+   - Performance: only flag issues with credible runtime or scale impact.
 
-Substitute the appropriate diff command for the active mode.
+5. Produce the review.
+   - Start with the reviewed target and file count when available.
+   - Lead with findings, grouped by severity.
+   - Omit empty severity groups.
+   - Include a specific positive observation only when there is one.
+   - If there are no findings, say so directly.
 
-## Step 4 — Review the code
+Use this output shape:
 
-Evaluate the changes against these categories. Focus on what matters; skip
-categories that do not apply.
-
-### Correctness
-- Does the code do what it claims?
-- Edge cases: empty inputs, nulls, zero-length collections, boundary values
-- Off-by-one errors in loops and slices
-- Error paths handled or propagated correctly
-
-### Security
-- No hardcoded secrets, API keys, or credentials in the diff
-- User-facing input validated before use
-- No SQL injection, XSS, command injection, or path traversal
-- Auth and authz checks present where required
-
-### Logic and data flow
-- Conditionals test the right thing
-- No unreachable code or dead branches
-- State mutations happen in the right order
-- Async code awaits correctly; no fire-and-forget promises hiding errors
-
-### Code quality
-- Naming is clear and consistent with the surrounding codebase
-- No unnecessary complexity or premature abstraction
-- Duplicated logic that should be extracted
-- Functions focused on a single responsibility
-
-### Testing
-- New behavior has corresponding tests
-- Tests cover both happy path and error cases
-- No tests that always pass (tautologies)
-
-### Performance (flag only when impact is real)
-- N+1 queries or unnecessary loops over large collections
-- Blocking calls in async code paths
-- Missing indexes for new query patterns
-
-## Step 5 — Present findings
-
-Use this structure for the review output:
-
-```
+```text
 ## Review Summary
 
-**Target:** [staged changes | unstaged changes | path/to/file | PR branch]
-**Files:** [N] ([+additions] [-deletions])
+Target: staged changes | unstaged changes | path/to/file | PR branch
+Files: N
 
 ### Critical
-- **file.py:line** — [what is wrong]. Fix: [concrete suggestion].
+- file.py:line - What is wrong. Fix: concrete direction.
 
 ### Warnings
-- **file.py:line** — [what is wrong].
+- file.py:line - What is wrong. Fix: concrete direction.
 
 ### Suggestions
-- **file.py:line** — [observation or improvement].
+- file.py:line - Improvement or observation.
 
 ### Looks good
-- [specific positive observation about the code]
+- Specific positive observation.
 ```
 
-Rules for the output:
-- Every finding references a file and line number.
-- Critical and Warning items include a concrete fix or direction, not just
-  "this is bad."
-- The Looks Good section names something specific. If nothing stands out,
-  omit it rather than writing filler.
-- Omit empty severity sections entirely.
-- If there are zero findings at any severity, say so directly: "No issues
-  found. The changes look clean."
+Severity guide:
 
-### Severity guide
-
-| Level      | Blocks merge? | Examples                                        |
-|------------|---------------|-------------------------------------------------|
-| Critical   | Yes           | Security holes, data loss, crashes               |
-| Warning    | Usually       | Bugs in secondary paths, missing error handling  |
-| Suggestion | No            | Style, naming, minor refactors, missing docs     |
-| Looks good | N/A           | Clean patterns, good test coverage, clear naming |
+| Level | Blocks merge? | Examples |
+|-------|---------------|----------|
+| Critical | Yes | Security holes, data loss, crashes |
+| Warning | Usually | Secondary-path bugs, missing error handling |
+| Suggestion | No | Naming, small refactors, missing docs |
+| Looks good | N/A | Clean patterns, useful tests, clear boundaries |
 
 ## Pitfalls
 
-- **Empty diff:** Check `git status` and report. Do not fabricate findings.
-- **Binary files in diff:** Skip them, note they were skipped.
-- **Very large diffs (>1000 lines):** Split by file. Summarize scope before
-  diving in. Prioritize files with the most additions.
-- **File mode on a non-existent path:** Report the error, do not guess.
-- **Not a git repo (for diff modes):** Tell the user and suggest file mode.
+- Empty diffs: check `git status`, report the state, and do not invent
+  findings.
+- Binary files: note that they were skipped.
+- Large diffs: split by file and prioritize files with the largest or riskiest
+  changes.
+- Missing file path: report that the file could not be read and stop file mode.
+- Non-git directory: explain that diff modes need git and suggest file mode.
+- Uncertain line numbers: cite the nearest stable location and explain the
+  context.
 
-## Relationship to other skills
+## Verification
 
-- **requesting-code-review:** A heavier pre-commit pipeline with static
-  scans, subagent verification, and auto-fix loops. Use that when you want
-  automated gate-keeping before a commit.
-- **github-code-review:** Reviews other people's PRs on GitHub with inline
-  comments via the GitHub API. Use that to post review comments on a remote PR.
-- **This skill (/review):** Quick, conversational review of your own changes.
-  No subagents, no API calls, no auto-fix. Just feedback.
+- Confirm the selected target matches the user's invocation.
+- Confirm every finding is tied to observed code, not speculation.
+- Confirm critical and warning findings include a concrete fix direction.
+- Confirm empty severity sections are omitted.
+- Confirm a no-issue review says "No issues found. The changes look clean."

--- a/skills/software-development/review/SKILL.md
+++ b/skills/software-development/review/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: review
+description: >
+  AI-powered code review via /review. Analyzes staged changes (default),
+  unstaged changes, specific files, or the current PR branch. Produces
+  structured feedback with severity levels using existing tools.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [code-review, quality, git, review, feedback]
+    related_skills: [requesting-code-review, github-code-review, test-driven-development]
+---
+
+# Code Review
+
+On-demand code review. Analyzes diffs or files and returns structured feedback
+organized by severity: critical issues, warnings, suggestions, and positives.
+
+## Invocation
+
+```
+/review              — review staged changes (git diff --cached)
+/review unstaged     — review working-tree changes (git diff)
+/review <file>       — review a specific file in full
+/review pr           — review all commits on the current branch vs main
+```
+
+## Step 1 — Determine the review target
+
+Parse the user instruction to select one of four modes:
+
+| Instruction        | Mode     | Diff command                          |
+|--------------------|----------|---------------------------------------|
+| (empty)            | staged   | `git diff --cached`                   |
+| `unstaged`         | unstaged | `git diff`                            |
+| a file path        | file     | `read_file` on the path               |
+| `pr`               | pr       | `git diff main...HEAD`                |
+
+If the mode is `staged` and `git diff --cached` is empty, check `git diff`.
+If that is also empty, tell the user there are no changes to review and stop.
+
+For `pr` mode, also run:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+## Step 2 — Gather context
+
+### For diff-based modes (staged, unstaged, pr)
+
+1. Get the stat summary first to understand scope:
+```bash
+git diff --cached --stat   # or git diff --stat / git diff main...HEAD --stat
+```
+
+2. If the diff exceeds 500 lines, review file-by-file:
+```bash
+git diff --cached --name-only
+# then for each file:
+git diff --cached -- path/to/file.py
+```
+
+3. For each changed file, use `read_file` to see surrounding context when the
+   diff alone is ambiguous. A diff shows what changed; the full file shows
+   whether the change is correct.
+
+### For file mode
+
+Use `read_file` on the target path. If the file is in a git repo, also run:
+```bash
+git log --oneline -5 -- path/to/file
+```
+
+## Step 3 — Scan for common problems
+
+Run these checks on the diff output (skip for file mode):
+
+```bash
+# Debug artifacts left behind
+git diff --cached | grep -n "print(\|console\.log\|debugger\|binding\.pry"
+
+# Credentials or secrets
+git diff --cached | grep -in "password\|secret\|api_key\|token.*=.*['\"]"
+
+# Merge conflict markers
+git diff --cached | grep -n "<<<<<<\|>>>>>>\|======="
+
+# TODO/FIXME/HACK markers (informational, not blocking)
+git diff --cached | grep -n "TODO\|FIXME\|HACK\|XXX"
+```
+
+Substitute the appropriate diff command for the active mode.
+
+## Step 4 — Review the code
+
+Evaluate the changes against these categories. Focus on what matters; skip
+categories that do not apply.
+
+### Correctness
+- Does the code do what it claims?
+- Edge cases: empty inputs, nulls, zero-length collections, boundary values
+- Off-by-one errors in loops and slices
+- Error paths handled or propagated correctly
+
+### Security
+- No hardcoded secrets, API keys, or credentials in the diff
+- User-facing input validated before use
+- No SQL injection, XSS, command injection, or path traversal
+- Auth and authz checks present where required
+
+### Logic and data flow
+- Conditionals test the right thing
+- No unreachable code or dead branches
+- State mutations happen in the right order
+- Async code awaits correctly; no fire-and-forget promises hiding errors
+
+### Code quality
+- Naming is clear and consistent with the surrounding codebase
+- No unnecessary complexity or premature abstraction
+- Duplicated logic that should be extracted
+- Functions focused on a single responsibility
+
+### Testing
+- New behavior has corresponding tests
+- Tests cover both happy path and error cases
+- No tests that always pass (tautologies)
+
+### Performance (flag only when impact is real)
+- N+1 queries or unnecessary loops over large collections
+- Blocking calls in async code paths
+- Missing indexes for new query patterns
+
+## Step 5 — Present findings
+
+Use this structure for the review output:
+
+```
+## Review Summary
+
+**Target:** [staged changes | unstaged changes | path/to/file | PR branch]
+**Files:** [N] ([+additions] [-deletions])
+
+### Critical
+- **file.py:line** — [what is wrong]. Fix: [concrete suggestion].
+
+### Warnings
+- **file.py:line** — [what is wrong].
+
+### Suggestions
+- **file.py:line** — [observation or improvement].
+
+### Looks good
+- [specific positive observation about the code]
+```
+
+Rules for the output:
+- Every finding references a file and line number.
+- Critical and Warning items include a concrete fix or direction, not just
+  "this is bad."
+- The Looks Good section names something specific. If nothing stands out,
+  omit it rather than writing filler.
+- Omit empty severity sections entirely.
+- If there are zero findings at any severity, say so directly: "No issues
+  found. The changes look clean."
+
+### Severity guide
+
+| Level      | Blocks merge? | Examples                                        |
+|------------|---------------|-------------------------------------------------|
+| Critical   | Yes           | Security holes, data loss, crashes               |
+| Warning    | Usually       | Bugs in secondary paths, missing error handling  |
+| Suggestion | No            | Style, naming, minor refactors, missing docs     |
+| Looks good | N/A           | Clean patterns, good test coverage, clear naming |
+
+## Pitfalls
+
+- **Empty diff:** Check `git status` and report. Do not fabricate findings.
+- **Binary files in diff:** Skip them, note they were skipped.
+- **Very large diffs (>1000 lines):** Split by file. Summarize scope before
+  diving in. Prioritize files with the most additions.
+- **File mode on a non-existent path:** Report the error, do not guess.
+- **Not a git repo (for diff modes):** Tell the user and suggest file mode.
+
+## Relationship to other skills
+
+- **requesting-code-review:** A heavier pre-commit pipeline with static
+  scans, subagent verification, and auto-fix loops. Use that when you want
+  automated gate-keeping before a commit.
+- **github-code-review:** Reviews other people's PRs on GitHub with inline
+  comments via the GitHub API. Use that to post review comments on a remote PR.
+- **This skill (/review):** Quick, conversational review of your own changes.
+  No subagents, no API calls, no auto-fix. Just feedback.

--- a/skills/software-development/review/references/review-checklist.md
+++ b/skills/software-development/review/references/review-checklist.md
@@ -1,0 +1,57 @@
+# Review Checklist
+
+Quick-reference checklist for code review. Load this file with `skill_view`
+when you need the full checklist during a review.
+
+## Pre-review
+
+- [ ] Identified the review target (staged, unstaged, file, PR)
+- [ ] Got the diff or file content
+- [ ] Ran common-problem scans (debug artifacts, secrets, conflict markers)
+
+## Correctness
+
+- [ ] Code does what its name/docstring/commit message claims
+- [ ] Edge cases handled: empty, null, zero, negative, max-size inputs
+- [ ] Loop boundaries correct (no off-by-one)
+- [ ] Error paths return/throw/propagate correctly
+- [ ] Type conversions are safe (no silent truncation or overflow)
+
+## Security
+
+- [ ] No hardcoded secrets, keys, or passwords in the diff
+- [ ] User input validated/sanitized before use
+- [ ] Database queries use parameterized statements
+- [ ] File paths validated against traversal (no unsanitized user input in paths)
+- [ ] Shell commands use array form, not string interpolation
+- [ ] Auth checks present on protected endpoints
+
+## Logic and data flow
+
+- [ ] Conditionals test the intended condition
+- [ ] No unreachable code after early returns/throws
+- [ ] State mutations sequenced correctly
+- [ ] Async/await used correctly (no missing await, no unhandled promise)
+- [ ] Race conditions considered for concurrent access
+
+## Code quality
+
+- [ ] Names are clear, consistent with codebase conventions
+- [ ] No unnecessary abstractions or premature generalization
+- [ ] Duplicated logic extracted if repeated 3+ times
+- [ ] Functions have a single clear responsibility
+- [ ] No commented-out code left behind
+
+## Testing
+
+- [ ] New behavior has tests
+- [ ] Both happy path and error cases covered
+- [ ] Tests are deterministic (no flaky timing, no external dependencies)
+- [ ] Test names describe the behavior being verified
+
+## Performance (flag only when real)
+
+- [ ] No N+1 queries
+- [ ] No blocking I/O in async code paths
+- [ ] Large collection operations are bounded or paginated
+- [ ] No unnecessary re-computation inside loops

--- a/tests/skills/test_review_skill.py
+++ b/tests/skills/test_review_skill.py
@@ -1,155 +1,57 @@
-"""Tests for the /review skill — frontmatter validation, slash command registration,
-and skill_view loading."""
+"""Tests for the /review skill slash command contract."""
 
 from pathlib import Path
+from shutil import copytree
 from unittest.mock import patch
 
-from tools.skills_tool import _parse_frontmatter, skill_matches_platform
 from agent.skill_commands import (
     build_skill_invocation_message,
     resolve_skill_command_key,
     scan_skill_commands,
 )
 
-REVIEW_SKILL_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "skills"
-    / "software-development"
-    / "review"
-    / "SKILL.md"
+REVIEW_SKILL_DIR = (
+    Path(__file__).resolve().parents[2] / "skills" / "software-development" / "review"
 )
 
 
-def _read_skill():
-    return REVIEW_SKILL_PATH.read_text(encoding="utf-8")
-
-
-class TestReviewSkillFrontmatter:
-    def test_skill_file_exists(self):
-        assert REVIEW_SKILL_PATH.exists(), "SKILL.md not found at expected path"
-
-    def test_frontmatter_has_required_fields(self):
-        fm, body = _parse_frontmatter(_read_skill())
-        assert fm.get("name") == "review"
-        assert fm.get("description"), "description must not be empty"
-        assert len(fm["description"]) <= 1024
-
-    def test_frontmatter_has_version(self):
-        fm, _ = _parse_frontmatter(_read_skill())
-        assert "version" in fm
-
-    def test_frontmatter_has_tags(self):
-        fm, _ = _parse_frontmatter(_read_skill())
-        tags = fm.get("metadata", {}).get("hermes", {}).get("tags", [])
-        assert isinstance(tags, list)
-        assert len(tags) > 0
-
-    def test_frontmatter_has_related_skills(self):
-        fm, _ = _parse_frontmatter(_read_skill())
-        related = fm.get("metadata", {}).get("hermes", {}).get("related_skills", [])
-        assert isinstance(related, list)
-        assert "requesting-code-review" in related
-        assert "github-code-review" in related
-
-    def test_no_platform_restriction(self):
-        fm, _ = _parse_frontmatter(_read_skill())
-        assert "platforms" not in fm, "/review should work on all platforms"
-
-    def test_platform_match_returns_true(self):
-        fm, _ = _parse_frontmatter(_read_skill())
-        assert skill_matches_platform(fm) is True
-
-    def test_body_is_not_empty(self):
-        _, body = _parse_frontmatter(_read_skill())
-        assert len(body.strip()) > 100, "skill body too short"
-
-
-class TestReviewSkillContent:
-    def test_documents_all_four_modes(self):
-        content = _read_skill()
-        assert "staged" in content.lower()
-        assert "unstaged" in content.lower()
-        assert "file" in content.lower()
-        assert "pr" in content.lower()
-
-    def test_documents_invocation_syntax(self):
-        content = _read_skill()
-        assert "/review" in content
-        assert "/review unstaged" in content
-        assert "/review pr" in content
-
-    def test_references_directory_exists(self):
-        references_dir = REVIEW_SKILL_PATH.parent / "references"
-        assert references_dir.is_dir()
-
-    def test_review_checklist_exists(self):
-        checklist = REVIEW_SKILL_PATH.parent / "references" / "review-checklist.md"
-        assert checklist.exists()
-        content = checklist.read_text(encoding="utf-8")
-        assert "Correctness" in content
-        assert "Security" in content
+def _setup_review_skill(tmp_path):
+    dest = tmp_path / "software-development" / "review"
+    copytree(REVIEW_SKILL_DIR, dest)
+    return tmp_path
 
 
 class TestReviewSkillSlashCommand:
-    def _setup_skills_dir(self, tmp_path):
-        """Copy the real review skill into a temp skills dir for scanning."""
-        dest = tmp_path / "software-development" / "review"
-        dest.mkdir(parents=True)
-        skill_content = _read_skill()
-        (dest / "SKILL.md").write_text(skill_content, encoding="utf-8")
-        return tmp_path
-
     def test_registers_as_slash_review(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
+        skills_dir = _setup_review_skill(tmp_path)
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
             result = scan_skill_commands()
+
         assert "/review" in result
         assert result["/review"]["name"] == "review"
 
-    def test_resolve_command_key(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
+    def test_resolves_review_command_key(self, tmp_path):
+        skills_dir = _setup_review_skill(tmp_path)
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
             scan_skill_commands()
             assert resolve_skill_command_key("review") == "/review"
 
-    def test_underscore_form_resolves(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
-        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
-            scan_skill_commands()
-            assert resolve_skill_command_key("review") == "/review"
-
-    def test_build_invocation_message(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
+    def test_invocation_preserves_user_instruction(self, tmp_path):
+        skills_dir = _setup_review_skill(tmp_path)
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
             scan_skill_commands()
             msg = build_skill_invocation_message("/review", "unstaged")
+
         assert msg is not None
-        assert "review" in msg.lower()
+        assert "The user has provided the following instruction" in msg
         assert "unstaged" in msg
 
-    def test_build_invocation_with_file_arg(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
-        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
-            scan_skill_commands()
-            msg = build_skill_invocation_message("/review", "src/main.py")
-        assert msg is not None
-        assert "src/main.py" in msg
-
-    def test_build_invocation_no_args(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
+    def test_invocation_lists_review_checklist_supporting_file(self, tmp_path):
+        skills_dir = _setup_review_skill(tmp_path)
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
             scan_skill_commands()
             msg = build_skill_invocation_message("/review")
-        assert msg is not None
-        assert "review" in msg.lower()
 
-    def test_supporting_files_hint_present(self, tmp_path):
-        skills_dir = self._setup_skills_dir(tmp_path)
-        refs = skills_dir / "software-development" / "review" / "references"
-        refs.mkdir(parents=True, exist_ok=True)
-        (refs / "review-checklist.md").write_text("checklist content")
-        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
-            scan_skill_commands()
-            msg = build_skill_invocation_message("/review")
         assert msg is not None
-        assert "supporting files" in msg.lower() or "skill_view" in msg
+        assert "supporting files" in msg.lower()
+        assert "references/review-checklist.md" in msg

--- a/tests/skills/test_review_skill.py
+++ b/tests/skills/test_review_skill.py
@@ -1,0 +1,155 @@
+"""Tests for the /review skill — frontmatter validation, slash command registration,
+and skill_view loading."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.skills_tool import _parse_frontmatter, skill_matches_platform
+from agent.skill_commands import (
+    build_skill_invocation_message,
+    resolve_skill_command_key,
+    scan_skill_commands,
+)
+
+REVIEW_SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "review"
+    / "SKILL.md"
+)
+
+
+def _read_skill():
+    return REVIEW_SKILL_PATH.read_text(encoding="utf-8")
+
+
+class TestReviewSkillFrontmatter:
+    def test_skill_file_exists(self):
+        assert REVIEW_SKILL_PATH.exists(), "SKILL.md not found at expected path"
+
+    def test_frontmatter_has_required_fields(self):
+        fm, body = _parse_frontmatter(_read_skill())
+        assert fm.get("name") == "review"
+        assert fm.get("description"), "description must not be empty"
+        assert len(fm["description"]) <= 1024
+
+    def test_frontmatter_has_version(self):
+        fm, _ = _parse_frontmatter(_read_skill())
+        assert "version" in fm
+
+    def test_frontmatter_has_tags(self):
+        fm, _ = _parse_frontmatter(_read_skill())
+        tags = fm.get("metadata", {}).get("hermes", {}).get("tags", [])
+        assert isinstance(tags, list)
+        assert len(tags) > 0
+
+    def test_frontmatter_has_related_skills(self):
+        fm, _ = _parse_frontmatter(_read_skill())
+        related = fm.get("metadata", {}).get("hermes", {}).get("related_skills", [])
+        assert isinstance(related, list)
+        assert "requesting-code-review" in related
+        assert "github-code-review" in related
+
+    def test_no_platform_restriction(self):
+        fm, _ = _parse_frontmatter(_read_skill())
+        assert "platforms" not in fm, "/review should work on all platforms"
+
+    def test_platform_match_returns_true(self):
+        fm, _ = _parse_frontmatter(_read_skill())
+        assert skill_matches_platform(fm) is True
+
+    def test_body_is_not_empty(self):
+        _, body = _parse_frontmatter(_read_skill())
+        assert len(body.strip()) > 100, "skill body too short"
+
+
+class TestReviewSkillContent:
+    def test_documents_all_four_modes(self):
+        content = _read_skill()
+        assert "staged" in content.lower()
+        assert "unstaged" in content.lower()
+        assert "file" in content.lower()
+        assert "pr" in content.lower()
+
+    def test_documents_invocation_syntax(self):
+        content = _read_skill()
+        assert "/review" in content
+        assert "/review unstaged" in content
+        assert "/review pr" in content
+
+    def test_references_directory_exists(self):
+        references_dir = REVIEW_SKILL_PATH.parent / "references"
+        assert references_dir.is_dir()
+
+    def test_review_checklist_exists(self):
+        checklist = REVIEW_SKILL_PATH.parent / "references" / "review-checklist.md"
+        assert checklist.exists()
+        content = checklist.read_text(encoding="utf-8")
+        assert "Correctness" in content
+        assert "Security" in content
+
+
+class TestReviewSkillSlashCommand:
+    def _setup_skills_dir(self, tmp_path):
+        """Copy the real review skill into a temp skills dir for scanning."""
+        dest = tmp_path / "software-development" / "review"
+        dest.mkdir(parents=True)
+        skill_content = _read_skill()
+        (dest / "SKILL.md").write_text(skill_content, encoding="utf-8")
+        return tmp_path
+
+    def test_registers_as_slash_review(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = scan_skill_commands()
+        assert "/review" in result
+        assert result["/review"]["name"] == "review"
+
+    def test_resolve_command_key(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            assert resolve_skill_command_key("review") == "/review"
+
+    def test_underscore_form_resolves(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            assert resolve_skill_command_key("review") == "/review"
+
+    def test_build_invocation_message(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/review", "unstaged")
+        assert msg is not None
+        assert "review" in msg.lower()
+        assert "unstaged" in msg
+
+    def test_build_invocation_with_file_arg(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/review", "src/main.py")
+        assert msg is not None
+        assert "src/main.py" in msg
+
+    def test_build_invocation_no_args(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/review")
+        assert msg is not None
+        assert "review" in msg.lower()
+
+    def test_supporting_files_hint_present(self, tmp_path):
+        skills_dir = self._setup_skills_dir(tmp_path)
+        refs = skills_dir / "software-development" / "review" / "references"
+        refs.mkdir(parents=True, exist_ok=True)
+        (refs / "review-checklist.md").write_text("checklist content")
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/review")
+        assert msg is not None
+        assert "supporting files" in msg.lower() or "skill_view" in msg


### PR DESCRIPTION
## Summary

- New `/review` skill under `skills/software-development/review/` that gives structured code review feedback via slash command
- Supports four targets: staged changes (default), unstaged changes, a specific file, or the current PR branch
- Includes a `references/review-checklist.md` for the agent to load during reviews
- 19 new tests covering frontmatter validation, slash command registration, invocation message building, and supporting file detection

## Context

Issue NousResearch/hermes-agent#4251 requested a `/review` command. The contributor (SHL0MS) specified it should be a skill, not a built-in command, to avoid loading review instructions into the token budget on sessions that do not need them.

Two related skills exist:
- `requesting-code-review` runs a heavy pre-commit pipeline with subagents and auto-fix loops
- `github-code-review` posts inline comments on other people's PRs via the GitHub API

`/review` fills the gap for quick, conversational review of your own changes. No subagents, no API calls, no auto-fix. You run `/review`, you get structured feedback.

## Files changed

| File | What |
|------|------|
| `skills/software-development/review/SKILL.md` | Skill definition with four review modes, structured output format, severity guide |
| `skills/software-development/review/references/review-checklist.md` | Loadable checklist covering correctness, security, logic, quality, testing, performance |
| `tests/skills/test_review_skill.py` | 19 tests for frontmatter, content, slash command registration, and invocation |

## Test plan

- [x] 19 new tests pass (`tests/skills/test_review_skill.py`)
- [x] 100 existing skill tests pass (no regressions in `test_skill_commands.py`, `test_skills_tool.py`)
- [x] Skill registers as `/review` via `scan_skill_commands()`
- [x] `resolve_skill_command_key("review")` resolves correctly
- [x] `build_skill_invocation_message("/review", "unstaged")` includes user instruction in output
- [x] Supporting files hint appears when references directory is present

Closes NousResearch/hermes-agent#4251