### PR TITLE
fix(kanban): honor notification source config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5175,6 +5175,18 @@ class GatewayRunner:
         except Exception:
             return "default"
 
+    @staticmethod
+    def _parse_notification_sources(raw: Any) -> tuple[bool, set[str]]:
+        """Parse documented cross-profile Kanban notification sources."""
+        if isinstance(raw, str):
+            values = [part.strip() for part in raw.split(",")]
+        elif isinstance(raw, (list, tuple, set)):
+            values = [str(part).strip() for part in raw]
+        else:
+            values = []
+        sources = {value for value in values if value}
+        return "*" in sources, {value for value in sources if value != "*"}
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -5251,6 +5263,9 @@ class GatewayRunner:
         if not notifier_profile:
             notifier_profile = self._active_profile_name()
             self._kanban_notifier_profile = notifier_profile
+        notify_all_profiles, notification_sources = self._parse_notification_sources(
+            cfg.get("notification_sources") if isinstance(cfg, dict) else None
+        )
 
         # Initial delay so the gateway can finish wiring adapters.
         await asyncio.sleep(5)
@@ -5314,10 +5329,16 @@ class GatewayRunner:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
                                 owner_profile = sub.get("notifier_profile") or None
-                                if owner_profile and owner_profile != notifier_profile:
+                                if (
+                                    owner_profile
+                                    and not notify_all_profiles
+                                    and owner_profile not in (notification_sources or {notifier_profile})
+                                ):
                                     logger.debug(
-                                        "kanban notifier: subscription for %s owned by profile %s; current profile %s skipping",
-                                        sub.get("task_id"), owner_profile, notifier_profile,
+                                        "kanban notifier: subscription for %s owned by profile %s; allowed sources %s; current profile %s skipping",
+                                        sub.get("task_id"), owner_profile,
+                                        sorted(notification_sources) if notification_sources else [notifier_profile],
+                                        notifier_profile,
                                     )
                                     continue
                                 platform = (sub.get("platform") or "").lower()

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -383,6 +383,129 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
 
 
 @pytest.mark.asyncio
+async def test_notifier_accepts_all_configured_notification_sources(kanban_home):
+    """notification_sources: ['*'] lets one gateway deliver another profile's sub."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cross profile task", assignee="backend-engineer")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat1",
+            notifier_profile="coder",
+        )
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+
+    fake_adapter = MagicMock()
+
+    async def _send_and_stop(chat_id, msg, metadata=None):
+        runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with (
+        patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep),
+        patch("hermes_cli.config.load_config", return_value={"notification_sources": ["*"]}),
+    ):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    fake_adapter.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_notifier_honors_configured_notification_source_allowlist(kanban_home):
+    """A configured source allowlist accepts listed profiles and skips others."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        allowed_tid = kb.create_task(conn, title="allowed task", assignee="backend-engineer")
+        kb.add_notify_sub(
+            conn,
+            task_id=allowed_tid,
+            platform="telegram",
+            chat_id="chat1",
+            notifier_profile="coder",
+        )
+        kb.complete_task(conn, allowed_tid, result="done")
+        skipped_tid = kb.create_task(conn, title="skipped task", assignee="backend-engineer")
+        kb.add_notify_sub(
+            conn,
+            task_id=skipped_tid,
+            platform="telegram",
+            chat_id="chat2",
+            notifier_profile="other",
+        )
+        kb.complete_task(conn, skipped_tid, result="done")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+
+    fake_adapter = MagicMock()
+    sent = 0
+
+    async def _send_and_stop_after_allowed(chat_id, msg, metadata=None):
+        nonlocal sent
+        sent += 1
+        if sent >= 1:
+            runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop_after_allowed)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with (
+        patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep),
+        patch("hermes_cli.config.load_config", return_value={"notification_sources": "coder,creator"}),
+    ):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    fake_adapter.send.assert_called_once()
+    assert fake_adapter.send.call_args[0][0] == "chat1"
+    conn = kb.connect()
+    try:
+        skipped_subs = kb.list_notify_subs(conn, skipped_tid)
+    finally:
+        conn.close()
+    assert len(skipped_subs) == 1
+    assert int(skipped_subs[0]["last_event_id"]) == 0
+
+
+@pytest.mark.asyncio
 async def test_notifier_delivers_subscription_owned_by_current_profile(kanban_home):
     """The gateway for the profile that created/subscribed the task reports it."""
     import hermes_cli.kanban_db as kb


### PR DESCRIPTION
## Summary
- parse the documented top-level `notification_sources` config for the Kanban notifier
- preserve default profile-isolated delivery when the key is omitted
- allow `notification_sources: ["*"]` and comma/list allowlists for cross-profile subscriptions

Fixes #39838.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py -- -k 'notifier_accepts_all_configured_notification_sources or notifier_honors_configured_notification_source_allowlist or notifier_skips_subscription_owned_by_other_profile or notifier_delivers_subscription_owned_by_current_profile'`\n- `scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py`\n- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py`\n- `.venv/bin/python -m py_compile gateway/run.py tests/hermes_cli/test_kanban_notify.py`\n- `git diff --check`