### PR TITLE
fix: add privileged post-review kanban reconciliation

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -528,6 +528,30 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
 
+    p_reconcile = sub.add_parser(
+        "reconcile-post-review",
+        help="Privileged: close a stale original task after approved+merged PR evidence",
+    )
+    p_reconcile.add_argument("--original", required=True, help="Original review-required task id")
+    p_reconcile.add_argument("--review", required=True, help="Reviewer bridge task id")
+    p_reconcile.add_argument("--closure", required=True, help="Post-review closure lane task id")
+    p_reconcile.add_argument(
+        "--evidence",
+        required=True,
+        help=(
+            "JSON object with explicit live evidence; must include "
+            "pr_merged=true and review_approved=true"
+        ),
+    )
+    p_reconcile.add_argument("--summary", default=None, help="Summary for the reconciled original task")
+    p_reconcile.add_argument("--metadata", default=None, help="JSON object merged into original task metadata")
+    p_reconcile.add_argument(
+        "--no-complete-closure",
+        action="store_true",
+        help="Only reconcile the original task; leave the closure task open",
+    )
+    p_reconcile.add_argument("--json", action="store_true", help="Emit machine-readable JSON result")
+
     p_edit = sub.add_parser(
         "edit",
         help="Edit recovery fields on an already-completed task",
@@ -937,6 +961,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "claim":    _cmd_claim,
             "comment":  _cmd_comment,
             "complete": _cmd_complete,
+            "reconcile-post-review": _cmd_reconcile_post_review,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
@@ -1906,6 +1931,69 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_reconcile_post_review(args: argparse.Namespace) -> int:
+    """Privileged, evidence-gated closure for approved+merged review lanes."""
+    # This command is an operator/runner surface, not a worker escape hatch.
+    # A dispatcher-spawned worker has HERMES_KANBAN_TASK set; require the
+    # embedding runner to explicitly opt into the privileged path (or run from
+    # an unscoped CLI/orchestrator context) so normal task workers do not gain
+    # a shell-level bypass for cross-task completion.
+    if os.environ.get("HERMES_KANBAN_TASK") and os.environ.get(
+        "HERMES_KANBAN_PRIVILEGED_RECONCILE"
+    ) != "1":
+        print(
+            "kanban: reconcile-post-review is privileged; run it from an "
+            "unscoped runner/orchestrator context, or set "
+            "HERMES_KANBAN_PRIVILEGED_RECONCILE=1 in trusted runner code",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        evidence = json.loads(args.evidence)
+        if not isinstance(evidence, dict):
+            raise ValueError("must be a JSON object")
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"kanban: --evidence: {exc}", file=sys.stderr)
+        return 2
+
+    metadata = None
+    raw_meta = getattr(args, "metadata", None)
+    if raw_meta:
+        try:
+            metadata = json.loads(raw_meta)
+            if not isinstance(metadata, dict):
+                raise ValueError("must be a JSON object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            print(f"kanban: --metadata: {exc}", file=sys.stderr)
+            return 2
+
+    with kb.connect_closing() as conn:
+        result = kb.reconcile_post_review_closure(
+            conn,
+            original_task_id=args.original,
+            review_task_id=args.review,
+            closure_task_id=args.closure,
+            evidence=evidence,
+            summary=getattr(args, "summary", None),
+            metadata=metadata,
+            complete_closure=not getattr(args, "no_complete_closure", False),
+        )
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif result.get("reconciled"):
+        print(
+            f"Reconciled {result['original_task_id']} via review "
+            f"{result['review_task_id']} and closure {result['closure_task_id']}"
+        )
+    else:
+        print(
+            f"No-op: {result['original_task_id']} already reconciled "
+            f"({result.get('reason', 'no change')})"
+        )
+    return 0
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7590,6 +7590,186 @@ def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
     return Run.from_row(row) if row else None
 
 
+def reconcile_post_review_closure(
+    conn: sqlite3.Connection,
+    *,
+    original_task_id: str,
+    review_task_id: str,
+    closure_task_id: str,
+    evidence: dict,
+    summary: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    complete_closure: bool = True,
+) -> dict[str, Any]:
+    """Privileged post-review closure reconciliation path.
+
+    Worker tools intentionally reject destructive cross-task mutations via
+    ``_enforce_worker_task_ownership``.  Post-review closure lanes are the
+    narrow exception: a runner/orchestrator that has explicit evidence that a
+    review-required task's PR was approved and merged may close the stale
+    original task without respawning the implementation worker or asking a
+    human to click through a false-positive block.
+
+    This helper is deliberately *not* registered as a worker tool.  Call it
+    from unscoped CLI/runner code after collecting live evidence.  Evidence is
+    fail-closed: both ``pr_merged`` and ``review_approved`` must be true, and
+    the review task's latest run must itself be completed with
+    ``metadata.approved=true`` for the same original task.
+    """
+    if not original_task_id or not review_task_id or not closure_task_id:
+        raise ValueError("original_task_id, review_task_id, and closure_task_id are required")
+    if not isinstance(evidence, dict):
+        raise ValueError("evidence must be a JSON object/dict")
+    if evidence.get("pr_merged") is not True:
+        raise ValueError("post-review reconciliation requires evidence.pr_merged=true")
+    if evidence.get("review_approved") is not True:
+        raise ValueError("post-review reconciliation requires evidence.review_approved=true")
+
+    original = get_task(conn, original_task_id)
+    review = get_task(conn, review_task_id)
+    closure = get_task(conn, closure_task_id)
+    if original is None:
+        raise ValueError(f"original task {original_task_id} not found")
+    if review is None:
+        raise ValueError(f"review task {review_task_id} not found")
+    if closure is None:
+        raise ValueError(f"closure task {closure_task_id} not found")
+    if len({original_task_id, review_task_id, closure_task_id}) != 3:
+        raise ValueError("original, review, and closure tasks must be distinct")
+
+    review_run = latest_run(conn, review_task_id)
+    review_meta = review_run.metadata if review_run and isinstance(review_run.metadata, dict) else {}
+    reviewed_task = review_meta.get("reviewed_task") or review_meta.get("original_task")
+    if review.status != "done" or review_run is None or review_run.outcome != "completed":
+        raise ValueError("review task must be completed before post-review reconciliation")
+    if review_meta.get("approved") is not True:
+        raise ValueError("review task latest run must carry metadata.approved=true")
+    if reviewed_task and reviewed_task != original_task_id:
+        raise ValueError(
+            f"review task metadata points at {reviewed_task}, not {original_task_id}"
+        )
+
+    pr_number = evidence.get("pr_number") or evidence.get("pr")
+    pr_label = f"PR #{pr_number}" if pr_number is not None else "the reviewed PR"
+    if summary is None:
+        summary = (
+            f"Reconciled post-review closure: {pr_label} is reviewer-approved "
+            f"and merged; closure task {closure_task_id} provided explicit live "
+            "evidence, so the stale original task is closed without respawning "
+            "the implementation lane."
+        )
+    reconciliation_metadata = dict(metadata or {})
+    reconciliation_metadata.update({
+        "post_review_reconciled": True,
+        "reconciled_from_live_evidence": True,
+        "original_task": original_task_id,
+        "review_task": review_task_id,
+        "closure_task": closure_task_id,
+        "evidence": dict(evidence),
+    })
+
+    if original.status == "done":
+        with write_txn(conn):
+            _append_event(
+                conn,
+                original_task_id,
+                "post_review_reconcile_noop",
+                {
+                    "reason": "original_already_done",
+                    "review_task": review_task_id,
+                    "closure_task": closure_task_id,
+                    "evidence": dict(evidence),
+                },
+            )
+        closure_completed = False
+        if complete_closure and closure.status != "done":
+            closure_completed = complete_task(
+                conn,
+                closure_task_id,
+                summary=(
+                    f"Post-review closure observed original task {original_task_id} "
+                    f"already reconciled from approved+merged evidence for {pr_label}; "
+                    "no human block emitted."
+                ),
+                metadata={
+                    "post_review_reconciled": True,
+                    "original_task": original_task_id,
+                    "review_task": review_task_id,
+                    "original_task_reconciled": True,
+                    "reason": "original_already_done",
+                    "evidence": dict(evidence),
+                },
+            )
+        return {
+            "ok": True,
+            "reconciled": False,
+            "reason": "original_already_done",
+            "original_task_id": original_task_id,
+            "review_task_id": review_task_id,
+            "closure_task_id": closure_task_id,
+            "closure_completed": closure_completed,
+        }
+
+    with write_txn(conn):
+        _append_event(
+            conn,
+            original_task_id,
+            "post_review_reconcile_requested",
+            {
+                "review_task": review_task_id,
+                "closure_task": closure_task_id,
+                "evidence": dict(evidence),
+            },
+        )
+        _append_event(
+            conn,
+            closure_task_id,
+            "post_review_reconcile_requested",
+            {
+                "original_task": original_task_id,
+                "review_task": review_task_id,
+                "evidence": dict(evidence),
+            },
+        )
+
+    if not complete_task(
+        conn,
+        original_task_id,
+        summary=summary,
+        metadata=reconciliation_metadata,
+    ):
+        raise RuntimeError(f"could not reconcile original task {original_task_id}")
+
+    closure_completed = False
+    if complete_closure and closure.status != "done":
+        closure_summary = (
+            f"Post-review closure reconciled original task {original_task_id} "
+            f"from approved+merged evidence for {pr_label}; no human block emitted."
+        )
+        closure_meta = {
+            "post_review_reconciled": True,
+            "original_task": original_task_id,
+            "review_task": review_task_id,
+            "original_task_reconciled": True,
+            "evidence": dict(evidence),
+        }
+        closure_completed = complete_task(
+            conn,
+            closure_task_id,
+            summary=closure_summary,
+            metadata=closure_meta,
+        )
+
+    return {
+        "ok": True,
+        "reconciled": True,
+        "original_task_id": original_task_id,
+        "review_task_id": review_task_id,
+        "closure_task_id": closure_task_id,
+        "closure_completed": closure_completed,
+    }
+
+
 def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return the latest non-null ``task_runs.summary`` for ``task_id``.
 

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -181,6 +181,8 @@ You can configure the gateway to receive cross-profile Kanban task notifications
 
 **Don't rely on the CLI when the guidance is available.** The `kanban_*` tools work across all terminal backends (Docker, Modal, SSH). `hermes kanban <verb>` from your terminal tool will fail in containerized backends because the CLI isn't installed there. When in doubt, use the tool.
 
+**Approved review + merged PR belongs to privileged post-review reconciliation.** A closure worker must not use `kanban_complete(task_id=<original>)` to mutate a foreign original task, and should not human-block when live evidence already proves the reviewed PR is approved and merged. The trusted runner/orchestrator should call the unscoped `hermes kanban reconcile-post-review --original <task> --review <bridge> --closure <closure> --evidence '{"review_approved":true,"pr_merged":true,...}'` path (or the equivalent DB helper) so the original stale task and closure lane close without weakening worker task-ownership guards.
+
 ## CLI fallback (for scripting)
 
 Every tool has a CLI equivalent for human operators and scripts:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -109,6 +109,143 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     assert "53 51 4c 69 74 17 03 03 00 13" in msg
 
 
+def test_post_review_closure_reconciles_original_from_privileged_evidence(kanban_home):
+    """Approved review + merged PR should close stale original/closure lanes.
+
+    This is the runner/orchestrator path for the incident where a closure
+    worker had explicit PR-merged evidence but could not call the worker tool
+    ``kanban_complete(task_id=<original>)`` because task ownership guards must
+    reject foreign destructive mutations. The DB helper is privileged and
+    evidence-gated; it is not registered as a worker tool.
+    """
+    with kb.connect() as conn:
+        original = kb.create_task(
+            conn,
+            title="[sdk] Migrate economy importer path to Codex TypeScript SDK",
+            assignee="coder",
+        )
+        kb.claim_task(conn, original)
+        assert kb.block_task(
+            conn,
+            original,
+            reason="review-required: PR #65 needs eyes before merge",
+            expected_run_id=kb.get_task(conn, original).current_run_id,
+        )
+
+        review = kb.create_task(
+            conn,
+            title=f"Review blocked task {original}",
+            assignee="reviewer",
+        )
+        kb.claim_task(conn, review)
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="Reviewed PR #65 and approved it",
+            metadata={"approved": True, "reviewed_task": original},
+            expected_run_id=kb.get_task(conn, review).current_run_id,
+        )
+
+        closure = kb.create_task(
+            conn,
+            title=f"Close approved PR for reviewed task {original}",
+            assignee="coder",
+        )
+        kb.claim_task(conn, closure)
+
+        result = kb.reconcile_post_review_closure(
+            conn,
+            original_task_id=original,
+            review_task_id=review,
+            closure_task_id=closure,
+            evidence={
+                "review_approved": True,
+                "pr_merged": True,
+                "pr_number": 65,
+                "merge_commit": "37deeb369a50b6b3769b0f93dceaf5f4023a242a",
+                "checks_passed": True,
+            },
+        )
+
+        assert result["ok"] is True
+        assert result["reconciled"] is True
+        assert result["closure_completed"] is True
+        assert kb.get_task(conn, original).status == "done"
+        assert kb.get_task(conn, closure).status == "done"
+
+        original_run = kb.latest_run(conn, original)
+        closure_run = kb.latest_run(conn, closure)
+        assert original_run.outcome == "completed"
+        assert original_run.metadata["post_review_reconciled"] is True
+        assert original_run.metadata["review_task"] == review
+        assert original_run.metadata["closure_task"] == closure
+        assert closure_run.outcome == "completed"
+        assert closure_run.metadata["original_task_reconciled"] is True
+
+        original_event_kinds = [e.kind for e in kb.list_events(conn, original)]
+        closure_event_kinds = [e.kind for e in kb.list_events(conn, closure)]
+        assert "post_review_reconcile_requested" in original_event_kinds
+        assert "post_review_reconcile_requested" in closure_event_kinds
+
+
+def test_post_review_reconciliation_fails_closed_without_merged_pr_evidence(kanban_home):
+    with kb.connect() as conn:
+        original = kb.create_task(conn, title="implementation", assignee="coder")
+        review = kb.create_task(conn, title="review", assignee="reviewer")
+        kb.claim_task(conn, review)
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="approved",
+            metadata={"approved": True, "reviewed_task": original},
+            expected_run_id=kb.get_task(conn, review).current_run_id,
+        )
+        closure = kb.create_task(conn, title="closure", assignee="coder")
+
+        with pytest.raises(ValueError, match="pr_merged=true"):
+            kb.reconcile_post_review_closure(
+                conn,
+                original_task_id=original,
+                review_task_id=review,
+                closure_task_id=closure,
+                evidence={"review_approved": True, "pr_merged": False},
+            )
+
+        assert kb.get_task(conn, original).status == "ready"
+
+
+def test_post_review_reconciliation_closes_closure_when_original_already_done(kanban_home):
+    """If the original was already operator-reconciled, closure still ends."""
+    with kb.connect() as conn:
+        original = kb.create_task(conn, title="implementation", assignee="coder")
+        assert kb.complete_task(conn, original, summary="already reconciled")
+        review = kb.create_task(conn, title="review", assignee="reviewer")
+        kb.claim_task(conn, review)
+        assert kb.complete_task(
+            conn,
+            review,
+            summary="approved",
+            metadata={"approved": True, "reviewed_task": original},
+            expected_run_id=kb.get_task(conn, review).current_run_id,
+        )
+        closure = kb.create_task(conn, title="closure", assignee="coder")
+        kb.claim_task(conn, closure)
+
+        result = kb.reconcile_post_review_closure(
+            conn,
+            original_task_id=original,
+            review_task_id=review,
+            closure_task_id=closure,
+            evidence={"review_approved": True, "pr_merged": True, "pr_number": 65},
+        )
+
+        assert result["reconciled"] is False
+        assert result["reason"] == "original_already_done"
+        assert result["closure_completed"] is True
+        assert kb.get_task(conn, closure).status == "done"
+        assert kb.latest_run(conn, closure).metadata["reason"] == "original_already_done"
+
+
 def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     """Legacy DBs missing additive indexed columns must migrate cleanly.
 


### PR DESCRIPTION
## Summary
- Add an evidence-gated `reconcile_post_review_closure` DB helper for approved+merged post-review lanes.
- Add `hermes kanban reconcile-post-review` as a privileged unscoped runner/orchestrator CLI path; dispatcher-scoped workers cannot use it unless trusted runner code explicitly opts in.
- Document the closure protocol in the bundled kanban-worker skill.

## Validation
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q -o 'addopts='` (298 passed, 1 warning)
- `python -m compileall -q hermes_cli/kanban.py hermes_cli/kanban_db.py`
- Read-only lineage check for web-archive tasks t_38969b18 / t_357a83e4 / t_be51753e confirmed original/review/closure done, approved metadata, and PR #65 merged summary evidence.

## Safety
- Keeps existing worker cross-task mutation guard intact.
- New reconciliation path requires explicit `review_approved=true` and `pr_merged=true` evidence plus completed reviewer metadata `approved=true` for the original task.
