### PR TITLE
fix(gateway): restart via launchd on macOS

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -812,6 +812,21 @@ def _home_thread_env_var(platform_name: str) -> str:
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
 
 
+def _gateway_should_restart_via_service_manager() -> bool:
+    """Return True when /restart should let the supervisor relaunch us.
+
+    systemd exposes ``INVOCATION_ID``.  macOS launchd jobs expose an
+    ``XPC_SERVICE_NAME`` label; interactive shells commonly set it to ``0``,
+    which is not a managed service.  Containers use their restart policy and
+    lose detached helpers when PID 1 exits, so they also need the service path.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return True
+    if sys.platform == "darwin" and os.environ.get("XPC_SERVICE_NAME") not in {None, "", "0"}:
+        return True
+    return os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+
+
 def _restart_notification_pending() -> bool:
     """Return True when a /restart completion marker is waiting to be delivered."""
     return (_hermes_home / ".restart_notify.json").exists()
@@ -10827,11 +10842,10 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        # under systemd (KillMode=mixed kills the cgroup), launchd (the helper
+        # races the managed job state), or Docker (tini exits when the gateway
+        # dies, taking the detached helper with it).
+        if _gateway_should_restart_via_service_manager():
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,7 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -99,10 +100,36 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under macOS launchd, /restart exits for launchd to relaunch."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
+    """Without systemd/launchd/container supervision, use detached subprocess."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.setattr(gateway_run.os.path, "exists", lambda path: False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary
- Route gateway `/restart` through the service-manager path when running as a macOS launchd job.
- Keep interactive macOS shells on the detached helper path by treating `XPC_SERVICE_NAME=0` as unmanaged.
- Add regression coverage for launchd-supervised restarts.

## Test Plan
- `/Users/jeeves/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_restart_notification.py -q -o 'addopts='`
- `/Users/jeeves/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py tests/gateway/test_restart_notification.py`
- `git diff --check`

## Notes
This fixes macOS LaunchAgent installs where `/restart` previously drained and exited cleanly, leaving launchd jobs with `KeepAlive.SuccessfulExit=false` stopped instead of relaunched.
