### PR TITLE
fix: satisfy successors from reconciled review closures

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2215,13 +2215,16 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
+                        # If any parent is not dependency-satisfied, we're todo.
                         rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
+                            "SELECT id, status FROM tasks WHERE id IN "
                             "(" + ",".join("?" * len(parents)) + ")",
                             parents,
                         ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if any(
+                            not _parent_satisfies_dependency(conn, r["id"], r["status"])
+                            for r in rows
+                        ):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -2300,6 +2303,120 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
     ).fetchall()
     present = {r["id"] for r in rows}
     return [p for p in parents if p not in present]
+
+
+def _payload_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        decoded = json.loads(str(raw))
+    except Exception:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            "1", "true", "yes", "y", "approved", "pass", "passed",
+        }
+    return False
+
+
+def _has_reconciled_merged_review_closure(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> bool:
+    """Return whether a stale parent has explicit merged-reviewed closure evidence.
+
+    This is a conservative escape hatch for post-review closure lanes.  It
+    treats an otherwise stale parent as dependency-satisfied only when a
+    machine-readable event says that the reviewed PR lineage was reconciled
+    after merge.  Comments or prose summaries are intentionally ignored: a
+    genuine human gate must remain sticky unless automation writes the
+    explicit event payload.
+    """
+    rows = conn.execute(
+        """
+        SELECT kind, payload
+          FROM task_events
+         WHERE task_id = ?
+           AND kind IN (
+               'post_review_closure',
+               'post_review_closure_reconciled',
+               'merged_reviewed_closure',
+               'dependency_reconciled'
+           )
+         ORDER BY created_at DESC, id DESC
+        """,
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        payload = _payload_dict(row["payload"])
+        if payload.get("original_task_id") not in (None, task_id):
+            continue
+        closure_action = str(payload.get("closure_action") or "").strip().lower()
+        status = str(payload.get("status") or payload.get("closure_status") or "").strip().lower()
+        reconciled = (
+            closure_action == "reconcile_merged_lineage"
+            or status in {"reconciled", "merged_reviewed", "merged-reviewed", "merged", "closed"}
+            or _truthy(payload.get("lineage_reconciled"))
+        )
+        github_raw = payload.get("github")
+        github: dict[str, Any] = github_raw if isinstance(github_raw, dict) else {}
+        pr_raw = payload.get("pr")
+        pr: dict[str, Any] = pr_raw if isinstance(pr_raw, dict) else {}
+        pr_state = str(
+            github.get("state") or pr.get("state") or payload.get("pr_state") or ""
+        ).strip().lower()
+        merged = (
+            _truthy(github.get("merged"))
+            or _truthy(pr.get("merged"))
+            or _truthy(payload.get("pr_merged"))
+            or bool(
+                github.get("merge_commit_sha")
+                or pr.get("merge_commit_sha")
+                or payload.get("merge_commit_sha")
+            )
+        )
+        if pr_state and pr_state not in {"closed", "merged"}:
+            merged = False
+        reviewer_raw = payload.get("reviewer_bridge")
+        reviewer: dict[str, Any] = reviewer_raw if isinstance(reviewer_raw, dict) else {}
+        reviewer_status = str(reviewer.get("status") or "").strip().lower()
+        approved = (
+            _truthy(payload.get("reviewer_bridge_approved"))
+            or _truthy(payload.get("review_approved"))
+            or reviewer_status in {"approved", "pass", "passed"}
+            # Existing runner evidence stores bridge_task_id without duplicating
+            # the bridge verdict.  Accept that compatibility shape only when no
+            # explicit reviewer status contradicts it.
+            or (
+                closure_action == "reconcile_merged_lineage"
+                and bool(payload.get("bridge_task_id"))
+                and not reviewer_status
+            )
+        )
+        if reconciled and merged and approved:
+            return True
+    return False
+
+
+def _parent_satisfies_dependency(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    status: str,
+) -> bool:
+    return (
+        status in ("done", "archived")
+        or _has_reconciled_merged_review_closure(conn, parent_id)
+    )
 
 
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
@@ -2425,11 +2542,11 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # If child was ready but parent is not dependency-satisfied, demote child to todo.
+        parent = conn.execute(
+            "SELECT id, status FROM tasks WHERE id = ?", (parent_id,)
+        ).fetchone()
+        if not _parent_satisfies_dependency(conn, parent["id"], parent["status"]):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -2881,7 +2998,12 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote tasks when every parent is dependency-satisfied.
+
+    A parent is normally satisfied by ``done`` / ``archived``.  The only
+    non-terminal satisfaction path is explicit machine-readable evidence that
+    a stale post-review parent already had its approved PR merged and lineage
+    reconciled.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
@@ -2927,12 +3049,12 @@ def recompute_ready(
                 # this predicate back).
                 continue
             parents = conn.execute(
-                "SELECT t.status FROM tasks t "
+                "SELECT t.id, t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(_parent_satisfies_dependency(conn, p["id"], p["status"]) for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -2986,19 +3108,27 @@ def claim_task(
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
-        # parent is not yet 'done'. This is the single enforcement point
-        # regardless of which writer (create_task, link_tasks, unblock_task,
-        # release_stale_claims, manual SQL) set status='ready'. If a racy
-        # writer promoted a task with undone parents, demote it back to
-        # 'todo' here — recompute_ready will re-promote when the parents
-        # actually finish. See RCA at
+        # parent is not dependency-satisfied. This is the single enforcement
+        # point regardless of which writer (create_task, link_tasks,
+        # unblock_task, release_stale_claims, manual SQL) set status='ready'.
+        # If a racy writer promoted a task with unsatisfied parents, demote it
+        # back to 'todo' here — recompute_ready will re-promote when the
+        # parents actually finish or when explicit merged-reviewed closure
+        # evidence is recorded. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
+        parents = conn.execute(
+            "SELECT p.id, p.status FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ?",
             (task_id,),
-        ).fetchone()
+        ).fetchall()
+        undone = next(
+            (
+                p for p in parents
+                if not _parent_satisfies_dependency(conn, p["id"], p["status"])
+            ),
+            None,
+        )
         if undone:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -325,7 +325,7 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
             (child,),
         )
         conn.commit()
-        assert kb.get_task(conn, child).status == "blocked"
+        assert _task_status(conn, child) == "blocked"
         # recompute_ready should promote blocked → ready
         promoted = kb.recompute_ready(conn)
         assert promoted == 1
@@ -344,6 +344,113 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
         assert kb.get_task(conn, c).status == "todo"
         kb.complete_task(conn, b)
         assert kb.get_task(conn, c).status == "ready"
+
+
+def _task_status(conn, task_id: str) -> str:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task.status
+
+
+def _review_blocked_task(conn, title: str) -> str:
+    task_id = kb.create_task(conn, title=title, assignee="coder")
+    claimed = kb.claim_task(conn, task_id, claimer="worker:review")
+    assert claimed is not None
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert kb.block_task(
+        conn,
+        task_id,
+        reason="review-required: merged PR closure pending",
+        expected_run_id=task.current_run_id,
+    )
+    return task_id
+
+
+def _record_merged_reviewed_closure(
+    conn,
+    task_id: str,
+    *,
+    merged: bool = True,
+    pr_state: str = "closed",
+    approved: bool = True,
+    action: str = "reconcile_merged_lineage",
+) -> None:
+    payload = {
+        "schema_version": "kanban.post_review_closure.v1",
+        "original_task_id": task_id,
+        "bridge_task_id": "t_357a83e4",
+        "closure_action": action,
+        "status": "reconciled",
+        "github": {
+            "url": "https://github.com/2seok2/web-archive/pull/65",
+            "state": pr_state,
+            "merged": merged,
+            "merge_commit_sha": "37deeb369a50b6b3769b0f93dceaf5f4023a242a" if merged else None,
+        },
+        "reviewer_bridge": {"task_id": "t_357a83e4", "status": "approved" if approved else "blocked"},
+    }
+    with kb.write_txn(conn):
+        kb._append_event(conn, task_id, "post_review_closure", payload)
+
+
+def test_reconciled_merged_reviewed_parent_promotes_successor(kanban_home):
+    """Reproducer: t_38969b18 -> t_01b569ad should not stall after merge closure.
+
+    The original parent can still be stale/blocked when the closure lane has
+    already merged the reviewed PR and recorded explicit reconciliation
+    evidence.  In that case descendants are dependency-satisfied without a
+    manual bookkeeping pass on the stale parent.
+    """
+    with kb.connect() as conn:
+        parent = _review_blocked_task(
+            conn,
+            title="t_38969b18 stale reviewed implementation parent",
+        )
+        child = kb.create_task(
+            conn,
+            title="t_01b569ad downstream successor",
+            assignee="coder",
+            parents=[parent],
+        )
+        assert _task_status(conn, parent) == "blocked"
+        assert _task_status(conn, child) == "todo"
+
+        _record_merged_reviewed_closure(conn, parent)
+
+        assert kb.recompute_ready(conn) == 1
+        assert _task_status(conn, child) == "ready"
+        claimed = kb.claim_task(conn, child, claimer="dispatcher:reproducer")
+        assert claimed is not None
+        assert claimed.status == "running"
+
+
+def test_reconciled_parent_satisfaction_requires_merged_review_evidence(kanban_home):
+    with kb.connect() as conn:
+        parent = _review_blocked_task(conn, title="human gate")
+        child = kb.create_task(conn, title="successor", parents=[parent])
+
+        assert kb.recompute_ready(conn) == 0
+        assert _task_status(conn, child) == "todo"
+
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        assert kb.claim_task(conn, child, claimer="dispatcher:no-evidence") is None
+        assert _task_status(conn, child) == "todo"
+
+
+def test_open_or_unapproved_pr_closure_does_not_satisfy_parent(kanban_home):
+    with kb.connect() as conn:
+        parent = _review_blocked_task(conn, title="open pr parent")
+        child = kb.create_task(conn, title="successor", parents=[parent])
+
+        _record_merged_reviewed_closure(conn, parent, merged=False, pr_state="open")
+        assert kb.recompute_ready(conn) == 0
+        assert _task_status(conn, child) == "todo"
+
+        _record_merged_reviewed_closure(conn, parent, merged=True, approved=False)
+        assert kb.recompute_ready(conn) == 0
+        assert _task_status(conn, child) == "todo"
 
 
 # ---------------------------------------------------------------------------
@@ -395,16 +502,16 @@ def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent")
         child = kb.create_task(conn, title="child", parents=[parent])
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         assert kb.schedule_task(conn, child, reason="wait until tomorrow") is True
 
         assert kb.unblock_task(conn, child) is True
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
 
         kb.complete_task(conn, parent)
         assert kb.schedule_task(conn, child, reason="second timer") is True
         assert kb.unblock_task(conn, child) is True
-        assert kb.get_task(conn, child).status == "ready"
+        assert _task_status(conn, child) == "ready"
 
 
 def test_stale_claim_reclaimed(kanban_home, monkeypatch):
@@ -1054,7 +1161,7 @@ def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
         # breaker has tripped and it should stay blocked.
         promoted = kb.recompute_ready(conn)
         assert promoted == 0
-        assert kb.get_task(conn, child).status == "blocked"
+        assert _task_status(conn, child) == "blocked"
 
         # Explicit unblock should still work and reset the counter.
         assert kb.unblock_task(conn, child)
@@ -1178,20 +1285,20 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
             conn, title="child", assignee="a", parents=[parent],
         )
         # Child correctly starts 'todo' because parent is not 'done'.
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         # Simulate the race: a racy writer force-promotes the child to
         # 'ready' while parent is still pending.
         conn.execute(
             "UPDATE tasks SET status='ready' WHERE id=?", (child,),
         )
         conn.commit()
-        assert kb.get_task(conn, child).status == "ready"
+        assert _task_status(conn, child) == "ready"
 
         result = kb.claim_task(conn, child, claimer="host:1")
 
     assert result is None
     with kb.connect() as conn:
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         events = conn.execute(
             "SELECT kind, payload FROM task_events "
             "WHERE task_id = ? ORDER BY id",
@@ -1213,7 +1320,7 @@ def test_claim_succeeds_once_parents_done(kanban_home):
         kb.claim_task(conn, parent)
         assert kb.complete_task(conn, parent, result="ok")
         kb.recompute_ready(conn)
-        assert kb.get_task(conn, child).status == "ready"
+        assert _task_status(conn, child) == "ready"
         claimed = kb.claim_task(conn, child, claimer="host:1")
     assert claimed is not None
     assert claimed.status == "running"
@@ -1226,17 +1333,17 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
         child = kb.create_task(
             conn, title="child", assignee="a", parents=[parent],
         )
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         # Dispatcher tick between create and some later event must NOT
         # produce a winner for this child.
         promoted = kb.recompute_ready(conn)
         assert promoted == 0
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         # Complete parent; complete_task internally runs recompute_ready,
         # which promotes the child to 'ready'.
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, result="ok")
-        assert kb.get_task(conn, child).status == "ready"
+        assert _task_status(conn, child) == "ready"
 
 
 def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
@@ -1258,12 +1365,12 @@ def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
         )
         conn.commit()
         assert kb.unblock_task(conn, child)
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         # After parent completes + recompute, the child is ready.
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, result="ok")
         kb.recompute_ready(conn)
-        assert kb.get_task(conn, child).status == "ready"
+        assert _task_status(conn, child) == "ready"
 
 
 def test_unblock_without_parents_goes_to_ready(kanban_home):
@@ -2663,10 +2770,10 @@ def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
         parent = kb.create_task(conn, title="obsolete parent")
         child = kb.create_task(conn, title="child", parents=[parent])
 
-        assert kb.get_task(conn, child).status == "todo"
+        assert _task_status(conn, child) == "todo"
         assert kb.archive_task(conn, parent) is True
 
-        assert kb.get_task(conn, child).status == "ready", (
+        assert _task_status(conn, child) == "ready", (
             "child should promote to ready immediately after its last blocking "
             "parent is archived"
         )

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -60,7 +60,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
 - **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
-- **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
+- **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are dependency-satisfied: normally `done`/`archived`, or an explicit machine-readable post-review closure event proves a reviewed PR lineage was merged and reconciled while the original parent card is stale.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design, so the dir is wiped the moment the worker (or `hermes kanban complete <id>`) marks the task done. If you want to keep the worker's output, use `worktree:` or `dir:<path>` instead. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
@@ -912,7 +912,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | Kind | Payload | When |
 |---|---|---|
 | `created` | `{assignee, status, parents, tenant}` | Task inserted. `run_id` is `NULL`. |
-| `promoted` | — | `todo → ready` because all parents hit `done`. `run_id` is `NULL`. |
+| `promoted` | — | `todo → ready` because all parents are dependency-satisfied (`done`/`archived`, or explicit merged-reviewed closure evidence for a stale post-review parent). `run_id` is `NULL`. |
 | `claimed` | `{lock, expires, run_id}` | Dispatcher atomically claimed a `ready` task for spawn. |
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason}` | Worker or human flipped the task to `blocked`. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |


### PR DESCRIPTION
## Summary
- Treat stale post-review parent tasks as dependency-satisfied only when a machine-readable closure event proves the reviewed PR lineage was merged and reconciled.
- Reuse that dependency-satisfaction check in task creation, linking, recompute, and claim-time structural guard paths.
- Document the new successor-promotion semantics for Kanban links/events.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py -q -o 'addopts='`

## Grounding
Covers the t_38969b18 -> t_01b569ad failure mode where the implementation PR was merged and closure evidence existed, but a stale original parent card kept successors in `todo` until manual reconciliation.
