### PR TITLE
fix(desktop): heal stale runtime-id cache + model on profile switch

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -29,7 +29,7 @@ import {
   unpinSession
 } from '../store/layout'
 import { $filePreviewTarget, $previewTarget, closeActiveRightRailTab } from '../store/preview'
-import { $freshSessionRequest, normalizeProfileKey, refreshActiveProfile } from '../store/profile'
+import { $activeGatewayProfile, $freshSessionRequest, normalizeProfileKey, refreshActiveProfile } from '../store/profile'
 import {
   $activeSessionId,
   $currentCwd,
@@ -505,6 +505,25 @@ export function DesktopController() {
     lastFreshRef.current = freshSessionRequest
     startFreshSessionDraft()
   }, [freshSessionRequest, startFreshSessionDraft])
+
+  // Swapping the live gateway to another profile must re-pull that profile's
+  // global model + active-profile pill. Both are nanostores, so the blanket
+  // invalidateQueries() the profile store fires on swap doesn't touch them —
+  // without this the statusbar keeps showing the previous profile's model
+  // (the "forgets the LLM setting" report). gatewayState stays 'open' across a
+  // swap (background sockets persist), so the open→open effect won't re-run.
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const lastGatewayProfileRef = useRef(activeGatewayProfile)
+
+  useEffect(() => {
+    if (activeGatewayProfile === lastGatewayProfileRef.current) {
+      return
+    }
+
+    lastGatewayProfileRef.current = activeGatewayProfile
+    void refreshCurrentModel()
+    void refreshActiveProfile()
+  }, [activeGatewayProfile, refreshCurrentModel])
 
   const composer = useComposerActions({
     activeSessionId,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -453,15 +453,31 @@ export function useSessionActions({
         clearComposerDraft()
         clearComposerAttachments()
 
-        void requestGateway<UsageStats>('session.usage', { session_id: cachedRuntimeId })
-          .then(usage => {
-            if (isCurrentResume() && usage) {
-              setCurrentUsage(current => ({ ...current, ...usage }))
-            }
-          })
-          .catch(() => undefined)
+        try {
+          const usage = await requestGateway<UsageStats>('session.usage', { session_id: cachedRuntimeId })
 
-        return
+          if (!isCurrentResume()) {
+            return
+          }
+
+          if (usage) {
+            setCurrentUsage(current => ({ ...current, ...usage }))
+          }
+
+          return
+        } catch {
+          // The cached runtime id was minted by a prior backend instance. A
+          // pooled profile backend that gets idle-reaped (pruneSecondaryGateways)
+          // and respawned across a profile swap mints fresh ids, so this mapping
+          // now 404s ("session not found"). Drop it and fall through to a full
+          // resume that rebinds a live runtime id.
+          if (!isCurrentResume()) {
+            return
+          }
+
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
+        }
       }
 
       setFreshDraftReady(false)


### PR DESCRIPTION
## Summary

Two switch-time regressions from the multi-profile rail work (`b94b3622b` per-session profiles, `4891f9ae7` concurrent sockets) — both surface when you switch profiles, neither is touched by the per-profile remote PR (#39778). Reported as: *"When switching between profiles I am noticing a new error 'Session not found', along with it forgetting the LLM setting."*

### 1. "Session not found" (4007) — stale runtime-id cache

`runtimeIdByStoredSessionIdRef` / `sessionStateByRuntimeIdRef` are process-lifetime maps that are **only ever `.set()`, never pruned** — but a runtime session id belongs to one backend *instance*.

`pruneSecondaryGateways()` idle-reaps a non-active profile's pooled backend. Switching back calls `ensureGatewayForProfile()`, which respawns a **fresh** backend that mints brand-new runtime ids. `resumeSession`'s cache fast-path still trusts the old mapping:

```ts
setActiveSessionId(cachedRuntimeId)        // dead id becomes active
void requestGateway('session.usage', …)    // 404, swallowed
return                                      // never rebinds via session.resume
```

→ `session.usage` and the **next prompt** both `4007`.

**Fix:** probe the cached runtime id; on rejection, drop the stale mapping and fall through to the existing full `session.resume` (which rebinds a live id, no flash via the equivalence reconcile). Self-healing, scoped to the one dead session, no impact on still-live background sockets.

### 2. "Forgets the LLM setting" — model not re-pulled on swap

`$currentModel` is a **nanostore**, set only by `refreshCurrentModel()` (gatewayState→open, onboarding, settings-save, model-pick). On a swap the profile store fires `invalidateQueries()` (react-query only — doesn't touch nanostores) and, because background sockets persist, `gatewayState` stays `'open'`, so the open→open effect never re-runs. The statusbar kept showing the previous profile's model.

**Fix:** re-pull global model + active-profile pill whenever `$activeGatewayProfile` changes (`setApiRequestProfile` has already routed to the new backend by then).

## Test plan

- [x] `tsc -b` + `eslint` clean on both files
- [x] `test:ui src/app/session` — `use-route-resume` (6) pass; the `use-prompt-actions.test.tsx` load failure is **pre-existing** (fails identically on the pristine tree — `@/hermes` unmocked when `profile.ts` subscriber runs at import)
- [ ] Manual: profile A (model X) + profile B (model Y), open a chat in A → switch to B → statusbar shows Y, not X
- [ ] Manual: open a session in B → switch to A, idle until B's pool backend is reaped → switch back to B → resume the session + send → no "Session not found"