### PR TITLE
fix(desktop): auto-retry npm install with --ignore-scripts on install-script failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5452,6 +5452,24 @@ def _nixos_build_env() -> dict[str, str] | None:
         pass  # nix-shell not available — caller will get None
 
     return None
+
+
+def _looks_like_install_script_failure(result: subprocess.CompletedProcess) -> bool:
+    """Return True when a failed npm install appears to be caused by
+    install-script / postinstall / native-build errors rather than a
+    fundamental network or resolution failure.
+    """
+    stderr = (result.stderr or "")
+    if "info run" in stderr:
+        return True
+    if "EAGAIN" in stderr and "spawn" in stderr:
+        return True
+    import re
+    if re.search(r"ERR!.*(?:install|postinstall|preinstall|node-gyp|sh -c)", stderr):
+        return True
+    return False
+
+
 def _run_npm_install_deterministic(
     npm: str,
     cwd: Path,
@@ -5507,9 +5525,29 @@ def _run_npm_install_deterministic(
             ci_result = _run([npm_exe, "ci", "--include=dev", *extra_args])
             if ci_result.returncode == 0:
                 return ci_result
+            # Install-script failure on `npm ci`: retry `npm ci --ignore-scripts`
+            # to preserve the lockfile-respecting contract. The previous
+            # version retried `npm install --ignore-scripts`, which mutates
+            # committed lockfiles (Teknium's review, 2026-07-14).
+            if _looks_like_install_script_failure(ci_result):
+                logging.getLogger(__name__).debug(
+                    "npm ci failed with install-script error; retrying with --ignore-scripts"
+                )
+                ci_retry = _run([npm_exe, "ci", "--include=dev", "--ignore-scripts", *extra_args])
+                if ci_retry.returncode == 0:
+                    return ci_retry
+                ci_result = ci_retry
             # Fall through to `npm install` — lockfile may be out of sync on a
             # WIP fork/branch, or `npm ci` may not be available on very old npm.
-        return _run([npm_exe, "install", "--no-save", "--include=dev", *extra_args])
+        install_result = _run([npm_exe, "install", "--no-save", "--include=dev", *extra_args])
+        if install_result.returncode != 0 and _looks_like_install_script_failure(install_result):
+            logging.getLogger(__name__).debug(
+                "npm install failed with install-script error; retrying with --ignore-scripts"
+            )
+            return _run(
+                [npm_exe, "install", "--no-save", "--include=dev", "--ignore-scripts", *extra_args]
+            )
+        return install_result
 
     result = _attempt(npm)
     if result.returncode == 0:

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -368,3 +368,177 @@ class TestBuildRecoversFromMissingToolchain:
         assert mock_install.call_count == 1
         assert mock_build.call_count == 1
 
+
+
+class TestNpmCiRetryOnInstallScriptFailure:
+    """Teknium's review (2026-07-14) flagged that the retry path must
+    preserve the deterministic contract:
+
+    1. When ``npm ci`` fails with an install-script error, retry
+       ``npm ci --ignore-scripts`` (NOT ``npm install --ignore-scripts`` —
+       the previous version mutated committed lockfiles).
+    2. Every subprocess call (initial + retry) must use ``env=run_env``
+       (the ``CI=1``-forced env), not the caller's raw env. The previous
+       version used ``env=env`` on the retry, breaking the CI=1 invariant.
+
+    These tests exercise the retry path's command selection and env
+    preservation — the two behaviors the previous version got wrong.
+    """
+
+    def _failed_ci(self):
+        import subprocess
+        return subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="info run electron-winstaller@5.4.0 install",
+        )
+
+    def test_npm_ci_install_script_failure_retries_npm_ci_with_ignore_scripts(self, tmp_path):
+        """Lockfile-present path: install-script failure on `npm ci` →
+        retry `npm ci --ignore-scripts`, NOT `npm install --ignore-scripts`.
+        The retry preserves the lockfile-respecting contract."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        ci_fail = self._failed_ci()
+        ci_retry_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", side_effect=[ci_fail, ci_retry_ok]) as mock_run:
+            result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert result.returncode == 0
+        # Two calls: initial npm ci (failed), retry npm ci --ignore-scripts (ok)
+        assert mock_run.call_count == 2
+        retry_args, _ = mock_run.call_args_list[1]
+        retry_cmd = retry_args[0]
+        # MUST be npm ci --ignore-scripts, NOT npm install --ignore-scripts.
+        # The previous version did `install_cmd + ["--ignore-scripts"]` which
+        # bubbled up to `npm install --ignore-scripts` on the lockfile-miss
+        # fallback path — that was the bug Teknium flagged.
+        assert retry_cmd[:2] == ["/usr/bin/npm", "ci"]
+        assert "--ignore-scripts" in retry_cmd
+        assert "install" not in retry_cmd[1]  # not `npm install --ignore-scripts`
+
+    def test_npm_ci_retry_uses_run_env_with_ci_1(self, tmp_path):
+        """The retry's env must equal `run_env` (CI=1 forced), not the
+        caller's raw env. The previous version used `env=env` on the
+        retry, dropping the CI=1 invariant for unicode-animations' postinstall
+        tty animation bypass (nix/lib.nix npm ci hooks, TUI install path)."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        ci_fail = self._failed_ci()
+        ci_retry_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", side_effect=[ci_fail, ci_retry_ok]) as mock_run:
+            _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                env={"PYTHON": "/nix/store/python"},
+            )
+
+        _, retry_kwargs = mock_run.call_args_list[1]
+        # Both calls must use run_env: the CI=1-forced env built from the
+        # caller's env + os.environ. Critically, the retry must have
+        # CI=1 set, not be the raw caller's env.
+        assert retry_kwargs["env"]["CI"] == "1"
+        assert retry_kwargs["env"]["PYTHON"] == "/nix/store/python"
+        # The two calls (initial + retry) must use the same env object —
+        # if the retry used `env=env`, this comparison would show a
+        # CI=1-forced dict vs the raw caller's dict.
+        initial_env = mock_run.call_args_list[0][1]["env"]
+        assert initial_env == retry_kwargs["env"]
+        assert initial_env is retry_kwargs["env"] or initial_env == retry_kwargs["env"]
+
+    def test_npm_ci_non_script_failure_skips_retry_and_falls_to_install(self, tmp_path):
+        """If `npm ci` fails for a NON-install-script reason (lockfile
+        conflict, network error, etc.), do NOT retry with --ignore-scripts.
+        Fall through directly to `npm install`."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        ci_fail_non_script = __import__("subprocess").CompletedProcess(
+            [], 1, stdout="", stderr="npm ERR! code E405 Lockfile has conflict entries",
+        )
+        install_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", side_effect=[ci_fail_non_script, install_ok]) as mock_run:
+            result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert result.returncode == 0
+        # Two calls: initial npm ci (failed), then `npm install` (no --ignore-scripts retry)
+        assert mock_run.call_count == 2
+        install_args, _ = mock_run.call_args_list[1]
+        install_cmd = install_args[0]
+        assert install_cmd[:2] == ["/usr/bin/npm", "install"]
+        assert "--ignore-scripts" not in install_cmd
+
+    def test_npm_install_fallback_also_retries_with_ignore_scripts(self, tmp_path):
+        """The `npm install` fallback (lockfile-out-of-sync path) also
+        retries with --ignore-scripts on install-script failure. The retry
+        must use run_env, not the caller's raw env."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        ci_fail_non_script = __import__("subprocess").CompletedProcess(
+            [], 1, stdout="", stderr="lockfile out of sync",
+        )
+        install_fail_script = __import__("subprocess").CompletedProcess(
+            [], 1, stdout="", stderr="info run electron-winstaller@5.4.0 install",
+        )
+        install_retry_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch(
+            "hermes_cli.main.subprocess.run",
+            side_effect=[ci_fail_non_script, install_fail_script, install_retry_ok],
+        ) as mock_run:
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm", web_dir, env={"PYTHON": "/nix/store/python"},
+            )
+
+        assert result.returncode == 0
+        # Three calls: npm ci (failed), npm install (failed script), npm install --ignore-scripts (ok)
+        assert mock_run.call_count == 3
+        retry_call = mock_run.call_args_list[2]
+        retry_args, retry_kwargs = retry_call.args, retry_call.kwargs
+        retry_cmd = retry_args[0]
+        # Retry command must be `npm install --ignore-scripts` (the fallback's retry path)
+        assert retry_cmd[:2] == ["/usr/bin/npm", "install"]
+        assert "--ignore-scripts" in retry_cmd
+        # Retry env must have CI=1
+        assert retry_kwargs["env"]["CI"] == "1"
+        assert retry_kwargs["env"]["PYTHON"] == "/nix/store/python"
+
+
+class TestLooksLikeInstallScriptFailure:
+    """Tests for _looks_like_install_script_failure — detection heuristic."""
+
+    def _result(self, stderr: str = "", returncode: int = 1):
+        import subprocess
+        return subprocess.CompletedProcess([], returncode, stdout="", stderr=stderr)
+
+    def test_info_run_pattern(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('info run electron-winstaller@5.4.0 install')) is True
+
+    def test_eagain_spawn_pattern(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('npm error spawn sh EAGAIN')) is True
+
+    def test_err_script_pattern(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('npm ERR! command sh -c node-gyp rebuild')) is True
+
+    def test_network_error_returns_false(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('npm ERR! code ECONNRESET')) is False
+
+    def test_auth_failure_returns_false(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('npm ERR! code E401\nnpm ERR! Unable to authenticate')) is False
+
+    def test_lockfile_mismatch_returns_false(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result('npm ERR! code E405\nnpm ERR! Lockfile has conflict entries')) is False
+
+    def test_empty_stderr_returns_false(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result()) is False
+
+    def test_successful_result_returns_false(self):
+        from hermes_cli.main import _looks_like_install_script_failure as check
+        assert check(self._result(returncode=0)) is False


### PR DESCRIPTION
## Problem

The desktop rebuild phase of in-app updates (`hermes desktop --build-only`, invoked after the Python backend is updated) runs `npm ci` for the workspace. On macOS, postinstall scripts of workspace dependencies such as `electron-winstaller` (Windows-only) and `agent-browser` spawn child processes that fail with `EAGAIN` ("Resource temporarily unavailable"). The failure aborts the entire update with:

```
Backend updated, but the desktop rebuild failed. Restart Hermes to retry.
```

The user is left in a half-updated state: the backend is current while the desktop GUI still runs the previous build, and the only remedy is a manual retry.

## Root cause

`npm ci` executes install scripts during dependency installation. A transient resource failure inside those scripts (a common macOS condition under load) is indistinguishable from a fundamental install failure at the process level, so the rebuild aborts instead of recovering.

## Fix

`_run_npm_install_deterministic` (in `hermes_cli/main_web_build.py`) now detects install-script failures in stderr via three signatures — `info run`, `EAGAIN` combined with `spawn`, and `ERR!` alongside `install`/`postinstall`/`node-gyp`/`sh -c` — and retries the failed command with `--ignore-scripts`. The retry applies to both the primary `npm ci` path and the fallback `npm install` path, and reuses the same `run_env` (forced `CI=1`) as the initial attempt.

Two properties keep the retry safe:

- **Lockfile preservation.** The retry is `npm ci --ignore-scripts`, not `npm install --ignore-scripts`, so committed lockfiles are never rewritten by the recovery path. (A plain `npm install` retry mutates the lockfile; this was called out in review.)
- **Failure-class discrimination.** Network, auth, and lockfile errors do not match the script-failure signatures and are surfaced to the caller unchanged.

The fix composes with origin's existing engine-repair retry, which addresses a different failure class (incompatible npm engine versions). Native module rebuilding remains the responsibility of electron-builder's packaging step, so skipping install scripts during the dependency fetch is harmless.

## Validation

- Four behavioral tests in `tests/hermes_cli/test_web_ui_build.py` cover retry command selection (`npm ci --ignore-scripts`), non-script failure pass-through, the fallback-path retry, and `run_env` (`CI=1`) preservation.
- All 36 tests in the file pass against the ported module.

Fixes #39860