### PR TITLE
docs(desktop): clarify macOS Gatekeeper first-open (no Apple Developer account needed)

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,6 +12,10 @@ Get Hermes Agent up and running in under two minutes!
 ### With the Hermes Desktop installer on macOS or Windows (recommended)
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/desktop) from our website and run it.
 
+:::note macOS: no Apple Developer account needed
+The macOS builds are code-signed and notarized, so a normal install just works — you do **not** need an Apple Developer account or any "developer password." If macOS Gatekeeper ever blocks first launch with an *"unidentified developer"* dialog, right-click the app and choose **Open**. See [Desktop App → Troubleshooting](../user-guide/desktop.md#macos-wont-open-the-app-asks-about-the-developer).
+:::
+
 ### Without Hermes Desktop:
 For a command-line only install without Hermes Desktop, run:
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -165,6 +165,24 @@ For the same setup from the web-dashboard angle, see [Web Dashboard → Connecti
 
 ## Troubleshooting
 
+### macOS won't open the app / asks about the "developer"
+
+You do **not** need an Apple Developer account, an Apple Developer Program membership, or any "developer password" to install or run Hermes Desktop. The official builds from [our download page](https://hermes-agent.nousresearch.com/desktop) are code-signed and notarized by Apple, so a normal install just works.
+
+If macOS still shows a dialog like *"Hermes can't be opened because Apple cannot check it for malicious software"* or *"…from an unidentified developer"*, that's **Gatekeeper**, not an account requirement. It usually means the download's quarantine attribute is in an odd state, or you built the app locally with `hermes desktop` (which produces an unsigned build from your own source). It is asking you to confirm you trust the app — there is no developer account or password involved.
+
+To open it anyway:
+
+1. **Right-click (or Control-click) the app** in Finder and choose **Open**, then click **Open** in the dialog. macOS remembers this choice, so you only do it once.
+2. If there's no **Open** option, go to **System Settings → Privacy & Security**, scroll to the **Security** section, and click **Open Anyway** next to the Hermes entry. (The macOS *login* password it may ask for here is your own Mac password to change a security setting — not a "developer" password.)
+
+If you'd rather not deal with Gatekeeper at all, the CLI install needs no signing prompts:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+hermes desktop   # launches the desktop app, building it locally
+```
+
 Boot logs land in `HERMES_HOME/logs/desktop.log` (it includes backend output and recent Python tracebacks) — check it first if the app reports a boot failure. You can also tail it from the CLI:
 
 ```bash


### PR DESCRIPTION
## What

Adds macOS Gatekeeper / first-open guidance to the docs so users stop misreading the "unidentified developer" dialog as an Apple Developer account requirement.

## Why

A user reported that installing Hermes Desktop "asked for my developer password which I don't believe I have." This is **not a real install requirement** — the desktop builds are code-signed and notarized in CI (`apps/desktop/scripts/notarize*.cjs`), and 500k+ installs work fine. What they actually hit is macOS **Gatekeeper's** *"can't be opened… unidentified developer"* dialog, which people commonly misremember as a request for a developer account/password.

The docs had **zero** macOS first-open guidance, so a confused user had nothing to reference and concluded they needed a paid Apple account. This closes that gap.

## Changes

- **`website/docs/user-guide/desktop.md`** — new Troubleshooting subsection *"macOS won't open the app / asks about the 'developer'"*:
  - States plainly that no Apple Developer account / Developer Program membership / "developer password" is needed.
  - Explains the dialog is Gatekeeper (often a quarantine-attribute quirk, or a locally-built unsigned `hermes desktop` app), not an account gate.
  - Gives the fix: right-click → **Open**, or **System Settings → Privacy & Security → Open Anyway**.
  - Clarifies that any password macOS asks for there is the user's own Mac login password, not a developer password.
  - Notes the CLI install path as a no-Gatekeeper alternative.
- **`website/docs/getting-started/installation.md`** — short macOS note on the recommended-installer step cross-linking to the section above.

## Notes

- Docs-only; no code paths touched.
- Verified the cross-link anchor against github-slugger (Docusaurus default): heading `macOS won't open the app / asks about the "developer"` → slug `macos-wont-open-the-app-asks-about-the-developer`, which both files reference.
