### PR TITLE
fix(kanban): preserve scratch artifacts before workspace cleanup (#39747)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3660,11 +3660,25 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        metadata_for_run = metadata
+        completed_artifacts: Optional[list[str]] = None
+        if isinstance(metadata, dict):
+            md_artifacts = metadata.get("artifacts")
+            if isinstance(md_artifacts, (list, tuple)):
+                cleaned_artifacts = [
+                    str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()
+                ]
+                if cleaned_artifacts:
+                    completed_artifacts = _preserve_completion_artifacts(
+                        conn, task_id, cleaned_artifacts
+                    )
+                    metadata_for_run = dict(metadata)
+                    metadata_for_run["artifacts"] = completed_artifacts
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",
             summary=summary if summary is not None else result,
-            metadata=metadata,
+            metadata=metadata_for_run,
         )
         # If complete_task was called on a never-claimed task (ready or
         # blocked → done with no run in flight), synthesize a
@@ -3675,7 +3689,7 @@ def complete_task(
                 conn, task_id,
                 outcome="completed",
                 summary=summary if summary is not None else result,
-                metadata=metadata,
+                metadata=metadata_for_run,
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
@@ -3695,14 +3709,8 @@ def complete_task(
         # ``kanban_complete(artifacts=[...])`` which stashes the list in
         # ``metadata["artifacts"]`` — we promote it onto the event so
         # consumers don't have to fetch the run row to find it.
-        if isinstance(metadata, dict):
-            md_artifacts = metadata.get("artifacts")
-            if isinstance(md_artifacts, (list, tuple)):
-                cleaned_artifacts = [
-                    str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()
-                ]
-                if cleaned_artifacts:
-                    completed_payload["artifacts"] = cleaned_artifacts
+        if completed_artifacts:
+            completed_payload["artifacts"] = completed_artifacts
         _append_event(
             conn, task_id, "completed",
             completed_payload,
@@ -3818,6 +3826,71 @@ def _is_managed_scratch_path(p: Path) -> bool:
         except ValueError:
             continue
     return False
+
+
+def _preserve_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    artifact_paths: list[str],
+) -> list[str]:
+    """Copy scratch-local completion artifacts to durable media cache paths."""
+    try:
+        row = conn.execute(
+            "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
+            return artifact_paths
+        kind: Optional[str] = row["workspace_kind"]
+        workspace_path: Optional[str] = row["workspace_path"]
+        if kind != "scratch" or not workspace_path:
+            return artifact_paths
+        workspace = Path(workspace_path)
+        if not _is_managed_scratch_path(workspace):
+            return artifact_paths
+        workspace_resolved = workspace.resolve(strict=False)
+    except Exception:
+        return artifact_paths
+
+    try:
+        cache_root = kanban_home() / "cache" / "documents" / "kanban-artifacts" / task_id
+    except Exception:
+        return artifact_paths
+    preserved: list[str] = []
+    for raw in artifact_paths:
+        try:
+            src = Path(raw).expanduser()
+            if not src.is_absolute():
+                candidate = workspace / src
+                if not candidate.is_file():
+                    preserved.append(raw)
+                    continue
+                src = candidate
+            if not src.is_file():
+                preserved.append(raw)
+                continue
+            src_resolved = src.resolve(strict=True)
+            try:
+                relative = src_resolved.relative_to(workspace_resolved)
+            except ValueError:
+                preserved.append(raw)
+                continue
+            if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+                safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", src.name).strip("._-")
+                relative = Path(safe_name or hashlib.sha256(raw.encode("utf-8")).hexdigest())
+            dest = cache_root / relative
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_resolved, dest)
+            preserved.append(str(dest))
+        except Exception:
+            _log.debug(
+                "Failed to preserve completion artifact for task %s: %s",
+                task_id,
+                raw,
+                exc_info=True,
+            )
+            preserved.append(raw)
+    return preserved
 
 
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1945,6 +1945,42 @@ def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
 
 
+def test_complete_task_preserves_scratch_artifacts_before_cleanup(kanban_home):
+    """Scratch-local completion artifacts survive workspace cleanup."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="artifact")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        artifact = ws / "reports" / "summary.txt"
+        artifact.parent.mkdir(parents=True)
+        artifact.write_text("done", encoding="utf-8")
+
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="finished",
+            metadata={"artifacts": [str(artifact)]},
+        )
+        events = kb.list_events(conn, t)
+        completed = next(e for e in events if e.kind == "completed")
+        payload = completed.payload or {}
+        run = kb.latest_run(conn, t)
+
+    assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
+    preserved = payload.get("artifacts")
+    assert isinstance(preserved, list)
+    assert len(preserved) == 1
+    preserved_path = Path(preserved[0])
+    cache_root = kanban_home / "cache" / "documents" / "kanban-artifacts" / t
+    assert preserved_path.is_relative_to(cache_root)
+    assert preserved_path.relative_to(cache_root) == Path("reports") / "summary.txt"
+    assert preserved_path.read_text(encoding="utf-8") == "done"
+    assert run is not None
+    assert run.metadata is not None
+    assert run.metadata.get("artifacts") == preserved
+
+
 def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_path):
     """A scratch task with a user path outside the workspaces root must NOT be deleted (#28818).
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -583,6 +583,91 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
 
 
 @pytest.mark.asyncio
+async def test_notifier_uploads_preserved_scratch_artifact(kanban_home, monkeypatch):
+    """Scratch-local artifacts are copied before cleanup and remain uploadable."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="render scratch report", assignee="worker1")
+        task = kb.get_task(conn, tid)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, tid, ws)
+        report_path = ws / "reports" / "scratch-report.pdf"
+        report_path.parent.mkdir(parents=True)
+        report_path.write_bytes(b"%PDF-scratch")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+    finally:
+        conn.close()
+
+    import os
+    os.environ["HERMES_KANBAN_TASK"] = tid
+    try:
+        out = kt._handle_complete({
+            "summary": "rendered scratch report",
+            "artifacts": [str(report_path)],
+        })
+    finally:
+        os.environ.pop("HERMES_KANBAN_TASK", None)
+    import json as _json
+    assert _json.loads(out)["ok"] is True
+    assert not ws.exists()
+
+    conn = kb.connect()
+    try:
+        completed = next(e for e in kb.list_events(conn, tid) if e.kind == "completed")
+        preserved = (completed.payload or {}).get("artifacts")
+    finally:
+        conn.close()
+    assert isinstance(preserved, list)
+    assert len(preserved) == 1
+    preserved_path = Path(preserved[0])
+    assert preserved_path.exists()
+    assert preserved_path.is_relative_to(
+        kanban_home / "cache" / "documents" / "kanban-artifacts" / tid
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+    fake_adapter.name = "telegram"
+
+    documents_uploaded: list = []
+
+    async def _send(chat_id, msg, metadata=None):
+        runner._running = False
+
+    async def _send_document(chat_id, file_path, metadata=None, **_kw):
+        documents_uploaded.append(file_path)
+
+    fake_adapter.send = AsyncMock(side_effect=_send)
+    fake_adapter.send_document = AsyncMock(side_effect=_send_document)
+    fake_adapter.send_multiple_images = AsyncMock()
+    from gateway.platforms.base import BasePlatformAdapter
+    fake_adapter.extract_local_files = BasePlatformAdapter.extract_local_files
+
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    assert documents_uploaded == [str(preserved_path)]
+
+
+@pytest.mark.asyncio
 async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path, monkeypatch):
     """Missing artifact paths are silently skipped — they may have been
     referenced by name only. The notifier must not crash and must still


### PR DESCRIPTION

## Summary

`kanban_complete(artifacts=[...])` promoted artifact paths into the completed event, but scratch workspaces were removed immediately after completion. The gateway notifier read the event later and skipped missing files, so artifacts created inside the worker scratch directory could be silently lost before delivery.

This preserves scratch-local artifacts into a durable Hermes cache path before workspace cleanup runs, then stores the preserved paths on both the completed event and run metadata. Non-scratch paths and missing paths keep the existing behavior.

## Changes

- `hermes_cli/kanban_db.py`: copy existing artifacts from managed scratch workspaces into a durable media-safe cache before `_cleanup_workspace` removes the workspace, and store the copied paths in completion metadata and event payload (~+70 lines)
- `tests/hermes_cli/test_kanban_db.py`: add a scratch cleanup regression that verifies artifact copies survive completion and metadata matches the event payload (~+35 lines)
- `tests/hermes_cli/test_kanban_notify.py`: add a notifier regression for scratch-local completion artifacts after workspace cleanup (~+45 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| Scratch worker completes with an artifact under its workspace | Event stores the scratch path, cleanup deletes the file, notifier skips it | Event stores a durable copied path, cleanup deletes only the scratch original, notifier uploads the copy |
| Worker completes with an external allowed artifact | Original path is stored and delivered if it exists | Original path is still stored and delivered if it exists |
| Worker references a missing artifact | Gateway silently skips it | Gateway still silently skips it |

## Test plan

- `pytest tests/hermes_cli/test_kanban_db.py -k "artifact or cleanup_workspace" -v --timeout=0` - 4 passed, 208 deselected
- `pytest tests/hermes_cli/test_kanban_notify.py -k "artifact" -v --timeout=0` - 3 passed, 10 deselected
- `pytest tests/tools/test_kanban_tools.py -k "artifacts" -v --timeout=0` - 4 passed, 80 deselected
- `pytest tests/ -v --timeout=60` - blocked on Windows before usable execution because pytest-timeout configured signal mode tries to access missing `signal.SIGALRM`; supplemental `--timeout-method=thread` run did not complete in the tool window

