### PR TITLE
fix(model_switch): use canonical URL for builtin endpoint dedup, not env-override

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1225,11 +1225,16 @@ def list_authenticated_providers(
         return str(url or "").strip().rstrip("/").lower()
 
     def _record_builtin_endpoint(slug: str) -> None:
-        """Record the effective base URL for a built-in provider row.
+        """Record the canonical base URL for a built-in provider row.
 
-        Prefers the live env-override (e.g. DASHSCOPE_BASE_URL) over the
-        static inference_base_url so the dedup matches what a user typing
-        that URL into custom_providers would actually hit."""
+        Uses the static inference_base_url only — NOT the live env-override
+        (e.g. OPENAI_BASE_URL).  The env override affects *routing*, not the
+        provider's identity.  Recording the overridden URL would incorrectly
+        shadow named custom providers that happen to share the override URL
+        (e.g. a ``Volcano GPT`` custom_providers entry collides with the
+        ``openai-api`` row when OPENAI_BASE_URL points at the same volcano
+        gateway).  The dedup in section 4 only needs to suppress accidental
+        duplicates, not hide intentionally-named custom providers."""
         try:
             from hermes_cli.auth import PROVIDER_REGISTRY as _reg
         except Exception:
@@ -1237,11 +1242,7 @@ def list_authenticated_providers(
         pcfg = _reg.get(slug)
         if not pcfg:
             return
-        url = ""
-        if getattr(pcfg, "base_url_env_var", ""):
-            url = os.environ.get(pcfg.base_url_env_var, "") or ""
-        if not url:
-            url = getattr(pcfg, "inference_base_url", "") or ""
+        url = getattr(pcfg, "inference_base_url", "") or ""
         normed = _norm_url(url)
         if normed:
             _builtin_endpoints.add(normed)


### PR DESCRIPTION
## Problem

When `OPENAI_BASE_URL` (or any provider's `*_BASE_URL` env var) is set to a custom endpoint, `_record_builtin_endpoint` records the **env-overridden** URL instead of the provider's canonical default URL. This causes section 4's dedup check to incorrectly skip **named custom providers** that happen to share the override URL.

### Repro

1. Set `OPENAI_BASE_URL=https://api.volcanowei.org/v1` in `.env`
2. Set `OPENAI_API_KEY=***` in `.env`
3. Add a named custom_providers entry pointing at the same gateway
4. Run `hermes model` or `/model` — the named custom provider is **not shown** in the provider list

### Root Cause

`_record_builtin_endpoint("openai-api")` reads `OPENAI_BASE_URL` from env and records the override URL. Section 4 processes the custom_providers entry, finds its URL matches the recorded builtin endpoint, and skips it.

## Fix

Change `_record_builtin_endpoint` to only use the static `inference_base_url`. The env override affects **routing**, not the provider's **identity**. Dedup should match on identity, not on where traffic happens to be routed.

## Testing

- **Volcano GPT case**: openai-api records `https://api.openai.com/v1` (default), no longer collides with custom gateway URL → custom provider shows correctly
- **#16970 DashScope case**: alibaba-coding-plan records its default URL, which still matches duplicate custom entries pointing at the same default endpoint → correct dedup preserved

## Related

- Fixes the named custom_providers + env-override collision case
- Does not regress #16970 (DashScope duplicate row suppression)
