### PR TITLE
docs: add agent learning loop skill

### DIFF
--- a/optional-skills/mlops/agent-learning-loop/SKILL.md
+++ b/optional-skills/mlops/agent-learning-loop/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: agent-learning-loop
+description: "Use when turning agent traces into reviewed memory/skill proposals and SFT/DPO datasets without mutating global Hermes state."
+version: 1.0.0
+author: lamenting-hawthorn
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [agent-learning, self-improvement, trace-curation, memory, skills, sft, dpo, evaluation]
+    related_skills: [fine-tuning-with-trl, axolotl, subagent-driven-development, requesting-code-review]
+---
+
+# Agent Learning Loop
+
+## Overview
+
+Use this skill to build or operate a review-first learning loop for agents: ingest completed traces, evaluate them, distill candidate memory and skill updates, review those proposals, and export supervised fine-tuning (SFT) or preference (DPO) datasets.
+
+The core rule is separation: the learning loop should be a sidecar/export layer, not an automatic self-mutating runtime. It may read Hermes traces and produce proposals, but it should not silently write into a user's live memory, bundled skills, config, or credentials.
+
+## When to Use
+
+Use this skill when:
+
+- The user wants an agent to "learn from itself" or improve from completed work
+- You need to curate Hermes sessions or other agent traces into training data
+- You want memory/skill candidates but need human review before applying them
+- You are designing a local self-improvement pipeline around SFT, DPO, or evals
+- You need a clean export path that stays separate from an existing Hermes install
+
+Do not use this skill for:
+
+- Directly editing live `~/.hermes/memories` or `~/.hermes/skills` without review
+- Storing API keys, cookies, tokens, or private credentials in training records
+- Treating every successful session as training data; curation is required
+- Replacing Hermes memory or skill tools; this is a sidecar workflow
+
+## Architecture
+
+The recommended pipeline is:
+
+```text
+agent session / trace
+  -> ingestion adapter
+  -> normalized trace schema
+  -> local store
+  -> evaluation
+  -> distillation
+  -> review queue
+  -> approved exports
+  -> SFT / DPO JSONL
+```
+
+Keep each boundary explicit:
+
+| Stage | Input | Output | Notes |
+|---|---|---|---|
+| Ingest | Hermes/session JSON, JSONL, logs | normalized trace | Preserve source metadata |
+| Evaluate | normalized trace | score, tags, notes | Prefer deterministic checks first |
+| Distill | trace + eval | memory/skill proposals | Proposal only, no mutation |
+| Review | proposals | approved/rejected state | Human or independent verifier gate |
+| Apply/export | approved proposals | markdown/JSONL artifacts | Write to project-local output |
+| Train | JSONL datasets | model artifacts | Run outside Hermes core |
+
+See `references/skillloop-architecture.md` for a more detailed reference design.
+
+## Clean Export Boundary
+
+For a local sidecar project, use a project root such as `./agent-learning/` and keep generated state underneath it:
+
+```text
+.agent-learning/
+  learning.db
+  approved/
+    memory/*.md
+    skill/*.md
+exports/
+  sft.jsonl
+  dpo.jsonl
+```
+
+Do not write directly into:
+
+```text
+~/.hermes/memories
+~/.hermes/skills
+~/.hermes/config.yaml
+~/.hermes/.env
+```
+
+If the user later wants to import approved outputs into Hermes, make that a separate explicit step with a final review.
+
+## Normalized Trace Shape
+
+Use a small schema that can represent multiple runtimes:
+
+```json
+{
+  "id": "trace-id",
+  "source": "hermes",
+  "created_at": "2026-06-05T00:00:00Z",
+  "messages": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."},
+    {"role": "tool", "name": "terminal", "content": "..."}
+  ],
+  "metadata": {}
+}
+```
+
+Keep tool calls and tool results if they are needed for evaluation, but redact secrets before writing shared datasets.
+
+## Evaluation Signals
+
+Start with deterministic signals before adding LLM judges:
+
+Positive signals:
+
+- final answer exists
+- task was verified with real commands or tool output
+- tests passed
+- user confirmed success
+- no unresolved tool failures
+
+Negative signals:
+
+- traceback or exception
+- failed command without recovery
+- user correction such as "wrong", "no", "actually", "don't do that"
+- fabricated or unverified output
+- unsafe credential handling
+
+Example evaluation record:
+
+```json
+{
+  "trace_id": "abc123",
+  "score": 82,
+  "tags": ["has_final_answer", "verified", "success_signal"],
+  "notes": ["Tests passed and user accepted result."]
+}
+```
+
+## Distilling Memory Proposals
+
+Only propose memory for durable facts that will remain useful across sessions:
+
+Good memory candidates:
+
+- stable user preferences
+- project conventions
+- environment facts that are hard to rediscover
+- recurring workflow constraints
+
+Bad memory candidates:
+
+- temporary task progress
+- PR numbers, commit SHAs, issue IDs
+- raw logs
+- credentials or tokens
+- facts that will be stale within a week
+
+Use declarative wording:
+
+```text
+User prefers final verifier agents only at pre-push/readiness gates.
+```
+
+Avoid imperative wording:
+
+```text
+Always use verifier agents only at the end.
+```
+
+## Distilling Skill Proposals
+
+Create skill proposals when a trace contains a reusable procedure, especially after an error was solved.
+
+A useful skill proposal includes:
+
+- trigger conditions
+- exact steps or commands
+- pitfalls encountered
+- verification checklist
+- boundaries and safety rules
+
+Keep generated skills as proposals until reviewed.
+
+## Dataset Export
+
+### SFT
+
+Export high-quality instruction-following conversations:
+
+```json
+{"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+Skip traces with unresolved failures unless they are intentionally used as negative examples elsewhere.
+
+### DPO
+
+Export preference pairs only when there is a clear chosen/rejected contrast:
+
+```json
+{"prompt": "...", "chosen": "...", "rejected": "..."}
+```
+
+Examples of valid DPO sources:
+
+- user rejected an answer and accepted a corrected one
+- reviewer identified a flawed output and a fixed output exists
+- two candidate agent responses were judged against a rubric
+
+Do not invent rejected responses.
+
+## Review Gate
+
+Before exporting or applying learning artifacts:
+
+1. Run deterministic checks.
+2. Scan for credentials and PII.
+3. Use an independent verifier for final readiness if available.
+4. Review memory and skill proposals manually.
+5. Export only approved artifacts.
+
+For Hermes coding work, use the user's verifier preference if known: reserve verifier subagents for the final pre-push/export gate unless explicitly requested earlier.
+
+## Example Local Workflow
+
+```bash
+# 1. Export or collect traces into ./traces
+mkdir -p traces exports
+
+# 2. Ingest traces into a sidecar DB or normalized JSONL
+python scripts/ingest_traces.py traces/*.jsonl --out .agent-learning/learning.db
+
+# 3. Evaluate and distill proposals
+python scripts/evaluate_traces.py --db .agent-learning/learning.db
+python scripts/distill_proposals.py --db .agent-learning/learning.db
+
+# 4. Review proposals
+python scripts/review_queue.py list --db .agent-learning/learning.db
+python scripts/review_queue.py approve <proposal-id>
+
+# 5. Export datasets
+python scripts/export_sft.py --db .agent-learning/learning.db --out exports/sft.jsonl
+python scripts/export_dpo.py --db .agent-learning/learning.db --out exports/dpo.jsonl
+```
+
+The script names are placeholders for your sidecar implementation. Keep the workflow shape even if the implementation differs.
+
+## Privacy and Safety Checklist
+
+Before sharing, training, or publishing any dataset:
+
+- [ ] No `.env`, API keys, tokens, cookies, SSH material, or auth JSON included
+- [ ] No private third-party messages included without consent
+- [ ] No sensitive local file paths unless necessary and sanitized
+- [ ] Generated state is ignored by git
+- [ ] Memory proposals are durable and non-stale
+- [ ] Skill proposals are reviewed before import
+- [ ] SFT records come from successful or intentionally curated traces
+- [ ] DPO records have real chosen/rejected pairs
+
+## Common Pitfalls
+
+1. **Making the loop self-mutating too early.** Start with proposals and explicit review. Automatic memory/skill writes should be opt-in and heavily tested.
+
+2. **Training on failures as if they were successes.** Failed traces are useful for evals and DPO only when clearly labeled.
+
+3. **Leaking secrets through traces.** Tool outputs may contain tokens, URLs, cookies, or env values. Redact before persistence or export.
+
+4. **Overfitting to one user's preferences.** Keep user-specific memory separate from general skills and public datasets.
+
+5. **Skipping provenance.** Preserve source, timestamp, model, and evaluation metadata so bad records can be traced and removed later.
+
+6. **Adding a core Hermes dependency for an experimental workflow.** Prefer an optional skill, plugin, or sidecar until the interface stabilizes.
+
+## Verification Checklist
+
+- [ ] Sidecar writes only inside its selected project root
+- [ ] Sample trace can be ingested, evaluated, distilled, reviewed, and exported
+- [ ] Generated outputs are gitignored by default
+- [ ] Tests cover ingestion, evaluation, review/apply, and export
+- [ ] SFT/DPO JSONL validates with a line-by-line JSON parser
+- [ ] Final output is backed by real tool/test results, not synthetic claims

--- a/optional-skills/mlops/agent-learning-loop/SKILL.md
+++ b/optional-skills/mlops/agent-learning-loop/SKILL.md
@@ -1,99 +1,97 @@
 ---
 name: agent-learning-loop
-description: "Use when turning agent traces into reviewed memory/skill proposals and SFT/DPO datasets without mutating global Hermes state."
+description: "Curate agent traces into reviewed learning artifacts."
 version: 1.0.0
 author: lamenting-hawthorn
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [agent-learning, self-improvement, trace-curation, memory, skills, sft, dpo, evaluation]
-    related_skills: [fine-tuning-with-trl, axolotl, subagent-driven-development, requesting-code-review]
+    tags: [agent-learning, trace-curation, memory, skills, sft, dpo, evaluation]
+    related_skills: [fine-tuning-with-trl, axolotl, requesting-code-review]
 ---
 
-# Agent Learning Loop
+# Agent Learning Loop Skill
 
-## Overview
-
-Use this skill to build or operate a review-first learning loop for agents: ingest completed traces, evaluate them, distill candidate memory and skill updates, review those proposals, and export supervised fine-tuning (SFT) or preference (DPO) datasets.
-
-The core rule is separation: the learning loop should be a sidecar/export layer, not an automatic self-mutating runtime. It may read Hermes traces and produce proposals, but it should not silently write into a user's live memory, bundled skills, config, or credentials.
+Build or operate a review-first sidecar that turns completed agent traces into
+evaluations, proposals, and training records. The sidecar may read Hermes
+trajectories, but it must not silently mutate live Hermes state.
 
 ## When to Use
 
 Use this skill when:
 
-- The user wants an agent to "learn from itself" or improve from completed work
-- You need to curate Hermes sessions or other agent traces into training data
-- You want memory/skill candidates but need human review before applying them
-- You are designing a local self-improvement pipeline around SFT, DPO, or evals
-- You need a clean export path that stays separate from an existing Hermes install
+- curating Hermes sessions or other agent traces into training data
+- proposing durable memory or reusable skill updates from completed work
+- designing a local SFT, DPO, or evaluation pipeline
+- adding explicit review between generated proposals and live state
 
-Do not use this skill for:
+Do not use it to import unreviewed output, retain credentials, or treat every
+successful session as training data.
 
-- Directly editing live `~/.hermes/memories` or `~/.hermes/skills` without review
-- Storing API keys, cookies, tokens, or private credentials in training records
-- Treating every successful session as training data; curation is required
-- Replacing Hermes memory or skill tools; this is a sidecar workflow
+## Prerequisites
 
-## Architecture
+- Completed trajectories; Hermes can save ShareGPT-compatible JSONL.
+- A project-local sidecar directory outside live Hermes state.
+- An explicit reviewer for memory, skill, and dataset proposals.
+- Access to `$HERMES_HOME` when locating profile-scoped Hermes state. Never
+  assume the default home directory; custom homes and named profiles keep
+  separate state.
 
-The recommended pipeline is:
+Use native Hermes tools such as `read_file`, `search_files`, `patch`, and
+`terminal` to inspect traces and build the sidecar. If an independent verifier
+is available, reserve it for the final readiness gate unless the user requests
+earlier review.
 
-```text
-agent session / trace
-  -> ingestion adapter
-  -> normalized trace schema
-  -> local store
-  -> evaluation
-  -> distillation
-  -> review queue
-  -> approved exports
-  -> SFT / DPO JSONL
-```
+## How to Run
 
-Keep each boundary explicit:
+This skill specifies an architecture, not a bundled executable. Implement the
+pipeline in the user's sidecar project, then run that project's documented
+commands with `terminal`. Do not copy command names from this document: no
+sidecar scripts are shipped by this skill.
 
-| Stage | Input | Output | Notes |
-|---|---|---|---|
-| Ingest | Hermes/session JSON, JSONL, logs | normalized trace | Preserve source metadata |
-| Evaluate | normalized trace | score, tags, notes | Prefer deterministic checks first |
-| Distill | trace + eval | memory/skill proposals | Proposal only, no mutation |
-| Review | proposals | approved/rejected state | Human or independent verifier gate |
-| Apply/export | approved proposals | markdown/JSONL artifacts | Write to project-local output |
-| Train | JSONL datasets | model artifacts | Run outside Hermes core |
-
-See `references/skillloop-architecture.md` for a more detailed reference design.
-
-## Clean Export Boundary
-
-For a local sidecar project, use a project root such as `./agent-learning/` and keep generated state underneath it:
+Keep generated state under the selected project root, for example:
 
 ```text
 .agent-learning/
   learning.db
+  proposals/
   approved/
-    memory/*.md
-    skill/*.md
 exports/
   sft.jsonl
   dpo.jsonl
 ```
 
-Do not write directly into:
+Importing an approved artifact into `$HERMES_HOME/memories` or
+`$HERMES_HOME/skills` is a separate, explicit operation.
 
-```text
-~/.hermes/memories
-~/.hermes/skills
-~/.hermes/config.yaml
-~/.hermes/.env
-```
+## Quick Reference
 
-If the user later wants to import approved outputs into Hermes, make that a separate explicit step with a final review.
+| Stage | Input | Output | Required boundary |
+|---|---|---|---|
+| Ingest | trajectory JSON/JSONL | normalized trace | preserve provenance |
+| Evaluate | normalized trace | score, tags, notes | deterministic checks first |
+| Distill | trace and evaluation | proposals | no live-state writes |
+| Review | pending proposals | decisions | explicit approval |
+| Export | approved records | Markdown/JSONL | redact and validate |
+| Import/train | approved exports | live artifact/model | separate workflow |
 
-## Normalized Trace Shape
+See `references/skillloop-architecture.md` for the detailed reference design.
 
-Use a small schema that can represent multiple runtimes:
+## Procedure
+
+### 1. Select and isolate inputs
+
+Locate the requested Hermes profile through `$HERMES_HOME`, or accept traces
+exported by the user. Copy or stream the selected completed traces into the
+sidecar boundary; do not edit the originals.
+
+Record source, timestamp, model, completion state, and available tool metadata.
+Add a stable trace ID so every proposal and export can be traced back.
+
+### 2. Normalize traces
+
+Map each runtime into a small internal shape:
 
 ```json
 {
@@ -109,180 +107,102 @@ Use a small schema that can represent multiple runtimes:
 }
 ```
 
-Keep tool calls and tool results if they are needed for evaluation, but redact secrets before writing shared datasets.
+Retain tool calls and results only when evaluation needs them. Redact secrets
+before persistence or export, not after publication.
 
-## Evaluation Signals
+### 3. Evaluate
 
-Start with deterministic signals before adding LLM judges:
+Run deterministic checks before adding an LLM judge.
 
-Positive signals:
+Positive evidence includes a final answer, passing tests, successful tool
+output, user confirmation, and recovery from earlier failures. Negative
+evidence includes incomplete traces, unresolved exceptions, user corrections,
+unsupported success claims, and unsafe credential handling.
 
-- final answer exists
-- task was verified with real commands or tool output
-- tests passed
-- user confirmed success
-- no unresolved tool failures
-
-Negative signals:
-
-- traceback or exception
-- failed command without recovery
-- user correction such as "wrong", "no", "actually", "don't do that"
-- fabricated or unverified output
-- unsafe credential handling
-
-Example evaluation record:
+Store the evidence, not only a score:
 
 ```json
 {
   "trace_id": "abc123",
   "score": 82,
-  "tags": ["has_final_answer", "verified", "success_signal"],
-  "notes": ["Tests passed and user accepted result."]
+  "tags": ["completed", "verified"],
+  "notes": ["Tests passed and the final answer cites the result."]
 }
 ```
 
-## Distilling Memory Proposals
+### 4. Distill proposals
 
-Only propose memory for durable facts that will remain useful across sessions:
+Propose memory only for durable facts such as stable preferences, recurring
+project conventions, or hard-to-rediscover environment constraints. Exclude
+temporary progress, raw logs, credentials, commit IDs, and soon-stale facts.
 
-Good memory candidates:
+Use declarative wording, for example: `User prefers final verification at the
+pre-push gate.` Do not turn a personal preference into a global imperative.
 
-- stable user preferences
-- project conventions
-- environment facts that are hard to rediscover
-- recurring workflow constraints
+Propose a skill only when a trace contains a reusable procedure. Include its
+trigger, sequence, pitfalls, verification, and safety boundaries. Keep every
+proposal pending until review.
 
-Bad memory candidates:
+### 5. Review
 
-- temporary task progress
-- PR numbers, commit SHAs, issue IDs
-- raw logs
-- credentials or tokens
-- facts that will be stale within a week
+Present pending proposals with their source evidence. The reviewer must be able
+to approve, reject, or edit each item. Record the decision and reviewer without
+overwriting the original proposal.
 
-Use declarative wording:
+Approval authorizes export only. It does not authorize an automatic write to
+`$HERMES_HOME`, bundled skills, configuration, or credentials.
 
-```text
-User prefers final verifier agents only at pre-push/readiness gates.
-```
+### 6. Export
 
-Avoid imperative wording:
-
-```text
-Always use verifier agents only at the end.
-```
-
-## Distilling Skill Proposals
-
-Create skill proposals when a trace contains a reusable procedure, especially after an error was solved.
-
-A useful skill proposal includes:
-
-- trigger conditions
-- exact steps or commands
-- pitfalls encountered
-- verification checklist
-- boundaries and safety rules
-
-Keep generated skills as proposals until reviewed.
-
-## Dataset Export
-
-### SFT
-
-Export high-quality instruction-following conversations:
+For SFT, export only curated, high-quality instruction-following records:
 
 ```json
 {"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
 ```
 
-Skip traces with unresolved failures unless they are intentionally used as negative examples elsewhere.
-
-### DPO
-
-Export preference pairs only when there is a clear chosen/rejected contrast:
+For DPO, require a real chosen/rejected contrast:
 
 ```json
 {"prompt": "...", "chosen": "...", "rejected": "..."}
 ```
 
-Examples of valid DPO sources:
+Valid contrasts include an answer rejected by the user and its accepted fix,
+or two responses reviewed against the same rubric. Never invent a rejected
+response. Validate every JSONL line and retain provenance separately.
 
-- user rejected an answer and accepted a corrected one
-- reviewer identified a flawed output and a fixed output exists
-- two candidate agent responses were judged against a rubric
+### 7. Verify before import or training
 
-Do not invent rejected responses.
+Scan approved output for credentials and PII. Review memory and skill content
+manually. If available, use an independent verifier at this final gate.
 
-## Review Gate
+Any later import must target the intended profile's `$HERMES_HOME`, use normal
+Hermes memory or skill mechanisms, and preserve a rollback path.
 
-Before exporting or applying learning artifacts:
+## Pitfalls
 
-1. Run deterministic checks.
-2. Scan for credentials and PII.
-3. Use an independent verifier for final readiness if available.
-4. Review memory and skill proposals manually.
-5. Export only approved artifacts.
+1. **Assuming the default home.** Resolve the selected profile through
+   `$HERMES_HOME`; named profiles and custom homes are isolated.
+2. **Self-mutation by default.** Generate proposals and require explicit
+   review before any live-state change.
+3. **Training on unresolved failures.** Use failed traces only when they are
+   clearly labeled for evaluation or genuine preference pairs.
+4. **Secret leakage.** Tool results can expose tokens, cookies, URLs, paths,
+   or environment values. Redact before storage and again before export.
+5. **Weak provenance.** Preserve enough source metadata to locate and remove
+   a bad record later.
+6. **Overfitting.** Keep user-specific memory separate from general skills and
+   public datasets.
 
-For Hermes coding work, use the user's verifier preference if known: reserve verifier subagents for the final pre-push/export gate unless explicitly requested earlier.
+## Verification
 
-## Example Local Workflow
-
-```bash
-# 1. Export or collect traces into ./traces
-mkdir -p traces exports
-
-# 2. Ingest traces into a sidecar DB or normalized JSONL
-python scripts/ingest_traces.py traces/*.jsonl --out .agent-learning/learning.db
-
-# 3. Evaluate and distill proposals
-python scripts/evaluate_traces.py --db .agent-learning/learning.db
-python scripts/distill_proposals.py --db .agent-learning/learning.db
-
-# 4. Review proposals
-python scripts/review_queue.py list --db .agent-learning/learning.db
-python scripts/review_queue.py approve <proposal-id>
-
-# 5. Export datasets
-python scripts/export_sft.py --db .agent-learning/learning.db --out exports/sft.jsonl
-python scripts/export_dpo.py --db .agent-learning/learning.db --out exports/dpo.jsonl
-```
-
-The script names are placeholders for your sidecar implementation. Keep the workflow shape even if the implementation differs.
-
-## Privacy and Safety Checklist
-
-Before sharing, training, or publishing any dataset:
-
-- [ ] No `.env`, API keys, tokens, cookies, SSH material, or auth JSON included
-- [ ] No private third-party messages included without consent
-- [ ] No sensitive local file paths unless necessary and sanitized
-- [ ] Generated state is ignored by git
-- [ ] Memory proposals are durable and non-stale
-- [ ] Skill proposals are reviewed before import
-- [ ] SFT records come from successful or intentionally curated traces
-- [ ] DPO records have real chosen/rejected pairs
-
-## Common Pitfalls
-
-1. **Making the loop self-mutating too early.** Start with proposals and explicit review. Automatic memory/skill writes should be opt-in and heavily tested.
-
-2. **Training on failures as if they were successes.** Failed traces are useful for evals and DPO only when clearly labeled.
-
-3. **Leaking secrets through traces.** Tool outputs may contain tokens, URLs, cookies, or env values. Redact before persistence or export.
-
-4. **Overfitting to one user's preferences.** Keep user-specific memory separate from general skills and public datasets.
-
-5. **Skipping provenance.** Preserve source, timestamp, model, and evaluation metadata so bad records can be traced and removed later.
-
-6. **Adding a core Hermes dependency for an experimental workflow.** Prefer an optional skill, plugin, or sidecar until the interface stabilizes.
-
-## Verification Checklist
-
-- [ ] Sidecar writes only inside its selected project root
-- [ ] Sample trace can be ingested, evaluated, distilled, reviewed, and exported
-- [ ] Generated outputs are gitignored by default
-- [ ] Tests cover ingestion, evaluation, review/apply, and export
-- [ ] SFT/DPO JSONL validates with a line-by-line JSON parser
-- [ ] Final output is backed by real tool/test results, not synthetic claims
+- [ ] The sidecar writes only inside its selected project root.
+- [ ] Live state is referenced through `$HERMES_HOME`, not a fixed home path.
+- [ ] The pipeline can normalize, evaluate, propose, review, and export a
+      sample trace.
+- [ ] Generated state is ignored by version control.
+- [ ] Tests cover the sidecar implementation's ingestion, evaluation, review,
+      and export behavior.
+- [ ] Every SFT/DPO JSONL line parses independently.
+- [ ] Credential and PII scans pass.
+- [ ] Only approved artifacts proceed to import or training.
+- [ ] Final claims are backed by real command or test output.

--- a/optional-skills/mlops/agent-learning-loop/references/skillloop-architecture.md
+++ b/optional-skills/mlops/agent-learning-loop/references/skillloop-architecture.md
@@ -1,0 +1,169 @@
+# SkillLoop-Style Agent Learning Loop Reference
+
+This reference describes a clean sidecar architecture for improving agents from their own traces while avoiding unsafe self-mutation.
+
+## Goals
+
+- Make agent learning inspectable and reviewable
+- Preserve a clean boundary between runtime state and learning artifacts
+- Support multiple agent runtimes through adapters
+- Export training data without requiring training inside Hermes
+- Avoid storing credentials or private data in public datasets
+
+## Non-goals
+
+- Replacing Hermes memory or skill tools
+- Automatically fine-tuning models after every session
+- Writing directly into live user memory or skills
+- Adding mandatory cloud dependencies
+
+## Components
+
+### 1. Trace adapters
+
+Adapters convert runtime-specific outputs into a common trace object.
+
+Recommended adapters:
+
+- generic JSONL messages
+- Hermes session exports
+- Codex/Claude/OpenCode transcripts
+- custom application logs
+
+Adapters should be tolerant of unknown fields and preserve source metadata.
+
+### 2. Local store
+
+A local SQLite database is enough for the first version. Store:
+
+- traces
+- evaluations
+- proposals
+- review status
+- export metadata
+
+Keep it under the chosen project root, not under global Hermes state.
+
+### 3. Evaluation engine
+
+Start deterministic:
+
+- final answer present?
+- tool failures?
+- tests or verification present?
+- user correction detected?
+- success signal detected?
+
+Add LLM judges later as optional evaluators, not as the only source of truth.
+
+### 4. Distillation engine
+
+Distill two proposal types first:
+
+- memory proposals for durable preferences/facts
+- skill proposals for reusable procedures
+
+Store proposed content plus reason/provenance. Do not apply directly.
+
+### 5. Review queue
+
+Every proposal should have a status:
+
+- pending
+- approved
+- rejected
+
+Approval can be manual, reviewer-agent-assisted, or policy-based, but the reviewed state should be explicit.
+
+### 6. Exporters
+
+Export approved or high-quality traces into:
+
+- SFT JSONL
+- DPO JSONL
+- approved memory markdown
+- approved skill markdown
+
+The exporter should be deterministic and repeatable.
+
+## Suggested record formats
+
+### SFT
+
+```json
+{"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+### DPO
+
+```json
+{"prompt": "...", "chosen": "...", "rejected": "..."}
+```
+
+### Memory proposal
+
+```json
+{
+  "kind": "memory",
+  "title": "Durable user preference",
+  "content": "User prefers concise terminal summaries.",
+  "reason": "User explicitly corrected response style.",
+  "status": "pending"
+}
+```
+
+### Skill proposal
+
+```json
+{
+  "kind": "skill",
+  "title": "Reusable debug workflow",
+  "content": "# Workflow...",
+  "reason": "Trace contains repeated fix/verify pattern.",
+  "status": "pending"
+}
+```
+
+## Review-first flow
+
+```text
+trace -> eval -> proposal -> review -> approved export -> optional import/train
+```
+
+This keeps experimental learning artifacts separate from live agent behavior.
+
+## Integration points with Hermes
+
+Safe first integrations:
+
+- Skill documenting the workflow
+- Optional plugin/sidecar that reads exported sessions
+- CLI command that exports traces to a neutral format
+- Docs showing how to curate datasets
+
+Avoid as first integrations:
+
+- Automatically writing to `~/.hermes/memories`
+- Automatically writing to bundled `skills/`
+- Adding fine-tuning dependencies to core install
+- Training jobs that run without user approval
+
+## Minimal acceptance criteria
+
+A sidecar implementation is useful when it can:
+
+1. Ingest a sample trace.
+2. Store it locally.
+3. Evaluate it deterministically.
+4. Produce at least one reviewable proposal from a learning signal.
+5. Export valid SFT JSONL.
+6. Leave no generated artifacts in source control.
+7. Pass tests for schema, store, adapters, evaluation, review, and export.
+
+## Contributor positioning
+
+For Hermes Agent upstream, this architecture is best contributed incrementally:
+
+1. Start as an optional skill and reference architecture.
+2. Add a standalone plugin or sidecar package after interface feedback.
+3. Only move pieces into core when they are stable, broadly useful, and dependency-light.

--- a/optional-skills/mlops/agent-learning-loop/references/skillloop-architecture.md
+++ b/optional-skills/mlops/agent-learning-loop/references/skillloop-architecture.md
@@ -42,7 +42,7 @@ A local SQLite database is enough for the first version. Store:
 - review status
 - export metadata
 
-Keep it under the chosen project root, not under global Hermes state.
+Keep it under the chosen project root, not under live profile-scoped Hermes state.
 
 ### 3. Evaluation engine
 
@@ -143,7 +143,7 @@ Safe first integrations:
 
 Avoid as first integrations:
 
-- Automatically writing to `~/.hermes/memories`
+- Automatically writing to the selected profile's `$HERMES_HOME/memories`
 - Automatically writing to bundled `skills/`
 - Adding fine-tuning dependencies to core install
 - Training jobs that run without user approval

--- a/tests/skills/test_agent_learning_loop_skill.py
+++ b/tests/skills/test_agent_learning_loop_skill.py
@@ -39,7 +39,8 @@ def test_required_sections_are_present_in_order():
 
 
 def test_docs_use_profile_safe_state_paths():
-    combined = _text(SKILL) + _text(GUIDE)
+    skill_docs = SKILL.parent.rglob("*.md")
+    combined = "\n".join(_text(path) for path in skill_docs) + _text(GUIDE)
     assert "$HERMES_HOME" in combined
     assert "`~/.hermes" not in combined
 

--- a/tests/skills/test_agent_learning_loop_skill.py
+++ b/tests/skills/test_agent_learning_loop_skill.py
@@ -1,0 +1,50 @@
+"""Contract tests for the optional agent-learning-loop skill."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / "optional-skills/mlops/agent-learning-loop/SKILL.md"
+GUIDE = ROOT / "website/docs/developer-guide/agent-learning-loop.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_description_matches_authoring_standard():
+    text = _text(SKILL)
+    match = re.search(r'^description: ["\']?(.*?)["\']?$', text, re.MULTILINE)
+    assert match is not None
+    description = match.group(1)
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_required_sections_are_present_in_order():
+    text = _text(SKILL)
+    headings = [
+        "# Agent Learning Loop Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.index(heading) for heading in headings]
+    assert positions == sorted(positions)
+
+
+def test_docs_use_profile_safe_state_paths():
+    combined = _text(SKILL) + _text(GUIDE)
+    assert "$HERMES_HOME" in combined
+    assert "`~/.hermes" not in combined
+
+
+def test_architecture_example_is_not_presented_as_executable():
+    text = _text(SKILL)
+    assert "not a bundled executable" in text
+    assert "python scripts/" not in text

--- a/website/docs/developer-guide/agent-learning-loop.md
+++ b/website/docs/developer-guide/agent-learning-loop.md
@@ -5,36 +5,38 @@ sidebar_label: "Agent Learning Loop"
 
 # Agent Learning Loop
 
-Hermes can save trajectories for training data and debugging. This page describes the missing next layer: how to curate those trajectories into reviewed learning artifacts without turning Hermes into an unsafe self-mutating runtime.
+Hermes can save trajectories for training data and debugging. This guide covers
+the next layer: curating those trajectories into reviewed learning artifacts
+without turning Hermes into an unsafe self-mutating runtime.
 
-Use this guide when building a sidecar, plugin, or external pipeline that reads Hermes trajectories and produces:
-
-- memory proposals
-- skill proposals
-- supervised fine-tuning (SFT) records
-- preference-tuning (DPO) records
-- evaluation reports
-
-The recommended posture is review-first: Hermes may generate evidence and proposals, but importing those proposals into live memory, skills, or configuration should remain an explicit reviewed step.
+A sidecar, plugin, or external pipeline can produce memory proposals, skill
+proposals, SFT records, DPO records, and evaluation reports. Importing a
+proposal into live memory, skills, or configuration remains an explicit,
+reviewed step.
 
 ## Why this is separate from core runtime
 
-A learning loop touches sensitive data: user messages, tool outputs, file paths, environment names, logs, and sometimes credentials accidentally printed by external tools. It can also change future agent behavior. For that reason, the first integration boundary should be a sidecar/export workflow, not automatic writes into `~/.hermes`.
+Learning loops touch user messages, tool output, file paths, logs, and sometimes
+credentials accidentally printed by external tools. They can also change future
+agent behavior. Start with a sidecar/export boundary, not automatic writes into
+the selected profile's `$HERMES_HOME` state.
 
-Keep these systems separate:
+Hermes resolves state through `HERMES_HOME`; the default home and each named or
+custom profile have separate state. Never assume a fixed home directory when
+reading from or importing into a live profile.
 
 | System | Responsibility |
 |---|---|
-| Hermes runtime | Execute the current task, persist sessions, save trajectories when enabled |
-| Learning sidecar | Read completed traces, score them, create proposals, export datasets |
-| Reviewer | Approve/reject memory and skill proposals |
-| Training stack | Fine-tune or preference-train models from curated datasets |
+| Hermes runtime | Execute tasks, persist sessions, save enabled trajectories |
+| Learning sidecar | Read traces, score them, create proposals, export datasets |
+| Reviewer | Approve or reject memory, skill, and dataset proposals |
+| Training stack | Train models from curated datasets |
 
 ## Recommended pipeline
 
 ```text
 Hermes trajectory JSONL
-  -> normalize / validate
+  -> normalize and validate
   -> evaluate
   -> distill proposals
   -> review queue
@@ -42,7 +44,7 @@ Hermes trajectory JSONL
   -> optional import or training
 ```
 
-A minimal local directory layout:
+Keep sidecar state project-local:
 
 ```text
 .agent-learning/
@@ -55,137 +57,54 @@ exports/
   dpo.jsonl
 ```
 
-The sidecar may live in a project directory, a plugin repo, or a separate package. It should not write directly to global Hermes state unless the user explicitly asks to import reviewed outputs.
+The sidecar should not write into `$HERMES_HOME` unless the user explicitly
+requests import of reviewed output into the selected profile.
 
 ## Inputs: Hermes trajectories
 
-Hermes trajectories are documented in [Trajectory Format](/developer-guide/trajectory-format). At minimum, each JSONL record includes:
-
-```json
-{
-  "conversations": [
-    {"from": "human", "value": "..."},
-    {"from": "gpt", "value": "..."},
-    {"from": "tool", "value": "..."}
-  ],
-  "timestamp": "2026-06-05T00:00:00",
-  "model": "provider/model",
-  "completed": true
-}
-```
-
-Batch trajectories may also include `tool_stats`, `tool_error_counts`, `metadata`, and `partial` fields. Preserve those fields as provenance; they are useful for filtering and evaluation.
+Hermes trajectories are documented in [Trajectory Format](/developer-guide/trajectory-format).
+Each JSONL record contains a conversation plus metadata such as timestamp,
+model, and completion state. Batch trajectories can also include `tool_stats`,
+`tool_error_counts`, `metadata`, and `partial`. Preserve these as provenance.
 
 ## Evaluation signals
 
-Start with deterministic checks before adding LLM judges.
+Start with deterministic checks before adding LLM judges. Positive evidence
+includes completed traces, final answers, passing tests, successful tool calls,
+and user confirmation. Negative evidence includes partial traces, unresolved
+errors, user corrections, unsupported success claims, and exposed secrets.
 
-Positive signals:
-
-- `completed` is true
-- final assistant answer exists
-- successful tool calls or test output are present
-- user confirmation exists in the trace
-- no unresolved tool errors remain
-
-Negative signals:
-
-- `completed` is false or `partial` is true
-- traceback, exception, failed command, or timeout without recovery
-- user corrections such as "wrong", "no", "actually", or "don't do that"
-- assistant claims success without tool evidence
-- tool output contains secrets or private data
-
-Example evaluation record:
+Store evidence with the score:
 
 ```json
 {
   "trace_id": "abc123",
   "score": 82,
   "tags": ["completed", "verified", "user-confirmed"],
-  "notes": ["Tests passed and final answer summarized real output."]
+  "notes": ["Tests passed and the final answer cited the output."]
 }
 ```
 
-## Distilling memory proposals
+## Distilling proposals
 
-Only propose memory for durable facts that are likely to be useful in future sessions.
+Memory proposals should capture durable facts: stable preferences, recurring
+project conventions, hard-to-rediscover environment details, and workflow
+constraints. Exclude temporary task progress, raw logs, credentials, commit
+IDs, and facts likely to go stale soon. Use declarative language so stored
+content cannot be confused with a system instruction.
 
-Good memory candidates:
+Skill proposals should describe a reusable procedure, including when to use it,
+the required sequence, known pitfalls, verification, and safety boundaries.
+Keep generated proposals in the review queue; do not write them directly into
+`$HERMES_HOME/skills` or repository skill directories.
 
-- stable user preferences
-- recurring project conventions
-- environment details that are hard to rediscover
-- workflow constraints that prevent repeated mistakes
+## Exporting datasets
 
-Do not propose memory for:
-
-- PR numbers, issue numbers, or commit SHAs
-- temporary task progress
-- raw logs or large transcripts
-- credentials, tokens, cookies, or API keys
-- facts likely to go stale within a week
-
-Memory proposal shape:
-
-```json
-{
-  "kind": "memory",
-  "title": "Verifier timing preference",
-  "content": "User prefers verifier subagents only at final pre-push/readiness gates.",
-  "reason": "User explicitly corrected verifier timing.",
-  "source_trace_id": "abc123",
-  "status": "pending"
-}
-```
-
-Use declarative language in memory content. Avoid imperative wording that may be re-read as a system instruction later.
-
-## Distilling skill proposals
-
-Create skill proposals when a trace contains a reusable procedure, especially if the agent overcame a non-obvious error.
-
-A useful skill proposal includes:
-
-- when to use it
-- exact commands or tool sequence
-- pitfalls encountered
-- verification steps
-- safety boundaries
-
-Skill proposal shape:
-
-```json
-{
-  "kind": "skill",
-  "title": "Safe trajectory curation workflow",
-  "content": "# Safe Trajectory Curation\n\n## When to use...",
-  "reason": "Trace contains reusable trace-evaluate-review-export workflow.",
-  "source_trace_id": "abc123",
-  "status": "pending"
-}
-```
-
-Do not write generated skill proposals directly into `skills/` or `optional-skills/`. Keep them in a review queue first.
-
-## Exporting SFT records
-
-SFT records should come from successful, high-quality traces. A simple export shape is:
+SFT records should come from verified, high-quality traces:
 
 ```json
 {"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
 ```
-
-Recommended filters:
-
-- include only completed traces by default
-- exclude traces with unresolved tool failures
-- exclude traces containing unredacted secrets or third-party private data
-- preserve metadata separately so bad records can be traced and removed later
-
-Do not train on failed traces as if they were success examples.
-
-## Exporting DPO records
 
 DPO records require a real preference contrast:
 
@@ -193,52 +112,37 @@ DPO records require a real preference contrast:
 {"prompt": "...", "chosen": "...", "rejected": "..."}
 ```
 
-Valid sources:
-
-- user rejected an earlier answer and accepted a corrected answer
-- a reviewer compared two candidate responses
-- an automated judge produced a clear chosen/rejected pair and the pair was reviewed
-
-Invalid sources:
-
-- invented rejected responses
-- traces where the chosen output was never verified
-- private messages or credentials used as preference examples
+Valid preference sources include a rejected answer and its accepted correction,
+or two candidates reviewed against the same rubric. Do not invent rejected
+responses or train on failed traces as if they were successful.
 
 ## Privacy and security checklist
 
-Before exporting or sharing learning artifacts:
+- [ ] No `.env`, API keys, tokens, cookies, SSH keys, or OAuth JSON included.
+- [ ] Tool output scanned for credential-like strings and sensitive PII.
+- [ ] Private third-party messages removed unless consent exists.
+- [ ] Irrelevant local file paths sanitized.
+- [ ] Failed traces labeled as failures.
+- [ ] Proposals remain pending until reviewed.
+- [ ] Approved exports retain provenance.
+- [ ] Generated sidecar and export directories are ignored by version control.
 
-- [ ] No `.env` files, API keys, tokens, cookies, SSH keys, or OAuth JSON are included
-- [ ] Tool outputs are scanned for credential-like strings
-- [ ] Private third-party messages are removed unless consent exists
-- [ ] Local file paths are sanitized when not relevant
-- [ ] Failed traces are labeled as failures, not success data
-- [ ] Memory and skill proposals remain pending until reviewed
-- [ ] Approved exports include source/provenance metadata
-- [ ] Generated `.agent-learning/` and `exports/` directories are gitignored
+## Importing approved artifacts
 
-## Importing approved artifacts back into Hermes
+Importing is separate from exporting:
 
-Importing is separate from exporting.
+1. Select the intended profile and resolve its `$HERMES_HOME`.
+2. Review the proposal for durability, secrets, and correct scope.
+3. Apply it through normal Hermes memory or skill mechanisms.
+4. Verify behavior in a new session.
+5. Preserve a rollback path.
 
-Safe import flow:
-
-1. Review the proposal content.
-2. Check that it is durable, non-secret, and scoped correctly.
-3. Apply through the normal Hermes memory or skill mechanisms.
-4. Verify the updated behavior in a new session.
-5. Keep a rollback path.
-
-Avoid background jobs that automatically ingest every session and mutate live Hermes state. A bad memory or skill can degrade future behavior across unrelated tasks.
+Avoid background jobs that mutate live Hermes state from every session. A bad
+memory or skill can degrade unrelated future work.
 
 ## Relationship to optional skills
 
-The optional `agent-learning-loop` skill packages this workflow for agents to follow during implementation work. This developer guide explains the same architecture from the maintainer/integrator perspective.
-
-The intended contribution path is incremental:
-
-1. document the review-first learning loop
-2. provide optional skill guidance
-3. build sidecar/plugin implementations outside core
-4. move stable, dependency-light interfaces into core only after real usage proves the shape
+The optional `agent-learning-loop` skill packages this architecture for agents
+performing implementation work. It intentionally ships no sidecar executable;
+the implementation belongs in a plugin or external project until real usage
+stabilizes the interface.

--- a/website/docs/developer-guide/agent-learning-loop.md
+++ b/website/docs/developer-guide/agent-learning-loop.md
@@ -1,0 +1,244 @@
+---
+title: "Agent Learning Loop"
+sidebar_label: "Agent Learning Loop"
+---
+
+# Agent Learning Loop
+
+Hermes can save trajectories for training data and debugging. This page describes the missing next layer: how to curate those trajectories into reviewed learning artifacts without turning Hermes into an unsafe self-mutating runtime.
+
+Use this guide when building a sidecar, plugin, or external pipeline that reads Hermes trajectories and produces:
+
+- memory proposals
+- skill proposals
+- supervised fine-tuning (SFT) records
+- preference-tuning (DPO) records
+- evaluation reports
+
+The recommended posture is review-first: Hermes may generate evidence and proposals, but importing those proposals into live memory, skills, or configuration should remain an explicit reviewed step.
+
+## Why this is separate from core runtime
+
+A learning loop touches sensitive data: user messages, tool outputs, file paths, environment names, logs, and sometimes credentials accidentally printed by external tools. It can also change future agent behavior. For that reason, the first integration boundary should be a sidecar/export workflow, not automatic writes into `~/.hermes`.
+
+Keep these systems separate:
+
+| System | Responsibility |
+|---|---|
+| Hermes runtime | Execute the current task, persist sessions, save trajectories when enabled |
+| Learning sidecar | Read completed traces, score them, create proposals, export datasets |
+| Reviewer | Approve/reject memory and skill proposals |
+| Training stack | Fine-tune or preference-train models from curated datasets |
+
+## Recommended pipeline
+
+```text
+Hermes trajectory JSONL
+  -> normalize / validate
+  -> evaluate
+  -> distill proposals
+  -> review queue
+  -> approved exports
+  -> optional import or training
+```
+
+A minimal local directory layout:
+
+```text
+.agent-learning/
+  learning.db
+  approved/
+    memory/*.md
+    skill/*.md
+exports/
+  sft.jsonl
+  dpo.jsonl
+```
+
+The sidecar may live in a project directory, a plugin repo, or a separate package. It should not write directly to global Hermes state unless the user explicitly asks to import reviewed outputs.
+
+## Inputs: Hermes trajectories
+
+Hermes trajectories are documented in [Trajectory Format](/developer-guide/trajectory-format). At minimum, each JSONL record includes:
+
+```json
+{
+  "conversations": [
+    {"from": "human", "value": "..."},
+    {"from": "gpt", "value": "..."},
+    {"from": "tool", "value": "..."}
+  ],
+  "timestamp": "2026-06-05T00:00:00",
+  "model": "provider/model",
+  "completed": true
+}
+```
+
+Batch trajectories may also include `tool_stats`, `tool_error_counts`, `metadata`, and `partial` fields. Preserve those fields as provenance; they are useful for filtering and evaluation.
+
+## Evaluation signals
+
+Start with deterministic checks before adding LLM judges.
+
+Positive signals:
+
+- `completed` is true
+- final assistant answer exists
+- successful tool calls or test output are present
+- user confirmation exists in the trace
+- no unresolved tool errors remain
+
+Negative signals:
+
+- `completed` is false or `partial` is true
+- traceback, exception, failed command, or timeout without recovery
+- user corrections such as "wrong", "no", "actually", or "don't do that"
+- assistant claims success without tool evidence
+- tool output contains secrets or private data
+
+Example evaluation record:
+
+```json
+{
+  "trace_id": "abc123",
+  "score": 82,
+  "tags": ["completed", "verified", "user-confirmed"],
+  "notes": ["Tests passed and final answer summarized real output."]
+}
+```
+
+## Distilling memory proposals
+
+Only propose memory for durable facts that are likely to be useful in future sessions.
+
+Good memory candidates:
+
+- stable user preferences
+- recurring project conventions
+- environment details that are hard to rediscover
+- workflow constraints that prevent repeated mistakes
+
+Do not propose memory for:
+
+- PR numbers, issue numbers, or commit SHAs
+- temporary task progress
+- raw logs or large transcripts
+- credentials, tokens, cookies, or API keys
+- facts likely to go stale within a week
+
+Memory proposal shape:
+
+```json
+{
+  "kind": "memory",
+  "title": "Verifier timing preference",
+  "content": "User prefers verifier subagents only at final pre-push/readiness gates.",
+  "reason": "User explicitly corrected verifier timing.",
+  "source_trace_id": "abc123",
+  "status": "pending"
+}
+```
+
+Use declarative language in memory content. Avoid imperative wording that may be re-read as a system instruction later.
+
+## Distilling skill proposals
+
+Create skill proposals when a trace contains a reusable procedure, especially if the agent overcame a non-obvious error.
+
+A useful skill proposal includes:
+
+- when to use it
+- exact commands or tool sequence
+- pitfalls encountered
+- verification steps
+- safety boundaries
+
+Skill proposal shape:
+
+```json
+{
+  "kind": "skill",
+  "title": "Safe trajectory curation workflow",
+  "content": "# Safe Trajectory Curation\n\n## When to use...",
+  "reason": "Trace contains reusable trace-evaluate-review-export workflow.",
+  "source_trace_id": "abc123",
+  "status": "pending"
+}
+```
+
+Do not write generated skill proposals directly into `skills/` or `optional-skills/`. Keep them in a review queue first.
+
+## Exporting SFT records
+
+SFT records should come from successful, high-quality traces. A simple export shape is:
+
+```json
+{"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+Recommended filters:
+
+- include only completed traces by default
+- exclude traces with unresolved tool failures
+- exclude traces containing unredacted secrets or third-party private data
+- preserve metadata separately so bad records can be traced and removed later
+
+Do not train on failed traces as if they were success examples.
+
+## Exporting DPO records
+
+DPO records require a real preference contrast:
+
+```json
+{"prompt": "...", "chosen": "...", "rejected": "..."}
+```
+
+Valid sources:
+
+- user rejected an earlier answer and accepted a corrected answer
+- a reviewer compared two candidate responses
+- an automated judge produced a clear chosen/rejected pair and the pair was reviewed
+
+Invalid sources:
+
+- invented rejected responses
+- traces where the chosen output was never verified
+- private messages or credentials used as preference examples
+
+## Privacy and security checklist
+
+Before exporting or sharing learning artifacts:
+
+- [ ] No `.env` files, API keys, tokens, cookies, SSH keys, or OAuth JSON are included
+- [ ] Tool outputs are scanned for credential-like strings
+- [ ] Private third-party messages are removed unless consent exists
+- [ ] Local file paths are sanitized when not relevant
+- [ ] Failed traces are labeled as failures, not success data
+- [ ] Memory and skill proposals remain pending until reviewed
+- [ ] Approved exports include source/provenance metadata
+- [ ] Generated `.agent-learning/` and `exports/` directories are gitignored
+
+## Importing approved artifacts back into Hermes
+
+Importing is separate from exporting.
+
+Safe import flow:
+
+1. Review the proposal content.
+2. Check that it is durable, non-secret, and scoped correctly.
+3. Apply through the normal Hermes memory or skill mechanisms.
+4. Verify the updated behavior in a new session.
+5. Keep a rollback path.
+
+Avoid background jobs that automatically ingest every session and mutate live Hermes state. A bad memory or skill can degrade future behavior across unrelated tasks.
+
+## Relationship to optional skills
+
+The optional `agent-learning-loop` skill packages this workflow for agents to follow during implementation work. This developer guide explains the same architecture from the maintainer/integrator perspective.
+
+The intended contribution path is incremental:
+
+1. document the review-first learning loop
+2. provide optional skill guidance
+3. build sidecar/plugin implementations outside core
+4. move stable, dependency-light interfaces into core only after real usage proves the shape

--- a/website/docs/developer-guide/trajectory-format.md
+++ b/website/docs/developer-guide/trajectory-format.md
@@ -2,6 +2,8 @@
 
 Hermes Agent saves conversation trajectories in ShareGPT-compatible JSONL format
 for use as training data, debugging artifacts, and reinforcement learning datasets.
+For the review-first workflow that turns these trajectories into memory/skill
+proposals and SFT/DPO exports, see [Agent Learning Loop](/developer-guide/agent-learning-loop).
 
 Source files: `agent/trajectory.py`, `run_agent.py` (search for `_save_trajectory`), `batch_runner.py`
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -103,3 +103,4 @@ See the [Messaging Gateway overview](/user-guide/messaging) for the platform com
 ## Training & Evaluation
 
 - **[Batch Processing](/user-guide/features/batch-processing)** — Run the agent across hundreds of prompts in parallel, generating structured ShareGPT-format trajectory data for training data generation or evaluation.
+- **[Agent Learning Loop](/developer-guide/agent-learning-loop)** — Curate Hermes trajectories into reviewed memory/skill proposals and SFT/DPO exports without automatic writes to live Hermes state.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -751,6 +751,7 @@ const sidebars: SidebarsConfig = {
             'developer-guide/acp-internals',
             'developer-guide/cron-internals',
             'developer-guide/trajectory-format',
+            'developer-guide/agent-learning-loop',
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- Add an official optional `agent-learning-loop` skill for review-first agent self-improvement workflows
- Document a SkillLoop-style sidecar architecture for trace ingestion, evaluation, proposal review, and SFT/DPO export
- Add a developer guide for safely curating Hermes trajectories into reviewed memory/skill proposals and training exports
- Link the new developer guide from trajectory-format docs, integrations overview, and the Developer Guide sidebar

## Why this belongs in Hermes
Hermes already saves ShareGPT-compatible trajectories, but the repo did not document the next safety-critical layer: how to turn those traces into learning artifacts without automatic mutation of live memory, skills, or config. This PR fills that gap as documentation + optional skill guidance instead of premature core runtime code.

## Safety boundaries
- No automatic writes to live Hermes memory, skills, or config
- No credential-bearing training data
- Failed traces are labeled as failures, not success data
- Memory/skill outputs are proposals until reviewed
- Sidecar/plugin implementation is recommended before stabilizing any core API

## Validation
- Validated `SKILL.md` frontmatter with Hermes skill validation helpers
- Ran `website/scripts/extract-skills.py` successfully and cleaned generated artifacts
- Validated new doc/sidebar links locally
- Ran static secret-pattern scan over the new optional skill and developer-guide content
