### PR TITLE
fix(tui): hydrate resumed compression history

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -336,6 +336,60 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
     ]
 
 
+def test_session_resume_hydrates_agent_history_with_ancestors(server, monkeypatch):
+    """A compression tip can have no direct rows while ancestors hold context.
+
+    The resume payload already renders ancestor-inclusive messages; the live
+    agent must receive that same lineage history or it starts with history=0.
+    """
+
+    target = "20260605_201511_a9e01a"
+    lineage_history = [
+        {"role": "user", "content": "before compression"},
+        {"role": "assistant", "content": "still remembered"},
+    ]
+    captured: dict[str, object] = {}
+
+    class _DB:
+        def get_session(self, _sid):
+            return {"id": target}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def reopen_session(self, _sid):
+            return None
+
+        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+            return list(lineage_history) if include_ancestors else []
+
+    def init_session(sid, key, agent, history, cols=80):
+        captured["sid"] = sid
+        captured["key"] = key
+        captured["history"] = history
+        captured["cols"] = cols
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: object())
+    monkeypatch.setattr(server, "_init_session", init_session)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {
+            "id": "r1",
+            "method": "session.resume",
+            "params": {"session_id": target, "cols": 100},
+        }
+    )
+
+    assert "error" not in resp
+    assert captured["history"] == lineage_history
+    assert resp["result"]["messages"] == [
+        {"role": "user", "text": "before compression"},
+        {"role": "assistant", "text": "still remembered"},
+    ]
+
+
 def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
     """A user message persisted with list-shaped multimodal content used to
     crash session resume with ``'list' object has no attribute 'strip'``."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3127,12 +3127,11 @@ def _(rid, params: dict) -> dict:
     _enable_gateway_prompts()
     try:
         db.reopen_session(target)
-        history = db.get_messages_as_conversation(target)
-        display_history = db.get_messages_as_conversation(
-            target, include_ancestors=True
-        )
+        direct_history = db.get_messages_as_conversation(target)
+        history = db.get_messages_as_conversation(target, include_ancestors=True)
+        display_history = history
         display_history_prefix = display_history[
-            : max(0, len(display_history) - len(history))
+            : max(0, len(display_history) - len(direct_history))
         ]
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
@@ -3313,9 +3312,12 @@ def _live_session_payload(
             session["transport"] = transport
         if touch:
             session["last_active"] = time.time()
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
+        prefix = list(session.get("display_history_prefix") or [])
+        current_history = list(session.get("history") or [])
+        if prefix and current_history[: len(prefix)] == prefix:
+            history = current_history
+        else:
+            history = prefix + current_history
         inflight = _inflight_snapshot(session)
         running = bool(session.get("running"))
     payload = {


### PR DESCRIPTION
## Summary
- hydrate TUI/Desktop resumed sessions with ancestor-inclusive compression lineage history
- keep the existing display-history prefix behavior for live resume payloads, while avoiding duplicate prefix rendering when in-memory history already includes it
- add a regression test for compression tips with zero direct message rows but non-empty ancestor context

## Why
When `session.resume` opens a compression continuation/tip, the response payload already renders ancestor-inclusive messages via `include_ancestors=True`. However the live agent/session history passed to `_init_session` was loaded without ancestors:

```py
history = db.get_messages_as_conversation(target)
display_history = db.get_messages_as_conversation(target, include_ancestors=True)
```

If the resumed target is a compression tip with zero direct rows, Desktop appears to show the old conversation, but the live agent starts from `history=0`, making follow-up turns lose context.

This PR makes the agent hydration history use the same ancestor-inclusive lineage that the UI renders.

## Related
Related to the existing resume/compression work, but this is the complementary hydration bug:
- #13374
- #26631
- #15742

Those PRs focus on resolving resume targets/tips. This patch fixes the remaining mismatch where display history includes ancestors but the agent history did not.

## Test plan
- `.venv/Scripts/python.exe -m pytest tests/tui_gateway/test_protocol.py::test_session_resume_hydrates_agent_history_with_ancestors tests/tui_gateway/test_protocol.py::test_session_resume_returns_hydrated_messages tests/tui_gateway/test_protocol.py::test_session_resume_live_payload_uses_current_history_with_ancestors -q -o addopts=''` — 3 passed
- `.venv/Scripts/python.exe -m pytest tests/tui_gateway/test_protocol.py -q -o addopts=''` — 59 passed
- `.venv/Scripts/python.exe -m compileall -q tui_gateway/server.py tests/tui_gateway/test_protocol.py`
- `git diff --check`
