### PR TITLE
fix(tools): preserve auxiliary config model precedence

### DIFF
--- a/tests/tools/test_auxiliary_tool_model_precedence.py
+++ b/tests/tools/test_auxiliary_tool_model_precedence.py
@@ -1,0 +1,130 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_browser_vision_config_model_beats_env_override():
+    from tools import browser_tool
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={
+            "auxiliary": {"vision": {"model": "config-vision"}}
+        }),
+        patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "stale-env"}, clear=False),
+    ):
+        assert browser_tool._get_vision_model() is None
+
+
+def test_browser_vision_env_model_remains_fallback_without_config_model():
+    from tools import browser_tool
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={"auxiliary": {"vision": {}}}),
+        patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "env-vision"}, clear=False),
+    ):
+        assert browser_tool._get_vision_model() == "env-vision"
+
+
+def test_browser_extraction_config_model_beats_env_override():
+    from tools import browser_tool
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={
+            "auxiliary": {"web_extract": {"model": "config-web"}}
+        }),
+        patch.dict(os.environ, {"AUXILIARY_WEB_EXTRACT_MODEL": "stale-env"}, clear=False),
+    ):
+        assert browser_tool._get_extraction_model() is None
+
+
+def test_browser_extraction_env_model_remains_fallback_without_config_model():
+    from tools import browser_tool
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={"auxiliary": {"web_extract": {}}}),
+        patch.dict(os.environ, {"AUXILIARY_WEB_EXTRACT_MODEL": "env-web"}, clear=False),
+    ):
+        assert browser_tool._get_extraction_model() == "env-web"
+
+
+def test_vision_handler_config_model_beats_env_override():
+    from tools import vision_tools
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={
+            "auxiliary": {"vision": {"model": "config-vision"}}
+        }),
+        patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "stale-env"}, clear=False),
+        patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+        patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool,
+    ):
+        coro = vision_tools._handle_vision_analyze({
+            "image_url": "https://example.com/img.png",
+            "question": "describe",
+        })
+        coro.close()
+
+    assert mock_tool.call_args.args[2] is None
+
+
+def test_vision_handler_env_model_remains_fallback_without_config_model():
+    from tools import vision_tools
+
+    with (
+        patch("hermes_cli.config.read_raw_config", return_value={"auxiliary": {"vision": {}}}),
+        patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "env-vision"}, clear=False),
+        patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
+        patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool,
+    ):
+        coro = vision_tools._handle_vision_analyze({
+            "image_url": "https://example.com/img.png",
+            "question": "describe",
+        })
+        coro.close()
+
+    assert mock_tool.call_args.args[2] == "env-vision"
+
+
+def test_web_extract_config_model_beats_env_override():
+    from tools import web_tools
+
+    client = MagicMock(base_url="https://api.openrouter.ai/v1")
+    with (
+        patch("tools.web_tools.get_async_text_auxiliary_client", return_value=(client, "config-web")),
+        patch("hermes_cli.config.read_raw_config", return_value={
+            "auxiliary": {"web_extract": {"model": "config-web"}}
+        }),
+        patch.dict(os.environ, {"AUXILIARY_WEB_EXTRACT_MODEL": "stale-env"}, clear=False),
+    ):
+        _, model, _ = web_tools._resolve_web_extract_auxiliary()
+
+    assert model == "config-web"
+
+
+def test_web_extract_env_model_remains_fallback_without_config_model():
+    from tools import web_tools
+
+    client = MagicMock(base_url="https://api.openrouter.ai/v1")
+    with (
+        patch("tools.web_tools.get_async_text_auxiliary_client", return_value=(client, "default-web")),
+        patch("hermes_cli.config.read_raw_config", return_value={"auxiliary": {"web_extract": {}}}),
+        patch.dict(os.environ, {"AUXILIARY_WEB_EXTRACT_MODEL": "env-web"}, clear=False),
+    ):
+        _, model, _ = web_tools._resolve_web_extract_auxiliary()
+
+    assert model == "env-web"
+
+
+def test_web_extract_explicit_model_still_wins_over_config_and_env():
+    from tools import web_tools
+
+    client = MagicMock(base_url="https://api.openrouter.ai/v1")
+    with (
+        patch("tools.web_tools.get_async_text_auxiliary_client", return_value=(client, "config-web")),
+        patch("hermes_cli.config.read_raw_config", return_value={
+            "auxiliary": {"web_extract": {"model": "config-web"}}
+        }),
+        patch.dict(os.environ, {"AUXILIARY_WEB_EXTRACT_MODEL": "stale-env"}, clear=False),
+    ):
+        _, model, _ = web_tools._resolve_web_extract_auxiliary("explicit-web")
+
+    assert model == "explicit-web"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -220,13 +220,30 @@ def _get_command_timeout() -> int:
     return result
 
 
+def _auxiliary_task_model_configured(task: str) -> bool:
+    """Return True when config.yaml sets auxiliary.<task>.model."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        model = cfg_get(cfg, "auxiliary", task, "model")
+        return bool(str(model or "").strip())
+    except Exception as e:
+        logger.debug("Could not read auxiliary.%s.model from config: %s", task, e)
+        return False
+
+
 def _get_vision_model() -> Optional[str]:
     """Model for browser_vision (screenshot analysis — multimodal)."""
+    if _auxiliary_task_model_configured("vision"):
+        return None
     return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
 
 
 def _get_extraction_model() -> Optional[str]:
     """Model for page snapshot text summarization — same as web_extract."""
+    if _auxiliary_task_model_configured("web_extract"):
+        return None
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -74,6 +74,25 @@ _VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
 _VISION_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 
 
+def _auxiliary_task_model_configured(task: str) -> bool:
+    """Return True when config.yaml sets auxiliary.<task>.model."""
+    try:
+        from hermes_cli.config import cfg_get, read_raw_config
+
+        cfg = read_raw_config()
+        model = cfg_get(cfg, "auxiliary", task, "model")
+        return bool(str(model or "").strip())
+    except Exception as e:
+        logger.debug("Could not read auxiliary.%s.model from config: %s", task, e)
+        return False
+
+
+def _resolve_vision_model_for_handler() -> Optional[str]:
+    if _auxiliary_task_model_configured("vision"):
+        return None
+    return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+
+
 def _image_url_shape_ok(url: str) -> bool:
     """HTTP(S) shape check only (scheme, netloc). No DNS."""
     if not url or not isinstance(url, str):
@@ -1209,7 +1228,7 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "Fully describe and explain everything about this image, then answer the "
         f"following question:\n\n{question}"
     )
-    model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    model = _resolve_vision_model_for_handler()
     return vision_analyze_tool(image_url, full_prompt, model)
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -285,6 +285,20 @@ def _web_requires_env() -> list[str]:
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000
 
+
+def _auxiliary_task_model_configured(task: str) -> bool:
+    """Return True when config.yaml sets auxiliary.<task>.model."""
+    try:
+        from hermes_cli.config import cfg_get, read_raw_config
+
+        cfg = read_raw_config()
+        model = cfg_get(cfg, "auxiliary", task, "model")
+        return bool(str(model or "").strip())
+    except Exception as e:
+        logger.debug("Could not read auxiliary.%s.model from config: %s", task, e)
+        return False
+
+
 def _is_nous_auxiliary_client(client: Any) -> bool:
     """Return True when the resolved auxiliary backend is Nous Portal."""
     from urllib.parse import urlparse
@@ -297,8 +311,12 @@ def _is_nous_auxiliary_client(client: Any) -> bool:
 def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optional[Any], Optional[str], Dict[str, Any]]:
     """Resolve the current web-extract auxiliary client, model, and extra body."""
     client, default_model = get_async_text_auxiliary_client("web_extract")
-    configured_model = os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip()
-    effective_model = model or configured_model or default_model
+    env_model = (
+        None
+        if _auxiliary_task_model_configured("web_extract")
+        else os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip()
+    )
+    effective_model = model or env_model or default_model
 
     extra_body: Dict[str, Any] = {}
     if client is not None and _is_nous_auxiliary_client(client):


### PR DESCRIPTION
## Summary

- stop stale `AUXILIARY_VISION_MODEL` / `AUXILIARY_WEB_EXTRACT_MODEL` bridge env vars from overriding configured `auxiliary.<task>.model` values
- let browser vision, browser page extraction, standalone vision, and web extraction route through the centralized auxiliary resolver when config already names the task model
- keep env-only setups working as the fallback when config does not set a task model

Fixes #14693

## Notes on related PRs

There are older/open vision-routing PRs in this area. This change is intentionally focused on the stale env bridge precedence reported in #14693 and also covers the web-extract path (`tools/web_tools.py`) so `auxiliary.web_extract.model` is not defeated by `AUXILIARY_WEB_EXTRACT_MODEL`.

## Tests

- `scripts/run_tests.sh tests/tools/test_auxiliary_tool_model_precedence.py tests/tools/test_vision_tools.py tests/tools/test_web_tools_config.py tests/tools/test_browser_content_none_guard.py`
- `.venv/bin/python -m py_compile tools/browser_tool.py tools/vision_tools.py tools/web_tools.py tests/tools/test_auxiliary_tool_model_precedence.py`
- `git diff --check`

## Verification details

The new regression tests cover:

- browser vision: config model suppresses stale env override; env remains fallback without config
- browser extraction: config model suppresses stale env override; env remains fallback without config
- standalone vision handler: config model suppresses stale env override; env remains fallback without config
- web extraction: config/default model wins over stale env, while an explicit call model still wins over both
