### PR TITLE
fix(auth): recover codex tokens from sibling profile stores (#6653)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -714,6 +714,9 @@ class CredentialPool:
             recovered = auth_mod._recover_codex_tokens_from_shared_sources(
                 current_auth_store=auth_store,
                 include_current=False,
+                sibling_pool_entry_id=entry.id,
+                sibling_pool_entry_source=entry.source,
+                sibling_last_refresh=entry.last_refresh,
             )
             if not isinstance(recovered, dict):
                 return entry

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -685,7 +685,8 @@ class CredentialPool:
             # another process means our entry's pair is consumed/stale.
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
-            if store_access and (
+            store_access_valid = bool(store_access) and not _codex_access_token_is_expiring(store_access, 0)
+            if store_access_valid and (
                 store_access != entry_access
                 or (store_refresh and store_refresh != entry_refresh)
             ):
@@ -706,6 +707,42 @@ class CredentialPool:
                 }
                 if state.get("last_refresh"):
                     field_updates["last_refresh"] = state["last_refresh"]
+                updated = replace(entry, **field_updates)
+                self._replace_entry(entry, updated)
+                self._persist()
+                return updated
+            recovered = auth_mod._recover_codex_tokens_from_shared_sources(
+                current_auth_store=auth_store,
+                include_current=False,
+            )
+            if not isinstance(recovered, dict):
+                return entry
+            recovered_tokens = recovered.get("tokens")
+            if not isinstance(recovered_tokens, dict):
+                return entry
+            recovered_access = recovered_tokens.get("access_token", "")
+            recovered_refresh = recovered_tokens.get("refresh_token", "")
+            if recovered_access and (
+                recovered_access != entry_access
+                or (recovered_refresh and recovered_refresh != entry_refresh)
+            ):
+                logger.debug(
+                    "Pool entry %s: syncing Codex tokens from recovered %s source",
+                    entry.id,
+                    recovered.get("source") or "shared",
+                )
+                field_updates = {
+                    "access_token": recovered_access,
+                    "refresh_token": recovered_refresh or entry.refresh_token,
+                    "last_status": None,
+                    "last_status_at": None,
+                    "last_error_code": None,
+                    "last_error_reason": None,
+                    "last_error_message": None,
+                    "last_error_reset_at": None,
+                }
+                if recovered.get("last_refresh"):
+                    field_updates["last_refresh"] = recovered["last_refresh"]
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
                 self._persist()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3179,6 +3179,14 @@ class _CodexTokenCandidate:
     last_refresh_ts: Optional[float]
 
 
+@dataclass(frozen=True)
+class _CodexSiblingRecoveryAnchor:
+    id: str
+    source: str
+    last_refresh: str
+    last_refresh_ts: float
+
+
 def _parse_codex_last_refresh(value: Any) -> Optional[float]:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -3283,6 +3291,88 @@ def _append_codex_candidates_from_store(
         ))
 
 
+def _codex_sibling_recovery_anchor(
+    *,
+    entry_id: Any,
+    entry_source: Any,
+    last_refresh: Any,
+) -> Optional[_CodexSiblingRecoveryAnchor]:
+    source = str(entry_source or "").strip()
+    anchor_id = str(entry_id or "").strip()
+    if not anchor_id or source != "device_code":
+        return None
+    last_refresh_ts = _parse_codex_last_refresh(last_refresh)
+    if last_refresh_ts is None:
+        return None
+    return _CodexSiblingRecoveryAnchor(
+        id=anchor_id,
+        source=source,
+        last_refresh=str(last_refresh).strip(),
+        last_refresh_ts=last_refresh_ts,
+    )
+
+
+def _codex_sibling_recovery_anchor_from_store(
+    auth_store: Dict[str, Any]
+) -> Optional[_CodexSiblingRecoveryAnchor]:
+    pool = auth_store.get("credential_pool")
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        anchor = _codex_sibling_recovery_anchor(
+            entry_id=entry.get("id"),
+            entry_source=entry.get("source"),
+            last_refresh=entry.get("last_refresh"),
+        )
+        if anchor is not None:
+            return anchor
+    return None
+
+
+def _append_matching_sibling_codex_candidate(
+    candidates: List[_CodexTokenCandidate],
+    auth_store: Dict[str, Any],
+    *,
+    profile_name: str,
+    source_rank: int,
+    refresh_skew_seconds: float,
+    anchor: _CodexSiblingRecoveryAnchor,
+) -> None:
+    pool = auth_store.get("credential_pool")
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("id") or "").strip() != anchor.id:
+            continue
+        if str(entry.get("source") or "").strip() != anchor.source:
+            continue
+        last_refresh = entry.get("last_refresh")
+        last_refresh_ts = _parse_codex_last_refresh(last_refresh)
+        if last_refresh_ts is None or last_refresh_ts <= anchor.last_refresh_ts:
+            return
+        tokens = _valid_codex_token_pair(
+            entry,
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+        if tokens is None:
+            return
+        candidates.append(_CodexTokenCandidate(
+            tokens=tokens,
+            last_refresh=last_refresh if isinstance(last_refresh, str) else None,
+            source=f"sibling:{profile_name}:pool:{anchor.source}",
+            source_rank=source_rank,
+            source_order=len(candidates),
+            last_refresh_ts=last_refresh_ts,
+        ))
+        return
+
+
 def _read_auth_store_readonly(auth_path: Path) -> Dict[str, Any]:
     try:
         raw = json.loads(auth_path.read_text(encoding="utf-8"))
@@ -3353,14 +3443,25 @@ def _find_codex_token_candidate(
     include_current: bool = True,
     include_codex_cli: bool = True,
     refresh_skew_seconds: float = 0,
+    sibling_pool_entry_id: Optional[str] = None,
+    sibling_pool_entry_source: Optional[str] = None,
+    sibling_last_refresh: Optional[str] = None,
 ) -> Optional[_CodexTokenCandidate]:
     """Find a valid Codex token pair without mutating any source store."""
+    current_store: Optional[Dict[str, Any]] = current_auth_store
+    if current_store is None and (
+        include_current
+        or sibling_pool_entry_id is None
+        or sibling_pool_entry_source is None
+        or sibling_last_refresh is None
+    ):
+        current_store = _load_auth_store()
+
     current_candidates: List[_CodexTokenCandidate] = []
     if include_current:
-        current_store = current_auth_store if current_auth_store is not None else _load_auth_store()
         _append_codex_candidates_from_store(
             current_candidates,
-            current_store,
+            current_store or {},
             source_prefix="current",
             source_rank=0,
             refresh_skew_seconds=refresh_skew_seconds,
@@ -3380,14 +3481,23 @@ def _find_codex_token_candidate(
             refresh_skew_seconds=refresh_skew_seconds,
         )
 
-    for index, (profile_name, store) in enumerate(_iter_sibling_codex_auth_stores()):
-        _append_codex_candidates_from_store(
-            candidates,
-            store,
-            source_prefix=f"sibling:{profile_name}",
-            source_rank=100 + (index * 10),
-            refresh_skew_seconds=refresh_skew_seconds,
-        )
+    sibling_anchor = _codex_sibling_recovery_anchor(
+        entry_id=sibling_pool_entry_id,
+        entry_source=sibling_pool_entry_source,
+        last_refresh=sibling_last_refresh,
+    )
+    if sibling_anchor is None and current_store is not None:
+        sibling_anchor = _codex_sibling_recovery_anchor_from_store(current_store)
+    if sibling_anchor is not None:
+        for index, (profile_name, store) in enumerate(_iter_sibling_codex_auth_stores()):
+            _append_matching_sibling_codex_candidate(
+                candidates,
+                store,
+                profile_name=profile_name,
+                source_rank=100 + (index * 10),
+                refresh_skew_seconds=refresh_skew_seconds,
+                anchor=sibling_anchor,
+            )
 
     if include_codex_cli:
         cli_tokens = _import_codex_cli_tokens()
@@ -3414,11 +3524,17 @@ def _recover_codex_tokens_from_shared_sources(
     current_auth_store: Optional[Dict[str, Any]] = None,
     include_current: bool = True,
     refresh_skew_seconds: float = 0,
+    sibling_pool_entry_id: Optional[str] = None,
+    sibling_pool_entry_source: Optional[str] = None,
+    sibling_last_refresh: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     candidate = _find_codex_token_candidate(
         current_auth_store=current_auth_store,
         include_current=include_current,
         refresh_skew_seconds=refresh_skew_seconds,
+        sibling_pool_entry_id=sibling_pool_entry_id,
+        sibling_pool_entry_source=sibling_pool_entry_source,
+        sibling_last_refresh=sibling_last_refresh,
     )
     if candidate is None:
         return None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3166,6 +3166,279 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+_CODEX_POOL_RECOVERY_SOURCES = frozenset({"device_code", "manual:device_code"})
+
+
+@dataclass(frozen=True)
+class _CodexTokenCandidate:
+    tokens: Dict[str, str]
+    last_refresh: Optional[str]
+    source: str
+    source_rank: int
+    source_order: int
+    last_refresh_ts: Optional[float]
+
+
+def _parse_codex_last_refresh(value: Any) -> Optional[float]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _valid_codex_token_pair(
+    tokens: Any,
+    *,
+    refresh_skew_seconds: float = 0,
+) -> Optional[Dict[str, str]]:
+    if not isinstance(tokens, dict):
+        return None
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return None
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        return None
+    access_token = access_token.strip()
+    refresh_token = refresh_token.strip()
+    if _codex_access_token_is_expiring(access_token, refresh_skew_seconds):
+        return None
+    candidate = {
+        key: tokens[key]
+        for key in ("access_token", "refresh_token", "id_token")
+        if key in tokens
+    }
+    candidate["access_token"] = access_token
+    candidate["refresh_token"] = refresh_token
+    return candidate
+
+
+def _codex_provider_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    providers = auth_store.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    state = providers.get("openai-codex")
+    if isinstance(state, dict):
+        return dict(state)
+    return None
+
+
+def _append_codex_candidates_from_store(
+    candidates: List[_CodexTokenCandidate],
+    auth_store: Dict[str, Any],
+    *,
+    source_prefix: str,
+    source_rank: int,
+    refresh_skew_seconds: float = 0,
+) -> None:
+    state = _codex_provider_state_from_store(auth_store)
+    if isinstance(state, dict):
+        tokens = _valid_codex_token_pair(
+            state.get("tokens"),
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+        if tokens is not None:
+            last_refresh = state.get("last_refresh")
+            candidates.append(_CodexTokenCandidate(
+                tokens=tokens,
+                last_refresh=last_refresh if isinstance(last_refresh, str) else None,
+                source=f"{source_prefix}:provider",
+                source_rank=source_rank,
+                source_order=len(candidates),
+                last_refresh_ts=_parse_codex_last_refresh(last_refresh),
+            ))
+
+    pool = auth_store.get("credential_pool")
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(entries, list):
+        return
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        source = str(entry.get("source") or "").strip()
+        if source and source not in _CODEX_POOL_RECOVERY_SOURCES:
+            continue
+        tokens = _valid_codex_token_pair(
+            entry,
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+        if tokens is None:
+            continue
+        last_refresh = entry.get("last_refresh")
+        candidates.append(_CodexTokenCandidate(
+            tokens=tokens,
+            last_refresh=last_refresh if isinstance(last_refresh, str) else None,
+            source=f"{source_prefix}:pool:{source or idx}",
+            source_rank=source_rank + 1,
+            source_order=len(candidates),
+            last_refresh_ts=_parse_codex_last_refresh(last_refresh),
+        ))
+
+
+def _read_auth_store_readonly(auth_path: Path) -> Dict[str, Any]:
+    try:
+        raw = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    raw.setdefault("providers", {})
+    return raw
+
+
+def _iter_sibling_codex_auth_stores() -> List[Tuple[str, Dict[str, Any]]]:
+    try:
+        from hermes_constants import get_default_hermes_root
+        root = get_default_hermes_root()
+    except Exception:
+        return []
+
+    profiles_dir = root / "profiles"
+    if not profiles_dir.is_dir():
+        return []
+
+    active_auth_path = _auth_file_path()
+    stores: List[Tuple[str, Dict[str, Any]]] = []
+    try:
+        profile_dirs = sorted(
+            (p for p in profiles_dir.iterdir() if p.is_dir()),
+            key=lambda p: (p.name.casefold(), str(p)),
+        )
+    except Exception:
+        return []
+
+    for profile_dir in profile_dirs:
+        auth_path = profile_dir / "auth.json"
+        if not auth_path.is_file():
+            continue
+        try:
+            if auth_path.resolve(strict=False) == active_auth_path.resolve(strict=False):
+                continue
+        except Exception:
+            if auth_path == active_auth_path:
+                continue
+        store = _read_auth_store_readonly(auth_path)
+        if store:
+            stores.append((profile_dir.name, store))
+    return stores
+
+
+def _choose_codex_candidate(candidates: List[_CodexTokenCandidate]) -> Optional[_CodexTokenCandidate]:
+    if not candidates:
+        return None
+    timestamped = [candidate for candidate in candidates if candidate.last_refresh_ts is not None]
+    if timestamped:
+        return max(
+            timestamped,
+            key=lambda candidate: (
+                candidate.last_refresh_ts or 0.0,
+                -candidate.source_rank,
+                -candidate.source_order,
+            ),
+        )
+    return min(candidates, key=lambda candidate: (candidate.source_rank, candidate.source_order))
+
+
+def _find_codex_token_candidate(
+    *,
+    current_auth_store: Optional[Dict[str, Any]] = None,
+    include_current: bool = True,
+    include_codex_cli: bool = True,
+    refresh_skew_seconds: float = 0,
+) -> Optional[_CodexTokenCandidate]:
+    """Find a valid Codex token pair without mutating any source store."""
+    current_candidates: List[_CodexTokenCandidate] = []
+    if include_current:
+        current_store = current_auth_store if current_auth_store is not None else _load_auth_store()
+        _append_codex_candidates_from_store(
+            current_candidates,
+            current_store,
+            source_prefix="current",
+            source_rank=0,
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+        current = _choose_codex_candidate(current_candidates)
+        if current is not None:
+            return current
+
+    candidates: List[_CodexTokenCandidate] = []
+    global_store = _load_global_auth_store()
+    if global_store:
+        _append_codex_candidates_from_store(
+            candidates,
+            global_store,
+            source_prefix="global",
+            source_rank=10,
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+
+    for index, (profile_name, store) in enumerate(_iter_sibling_codex_auth_stores()):
+        _append_codex_candidates_from_store(
+            candidates,
+            store,
+            source_prefix=f"sibling:{profile_name}",
+            source_rank=100 + (index * 10),
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+
+    if include_codex_cli:
+        cli_tokens = _import_codex_cli_tokens()
+        if cli_tokens:
+            tokens = _valid_codex_token_pair(
+                cli_tokens,
+                refresh_skew_seconds=refresh_skew_seconds,
+            )
+            if tokens is not None:
+                candidates.append(_CodexTokenCandidate(
+                    tokens=tokens,
+                    last_refresh=None,
+                    source="codex-cli",
+                    source_rank=100000,
+                    source_order=len(candidates),
+                    last_refresh_ts=None,
+                ))
+
+    return _choose_codex_candidate(candidates)
+
+
+def _recover_codex_tokens_from_shared_sources(
+    *,
+    current_auth_store: Optional[Dict[str, Any]] = None,
+    include_current: bool = True,
+    refresh_skew_seconds: float = 0,
+) -> Optional[Dict[str, Any]]:
+    candidate = _find_codex_token_candidate(
+        current_auth_store=current_auth_store,
+        include_current=include_current,
+        refresh_skew_seconds=refresh_skew_seconds,
+    )
+    if candidate is None:
+        return None
+    _save_codex_tokens(candidate.tokens, last_refresh=candidate.last_refresh)
+    return {
+        "tokens": dict(candidate.tokens),
+        "last_refresh": candidate.last_refresh,
+        "source": candidate.source,
+    }
+
+
+def _raise_codex_auth_error(message: str, *, code: str) -> None:
+    raise AuthError(
+        message,
+        provider="openai-codex",
+        code=code,
+        relogin_required=True,
+    )
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
@@ -3177,37 +3450,53 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
             auth_store = _load_auth_store()
     else:
         auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+    state = _codex_provider_state_from_store(auth_store)
     if not state:
-        raise AuthError(
+        recovered = _recover_codex_tokens_from_shared_sources(
+            current_auth_store=auth_store,
+            include_current=False,
+        )
+        if recovered is not None:
+            return {"tokens": recovered["tokens"], "last_refresh": recovered.get("last_refresh")}
+        _raise_codex_auth_error(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
-            provider="openai-codex",
             code="codex_auth_missing",
-            relogin_required=True,
         )
     tokens = state.get("tokens")
     if not isinstance(tokens, dict):
-        raise AuthError(
+        recovered = _recover_codex_tokens_from_shared_sources(
+            current_auth_store=auth_store,
+            include_current=False,
+        )
+        if recovered is not None:
+            return {"tokens": recovered["tokens"], "last_refresh": recovered.get("last_refresh")}
+        _raise_codex_auth_error(
             "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
             code="codex_auth_invalid_shape",
-            relogin_required=True,
         )
     access_token = tokens.get("access_token")
     refresh_token = tokens.get("refresh_token")
     if not isinstance(access_token, str) or not access_token.strip():
-        raise AuthError(
+        recovered = _recover_codex_tokens_from_shared_sources(
+            current_auth_store=auth_store,
+            include_current=False,
+        )
+        if recovered is not None:
+            return {"tokens": recovered["tokens"], "last_refresh": recovered.get("last_refresh")}
+        _raise_codex_auth_error(
             "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
             code="codex_auth_missing_access_token",
-            relogin_required=True,
         )
     if not isinstance(refresh_token, str) or not refresh_token.strip():
-        raise AuthError(
+        recovered = _recover_codex_tokens_from_shared_sources(
+            current_auth_store=auth_store,
+            include_current=False,
+        )
+        if recovered is not None:
+            return {"tokens": recovered["tokens"], "last_refresh": recovered.get("last_refresh")}
+        _raise_codex_auth_error(
             "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
             code="codex_auth_missing_refresh_token",
-            relogin_required=True,
         )
     return {
         "tokens": tokens,
@@ -3670,7 +3959,36 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                recovered = None
+                if not force_refresh:
+                    recovered = _recover_codex_tokens_from_shared_sources(
+                        current_auth_store=_load_auth_store(),
+                        include_current=True,
+                        refresh_skew_seconds=refresh_skew_seconds,
+                    )
+                if recovered is not None:
+                    data = {
+                        "tokens": recovered["tokens"],
+                        "last_refresh": recovered.get("last_refresh"),
+                    }
+                    tokens = dict(data["tokens"])
+                else:
+                    try:
+                        tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                    except AuthError as exc:
+                        if not _is_terminal_codex_oauth_refresh_error(exc):
+                            raise
+                        recovered = _recover_codex_tokens_from_shared_sources(
+                            current_auth_store=_load_auth_store(),
+                            include_current=False,
+                        )
+                        if recovered is None:
+                            raise
+                        data = {
+                            "tokens": recovered["tokens"],
+                            "last_refresh": recovered.get("last_refresh"),
+                        }
+                        tokens = dict(data["tokens"])
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
@@ -3776,9 +4094,21 @@ def _pool_codex_access_token() -> str:
             auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
+            recovered = _recover_codex_tokens_from_shared_sources(
+                current_auth_store=auth_store,
+                include_current=False,
+            )
+            if recovered is not None:
+                return str(recovered["tokens"].get("access_token", "")).strip()
             return ""
         entries = pool.get("openai-codex")
         if not isinstance(entries, list):
+            recovered = _recover_codex_tokens_from_shared_sources(
+                current_auth_store=auth_store,
+                include_current=False,
+            )
+            if recovered is not None:
+                return str(recovered["tokens"].get("access_token", "")).strip()
             return ""
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
@@ -3796,6 +4126,12 @@ def _pool_codex_access_token() -> str:
         for entry in entries:
             if _entry_usable(entry):
                 return str(entry.get("access_token", "")).strip()
+        recovered = _recover_codex_tokens_from_shared_sources(
+            current_auth_store=auth_store,
+            include_current=False,
+        )
+        if recovered is not None:
+            return str(recovered["tokens"].get("access_token", "")).strip()
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2654,6 +2654,26 @@ def _codex_auth_store(
     }
 
 
+def _codex_pool_entry(
+    *,
+    entry_id: str,
+    access_token: str,
+    refresh_token: str,
+    last_refresh: str,
+    source: str = "device_code",
+) -> dict:
+    return {
+        "id": entry_id,
+        "label": source,
+        "source": source,
+        "auth_type": "oauth",
+        "priority": 0,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "last_refresh": last_refresh,
+    }
+
+
 def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypatch):
     """When auth.json has newer Codex tokens, the pool entry should adopt them."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -2791,13 +2811,34 @@ def test_sync_codex_entry_from_auth_store_adopts_sibling_tokens_and_clears_statu
     sibling.mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(active))
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    copied_id = "copied-device"
 
     (active / "auth.json").write_text(json.dumps(
-        _codex_auth_store("access-OLD", "refresh-OLD", "2026-01-01T00:00:00Z"),
+        _codex_auth_store(
+            "access-OLD",
+            "refresh-OLD",
+            "2026-01-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id=copied_id,
+                access_token="access-OLD",
+                refresh_token="refresh-OLD",
+                last_refresh="2026-01-01T00:00:00Z",
+            )],
+        ),
         indent=2,
     ))
     (sibling / "auth.json").write_text(json.dumps(
-        _codex_auth_store("access-FRESH", "refresh-FRESH", "2026-05-01T00:00:00Z"),
+        _codex_auth_store(
+            "access-FRESH",
+            "refresh-FRESH",
+            "2026-05-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id=copied_id,
+                access_token="access-FRESH",
+                refresh_token="refresh-FRESH",
+                last_refresh="2026-05-01T00:00:00Z",
+            )],
+        ),
         indent=2,
     ))
 
@@ -2828,6 +2869,135 @@ def test_sync_codex_entry_from_auth_store_adopts_sibling_tokens_and_clears_statu
     assert synced.last_error_reset_at is None
     active_auth = json.loads((active / "auth.json").read_text())
     assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-FRESH"
+
+
+def test_sync_codex_entry_from_auth_store_ignores_unrelated_sibling_tokens(tmp_path, monkeypatch):
+    """Sibling recovery must not adopt a different copied-entry lineage."""
+    from dataclasses import replace as dc_replace
+    from agent.credential_pool import load_pool, STATUS_DEAD
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    active = root / "profiles" / "coder"
+    sibling = root / "profiles" / "writer"
+    active.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+
+    (active / "auth.json").write_text(json.dumps(
+        _codex_auth_store(
+            "access-OLD",
+            "refresh-OLD",
+            "2026-01-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id="active-device",
+                access_token="access-OLD",
+                refresh_token="refresh-OLD",
+                last_refresh="2026-01-01T00:00:00Z",
+            )],
+        ),
+        indent=2,
+    ))
+    (sibling / "auth.json").write_text(json.dumps(
+        _codex_auth_store(
+            "access-FRESH",
+            "refresh-FRESH",
+            "2026-05-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id="other-device",
+                access_token="access-FRESH",
+                refresh_token="refresh-FRESH",
+                last_refresh="2026-05-01T00:00:00Z",
+            )],
+        ),
+        indent=2,
+    ))
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    stale = dc_replace(
+        entry,
+        last_status=STATUS_DEAD,
+        last_error_code=401,
+        last_error_reason="refresh_token_reused",
+        last_error_message="token reused",
+        last_error_reset_at=time.time() + 3600,
+    )
+    pool._replace_entry(entry, stale)
+    pool._persist()
+
+    synced = pool._sync_codex_entry_from_auth_store(stale)
+
+    assert synced is stale
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-OLD"
+
+
+def test_sync_codex_entry_from_auth_store_requires_strictly_newer_sibling_rotation(tmp_path, monkeypatch):
+    """Sibling recovery ignores matching copies when the recorded rotation is not newer."""
+    from dataclasses import replace as dc_replace
+    from agent.credential_pool import load_pool, STATUS_DEAD
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    active = root / "profiles" / "coder"
+    sibling = root / "profiles" / "writer"
+    active.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    copied_id = "copied-device"
+
+    (active / "auth.json").write_text(json.dumps(
+        _codex_auth_store(
+            "access-OLD",
+            "refresh-OLD",
+            "2026-05-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id=copied_id,
+                access_token="access-OLD",
+                refresh_token="refresh-OLD",
+                last_refresh="2026-05-01T00:00:00Z",
+            )],
+        ),
+        indent=2,
+    ))
+    (sibling / "auth.json").write_text(json.dumps(
+        _codex_auth_store(
+            "access-FRESH",
+            "refresh-FRESH",
+            "2026-05-01T00:00:00Z",
+            pool_entries=[_codex_pool_entry(
+                entry_id=copied_id,
+                access_token="access-FRESH",
+                refresh_token="refresh-FRESH",
+                last_refresh="2026-05-01T00:00:00Z",
+            )],
+        ),
+        indent=2,
+    ))
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    stale = dc_replace(
+        entry,
+        last_status=STATUS_DEAD,
+        last_error_code=401,
+        last_error_reason="refresh_token_reused",
+        last_error_message="token reused",
+        last_error_reset_at=time.time() + 3600,
+    )
+    pool._replace_entry(entry, stale)
+    pool._persist()
+
+    synced = pool._sync_codex_entry_from_auth_store(stale)
+
+    assert synced is stale
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-OLD"
 
 
 # ---------------------------------------------------------------------------
@@ -2977,22 +3147,28 @@ def _codex_auth_store(
     access_token: str,
     refresh_token: str,
     last_refresh: str | None = None,
+    *,
+    pool_entries: list[dict] | None = None,
 ) -> dict:
     state = {
         "tokens": {
             "access_token": access_token,
             "refresh_token": refresh_token,
+            "id_token": "id-" + access_token,
         },
     }
     if last_refresh is not None:
         state["last_refresh"] = last_refresh
-    return {
+    auth_store = {
         "version": 1,
         "active_provider": "openai-codex",
         "providers": {
             "openai-codex": state
         },
     }
+    if pool_entries is not None:
+        auth_store["credential_pool"] = {"openai-codex": pool_entries}
+    return auth_store
 
 
 def test_is_terminal_codex_oauth_refresh_error():

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -742,6 +743,7 @@ def test_dead_singleton_seeded_entry_not_pruned(tmp_path, monkeypatch):
     with the DEAD marker so the user knows what's broken.
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     long_ago = time.time() - (48 * 3600)
     _write_auth_store(
         tmp_path,
@@ -2630,7 +2632,11 @@ def test_nous_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch
 
 # ── OpenAI Codex OAuth cross-process sync tests ────────────────────────────
 
-def _codex_auth_store(access: str, refresh: str) -> dict:
+def _codex_auth_store(
+    access: str,
+    refresh: str,
+    last_refresh: str = "2026-04-28T00:00:00Z",
+) -> dict:
     return {
         "version": 1,
         "active_provider": "openai-codex",
@@ -2642,7 +2648,7 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
                     "refresh_token": refresh,
                     "id_token": "id-" + access,
                 },
-                "last_refresh": "2026-04-28T00:00:00Z",
+                "last_refresh": last_refresh,
             }
         },
     }
@@ -2651,6 +2657,7 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
 def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypatch):
     """When auth.json has newer Codex tokens, the pool entry should adopt them."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
 
     from agent.credential_pool import load_pool
@@ -2676,6 +2683,7 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
 def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
     """When auth.json has the same tokens, sync should be a no-op."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
 
     from agent.credential_pool import load_pool
@@ -2698,6 +2706,7 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     request failed with "no available entries (all exhausted or empty)".
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
@@ -2740,8 +2749,9 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
 def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, monkeypatch):
     """Regression guard: if auth.json tokens haven't changed, the exhausted
     entry must stay stuck behind its reset window — sync must not spuriously
-    clear status just because the entry is STATUS_EXHAUSTED."""
+        clear status just because the entry is STATUS_EXHAUSTED."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
@@ -2766,6 +2776,58 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+def test_sync_codex_entry_from_auth_store_adopts_sibling_tokens_and_clears_status(tmp_path, monkeypatch):
+    """A stale device_code entry can recover from a sibling profile auth store."""
+    from dataclasses import replace as dc_replace
+    from agent.credential_pool import load_pool, STATUS_DEAD
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    active = root / "profiles" / "coder"
+    sibling = root / "profiles" / "writer"
+    active.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+
+    (active / "auth.json").write_text(json.dumps(
+        _codex_auth_store("access-OLD", "refresh-OLD", "2026-01-01T00:00:00Z"),
+        indent=2,
+    ))
+    (sibling / "auth.json").write_text(json.dumps(
+        _codex_auth_store("access-FRESH", "refresh-FRESH", "2026-05-01T00:00:00Z"),
+        indent=2,
+    ))
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    stale = dc_replace(
+        entry,
+        last_status=STATUS_DEAD,
+        last_error_code=401,
+        last_error_reason="refresh_token_reused",
+        last_error_message="token reused",
+        last_error_reset_at=time.time() + 3600,
+    )
+    pool._replace_entry(entry, stale)
+    pool._persist()
+
+    synced = pool._sync_codex_entry_from_auth_store(stale)
+
+    assert synced is not stale
+    assert synced.access_token == "access-FRESH"
+    assert synced.refresh_token == "refresh-FRESH"
+    assert synced.last_refresh == "2026-05-01T00:00:00Z"
+    assert synced.last_status is None
+    assert synced.last_error_code is None
+    assert synced.last_error_reason is None
+    assert synced.last_error_message is None
+    assert synced.last_error_reset_at is None
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-FRESH"
 
 
 # ---------------------------------------------------------------------------
@@ -2911,17 +2973,24 @@ def test_xai_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch
 # ---------------------------------------------------------------------------
 
 
-def _codex_auth_store(access_token: str, refresh_token: str) -> dict:
+def _codex_auth_store(
+    access_token: str,
+    refresh_token: str,
+    last_refresh: str | None = None,
+) -> dict:
+    state = {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+    }
+    if last_refresh is not None:
+        state["last_refresh"] = last_refresh
     return {
         "version": 1,
         "active_provider": "openai-codex",
         "providers": {
-            "openai-codex": {
-                "tokens": {
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                },
-            }
+            "openai-codex": state
         },
     }
 
@@ -2957,6 +3026,7 @@ def test_codex_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
 
@@ -3016,6 +3086,7 @@ def test_codex_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
 
 def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -66,9 +66,9 @@ def _write_codex_profile_auth(
     access_token: str,
     refresh_token: str,
     last_refresh: str,
+    pool_entries: list[dict] | None = None,
 ) -> None:
-    auth_dir.mkdir(parents=True, exist_ok=True)
-    (auth_dir / "auth.json").write_text(json.dumps({
+    auth_store = {
         "version": 1,
         "providers": {
             "openai-codex": {
@@ -80,7 +80,31 @@ def _write_codex_profile_auth(
                 "auth_mode": "chatgpt",
             },
         },
-    }, indent=2))
+    }
+    if pool_entries is not None:
+        auth_store["credential_pool"] = {"openai-codex": pool_entries}
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    (auth_dir / "auth.json").write_text(json.dumps(auth_store, indent=2))
+
+
+def _codex_pool_entry(
+    *,
+    entry_id: str,
+    access_token: str,
+    refresh_token: str,
+    last_refresh: str,
+    source: str = "device_code",
+) -> dict:
+    return {
+        "id": entry_id,
+        "label": source,
+        "source": source,
+        "auth_type": "oauth",
+        "priority": 0,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "last_refresh": last_refresh,
+    }
 
 
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
@@ -141,6 +165,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
 def test_resolve_codex_runtime_credentials_recovers_stale_current_from_fresher_sibling(tmp_path, monkeypatch):
     root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    copied_id = "copied-device"
     expired_current = _jwt_with_exp(int(time.time()) - 10)
     older_sibling = _jwt_with_exp(int(time.time()) + 1800)
     fresher_sibling = _jwt_with_exp(int(time.time()) + 3600)
@@ -150,18 +175,36 @@ def test_resolve_codex_runtime_credentials_recovers_stale_current_from_fresher_s
         access_token=expired_current,
         refresh_token="refresh-stale",
         last_refresh="2026-01-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id=copied_id,
+            access_token=expired_current,
+            refresh_token="refresh-stale",
+            last_refresh="2026-01-01T00:00:00Z",
+        )],
     )
     _write_codex_profile_auth(
         root / "profiles" / "alpha",
         access_token=older_sibling,
         refresh_token="refresh-older",
         last_refresh="2026-02-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id="other-device",
+            access_token=older_sibling,
+            refresh_token="refresh-older",
+            last_refresh="2026-02-01T00:00:00Z",
+        )],
     )
     _write_codex_profile_auth(
         root / "profiles" / "writer",
         access_token=fresher_sibling,
         refresh_token="refresh-fresher",
         last_refresh="2026-05-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id=copied_id,
+            access_token=fresher_sibling,
+            refresh_token="refresh-fresher",
+            last_refresh="2026-05-01T00:00:00Z",
+        )],
     )
 
     monkeypatch.setattr(
@@ -178,6 +221,7 @@ def test_resolve_codex_runtime_credentials_recovers_stale_current_from_fresher_s
 
 def test_resolve_codex_runtime_credentials_does_not_reuse_current_token_inside_refresh_skew(tmp_path, monkeypatch):
     root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    copied_id = "copied-device"
     now = int(time.time())
     soon_expiring_current = _jwt_with_exp(now + 60)
     sibling_token = _jwt_with_exp(now + 3600)
@@ -187,12 +231,24 @@ def test_resolve_codex_runtime_credentials_does_not_reuse_current_token_inside_r
         access_token=soon_expiring_current,
         refresh_token="refresh-soon",
         last_refresh="2026-01-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id=copied_id,
+            access_token=soon_expiring_current,
+            refresh_token="refresh-soon",
+            last_refresh="2026-01-01T00:00:00Z",
+        )],
     )
     _write_codex_profile_auth(
         root / "profiles" / "writer",
         access_token=sibling_token,
         refresh_token="refresh-sibling",
         last_refresh="2026-05-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id=copied_id,
+            access_token=sibling_token,
+            refresh_token="refresh-sibling",
+            last_refresh="2026-05-01T00:00:00Z",
+        )],
     )
 
     monkeypatch.setattr(
@@ -205,6 +261,53 @@ def test_resolve_codex_runtime_credentials_does_not_reuse_current_token_inside_r
     assert resolved["api_key"] == sibling_token
     active_auth = json.loads((active / "auth.json").read_text())
     assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-sibling"
+
+
+def test_resolve_codex_runtime_credentials_does_not_adopt_unrelated_sibling_account(tmp_path, monkeypatch):
+    root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    now = int(time.time())
+    soon_expiring_current = _jwt_with_exp(now + 60)
+    sibling_token = _jwt_with_exp(now + 3600)
+
+    _write_codex_profile_auth(
+        active,
+        access_token=soon_expiring_current,
+        refresh_token="refresh-soon",
+        last_refresh="2026-01-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id="active-device",
+            access_token=soon_expiring_current,
+            refresh_token="refresh-soon",
+            last_refresh="2026-01-01T00:00:00Z",
+        )],
+    )
+    _write_codex_profile_auth(
+        root / "profiles" / "writer",
+        access_token=sibling_token,
+        refresh_token="refresh-sibling",
+        last_refresh="2026-05-01T00:00:00Z",
+        pool_entries=[_codex_pool_entry(
+            entry_id="other-device",
+            access_token=sibling_token,
+            refresh_token="refresh-sibling",
+            last_refresh="2026-05-01T00:00:00Z",
+        )],
+    )
+
+    called = {"count": 0}
+
+    def _fake_refresh(tokens, timeout_seconds):
+        called["count"] += 1
+        return {"access_token": "access-network", "refresh_token": "refresh-network"}
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+
+    resolved = resolve_codex_runtime_credentials(refresh_skew_seconds=300)
+
+    assert called["count"] == 1
+    assert resolved["api_key"] == "access-network"
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-soon"
 
 
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -50,6 +50,39 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     return f"h.{encoded}.s"
 
 
+def _setup_profile_codex_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    active = root / "profiles" / "coder"
+    active.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    return root, active
+
+
+def _write_codex_profile_auth(
+    auth_dir: Path,
+    *,
+    access_token: str,
+    refresh_token: str,
+    last_refresh: str,
+) -> None:
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    (auth_dir / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "last_refresh": last_refresh,
+                "auth_mode": "chatgpt",
+            },
+        },
+    }, indent=2))
+
+
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home)
@@ -66,6 +99,7 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     # Empty auth store
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     with pytest.raises(AuthError) as exc:
         _read_codex_tokens()
@@ -76,7 +110,7 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
@@ -89,6 +123,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
     _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     called = {"count": 0}
 
@@ -102,6 +137,74 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
     assert called["count"] == 1
     assert resolved["api_key"] == "access-new"
+
+
+def test_resolve_codex_runtime_credentials_recovers_stale_current_from_fresher_sibling(tmp_path, monkeypatch):
+    root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    expired_current = _jwt_with_exp(int(time.time()) - 10)
+    older_sibling = _jwt_with_exp(int(time.time()) + 1800)
+    fresher_sibling = _jwt_with_exp(int(time.time()) + 3600)
+
+    _write_codex_profile_auth(
+        active,
+        access_token=expired_current,
+        refresh_token="refresh-stale",
+        last_refresh="2026-01-01T00:00:00Z",
+    )
+    _write_codex_profile_auth(
+        root / "profiles" / "alpha",
+        access_token=older_sibling,
+        refresh_token="refresh-older",
+        last_refresh="2026-02-01T00:00:00Z",
+    )
+    _write_codex_profile_auth(
+        root / "profiles" / "writer",
+        access_token=fresher_sibling,
+        refresh_token="refresh-fresher",
+        last_refresh="2026-05-01T00:00:00Z",
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._refresh_codex_auth_tokens",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("network refresh should not run")),
+    )
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == fresher_sibling
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-fresher"
+
+
+def test_resolve_codex_runtime_credentials_does_not_reuse_current_token_inside_refresh_skew(tmp_path, monkeypatch):
+    root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    now = int(time.time())
+    soon_expiring_current = _jwt_with_exp(now + 60)
+    sibling_token = _jwt_with_exp(now + 3600)
+
+    _write_codex_profile_auth(
+        active,
+        access_token=soon_expiring_current,
+        refresh_token="refresh-soon",
+        last_refresh="2026-01-01T00:00:00Z",
+    )
+    _write_codex_profile_auth(
+        root / "profiles" / "writer",
+        access_token=sibling_token,
+        refresh_token="refresh-sibling",
+        last_refresh="2026-05-01T00:00:00Z",
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._refresh_codex_auth_tokens",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("network refresh should not run")),
+    )
+
+    resolved = resolve_codex_runtime_credentials(refresh_skew_seconds=300)
+
+    assert resolved["api_key"] == sibling_token
+    active_auth = json.loads((active / "auth.json").read_text())
+    assert active_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-sibling"
 
 
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
@@ -154,6 +257,7 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "pool-fallback-token"
@@ -188,6 +292,7 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "usable-token"
@@ -209,9 +314,45 @@ def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_pat
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
+    assert exc.value.code == "codex_auth_missing"
+
+
+def test_read_codex_tokens_ignores_malformed_sibling_profile(tmp_path, monkeypatch):
+    root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    (active / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    sibling = root / "profiles" / "writer"
+    sibling.mkdir(parents=True)
+    (sibling / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": "not-a-token-dict",
+                "last_refresh": "2026-05-01T00:00:00Z",
+            },
+        },
+    }))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+
+def test_read_codex_tokens_ignores_expired_sibling_profile(tmp_path, monkeypatch):
+    root, active = _setup_profile_codex_env(tmp_path, monkeypatch)
+    (active / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    _write_codex_profile_auth(
+        root / "profiles" / "writer",
+        access_token=_jwt_with_exp(int(time.time()) - 10),
+        refresh_token="refresh-expired",
+        last_refresh="2026-05-01T00:00:00Z",
+    )
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
     assert exc.value.code == "codex_auth_missing"
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -69,6 +69,26 @@ def _codex_provider(access_token: str, refresh_token: str, last_refresh: str) ->
     }
 
 
+def _codex_pool_entry(
+    *,
+    entry_id: str,
+    access_token: str,
+    refresh_token: str,
+    last_refresh: str,
+    source: str = "device_code",
+) -> dict:
+    return {
+        "id": entry_id,
+        "label": source,
+        "source": source,
+        "auth_type": "oauth",
+        "priority": 0,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "last_refresh": last_refresh,
+    }
+
+
 # ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
@@ -376,17 +396,36 @@ def test_codex_profile_missing_current_recovers_from_sibling_profile(profile_env
     from hermes_cli.auth import _read_codex_tokens
 
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    copied_id = "copied-device"
     sibling_dir = profile_env["global"] / "profiles" / "writer"
     sibling_dir.mkdir(parents=True)
+    stale_token = _jwt_with_exp(int(time.time()) - 10)
     access_token = _jwt_with_exp(int(time.time()) + 3600)
 
-    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(
+        pool={
+            "openai-codex": [_codex_pool_entry(
+                entry_id=copied_id,
+                access_token=stale_token,
+                refresh_token="refresh-stale",
+                last_refresh="2026-01-01T00:00:00Z",
+            )],
+        },
+        providers={},
+    ))
     _write(sibling_dir / "auth.json", _make_auth_store(providers={
         "openai-codex": _codex_provider(
             access_token,
             "refresh-sibling",
             "2026-05-01T00:00:00Z",
         ),
+    }, pool={
+        "openai-codex": [_codex_pool_entry(
+            entry_id=copied_id,
+            access_token=access_token,
+            refresh_token="refresh-sibling",
+            last_refresh="2026-05-01T00:00:00Z",
+        )],
     }))
 
     data = _read_codex_tokens()

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -12,6 +12,8 @@ authenticated only at the global root.
 from __future__ import annotations
 
 import json
+import base64
+import time
 from pathlib import Path
 
 import pytest
@@ -48,6 +50,23 @@ def profile_env(tmp_path, monkeypatch):
 
 def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
+
+
+def _jwt_with_exp(exp_epoch: int) -> str:
+    payload = {"exp": exp_epoch}
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    return f"h.{encoded}.s"
+
+
+def _codex_provider(access_token: str, refresh_token: str, last_refresh: str) -> dict:
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+        "last_refresh": last_refresh,
+        "auth_mode": "chatgpt",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +369,34 @@ def test_load_provider_state_classic_mode_no_fallback(tmp_path, monkeypatch):
     assert state["access_token"] == "classic-token"
     # Absent providers still return None.
     assert _load_provider_state(auth_store, "anthropic") is None
+
+
+def test_codex_profile_missing_current_recovers_from_sibling_profile(profile_env, monkeypatch, tmp_path):
+    """Codex can recover a valid token pair from a sibling profile store."""
+    from hermes_cli.auth import _read_codex_tokens
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    sibling_dir = profile_env["global"] / "profiles" / "writer"
+    sibling_dir.mkdir(parents=True)
+    access_token = _jwt_with_exp(int(time.time()) + 3600)
+
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+    _write(sibling_dir / "auth.json", _make_auth_store(providers={
+        "openai-codex": _codex_provider(
+            access_token,
+            "refresh-sibling",
+            "2026-05-01T00:00:00Z",
+        ),
+    }))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == access_token
+    assert data["tokens"]["refresh_token"] == "refresh-sibling"
+    profile_auth = json.loads((profile_env["profile"] / "auth.json").read_text())
+    profile_tokens = profile_auth["providers"]["openai-codex"]["tokens"]
+    assert profile_tokens["access_token"] == access_token
+    assert profile_tokens["refresh_token"] == "refresh-sibling"
 
 
 def test_load_provider_state_malformed_global_does_not_break_profile(profile_env):


### PR DESCRIPTION
## Summary

Codex OAuth refresh tokens rotate, so one Hermes profile can be left with a stale refresh token while another profile under the same Hermes root has already refreshed and still works. The current Codex paths already resync from the active auth store, the profile global-root fallback, and the Codex CLI import path, but the original sibling-profile expansion in this PR was too broad: it could adopt any fresher sibling account by timestamp alone.

This narrows sibling recovery to copied `device_code` lineage only. Hermes now requires the active profile to carry the same copied `openai-codex` pool entry, matched by stable pool `id` plus `source`, and it only adopts that sibling copy when the sibling entry recorded a strictly newer `last_refresh`. That keeps local-state shadowing intact and preserves unrelated `manual:device_code` accounts.

## Changes

- `hermes_cli/auth.py`: gate sibling Codex recovery on an exact copied `device_code` pool-entry match and a strictly newer recorded rotation.
- `agent/credential_pool.py`: pass the active pool entry identity into the pre-refresh recovery helper so only the same copied lineage can be adopted.
- `tests/agent/test_credential_pool.py`: cover copied-entry sibling recovery, unrelated-sibling rejection, and the strictly-newer requirement.
- `tests/hermes_cli/test_auth_codex_provider.py`: cover runtime recovery for copied entries and prove an unrelated sibling account is not adopted.
- `tests/hermes_cli/test_auth_profile_fallback.py`: cover singleton recovery from a sibling only when the active profile carries the copied-entry anchor.

## Validation

| Scenario | Before | After |
|---|---|---|
| active profile has valid Codex tokens | active profile wins | active profile wins, unchanged |
| active profile has a stale copied `device_code` entry, sibling copied profile rotated that same entry later | stale local state can survive until refresh or relogin | later copied rotation is adopted |
| sibling profile has valid but unrelated Codex tokens | fresher sibling account could be adopted by timestamp alone | unrelated sibling is ignored |
| sibling copied entry is equal-age or older | non-newer sibling could still compete in the freshness scan | non-newer sibling is ignored |
| malformed or expired sibling profile state | not a reliable source | ignored, unchanged |

## Test plan

- `pytest tests\agent\test_credential_pool.py -v --timeout=0` - 88 passed
- `pytest tests\hermes_cli\test_auth_codex_provider.py -v --timeout=0` - 37 passed
- `pytest tests\hermes_cli\test_auth_profile_fallback.py -v --timeout=0` - 17 passed

## Not in scope

This does not make sibling profiles generic recovery sources, does not write to sibling profile stores, and does not widen the existing global-root fallback rules.

## Upstream

Closes #6653.
Reported by @TwilightSeibei.
