### PR TITLE
feat(tui): show tool emojis in session UI

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4770,10 +4770,12 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
 def test_session_info_includes_tool_emojis(monkeypatch):
     fake_model_tools = types.ModuleType("model_tools")
     fake_model_tools.get_toolset_for_tool = lambda name: "file"
-    fake_display = types.ModuleType("agent.display")
-    fake_display.get_tool_emoji = lambda name, default="⚡": {"read_file": "📖"}.get(name, default)
     monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
-    monkeypatch.setitem(sys.modules, "agent.display", fake_display)
+    monkeypatch.setattr(
+        server,
+        "_get_tool_emoji",
+        lambda name, default="⚡": {"read_file": "📖"}.get(name, default),
+    )
 
     agent = types.SimpleNamespace(
         model="test-model",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4767,6 +4767,26 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
     assert resp["error"]["code"] == 4010
 
 
+def test_session_info_includes_tool_emojis(monkeypatch):
+    fake_model_tools = types.ModuleType("model_tools")
+    fake_model_tools.get_toolset_for_tool = lambda name: "file"
+    fake_display = types.ModuleType("agent.display")
+    fake_display.get_tool_emoji = lambda name, default="⚡": {"read_file": "📖"}.get(name, default)
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+    monkeypatch.setitem(sys.modules, "agent.display", fake_display)
+
+    agent = types.SimpleNamespace(
+        model="test-model",
+        tools=[{"function": {"name": "read_file"}}, {"function": {"name": "unknown_tool"}}],
+    )
+
+    info = server._session_info(agent)
+
+    assert info["tools"]["file"] == ["read_file", "unknown_tool"]
+    assert info["tool_emojis"]["read_file"] == "📖"
+    assert info["tool_emojis"]["unknown_tool"] == "⚡"
+
+
 def test_session_info_includes_mcp_servers(monkeypatch):
     fake_status = [
         {"name": "github", "transport": "http", "tools": 12, "connected": True},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -38,6 +38,21 @@ from tui_gateway.transport import (
 
 logger = logging.getLogger(__name__)
 
+try:
+    from agent.display import get_tool_emoji as _display_get_tool_emoji
+except Exception:
+    _display_get_tool_emoji = None
+
+
+def _get_tool_emoji(name: str, default: str = "⚡") -> str:
+    if _display_get_tool_emoji is None:
+        return default
+    try:
+        return _display_get_tool_emoji(name, default=default)
+    except Exception:
+        return default
+
+
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
     hermes_home=_hermes_home, project_env=Path(__file__).parent.parent / ".env"
@@ -3401,14 +3416,13 @@ def _session_info(agent, session: dict | None = None) -> dict:
         pass
     try:
         from model_tools import get_toolset_for_tool
-        from agent.display import get_tool_emoji
 
         for t in getattr(agent, "tools", []) or []:
             name = t["function"]["name"]
             info["tools"].setdefault(get_toolset_for_tool(name) or "other", []).append(
                 name
             )
-            info["tool_emojis"][name] = get_tool_emoji(name, default="⚡")
+            info["tool_emojis"][name] = _get_tool_emoji(name, default="⚡")
     except Exception:
         pass
     try:
@@ -3601,12 +3615,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             "name": name,
             "context": _tool_ctx(name, args),
         }
-        try:
-            from agent.display import get_tool_emoji
-
-            payload["emoji"] = get_tool_emoji(name, default="⚡")
-        except Exception:
-            pass
+        payload["emoji"] = _get_tool_emoji(name, default="⚡")
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3365,6 +3365,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "fast": service_tier == "priority",
         "yolo": yolo,
         "tools": {},
+        "tool_emojis": {},
         "skills": {},
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
@@ -3400,12 +3401,14 @@ def _session_info(agent, session: dict | None = None) -> dict:
         pass
     try:
         from model_tools import get_toolset_for_tool
+        from agent.display import get_tool_emoji
 
         for t in getattr(agent, "tools", []) or []:
             name = t["function"]["name"]
             info["tools"].setdefault(get_toolset_for_tool(name) or "other", []).append(
                 name
             )
+            info["tool_emojis"][name] = get_tool_emoji(name, default="⚡")
     except Exception:
         pass
     try:
@@ -3598,6 +3601,12 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             "name": name,
             "context": _tool_ctx(name, args),
         }
+        try:
+            from agent.display import get_tool_emoji
+
+            payload["emoji"] = get_tool_emoji(name, default="⚡")
+        except Exception:
+            pass
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -112,6 +112,35 @@ describe('createGatewayEventHandler', () => {
     })
   })
 
+  it('stores tool emoji metadata on the active session info', () => {
+    const appended: Msg[] = []
+    patchUiState({ sid: 'sid-abc' })
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: {
+        model: 'test',
+        skills: {},
+        tool_emojis: { read_file: '📖' },
+        tools: { file: ['read_file', 'terminal'] }
+      },
+      session_id: 'sid-abc',
+      type: 'session.info'
+    } as any)
+    onEvent({
+      payload: { context: 'npm test', emoji: '💻', name: 'terminal', tool_id: 'tool-1' },
+      session_id: 'sid-abc',
+      type: 'tool.start'
+    } as any)
+
+    expect(getUiState().info?.tool_emojis).toMatchObject({
+      'Read File': '📖',
+      Terminal: '💻',
+      read_file: '📖',
+      terminal: '💻'
+    })
+  })
+
   it('keeps the current todo list visible when the next message starts', () => {
     const appended: Msg[] = []
     const todos = [{ content: 'Boil water', id: 'boil', status: 'in_progress' }]

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -11,11 +11,11 @@ import {
   hasAnsi,
   isToolTrailResultLine,
   lastCotTrailIndex,
+  normalizeToolEmojis,
   parseToolTrailResultLine,
   pasteTokenLabel,
   sameToolTrailGroup,
   sanitizeAnsiForRender,
-  setToolEmojis,
   splitToolDuration,
   stripAnsi,
   thinkingPreview,
@@ -123,15 +123,22 @@ describe('sameToolTrailGroup', () => {
 
 describe('tool emojis', () => {
   it('maps backend tool emoji metadata onto raw names and rendered call labels', () => {
-    setToolEmojis({ read_file: '📖', terminal: '💻' })
+    const emojis = normalizeToolEmojis({ read_file: '📖', terminal: '💻' })
 
-    expect(toolEmoji('read_file')).toBe('📖')
-    expect(toolEmoji('Read File')).toBe('📖')
-    expect(toolCallEmoji('Read File("/tmp/x") (0.9s)')).toBe('📖')
-    expect(toolCallEmoji('Terminal("npm test")')).toBe('💻')
-    expect(toolEmoji('unknown_tool')).toBe('⚡')
+    expect(toolEmoji('read_file', '⚡', emojis)).toBe('📖')
+    expect(toolEmoji('Read File', '⚡', emojis)).toBe('📖')
+    expect(toolCallEmoji('Read File("/tmp/x") (0.9s)', '⚡', emojis)).toBe('📖')
+    expect(toolCallEmoji('Terminal("npm test")', '⚡', emojis)).toBe('💻')
+    expect(toolEmoji('unknown_tool', '⚡', emojis)).toBe('⚡')
+  })
 
-    setToolEmojis({})
+  it('keeps emoji maps isolated per session', () => {
+    const left = normalizeToolEmojis({ read_file: '📖' })
+    const right = normalizeToolEmojis({ terminal: '💻' })
+
+    expect(toolEmoji('Read File', '⚡', left)).toBe('📖')
+    expect(toolEmoji('Read File', '⚡', right)).toBe('⚡')
+    expect(toolEmoji('Terminal', '⚡', right)).toBe('💻')
   })
 })
 

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -15,9 +15,12 @@ import {
   pasteTokenLabel,
   sameToolTrailGroup,
   sanitizeAnsiForRender,
+  setToolEmojis,
   splitToolDuration,
   stripAnsi,
-  thinkingPreview
+  thinkingPreview,
+  toolCallEmoji,
+  toolEmoji
 } from '../lib/text.js'
 
 describe('isToolTrailResultLine', () => {
@@ -115,6 +118,20 @@ describe('sameToolTrailGroup', () => {
   it('rejects other tools', () => {
     expect(sameToolTrailGroup('searching', 'reading ✓')).toBe(false)
     expect(sameToolTrailGroup('searching', 'searching extra ✓')).toBe(false)
+  })
+})
+
+describe('tool emojis', () => {
+  it('maps backend tool emoji metadata onto raw names and rendered call labels', () => {
+    setToolEmojis({ read_file: '📖', terminal: '💻' })
+
+    expect(toolEmoji('read_file')).toBe('📖')
+    expect(toolEmoji('Read File')).toBe('📖')
+    expect(toolCallEmoji('Read File("/tmp/x") (0.9s)')).toBe('📖')
+    expect(toolCallEmoji('Terminal("npm test")')).toBe('💻')
+    expect(toolEmoji('unknown_tool')).toBe('⚡')
+
+    setToolEmojis({})
   })
 })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -13,7 +13,7 @@ import { isTodoDone } from '../lib/liveProgress.js'
 import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
-import { formatAbandonedClarify, formatToolCall, setToolEmoji, setToolEmojis, stripAnsi } from '../lib/text.js'
+import { formatAbandonedClarify, formatToolCall, normalizeToolEmojis, stripAnsi, withToolEmoji } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
@@ -421,9 +421,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'session.info': {
-        const info = ev.payload
+        const info = { ...ev.payload, tool_emojis: normalizeToolEmojis(ev.payload.tool_emojis) }
 
-        setToolEmojis(info.tool_emojis)
         patchUiState(state => ({
           ...state,
           info,
@@ -720,7 +719,19 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'tool.start':
         if (ev.payload.name && ev.payload.emoji) {
-          setToolEmoji(ev.payload.name, ev.payload.emoji)
+          patchUiState(state => {
+            if (!state.info) {
+              return state
+            }
+
+            return {
+              ...state,
+              info: {
+                ...state.info,
+                tool_emojis: withToolEmoji(state.info.tool_emojis, ev.payload.name!, ev.payload.emoji)
+              }
+            }
+          })
         }
 
         turnController.recordTodos(ev.payload.todos)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -13,7 +13,7 @@ import { isTodoDone } from '../lib/liveProgress.js'
 import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
-import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
+import { formatAbandonedClarify, formatToolCall, setToolEmoji, setToolEmojis, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
@@ -423,6 +423,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
+        setToolEmojis(info.tool_emojis)
         patchUiState(state => ({
           ...state,
           info,
@@ -718,6 +719,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'tool.start':
+        if (ev.payload.name && ev.payload.emoji) {
+          setToolEmoji(ev.payload.name, ev.payload.emoji)
+        }
+
         turnController.recordTodos(ev.payload.todos)
         turnController.recordToolStart(
           ev.payload.tool_id,

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useStdout } from '@hermes/ink'
+import { Box, stringWidth, Text, useStdout } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
@@ -175,13 +175,14 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const [mcpOpen, setMcpOpen] = useState(false)
 
   const truncLine = (pfx: string, items: string[]) => {
+    const prefixWidth = stringWidth(pfx)
     let line = ''
     let shown = 0
 
-    for (const item of items) {
+    for (const item of [...items].sort()) {
       const next = line ? `${line}, ${item}` : item
 
-      if (pfx.length + next.length > lineBudget) {
+      if (prefixWidth + stringWidth(next) > lineBudget) {
         return line ? `${line}, …+${items.length - shown}` : `${item}, …`
       }
 
@@ -235,7 +236,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
     return (
       <>
         {shown.map(([k, vs]) => {
-          const toolItems = [...vs].sort().map(name => `${toolEmoji(name)} ${name}`)
+          const toolItems = [...vs].sort().map(name => `${toolEmoji(name, '⚡', info.tool_emojis)} ${name}`)
 
           return (
             <Text key={k} wrap="truncate">

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
-import { flat } from '../lib/text.js'
+import { flat, toolEmoji } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { PanelSection, SessionInfo } from '../types.js'
 
@@ -178,7 +178,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
     let line = ''
     let shown = 0
 
-    for (const item of [...items].sort()) {
+    for (const item of items) {
       const next = line ? `${line}, ${item}` : item
 
       if (pfx.length + next.length > lineBudget) {
@@ -210,7 +210,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
         {shown.map(([k, vs]) => (
           <Text key={k} wrap="truncate">
             <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
+            <Text color={t.color.text}>{truncLine(strip(k) + ': ', [...vs].sort())}</Text>
           </Text>
         ))}
         {overflow > 0 && <Text color={t.color.muted}>(and {overflow} more categories…)</Text>}
@@ -234,12 +234,16 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
 
     return (
       <>
-        {shown.map(([k, vs]) => (
-          <Text key={k} wrap="truncate">
-            <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-          </Text>
-        ))}
+        {shown.map(([k, vs]) => {
+          const toolItems = [...vs].sort().map(name => `${toolEmoji(name)} ${name}`)
+
+          return (
+            <Text key={k} wrap="truncate">
+              <Text color={t.color.muted}>{strip(k)}: </Text>
+              <Text color={t.color.text}>{truncLine(strip(k) + ': ', toolItems)}</Text>
+            </Text>
+          )
+        })}
         {overflow > 0 && <Text color={t.color.muted}>(and {overflow} more toolsets…)</Text>}
       </>
     )

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -1,7 +1,9 @@
 import { Box, NoSelect, Text } from '@hermes/ink'
+import { useStore } from '@nanostores/react'
 import { memo, type ReactNode, useEffect, useMemo, useState } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
+import { $uiState } from '../app/uiStore.js'
 import { THINKING_COT_MAX } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import {
@@ -707,6 +709,8 @@ export const ToolTrail = memo(function ToolTrail({
   trail?: string[]
   activity?: ActivityItem[]
 }) {
+  const toolEmojis = useStore($uiState).info?.tool_emojis
+
   const visible = useMemo(
     () => ({
       thinking: sectionMode('thinking', detailsMode, sections, commandOverride),
@@ -1073,7 +1077,7 @@ export const ToolTrail = memo(function ToolTrail({
                   color={group.color}
                   content={
                     <>
-                      <Text color={t.color.accent}>{toolCallEmoji(group.label)} </Text>
+                      <Text color={t.color.accent}>{toolCallEmoji(group.label, '⚡', toolEmojis)} </Text>
                       {toolLabel(group)}
                       {isDelegateGroup ? (
                         <Text color={t.color.statusFg} dim>

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -24,6 +24,7 @@ import {
   pick,
   splitToolDuration,
   thinkingPreview,
+  toolCallEmoji,
   toolTrailLabel
 } from '../lib/text.js'
 import type { Theme } from '../theme.js'
@@ -1072,7 +1073,7 @@ export const ToolTrail = memo(function ToolTrail({
                   color={group.color}
                   content={
                     <>
-                      <Text color={t.color.accent}>● </Text>
+                      <Text color={t.color.accent}>{toolCallEmoji(group.label)} </Text>
                       {toolLabel(group)}
                       {isDelegateGroup ? (
                         <Text color={t.color.statusFg} dim>

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -667,7 +667,7 @@ export type GatewayEvent =
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
-      payload: { args_text?: string; context?: string; name?: string; tool_id: string; todos?: unknown[] }
+      payload: { args_text?: string; context?: string; emoji?: string; name?: string; tool_id: string; todos?: unknown[] }
       session_id?: string
       type: 'tool.start'
     }

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -195,36 +195,41 @@ export const toolTrailLabel = (name: string) =>
     .map(p => p[0]!.toUpperCase() + p.slice(1))
     .join(' ') || name
 
-let toolEmojiOverrides: Record<string, string> = {}
+export type ToolEmojiMap = Record<string, string>
 
 const toolEmojiKey = (nameOrLabel: string) => nameOrLabel.trim()
 const toolEmojiSnakeKey = (nameOrLabel: string) => toolEmojiKey(nameOrLabel).toLowerCase().replace(/\s+/g, '_')
 
-export const setToolEmoji = (name: string, emoji?: string) => {
+export const withToolEmoji = (emojis: ToolEmojiMap = {}, name: string, emoji?: string): ToolEmojiMap => {
   const cleanName = toolEmojiKey(name)
   const cleanEmoji = String(emoji ?? '').trim()
 
   if (!cleanName || !cleanEmoji) {
-    return
+    return emojis
   }
 
-  toolEmojiOverrides[cleanName] = cleanEmoji
-  toolEmojiOverrides[toolTrailLabel(cleanName)] = cleanEmoji
-  toolEmojiOverrides[toolEmojiSnakeKey(cleanName)] = cleanEmoji
+  return {
+    ...emojis,
+    [cleanName]: cleanEmoji,
+    [toolTrailLabel(cleanName)]: cleanEmoji,
+    [toolEmojiSnakeKey(cleanName)]: cleanEmoji
+  }
 }
 
-export const setToolEmojis = (emojis?: Record<string, string>) => {
-  toolEmojiOverrides = {}
+export const normalizeToolEmojis = (emojis?: ToolEmojiMap): ToolEmojiMap => {
+  let normalized: ToolEmojiMap = {}
 
   for (const [name, emoji] of Object.entries(emojis ?? {})) {
-    setToolEmoji(name, emoji)
+    normalized = withToolEmoji(normalized, name, emoji)
   }
+
+  return normalized
 }
 
-export const toolEmoji = (nameOrLabel: string, fallback = '⚡') => {
+export const toolEmoji = (nameOrLabel: string, fallback = '⚡', emojis?: ToolEmojiMap) => {
   const key = toolEmojiKey(nameOrLabel)
 
-  return toolEmojiOverrides[key] ?? toolEmojiOverrides[toolEmojiSnakeKey(key)] ?? fallback
+  return emojis?.[key] ?? emojis?.[toolEmojiSnakeKey(key)] ?? fallback
 }
 
 const toolCallBaseLabel = (call: string) => {
@@ -234,7 +239,8 @@ const toolCallBaseLabel = (call: string) => {
   return (paren >= 0 ? noDuration.slice(0, paren) : noDuration).trim()
 }
 
-export const toolCallEmoji = (call: string, fallback = '⚡') => toolEmoji(toolCallBaseLabel(call), fallback)
+export const toolCallEmoji = (call: string, fallback = '⚡', emojis?: ToolEmojiMap) =>
+  toolEmoji(toolCallBaseLabel(call), fallback, emojis)
 
 export const formatToolCall = (name: string, context = '') => {
   const label = toolTrailLabel(name)

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -195,6 +195,47 @@ export const toolTrailLabel = (name: string) =>
     .map(p => p[0]!.toUpperCase() + p.slice(1))
     .join(' ') || name
 
+let toolEmojiOverrides: Record<string, string> = {}
+
+const toolEmojiKey = (nameOrLabel: string) => nameOrLabel.trim()
+const toolEmojiSnakeKey = (nameOrLabel: string) => toolEmojiKey(nameOrLabel).toLowerCase().replace(/\s+/g, '_')
+
+export const setToolEmoji = (name: string, emoji?: string) => {
+  const cleanName = toolEmojiKey(name)
+  const cleanEmoji = String(emoji ?? '').trim()
+
+  if (!cleanName || !cleanEmoji) {
+    return
+  }
+
+  toolEmojiOverrides[cleanName] = cleanEmoji
+  toolEmojiOverrides[toolTrailLabel(cleanName)] = cleanEmoji
+  toolEmojiOverrides[toolEmojiSnakeKey(cleanName)] = cleanEmoji
+}
+
+export const setToolEmojis = (emojis?: Record<string, string>) => {
+  toolEmojiOverrides = {}
+
+  for (const [name, emoji] of Object.entries(emojis ?? {})) {
+    setToolEmoji(name, emoji)
+  }
+}
+
+export const toolEmoji = (nameOrLabel: string, fallback = '⚡') => {
+  const key = toolEmojiKey(nameOrLabel)
+
+  return toolEmojiOverrides[key] ?? toolEmojiOverrides[toolEmojiSnakeKey(key)] ?? fallback
+}
+
+const toolCallBaseLabel = (call: string) => {
+  const noDuration = call.replace(/ \(\d+(?:\.\d)?s\)$/, '').trim()
+  const paren = noDuration.indexOf('(')
+
+  return (paren >= 0 ? noDuration.slice(0, paren) : noDuration).trim()
+}
+
+export const toolCallEmoji = (call: string, fallback = '⚡') => toolEmoji(toolCallBaseLabel(call), fallback)
+
 export const formatToolCall = (name: string, context = '') => {
   const label = toolTrailLabel(name)
   const preview = compactPreview(context, 64)

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -161,6 +161,7 @@ export interface SessionInfo {
   skills: Record<string, string[]>
   system_prompt?: string
   tools: Record<string, string[]>
+  tool_emojis?: Record<string, string>
   update_behind?: number | null
   update_command?: string
   usage?: Usage


### PR DESCRIPTION
## Summary
- Surface backend per-tool emoji metadata in TUI `session.info` and live `tool.start` events.
- Keep emoji mappings in per-session UI state so resumed or switched sessions cannot leak icons into each other.
- Render tool icons in the startup/session tool list and completed tool trail.
- Use terminal display width when truncating emoji-prefixed tool lists.
- Add backend and frontend coverage for the metadata flow and session isolation.

## Why
The classic CLI already renders the registry/skin-defined tool emojis, while the TUI currently replaces them with a generic bullet. This closes that UI parity gap without adding a new configuration surface.

Addresses the `tool_emojis` rendering portion of #17977. The skin payload work in #31722 is complementary; this PR consumes tool emoji metadata in the actual TUI renderers.

## Test Plan
- `python -m pytest tests/test_tui_gateway_server.py -q` — 316 passed on native Windows
- `npm --prefix ui-tui run test -- src/__tests__/createGatewayEventHandler.test.ts src/__tests__/text.test.ts` — 109 passed
- `npm --prefix ui-tui run typecheck` — passed
- `npm --prefix ui-tui run build` — passed
- ESLint on all frontend files changed by this PR — passed
- `scripts/check-windows-footguns.py --diff origin/main` — passed
- Real metadata-path smoke with `terminal`, `read_file`, and `web_search` registry emojis — passed
- `git diff --check origin/main...HEAD` — passed

### Baseline note
The full TUI suite on native Windows currently has unrelated failures on `origin/main` (Windows path/editor expectations and stale status/height assertions). Eleven of those failures reproduce in an isolated pristine `origin/main` worktree. The files and code paths involved are outside this PR.

## Platforms Tested
- Native Windows 10, Git Bash/MSYS
- Python 3.11.15
- Node.js 24.14.0
