### PR TITLE
fix(lazy-deps): set CMAKE_POLICY_VERSION_MINIMUM=3.5 for native builds

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -356,7 +356,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         return _InstallResult(True, "", "")
 
     venv_root = Path(sys.executable).parent.parent
-    uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
+    # cmake 4.x removed compatibility with cmake_minimum_required < 3.5.
+    # python-olm (mautrix[encryption]) bundles libolm/CMakeLists.txt that
+    # declares VERSION 3.4; this env var lets cmake 4.x configure it anyway.
+    uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root), "CMAKE_POLICY_VERSION_MINIMUM": "3.5"}
 
     # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
     uv_bin = shutil.which("uv")


### PR DESCRIPTION
## Problem

On macOS 26 with cmake 4.x, `ensure("platform.matrix")` fails at the cmake *configure* step before it even gets to compile:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

cmake 4.x dropped support for `cmake_minimum_required(VERSION < 3.5)`. `python-olm 3.2.16` bundles libolm source with `CMakeLists.txt` declaring `VERSION 3.4`.

## Fix

Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` in the build environment passed to uv/pip. cmake 4.x reads this env var and treats the project as though it declared the minimum as 3.5. One env key, no source patching, no platform gating.

## Relationship to #31354

#31354 fixes the C++ const-pointer compile error in `list.hh`. This fixes the cmake configure error that fires *before* compilation starts. On macOS 26 / cmake 4.3.x, both are needed. Without this change, #31354's patched source build still aborts at the configure step.

Note: the subprocess in `_python_olm_macos_install` (added by #31354) doesn't pass an explicit `env=`, so it'll also need this fix when that PR merges — either inherit it from the calling process or pass `env={**os.environ, "CMAKE_POLICY_VERSION_MINIMUM": "3.5"}` directly.

## Testing

```
# Fresh hermes venv, cmake 4.3.3, Apple clang 21.0.0 (macOS 26)
uv pip uninstall python-olm mautrix
CMAKE_POLICY_VERSION_MINIMUM=3.5 uv pip install "mautrix[encryption]==0.21.0"
# → installs cleanly; previously failed at cmake configure step
```