### PR TITLE
fix(agent): add stale-state guard to background review writes (#9055)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,70 @@ from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
 
+_SNAPSHOT_MESSAGE_FIELDS = ("role", "content", "tool_calls", "tool_call_id")
+_BACKGROUND_REVIEW_STALE_WRITE_MESSAGE = (
+    "Background review skipped memory/skill write because the parent "
+    "conversation changed after the review snapshot was taken."
+)
+_BACKGROUND_REVIEW_MEMORY_WRITE_ACTIONS = {"add", "replace", "remove"}
+_BACKGROUND_REVIEW_SKILL_WRITE_ACTIONS = {
+    "create",
+    "edit",
+    "patch",
+    "delete",
+    "write_file",
+    "remove_file",
+}
+
+
+# Uses {"type": type.__name__} instead of repr/default=str so distinct instances of the same
+# class canonicalize to the same token; avoids address churn that canonical_tool_args() would
+# produce for non-JSON-serializable objects that appear in message fields.
+def _json_normalized(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _json_normalized(val)
+            for key, val in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_normalized(item) for item in value]
+    return {"type": type(value).__name__}
+
+
+def _background_review_snapshot_token(messages: Optional[List[Dict]]) -> str:
+    normalized_messages = []
+    for message in messages or []:
+        if not isinstance(message, dict):
+            normalized_messages.append(_json_normalized(message))
+            continue
+        normalized_messages.append(
+            {
+                field: _json_normalized(message.get(field))
+                for field in _SNAPSHOT_MESSAGE_FIELDS
+                if field in message
+            }
+        )
+    return json.dumps(
+        normalized_messages,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _is_background_review_write_tool(tool_name: str, args: Dict[str, Any]) -> bool:
+    if tool_name == "memory":
+        action = str(args.get("action", "")).lower()
+        if action in _BACKGROUND_REVIEW_MEMORY_WRITE_ACTIONS:
+            return True
+        return bool(args.get("operations"))
+    if tool_name == "skill_manage":
+        action = str(args.get("action", "")).lower()
+        return action in _BACKGROUND_REVIEW_SKILL_WRITE_ACTIONS
+    return False
+
 
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
@@ -647,6 +711,28 @@ def _run_review_in_thread(
     from run_agent import AIAgent
     from tools.terminal_tool import set_approval_callback as _set_approval_callback
 
+    snapshot_token = _background_review_snapshot_token(messages_snapshot)
+
+    def _block_stale_parent_write(
+        tool_name: str,
+        args: Dict[str, Any],
+        **_kwargs: Any,
+    ) -> Optional[str]:
+        if not _is_background_review_write_tool(tool_name, args):
+            return None
+        live_messages = getattr(agent, "_session_messages", None)
+        if not isinstance(live_messages, list) or not all(
+            isinstance(m, dict) for m in live_messages
+        ):
+            return _BACKGROUND_REVIEW_STALE_WRITE_MESSAGE
+        try:
+            live_token = _background_review_snapshot_token(live_messages)
+        except Exception:
+            return _BACKGROUND_REVIEW_STALE_WRITE_MESSAGE
+        if live_token != snapshot_token:
+            return _BACKGROUND_REVIEW_STALE_WRITE_MESSAGE
+        return None
+
     # Install a non-interactive approval callback on this worker
     # thread so any dangerous-command guard the review agent trips
     # resolves to "deny" instead of falling back to input() -- which
@@ -850,6 +936,7 @@ def _run_review_in_thread(
                     "Background review denied non-whitelisted tool: "
                     "{tool_name}. Only memory/skill tools are allowed."
                 ),
+                block_callback=_block_stale_parent_write,
             )
             try:
                 from tools.skill_manager_tool import _reset_background_review_read_marks

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2108,13 +2108,16 @@ class _PreToolCallDirective:
 def set_thread_tool_whitelist(
     allowed: Optional[Set[str]],
     deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
+    block_callback: Optional[Callable[..., Optional[str]]] = None,
 ) -> None:
     _thread_tool_whitelist.allowed = allowed
     _thread_tool_whitelist.fmt = deny_msg_fmt
+    _thread_tool_whitelist.block_callback = block_callback
 
 
 def clear_thread_tool_whitelist() -> None:
     _thread_tool_whitelist.allowed = None
+    _thread_tool_whitelist.block_callback = None
 
 
 def _get_pre_tool_call_directive_details(
@@ -2160,6 +2163,21 @@ def _get_pre_tool_call_directive_details(
             action="block",
             message=fmt.format(tool_name=tool_name),
         )
+
+    block_callback = getattr(_thread_tool_whitelist, "block_callback", None)
+    if block_callback is not None:
+        message = block_callback(
+            tool_name=tool_name,
+            args=args if isinstance(args, dict) else {},
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            middleware_trace=list(middleware_trace or []),
+        )
+        if isinstance(message, str) and message:
+            return _PreToolCallDirective(action="block", message=message)
 
     hook_results = invoke_hook(
         "pre_tool_call",

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import types
+import pytest
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -29,6 +31,21 @@ def _bare_agent() -> AIAgent:
     agent.background_review_callback = None
     agent.status_callback = None
     agent._safe_print = lambda *_args, **_kwargs: None
+    agent._session_messages = []
+    # Required by _run_agent_tool_execution_middleware used in dispatch-seam tests.
+    agent.quiet_mode = True
+    agent._current_tool = None
+    agent._touch_activity = lambda *_a, **_kw: None
+    agent.tool_progress_callback = None
+    agent.tool_start_callback = None
+    agent._memory_manager = None
+    agent._turns_since_memory = 0
+    agent._iters_since_skill = 0
+    agent._should_emit_quiet_tool_messages = False
+    agent._guardrail_block_result = lambda _d: '{"blocked": true}'
+    agent._tool_guardrails = types.SimpleNamespace(
+        before_call=lambda tn, a: types.SimpleNamespace(allows_execution=True)
+    )
     return agent
 
 
@@ -38,6 +55,25 @@ class ImmediateThread:
 
     def start(self):
         self._target()
+
+
+def _dispatch(parent_agent, tool_name, args):
+    """Route one tool call through the production dispatch seam.
+
+    Returns (blocked: bool, sentinel_called: bool). The sentinel stands in for
+    the real tool handler; it must NOT be called when the guard blocks.
+    """
+    from agent import tool_executor as _te
+    sentinel = []
+    result = _te._run_agent_tool_execution_middleware(
+        parent_agent,
+        function_name=tool_name,
+        function_args=args,
+        effective_task_id="",
+        tool_call_id="",
+        execute=lambda final_args: sentinel.append(final_args) or '{"ok": true}',
+    )
+    return result.blocked, bool(sentinel)
 
 
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
@@ -223,3 +259,486 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def test_background_review_allows_memory_write_when_parent_state_matches(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            blocked, sentinel_called = _dispatch(agent, "memory", {"action": "add"})
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = [{"content": "hello", "role": "user"}]
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is False
+    assert observed["sentinel_called"]
+
+
+def test_background_review_blocks_memory_and_skill_writes_when_parent_state_changes(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            agent._session_messages.append(
+                {"role": "assistant", "content": "new foreground reply"}
+            )
+            observed["memory"] = _dispatch(agent, "memory", {"action": "add"})
+            observed["skill"] = _dispatch(agent, "skill_manage", {"action": "patch"})
+            observed["skill_view"] = _dispatch(agent, "skill_view", {"name": "python"})
+            observed["skills_list"] = _dispatch(agent, "skills_list", {})
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    memory_blocked, memory_sentinel = observed["memory"]
+    assert memory_blocked is True
+    assert not memory_sentinel
+
+    skill_blocked, skill_sentinel = observed["skill"]
+    assert skill_blocked is True
+    assert not skill_sentinel
+
+    skill_view_blocked, skill_view_sentinel = observed["skill_view"]
+    assert skill_view_blocked is False
+    assert skill_view_sentinel
+
+    skills_list_blocked, skills_list_sentinel = observed["skills_list"]
+    assert skills_list_blocked is False
+    assert skills_list_sentinel
+
+
+@pytest.mark.parametrize("action", [
+    "create", "patch", "edit", "delete", "write_file", "remove_file",
+])
+def test_background_review_blocks_all_skill_manage_write_actions_when_parent_state_changes(
+    monkeypatch, action
+):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            agent._session_messages.append(
+                {"role": "assistant", "content": "foreground advanced"}
+            )
+            blocked, sentinel_called = _dispatch(
+                agent, "skill_manage", {"action": action, "name": "demo"}
+            )
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is True, f"action={action} was not blocked"
+    assert not observed["sentinel_called"], f"action={action}: sentinel must not fire on block"
+
+
+@pytest.mark.parametrize("operations", [
+    [{"action": "add", "key": "x", "value": "y"}],
+    [{"action": "replace", "key": "x", "value": "z"}],
+    [{"action": "remove", "key": "x"}],
+    [{"action": "add", "key": "a"}, {"action": "remove", "key": "b"}],
+])
+def test_background_review_blocks_memory_batch_write_when_parent_state_changes(
+    monkeypatch, operations
+):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            agent._session_messages.append(
+                {"role": "assistant", "content": "foreground advanced"}
+            )
+            blocked, sentinel_called = _dispatch(agent, "memory", {"operations": operations})
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is True
+    assert not observed["sentinel_called"]
+
+
+def test_background_review_allows_memory_batch_write_when_parent_state_matches(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            blocked, sentinel_called = _dispatch(
+                agent,
+                "memory",
+                {"operations": [{"action": "add", "key": "x", "value": "y"}]},
+            )
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = [{"content": "hello", "role": "user"}]
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is False
+    assert observed["sentinel_called"]
+
+
+@pytest.mark.parametrize("bad_state,label", [
+    (None, "none"),
+    ({}, "dict"),
+    ("not a list", "string"),
+    (["not a dict"], "list_with_non_dict"),
+])
+def test_background_review_blocks_write_when_parent_state_invalid(
+    monkeypatch, bad_state, label
+):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            agent._session_messages = bad_state
+            blocked_mem, _ = _dispatch(
+                agent,
+                "memory",
+                {"operations": [{"action": "add", "key": "x", "value": "y"}]},
+            )
+            blocked_skill, _ = _dispatch(agent, "skill_manage", {"action": "edit"})
+            observed["memory_blocked"] = blocked_mem
+            observed["skill_blocked"] = blocked_skill
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["memory_blocked"] is True, label
+    assert observed["skill_blocked"] is True, label
+
+
+def test_background_review_blocks_write_when_session_messages_absent(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            if hasattr(agent, "_session_messages"):
+                del agent._session_messages
+            blocked, sentinel_called = _dispatch(agent, "memory", {"action": "add"})
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is True
+    assert not observed["sentinel_called"]
+
+
+def test_background_review_allows_write_for_empty_matching_parent(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # Both snapshot and live state are valid empty lists; tokens match.
+            blocked, sentinel_called = _dispatch(agent, "memory", {"action": "add"})
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot: list = []
+    agent = _bare_agent()
+    agent._session_messages = []
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is False
+    assert observed["sentinel_called"]
+
+
+def test_background_review_blocks_write_on_tool_calls_field_drift(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # Parent's message gains a tool_calls field after the snapshot was taken.
+            agent._session_messages[-1]["tool_calls"] = [
+                {"id": "c1", "function": {"name": "memory", "arguments": "{}"}}
+            ]
+            blocked, sentinel_called = _dispatch(agent, "memory", {"action": "add"})
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = [{"role": "user", "content": "hello"}]
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is True
+    assert not observed["sentinel_called"]
+
+
+def test_background_review_whitelist_denies_before_callback_for_non_whitelisted_tool(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    observed: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # write_file is not in the review whitelist. Parent state MATCHES,
+            # so the callback would allow — but the whitelist fires first and denies.
+            blocked, sentinel_called = _dispatch(
+                agent, "write_file", {"path": "x.txt", "content": "y"}
+            )
+            observed["blocked"] = blocked
+            observed["sentinel_called"] = sentinel_called
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(_plugins, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    assert observed["blocked"] is True
+    assert not observed["sentinel_called"]
+
+
+def test_background_review_clears_block_callback_on_completion(monkeypatch):
+    from hermes_cli import plugins as _plugins
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # Callback must be callable while the review is executing.
+            assert callable(
+                getattr(_plugins._thread_tool_whitelist, "block_callback", None)
+            ), "block_callback should be callable during review"
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    messages_snapshot = [{"role": "user", "content": "hello"}]
+    agent = _bare_agent()
+    agent._session_messages = list(messages_snapshot)
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_memory=True,
+    )
+
+    post_callback = getattr(_plugins._thread_tool_whitelist, "block_callback", None)
+    assert post_callback is None, "block_callback must be cleared after review completes"

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -98,9 +98,10 @@ def test_background_review_installs_thread_local_whitelist():
 
     captured = {}
 
-    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+    def _capture_whitelist(whitelist, deny_msg_fmt=None, block_callback=None):
         captured["whitelist"] = set(whitelist)
         captured["deny_msg_fmt"] = deny_msg_fmt
+        captured["block_callback"] = block_callback
         # Stop here — we just want to see what gets installed.
         raise RuntimeError("stop after capturing whitelist")
 
@@ -133,9 +134,7 @@ def test_background_review_installs_thread_local_whitelist():
     assert "delegate_task" not in whitelist
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
-
-
-
+    assert callable(captured["block_callback"])
 
 
 


### PR DESCRIPTION
## Summary

Background self-improvement review can write memory or skill updates after the parent agent has moved on to a new conversation turn. This adds a live-state guard to the background review tool dispatch path that classifies both memory payload forms and fails closed when the parent state is unavailable.

Write-capable memory calls now include top-level `add`, `replace`, and `remove` plus every nonempty `operations` batch — the batch form that `memory_tool()` routes to `apply_batch()`. All six `skill_manage` write actions (`create`, `edit`, `patch`, `delete`, `write_file`, `remove_file`) require a matching parent snapshot. `skill_view` and `skills_list` pass through unchanged.

A write proceeds only when the parent exposes a valid live message list whose canonical token matches the review snapshot. A missing, non-list, or non-dict-containing `_session_messages` blocks the write rather than falling back to the snapshot.

## Changes

- `agent/background_review.py`: add payload classifier for both memory forms and all six `skill_manage` write actions, add fail-closed freshness predicate, install callback via `set_thread_tool_whitelist`, keep cleanup in the existing `finally` (~+80 lines net)
- `hermes_cli/plugins.py`: extend `set_thread_tool_whitelist` with optional `block_callback`, clear it in `clear_thread_tool_whitelist`, invoke it in `_get_pre_tool_call_directive_details` after the whitelist admit-check and convert a non-empty string result to a block directive (~+20 lines)
- `tests/run_agent/test_background_review.py`: add regression coverage for memory batch writes (all four `operations` mutation shapes), all four invalid parent-state variants, absent `_session_messages` attribute, matching-state single-action and batch writes, and read-only skill calls, all routed through `_run_agent_tool_execution_middleware` and the installed callback (~+180 lines)
- `tests/run_agent/test_background_review_toolset_restriction.py`: extend `_capture_whitelist` stub to accept and assert `block_callback` without changing whitelist membership assertions (~+3 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| Parent unchanged; background review writes memory (top-level action) | Write succeeds | Write succeeds |
| Parent changes; background review writes memory (top-level action) | Stale write persists | Blocked before persistence |
| Parent changes; background review writes memory (batch `operations`) | Stale write persists — guard missed batch form | Blocked before `apply_batch()` |
| Parent changes; background review patches a skill | Stale update persists | Blocked before persistence |
| `_session_messages` absent | Write permitted — fallback to snapshot | Blocked |
| `_session_messages` is `None`, dict, string, or list with non-dict item | Write permitted — fallback to snapshot | Blocked |
| Non-whitelisted tool | Denied by whitelist | Still denied (runs before callback) |
| `skill_view` or `skills_list` | Allowed | Still allowed |

`pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py -v --timeout=0` — 28 passed

## Not in scope

This PR does not serialize cross-session, cron, or sibling-review writers. PR #55906 separately requires background review to read the exact skill target before writing; it covers a different cross-writer path and does not supersede this same-parent freshness guard.

Closes #9055.
Reported by @yexxx.