### PR TITLE
fix(tui): ship ESM package marker in wheel bundle

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -65,11 +65,13 @@ jobs:
         run: |
           mkdir -p hermes_cli/tui_dist
           cp ui-tui/dist/entry.js hermes_cli/tui_dist/entry.js
+          printf '{"type":"module"}\n' > hermes_cli/tui_dist/package.json
 
       - name: Verify frontend assets exist
         run: |
           test -f hermes_cli/web_dist/index.html || { echo "ERROR: web_dist not built"; exit 1; }
           test -f hermes_cli/tui_dist/entry.js || { echo "ERROR: tui_dist not built"; exit 1; }
+          test -f hermes_cli/tui_dist/package.json || { echo "ERROR: tui_dist package.json not built"; exit 1; }
 
       - name: Bundle install scripts into wheel
         run: |

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_tui_finds_bundled_entry_js(tmp_path):
@@ -18,3 +22,15 @@ def test_tui_returns_none_when_no_bundle(tmp_path):
     from hermes_cli.main import _find_bundled_tui
     result = _find_bundled_tui(hermes_cli_dir=tmp_path / "hermes_cli")
     assert result is None
+
+
+def test_pypi_workflow_bundles_tui_esm_package_json():
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "upload_to_pypi.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        'printf \'{"type":"module"}\\n\' > hermes_cli/tui_dist/package.json'
+        in workflow
+    )
+    assert "test -f hermes_cli/tui_dist/package.json" in workflow


### PR DESCRIPTION
## Summary
- write `hermes_cli/tui_dist/package.json` with `{"type":"module"}` during the PyPI bundle step
- verify the wheel bundle includes that marker alongside `entry.js`
- add a focused regression test for the release workflow contract

Fixes #39805.

## Tests
- `pytest tests/hermes_cli/test_tui_bundled.py -q`