### PR TITLE
fix(desktop): omit oauth content-length header

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { jsonBodyBuffer, jsonRequestHeaders } = require('./net-json.cjs')
 const {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -2193,7 +2194,7 @@ async function pickPort() {
 
 function fetchJson(url, token, options = {}) {
   return new Promise((resolve, reject) => {
-    const body = options.body === undefined ? undefined : Buffer.from(JSON.stringify(options.body))
+    const body = jsonBodyBuffer(options.body)
     const parsed = new URL(url)
     const client = parsed.protocol === 'https:' ? https : http
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
@@ -2207,11 +2208,7 @@ function fetchJson(url, token, options = {}) {
       parsed,
       {
         method: options.method || 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Hermes-Session-Token': token,
-          ...(body ? { 'Content-Length': String(body.length) } : {})
-        }
+        headers: jsonRequestHeaders({ body, token })
       },
       res => {
         const chunks = []
@@ -2267,7 +2264,7 @@ function fetchPublicJson(url, options = {}) {
   // any credentials exist, and any time we must not leak a token to an
   // endpoint that doesn't need one.
   return new Promise((resolve, reject) => {
-    const body = options.body === undefined ? undefined : Buffer.from(JSON.stringify(options.body))
+    const body = jsonBodyBuffer(options.body)
     let parsed
     try {
       parsed = new URL(url)
@@ -2287,10 +2284,7 @@ function fetchPublicJson(url, options = {}) {
       parsed,
       {
         method: options.method || 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(body ? { 'Content-Length': String(body.length) } : {})
-        }
+        headers: jsonRequestHeaders({ body })
       },
       res => {
         const chunks = []
@@ -3467,7 +3461,7 @@ function fetchJsonViaOauthSession(url, options = {}) {
       reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
       return
     }
-    const body = options.body === undefined ? undefined : Buffer.from(JSON.stringify(options.body))
+    const body = jsonBodyBuffer(options.body)
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const request = electronNet.request({
@@ -3477,8 +3471,9 @@ function fetchJsonViaOauthSession(url, options = {}) {
       useSessionCookies: true,
       redirect: 'follow'
     })
-    request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
+    for (const [name, value] of Object.entries(jsonRequestHeaders({ body, includeContentLength: false }))) {
+      request.setHeader(name, value)
+    }
 
     let timedOut = false
     const timer = setTimeout(() => {

--- a/apps/desktop/electron/net-json.cjs
+++ b/apps/desktop/electron/net-json.cjs
@@ -1,0 +1,35 @@
+/**
+ * Pure JSON request helpers shared by Node's http(s) client and Electron's
+ * net.ClientRequest path.
+ *
+ * Electron's net stack rejects manually setting Content-Length on requests
+ * with a body (`net::ERR_INVALID_ARGUMENT`). Chromium computes the header from
+ * request.write() itself, so OAuth/cookie-authenticated Electron requests must
+ * opt out of manual Content-Length while Node http(s) requests can keep it.
+ */
+
+function jsonBodyBuffer(value) {
+  return value === undefined ? undefined : Buffer.from(JSON.stringify(value))
+}
+
+function jsonRequestHeaders(options = {}) {
+  const { body, token, includeContentLength = true } = options
+  const headers = {
+    'Content-Type': 'application/json'
+  }
+
+  if (Object.hasOwn(options, 'token')) {
+    headers['X-Hermes-Session-Token'] = token
+  }
+
+  if (body && includeContentLength) {
+    headers['Content-Length'] = String(body.length)
+  }
+
+  return headers
+}
+
+module.exports = {
+  jsonBodyBuffer,
+  jsonRequestHeaders
+}

--- a/apps/desktop/electron/net-json.test.cjs
+++ b/apps/desktop/electron/net-json.test.cjs
@@ -1,0 +1,50 @@
+/**
+ * Tests for Electron/Node JSON request header helpers.
+ *
+ * Run with: node --test electron/net-json.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { jsonBodyBuffer, jsonRequestHeaders } = require('./net-json.cjs')
+
+test('jsonBodyBuffer returns undefined when no body is provided', () => {
+  assert.equal(jsonBodyBuffer(undefined), undefined)
+})
+
+test('jsonBodyBuffer serializes request bodies to byte buffers', () => {
+  const body = jsonBodyBuffer({ config: { approvals: { mode: 'smart' } } })
+
+  assert.ok(Buffer.isBuffer(body))
+  assert.equal(body.toString('utf8'), '{"config":{"approvals":{"mode":"smart"}}}')
+})
+
+test('Node JSON request headers include session token and content length', () => {
+  const body = jsonBodyBuffer({ config: { approvals: { mode: 'off' } } })
+
+  assert.deepEqual(jsonRequestHeaders({ body, token: 'tok_123' }), {
+    'Content-Type': 'application/json',
+    'X-Hermes-Session-Token': 'tok_123',
+    'Content-Length': String(body.length)
+  })
+})
+
+test('Public JSON request headers omit the session token when none is provided', () => {
+  const headers = jsonRequestHeaders()
+
+  assert.deepEqual(headers, {
+    'Content-Type': 'application/json'
+  })
+  assert.equal(Object.hasOwn(headers, 'X-Hermes-Session-Token'), false)
+})
+
+test('OAuth Electron JSON request headers omit manual content length for bodies', () => {
+  const body = jsonBodyBuffer({ config: { approvals: { mode: 'manual' } } })
+  const headers = jsonRequestHeaders({ body, includeContentLength: false })
+
+  assert.deepEqual(headers, {
+    'Content-Type': 'application/json'
+  })
+  assert.equal(Object.hasOwn(headers, 'Content-Length'), false)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/net-json.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

- Add a small desktop JSON request helper for body serialization and header construction.
- Keep `Content-Length` on Node `http`/`https` JSON requests, but omit manual `Content-Length` for OAuth `electronNet.request` calls so Chromium/Electron can compute it from `request.write()`.
- Add Node test coverage for token/public/OAuth header behavior and include it in `test:desktop:platforms`.

## Why

OAuth/cookie-authenticated desktop REST calls use Electron's `net.ClientRequest` so the OAuth session partition can attach HttpOnly cookies. Electron/Chromium rejects manually setting `Content-Length` on a request with a written body (`net::ERR_INVALID_ARGUMENT`), which can break OAuth-backed REST calls such as WS ticket minting or remote config writes.

The Node request paths still include `Content-Length`; only the Electron OAuth session path opts out.

## Test plan

Passing checks on this branch:

- `git diff --check origin/main..HEAD`
- `node --check apps/desktop/electron/main.cjs`
- `node --check apps/desktop/electron/net-json.cjs`
- `node --check apps/desktop/electron/net-json.test.cjs`
- `cd apps/desktop && ../../node_modules/.bin/eslint electron/main.cjs electron/net-json.cjs electron/net-json.test.cjs`
- `cd apps/desktop && node --test electron/net-json.test.cjs` — 5/5 passing
- `env NPM_CONFIG_ENGINE_STRICT=false npm --prefix apps/desktop run test:desktop:platforms` — 81/81 passing

Additional local notes:

- I also attempted full `npm --prefix apps/desktop run lint`; it currently fails on unrelated `origin/main` files (`src/app/settings/env-var-actions-menu.tsx` import ordering plus existing padding warnings in other TS/TSX files). The changed Electron files pass targeted lint.
- I attempted full `npm --prefix apps/desktop run type-check`; it currently fails on unrelated existing `findLast` / `findLastIndex` lib-target issues in `src/app/chat/composer/index.tsx` and `src/app/session/hooks/use-session-actions.ts`.
