### PR TITLE
fix(state): compute message_count from messages table (#39734)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1758,6 +1758,7 @@ class SessionDB:
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
+                    (SELECT COUNT(*) FROM messages m3 WHERE m3.session_id = s.id) AS _computed_message_count,
                     COALESCE(
                         (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
                         s.started_at
@@ -1782,6 +1783,7 @@ class SessionDB:
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
+                    (SELECT COUNT(*) FROM messages m3 WHERE m3.session_id = s.id) AS _computed_message_count,
                     COALESCE(
                         (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
                         s.started_at
@@ -1800,6 +1802,12 @@ class SessionDB:
             s = dict(row)
             # Build the preview from the raw substring
             raw = s.pop("_preview_raw", "").strip()
+            # Override the denormalized message_count with the actual count
+            # from the messages table — the sessions.message_count column can
+            # lag behind (e.g. after a partial write, crash, or race).
+            computed = s.pop("_computed_message_count", None)
+            if computed is not None:
+                s["message_count"] = computed
             if raw:
                 text = raw[:60]
                 s["preview"] = text + ("..." if len(raw) > 60 else "")
@@ -1859,6 +1867,7 @@ class SessionDB:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
+                (SELECT COUNT(*) FROM messages m3 WHERE m3.session_id = s.id) AS _computed_message_count,
                 COALESCE(
                     (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
                     s.started_at
@@ -1873,6 +1882,9 @@ class SessionDB:
             return None
         s = dict(row)
         raw = s.pop("_preview_raw", "").strip()
+        computed = s.pop("_computed_message_count", None)
+        if computed is not None:
+            s["message_count"] = computed
         if raw:
             text = raw[:60]
             s["preview"] = text + ("..." if len(raw) > 60 else "")


### PR DESCRIPTION
Fixes #39734. The denormalized sessions.message_count column can lag behind the actual messages table after a partial write, crash, or race condition, causing session search/browse to report message_count=0 and empty preview for sessions that actually had persisted messages. This computes message_count via a correlated subquery on the messages table in list_sessions_rich and _get_session_rich_row, overriding the stale denormalized value.