### PR TITLE
fix(version): handle detached release tags in update check

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -197,15 +197,82 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _git_head_file(repo_dir: Path) -> Optional[Path]:
+    """Return a checkout's HEAD file, including linked-worktree gitdirs."""
+    dotgit = repo_dir / ".git"
+    if dotgit.is_dir():
+        return dotgit / "HEAD"
+    if not dotgit.is_file():
+        return None
+    try:
+        text = dotgit.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not text.startswith("gitdir:"):
+        return None
+    gitdir = Path(text.split(":", 1)[1].strip())
+    if not gitdir.is_absolute():
+        gitdir = (dotgit.parent / gitdir).resolve()
+    return gitdir / "HEAD"
+
+
+def _detached_release_tag_status(repo_dir: Path, origin_url: str | None) -> Optional[int]:
+    """Compare an exact detached release tag with the latest upstream tag."""
+    if _canonical_github_remote(origin_url) != _OFFICIAL_REPO_CANONICAL:
+        return None
+
+    head_file = _git_head_file(repo_dir)
+    if head_file is None:
+        return None
+    try:
+        head_text = head_file.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not head_text or head_text.startswith("ref:"):
+        return None
+
+    # Numeric v-tags are published releases. Ad-hoc tags such as v-nightly
+    # retain the normal main-branch comparison.
+    current_tag = _git_stdout(
+        ["describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"],
+        cwd=repo_dir,
+    )
+    if not current_tag:
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "ls-remote",
+                "--refs",
+                "--sort=-version:refname",
+                "--tags",
+                _UPSTREAM_REPO_URL,
+                "refs/tags/v[0-9]*",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+
+    for line in (result.stdout or "").splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2 and parts[1].startswith("refs/tags/"):
+            latest_tag = parts[1].removeprefix("refs/tags/")
+            return 0 if current_tag == latest_tag else UPDATE_AVAILABLE_NO_COUNT
+    return None
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
-    if _is_official_ssh_remote(origin_url):
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would
@@ -217,6 +284,18 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
     shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
     is_shallow = shallow == "true"
+
+    if not is_shallow:
+        tagged_status = _detached_release_tag_status(repo_dir, origin_url)
+        if tagged_status is not None:
+            return tagged_status
+
+    if _is_official_ssh_remote(origin_url):
+        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+        checked = _check_via_rev(head_rev) if head_rev else None
+        if checked == UPDATE_AVAILABLE_NO_COUNT:
+            return 1
+        return checked
 
     try:
         # Scope the fetch to the one branch the behind-count compares against.

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -58,5 +58,183 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_detached_latest_release_tag_is_current_in_full_clone(tmp_path):
+    """Latest stable tag is current even when main has moved ahead (#39771)."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("local-sha\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(
+                returncode=0,
+                stdout="git@github.com:NousResearch/hermes-agent.git\n",
+            )
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"]:
+            return MagicMock(returncode=0, stdout="v2026.5.29.2\n")
+        if cmd[:2] == ["git", "ls-remote"]:
+            return MagicMock(
+                returncode=0,
+                stdout=(
+                    "new-sha\trefs/tags/v2026.5.29.2\n"
+                    "old-sha\trefs/tags/v2026.5.29\n"
+                ),
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 0
+    assert not any(cmd[:2] == ["git", "fetch"] for cmd in calls)
+    assert not any(cmd[:3] == ["git", "rev-list", "--count"] for cmd in calls)
+
+
+def test_detached_older_release_tag_reports_update_without_count(tmp_path):
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("local-sha\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout=f"{banner._UPSTREAM_REPO_URL}\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"]:
+            return MagicMock(returncode=0, stdout="v2026.5.29\n")
+        if cmd[:2] == ["git", "ls-remote"]:
+            return MagicMock(
+                returncode=0,
+                stdout=(
+                    "new-sha\trefs/tags/v2026.5.29.2\n"
+                    "old-sha\trefs/tags/v2026.5.29\n"
+                ),
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+@pytest.mark.parametrize(
+    ("origin", "head", "expected"),
+    [
+        ("https://github.com/someone/hermes-agent.git", "local-sha\n", 7),
+        ("https://github.com/NousResearch/hermes-agent.git", "ref: refs/heads/main\n", 7),
+        ("git@github.com:NousResearch/hermes-agent.git", "ref: refs/heads/main\n", 1),
+    ],
+)
+def test_nonrelease_checkout_keeps_full_clone_path(tmp_path, origin, head, expected):
+    """Forks and attached branches retain their origin/main comparison."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text(head, encoding="utf-8")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout=f"{origin}\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="local-sha\n")
+        if cmd == [
+            "git",
+            "ls-remote",
+            banner._UPSTREAM_REPO_URL,
+            "refs/heads/main",
+        ]:
+            return MagicMock(returncode=0, stdout="upstream-sha\trefs/heads/main\n")
+        if cmd == ["git", "fetch", "origin", "main", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="7\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == expected
+    assert not any(len(cmd) > 1 and cmd[1] == "describe" for cmd in calls)
+    if "someone" in origin:
+        assert not any(cmd[:2] == ["git", "ls-remote"] for cmd in calls)
+
+
+def test_detached_nonrelease_tag_keeps_full_clone_count_path(tmp_path):
+    """Ad-hoc v-tags are not treated as published releases."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("local-sha\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout=f"{banner._UPSTREAM_REPO_URL}\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd == ["git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*", "HEAD"]:
+            return MagicMock(returncode=1, stdout="")
+        if cmd == ["git", "fetch", "origin", "main", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="4\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == 4
+    assert not any(cmd[:2] == ["git", "ls-remote"] for cmd in calls)
+
+
+def test_shallow_detached_release_keeps_presence_only_path(tmp_path):
+    """Shallow installer checkouts must not switch to release-tag probing."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "repo"
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("local-sha\n", encoding="utf-8")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout=f"{banner._UPSTREAM_REPO_URL}\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="true\n")
+        if cmd == ["git", "fetch", "origin", "main", "--depth", "1", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="local-sha\n")
+        if cmd == ["git", "rev-parse", "FETCH_HEAD"]:
+            return MagicMock(returncode=0, stdout="upstream-sha\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert not any(len(cmd) > 1 and cmd[1] in {"describe", "ls-remote"} for cmd in calls)
 
 


### PR DESCRIPTION
## Summary
- detect detached HEAD checkouts that exactly match a local release tag before counting commits behind `origin/main`
- treat the newest local `v*` release tag as up to date so `hermes version` does not report a misleading main-branch commit delta
- keep attached branch installs on the existing `HEAD..origin/main` commit-count path

Addresses the version-reporting part of #39771.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_update_check.py -q -o addopts= --tb=short`
- `.venv/bin/python -m pytest tests/hermes_cli/test_banner.py tests/hermes_cli/test_banner_git_state.py -q -o addopts= --tb=short`
- `.venv/bin/python -m py_compile hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `/opt/homebrew/bin/ruff check hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `git diff --check`

## Duplicate check
- `gh search prs --repo NousResearch/hermes-agent --state open '39771 "commits behind" "hermes version" tag'`
- `gh search prs --repo NousResearch/hermes-agent --state open '"detached" "origin/main" "hermes version"'`
