### PR TITLE
fix: Rich MarkupError in _restore_session_cwd on session resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5378,7 +5378,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(_RichText.from_ansi(f"{_DIM}{msg}\x1b[0m"))
             return
 
         try:
@@ -5388,7 +5388,7 @@ class HermesCLI:
             if quiet:
                 print(msg, file=sys.stderr)
             else:
-                self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+                self._console_print(_RichText.from_ansi(f"{_DIM}{msg}\x1b[0m"))
             return
 
         # Retarget the terminal/code-exec tools to match the process cwd.
@@ -5398,7 +5398,7 @@ class HermesCLI:
         if quiet:
             print(msg, file=sys.stderr)
         else:
-            self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
+            self._console_print(_RichText.from_ansi(f"{_DIM}{msg}\x1b[0m"))
 
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).


### PR DESCRIPTION
## Problem
`hermes --continue` crashes with:
```
rich.errors.MarkupError: closing tag '[/]' at position 82 has nothing to close
```

## Root Cause
`_DIM` is a raw ANSI escape sequence (`\x1b[2;3m`), not a Rich markup style. When used in `f"[{_DIM}]{_escape(msg)}[/]"`, Rich cannot parse the opening tag, so `[/]` has nothing to close.

## Fix
Replace Rich markup with `_RichText.from_ansi()` in the three affected calls in `_restore_session_cwd()`, which properly renders raw ANSI codes without going through the markup parser.

**Before:**
```python
self._console_print(f"[{_DIM}]{_escape(msg)}[/]")
```

**After:**
```python
self._console_print(_RichText.from_ansi(f"{_DIM}{msg}\x1b[0m"))
```

---
[Warp conversation](https://app.warp.dev/conversation/ab58913f-65e3-4396-a663-6428faeffc4c)

Co-Authored-By: Oz <oz-agent@warp.dev>