### PR TITLE
fix(gateway): read WhatsApp LID mappings from modern session dir

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_dir
 
 
 def normalize_whatsapp_identifier(value: str) -> str:
@@ -71,7 +71,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
     """Resolve WhatsApp phone/LID aliases via bridge session mapping files.
 
     Returns the set of all identifiers transitively reachable through the
-    bridge's ``$HERMES_HOME/whatsapp/session/lid-mapping-*.json`` files,
+    bridge's WhatsApp session ``lid-mapping-*.json`` files,
     starting from ``identifier``. The result always includes the
     normalized input itself, so callers can safely ``in`` check against
     the return value without a separate fallback branch.
@@ -82,7 +82,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
     if not normalized:
         return set()
 
-    session_dir = get_hermes_home() / "whatsapp" / "session"
+    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
     resolved: Set[str] = set()
     queue = [normalized]
 
@@ -128,7 +128,7 @@ def canonical_whatsapp_identifier(identifier: str) -> str:
     member inside a group chat — both represent a user identity, and the
     bridge may flip between the two for the same human.
 
-    This helper reads the bridge's ``whatsapp/session/lid-mapping-*.json``
+    This helper reads the bridge's WhatsApp session ``lid-mapping-*.json``
     files, walks the mapping transitively, and picks the shortest
     (numeric-preferred) alias as the canonical identity.
     :func:`gateway.session.build_session_key` uses this for both WhatsApp

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -970,6 +970,20 @@ class TestWhatsAppIdentifierPublicHelpers:
         assert canonical == "15551234567"
         assert canonical_whatsapp_identifier("15551234567@s.whatsapp.net") == "15551234567"
 
+    def test_canonical_walks_modern_lid_mapping(self, tmp_path, monkeypatch):
+        """Fresh installs store WhatsApp bridge mappings under platforms/."""
+        mapping_dir = tmp_path / "platforms" / "whatsapp" / "session"
+        mapping_dir.mkdir(parents=True, exist_ok=True)
+        (mapping_dir / "lid-mapping-999999999999999.json").write_text(
+            json.dumps("15551234567@s.whatsapp.net"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        canonical = canonical_whatsapp_identifier("999999999999999@lid")
+        assert canonical == "15551234567"
+        assert canonical_whatsapp_identifier("15551234567@s.whatsapp.net") == "15551234567"
+
     def test_canonical_empty_input(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert canonical_whatsapp_identifier("") == ""

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -100,6 +100,38 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_session_mapping(monkeypat
     assert runner._is_user_authorized(source) is True
 
 
+def test_whatsapp_lid_user_matches_phone_allowlist_via_modern_session_mapping(
+    monkeypatch, tmp_path,
+):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15550000001")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    session_dir = tmp_path / "platforms" / "whatsapp" / "session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "lid-mapping-15550000001.json").write_text(
+        '"900000000000001"', encoding="utf-8",
+    )
+    (session_dir / "lid-mapping-900000000000001_reverse.json").write_text(
+        '"15550000001"', encoding="utf-8",
+    )
+
+    runner, _adapter = _make_runner(
+        Platform.WHATSAPP,
+        GatewayConfig(platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="900000000000001@lid",
+        chat_id="900000000000001@lid",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
 def test_star_wildcard_in_allowlist_authorizes_any_user(monkeypatch):
     """WHATSAPP_ALLOWED_USERS=* should act as allow-all wildcard."""
     _clear_auth_env(monkeypatch)


### PR DESCRIPTION
## Summary
- route WhatsApp identity alias resolution through the same `get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")` helper used by the adapter
- preserve legacy `whatsapp/session` behavior when that directory exists
- add modern-layout regressions for canonical session IDs and allowlist authorization

Fixes #36664.

## Tests
- `pytest tests/gateway/test_session.py tests/gateway/test_unauthorized_dm_behavior.py -q`