### PR TITLE
fix(tui): route embedded image markers natively

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2568,6 +2568,82 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+def test_prompt_submit_attaches_image_marker_natively(monkeypatch, tmp_path):
+    """A prompt-level image marker should become native multimodal input.
+
+    Desktop/TUI clients can send text that already contains
+    ``[Image attached at: /path]`` while the session's attached_images queue is
+    empty. Vision-capable models should see that image on the first API call
+    instead of needing a vision_analyze tool round-trip.
+    """
+    img = tmp_path / "screen.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+    captured = {}
+
+    class _Agent:
+        model = "MiniMax-M3"
+        provider = "minimax-cn"
+        base_url = ""
+        api_key = ""
+        api_mode = "anthropic_messages"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    import agent.auxiliary_client as aux_client
+    import agent.image_routing as image_routing
+    import hermes_cli.config as config
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(aux_client, "_read_main_provider", lambda: "minimax-cn")
+    monkeypatch.setattr(aux_client, "_read_main_model", lambda: "MiniMax-M3")
+    monkeypatch.setattr(config, "load_config", lambda: {})
+    monkeypatch.setattr(
+        image_routing, "decide_image_input_mode", lambda *args, **kwargs: "native"
+    )
+
+    try:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": (
+                        "[1 image] What do you see in this image?\n\n"
+                        f"[Image attached at: {img}]"
+                    ),
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    prompt = captured["prompt"]
+    assert isinstance(prompt, list)
+    assert prompt[0]["type"] == "text"
+    assert f"[Image attached at: {img}]" in prompt[0]["text"]
+    assert prompt[1]["type"] == "image_url"
+    assert prompt[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4402,6 +4402,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
+            run_images = list(images)
 
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references
@@ -4440,7 +4441,20 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # "text"   → pre-analyze with vision_analyze and prepend the text.
             # See agent/image_routing.py for the full decision table.
             run_message: Any = prompt
-            if images:
+            image_urls: list[str] = []
+            if not run_images and isinstance(prompt, str):
+                try:
+                    from agent.image_routing import extract_image_refs
+
+                    _prompt_image_paths, _prompt_image_urls = extract_image_refs(prompt)
+                    run_images = list(_prompt_image_paths)
+                    image_urls = list(_prompt_image_urls)
+                except Exception as _img_ref_exc:
+                    print(
+                        f"[tui_gateway] image reference extraction failed: {_img_ref_exc}",
+                        file=sys.stderr,
+                    )
+            if run_images or image_urls:
                 try:
                     from agent.image_routing import (
                         decide_image_input_mode,
@@ -4471,7 +4485,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     try:
                         _parts, _skipped = build_native_content_parts(
                             prompt,
-                            images,
+                            run_images,
+                            image_urls=image_urls or None,
                         )
                         if _skipped:
                             print(
@@ -4481,15 +4496,15 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         if any(p.get("type") == "image_url" for p in _parts):
                             run_message = _parts
                         else:
-                            run_message = _enrich_with_attached_images(prompt, images)
+                            run_message = _enrich_with_attached_images(prompt, run_images)
                     except Exception as _img_exc:
                         print(
                             f"[tui_gateway] native attach failed, falling back to text: {_img_exc}",
                             file=sys.stderr,
                         )
-                        run_message = _enrich_with_attached_images(prompt, images)
+                        run_message = _enrich_with_attached_images(prompt, run_images)
                 else:
-                    run_message = _enrich_with_attached_images(prompt, images)
+                    run_message = _enrich_with_attached_images(prompt, run_images)
 
             def _stream(delta):
                 with session["history_lock"]:


### PR DESCRIPTION
## What does this PR do?

Fixes TUI prompt submissions that contain embedded `[Image attached at: ...]` markers but no queued `attached_images` entry.

When the selected model supports native vision, those image markers are now extracted from prompt text and routed into native multimodal content for the first model call. This prevents an unnecessary `vision_analyze` follow-up round-trip for native multimodal models such as MiniMax-M3.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: detect local/remote image references embedded in prompt text when the attachment queue is empty, then pass them through the existing native/text image routing path.
- `tests/test_tui_gateway_server.py`: add regression coverage that verifies prompt-level image markers become native `image_url` content for vision-capable models.

## How to Test

1. Configure a native vision-capable model and submit a TUI/Desktop prompt containing `[Image attached at: /path/to/image.png]` with no queued attachment.
2. Confirm the first `run_conversation` input contains native multimodal content parts instead of plain text only.
3. Run targeted tests:

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k test_prompt_submit_attaches_image_marker_natively
scripts/run_tests.sh tests/agent/test_image_routing.py
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I have updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Targeted test output:

```text
scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k test_prompt_submit_attaches_image_marker_natively
1 passed

scripts/run_tests.sh tests/agent/test_image_routing.py
76 passed
```
