### PR TITLE
fix: preserve gateway restart in-flight resume state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -407,6 +407,54 @@ def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     return None
 
 
+def _format_resume_checkpoint_note(checkpoint: Optional[Dict[str, Any]]) -> str:
+    """Render a compact restart checkpoint for the resumed agent."""
+    if not isinstance(checkpoint, dict) or not checkpoint:
+        return ""
+    parts: list[str] = []
+    last_activity = checkpoint.get("last_activity_desc")
+    if isinstance(last_activity, str) and last_activity.strip():
+        parts.append(last_activity.strip()[:240])
+    current_tool = checkpoint.get("current_tool")
+    if isinstance(current_tool, str) and current_tool.strip():
+        parts.append(f"current tool: {current_tool.strip()[:80]}")
+    api_calls = checkpoint.get("api_call_count")
+    max_iterations = checkpoint.get("max_iterations")
+    if isinstance(api_calls, int) and isinstance(max_iterations, int) and max_iterations:
+        parts.append(f"iteration {api_calls}/{max_iterations}")
+    elif isinstance(api_calls, int):
+        parts.append(f"iteration {api_calls}")
+    return "Restart checkpoint: " + "; ".join(parts) + "." if parts else ""
+
+
+def _resume_checkpoint_from_agent(agent: Any) -> Optional[Dict[str, Any]]:
+    """Capture a JSON-safe activity snapshot from a running AIAgent."""
+    if agent is None or agent is _AGENT_PENDING_SENTINEL:
+        return None
+    summary_fn = getattr(agent, "get_activity_summary", None)
+    if not callable(summary_fn):
+        return None
+    try:
+        summary = summary_fn()
+    except Exception:
+        return None
+    if not isinstance(summary, dict):
+        return None
+    allowed = (
+        "last_activity_desc",
+        "current_tool",
+        "api_call_count",
+        "max_iterations",
+        "seconds_since_activity",
+    )
+    checkpoint: Dict[str, Any] = {}
+    for key in allowed:
+        value = summary.get(key)
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            checkpoint[key] = value
+    return checkpoint or None
+
+
 def _auto_continue_freshness_window() -> float:
     """Return the configured auto-continue freshness window in seconds.
 
@@ -810,6 +858,21 @@ def _home_target_env_var(platform_name: str) -> str:
 def _home_thread_env_var(platform_name: str) -> str:
     """Return the optional thread/topic env var for a platform home target."""
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
+
+
+def _gateway_should_restart_via_service_manager() -> bool:
+    """Return True when /restart should let the supervisor relaunch us.
+
+    systemd exposes ``INVOCATION_ID``.  macOS launchd jobs expose an
+    ``XPC_SERVICE_NAME`` label; interactive shells commonly set it to ``0``,
+    which is not a managed service.  Containers use their restart policy and
+    lose detached helpers when PID 1 exits, so they also need the service path.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return True
+    if sys.platform == "darwin" and os.environ.get("XPC_SERVICE_NAME") not in {None, "", "0"}:
+        return True
+    return os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
 
 
 def _restart_notification_pending() -> bool:
@@ -6479,6 +6542,7 @@ class GatewayRunner:
                     self.session_store.mark_resume_pending(
                         _sk,
                         "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        checkpoint=_resume_checkpoint_from_agent(_agent),
                     )
                     _pre_drain_keys.append(_sk)
                 except Exception as _e:
@@ -6544,7 +6608,11 @@ class GatewayRunner:
                     if _agent is _AGENT_PENDING_SENTINEL:
                         continue
                     try:
-                        self.session_store.mark_resume_pending(_sk, _resume_reason)
+                        self.session_store.mark_resume_pending(
+                            _sk,
+                            _resume_reason,
+                            checkpoint=_resume_checkpoint_from_agent(_agent),
+                        )
                     except Exception as _e:
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
@@ -9428,6 +9496,16 @@ class GatewayRunner:
         if message_text is None:
             return
 
+        if not getattr(event, "internal", False):
+            try:
+                self.session_store.record_inflight_message(
+                    session_key,
+                    message_text,
+                    message_id=str(event.message_id) if event.message_id else None,
+                )
+            except Exception as _e:
+                logger.debug("record_inflight_message failed for %s: %s", session_key, _e)
+
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
@@ -9520,6 +9598,7 @@ class GatewayRunner:
                 self._clear_restart_failure_count(session_key)
                 try:
                     self.session_store.clear_resume_pending(session_key)
+                    self.session_store.clear_inflight_message(session_key)
                 except Exception as _e:
                     logger.debug(
                         "clear_resume_pending failed for %s: %s",
@@ -10827,11 +10906,10 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        # under systemd (KillMode=mixed kills the cgroup), launchd (the helper
+        # races the managed job state), or Docker (tini exits when the gateway
+        # dies, taking the detached helper with it).
+        if _gateway_should_restart_via_service_manager():
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)
@@ -18160,12 +18238,30 @@ class GatewayRunner:
                     if _reason == "shutdown_timeout"
                     else "a gateway interruption"
                 )
+                _inflight_text = (
+                    getattr(_resume_entry, "inflight_message_text", None)
+                    if _resume_entry is not None
+                    else None
+                )
+                _checkpoint_note = _format_resume_checkpoint_note(
+                    getattr(_resume_entry, "resume_checkpoint", None)
+                    if _resume_entry is not None
+                    else None
+                )
+                _is_auto_resume_event = bool(not (message or "").strip())
+                if _is_auto_resume_event and isinstance(_inflight_text, str) and _inflight_text.strip():
+                    message = _inflight_text
+                    _tail_instruction = "resume the in-flight user request below"
+                else:
+                    _tail_instruction = "then address the user's new message below"
+                _checkpoint_suffix = f" {_checkpoint_note}" if _checkpoint_note else ""
                 message = (
                     f"[System note: Your previous turn in this session was interrupted "
-                    f"by {_reason_phrase}. The conversation history below is intact. "
-                    f"If it contains unfinished tool result(s), process them first and "
-                    f"summarize what was accomplished, then address the user's new "
-                    f"message below.]\n\n"
+                    f"by {_reason_phrase}. The conversation history below is intact, "
+                    f"and the current in-flight user request has been restored below."
+                    f"{_checkpoint_suffix} If the history contains unfinished tool "
+                    f"result(s), process them first and summarize what was accomplished; "
+                    f"otherwise {_tail_instruction}.]\n\n"
                     + message
                 )
             elif _has_fresh_tool_tail:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -490,6 +490,18 @@ class SessionEntry:
     resume_pending: bool = False
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
+    # Durable copy of the *current* user request while an agent turn is running.
+    # Gateway transcripts are normally written after a turn completes; without
+    # this, a restart mid-turn can only see the previous completed transcript and
+    # auto-resume the wrong request.
+    inflight_message_text: Optional[str] = None
+    inflight_message_id: Optional[str] = None
+    inflight_message_recorded_at: Optional[datetime] = None
+    # Compact, JSON-serializable activity snapshot captured when the gateway
+    # interrupts an in-flight turn during restart/shutdown.  It gives the
+    # resumed agent a durable hint about what it was doing beyond the raw
+    # transcript tail (current tool, iteration, last activity).
+    resume_checkpoint: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -517,6 +529,14 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "inflight_message_text": self.inflight_message_text,
+            "inflight_message_id": self.inflight_message_id,
+            "inflight_message_recorded_at": (
+                self.inflight_message_recorded_at.isoformat()
+                if self.inflight_message_recorded_at
+                else None
+            ),
+            "resume_checkpoint": self.resume_checkpoint,
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -547,6 +567,14 @@ class SessionEntry:
             except (TypeError, ValueError):
                 last_resume_marked_at = None
 
+        inflight_message_recorded_at = None
+        _imra = data.get("inflight_message_recorded_at")
+        if _imra:
+            try:
+                inflight_message_recorded_at = datetime.fromisoformat(_imra)
+            except (TypeError, ValueError):
+                inflight_message_recorded_at = None
+
         return cls(
             session_key=data["session_key"],
             session_id=data["session_id"],
@@ -569,6 +597,22 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            inflight_message_text=(
+                data.get("inflight_message_text")
+                if isinstance(data.get("inflight_message_text"), str)
+                else None
+            ),
+            inflight_message_id=(
+                data.get("inflight_message_id")
+                if isinstance(data.get("inflight_message_id"), str)
+                else None
+            ),
+            inflight_message_recorded_at=inflight_message_recorded_at,
+            resume_checkpoint=(
+                data.get("resume_checkpoint")
+                if isinstance(data.get("resume_checkpoint"), dict)
+                else None
+            ),
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -985,10 +1029,56 @@ class SessionStore:
                 return True
         return False
 
+    def record_inflight_message(
+        self,
+        session_key: str,
+        message_text: str,
+        message_id: Optional[str] = None,
+    ) -> bool:
+        """Persist the current user request before the agent starts work.
+
+        Transcript rows are normally written after a turn completes.  This
+        lightweight checkpoint lets restart recovery know the actual in-flight
+        prompt even if the process exits before transcript persistence.
+        """
+        text = message_text if isinstance(message_text, str) else ""
+        if not text.strip():
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.suspended:
+                return False
+            entry.inflight_message_text = text
+            entry.inflight_message_id = str(message_id) if message_id else None
+            entry.inflight_message_recorded_at = _now()
+            self._save()
+            return True
+
+    def clear_inflight_message(self, session_key: str) -> bool:
+        """Clear the durable in-flight prompt after the turn is no longer in flight."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            if (
+                entry.inflight_message_text is None
+                and entry.inflight_message_id is None
+                and entry.inflight_message_recorded_at is None
+            ):
+                return False
+            entry.inflight_message_text = None
+            entry.inflight_message_id = None
+            entry.inflight_message_recorded_at = None
+            self._save()
+            return True
+
     def mark_resume_pending(
         self,
         session_key: str,
         reason: str = "restart_timeout",
+        checkpoint: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Mark a session as resumable after a restart interruption.
 
@@ -1010,6 +1100,7 @@ class SessionStore:
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
+                entry.resume_checkpoint = checkpoint if isinstance(checkpoint, dict) else None
                 self._save()
                 return True
         return False
@@ -1031,6 +1122,7 @@ class SessionStore:
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
+            entry.resume_checkpoint = None
             self._save()
             return True
 
@@ -1103,9 +1195,13 @@ class SessionStore:
 
         Entries already flagged ``resume_pending=True`` are skipped.  Entries
         explicitly ``suspended=True`` (from /stop or stuck-loop escalation)
-        are also skipped.  Terminal escalation for genuinely stuck sessions
-        is still handled by the existing ``.restart_failure_counts`` counter
-        (threshold 3), which runs after this method and sets ``suspended=True``.
+        are also skipped.  A session is considered in-flight only if the
+        previous process recorded ``inflight_message_text`` before starting the
+        agent.  Recently updated sessions without that marker completed their
+        last turn and must not be auto-resumed after an unclean restart.
+        Terminal escalation for genuinely stuck sessions is still handled by
+        the existing ``.restart_failure_counts`` counter (threshold 3), which
+        runs after this method and sets ``suspended=True``.
 
         Returns the number of sessions marked resumable.
         """
@@ -1118,10 +1214,14 @@ class SessionStore:
             for entry in self._entries.values():
                 if entry.resume_pending:
                     continue
-                if not entry.suspended and entry.updated_at >= cutoff:
+                if not entry.inflight_message_text:
+                    continue
+                marker = entry.inflight_message_recorded_at or entry.updated_at
+                if not entry.suspended and marker >= cutoff:
                     entry.resume_pending = True
                     entry.resume_reason = "restart_interrupted"
                     entry.last_resume_marked_at = _now()
+                    entry.resume_checkpoint = None
                     count += 1
             if count:
                 self._save()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,7 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -99,10 +100,36 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under macOS launchd, /restart exits for launchd to relaunch."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
+    """Without systemd/launchd/container supervision, use detached subprocess."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.setattr(gateway_run.os.path, "exists", lambda path: False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -37,6 +37,7 @@ from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
     _auto_continue_freshness_window,
     _coerce_gateway_timestamp,
+    _format_resume_checkpoint_note,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
     _should_clear_resume_pending_after_turn,
@@ -152,12 +153,24 @@ def _simulate_note_injection(
             if reason == "shutdown_timeout"
             else "a gateway interruption"
         )
+        inflight_text = getattr(resume_entry, "inflight_message_text", None)
+        checkpoint_note = _format_resume_checkpoint_note(
+            getattr(resume_entry, "resume_checkpoint", None)
+        )
+        is_auto_resume_event = bool(not (message or "").strip())
+        if is_auto_resume_event and isinstance(inflight_text, str) and inflight_text.strip():
+            message = inflight_text
+            tail_instruction = "resume the in-flight user request below"
+        else:
+            tail_instruction = "then address the user's new message below"
+        checkpoint_suffix = f" {checkpoint_note}" if checkpoint_note else ""
         message = (
             f"[System note: Your previous turn in this session was interrupted "
-            f"by {reason_phrase}. The conversation history below is intact. "
-            f"If it contains unfinished tool result(s), process them first and "
-            f"summarize what was accomplished, then address the user's new "
-            f"message below.]\n\n"
+            f"by {reason_phrase}. The conversation history below is intact, "
+            f"and the current in-flight user request has been restored below."
+            f"{checkpoint_suffix} If the history contains unfinished tool "
+            f"result(s), process them first and summarize what was accomplished; "
+            f"otherwise {tail_instruction}.]\n\n"
             + message
         )
     elif has_fresh_tool_tail:
@@ -189,6 +202,10 @@ class TestSessionEntryResumeFields:
         assert entry.resume_pending is False
         assert entry.resume_reason is None
         assert entry.last_resume_marked_at is None
+        assert entry.inflight_message_text is None
+        assert entry.inflight_message_id is None
+        assert entry.inflight_message_recorded_at is None
+        assert entry.resume_checkpoint is None
 
     def test_roundtrip_with_resume_fields(self):
         now = datetime(2026, 4, 18, 12, 0, 0)
@@ -200,11 +217,19 @@ class TestSessionEntryResumeFields:
             resume_pending=True,
             resume_reason="restart_timeout",
             last_resume_marked_at=now,
+            inflight_message_text="please finish important work",
+            inflight_message_id="msg-123",
+            inflight_message_recorded_at=now,
+            resume_checkpoint={"current_tool": "terminal", "api_call_count": 3},
         )
         restored = SessionEntry.from_dict(entry.to_dict())
         assert restored.resume_pending is True
         assert restored.resume_reason == "restart_timeout"
         assert restored.last_resume_marked_at == now
+        assert restored.inflight_message_text == "please finish important work"
+        assert restored.inflight_message_id == "msg-123"
+        assert restored.inflight_message_recorded_at == now
+        assert restored.resume_checkpoint == {"current_tool": "terminal", "api_call_count": 3}
 
     def test_from_dict_legacy_without_resume_fields(self):
         """Old sessions.json without the new fields deserialize cleanly."""
@@ -256,6 +281,13 @@ class TestMarkResumePending:
         assert refreshed.resume_reason == "restart_timeout"
         assert refreshed.last_resume_marked_at is not None
 
+    def test_checkpoint_persists(self, tmp_path):
+        store = _make_store(tmp_path)
+        entry = store.get_or_create_session(_make_source())
+
+        assert store.mark_resume_pending(entry.session_key, checkpoint={"current_tool": "terminal"}) is True
+        assert store._entries[entry.session_key].resume_checkpoint == {"current_tool": "terminal"}
+
     def test_custom_reason_persists(self, tmp_path):
         store = _make_store(tmp_path)
         source = _make_source()
@@ -299,13 +331,14 @@ class TestClearResumePending:
         store = _make_store(tmp_path)
         source = _make_source()
         entry = store.get_or_create_session(source)
-        store.mark_resume_pending(entry.session_key)
+        store.mark_resume_pending(entry.session_key, checkpoint={"current_tool": "terminal"})
 
         assert store.clear_resume_pending(entry.session_key) is True
         e = store._entries[entry.session_key]
         assert e.resume_pending is False
         assert e.resume_reason is None
         assert e.last_resume_marked_at is None
+        assert e.resume_checkpoint is None
 
     def test_returns_false_when_not_pending(self, tmp_path):
         store = _make_store(tmp_path)
@@ -317,6 +350,32 @@ class TestClearResumePending:
     def test_returns_false_for_unknown_key(self, tmp_path):
         store = _make_store(tmp_path)
         assert store.clear_resume_pending("no-such-key") is False
+
+
+class TestInflightMessageCheckpoint:
+    def test_record_and_clear_inflight_message(self, tmp_path):
+        store = _make_store(tmp_path)
+        entry = store.get_or_create_session(_make_source())
+
+        assert store.record_inflight_message(entry.session_key, "do the current thing", "m1") is True
+        e = store._entries[entry.session_key]
+        assert e.inflight_message_text == "do the current thing"
+        assert e.inflight_message_id == "m1"
+        assert e.inflight_message_recorded_at is not None
+
+        assert store.clear_inflight_message(entry.session_key) is True
+        e = store._entries[entry.session_key]
+        assert e.inflight_message_text is None
+        assert e.inflight_message_id is None
+        assert e.inflight_message_recorded_at is None
+
+    def test_record_ignores_empty_and_unknown(self, tmp_path):
+        store = _make_store(tmp_path)
+        entry = store.get_or_create_session(_make_source())
+
+        assert store.record_inflight_message(entry.session_key, "   ") is False
+        assert store.record_inflight_message("missing", "real work") is False
+        assert store._entries[entry.session_key].inflight_message_text is None
 
 
 # ---------------------------------------------------------------------------
@@ -395,14 +454,26 @@ class TestSuspendRecentlyActiveSkipsResumePending:
         assert e.suspended is False
         assert e.resume_pending is True
 
-    def test_non_resume_pending_gets_resume_pending(self, tmp_path):
-        """Non-resume sessions are now marked resume_pending (not suspended)."""
+    def test_non_resume_pending_without_inflight_marker_is_ignored(self, tmp_path):
+        """Completed sessions must not be revived just because they were recent."""
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="b")
+        entry = store.get_or_create_session(source)
+
+        count = store.suspend_recently_active()
+        assert count == 0
+        assert store._entries[entry.session_key].resume_pending is False
+        assert store._entries[entry.session_key].suspended is False
+
+    def test_non_resume_pending_with_inflight_marker_gets_resume_pending(self, tmp_path):
+        """Only sessions with a durable in-flight prompt are auto-resumed."""
         store = _make_store(tmp_path)
         source_a = _make_source(chat_id="a")
         source_b = _make_source(chat_id="b")
         entry_a = store.get_or_create_session(source_a)
         entry_b = store.get_or_create_session(source_b)
         store.mark_resume_pending(entry_a.session_key)
+        store.record_inflight_message(entry_b.session_key, "finish the real in-flight request")
 
         count = store.suspend_recently_active()
         # entry_a is already resume_pending → skipped. entry_b gets marked.
@@ -442,6 +513,23 @@ class TestResumePendingSystemNote:
         assert "[System note:" in result
         assert "gateway restart" in result
         assert "what happened?" in result
+
+    def test_empty_auto_resume_event_restores_inflight_prompt(self):
+        entry = self._pending_entry(reason="restart_timeout")
+        entry.inflight_message_text = "finish the actual in-flight request"
+        entry.resume_checkpoint = {"current_tool": "terminal", "api_call_count": 2, "max_iterations": 8}
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "previous completed turn", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=entry,
+        )
+        assert "finish the actual in-flight request" in result
+        assert "previous completed turn" not in result.split("\n\n", 1)[1]
+        assert "Restart checkpoint:" in result
+        assert "current tool: terminal" in result
+        assert "resume the in-flight user request below" in result
 
     def test_resume_pending_shutdown_note_mentions_shutdown(self):
         entry = self._pending_entry(reason="shutdown_timeout")


### PR DESCRIPTION
## Summary
- persist the current in-flight gateway user request before agent execution so auto-resume does not replay the prior completed prompt
- capture a compact restart checkpoint from the active agent when marking resume-pending sessions
- route macOS launchd-managed /restart through the service-manager exit path instead of a detached helper

## Test Plan
- uv run python -m py_compile gateway/run.py gateway/session.py
- uv run --extra dev pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_restart_notification.py -q
- git diff --check
- lightweight diff secret-pattern scan (0 findings; gitleaks/trufflehog/detect-secrets not installed locally)
