### PR TITLE
test(desktop): cover profile-scoped session mutations

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteSession, setSessionArchived } from './hermes'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function installApiMock() {
+  const api = vi.fn(async () => ({ ok: true }))
+
+  vi.stubGlobal('window', {})
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { api }
+  })
+
+  return api
+}
+
+describe('Hermes session API wrappers', () => {
+  it('routes archive mutations to the owning profile', async () => {
+    const api = installApiMock()
+
+    await setSessionArchived('sess-1', true, 'worker-alpha')
+
+    expect(api).toHaveBeenCalledWith({
+      profile: 'worker-alpha',
+      path: '/api/sessions/sess-1',
+      method: 'PATCH',
+      body: { archived: true }
+    })
+  })
+
+  it('routes delete mutations to the owning profile', async () => {
+    const api = installApiMock()
+
+    await deleteSession('sess/1', 'worker alpha')
+
+    expect(api).toHaveBeenCalledWith({
+      profile: 'worker alpha',
+      path: '/api/sessions/sess%2F1',
+      method: 'DELETE'
+    })
+  })
+})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -368,6 +368,37 @@ class TestWebServerEndpoints:
         restored = self.client.get("/api/sessions").json()
         assert any(s["id"] == "arch-me" for s in restored["sessions"])
 
+    def test_delete_session_targets_profile_db(self):
+        """DELETE can target another profile's state.db.
+
+        Cross-profile session lists tag rows with profile names; deleting one
+        of those rows must not resolve against the default profile DB.
+        """
+        from hermes_cli.profiles import get_profile_dir
+        from hermes_state import SessionDB
+
+        profile_home = get_profile_dir("worker-alpha")
+        profile_home.mkdir(parents=True, exist_ok=True)
+
+        db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            db.create_session(session_id="worker-session", source="cli")
+        finally:
+            db.close()
+
+        missing_default = self.client.delete("/api/sessions/worker-session")
+        assert missing_default.status_code == 404
+
+        resp = self.client.delete("/api/sessions/worker-session?profile=worker-alpha")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            assert db.resolve_session_id("worker-session") is None
+        finally:
+            db.close()
+
     def test_patch_session_without_fields_is_400(self):
         """An existing session + empty body is a bad request, not a 404."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## Summary
- rebase onto current `main` and keep upstream’s current remote/profile routing code
- add Desktop wrapper coverage that archive/delete mutations carry the owning profile as request metadata
- add backend coverage that `DELETE /api/sessions/{id}?profile=...` targets the requested profile DB

This is now intentionally test-only: current `main` already contains the routing behavior, and this PR preserves focused regression coverage for the session-mutation path.

## Verification
- `npm --prefix apps/desktop exec vitest run -- --environment jsdom src/hermes.test.ts`
- `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_delete_session_targets_profile_db -q -o addopts= --tb=short`
- `npm exec eslint -- src/hermes.test.ts` from `apps/desktop/`
- `.venv/bin/python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check --cached` during conflict resolution
