### PR TITLE
fix(bedrock): replace whitespace-only ' ' placeholder with '(empty message)' in Converse adapter

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -446,13 +446,14 @@ def _convert_content_to_converse(content) -> List[Dict]:
       - Content arrays with text/image_url parts → mixed text/image blocks
 
     Filters out empty text blocks — Bedrock's Converse API rejects messages
-    where a text content block has an empty ``text`` field (ValidationException:
-    "text content blocks must be non-empty"). Ref: issue #9486.
+    where a text content block has an empty or whitespace-only ``text`` field
+    (ValidationException: "text content blocks must contain non-whitespace
+    text"). Ref: issue #9486, #39829.
     """
     if content is None:
-        return [{"text": " "}]
+        return [{"text": "(empty message)"}]
     if isinstance(content, str):
-        return [{"text": content}] if content.strip() else [{"text": " "}]
+        return [{"text": content}] if content.strip() else [{"text": "(empty message)"}]
     if isinstance(content, list):
         blocks = []
         for part in content:
@@ -464,7 +465,7 @@ def _convert_content_to_converse(content) -> List[Dict]:
             part_type = part.get("type", "")
             if part_type == "text":
                 text = part.get("text", "")
-                blocks.append({"text": text if text else " "})
+                blocks.append({"text": text if text.strip() else "(empty message)"})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
                 url = image_url.get("url", "") if isinstance(image_url, dict) else ""
@@ -486,7 +487,7 @@ def _convert_content_to_converse(content) -> List[Dict]:
                     # Remote URL — Converse doesn't support URLs directly,
                     # include as text reference for the model.
                     blocks.append({"text": f"[Image: {url}]"})
-        return blocks if blocks else [{"text": " "}]
+        return blocks if blocks else [{"text": "(empty message)"}]
     return [{"text": str(content)}]
 
 
@@ -574,7 +575,7 @@ def convert_messages_to_converse(
                 })
 
             if not content_blocks:
-                content_blocks = [{"text": " "}]
+                content_blocks = [{"text": "(empty message)"}]
 
             # Merge with previous assistant message if needed (strict alternation)
             if converse_msgs and converse_msgs[-1]["role"] == "assistant":
@@ -600,11 +601,11 @@ def convert_messages_to_converse(
 
     # Converse requires the first message to be from the user
     if converse_msgs and converse_msgs[0]["role"] != "user":
-        converse_msgs.insert(0, {"role": "user", "content": [{"text": " "}]})
+        converse_msgs.insert(0, {"role": "user", "content": [{"text": "(empty message)"}]})
 
     # Converse requires the last message to be from the user
     if converse_msgs and converse_msgs[-1]["role"] != "user":
-        converse_msgs.append({"role": "user", "content": [{"text": " "}]})
+        converse_msgs.append({"role": "user", "content": [{"text": "(empty message)"}]})
 
     return (system_blocks if system_blocks else None, converse_msgs)
 


### PR DESCRIPTION
## Bug

gent/bedrock_adapter.py uses a single space ({"text": " "}) as a placeholder for empty/missing message content and for the synthetic user-padding turns that enforce Converse's strict user/assistant alternation requirement. AWS Bedrock's Converse/ConverseStream API - when fronting Anthropic Claude models - rejects whitespace-only text blocks:

`
ValidationException: text content blocks must contain non-whitespace text
`

This is the sequel to #9486. That fix replaced empty strings with " ", which passes the *non-empty* check but fails the *non-whitespace* check introduced subsequently by the Converse validation layer. The result is a hard, non-retryable failure that fires every time a persisted session is resumed whose earliest stored message is an assistant turn (triggering the leading-user padding path).

## Impact

Every edrock / edrock_converse request that hits any of the following paths produces an unrecoverable ValidationException:

- Resuming a session whose history starts with an assistant message (leading-user pad)
- None or empty-string message content (_convert_content_to_converse)
- Whitespace-only text parts ("\n", "\t", etc.) passing the bare-truthiness gate
- An assistant message with no text and no tool calls (empty-assistant fallback)

## Fix

Replace all seven {"text": " "} placeholder occurrences in _convert_content_to_converse() and convert_messages_to_converse() with {"text": "(empty message)"}, mirroring the already-correct handling in gent/anthropic_adapter.py::_convert_user_message. Also tighten the truthiness gate on individual text parts from 	ext if text to 	ext if text.strip() so that genuinely whitespace-only text blocks (e.g. "\n") are also caught and replaced with the non-whitespace placeholder.

No behaviour change for any request that does not hit these paths.

Closes #39829