### PR TITLE
fix(browser): require agent-browser CLI for dep_ensure browser readiness

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -26,9 +26,16 @@ _IS_WINDOWS = platform.system() == "Windows"
 
 _DEP_CHECKS = {
     "node": lambda: shutil.which("node") is not None,
+    # The browser toolset's hard dependency is the agent-browser CLI, not a
+    # system browser. A system Chrome/Edge only provides the engine that
+    # agent-browser drives — it is not a substitute for the CLI itself. The
+    # runtime gate (tools.browser_tool.check_browser_requirements) returns
+    # False without agent-browser, so accepting a bare system browser here
+    # would make bootstrap falsely report success and would short-circuit the
+    # lazy installer in browser_tool._find_agent_browser() (it never runs the
+    # install script, then fails to resolve agent-browser anyway).
     "browser": lambda: (
         shutil.which("agent-browser") is not None
-        or _has_system_browser()
         or _has_hermes_agent_browser()
     ),
     "ripgrep": lambda: shutil.which("rg") is not None,
@@ -37,21 +44,10 @@ _DEP_CHECKS = {
 
 _DEP_DESCRIPTIONS = {
     "node": "Node.js (required for browser tools and TUI)",
-    "browser": "Browser engine (Chromium, for web browsing tools)",
+    "browser": "Browser tools (agent-browser CLI + Chromium)",
     "ripgrep": "ripgrep (fast file search)",
     "ffmpeg": "ffmpeg (TTS voice messages)",
 }
-
-
-def _has_system_browser() -> bool:
-    if _IS_WINDOWS:
-        names = ("chrome", "msedge", "chromium")
-    else:
-        names = ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser", "chrome")
-    for name in names:
-        if shutil.which(name):
-            return True
-    return False
 
 
 def _has_hermes_agent_browser() -> bool:

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -153,3 +153,32 @@ def test_main_setup_browser_propagates_browser_failure(monkeypatch):
     with pytest.raises(SystemExit) as excinfo:
         entry.main(["--setup-browser"])
     assert excinfo.value.code == 1
+
+
+def test_main_setup_browser_fails_with_only_system_chrome(monkeypatch):
+    """Regression: a system Chrome/Edge must not let browser bootstrap report
+    success when agent-browser is absent.
+
+    Drives the real ``dep_ensure.ensure_dependency`` (not a stub) so the
+    bootstrap success criterion stays aligned with the runtime gate in
+    ``tools.browser_tool.check_browser_requirements``, which hard-requires the
+    agent-browser CLI.
+    """
+    def fake_which(name, path=None):
+        if name == "node":
+            return "/usr/bin/node"
+        # System browser is present; agent-browser / npx are not.
+        if name in ("google-chrome", "google-chrome-stable", "chromium",
+                    "chromium-browser", "chrome", "msedge"):
+            return f"/usr/bin/{name}"
+        return None
+
+    monkeypatch.setattr("hermes_cli.dep_ensure.shutil.which", fake_which)
+    monkeypatch.setattr("hermes_cli.dep_ensure._has_hermes_agent_browser", lambda: False)
+    # No install script available, so the missing agent-browser cannot be
+    # installed and the dep stays unsatisfied.
+    monkeypatch.setattr("hermes_cli.dep_ensure._find_install_script", lambda *a, **k: (None, None))
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry.main(["--setup-browser", "--yes"])
+    assert excinfo.value.code == 1

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -91,20 +91,49 @@ def test_find_install_script_returns_none_when_missing(tmp_path):
         assert result == (None, None)
 
 
-def test_has_system_browser_checks_windows_names():
-    from hermes_cli.dep_ensure import _has_system_browser
-    with patch("hermes_cli.dep_ensure._IS_WINDOWS", True), \
-         patch("hermes_cli.dep_ensure.shutil") as mock_shutil:
-        mock_shutil.which.side_effect = lambda name: "/fake/msedge.exe" if name == "msedge" else None
-        assert _has_system_browser() is True
+def test_browser_dep_rejects_system_chrome_without_agent_browser():
+    """A system Chrome/Edge must NOT satisfy the browser dep.
+
+    The runtime gate (tools.browser_tool.check_browser_requirements) hard-requires
+    the agent-browser CLI, so a bare system browser must leave the dep unsatisfied
+    — otherwise bootstrap falsely reports success and the lazy installer is skipped.
+    """
+    from hermes_cli.dep_ensure import ensure_dependency
+
+    def fake_which(name, path=None):
+        # System Chrome is present; agent-browser is not.
+        if name in ("google-chrome", "google-chrome-stable", "chromium",
+                    "chromium-browser", "chrome", "msedge"):
+            return f"/usr/bin/{name}"
+        return None
+
+    with patch("hermes_cli.dep_ensure.shutil.which", side_effect=fake_which), \
+         patch("hermes_cli.dep_ensure._has_hermes_agent_browser", return_value=False), \
+         patch("hermes_cli.dep_ensure._find_install_script", return_value=(None, None)):
+        assert ensure_dependency("browser", interactive=False) is False
 
 
-def test_has_system_browser_checks_posix_names():
-    from hermes_cli.dep_ensure import _has_system_browser
+def test_browser_dep_satisfied_by_agent_browser_on_path():
+    """agent-browser on PATH satisfies the browser dep without an install."""
+    from hermes_cli.dep_ensure import ensure_dependency
+
+    def fake_which(name, path=None):
+        return "/usr/local/bin/agent-browser" if name == "agent-browser" else None
+
+    with patch("hermes_cli.dep_ensure.shutil.which", side_effect=fake_which):
+        assert ensure_dependency("browser", interactive=False) is True
+
+
+def test_browser_dep_satisfied_by_hermes_managed_agent_browser(tmp_path):
+    """A hermes-managed agent-browser (off PATH) satisfies the browser dep."""
+    from hermes_cli.dep_ensure import ensure_dependency
+    bin_dir = tmp_path / "node" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "agent-browser").write_text("#!/bin/sh")
     with patch("hermes_cli.dep_ensure._IS_WINDOWS", False), \
-         patch("hermes_cli.dep_ensure.shutil") as mock_shutil:
-        mock_shutil.which.return_value = None
-        assert _has_system_browser() is False
+         patch("hermes_cli.dep_ensure.shutil.which", return_value=None), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert ensure_dependency("browser", interactive=False) is True
 
 
 def test_has_hermes_agent_browser_windows_path(tmp_path):


### PR DESCRIPTION
## What does this PR do?

`ensure_dependency("browser")` treated a system Chrome/Edge as enough to satisfy the
browser dependency, but the runtime gate (`tools.browser_tool.check_browser_requirements`)
hard-requires the `agent-browser` CLI. The mismatch let browser bootstrap report success
when browser tools couldn't actually run, and it silently defeated the lazy installer in
`_find_agent_browser()` — a system browser short-circuited the check to `True`, so the
install script never ran and `agent-browser` was never installed.

This aligns the dep check with the runtime gate (and the module's own docstring,
"browser tool needs agent-browser"): the `browser` dep is satisfied only when the
`agent-browser` CLI is resolvable (PATH or hermes-managed). A system browser is just the
engine `agent-browser` drives, not a substitute. Chromium nuance is intentionally left to
the mode-aware runtime gate to avoid over-narrowing cloud/Lightpanda/Camofox/CDP flows.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dep_ensure.py`: `"browser"` predicate now requires the `agent-browser` CLI
  (PATH or hermes-managed); removed the system-browser shortcut and the now-unused
  `_has_system_browser()`; updated the dep description.
- `tests/hermes_cli/test_dep_ensure.py`: replaced the `_has_system_browser` unit tests with
  regression tests (system Chrome → unsatisfied; agent-browser on PATH / hermes-managed → satisfied).
- `tests/acp/test_entry.py`: added a regression test that drives the real `dep_ensure` so
  `--setup-browser` exits 1 when only a system browser is present.

## How to Test

1. On a host with Chrome/Edge but no `agent-browser`, run `hermes-acp --setup-browser`:
   - Before: exits `0` (false success); browser tools never advertise at runtime.
   - After: exits `1` ("Browser tools installation failed."), matching `check_browser_requirements`.
2. `scripts/run_tests.sh tests/hermes_cli/test_dep_ensure.py tests/acp/test_entry.py tests/hermes_cli/test_setup_model_provider.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(browser): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites and they pass (full `scripts/run_tests.sh` on Linux recommended for CI parity)
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered (`shutil.which` + hermes-managed `.cmd`/POSIX paths)
- [x] Tool descriptions/schemas — N/A