### PR TITLE
fix(tests): use cross-platform pytest timeout method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,12 +294,13 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap with thread method.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
-# hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+# hangs within a file. The thread method is cross-platform; the signal
+# method depends on SIGALRM and crashes pytest on Windows.
+addopts = "-m 'not integration' --timeout=30 --timeout-method=thread"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Summary
- switch pytest-timeout from the POSIX-only signal method to the cross-platform thread method
- keep the existing 30s per-test timeout and per-file subprocess runner backstop unchanged
- update the nearby comment so the Windows SIGALRM failure mode is documented

Fixes #39880.

## Tests
- ............                                                             [100%]
12 passed in 0.19s
-                         Deprecated, use --timeout-method
  --timeout-method={signal,thread}
                        Timeout mechanism to use.  'signal' uses SIGALRM,
                        'thread' uses a timer
- 

## Duplicate check
- 
