### PR TITLE
fix(config): accept string home channel values

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -225,9 +225,22 @@ class HomeChannel:
         return result
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
+    def from_dict(
+        cls,
+        data: Any,
+        platform: Optional[Platform] = None,
+    ) -> "HomeChannel":
+        if isinstance(data, str):
+            if platform is None:
+                raise ValueError("home_channel string requires platform context")
+            return cls(platform=platform, chat_id=data, name="Home")
+        if not isinstance(data, dict):
+            raise ValueError(f"home_channel must be a dict or string, got {type(data).__name__}")
+        resolved_platform = data.get("platform")
+        if resolved_platform is None and platform is not None:
+            resolved_platform = platform.value
         return cls(
-            platform=Platform(data["platform"]),
+            platform=Platform(resolved_platform),
             chat_id=str(data["chat_id"]),
             name=data.get("name", "Home"),
             thread_id=str(data["thread_id"]) if data.get("thread_id") else None,
@@ -317,10 +330,14 @@ class PlatformConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        platform: Optional[Platform] = None,
+    ) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
+            home_channel = HomeChannel.from_dict(data["home_channel"], platform=platform)
 
         # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
@@ -611,7 +628,7 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                platforms[platform] = PlatformConfig.from_dict(platform_data, platform=platform)
             except ValueError:
                 pass  # Skip unknown platforms
         

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -25,6 +25,18 @@ class TestHomeChannelRoundtrip:
         assert restored.chat_id == "999"
         assert restored.name == "general"
 
+    def test_from_string_uses_platform_context(self):
+        restored = HomeChannel.from_dict(
+            "oc_b0b897cce6e70190959898f94fe8f9a8",
+            platform=Platform.FEISHU,
+        )
+
+        assert restored == HomeChannel(
+            platform=Platform.FEISHU,
+            chat_id="oc_b0b897cce6e70190959898f94fe8f9a8",
+            name="Home",
+        )
+
 
 class TestPlatformConfigRoundtrip:
     def test_to_dict_from_dict(self):
@@ -69,6 +81,21 @@ class TestPlatformConfigRoundtrip:
     def test_gateway_restart_notification_coerces_quoted_false(self):
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
+
+    def test_string_home_channel_uses_platform_context(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "home_channel": "oc_b0b897cce6e70190959898f94fe8f9a8",
+            },
+            platform=Platform.FEISHU,
+        )
+
+        assert restored.home_channel == HomeChannel(
+            platform=Platform.FEISHU,
+            chat_id="oc_b0b897cce6e70190959898f94fe8f9a8",
+            name="Home",
+        )
 
 
 class TestGetConnectedPlatforms:
@@ -446,6 +473,28 @@ class TestLoadGatewayConfig:
             name="Nested Home",
         )
         assert telegram.extra["reply_prefix"] == "nested"
+
+    def test_load_gateway_config_accepts_string_home_channel(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  feishu:\n"
+            "    enabled: true\n"
+            "    home_channel: oc_b0b897cce6e70190959898f94fe8f9a8\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.FEISHU].home_channel == HomeChannel(
+            platform=Platform.FEISHU,
+            chat_id="oc_b0b897cce6e70190959898f94fe8f9a8",
+            name="Home",
+        )
 
     def test_top_level_platforms_override_nested_gateway_platforms(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- allow `HomeChannel.from_dict()` to wrap string `home_channel` values when platform context is available
- pass platform context through `PlatformConfig.from_dict()` and `GatewayConfig.from_dict()`
- add regressions for direct parsing and the `config.yaml` shape written by `hermes config set platforms.<name>.home_channel <chat_id>`

Fixes #33141.

## Tests
- `pytest tests/gateway/test_config.py -q`