### PR TITLE
[codex] fix ACP tool completion updates

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -143,7 +143,8 @@ def make_tool_progress_cb(
         if not isinstance(args, dict):
             args = {}
 
-        tc_id = make_tool_call_id()
+        raw_tool_call_id = kwargs.get("tool_call_id")
+        tc_id = str(raw_tool_call_id).strip() if raw_tool_call_id else make_tool_call_id()
         queue = tool_call_ids.get(name)
         if queue is None:
             queue = deque()
@@ -180,6 +181,67 @@ def make_tool_progress_cb(
         _send_update(conn, session_id, loop, update)
 
     return _tool_progress
+
+
+def _pop_next_tool_call_id(
+    tool_call_ids: Dict[str, Deque[str]],
+    tool_name: str,
+    preferred_tool_call_id: str | None = None,
+) -> str | None:
+    queue = tool_call_ids.get(tool_name or "")
+    if queue is None:
+        return None
+    if isinstance(queue, str):
+        queue = deque([queue])
+        tool_call_ids[tool_name] = queue
+    if not queue:
+        return None
+    if preferred_tool_call_id and preferred_tool_call_id in queue:
+        queue.remove(preferred_tool_call_id)
+        tool_call_id = preferred_tool_call_id
+    else:
+        tool_call_id = queue.popleft()
+    if not queue:
+        tool_call_ids.pop(tool_name, None)
+    return tool_call_id
+
+
+def make_tool_complete_cb(
+    conn: acp.Client,
+    session_id: str,
+    loop: asyncio.AbstractEventLoop,
+    tool_call_ids: Dict[str, Deque[str]],
+    tool_call_meta: Dict[str, Dict[str, Any]],
+) -> Callable:
+    """Create a ``tool_complete_callback`` that emits ACP completion updates."""
+
+    def _tool_complete(
+        tool_call_id: str,
+        function_name: str,
+        function_args: Any,
+        function_result: Any,
+    ) -> None:
+        preferred = str(tool_call_id).strip() if tool_call_id else None
+        acp_tool_call_id = _pop_next_tool_call_id(tool_call_ids, function_name, preferred)
+        if not acp_tool_call_id:
+            return
+
+        meta = tool_call_meta.pop(acp_tool_call_id, {})
+        result = str(function_result) if function_result is not None else None
+        update = build_tool_complete(
+            acp_tool_call_id,
+            function_name,
+            result=result,
+            function_args=function_args if isinstance(function_args, dict) else meta.get("args"),
+            snapshot=meta.get("snapshot"),
+        )
+        _send_update(conn, session_id, loop, update)
+        if function_name == "todo":
+            plan_update = _build_plan_update_from_todo_result(result)
+            if plan_update is not None:
+                _send_update(conn, session_id, loop, plan_update)
+
+    return _tool_complete
 
 
 # ------------------------------------------------------------------

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -68,6 +68,7 @@ from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
+    make_tool_complete_cb,
     make_tool_progress_cb,
 )
 from acp_adapter.permissions import make_approval_callback
@@ -1355,6 +1356,7 @@ class HermesACPAgent(acp.Agent):
                 tool_call_meta,
                 edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
             )
+            tool_complete_cb = make_tool_complete_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
             step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             message_cb = make_message_cb(conn, session_id, loop)
@@ -1379,6 +1381,7 @@ class HermesACPAgent(acp.Agent):
                 logger.debug("Could not create ACP edit approval requester", exc_info=True)
         else:
             tool_progress_cb = None
+            tool_complete_cb = None
             reasoning_cb = None
             step_cb = None
             stream_delta_cb = None
@@ -1386,6 +1389,7 @@ class HermesACPAgent(acp.Agent):
 
         agent = state.agent
         agent.tool_progress_callback = tool_progress_cb
+        agent.tool_complete_callback = tool_complete_cb
         # ACP thought panes should not receive Hermes' local kawaii waiting/status
         # updates. Route provider/model reasoning deltas instead; if the provider
         # emits no reasoning, Zed should not get a fake "thinking" accordion.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -359,7 +359,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(name, args)
-                agent.tool_progress_callback("tool.started", name, preview, args)
+                agent.tool_progress_callback("tool.started", name, preview, args, tool_call_id=tc.id)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -803,7 +803,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if not _execution_blocked and agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(function_name, function_args)
-                agent.tool_progress_callback("tool.started", function_name, preview, function_args)
+                agent.tool_progress_callback("tool.started", function_name, preview, function_args, tool_call_id=tool_call.id)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -17,6 +17,7 @@ from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
+    make_tool_complete_cb,
     make_tool_progress_cb,
 )
 
@@ -126,6 +127,46 @@ class TestToolProgressCallback:
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
 
+
+class TestToolLifecycleCallbacks:
+    def test_tool_complete_emits_update_without_waiting_for_step(self, mock_conn, event_loop_fixture):
+        """Tool completion callback should immediately emit ACP completion."""
+        tool_call_ids = {}
+        tool_call_meta = {}
+        progress_cb = make_tool_progress_cb(
+            mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta
+        )
+        complete_cb = make_tool_complete_cb(
+            mock_conn,
+            "session-1",
+            event_loop_fixture,
+            tool_call_ids,
+            tool_call_meta,
+        )
+
+        with patch("acp_adapter.events._send_update"):
+            progress_cb(
+                "tool.started",
+                "read_file",
+                "read: /tmp/a.txt",
+                {"path": "/tmp/a.txt"},
+                tool_call_id="provider-read",
+            )
+
+        with patch("acp_adapter.events._send_update") as mock_send, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            complete_cb("provider-read", "read_file", {"path": "/tmp/a.txt"}, "file contents")
+
+        mock_btc.assert_called_once_with(
+            "provider-read",
+            "read_file",
+            result="file contents",
+            function_args={"path": "/tmp/a.txt"},
+            snapshot=None,
+        )
+        mock_send.assert_called_once()
+        assert "read_file" not in tool_call_ids
+        assert tool_call_meta == {}
 
 # ---------------------------------------------------------------------------
 # Thinking callback

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -215,7 +215,9 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert starts == [("c-allow", "web_search", allowed_args)]
     started_events = [event for event in progress_events if event[0] == "tool.started"]
     completed_events = [event for event in progress_events if event[0] == "tool.completed"]
-    assert started_events == [("tool.started", "web_search", allowed_args, {})]
+    assert started_events == [
+        ("tool.started", "web_search", allowed_args, {"tool_call_id": "c-allow"})
+    ]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
 


### PR DESCRIPTION
## Summary
- pass Hermes real tool call id into ACP tool start updates
- emit ACP tool completion updates from Hermes real tool completion callback instead of waiting for the next step callback
- keep the existing step callback as a fallback for older paths
- reopen/resolved version of #27854, rebased onto current main with unrelated generated/model-catalog changes dropped

## Root cause
ACP start events were emitted from `tool_progress_callback`, but completion updates were only sent later from `step_callback(prev_tools)`, which depends on reconstructing prior tool results from conversation messages. Some successful tools can be missed by that reconstruction path, leaving ACP clients rendering the tool as loading.

## Validation
- `scripts/run_tests.sh tests/acp/test_events.py tests/acp/test_tools.py tests/acp/test_mcp_e2e.py`
- `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py`
- `python3 -m py_compile acp_adapter/events.py acp_adapter/server.py agent/tool_executor.py`
- `$HOME/.hermes/hermes-agent/venv/bin/ruff check acp_adapter/events.py acp_adapter/server.py agent/tool_executor.py tests/acp/test_events.py tests/run_agent/test_tool_call_guardrail_runtime.py`