### PR TITLE
fix(nix): add trailing newline to REPORT_EOF heredoc in fix-lockfiles

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -317,7 +317,7 @@ in
           [ "$FIXED" -eq 1 ] && echo "changed=true" || echo "changed=false"
           if [ -n "$REPORT" ]; then
             echo "report<<REPORT_EOF"
-            printf "%s" "$REPORT"
+            printf "%s\n" "$REPORT"
             echo "REPORT_EOF"
           fi
         } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The `fix-lockfiles` script in `nix/lib.nix` writes to `$GITHUB_OUTPUT` using a heredoc delimiter. `printf "%s" "$REPORT"` does NOT add a trailing newline, which causes `Matching delimiter not found "REPORT_EOF"` error in GitHub Actions.

```
##[error]Invalid value. Matching delimiter not found "REPORT_EOF"
```

## Fix

Change `printf "%s" "$REPORT"` to `printf "%s\n" "$REPORT"` — one character.

## Impact

Prevents CI failures in the Nix Lockfile Fix workflow when report output is generated. The hash computation succeeds; only the report output step fails without this fix.