### PR TITLE
fix(api-server): honor per-request model overrides

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -766,6 +766,34 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return "hermes-agent"
 
+    def _resolve_model_alias(self, model_name: str) -> str:
+        """Resolve a per-request model name through config.yaml model_aliases.
+
+        If the name matches an alias, expand it.  Otherwise use it as-is
+        (the provider proxy — e.g. litellm — will handle the routing).
+        """
+        from gateway.run import _resolve_gateway_model, _load_gateway_config
+
+        if not model_name or not model_name.strip():
+            return _resolve_gateway_model()
+        name = model_name.strip()
+        try:
+            user_config = _load_gateway_config()
+        except Exception:
+            user_config = {}
+        aliases = user_config.get("model_aliases", {})
+        if isinstance(aliases, dict):
+            entry = aliases.get(name)
+            if isinstance(entry, dict):
+                # dict form: {model: "full-name", provider: "..."}
+                resolved = entry.get("model", name)
+                return resolved if resolved else name
+            elif isinstance(entry, str):
+                # simple string alias
+                return entry
+        # No alias match — use the name directly.
+        return name
+
     def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
         """Return CORS headers for an allowed browser origin."""
         if not origin or not self._cors_origins:
@@ -974,6 +1002,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -989,6 +1018,11 @@ class APIServerAdapter(BasePlatformAdapter):
         key is meant to persist across transcripts so long-term memory
         providers (e.g. Honcho) can scope their per-chat state correctly
         — matching the semantics of the native gateway's ``session_key``.
+
+        ``model_override`` allows per-request model switching.  When
+        provided, the model name is resolved through config.yaml model_aliases
+        and used instead of the gateway default.  This intentionally does not
+        change provider credentials; provider switching is a separate concern.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
@@ -996,7 +1030,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
-        model = _resolve_gateway_model()
+
+        # Per-request model switching: resolve aliases, fall back to default.
+        if model_override:
+            model = self._resolve_model_alias(model_override)
+        else:
+            model = _resolve_gateway_model()
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -1796,6 +1835,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
+        # Per-request model switching: prefer X-Hermes-Model header, then body model.
+        requested_model = (request.headers.get("X-Hermes-Model", "") or "").strip()
+        model_override = requested_model or (model_name if model_name != self._model_name else None)
+        # Echo the effective model in the response so callers can verify which
+        # model actually served the request.  When no override is active the
+        # advertised model name is used (same as before).
+        effective_model = model_override or model_name
         created = int(time.time())
 
         if stream:
@@ -1880,13 +1926,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
             agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
 
             return await self._write_sse_chat_completion(
-                request, completion_id, model_name, created, _stream_q,
+                request, completion_id, effective_model, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
             )
@@ -1899,11 +1946,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            # Fold the model override into the fingerprint so two requests
+            # with the same Idempotency-Key but different routed models
+            # don't collide on the cached response.
+            fp_body = dict(body)
+            if model_override:
+                fp_body["__override_model__"] = model_override
+            fp = _make_request_fingerprint(
+                fp_body,
+                keys=["model", "messages", "tools", "tool_choice", "stream", "__override_model__"],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -1969,7 +2026,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "id": completion_id,
             "object": "chat.completion",
             "created": created,
-            "model": model_name,
+            "model": effective_model,
             "choices": [
                 {
                     "index": 0,
@@ -2778,6 +2835,14 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
 
+        # Per-request model switching: prefer X-Hermes-Model header, then body model.
+        _resp_model_name = body.get("model", self._model_name)
+        _resp_requested_model = (request.headers.get("X-Hermes-Model", "") or "").strip()
+        model_override = _resp_requested_model or (_resp_model_name if _resp_model_name != self._model_name else None)
+        # Echo the effective model in the response so callers can verify which
+        # model actually served the request.
+        _resp_effective_model = model_override or _resp_model_name
+
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
             return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
@@ -2912,6 +2977,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2919,12 +2985,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)
+            _resp_effective_model_sse = model_override or model_name
             created_at = int(time.time())
 
             return await self._write_sse_responses(
                 request=request,
                 response_id=response_id,
-                model=model_name,
+                model=_resp_effective_model_sse,
                 created_at=created_at,
                 stream_q=_stream_q,
                 agent_task=agent_task,
@@ -2945,13 +3012,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            fp_body = dict(body)
+            if model_override:
+                fp_body["__override_model__"] = model_override
             fp = _make_request_fingerprint(
-                body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                fp_body,
+                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools", "__override_model__"],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -3002,7 +3073,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "status": "completed",
             "created_at": created_at,
-            "model": body.get("model", self._model_name),
+            "model": _resp_effective_model,
             "output": output_items,
             "usage": {
                 "input_tokens": usage.get("input_tokens", 0),
@@ -3447,6 +3518,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3470,6 +3542,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
+                model_override=model_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -3597,6 +3670,11 @@ class APIServerAdapter(BasePlatformAdapter):
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
+        # Per-request model switching for /v1/runs
+        _runs_model_name = body.get("model", self._model_name)
+        _runs_requested_model = (request.headers.get("X-Hermes-Model", "") or "").strip()
+        runs_model_override = _runs_requested_model or (_runs_model_name if _runs_model_name != self._model_name else None)
+
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []
@@ -3685,6 +3763,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    model_override=runs_model_override,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -337,6 +337,57 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_resolve_model_alias_uses_string_and_dict_entries(self, monkeypatch):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {
+                "model_aliases": {
+                    "fast": "openrouter/deepseek/deepseek-chat",
+                    "smart": {"model": "anthropic/claude-sonnet-4.5", "provider": "openrouter"},
+                }
+            },
+        )
+
+        assert adapter._resolve_model_alias("fast") == "openrouter/deepseek/deepseek-chat"
+        assert adapter._resolve_model_alias("smart") == "anthropic/claude-sonnet-4.5"
+        assert adapter._resolve_model_alias("raw-model-name") == "raw-model-name"
+
+    def test_create_agent_uses_request_model_override_without_changing_provider(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom:gateway",
+                "base_url": "https://gateway.example.test/v1",
+                "api_key": "sk-test",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "default-model")
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {"model_aliases": {"fast": "openrouter/deepseek/deepseek-chat"}},
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: None))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session", model_override="fast")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "openrouter/deepseek/deepseek-chat"
+        assert captured["provider"] == "custom:gateway"
+        assert captured["base_url"] == "https://gateway.example.test/v1"
+
 
 # ---------------------------------------------------------------------------
 # Auth checking
@@ -3464,6 +3515,156 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             # _create_agent must be called with gateway_session_key threaded through
             assert captured_kwargs.get("gateway_session_key") == "agent:main:webui:dm:user-7"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_threads_body_model_override(self, auth_adapter):
+        """The documented request body model field selects the backing AIAgent model."""
+        captured_kwargs = {}
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "deepseek-v4-pro", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert captured_kwargs.get("model_override") == "deepseek-v4-pro"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_header_model_override_wins_over_body(self, auth_adapter):
+        """X-Hermes-Model takes precedence over the OpenAI body model field."""
+        captured_kwargs = {}
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "X-Hermes-Model": "header-model"},
+                    json={"model": "body-model", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert captured_kwargs.get("model_override") == "header-model"
+
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_threads_body_model_override(self, auth_adapter):
+        """Responses API also honors the documented request body model field."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "deepseek-v4-pro", "input": "hello", "store": False},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["model_override"] == "deepseek-v4-pro"
+
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_header_model_override_wins_over_body(self, auth_adapter):
+        """Responses API gives X-Hermes-Model the same precedence as chat completions."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret", "X-Hermes-Model": "header-model"},
+                    json={"model": "body-model", "input": "hello", "store": False},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["model_override"] == "header-model"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_echoes_effective_model_in_response(self, auth_adapter):
+        """The OpenAI response model field reflects the actually-routed model, not the gateway default."""
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["model"] == "claude-sonnet-4"
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_isolates_different_models(self, auth_adapter):
+        """Two requests with the same Idempotency-Key but different model overrides
+        must not collide on the cached response."""
+        mock_result = {"final_response": "alpha", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", return_value=MagicMock(
+                run_conversation=MagicMock(return_value=mock_result),
+                session_prompt_tokens=0,
+                session_completion_tokens=0,
+                session_total_tokens=0,
+            )):
+                resp1 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "idem-same-key",
+                        "X-Hermes-Model": "model-a",
+                    },
+                    json={"messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp1.status == 200
+
+            mock_result_b = {"final_response": "beta", "messages": [], "api_calls": 1}
+            with patch.object(auth_adapter, "_create_agent", return_value=MagicMock(
+                run_conversation=MagicMock(return_value=mock_result_b),
+                session_prompt_tokens=0,
+                session_completion_tokens=0,
+                session_total_tokens=0,
+            )):
+                resp2 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "idem-same-key",
+                        "X-Hermes-Model": "model-b",
+                    },
+                    json={"messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp2.status == 200
+            # Different model overrides produce different fingerprints,
+            # so the second request must hit the agent, not the idempotency cache.
+            data1 = await resp1.json()
+            data2 = await resp2.json()
+            assert data1["choices"][0]["message"]["content"] != data2["choices"][0]["message"]["content"]
 
     @pytest.mark.asyncio
     async def test_responses_endpoint_accepts_session_key(self, auth_adapter):


### PR DESCRIPTION
## Summary

Fixes the API server's documented per-request model override support for OpenAI-compatible requests.

The developer docs say API-server callers can select a model by either:

- setting the request body `model` field, or
- sending `X-Hermes-Model`

Before this change, the API server parsed/echoed the request model but still created `AIAgent` with the gateway default from config, so every request used the configured default model regardless of what the caller sent.

## What changed

- Resolve per-request model overrides through `config.yaml` `model_aliases`.
- Pass the resolved model override into `AIAgent` creation for:
  - `/v1/chat/completions`
  - `/v1/responses`
  - `/v1/runs`
- Give `X-Hermes-Model` precedence over the body `model` field.
- Leave provider/base URL/API key resolution unchanged. This PR intentionally fixes model selection only; provider switching is separate.

## Testing

- `python -m pytest tests/gateway/test_api_server.py -q -o 'addopts='`
  - `162 passed, 108 warnings`

Fixes #16216
