### PR TITLE
fix: respect user interrupt in busy_input_mode=interrupt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1833,6 +1833,7 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _interrupted_by_user_msg: set = set()
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -3461,6 +3462,7 @@ class GatewayRunner:
         if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 running_agent.interrupt(event.text)
+                self._interrupted_by_user_msg.add(session_key)
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
@@ -8024,6 +8026,7 @@ class GatewayRunner:
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
             running_agent.interrupt(event.text)
+            self._interrupted_by_user_msg.add(_quick_key)
             # NOTE: self._pending_messages was write-only (never consumed).
             # The actual interrupt message is delivered via adapter._pending_messages
             # which is read by _run_agent. Removed to prevent unbounded growth.
@@ -18208,7 +18211,7 @@ class GatewayRunner:
                 and _interruption_is_fresh
             )
 
-            if _is_resume_pending:
+            if _is_resume_pending and session_key not in self._interrupted_by_user_msg:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _reason_phrase = (
                     "a gateway restart"
@@ -18225,7 +18228,7 @@ class GatewayRunner:
                     f"message below.]\n\n"
                     + message
                 )
-            elif _has_fresh_tool_tail:
+            elif _has_fresh_tool_tail and session_key not in self._interrupted_by_user_msg:
                 message = (
                     "[System note: Your previous turn was interrupted before you could "
                     "process the last tool result(s). The conversation history contains "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18238,6 +18238,10 @@ class GatewayRunner:
                     + message
                 )
 
+            # Clean up per-session interrupt flag after use to prevent unbounded
+            # set growth (#39813 review feedback).
+            self._interrupted_by_user_msg.discard(session_key)
+
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
             # queue pattern as CLI: prepend to the NEXT user message, then


### PR DESCRIPTION
When a user sends a message to interrupt a running agent with
`busy_input_mode=interrupt`, the gateway correctly calls
`agent.interrupt()` but then injects a System note telling the agent
to "finish processing old tool results first", overriding the user's
intent to stop.

Root cause: the gateway's message processing code cannot distinguish
between "interrupted by gateway restart/timeout" and "interrupted by
user message". Both cases inject the same System note.

Fix: add an `_interrupted_by_user_msg` set to track which sessions
were interrupted by user messages, and skip System note injection
in both system-note injection branches.

Changes in `gateway/run.py`:

1. Class attribute: `_interrupted_by_user_msg: set = set()`
2. Mark session in `_handle_active_session_busy_message` interrupt path
3. Mark session in `PRIORITY` interrupt path
4. Gate `_is_resume_pending` System note injection
5. Gate `_has_fresh_tool_tail` System note injection

Gateway restart/timeout interruptions still inject the System note
as expected — only user-initiated interrupts are affected.