### PR TITLE
fix(nix): stage consolidated lockfile hash

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -77,7 +77,7 @@ jobs:
 
           # Ensure only nix files were modified — prevents accidental
           # self-triggering if fix-lockfiles ever touches package files.
-          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          unexpected="$(git diff --name-only | grep -Ev '^nix/lib\.nix$' || true)"
           if [ -n "$unexpected" ]; then
             echo "::error::Unexpected modified files: $unexpected"
             exit 1
@@ -89,7 +89,7 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): auto-refresh npm lockfile hashes" \
             -m "Source: $GITHUB_SHA" \
             -m "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -216,7 +216,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): refresh npm lockfile hashes"
           git push
 


### PR DESCRIPTION
## Summary
- update the Nix lockfile fix workflow whitelist to allow `nix/lib.nix`
- stage `nix/lib.nix` in both the main auto-fix and manual PR fix jobs

## Context
Fixes #39455. `fix-lockfiles` now writes the consolidated npm hash in `nix/lib.nix`, but `nix-lockfile-fix.yml` still whitelisted and staged the old per-package files (`nix/tui.nix`, `nix/web.nix`). That made the auto-fix path reject the actual hash update as unexpected or commit nothing.

## Verification
- `rg -n "nix/tui\.nix|nix/web\.nix|grep -Ev|git add nix/" .github/workflows/nix-lockfile-fix.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nix-lockfile-fix.yml"); puts "yaml ok"'`
- `git diff --check`

`actionlint` and `yamllint` are not installed in this environment, so I could not run those local validators.