### PR TITLE
fix(desktop): await gateway swap in selectProfile before requesting fresh session

### DIFF
--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -256,7 +256,7 @@ export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile],
 // Switch the active context to `name`: leave "All profiles" mode, point new
 // chats at it, and swap the single live gateway onto its backend (which moves
 // $activeGatewayProfile → name, so $profileScope follows).
-export function selectProfile(name: string): void {
+export async function selectProfile(name: string): Promise<void> {
   const target = normalizeProfileKey(name)
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
@@ -265,10 +265,17 @@ export function selectProfile(name: string): void {
   $newChatProfile.set(target)
 
   if (switching) {
+    // Await the gateway swap before requesting a fresh session draft so the
+    // subsequent message.create is guaranteed to land on the right profile's
+    // backend. Without the await a fire-and-forget ensureGatewayProfile races
+    // with startFreshSessionDraft — the UI swaps immediately (pill highlight,
+    // new chat draft), but the actual backend socket may not be connected yet,
+    // causing the session to be created on the old profile's agent.
+    await ensureGatewayProfile(target)
     requestFreshSession()
+  } else {
+    void ensureGatewayProfile(target)
   }
-
-  void ensureGatewayProfile(target)
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
@@ -277,11 +284,13 @@ export function selectProfile(name: string): void {
 // session list, where switching scope would throw away the browse state the user
 // is in. Points new chats at the profile and opens its backend so the next
 // message lands in the right place.
-export function newSessionInProfile(name: string): void {
+export async function newSessionInProfile(name: string): Promise<void> {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
+  // Ensure the gateway is on the target profile before requesting a fresh
+  // session — same race-condition fix as selectProfile.
+  await ensureGatewayProfile(target)
   requestFreshSession()
-  void ensureGatewayProfile(target)
 }
 
 export function setShowAllProfiles(value: boolean): void {


### PR DESCRIPTION
## Problem

When clicking a profile square in the desktop sidebar's ProfileRail, the profile pill highlights correctly but the chat continues talking to the old profile's agent. The user sees the new profile selected in the UI but their messages still go to the previous profile's backend.

## Root cause

`selectProfile()` in `store/profile.ts` calls `ensureGatewayProfile(target)` with `void` (fire-and-forget), then immediately calls `requestFreshSession()` to navigate to a new chat. This creates a race condition:

1. `void ensureGatewayProfile(target)` starts the async gateway swap (spawning a pooled backend, establishing WebSocket)
2. `requestFreshSession()` runs synchronously — clears state, navigates to NEW_CHAT_ROUTE, shows a fresh draft
3. The gateway swap is still in flight — the secondary socket to the target profile's backend isn't connected yet
4. User types a message → `createBackendSessionForSend` does eventually `await ensureGatewayProfile()`, but by then the session state is already cleared and the fresh chat is rendered as ready

The same bug exists in `newSessionInProfile()`.

## Fix

Make `selectProfile` and `newSessionInProfile` async. When a real profile switch is happening (`switching === true`), `await` the gateway swap before calling `requestFreshSession()`. For the no-switch case (re-tapping the same profile), keep the fire-and-forget as a keepalive ping.

## Changes

```diff
-export function selectProfile(name: string): void {
+export async function selectProfile(name: string): Promise<void> {
   ...
   if (switching) {
+    await ensureGatewayProfile(target)
     requestFreshSession()
-  }
-  void ensureGatewayProfile(target)
+  } else {
+    void ensureGatewayProfile(target)
+  }
}

-export function newSessionInProfile(name: string): void {
+export async function newSessionInProfile(name: string): Promise<void> {
   ...
+  await ensureGatewayProfile(target)
   requestFreshSession()
-  void ensureGatewayProfile(target)
 }
```

## Related

- #38157 "Add desktop profile switcher and stabilize composer scrolling" — takes a different approach (full window reload via `mainWindow?.reload()`)
- #33973 "feat: complete profile switcher — backend + frontend" — web dashboard only