### PR TITLE
fix(update/windows): retry handoff hermes update once on first-run crash

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -176,7 +176,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     emit_stage(&app, "update", StageState::Running, None, None);
     let started = Instant::now();
-    let update = run_streamed(
+    let mut update = run_streamed(
         &app,
         &hermes,
         &update_args,
@@ -185,6 +185,38 @@ async fn run_update(app: AppHandle) -> Result<()> {
         Some("update"),
     )
     .await?;
+
+    // Retry-once for the update-boundary crash. `hermes update` lazily imports
+    // the FRESHLY PULLED modules, but the dependency-install step still runs the
+    // already-in-memory pre-pull code for one invocation. A release that changed
+    // an updater-path contract across that boundary (e.g. #39780's `_UvResult`,
+    // whose `__iter__` injected a bool into the argv and crashed Windows
+    // `list2cmdline` with `TypeError: sequence item 1: expected str instance,
+    // bool found`, fixed in #39820) therefore kills the FIRST update on the
+    // parked population — even though the fix is already on disk by then. A
+    // second `hermes update` runs clean because the now-current module is loaded
+    // from the start. Rather than make the parked user click Update twice (and
+    // stare at a scary crash first), retry once automatically. Skip the retry
+    // for the concurrent-instance guard (exit 2) — that's a "close Hermes" state
+    // a retry can't fix.
+    if !matches!(update.exit_code, Some(0) | Some(UPDATE_EXIT_CONCURRENT)) {
+        emit_log(
+            &app,
+            Some("update"),
+            LogStream::Stdout,
+            "[update] first update attempt failed; retrying once (the fix it just \
+             pulled loads on the second run)…",
+        );
+        update = run_streamed(
+            &app,
+            &hermes,
+            &update_args,
+            &install_root,
+            &child_env,
+            Some("update"),
+        )
+        .await?;
+    }
     let update_ms = started.elapsed().as_millis() as u64;
 
     match update.exit_code {


### PR DESCRIPTION
## Summary

A parked Windows user clicking **Update** in the desktop crashes on the **first** attempt and only succeeds on the **second** — even when the fix is already merged. This auto-retries once so the first click just works.

## Why the first update crashes

The in-app updater (`Hermes-Setup --update` → `update.rs`) runs `hermes update`. That command **lazily imports the freshly-pulled modules**, but the dependency-install step runs the **already-in-memory, pre-pull** code for one invocation. So a release that changes an updater-path contract across that boundary kills the *first* update on everyone parked behind it — despite the fix being on disk by then.

Concretely, this is #39780's `_UvResult` (a `str` subclass whose `__iter__` yields `(path, fresh_bootstrap)`):

```
File ".../hermes_cli/main.py", line 8682, in _run_install_with_heartbeat
File ".../subprocess.py", line 643, in list2cmdline
    return ''.join(result)
TypeError: sequence item 1: expected str instance, bool found
update stage … state=Failed
```

Windows `subprocess.list2cmdline([uv_bin, "pip", ...])` iterates each arg as a string; `_UvResult.__iter__` injects the bool → `TypeError`. #39820 fixes the root cause (gates `_UvResult` off Windows), **but**: a parked user clicking Update pulls #39820 to disk, then still crashes on the *in-memory* pre-merge module. Only the **second** click runs clean (now-current module loaded from the start).

**Field repro:** ryanc's `bootstrap.log`, 2026-06-05 12:41:41 — exact `TypeError ... bool found` on the handoff update path.

## Fix

When the first `hermes update` exits non-zero, retry it **once** automatically. The retry re-execs `hermes update`, which loads the now-current module and succeeds.

- Skips the retry for `UPDATE_EXIT_CONCURRENT` (exit 2) — that's a "close Hermes" state a retry can't fix.
- One extra attempt only; a persistent failure still surfaces the same error as before.

## Relationship to #39820

#39820 (merged) is the **root-cause** fix. This is the **migration-boundary** companion that spares the already-parked Windows population the one-time crash + manual second click while they cross onto #39820.

## Test plan

- [x] `cargo check` clean
- [ ] Windows smoke: click Update on a pre-#39820 install → expect first `hermes update` to crash with the `_UvResult` TypeError, auto-retry log line, second attempt succeeds, rebuild + relaunch. (Can't exercise Windows from this box.)
