### PR TITLE
Fix AIHQ Slack continuity and upload guards

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1731,10 +1731,10 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"🖼️ Image: {image_path}"
-            if caption:
-                text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            return SendResult(
+                success=False,
+                error=f"upload_blocker: Slack image upload failed for {os.path.basename(image_path)}: {e}",
+            )
 
     async def send_image(
         self,
@@ -1883,10 +1883,10 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"🎬 Video: {video_path}"
-            if caption:
-                text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            return SendResult(
+                success=False,
+                error=f"upload_blocker: Slack video upload failed for {os.path.basename(video_path)}: {e}",
+            )
 
     async def send_document(
         self,
@@ -1942,10 +1942,30 @@ class SlackAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            text = f"📎 File: {file_path}"
-            if caption:
-                text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            response = getattr(e, "response", None)
+            api_notice = self._describe_slack_api_error(
+                response,
+                file_obj={"name": display_name},
+            )
+            if api_notice is None and "missing_scope" in str(e):
+                api_notice = (
+                    f"Slack attachment upload failed for {display_name}. "
+                    "Missing scope: files:write. Update the Slack app scopes/settings "
+                    "and reinstall the app to the workspace."
+                )
+            if api_notice:
+                notice = (
+                    "파일 첨부 실패: Slack 앱 권한 문제로 업로드하지 못했습니다.\n"
+                    f"{api_notice}\n"
+                    "상태: upload_blocker"
+                )
+                await self.send(chat_id, notice, reply_to=reply_to, metadata=metadata)
+                return SendResult(success=False, error=api_notice)
+
+            return SendResult(
+                success=False,
+                error=f"upload_blocker: Slack attachment upload failed for {display_name}: {e}",
+            )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Slack channel."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
 
 import asyncio
 import dataclasses
+import hashlib
 import inspect
 import json
 import logging
@@ -1154,6 +1155,334 @@ from gateway.whatsapp_identity import (
 
 
 logger = logging.getLogger(__name__)
+
+_AIHQ_RUNTIME_ROOT = Path(
+    os.getenv("AIHQ_HERMES_WORKSPACE", "/Users/dongiksmac/hermes-workspaces/aihq-runtime")
+)
+_AIHQ_THREAD_INDEX_PATH = (
+    _AIHQ_RUNTIME_ROOT / "04_Data" / "runtime-project-index" / "slack-thread-projects.jsonl"
+)
+_AIHQ_GROWTH_DIR = _AIHQ_RUNTIME_ROOT / "04_Data" / "growth"
+
+_AIHQ_RESUME_RE = re.compile(
+    r"(이어서|계속|재개|어제\s*하던|같은\s*스레드|하던\s*거|resume|continue)",
+    re.IGNORECASE,
+)
+_AIHQ_CORRECTIVE_RE = re.compile(
+    r"(또|아니|다시|수정|v\d+\s*말고\s*v\d+|경로만\s*보내지\s*말고|업로드|upload|wrong|not\s+that)",
+    re.IGNORECASE,
+)
+_AIHQ_DETAIL_RE = re.compile(r"(상세페이지|상세\s*페이지|detail\s*page|쿠팡|브랜드스토어)", re.IGNORECASE)
+_AIHQ_PROPOSAL_RE = re.compile(r"(제안서|proposal|입점|바이어|이마트24|gs25|cu)", re.IGNORECASE)
+_AIHQ_MARKET_RESEARCH_RE = re.compile(r"(시장조사|경쟁조사|리서치|보고서|market\s*research)", re.IGNORECASE)
+_AIHQ_AUTOMATION_RE = re.compile(r"(자동화|개발복구|개발|gateway|slack|cron|봇|연동)", re.IGNORECASE)
+_AIHQ_MEETING_RE = re.compile(r"(회의|같이\s*보자|논의|미팅)", re.IGNORECASE)
+_AIHQ_MEETING_CHANNEL_ID = "C0B4TLSMNJG"
+_AIHQ_TEAM_CHANNEL_IDS = {"C0B487QE023"}
+
+
+def _aihq_source_platform(source: Any) -> str:
+    platform = getattr(source, "platform", None)
+    return str(getattr(platform, "value", platform) or "").strip().lower()
+
+
+def _aihq_is_slack_source(source: Any) -> bool:
+    return _aihq_source_platform(source) == "slack"
+
+
+def _aihq_detect_pipeline(message: str) -> str | None:
+    text = str(message or "")
+    if _AIHQ_DETAIL_RE.search(text):
+        return "detail_page"
+    if _AIHQ_PROPOSAL_RE.search(text):
+        return "proposal"
+    if _AIHQ_MARKET_RESEARCH_RE.search(text):
+        return "market_research"
+    if _AIHQ_AUTOMATION_RE.search(text):
+        return "automation_dev"
+    return None
+
+
+def _aihq_joint_meeting_router_intercept(message: str, source: Any) -> bool:
+    if not _aihq_is_slack_source(source):
+        return False
+    channel_id = str(getattr(source, "chat_id", "") or "")
+    if channel_id == _AIHQ_MEETING_CHANNEL_ID:
+        return True
+    return channel_id in _AIHQ_TEAM_CHANNEL_IDS and bool(_AIHQ_MEETING_RE.search(str(message or "")))
+
+
+def _aihq_load_thread_index_entries(index_path: Path | None = None) -> list[dict[str, Any]]:
+    path = Path(index_path) if index_path is not None else _AIHQ_THREAD_INDEX_PATH
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                entries.append(item)
+    except OSError:
+        return []
+    return entries
+
+
+def _aihq_matching_thread_entries(source: Any) -> list[dict[str, Any]]:
+    channel_id = str(getattr(source, "chat_id", "") or "")
+    thread_ts = str(getattr(source, "thread_id", "") or "")
+    if not channel_id or not thread_ts:
+        return []
+    matches = []
+    for item in _aihq_load_thread_index_entries():
+        if str(item.get("workspace") or "") != "hermes":
+            continue
+        if str(item.get("slack_channel_id") or "") != channel_id:
+            continue
+        if str(item.get("slack_thread_ts") or "") != thread_ts:
+            continue
+        if str(item.get("status") or "active").lower() in {"closed", "archived", "done"}:
+            continue
+        matches.append(item)
+    return matches
+
+
+def _aihq_progress_excerpt(progress_path: str, max_chars: int = 1800) -> str:
+    if not progress_path:
+        return ""
+    path = Path(progress_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return "[canonical progress file could not be read]"
+    return text[-max_chars:]
+
+
+def _aihq_continuity_prompt(message: str, source: Any) -> str:
+    if not (_aihq_is_slack_source(source) and _AIHQ_RESUME_RE.search(str(message or ""))):
+        return ""
+    entries = _aihq_matching_thread_entries(source)
+    if not entries:
+        return (
+            "[AIHQ Project Continuity Guard]\n"
+            "This Slack turn contains a same-thread resume signal, but there is no project index entry in "
+            f"{_AIHQ_THREAD_INDEX_PATH}.\n"
+            "Do not start a new project, do not create a fresh output_root, and ask for the canonical "
+            "YYYYMMDD_프로젝트명_PROGRESS.md path or project name first."
+        )
+    if len(entries) > 1:
+        candidates = "\n".join(
+            f"- {item.get('project_slug')}: {item.get('progress_path')}" for item in entries
+        )
+        return (
+            "[AIHQ Project Continuity Guard]\n"
+            "This Slack thread has multiple canonical progress-file candidates. Stop production and report the conflict.\n"
+            f"{candidates}\n"
+            "Resolve by exact channel_id + thread_ts before continuing."
+        )
+    entry = entries[0]
+    progress_path = str(entry.get("progress_path") or "")
+    excerpt = _aihq_progress_excerpt(progress_path)
+    return (
+        "[AIHQ Project Continuity Guard]\n"
+        f"canonical_progress_path: {progress_path}\n"
+        f"output_root: {entry.get('output_root')}\n"
+        f"pipeline_id: {entry.get('pipeline_id')}\n"
+        f"project_slug: {entry.get('project_slug')}\n"
+        f"run_id: {entry.get('run_id')}\n"
+        "Read the canonical progress file first, resume from current_phase and active_next_action, "
+        "and do not modify older versions unless the user explicitly names them.\n"
+        "[canonical progress excerpt]\n"
+        f"{excerpt}"
+    )
+
+
+def _aihq_meeting_guard_prompt(message: str, source: Any) -> str:
+    if not _aihq_joint_meeting_router_intercept(message, source):
+        return ""
+    channel_id = str(getattr(source, "chat_id", "") or "")
+    if channel_id == _AIHQ_MEETING_CHANNEL_ID:
+        route_note = (
+            "Direct #aihq-meeting agenda. Deduplicate only by exact channel_id + thread_ts; "
+            "the same topic in a different thread is a new meeting and must never block a new direct `#aihq-meeting` agenda."
+        )
+    else:
+        route_note = (
+            "Team-channel meeting trigger. Transfer the agenda to #aihq-meeting. "
+            "Do not answer as a normal channel reply."
+        )
+    return (
+        "[AIHQ Joint Meeting Guard]\n"
+        f"{route_note}\n"
+        "Use meeting-sessions.jsonl for exact thread binding. Include 정실장 and 김팀장 as participants, "
+        "keep kim-teamlead as Hermes owner, do not load AIHQ workflow skills inside the meeting router, "
+        "and keep the routing notice under 900 Korean characters."
+    )
+
+
+def _aihq_pipeline_instruction(pipeline_id: str) -> str:
+    return (
+        "[AIHQ Slack Pipeline Guard]\n"
+        f"pipeline_id: {pipeline_id}\n"
+        "Use the canonical 9 pipeline before production: intake -> /mywiki -> My Note -> additional research if needed -> "
+        "actual working team-lead roster -> plan -> execution -> verification -> record/learning.\n"
+        "Do not jump directly into copy, layout, code, report prose, or file generation.\n"
+        "Declare pipeline_id, workflow, /mywiki plan, My Note plan, actual working team-lead roster, "
+        "Superpowers/GStack verification plan, approval boundary, output_root, and YYYYMMDD_프로젝트명_PROGRESS.md first.\n"
+        "Bind Slack channel_id + thread_ts in slack-thread-projects.jsonl before producing user-facing artifacts.\n"
+        "For design/detail-page work include Supanova and Open Design AIHQ Supanova after My Note design reference lookup.\n"
+        "Maintain artifact_manifest.jsonl under the project output_root. For minor edits to v3, read v3 as source_version "
+        "and create v3.1 or the next patch version; never overwrite or silently edit v2 unless the user explicitly names v2.\n"
+        "Completion for Slack file artifacts requires uploaded_artifacts. If upload fails, report upload_blocker and do not send only a local path."
+    )
+
+
+def _aihq_learning_recall_prompt(message: str, limit: int = 3) -> str:
+    text = str(message or "").lower()
+    feedback_path = _AIHQ_GROWTH_DIR / "corrective-feedback.jsonl"
+    if not feedback_path.exists():
+        return ""
+    matches: list[str] = []
+    try:
+        for line in reversed(feedback_path.read_text(encoding="utf-8").splitlines()):
+            if not line.strip():
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            summary = str(item.get("summary") or item.get("message") or "").strip()
+            if not summary:
+                continue
+            tags = [token.strip() for token in str(item.get("tags") or "").lower().split(",")]
+            if _AIHQ_CORRECTIVE_RE.search(str(message or "")) or any(token and token in text for token in tags):
+                matches.append(summary[:400])
+            if len(matches) >= limit:
+                break
+    except OSError:
+        return ""
+    if not matches:
+        return ""
+    return "[AIHQ Learning Recall]\n" + "\n".join(f"- {m}" for m in matches)
+
+
+def _aihq_record_corrective_feedback(message: str, source: Any) -> None:
+    if not (_aihq_is_slack_source(source) and _AIHQ_CORRECTIVE_RE.search(str(message or ""))):
+        return
+    try:
+        _AIHQ_GROWTH_DIR.mkdir(parents=True, exist_ok=True)
+        record = {
+            "created_at": datetime.now().isoformat(),
+            "surface": "slack",
+            "channel_id": getattr(source, "chat_id", None),
+            "thread_ts": getattr(source, "thread_id", None),
+            "message": str(message or "")[:1200],
+            "summary": str(message or "")[:240],
+            "tags": "correction,slack,upload,version,continuity",
+            "status": "captured",
+        }
+        with (_AIHQ_GROWTH_DIR / "corrective-feedback.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError:
+        logger.debug("Failed to record AIHQ corrective feedback", exc_info=True)
+
+
+def _aihq_pipeline_guard(message: str, source: Any) -> str:
+    if not _aihq_is_slack_source(source):
+        return ""
+    parts = []
+    meeting = _aihq_meeting_guard_prompt(message, source)
+    if meeting:
+        parts.append(meeting)
+    continuity = _aihq_continuity_prompt(message, source)
+    if continuity:
+        parts.append(continuity)
+    pipeline_id = _aihq_detect_pipeline(message)
+    if pipeline_id and not continuity:
+        parts.append(_aihq_pipeline_instruction(pipeline_id))
+    recall = _aihq_learning_recall_prompt(message)
+    if recall and (pipeline_id or continuity or meeting or _AIHQ_CORRECTIVE_RE.search(str(message or ""))):
+        parts.append(recall)
+    return "\n\n".join(part for part in parts if part)
+
+
+def _aihq_detail_page_pipeline_guard(message: str, source: Any) -> str:
+    return _aihq_pipeline_guard(message, source)
+
+
+def _aihq_parse_version(version: str) -> tuple[int, ...]:
+    match = re.search(r"v?(\d+(?:\.\d+)*)", str(version or ""), re.IGNORECASE)
+    if not match:
+        return (0,)
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _aihq_next_patch_version(source_version: str, manifest_entries: list[dict[str, Any]] | None = None) -> str:
+    base = _aihq_parse_version(source_version)
+    if not base or base == (0,):
+        base = (1,)
+    prefix = f"v{base[0]}"
+    existing_patch_numbers = [0]
+    for item in manifest_entries or []:
+        parsed = _aihq_parse_version(str(item.get("version") or ""))
+        if len(parsed) >= 2 and parsed[0] == base[0]:
+            existing_patch_numbers.append(parsed[1])
+    return f"{prefix}.{max(existing_patch_numbers) + 1}"
+
+
+def _aihq_read_artifact_manifest(manifest_path: str | Path) -> list[dict[str, Any]]:
+    path = Path(manifest_path)
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            item = json.loads(line)
+            if isinstance(item, dict):
+                entries.append(item)
+    except (OSError, json.JSONDecodeError):
+        return entries
+    return entries
+
+
+def _aihq_record_artifact_manifest(
+    manifest_path: str | Path,
+    *,
+    version: str,
+    path: str,
+    source_version: str | None = None,
+    slack_upload_ts: str | None = None,
+    status: str = "created",
+) -> dict[str, Any]:
+    artifact_path = Path(path)
+    sha256 = ""
+    if artifact_path.exists() and artifact_path.is_file():
+        h = hashlib.sha256()
+        with artifact_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(chunk)
+        sha256 = h.hexdigest()
+    record = {
+        "version": version,
+        "path": str(artifact_path),
+        "sha256": sha256,
+        "source_version": source_version,
+        "created_at": datetime.now().isoformat(),
+        "slack_upload_ts": slack_upload_ts,
+        "status": status,
+    }
+    manifest = Path(manifest_path)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    with manifest.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return record
 
 
 # Sentinel placed into _running_agents immediately when a session starts
@@ -2674,6 +3003,62 @@ class GatewayRunner:
                 _last_good["*"] = model
 
         return model, runtime_kwargs
+
+    def _apply_aihq_model_routing_for_turn(
+        self,
+        *,
+        message: str,
+        source: Optional[SessionSource],
+        session_key: Optional[str],
+    ) -> None:
+        """Apply AIHQ work-turn model/reasoning overrides without changing global config."""
+        if not session_key or source is None or not _aihq_is_slack_source(source):
+            return
+        is_work = bool(
+            _aihq_detect_pipeline(message)
+            or _AIHQ_RESUME_RE.search(str(message or ""))
+            or _AIHQ_CORRECTIVE_RE.search(str(message or ""))
+            or _aihq_joint_meeting_router_intercept(message, source)
+        )
+        if not is_work:
+            return
+        try:
+            cfg = _load_gateway_config()
+        except Exception:
+            cfg = {}
+        routing = cfg.get("aihq_model_routing") if isinstance(cfg, dict) else None
+        if not isinstance(routing, dict) or not routing.get("enabled", False):
+            return
+        provider = str(routing.get("provider") or "").strip()
+        if not provider:
+            model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            if isinstance(model_cfg, dict):
+                provider = str(model_cfg.get("provider") or "").strip()
+        model = str(routing.get("work_intake_model") or "").strip()
+        if not model:
+            return
+        previous = dict(getattr(self, "_session_model_overrides", {}).get(session_key) or {})
+        next_override = {
+            "model": model,
+            "provider": provider or previous.get("provider"),
+            "api_key": previous.get("api_key"),
+            "base_url": previous.get("base_url"),
+            "api_mode": previous.get("api_mode"),
+        }
+        self._session_model_overrides[session_key] = next_override
+        if previous != next_override:
+            self._evict_cached_agent(session_key)
+
+        effort = str(routing.get("work_intake_reasoning_effort") or "").strip()
+        if effort:
+            try:
+                from hermes_constants import parse_reasoning_effort
+
+                parsed = parse_reasoning_effort(effort)
+            except Exception:
+                parsed = None
+            if parsed:
+                self._set_session_reasoning_override(session_key, parsed)
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
@@ -8942,6 +9327,16 @@ class GatewayRunner:
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+
+        _aihq_record_corrective_feedback(message, source)
+        self._apply_aihq_model_routing_for_turn(
+            message=message,
+            source=source,
+            session_key=session_key,
+        )
+        _aihq_guard_prompt = _aihq_pipeline_guard(message, source)
+        if _aihq_guard_prompt:
+            context_prompt = (context_prompt + "\n\n" + _aihq_guard_prompt).strip()
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/tests/gateway/test_aihq_detail_page_guard.py
+++ b/tests/gateway/test_aihq_detail_page_guard.py
@@ -1,0 +1,241 @@
+from types import SimpleNamespace
+
+from gateway.run import (
+    GatewayRunner,
+    _aihq_detail_page_pipeline_guard,
+    _aihq_next_patch_version,
+    _aihq_joint_meeting_router_intercept,
+    _aihq_pipeline_guard,
+    _aihq_read_artifact_manifest,
+    _aihq_record_artifact_manifest,
+)
+
+
+def _source(platform: str) -> SimpleNamespace:
+    return SimpleNamespace(platform=SimpleNamespace(value=platform))
+
+
+def _slack_source(channel_id: str = "C123", thread_ts: str = "171.000") -> SimpleNamespace:
+    return SimpleNamespace(platform=SimpleNamespace(value="slack"), chat_id=channel_id, thread_id=thread_ts)
+
+
+def test_aihq_detail_page_guard_injects_for_slack_detail_page_request():
+    prompt = _aihq_pipeline_guard("곰돌이 상세페이지 만들어줘", _source("slack"))
+
+    assert "canonical 9 pipeline" in prompt
+    assert "pipeline_id" in prompt
+    assert "/mywiki" in prompt
+    assert "Supanova" in prompt
+    assert "Open Design AIHQ Supanova" in prompt
+    assert "Do not jump directly" in prompt
+    assert "YYYYMMDD_프로젝트명_PROGRESS.md" in prompt
+    assert "slack-thread-projects.jsonl" in prompt
+
+
+def test_aihq_detail_page_guard_skips_non_slack_sources():
+    prompt = _aihq_pipeline_guard("상세페이지 만들어줘", _source("local"))
+
+    assert prompt == ""
+
+
+def test_aihq_detail_page_guard_skips_unrelated_slack_messages():
+    prompt = _aihq_pipeline_guard("오늘 재고만 확인해줘", _source("slack"))
+
+    assert prompt == ""
+
+
+def test_aihq_pipeline_guard_injects_for_proposal_request():
+    prompt = _aihq_pipeline_guard("이마트24 제안서 만들어줘", _source("slack"))
+
+    assert "canonical 9 pipeline" in prompt
+    assert "pipeline_id" in prompt
+    assert "actual working team-lead roster" in prompt
+
+
+def test_aihq_pipeline_guard_injects_for_market_research_report_request():
+    prompt = _aihq_pipeline_guard("시장조사 보고서 작성해줘", _source("slack"))
+
+    assert "canonical 9 pipeline" in prompt
+    assert "/mywiki" in prompt
+    assert "My Note" in prompt
+
+
+def test_aihq_pipeline_guard_injects_for_automation_dev_request():
+    prompt = _aihq_pipeline_guard("Slack 자동화 개발복구 작업 진행해줘", _source("slack"))
+
+    assert "canonical 9 pipeline" in prompt
+    assert "Superpowers/GStack" in prompt
+    assert "verification plan" in prompt
+
+
+def test_aihq_detail_page_guard_wrapper_matches_pipeline_guard():
+    message = "곰돌이 상세페이지 만들어줘"
+    source = _source("slack")
+
+    assert _aihq_detail_page_pipeline_guard(message, source) == _aihq_pipeline_guard(message, source)
+
+
+def test_aihq_pipeline_guard_resume_without_index_blocks_new_work(tmp_path, monkeypatch):
+    index = tmp_path / "missing.jsonl"
+    monkeypatch.setattr("gateway.run._AIHQ_THREAD_INDEX_PATH", index)
+
+    prompt = _aihq_pipeline_guard("어제 하던 거 이어서 진행", _slack_source())
+
+    assert "Project Continuity Guard" in prompt
+    assert "no project index entry" in prompt
+    assert "Do not start a new project" in prompt
+
+
+def test_aihq_pipeline_guard_resume_injects_canonical_progress(tmp_path, monkeypatch):
+    progress = tmp_path / "02_Projects" / "20260522_테스트_PROGRESS.md"
+    progress.parent.mkdir(parents=True)
+    progress.write_text("- current_phase: GATE 3 시안 승인 대기\n- active_next_action: QA\n", encoding="utf-8")
+    index = tmp_path / "04_Data" / "runtime-project-index" / "slack-thread-projects.jsonl"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        '{"workspace":"hermes","pipeline_id":"detail_page","project_slug":"test","progress_path":"'
+        + str(progress)
+        + '","output_root":"/tmp/out","slack_channel_id":"C123","slack_thread_ts":"171.000","session_key":"s","run_id":"r","status":"active","updated_at":"2026-05-22T00:00:00+09:00"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.run._AIHQ_THREAD_INDEX_PATH", index)
+
+    prompt = _aihq_pipeline_guard("같은 스레드 이어서 해줘", _slack_source())
+
+    assert "canonical_progress_path" in prompt
+    assert str(progress) in prompt
+    assert "GATE 3 시안 승인 대기" in prompt
+    assert "active_next_action" in prompt
+
+
+def test_aihq_pipeline_guard_resume_conflict_reports_candidates(tmp_path, monkeypatch):
+    index = tmp_path / "04_Data" / "runtime-project-index" / "slack-thread-projects.jsonl"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        "\n".join(
+            [
+                '{"workspace":"hermes","pipeline_id":"detail_page","project_slug":"a","progress_path":"/tmp/a_PROGRESS.md","output_root":"/tmp/a","slack_channel_id":"C123","slack_thread_ts":"171.000","session_key":"s","run_id":"r1","status":"active","updated_at":"2026-05-22T00:00:00+09:00"}',
+                '{"workspace":"hermes","pipeline_id":"detail_page","project_slug":"b","progress_path":"/tmp/b_PROGRESS.md","output_root":"/tmp/b","slack_channel_id":"C123","slack_thread_ts":"171.000","session_key":"s","run_id":"r2","status":"active","updated_at":"2026-05-22T00:01:00+09:00"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.run._AIHQ_THREAD_INDEX_PATH", index)
+
+    prompt = _aihq_pipeline_guard("계속 진행", _slack_source())
+
+    assert "multiple canonical progress-file candidates" in prompt
+    assert "/tmp/a_PROGRESS.md" in prompt
+    assert "/tmp/b_PROGRESS.md" in prompt
+
+
+def test_aihq_pipeline_guard_new_work_does_not_inject_old_progress(tmp_path, monkeypatch):
+    index = tmp_path / "04_Data" / "runtime-project-index" / "slack-thread-projects.jsonl"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        '{"workspace":"hermes","pipeline_id":"detail_page","project_slug":"test","progress_path":"/tmp/test_PROGRESS.md","output_root":"/tmp/out","slack_channel_id":"C123","slack_thread_ts":"171.000","session_key":"s","run_id":"r","status":"active","updated_at":"2026-05-22T00:00:00+09:00"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.run._AIHQ_THREAD_INDEX_PATH", index)
+
+    prompt = _aihq_pipeline_guard("새 상세페이지 만들어줘", _slack_source())
+
+    assert "canonical 9 pipeline" in prompt
+    assert "canonical_progress_path" not in prompt
+
+
+def test_aihq_pipeline_guard_direct_meeting_channel_injects_joint_meeting_guard():
+    prompt = _aihq_pipeline_guard("신규 상품 후보를 같이 보자", _slack_source("C0B4TLSMNJG", "1779762018.415589"))
+
+    assert "AIHQ Joint Meeting Guard" in prompt
+    assert "정실장" in prompt
+    assert "김팀장" in prompt
+    assert "meeting-sessions.jsonl" in prompt
+    assert "kim-teamlead" in prompt
+    assert "do not load AIHQ workflow skills" in prompt
+    assert "under 900 Korean characters" in prompt
+
+
+def test_aihq_pipeline_guard_team_channel_meeting_trigger_transfers_to_meeting_channel():
+    prompt = _aihq_pipeline_guard("이 건 회의 진행하자", _slack_source("C0B487QE023", "1779762018.415589"))
+
+    assert "AIHQ Joint Meeting Guard" in prompt
+    assert "#aihq-meeting" in prompt
+    assert "Do not answer as a normal channel reply" in prompt
+
+
+def test_aihq_pipeline_guard_meeting_duplicate_scope_is_exact_thread():
+    prompt = _aihq_pipeline_guard("같은 안건으로 2라운드 회의 진행해봐", _slack_source("C0B4TLSMNJG", "1779779206.066769"))
+
+    assert "AIHQ Joint Meeting Guard" in prompt
+    assert "channel_id + thread_ts" in prompt
+    assert "same topic in a different thread is a new meeting" in prompt
+    assert "must never block a new direct `#aihq-meeting` agenda" in prompt
+
+
+def test_aihq_joint_meeting_router_intercepts_meeting_channel_and_team_trigger():
+    assert _aihq_joint_meeting_router_intercept(
+        "새 안건 회의하자",
+        _slack_source("C0B4TLSMNJG", "1779780000.1"),
+    )
+    assert _aihq_joint_meeting_router_intercept(
+        "이 건 회의 진행하자",
+        _slack_source("C0B487QE023", "1779780000.2"),
+    )
+    assert not _aihq_joint_meeting_router_intercept(
+        "오늘 상태만 확인",
+        _slack_source("C0B487QE023", "1779780000.3"),
+    )
+
+
+def test_aihq_artifact_manifest_records_hash_and_next_patch(tmp_path):
+    artifact = tmp_path / "preview_v3_1.html"
+    artifact.write_text("<html>v3.1</html>", encoding="utf-8")
+    manifest = tmp_path / "artifact_manifest.jsonl"
+
+    record = _aihq_record_artifact_manifest(
+        manifest,
+        version="v3.1",
+        path=str(artifact),
+        source_version="v3",
+        slack_upload_ts="171.123",
+        status="uploaded",
+    )
+    entries = _aihq_read_artifact_manifest(manifest)
+
+    assert record["sha256"]
+    assert entries[0]["version"] == "v3.1"
+    assert entries[0]["source_version"] == "v3"
+    assert _aihq_next_patch_version("v3", entries) == "v3.2"
+
+
+def test_aihq_model_routing_applies_work_turn_session_override(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._agent_cache_lock = None
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {"provider": "openai-codex"},
+            "aihq_model_routing": {
+                "enabled": True,
+                "provider": "openai-codex",
+                "work_intake_model": "gpt-5.5",
+                "work_intake_reasoning_effort": "medium",
+            },
+        },
+    )
+
+    runner._apply_aihq_model_routing_for_turn(
+        message="상세페이지 수정해줘",
+        source=_slack_source(),
+        session_key="agent:main:slack:channel:C123:171.000",
+    )
+
+    override = runner._session_model_overrides["agent:main:slack:channel:C123:171.000"]
+    assert override["model"] == "gpt-5.5"
+    assert override["provider"] == "openai-codex"
+    assert runner._session_reasoning_overrides["agent:main:slack:channel:C123:171.000"]

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -948,7 +948,7 @@ class TestSendDocument:
         assert "Not connected" in result.error
 
     @pytest.mark.asyncio
-    async def test_send_document_api_error_falls_back(self, adapter, tmp_path):
+    async def test_send_document_api_error_reports_upload_blocker(self, adapter, tmp_path):
         test_file = tmp_path / "doc.pdf"
         test_file.write_bytes(b"content")
 
@@ -956,14 +956,36 @@ class TestSendDocument:
             side_effect=RuntimeError("Slack API error")
         )
 
-        # Should fall back to base class (text message)
         result = await adapter.send_document(
             chat_id="C123",
             file_path=str(test_file),
         )
 
-        # Base class send() is also mocked, so check it was attempted
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(test_file) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_document_missing_scope_reports_upload_blocker(self, adapter, tmp_path):
+        test_file = tmp_path / "doc.pdf"
+        test_file.write_bytes(b"content")
+
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            side_effect=Exception("missing_scope")
+        )
+
+        result = await adapter.send_document(
+            chat_id="C123",
+            file_path=str(test_file),
+        )
+
+        assert not result.success
+        assert "files:write" in result.error
         adapter._app.client.chat_postMessage.assert_called_once()
+        sent_text = adapter._app.client.chat_postMessage.call_args.kwargs["text"]
+        assert "upload_blocker" in sent_text
+        assert str(test_file) not in sent_text
 
     @pytest.mark.asyncio
     async def test_send_document_with_thread(self, adapter, tmp_path):
@@ -1091,7 +1113,7 @@ class TestSendVideo:
         assert "Not connected" in result.error
 
     @pytest.mark.asyncio
-    async def test_send_video_api_error_falls_back(self, adapter, tmp_path):
+    async def test_send_video_api_error_reports_upload_blocker(self, adapter, tmp_path):
         video = tmp_path / "clip.mp4"
         video.write_bytes(b"fake video")
 
@@ -1099,13 +1121,15 @@ class TestSendVideo:
             side_effect=RuntimeError("Slack API error")
         )
 
-        # Should fall back to base class (text message)
         result = await adapter.send_video(
             chat_id="C123",
             video_path=str(video),
         )
 
-        adapter._app.client.chat_postMessage.assert_called_once()
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(video) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -3043,9 +3067,7 @@ class TestReplyBroadcast:
 
 
 class TestFallbackPreservesThreadContext:
-    """Bug fix: file upload fallbacks lost thread context (metadata) when
-    calling super() without metadata, causing replies to appear outside
-    the thread."""
+    """Slack file upload failures should fail closed instead of posting local paths."""
 
     @pytest.mark.asyncio
     async def test_send_image_file_fallback_preserves_thread(self, adapter, tmp_path):
@@ -3058,15 +3080,17 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_123"}
-        await adapter.send_image_file(
+        result = await adapter.send_image_file(
             chat_id="C123",
             image_path=str(test_file),
             caption="test image",
             metadata=metadata,
         )
 
-        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
-        assert call_kwargs.get("thread_ts") == "parent_ts_123"
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(test_file) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_video_fallback_preserves_thread(self, adapter, tmp_path):
@@ -3079,14 +3103,16 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_456"}
-        await adapter.send_video(
+        result = await adapter.send_video(
             chat_id="C123",
             video_path=str(test_file),
             metadata=metadata,
         )
 
-        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
-        assert call_kwargs.get("thread_ts") == "parent_ts_456"
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(test_file) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_document_fallback_preserves_thread(self, adapter, tmp_path):
@@ -3099,15 +3125,17 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_789"}
-        await adapter.send_document(
+        result = await adapter.send_document(
             chat_id="C123",
             file_path=str(test_file),
             caption="report",
             metadata=metadata,
         )
 
-        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
-        assert call_kwargs.get("thread_ts") == "parent_ts_789"
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(test_file) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_image_file_fallback_includes_caption(self, adapter, tmp_path):
@@ -3119,14 +3147,16 @@ class TestFallbackPreservesThreadContext:
         )
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
-        await adapter.send_image_file(
+        result = await adapter.send_image_file(
             chat_id="C123",
             image_path=str(test_file),
             caption="important screenshot",
         )
 
-        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
-        assert "important screenshot" in call_kwargs["text"]
+        assert not result.success
+        assert "upload_blocker" in result.error
+        assert str(test_file) not in result.error
+        adapter._app.client.chat_postMessage.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_aihq_detail_delegate_gate.py
+++ b/tests/tools/test_aihq_detail_delegate_gate.py
@@ -1,0 +1,78 @@
+from tools.delegate_tool import (
+    _aihq_detail_delegate_missing_requirements,
+    _aihq_pipeline_delegate_missing_requirements,
+)
+
+
+def test_aihq_detail_delegate_gate_blocks_copy_task_without_intake_context():
+    missing = _aihq_detail_delegate_missing_requirements(
+        [
+            {
+                "goal": "쿠팡용 햄버거 카피바라 봉제인형 2종 공용 상세페이지의 상품명 후보와 핵심 카피를 제안하라.",
+                "context": "",
+            }
+        ]
+    )
+
+    assert "pipeline_id" in missing
+    assert "/mywiki" in missing
+    assert "실제 작업 에이전트 팀장 회의" in missing
+
+
+def test_aihq_detail_delegate_gate_allows_task_with_full_intake_context():
+    context = """
+    pipeline_id: detail_page
+    /mywiki 조회 완료
+    My Note 기록 예정
+    실제 작업 에이전트 팀장 회의 완료
+    superpowers 계획 적용
+    GStack 검수 적용
+    김팀장 최종 취합 예정
+    """
+
+    missing = _aihq_detail_delegate_missing_requirements(
+        [
+            {
+                "goal": "쿠팡 780px 상세페이지 섹션 카피 검토",
+                "context": context,
+            }
+        ]
+    )
+
+    assert missing == []
+
+
+def test_aihq_detail_delegate_gate_skips_unrelated_tasks():
+    missing = _aihq_detail_delegate_missing_requirements(
+        [{"goal": "오늘 재고 확인 기준을 정리하라.", "context": ""}]
+    )
+
+    assert missing == []
+
+
+def test_aihq_pipeline_delegate_gate_blocks_proposal_without_intake_context():
+    missing = _aihq_pipeline_delegate_missing_requirements(
+        [{"goal": "이마트24 제안서 핵심 카피와 섹션 구성을 작성하라.", "context": ""}]
+    )
+
+    assert "pipeline_id" in missing
+    assert "/mywiki" in missing
+    assert "김팀장 최종 취합" in missing
+
+
+def test_aihq_pipeline_delegate_gate_blocks_market_research_without_intake_context():
+    missing = _aihq_pipeline_delegate_missing_requirements(
+        [{"goal": "경쟁조사 보고서 초안을 작성하라.", "context": ""}]
+    )
+
+    assert "pipeline_id" in missing
+    assert "실제 작업 에이전트 팀장 회의" in missing
+
+
+def test_aihq_pipeline_delegate_gate_blocks_automation_without_intake_context():
+    missing = _aihq_pipeline_delegate_missing_requirements(
+        [{"goal": "Slack 자동화 개발복구 작업을 하위 에이전트에게 맡겨라.", "context": ""}]
+    )
+
+    assert "superpowers" in missing
+    assert "GStack" in missing

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -680,6 +680,33 @@ class TestSendToPlatformChunking:
         sent_text = send.await_args.args[2]
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in sent_text
 
+    def test_slack_media_uses_native_upload_helper(self, tmp_path, monkeypatch):
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF-1.4")
+        upload = AsyncMock(return_value={"success": True, "uploaded_artifacts": [{"path": str(doc)}]})
+        text_send = AsyncMock()
+        with patch("tools.send_message_tool._send_slack_media", upload), \
+             patch("tools.send_message_tool._send_slack", text_send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "C123",
+                    "업로드합니다",
+                    thread_id="171.000",
+                    media_files=[(str(doc), False)],
+                )
+            )
+
+        assert result["success"] is True
+        upload.assert_awaited_once()
+        assert upload.await_args.kwargs["thread_id"] == "171.000"
+        assert upload.await_args.kwargs["media_files"] == [(str(doc), False)]
+        text_send.assert_not_called()
+
     def test_telegram_media_attaches_to_last_chunk(self):
 
         sent_calls = []

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,6 +19,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 import os
@@ -137,6 +138,76 @@ _MIN_SPAWN_DEPTH = 1
 # No upper ceiling on spawn depth — like max_concurrent_children, depth has a
 # floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
 # stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+
+_AIHQ_DETAIL_GOAL_RE = re.compile(
+    r"(상세페이지|상세\s*페이지|detail\s*page|쿠팡|브랜드스토어)",
+    re.IGNORECASE,
+)
+_AIHQ_PROPOSAL_GOAL_RE = re.compile(r"(제안서|proposal|입점|바이어|이마트24|gs25|cu)", re.IGNORECASE)
+_AIHQ_RESEARCH_GOAL_RE = re.compile(r"(시장조사|경쟁조사|리서치|보고서|market\s*research)", re.IGNORECASE)
+_AIHQ_AUTOMATION_GOAL_RE = re.compile(r"(자동화|개발복구|개발|gateway|slack|cron|봇|연동)", re.IGNORECASE)
+
+
+def _task_text(task: Dict[str, Any]) -> str:
+    return f"{task.get('goal') or ''}\n{task.get('context') or ''}"
+
+
+def _context_has(context: str, needle: str) -> bool:
+    return needle.lower() in str(context or "").lower()
+
+
+def _missing_context_requirements(context: str, requirements: list[tuple[str, list[str]]]) -> list[str]:
+    missing = []
+    for label, alternatives in requirements:
+        if not any(_context_has(context, alt) for alt in alternatives):
+            missing.append(label)
+    return missing
+
+
+def _aihq_detail_delegate_missing_requirements(tasks: List[Dict[str, Any]]) -> list[str]:
+    required = [
+        ("pipeline_id", ["pipeline_id"]),
+        ("/mywiki", ["/mywiki", "mywiki"]),
+        ("My Note", ["My Note", "마이노트"]),
+        ("실제 작업 에이전트 팀장 회의", ["실제 작업 에이전트 팀장 회의", "actual working team-lead roster", "팀장 회의"]),
+        ("superpowers", ["superpowers"]),
+        ("GStack", ["GStack"]),
+        ("김팀장 최종 취합", ["김팀장 최종 취합", "김팀장 final", "final orchestration"]),
+    ]
+    missing: list[str] = []
+    for task in tasks or []:
+        if not isinstance(task, dict):
+            continue
+        if not _AIHQ_DETAIL_GOAL_RE.search(_task_text(task)):
+            continue
+        missing.extend(_missing_context_requirements(str(task.get("context") or ""), required))
+    return sorted(set(missing), key=missing.index)
+
+
+def _aihq_pipeline_delegate_missing_requirements(tasks: List[Dict[str, Any]]) -> list[str]:
+    required = [
+        ("pipeline_id", ["pipeline_id"]),
+        ("/mywiki", ["/mywiki", "mywiki"]),
+        ("My Note", ["My Note", "마이노트"]),
+        ("실제 작업 에이전트 팀장 회의", ["실제 작업 에이전트 팀장 회의", "actual working team-lead roster", "팀장 회의"]),
+        ("superpowers", ["superpowers"]),
+        ("GStack", ["GStack"]),
+        ("김팀장 최종 취합", ["김팀장 최종 취합", "김팀장 final", "final orchestration"]),
+    ]
+    missing: list[str] = []
+    for task in tasks or []:
+        if not isinstance(task, dict):
+            continue
+        text = _task_text(task)
+        if not (
+            _AIHQ_DETAIL_GOAL_RE.search(text)
+            or _AIHQ_PROPOSAL_GOAL_RE.search(text)
+            or _AIHQ_RESEARCH_GOAL_RE.search(text)
+            or _AIHQ_AUTOMATION_GOAL_RE.search(text)
+        ):
+            continue
+        missing.extend(_missing_context_requirements(str(task.get("context") or ""), required))
+    return sorted(set(missing), key=missing.index)
 
 
 # ---------------------------------------------------------------------------
@@ -2053,6 +2124,13 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    missing_aihq_requirements = _aihq_pipeline_delegate_missing_requirements(task_list)
+    if missing_aihq_requirements:
+        return tool_error(
+            "AIHQ delegate preflight blocked: missing required pipeline context before child-agent spawn: "
+            + ", ".join(missing_aihq_requirements)
+        )
 
     overall_start = time.monotonic()
     results = []

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -749,6 +749,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: native file upload support via files_upload_v2 ---
+    if platform == Platform.SLACK and media_files:
+        comment = "\n".join(chunk for chunk in chunks if chunk).strip()
+        return await _send_slack_media(
+            pconfig.token,
+            chat_id,
+            comment,
+            thread_id=thread_id,
+            media_files=media_files,
+        )
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
@@ -1072,6 +1083,77 @@ async def _send_slack(token, chat_id, message, thread_ts=None):
                 return _error(f"Slack API error: {data.get('error', 'unknown')}")
     except Exception as e:
         return _error(f"Slack send failed: {e}")
+
+
+async def _send_slack_media(token, chat_id, message, *, thread_id=None, media_files=None):
+    """Upload local MEDIA attachments to Slack, failing closed on upload errors."""
+    media_files = media_files or []
+    try:
+        from slack_sdk.web.async_client import AsyncWebClient
+        from gateway.platforms.base import resolve_proxy_url
+    except Exception as exc:
+        return _error(
+            "upload_blocker: Slack MEDIA upload requires slack-sdk. "
+            f"Could not import Slack client: {exc}"
+        )
+
+    proxy = None
+    try:
+        proxy = resolve_proxy_url()
+    except Exception:
+        proxy = None
+    client = AsyncWebClient(token=token, proxy=proxy)
+    uploaded = []
+
+    def _slack_response_data(response):
+        if isinstance(response, dict):
+            return response
+        data = getattr(response, "data", None)
+        if isinstance(data, dict):
+            return data
+        try:
+            return dict(response)
+        except Exception:
+            return {}
+
+    for idx, item in enumerate(media_files):
+        media_path = item[0] if isinstance(item, (list, tuple)) else item
+        media_path = str(media_path)
+        if not os.path.exists(media_path):
+            return _error(f"upload_blocker: Slack MEDIA file not found: {media_path}")
+        try:
+            result = await client.files_upload_v2(
+                channel=chat_id,
+                file=media_path,
+                filename=os.path.basename(media_path),
+                initial_comment=message if idx == 0 else "",
+                thread_ts=thread_id,
+            )
+        except Exception as exc:
+            detail = _sanitize_error_text(str(exc))
+            if "missing_scope" in detail:
+                detail = "Missing scope: files:write. Update Slack app scopes/settings and reinstall."
+            return _error(
+                f"upload_blocker: Slack MEDIA upload failed for {os.path.basename(media_path)}: {detail}"
+            )
+        data = _slack_response_data(result)
+        files = data.get("files") or []
+        first_file = files[0] if files and isinstance(files[0], dict) else {}
+        uploaded.append(
+            {
+                "path": media_path,
+                "filename": os.path.basename(media_path),
+                "slack_upload_ts": data.get("ts") or first_file.get("created"),
+                "file_id": first_file.get("id"),
+                "permalink": first_file.get("permalink"),
+            }
+        )
+    return {
+        "success": True,
+        "platform": "slack",
+        "chat_id": chat_id,
+        "uploaded_artifacts": uploaded,
+    }
 
 
 async def _send_whatsapp(extra, chat_id, message):


### PR DESCRIPTION
## Summary
- Add AIHQ Slack project-continuity guards that bind same-thread work to the Hermes thread index and canonical progress files.
- Fail closed on Slack file upload errors instead of falling back to local file-path messages, and route `send_message` Slack `MEDIA:` delivery through native uploads.
- Add AIHQ delegation preflight checks plus artifact manifest/version helpers to prevent contextless fan-out and v2/v3 overwrite confusion.

## Test Plan
- `venv/bin/python -m pytest -q tests/gateway/test_aihq_detail_page_guard.py tests/tools/test_aihq_detail_delegate_gate.py tests/tools/test_send_message_tool.py tests/gateway/test_slack.py`

## Runtime Verification
- Restarted local Hermes gateway after patch application.
- Verified Slack `auth.test` and `conversations.info` against the configured Hermes Slack token/channel.
- Verified direct `files_upload_v2` upload and Hermes `send_message MEDIA:` upload path both created Slack files successfully.
