### PR TITLE
fix(desktop): avoid slow local update rebuilds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7331,6 +7331,36 @@ def _purge_electron_build_cache(desktop_dir: Path) -> list[Path]:
     return removed
 
 
+_DESKTOP_MACOS_SIGNING_ENV_VARS = (
+    "CSC_LINK",
+    "CSC_NAME",
+    "APPLE_SIGNING_IDENTITY",
+)
+
+
+def _desktop_explicit_macos_signing_requested(env) -> bool:
+    """Return True when the caller explicitly asked electron-builder to sign.
+
+    Local self-updates should not accidentally pick up whatever Developer ID
+    happens to be in the user's keychain. Explicit signing knobs still win.
+    """
+    if any((env.get(key) or "").strip() for key in _DESKTOP_MACOS_SIGNING_ENV_VARS):
+        return True
+    auto = (env.get("CSC_IDENTITY_AUTO_DISCOVERY") or "").strip().lower()
+    return auto not in {"", "0", "false", "no", "off"}
+
+
+def _desktop_build_env(env: dict[str, str], *, source_mode: bool) -> dict[str, str]:
+    build_env = dict(env)
+    if (
+        sys.platform == "darwin"
+        and not source_mode
+        and not _desktop_explicit_macos_signing_requested(build_env)
+    ):
+        build_env["CSC_IDENTITY_AUTO_DISCOVERY"] = "false"
+    return build_env
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
 
@@ -7344,12 +7374,12 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
     (omitting the hardened-runtime flag, which is meaningless without a real
     Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
+    identity is configured (CSC_LINK / CSC_NAME / APPLE_SIGNING_IDENTITY) so a properly
     signed/notarized build is never clobbered. Best-effort: never raises.
     """
     if sys.platform != "darwin":
         return
-    if os.environ.get("CSC_LINK") or os.environ.get("APPLE_SIGNING_IDENTITY"):
+    if _desktop_explicit_macos_signing_requested(os.environ):
         return
     exe = _desktop_packaged_executable(desktop_dir)
     if exe is None:
@@ -7486,7 +7516,8 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"→ Building desktop {build_label}...")
             build_script = "build" if source_mode else "pack"
-            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+            build_env = _desktop_build_env(env, source_mode=source_mode)
+            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=build_env, check=False)
             if build_result.returncode != 0 and not source_mode:
                 # A corrupt cached Electron zip makes `pack` fail with an ENOENT
                 # on the final `electron` -> `Hermes` rename: unpack-electron
@@ -7506,7 +7537,7 @@ def cmd_gui(args: argparse.Namespace):
                     print("  ⚠ Desktop build failed; cleared cached Electron download and retrying once...")
                     for p in purged:
                         print(f"    - {p}")
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=build_env, check=False)
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
@@ -10593,12 +10624,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("→ Checking if desktop app needs rebuilding...")
             _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
             # Stream the build output live (long Electron builds otherwise
-            # look hung). On the rare nonzero exit, retry once after waiting
-            # again for the venv — this covers a still-settling rebuild window
-            # the first wait didn't fully catch.
+            # look hung). ``cmd_gui`` already owns retryable desktop packaging
+            # recovery (Electron cache purge + one retry), so do not rerun the
+            # whole build command here: that repeats npm install/download work
+            # and makes in-app updates feel stuck after a transient pack failure.
             build_result = subprocess.run(_desktop_build_cmd, cwd=PROJECT_ROOT, check=False)
-            if build_result.returncode != 0:
-                build_result = subprocess.run(_desktop_build_cmd, cwd=PROJECT_ROOT, check=False)
             if build_result.returncode != 0:
                 print("  ⚠ Desktop build failed (non-fatal; run `hermes desktop` to retry)")
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -220,6 +220,7 @@ class TestCmdUpdateBranchFallback:
         import subprocess as _subprocess
         build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_web_ui_build_needed", return_value=True), \
              patch.object(hm, "_run_with_idle_timeout", return_value=build_ok) as mock_idle:
             cmd_update(mock_args)
 
@@ -300,6 +301,41 @@ class TestCmdUpdateBranchFallback:
                 "repo-root npm install must stream output "
                 "(no capture_output) so postinstall progress is visible"
             )
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_update_does_not_rerun_failed_desktop_build(
+        self, mock_run, mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        git_side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        def run_side_effect(cmd, **kwargs):
+            if "desktop" in cmd and "--build-only" in cmd:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            return git_side_effect(cmd, **kwargs)
+
+        mock_run.side_effect = run_side_effect
+        build_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        desktop_exe = PROJECT_ROOT / "apps" / "desktop" / "release" / "mac-arm64" / "Hermes.app"
+
+        with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_run_with_idle_timeout", return_value=build_ok), \
+             patch.object(hm, "_desktop_packaged_executable", return_value=desktop_exe), \
+             patch.object(hm, "_desktop_dist_exists", return_value=False):
+            cmd_update(mock_args)
+
+        desktop_build_calls = [
+            call
+            for call in mock_run.call_args_list
+            if "desktop" in call.args[0] and "--build-only" in call.args[0]
+        ]
+        assert len(desktop_build_calls) == 1
+        assert "Desktop build failed" in capsys.readouterr().out
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -109,6 +109,70 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
     assert launch_env["HERMES_DESKTOP_CWD"] == str(cwd)
 
 
+def test_gui_packaged_build_disables_macos_signing_auto_discovery_by_default(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("CSC_NAME", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    monkeypatch.delenv("CSC_IDENTITY_AUTO_DISCOVERY", raising=False)
+
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns())
+
+    build_env = mock_run.call_args_list[0].kwargs["env"]
+    launch_env = mock_run.call_args_list[1].kwargs["env"]
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+    assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
+    assert build_env["CSC_IDENTITY_AUTO_DISCOVERY"] == "false"
+    assert "CSC_IDENTITY_AUTO_DISCOVERY" not in launch_env
+
+
+def test_gui_packaged_build_preserves_explicit_macos_signing(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    monkeypatch.setenv("CSC_NAME", "Developer ID Application: Example")
+    monkeypatch.delenv("CSC_IDENTITY_AUTO_DISCOVERY", raising=False)
+
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns())
+
+    build_env = mock_run.call_args_list[0].kwargs["env"]
+    assert build_env["CSC_NAME"] == "Developer ID Application: Example"
+    assert "CSC_IDENTITY_AUTO_DISCOVERY" not in build_env
+
+
+def test_macos_relaunch_fixup_skips_explicit_csc_name(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    monkeypatch.setenv("CSC_NAME", "Developer ID Application: Example")
+
+    with patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    mock_run.assert_not_called()
+
+
 def test_gui_exits_when_npm_missing(tmp_path, monkeypatch, capsys):
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)


### PR DESCRIPTION
## What does this PR do?

Improves the macOS/Desktop local update path so a transient desktop packaging failure does not feel like a hung update.

Two things were making local Desktop updates unnecessarily slow or fragile:

- macOS packaged builds could auto-discover a Developer ID certificate from the user keychain even when the user did not request signed/notarized output.
- `hermes update` retried the entire `hermes desktop --build-only` command after failure, even though `cmd_gui` already owns retryable Electron packaging recovery. That repeated npm install/download/build work after failures like Electron download EOFs.

This PR disables electron-builder signing auto-discovery for default local packaged macOS builds, preserves explicit signing configuration, and removes the outer whole-command desktop build retry from `hermes update`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add desktop build environment handling that disables electron-builder signing identity auto-discovery for default local macOS packaged builds.
- `hermes_cli/main.py`: reuse the same explicit-signing detection in the post-build ad-hoc relaunch fixup so real signed builds are not clobbered.
- `hermes_cli/main.py`: avoid rerunning the entire desktop build command from `hermes update` after a non-fatal desktop build failure.
- `tests/hermes_cli/test_gui_command.py`: add regression coverage for default signing auto-discovery suppression and explicit signing preservation.
- `tests/hermes_cli/test_cmd_update.py`: add regression coverage that failed desktop rebuilds are not repeated by the update wrapper.

## How to Test

1. On macOS, run a desktop packaged build without explicit signing variables.
2. Confirm the build environment includes `CSC_IDENTITY_AUTO_DISCOVERY=false` and does not auto-pick a keychain signing identity.
3. Confirm explicitly configured signing still passes through.
4. Confirm `hermes update` calls `hermes desktop --build-only` at most once; `cmd_gui` still handles its own Electron cache purge/retry path.
5. Run targeted checks:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_cmd_update.py
uvx ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_cmd_update.py
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I have updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Targeted test output:

```text
scripts/run_tests.sh tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_cmd_update.py
52 passed

uvx ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_cmd_update.py
All checks passed
```
