### PR TITLE
fix(config): guard _secure_file behind else to preserve original .env permissions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5519,13 +5519,14 @@ def save_env_value(key: str, value: str):
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -5575,13 +5576,14 @@ def remove_env_value(key: str) -> bool:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()


### PR DESCRIPTION
## Bug

In `save_env_value()` and `remove_env_value()`, `_secure_file()` was called unconditionally after restoring original file permissions via `os.chmod()`. This defeated the permission restore — `_secure_file()` tightens permissions back to 0600, undoing the `original_mode` preservation that Docker volume mounts depend on.

## Fix

Move `_secure_file()` into the `else` branch so it only runs for newly created .env files (when `original_mode is None`), not for existing ones with custom permissions.

## Changes

- `hermes_cli/config.py`: 2 locations fixed (save_env_value, remove_env_value)
- 4 insertions, 2 deletions

## Testing

All 94 tests in `tests/hermes_cli/test_config.py` pass.