### PR TITLE
fix(dashboard): accept nonstandard loopback host headers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 import asyncio
 import base64
 import binascii
+import ipaddress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hmac
@@ -218,6 +219,17 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _is_loopback_host_value(host: str) -> bool:
+    """True when *host* names the local machine's loopback interface."""
+    normalized = (host or "").strip().strip("[]").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
 def should_require_auth(host: str, allow_public: bool) -> bool:
     """Return True iff the dashboard OAuth auth gate must be active.
 
@@ -231,7 +243,7 @@ def should_require_auth(host: str, allow_public: bool) -> bool:
     are deliberately treated as PUBLIC — a hostile device on the same LAN is
     exactly the threat model the gate is designed for.
     """
-    return (host not in _LOOPBACK_HOST_VALUES) and (not allow_public)
+    return (not _is_loopback_host_value(host)) and (not allow_public)
 
 
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
@@ -271,8 +283,8 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
 
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
-    if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+    if _is_loopback_host_value(bound_lc):
+        return _is_loopback_host_value(host_only)
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -86,6 +86,8 @@ def test_loopback_host_header_validation_still_enforced(client_loopback):
 @pytest.mark.parametrize("host,allow_public,expected", [
     ("127.0.0.1", False, False),
     ("127.0.0.1", True,  False),
+    ("127.0.0.11", False, False),
+    ("127.0.0.11", True,  False),
     ("localhost", False, False),
     ("::1",       False, False),
     ("0.0.0.0",   True,  False),    # --insecure escape hatch

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -26,9 +26,10 @@ class TestHostHeaderValidator:
     def test_loopback_bind_accepts_loopback_names(self):
         from hermes_cli.web_server import _is_accepted_host
 
-        for bound in ("127.0.0.1", "localhost", "::1"):
+        for bound in ("127.0.0.1", "127.0.0.11", "localhost", "::1"):
             for host_header in (
                 "127.0.0.1", "127.0.0.1:9119",
+                "127.0.0.11", "127.0.0.11:9119",
                 "localhost", "localhost:9119",
                 "[::1]", "[::1]:9119",
             ):
@@ -36,18 +37,26 @@ class TestHostHeaderValidator:
                     f"bound={bound} must accept host={host_header}"
                 )
 
+    def test_loopback_bind_accepts_127_subnet_aliases(self):
+        """Container DNS can bind/callback through non-127.0.0.1 loopback IPs."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert _is_accepted_host("localhost:9119", "127.0.0.11")
+        assert _is_accepted_host("127.0.0.42:9119", "127.0.0.11")
+
     def test_loopback_bind_rejects_attacker_hostnames(self):
         """The core rebinding defence: attacker-controlled hosts that
         TTL-flip to 127.0.0.1 must be rejected."""
         from hermes_cli.web_server import _is_accepted_host
 
-        for bound in ("127.0.0.1", "localhost"):
+        for bound in ("127.0.0.1", "127.0.0.11", "localhost"):
             for attacker in (
                 "evil.example",
                 "evil.example:9119",
                 "rebind.attacker.test:80",
                 "localhost.attacker.test",  # subdomain trick
                 "127.0.0.1.evil.test",  # lookalike IP prefix
+                "127.0.0.11.evil.test",  # lookalike non-standard loopback
                 "",  # missing Host
             ):
                 assert not _is_accepted_host(attacker, bound), (


### PR DESCRIPTION
## Summary
- treat loopback host checks by IP semantics instead of a fixed localhost/127.0.0.1/::1 string set
- allow non-standard 127/8 loopback binds such as 127.0.0.11 to accept localhost/127.x Host headers
- keep DNS rebinding protection for attacker-controlled lookalike hostnames and non-loopback binds

Fixes #39280.

## Tests
- .venv/bin/python -m pytest tests/hermes_cli/test_web_server_host_header.py -q -o addopts= --tb=short
- .venv/bin/python -m pytest tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_gate.py -q -o addopts= --tb=short
- .venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_web_server_host_header.py -q -o addopts= --tb=short
- .venv/bin/python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_gate.py
- git diff --check
