### PR TITLE
fix(kanban): keep initial blocked tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2859,23 +2859,34 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    ``"created"`` / ``"blocked"`` / ``"unblocked"`` event for the task.
+    If the most recent one is ``"blocked"``, or the task was created
+    directly in ``status='blocked'`` and no ``"unblocked"`` event has
+    fired since, the task is sticky and ``recompute_ready`` must *not*
+    auto-promote it.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    Returns ``False`` when there is no sticky signal at all (e.g. the
+    task was set to ``status='blocked'`` by the circuit breaker or by
+    direct DB manipulation) — preserves the pre-#28712 auto-recover
+    semantics for that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('created', 'blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row:
+        return False
+    if row["kind"] == "blocked":
+        return True
+    if row["kind"] != "created":
+        return False
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else {}
+    except Exception:
+        return False
+    return payload.get("status") == "blocked"
 
 
 def recompute_ready(

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -99,6 +99,50 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         assert kb.get_task(conn, child).status == "blocked"
 
 
+def test_initial_blocked_task_is_not_auto_promoted(kanban_home: Path) -> None:
+    """Tasks born blocked are human-gated and must not silently promote.
+
+    Regression for #39609: ``create --initial-status blocked`` records only
+    a ``created`` event with ``status=blocked``.  The sticky guard must treat
+    that as deliberately blocked, not as a transient circuit-breaker block.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ASSENT: gated production change",
+            assignee="worker",
+            initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert kinds == ["created"]
+
+
+def test_initial_blocked_task_unblock_releases_sticky_state(kanban_home: Path) -> None:
+    """Explicit operator unblock is still the legitimate exit path."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="approved gated change",
+            assignee="worker",
+            initial_status="blocked",
+        )
+
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "ready"
+
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert kinds == ["created", "unblocked"]
+
+
 # ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- treat tasks created directly with `status=blocked` as sticky human-gated blocks
- prevent `recompute_ready()` from silently promoting `--initial-status blocked` tasks to `ready`
- preserve the existing recovery behavior for circuit-breaker/direct-DB transient blocks and keep explicit `unblock_task()` as the release path

Fixes #39609

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -- -k 'not dashboard_direct_status_change'`\n- `.venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py`\n- `git diff --check`\n\n## Local environment note\n\nI also attempted the dashboard plugin/core import tests that touch `plugins.kanban.dashboard.plugin_api`; this local venv fails before exercising this patch because `python-multipart` is not installed. The kanban DB/tool tests covering this lifecycle behavior pass.\n