### PR TITLE
fix(bedrock): replace whitespace-only placeholder text (#39829)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -57,6 +57,8 @@ except Exception:
 _bedrock_runtime_client_cache: Dict[str, Any] = {}
 _bedrock_control_client_cache: Dict[str, Any] = {}
 
+_EMPTY_MESSAGE_PLACEHOLDER = "(empty message)"
+
 
 def _require_boto3():
     """Import boto3, raising a clear error if not installed."""
@@ -445,26 +447,27 @@ def _convert_content_to_converse(content) -> List[Dict]:
       - Plain text strings → [{"text": "..."}]
       - Content arrays with text/image_url parts → mixed text/image blocks
 
-    Filters out empty text blocks — Bedrock's Converse API rejects messages
-    where a text content block has an empty ``text`` field (ValidationException:
-    "text content blocks must be non-empty"). Ref: issue #9486.
+    Filters out empty or whitespace-only text blocks — Bedrock's Converse API
+    rejects messages where a text content block is empty or whitespace-only
+    (ValidationException: "text content blocks must contain non-whitespace
+    text"). Ref: issues #9486 and #39829.
     """
     if content is None:
-        return [{"text": " "}]
+        return [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]
     if isinstance(content, str):
-        return [{"text": content}] if content.strip() else [{"text": " "}]
+        return [{"text": content}] if content.strip() else [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]
     if isinstance(content, list):
         blocks = []
         for part in content:
             if isinstance(part, str):
-                blocks.append({"text": part})
+                blocks.append({"text": part if part.strip() else _EMPTY_MESSAGE_PLACEHOLDER})
                 continue
             if not isinstance(part, dict):
                 continue
             part_type = part.get("type", "")
             if part_type == "text":
                 text = part.get("text", "")
-                blocks.append({"text": text if text else " "})
+                blocks.append({"text": text if text and text.strip() else _EMPTY_MESSAGE_PLACEHOLDER})
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
                 url = image_url.get("url", "") if isinstance(image_url, dict) else ""
@@ -486,7 +489,7 @@ def _convert_content_to_converse(content) -> List[Dict]:
                     # Remote URL — Converse doesn't support URLs directly,
                     # include as text reference for the model.
                     blocks.append({"text": f"[Image: {url}]"})
-        return blocks if blocks else [{"text": " "}]
+        return blocks if blocks else [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]
     return [{"text": str(content)}]
 
 
@@ -574,7 +577,7 @@ def convert_messages_to_converse(
                 })
 
             if not content_blocks:
-                content_blocks = [{"text": " "}]
+                content_blocks = [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]
 
             # Merge with previous assistant message if needed (strict alternation)
             if converse_msgs and converse_msgs[-1]["role"] == "assistant":
@@ -600,11 +603,11 @@ def convert_messages_to_converse(
 
     # Converse requires the first message to be from the user
     if converse_msgs and converse_msgs[0]["role"] != "user":
-        converse_msgs.insert(0, {"role": "user", "content": [{"text": " "}]})
+        converse_msgs.insert(0, {"role": "user", "content": [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]})
 
     # Converse requires the last message to be from the user
     if converse_msgs and converse_msgs[-1]["role"] != "user":
-        converse_msgs.append({"role": "user", "content": [{"text": " "}]})
+        converse_msgs.append({"role": "user", "content": [{"text": _EMPTY_MESSAGE_PLACEHOLDER}]})
 
     return (system_blocks if system_blocks else None, converse_msgs)
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -326,8 +326,89 @@ class TestConvertMessagesToConverse:
         from agent.bedrock_adapter import convert_messages_to_converse
         messages = [{"role": "user", "content": ""}]
         system, msgs = convert_messages_to_converse(messages)
-        # Empty string should get a space placeholder
-        assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
+        # Empty string must get a non-whitespace placeholder (#39829)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+
+    def test_whitespace_only_content_gets_placeholder(self):
+        """Whitespace-only user content must not produce whitespace-only text blocks (#39829)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": "   \n\t  "}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+
+    def test_none_content_gets_non_whitespace_placeholder(self):
+        """None content must produce non-whitespace placeholder (#39829, layer 1)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": None}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+        assert msgs[0]["content"][0]["text"].strip() != ""
+
+    def test_empty_text_part_in_list_gets_placeholder(self):
+        """Empty text part in content array must not produce whitespace-only block (#39829, layer 3)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+
+    def test_whitespace_text_part_in_list_gets_placeholder(self):
+        """Whitespace-only text part must be replaced with non-whitespace placeholder (#39829, edge case)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": [{"type": "text", "text": "\n"}]}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+
+    def test_whitespace_string_part_in_list_gets_placeholder(self):
+        """String entries in content arrays must not pass through whitespace-only blocks (#39829)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": ["\t\n"]}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+
+    def test_empty_assistant_content_gets_placeholder(self):
+        """Assistant with no content blocks must get non-whitespace placeholder (#39829, layer 5)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        # Assistant content is at index 1; last is trailing user pad
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        assert msgs[1]["content"][0]["text"] == "(empty message)"
+
+    def test_assistant_first_history_gets_non_whitespace_leading_pad(self):
+        """History starting with assistant must get non-whitespace user padding (#39829, layer 6)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "assistant", "content": "Sure, let me help."},
+            {"role": "user", "content": "thanks"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
+        assert msgs[0]["content"][0]["text"].strip() != ""
+
+    def test_trailing_user_pad_is_non_whitespace(self):
+        """Trailing user pad for assistant-last history must be non-whitespace (#39829, layer 7)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        last = msgs[-1]
+        assert last["role"] == "user"
+        assert last["content"][0]["text"] == "(empty message)"
+        assert last["content"][0]["text"].strip() != ""
+
+    def test_no_valid_blocks_in_list_gets_placeholder(self):
+        """Content array with no extractable blocks must get non-whitespace placeholder (#39829, layer 4)."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "user", "content": [{}]}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert msgs[0]["content"][0]["text"] == "(empty message)"
 
     def test_image_data_url_converted(self):
         from agent.bedrock_adapter import convert_messages_to_converse
@@ -1237,22 +1318,22 @@ class TestIsAnthropicBedrockModel:
 
 
 class TestEmptyTextBlockFix:
-    """Test that empty text blocks are replaced with space placeholders."""
+    """Test that empty text blocks are replaced with non-whitespace placeholders (#39829)."""
 
-    def test_none_content_gets_space(self):
+    def test_none_content_gets_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse(None)
-        assert blocks[0]["text"] == " "
+        assert blocks[0]["text"] == "(empty message)"
 
-    def test_empty_string_gets_space(self):
+    def test_empty_string_gets_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("")
-        assert blocks[0]["text"] == " "
+        assert blocks[0]["text"] == "(empty message)"
 
-    def test_whitespace_only_gets_space(self):
+    def test_whitespace_only_gets_placeholder(self):
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("   ")
-        assert blocks[0]["text"] == " "
+        assert blocks[0]["text"] == "(empty message)"
 
     def test_real_text_preserved(self):
         from agent.bedrock_adapter import _convert_content_to_converse


### PR DESCRIPTION
## Summary

- Replace Bedrock Converse whitespace-only placeholder text blocks with a non-whitespace `"(empty message)"` placeholder.
- Cover all empty-content and synthetic user-padding paths from #39829: `None`, empty/whitespace strings, empty text parts, no valid blocks, assistant empty content, leading user padding, and trailing user padding.
- Tighten list text handling so whitespace-only text parts (including raw string entries in content arrays) do not pass through to Bedrock.

## Why

AWS Bedrock Converse/ConverseStream rejects text content blocks that contain only whitespace:

```text
ValidationException: messages: text content blocks must contain non-whitespace text
```

The previous single-space fallback fixed the older "non-empty" validation, but now creates a hard validation failure for Claude-on-Bedrock requests that hit empty message or padding paths.

## Verification

- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_bedrock_adapter.py -v -o "addopts=" --tb=short`
- Result: `127 passed in 0.21s`

Fail-without-fix proof was captured in `.automation/runs/20260605-141157/39829/fail-without-fix.txt`; the new regression tests fail on upstream/main where the adapter emits whitespace-only placeholders.

## Competitor analysis

Open competitor PR #39850 addresses the same production surface but has no regression tests and does not cover the additional raw string content-array edge case added during review. Scored 6/10, below the auto-publish exclusion threshold.

Auto-published by Moonsong via Path B automated pipeline.