### PR TITLE
fix(desktop/windows): stop racing our own backend during in-app update

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -171,6 +171,13 @@ async fn run_update(app: AppHandle) -> Result<()> {
     let child_env = update_child_env(&install_root);
     let mut update_args: Vec<String> =
         vec!["update".into(), "--yes".into(), "--gateway".into()];
+    // --force skips `hermes update`'s Windows running-exe guard (which would
+    // `sys.exit(2)` and dead-end the handoff). By contract the desktop has
+    // already exited and waited for the venv shim to unlock before launching
+    // us, and wait_for_venv_free below force-kills any straggler — so by the
+    // time `hermes update` runs there is no legitimate hermes.exe to protect,
+    // and the guard would only produce a false "Hermes is still running" stop.
+    update_args.push("--force".into());
     update_args.push("--branch".into());
     update_args.push(update_branch);
 
@@ -366,15 +373,74 @@ async fn wait_for_venv_free(install_root: &Path, app: &AppHandle) {
             return;
         }
         if Instant::now() >= deadline {
+            // Last resort: a backend hermes.exe (or a grandchild it spawned)
+            // is still holding the shim. The desktop should have reaped its
+            // tree before handing off, but SIGTERM races / detached
+            // grandchildren / AV handles can leave a straggler. Rather than
+            // "proceed anyway" straight into uv's "Access is denied", force-kill
+            // every hermes.exe except ourselves, then give the OS a beat to
+            // unload the image.
             emit_log(
                 app,
                 Some("update"),
                 LogStream::Stdout,
-                "[update] timed out waiting for Hermes to exit; proceeding anyway",
+                "[update] Hermes still holding the venv shim; force-killing stragglers…",
             );
+            force_kill_other_hermes();
+            tokio::time::sleep(Duration::from_millis(800)).await;
+            if !is_locked(&shim) {
+                emit_log(
+                    app,
+                    Some("update"),
+                    LogStream::Stdout,
+                    "[update] venv shim freed after force-kill",
+                );
+            } else {
+                emit_log(
+                    app,
+                    Some("update"),
+                    LogStream::Stdout,
+                    "[update] venv shim still locked; proceeding (--force + quarantine will handle it)",
+                );
+            }
             return;
         }
         tokio::time::sleep(DESKTOP_EXIT_POLL).await;
+    }
+}
+
+/// Force-kill any `hermes.exe` other than this process. Windows-only; a no-op
+/// elsewhere (POSIX has no mandatory-lock contention). We can't selectively
+/// target "the backend" by PID here — the desktop already exited and we never
+/// knew its children — so we kill the whole `hermes.exe` image tree via
+/// taskkill, excluding our own PID.
+///
+/// Safe w.r.t. our own update child: this runs inside `wait_for_venv_free`,
+/// which completes BEFORE we spawn `venv\Scripts\hermes.exe update`. At this
+/// point no update-driven hermes.exe exists yet, so the only hermes.exe images
+/// are stragglers from the old desktop — exactly what we want gone. (`/FI PID
+/// ne <self>` also spares this Tauri process, though it isn't named
+/// hermes.exe.)
+fn force_kill_other_hermes() {
+    if !cfg!(target_os = "windows") {
+        return;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let my_pid = std::process::id();
+        // /FI excludes our own PID; /T kills the tree; /F forces.
+        let _ = std::process::Command::new("taskkill")
+            .args([
+                "/F",
+                "/T",
+                "/IM",
+                "hermes.exe",
+                "/FI",
+                &format!("PID ne {my_pid}"),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
     }
 }
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1313,6 +1313,110 @@ function resolveUpdaterBinary() {
   return fileExists(candidate) ? candidate : null
 }
 
+// Path to the venv shim whose lock decides whether `hermes update` can write
+// fresh entry points. On Windows this is the file the running backend
+// `hermes.exe` holds open; on POSIX it's never mandatory-locked.
+function venvHermesShimPath(updateRoot) {
+  return IS_WINDOWS
+    ? path.join(updateRoot, 'venv', 'Scripts', 'hermes.exe')
+    : path.join(updateRoot, 'venv', 'bin', 'hermes')
+}
+
+// Best-effort lock probe mirroring the Rust updater's is_locked(): a running
+// .exe on Windows refuses an O_RDWR open with a sharing violation. On POSIX
+// this practically always succeeds (no mandatory locking), so it returns false
+// — correct, since the shim-contention brick is Windows-only.
+function isShimLocked(shimPath) {
+  if (!IS_WINDOWS) return false
+  let fd
+  try {
+    fd = fs.openSync(shimPath, 'r+')
+    return false
+  } catch (err) {
+    // ENOENT ⇒ not there ⇒ nothing locking it. Anything else (EBUSY/EPERM/
+    // EACCES) on Windows means a live handle holds it.
+    return err && err.code !== 'ENOENT'
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        void 0
+      }
+    }
+  }
+}
+
+// Force-kill the entire process TREE rooted at each PID. Node's child.kill()
+// only signals the direct child, so on Windows a backend `hermes.exe` that
+// spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
+// gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
+// the whole tree synchronously. POSIX uses SIGKILL on the negative pgid where
+// possible, falling back to a plain kill.
+function forceKillProcessTree(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return
+  try {
+    if (IS_WINDOWS) {
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
+    } else {
+      try {
+        process.kill(-pid, 'SIGKILL')
+      } catch {
+        process.kill(pid, 'SIGKILL')
+      }
+    }
+  } catch {
+    // Already gone, or no permission — best effort; the unlock wait below is
+    // the real gate.
+  }
+}
+
+// Before handing off the update on Windows, the desktop MUST stop every backend
+// it spawned and WAIT for the venv shim to actually unlock. The old code did
+// `hermesProcess.kill('SIGTERM')` + `app.quit()` fire-and-forget: SIGTERM on
+// Windows doesn't reap the backend's grandchildren, and quit didn't wait for
+// teardown, so the updater raced a still-locked `hermes.exe`, the quarantine
+// rename failed, uv's `pip install` hit "Access is denied", and the git path
+// bailed into a full ZIP re-download that ALSO couldn't write the locked shim —
+// a half-applied install (ryanc's update.log). Here we tree-kill the primary +
+// pool backends and poll the shim until it's writable (or a bounded timeout),
+// so by the time we spawn the updater the lock is genuinely gone.
+async function releaseBackendLockForUpdate(updateRoot) {
+  // Collect every backend PID the desktop owns: primary window backend + pool.
+  const pids = []
+  if (hermesProcess && Number.isInteger(hermesProcess.pid)) pids.push(hermesProcess.pid)
+  for (const entry of backendPool.values()) {
+    if (entry.process && Number.isInteger(entry.process.pid)) pids.push(entry.process.pid)
+  }
+
+  // Graceful first (lets Python flush), then tree-kill to catch grandchildren.
+  if (hermesProcess && !hermesProcess.killed) {
+    try {
+      hermesProcess.kill('SIGTERM')
+    } catch {
+      void 0
+    }
+  }
+  stopAllPoolBackends()
+  for (const pid of pids) forceKillProcessTree(pid)
+
+  if (!IS_WINDOWS) return { unlocked: true }
+
+  const shim = venvHermesShimPath(updateRoot)
+  const deadlineMs = Date.now() + 15000
+  while (Date.now() < deadlineMs) {
+    if (!isShimLocked(shim)) {
+      rememberLog('[updates] venv shim unlocked; safe to hand off the update')
+      return { unlocked: true }
+    }
+    await new Promise(r => setTimeout(r, 300))
+  }
+  // Timed out: the updater's own wait_for_venv_free + force-kill is the second
+  // line of defense, and we pass --force so the guard won't dead-end. Log it.
+  rememberLog('[updates] venv shim still locked after 15s; handing off anyway (updater will force)')
+  return { unlocked: false }
+}
+
 // applyUpdates — hand off to the installer's --update flow, then exit.
 //
 // The desktop is a pure consumer: it does NOT git pull / pip install / rebuild
@@ -1378,6 +1482,12 @@ async function applyUpdates(opts = {}) {
       updaterArgs.push('--target-app', targetApp)
     }
     const venvBin = path.join(updateRoot, 'venv', IS_WINDOWS ? 'Scripts' : 'bin')
+
+    // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
+    // spawn the updater. Without this the updater races a still-locked
+    // hermes.exe (held by the backend child / its grandchildren) and the update
+    // bricks. See releaseBackendLockForUpdate for the full failure analysis.
+    await releaseBackendLockForUpdate(updateRoot)
 
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1351,20 +1351,15 @@ function isShimLocked(shimPath) {
 // only signals the direct child, so on Windows a backend `hermes.exe` that
 // spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
 // gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
-// the whole tree synchronously. POSIX uses SIGKILL on the negative pgid where
-// possible, falling back to a plain kill.
+// the whole tree synchronously. Windows-only: this is called solely from the
+// Windows shim-unlock path, and the backend is NOT spawned detached (so it's
+// not a process-group leader — a POSIX negative-pgid kill would be meaningless
+// here anyway). POSIX teardown stays with the existing before-quit SIGTERM.
 function forceKillProcessTree(pid) {
+  if (!IS_WINDOWS) return
   if (!Number.isInteger(pid) || pid <= 0) return
   try {
-    if (IS_WINDOWS) {
-      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
-    } else {
-      try {
-        process.kill(-pid, 'SIGKILL')
-      } catch {
-        process.kill(pid, 'SIGKILL')
-      }
-    }
+    execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
   } catch {
     // Already gone, or no permission — best effort; the unlock wait below is
     // the real gate.
@@ -1381,7 +1376,15 @@ function forceKillProcessTree(pid) {
 // a half-applied install (ryanc's update.log). Here we tree-kill the primary +
 // pool backends and poll the shim until it's writable (or a bounded timeout),
 // so by the time we spawn the updater the lock is genuinely gone.
+//
+// Windows-only: the venv-shim mandatory lock is a Windows phenomenon. On
+// macOS/Linux there's no REPLACE-on-running-exe block, the existing before-quit
+// SIGTERM + app.quit() teardown already works (the macOS path is flawless), and
+// aggressively SIGKILL-ing the backend here would be an untested behavior change
+// for no benefit. So we no-op off Windows and leave that path exactly as it was.
 async function releaseBackendLockForUpdate(updateRoot) {
+  if (!IS_WINDOWS) return { unlocked: true }
+
   // Collect every backend PID the desktop owns: primary window backend + pool.
   const pids = []
   if (hermesProcess && Number.isInteger(hermesProcess.pid)) pids.push(hermesProcess.pid)
@@ -1399,8 +1402,6 @@ async function releaseBackendLockForUpdate(updateRoot) {
   }
   stopAllPoolBackends()
   for (const pid of pids) forceKillProcessTree(pid)
-
-  if (!IS_WINDOWS) return { unlocked: true }
 
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000


### PR DESCRIPTION
## Summary

The Windows **in-app** desktop update (Update button → `hermes-setup.exe --update` handoff) bricks because it **races our own backend's lock on `hermes.exe`**. macOS is flawless because it doesn't block REPLACE on a running executable; Windows does, so the whole update hinges on the venv shim being unlocked *before* `hermes update` runs — and it isn't.

### Root cause (from a field `update.log`)

The handoff did `hermesProcess.kill('SIGTERM')` + `app.quit()` **fire-and-forget**:

1. SIGTERM on Windows doesn't reap the backend's **grandchildren** (a `hermes` REPL, a pty terminal session, the gateway), and `app.quit()` doesn't **wait** for teardown.
2. The updater (`update.rs`) then runs `hermes update`, but `hermes.exe` is still held open.
3. `_quarantine_running_hermes_exe`'s rename fails → uv `pip install -e .` → **`Access is denied`**.
4. The git path bails to a **full ZIP re-download** ("reinstall"), which *also* can't write the locked shim.
5. Result: a **half-applied install**, and the app doesn't cleanly relaunch.

Even when the updater's `wait_for_venv_free` fired, it just logged *"timed out … proceeding anyway"* and marched straight into the lock; and the update ran **without `--force`**, so the running-exe guard could `sys.exit(2)` into a false *"Hermes is still running. Close all windows"* — after the desktop had already quit (it's the invisible backend child).

### Fix — Mac-style parity (click Update → progress → relaunch, no terminal)

Three coordinated changes:

**A. Desktop (`apps/desktop/electron/main.cjs`)** — new `releaseBackendLockForUpdate()` runs *before* spawning the updater:
- Tree-kills the primary **and** pool backends (`taskkill /T /F` on Windows to catch grandchildren SIGTERM misses; SIGKILL on POSIX).
- **Polls the venv shim until it's actually writable** (bounded 15s) so the lock is genuinely gone before handoff.
- Also fixes `resolveHermesCliBinary` to resolve `venv\Scripts\hermes.exe` on Windows (it only checked the POSIX `venv/bin/hermes`).

**B. Updater (`apps/bootstrap-installer/src-tauri/src/update.rs`)** — `wait_for_venv_free` no longer "proceeds anyway" on timeout. It **force-kills any lingering `hermes.exe`** (excluding itself) and re-checks, so a straggler (AV handle, detached grandchild) can't doom the install. Safe w.r.t. the updater's own child because this runs *before* `venv\Scripts\hermes.exe update` is spawned.

**C. Updater** — pass `--force` to `hermes update`. By contract the desktop has exited and waited, and B force-kills stragglers, so the running-exe guard would only produce a false dead-end. (`--force` only skips that early guard; the real shim write still relies on the quarantine→rename→reboot-fallback machinery, which now succeeds because the shim is free.)

### Why all three (not just one)

`--force` **alone** would be *worse*: it removes the clean `sys.exit(2)` stop and marches into the quarantine-fail → ZIP cascade if the backend is still alive. The pieces are interdependent: kill+wait (A) makes `--force` (C) safe; force-kill-on-timeout (B) is the belt-and-suspenders for stragglers A missed.

## Test plan

- [x] `node --check apps/desktop/electron/main.cjs` → OK
- [x] `cargo check` on the updater → clean (only pre-existing dead-code warnings)
- [x] Windows-gated `taskkill` body type-checks standalone (no Windows target installed in CI box; `#[cfg(target_os = "windows")]` block uses only cross-platform std APIs — `std::process::id`, `Command`, `format!`)
- [ ] **Needs a Windows smoke test**: click Update in the desktop with the app open → expect progress UI → backend reaped → `hermes update --force` completes (no `Access is denied`, no ZIP fallback) → rebuild → relaunch. (I can't exercise Windows from this box.)

## Notes

- POSIX paths are unaffected: `isShimLocked`/`forceKillProcessTree` are Windows-specialized; `force_kill_other_hermes()` is a no-op off Windows; the macOS in-app swapper path is untouched.
- Scope: the in-app handoff path only. The bare-terminal `hermes update` race (user types it while Desktop is open) is a separate UX hardening and not in this PR.
