### PR TITLE
[desktop] Fix desktop bootstrap existing install pinning

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -351,12 +351,22 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // Manifest + stage dispatch
 // ---------------------------------------------------------------------------
 
-// Build the install.ps1 pin args (-Commit / -Branch) from the install-stamp
-// so the repository stage clones the exact SHA the .exe was tested with
-// instead of falling back to install.ps1's default ($Branch = "main").
-function buildPinArgs(installStamp) {
+function hasExistingGitCheckout(activeRoot) {
+  if (!activeRoot) return false
+  return fs.existsSync(path.join(activeRoot, '.git'))
+}
+
+function shouldPinBootstrapCommit({ installStamp, activeRoot }) {
+  return Boolean(installStamp && installStamp.commit && !hasExistingGitCheckout(activeRoot))
+}
+
+// Build installer pin args from the install-stamp. Fresh desktop bootstrap
+// clones are pinned to the SHA the app was packaged with, while existing
+// checkouts are left on their branch so a rerun cannot detach them back to an
+// older packaged stamp after `hermes update`.
+function buildPinArgs({ installStamp, activeRoot }) {
   const args = []
-  if (installStamp && installStamp.commit) {
+  if (shouldPinBootstrapCommit({ installStamp, activeRoot })) {
     args.push('-Commit', installStamp.commit)
   }
   if (installStamp && installStamp.branch) {
@@ -370,7 +380,7 @@ function buildPosixPinArgs({ installStamp, activeRoot, hermesHome }) {
   if (installStamp && installStamp.branch) {
     args.push('--branch', installStamp.branch)
   }
-  if (installStamp && installStamp.commit) {
+  if (shouldPinBootstrapCommit({ installStamp, activeRoot })) {
     args.push('--commit', installStamp.commit)
   }
   return args
@@ -380,7 +390,7 @@ async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, acti
   const isPosix = installerKind === 'posix'
   const args = isPosix
     ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })]
-    : ['-Manifest', ...buildPinArgs(installStamp)]
+    : ['-Manifest', ...buildPinArgs({ installStamp, activeRoot })]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: '__manifest__',
@@ -441,7 +451,7 @@ async function runStage({ scriptPath, installerKind, stage, emit, hermesHome, ac
         '--json',
         ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })
       ]
-    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp)]
+    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs({ installStamp, activeRoot })]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: stage.name,
@@ -631,7 +641,11 @@ async function runBootstrap(opts) {
 module.exports = {
   runBootstrap,
   // Exposed for testability
+  buildPinArgs,
+  buildPosixPinArgs,
+  hasExistingGitCheckout,
   parseStageResult,
   resolveLocalInstallScript,
-  cachedScriptPath
+  cachedScriptPath,
+  shouldPinBootstrapCommit
 }

--- a/apps/desktop/electron/bootstrap-runner.test.cjs
+++ b/apps/desktop/electron/bootstrap-runner.test.cjs
@@ -1,7 +1,15 @@
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const test = require('node:test')
 
-const { runBootstrap } = require('./bootstrap-runner.cjs')
+const {
+  buildPinArgs,
+  buildPosixPinArgs,
+  runBootstrap,
+  shouldPinBootstrapCommit
+} = require('./bootstrap-runner.cjs')
 
 test('runBootstrap bails immediately when the signal is already aborted', async () => {
   const controller = new AbortController()
@@ -24,4 +32,46 @@ test('runBootstrap bails immediately when the signal is already aborted', async 
     events.some(ev => ev.type === 'failed' && /cancelled/i.test(ev.error)),
     'should emit a cancelled failure event'
   )
+})
+
+test('bootstrap keeps commit pins for fresh desktop installs', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-runner-fresh-'))
+  const activeRoot = path.join(tmpRoot, 'hermes-agent')
+  const stamp = { commit: 'abcdef1234567890abcdef1234567890abcdef12', branch: 'main' }
+
+  assert.equal(shouldPinBootstrapCommit({ installStamp: stamp, activeRoot }), true)
+  assert.deepEqual(buildPinArgs({ installStamp: stamp, activeRoot }), [
+    '-Commit',
+    stamp.commit,
+    '-Branch',
+    'main'
+  ])
+  assert.deepEqual(buildPosixPinArgs({ installStamp: stamp, activeRoot, hermesHome: '/tmp/hermes-home' }), [
+    '--dir',
+    activeRoot,
+    '--hermes-home',
+    '/tmp/hermes-home',
+    '--branch',
+    'main',
+    '--commit',
+    stamp.commit
+  ])
+})
+
+test('bootstrap skips commit pins when repairing an existing git checkout', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-runner-existing-'))
+  const activeRoot = path.join(tmpRoot, 'hermes-agent')
+  fs.mkdirSync(path.join(activeRoot, '.git'), { recursive: true })
+  const stamp = { commit: 'abcdef1234567890abcdef1234567890abcdef12', branch: 'main' }
+
+  assert.equal(shouldPinBootstrapCommit({ installStamp: stamp, activeRoot }), false)
+  assert.deepEqual(buildPinArgs({ installStamp: stamp, activeRoot }), ['-Branch', 'main'])
+  assert.deepEqual(buildPosixPinArgs({ installStamp: stamp, activeRoot, hermesHome: '/tmp/hermes-home' }), [
+    '--dir',
+    activeRoot,
+    '--hermes-home',
+    '/tmp/hermes-home',
+    '--branch',
+    'main'
+  ])
 })


### PR DESCRIPTION
## What does this PR do?

Prevents packaged desktop bootstrap reruns from passing the build-stamp commit to the installer when `activeRoot` is already a git checkout. Fresh desktop bootstrap installs still receive the exact commit pin, but existing installs now stay on their configured branch during bootstrap repair/update instead of getting detached back to an older packaged stamp after `hermes update`.

I reproduced this from local desktop logs: bootstrap found an existing installation, updated to a newer HEAD, then immediately passed the packaged commit and ran `Pinning checkout to commit ...`, which detached the checkout back to the packaged app build stamp.

Related: #39192 also touches desktop install stamps, but it still pins official stamped commits unless `commitPinned=false`. This focused fix covers existing git checkouts on current `main`.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/bootstrap-runner.cjs`: add existing-git-checkout detection and skip commit pins for existing installs while preserving branch args.
- `apps/desktop/electron/bootstrap-runner.test.cjs`: add regression coverage for fresh installs keeping commit pins and existing checkouts omitting them.

## How to Test

1. Start from a packaged desktop app whose install stamp points at an older commit.
2. Ensure `~/.hermes/hermes-agent` is an existing git checkout that has been updated beyond that stamp.
3. Trigger desktop bootstrap again; the repository stage should not pass `--commit`/`-Commit`, so it should not detach the checkout back to the packaged stamp.

Validation run locally:

- `node --test apps/desktop/electron/bootstrap-runner.test.cjs`
- `npm run test:desktop:platforms --workspace apps/desktop`
- `npx eslint electron/bootstrap-runner.cjs electron/bootstrap-runner.test.cjs` from `apps/desktop`
- `git diff --check`
- `python3 scripts/check-windows-footguns.py apps/desktop/electron/bootstrap-runner.cjs apps/desktop/electron/bootstrap-runner.test.cjs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Local log evidence before the fix showed repeated bootstrap repository stages like:

- `Existing installation found, updating...`
- `HEAD is now at <newer branch head>`
- `Pinning checkout to commit <older packaged stamp>...`
- `HEAD is now at <older packaged stamp>`
