### PR TITLE
fix(agent/error_classifier): match backtick-wrapped MiMo error variant (#37469)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -188,7 +188,9 @@ _IMAGE_TOO_LARGE_PATTERNS = [
 # See: https://github.com/NousResearch/hermes-agent/issues/27344
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     # Xiaomi MiMo: {"error":{"code":"400","message":"Param Incorrect","param":"text is not set"}}
+    # Backtick-wrapped variant also seen from MiMo API (#37469).
     "text is not set",
+    "`text` is not set",
     # Generic "tool message must be string" shapes
     "tool message content must be a string",
     "tool content must be a string",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1525,6 +1525,21 @@ class TestMultimodalToolContentUnsupported:
         assert result.reason == FailoverReason.multimodal_tool_content_unsupported
         assert result.retryable is True
 
+    def test_xiaomi_mimo_backtick_text_is_not_set_variant(self):
+        """Regression #37469 — MiMo returns backtick-wrapped param variant.
+
+        The pattern ``\"`text` is not set\"`` must match so the error is
+        classified as ``multimodal_tool_content_unsupported`` (retryable)
+        instead of falling through to ``format_error`` (non-retryable).
+        """
+        e = MockAPIError(
+            "Error code: 400 - {'error': {'code': '400', 'message': 'Param Incorrect', 'param': '`text` is not set', 'type': ''}}",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="xiaomi", model="mimo-v2.5")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
     def test_generic_tool_message_must_be_string(self):
         e = MockAPIError(
             "tool message content must be a string",


### PR DESCRIPTION
## Summary

Fixes #37469

Xiaomi MiMo API returns errors with backtick-wrapped params:
```json
{"error":{"code":"400","message":"Param Incorrect","param":"`text` is not set"}}
```

The existing pattern `"text is not set"` failed substring matching because backticks break the simple check. This caused the error to fall through as a non-retryable `BadRequestError` instead of being classified as `multimodal_tool_content_unsupported` (retryable), preventing the automatic text-content downgrade + retry path.

## Changes

- **agent/error_classifier.py**: Add the backtick variant ```text` is not set``` to `_MULTIMODAL_TOOL_CONTENT_PATTERNS`.
- **tests/agent/test_error_classifier.py**: Regression test covering backtick-wrapped MiMo error message.

## Verification

```bash
python -m pytest tests/agent/test_error_classifier.py -v
# passed
```