### PR TITLE
fix(gateway/hooks): normalize scalar events string to list (#11902)

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -94,6 +94,8 @@ class HookRegistry:
 
                 hook_name = manifest.get("name", hook_dir.name)
                 events = manifest.get("events", [])
+                if isinstance(events, str):
+                    events = [events]
                 if not events:
                     print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)
                     continue

--- a/tests/test_gateway_hooks.py
+++ b/tests/test_gateway_hooks.py
@@ -1,0 +1,101 @@
+"""Tests for gateway/hooks.py — HookRegistry discover_and_load semantics.
+
+Regression coverage for Issue #11902: scalar ``events: agent:start`` in a
+HOOK.yaml was iterated character-by-character, registering handlers for
+``[':', 'a', 'e', 'g', 'n', 'r', 's', 't']`` instead of ``['agent:start']``.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _make_hook(hooks_dir: Path, name: str, manifest_yaml: str, handler_py: str) -> Path:
+    """Create a hook directory with HOOK.yaml and handler.py."""
+    hook_dir = hooks_dir / name
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(manifest_yaml, encoding="utf-8")
+    (hook_dir / "handler.py").write_text(handler_py, encoding="utf-8")
+    return hook_dir
+
+
+def _fresh_registry():
+    """Return a fresh HookRegistry with a reloaded gateway.hooks module.
+
+    HOOKS_DIR is computed at import time from HERMES_HOME, so we reload
+    after the conftest autouse fixture has set the env var.
+    """
+    import importlib
+    import gateway.hooks as hooks_mod
+    importlib.reload(hooks_mod)
+    return hooks_mod.HookRegistry()
+
+
+def test_scalar_events_normalized_to_list(tmp_path):
+    """Scalar string events should be treated as a single-item list."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    hooks_dir = hermes_home / "hooks"
+    hooks_dir.mkdir()
+
+    _make_hook(
+        hooks_dir,
+        "scalar_events_hook",
+        manifest_yaml="name: scalar_events_hook\nevents: agent:start\n",
+        handler_py="def handle(event_type, context): pass\n",
+    )
+
+    registry = _fresh_registry()
+    registry.discover_and_load()
+
+    assert "agent:start" in registry._handlers
+    # Ensure no character-level keys were registered
+    for char in "agent:start":
+        assert char not in registry._handlers, f"unexpected char key: {char!r}"
+
+    loaded = registry.loaded_hooks
+    assert len(loaded) == 1
+    assert loaded[0]["events"] == ["agent:start"]
+
+
+def test_list_events_preserved(tmp_path):
+    """Normal list-of-strings events should work unchanged."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    hooks_dir = hermes_home / "hooks"
+    hooks_dir.mkdir()
+
+    _make_hook(
+        hooks_dir,
+        "list_events_hook",
+        manifest_yaml="name: list_events_hook\nevents:\n  - gateway:startup\n  - agent:start\n",
+        handler_py="def handle(event_type, context): pass\n",
+    )
+
+    registry = _fresh_registry()
+    registry.discover_and_load()
+
+    assert "gateway:startup" in registry._handlers
+    assert "agent:start" in registry._handlers
+    loaded = registry.loaded_hooks
+    assert len(loaded) == 1
+    assert loaded[0]["events"] == ["gateway:startup", "agent:start"]
+
+
+def test_empty_events_skipped(tmp_path):
+    """Hooks with empty or missing events should be skipped."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    hooks_dir = hermes_home / "hooks"
+    hooks_dir.mkdir()
+
+    _make_hook(
+        hooks_dir,
+        "no_events_hook",
+        manifest_yaml="name: no_events_hook\n",
+        handler_py="def handle(event_type, context): pass\n",
+    )
+
+    registry = _fresh_registry()
+    registry.discover_and_load()
+
+    assert not registry._handlers
+    assert not registry.loaded_hooks


### PR DESCRIPTION
## Summary

Fixes #11902

When a HOOK.yaml declared events as a scalar string (e.g. `events: agent:start`), the loader iterated over the string character-by-character, registering handlers for individual chars instead of the intended event name.

## Changes

- **gateway/hooks.py**: After reading `manifest.get('events', [])`, check `isinstance(events, str)` and wrap in a list before iterating.
- **tests/test_gateway_hooks.py**: Regression tests covering scalar string, list, and empty/missing events cases.

## Verification

```bash
python -m pytest tests/test_gateway_hooks.py -v
# passed
```