### PR TITLE
fix(tests): use cross-platform pytest-timeout method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,12 +294,12 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap with cross-platform thread method.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
 # hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+addopts = "-m 'not integration' --timeout=30 --timeout-method=thread"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Summary

Windows pytest runs inherited `--timeout-method=signal` from `pyproject.toml`, and pytest-timeout implements that method with `SIGALRM`. Windows does not expose `signal.SIGALRM`, so local suite runs crashed with `INTERNALERROR: AttributeError: module 'signal' has no attribute 'SIGALRM'` before reaching normal test failures.

This switches the per-test timeout method to `thread`, which is pytest-timeout's cross-platform mode. The repo still has the outer per-file subprocess timeout from `scripts/run_tests_parallel.py`, so process-level hang protection remains in place while direct Windows pytest runs can execute.

Fixes #39880

## Changes

- `pyproject.toml`: updates the pytest-timeout comment and changes `--timeout-method=signal` to `--timeout-method=thread` in `[tool.pytest.ini_options]` addopts.

## Validation

| Scenario | Before | After |
|---|---|---|
| Windows full-suite pytest | Crashed during collection with `AttributeError: module 'signal' has no attribute 'SIGALRM'` | Reached normal test execution without SIGALRM or INTERNALERROR |
| Per-test timeout behavior | POSIX-only signal alarm | Cross-platform thread timeout |
| Outer process timeout | Unchanged | Unchanged, `scripts/run_tests_parallel.py` still owns per-file process isolation |

## Test plan

- `$env:BROWSER='echo'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -q --tb=line 2>&1 | Select-String 'SIGALRM'` before the change reproduced the crash with `AttributeError: module 'signal' has no attribute 'SIGALRM'`.
- `$env:BROWSER='echo'; C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/ -q --tb=line` after the change reached ordinary test execution and stopped on a Python-level pytest-timeout in `tests/cli/test_surrogate_sanitization.py`; no `SIGALRM` or `INTERNALERROR` appeared in the captured log.