### PR TITLE
Fix Codex app-server cwd in gateway sessions

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -47,7 +47,9 @@ def run_codex_app_server_turn(
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
     if not hasattr(agent, "_codex_session") or agent._codex_session is None:
-        cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
         # Approval callback: defer to Hermes' standard prompt flow if a
         # CLI thread has installed one. Gateway / cron contexts get the
         # codex-side fail-closed default.

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -130,6 +130,24 @@ class TestRunConversationCodexPath:
         )
         assert user_count == 1, f"user message appeared {user_count}× in {result['messages']}"
 
+    def test_codex_session_uses_terminal_cwd_in_gateway_context(
+        self, fake_session, monkeypatch, tmp_path
+    ):
+        """Gateway processes are anchored in HERMES_HOME, so Codex must use
+        TERMINAL_CWD rather than os.getcwd() when starting its thread."""
+        project_dir = tmp_path / "project"
+        gateway_home = tmp_path / "hermes-home"
+        project_dir.mkdir()
+        gateway_home.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(project_dir))
+        monkeypatch.chdir(gateway_home)
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("ping")
+
+        assert agent._codex_session._cwd == str(project_dir)
+
     def test_background_review_NOT_invoked_below_threshold(self, fake_session):
         """A single turn shouldn't trigger background review — counters
         haven't reached the nudge interval (default 10)."""


### PR DESCRIPTION
## What does this PR do?

Fixes Codex app-server sessions starting in the wrong working directory when Hermes gateway is launched outside the user project directory.

Previously, Codex runtime fell back to `os.getcwd()` when `agent.session_cwd` was not set. In gateway usage, that process cwd is often Hermes home, such as `~/.hermes`, not the configured project directory. This caused Codex to treat Hermes home as the working directory.

This PR routes the fallback through Hermes' shared cwd resolver, `resolve_agent_cwd()`, so Codex runtime now follows the same cwd precedence as the rest of the agent runtime:

1. session cwd override
2. `TERMINAL_CWD`
3. final fallback to `os.getcwd()`

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/codex_runtime.py` to use `resolve_agent_cwd()` instead of directly falling back to `os.getcwd()`.
- Added a regression test covering the gateway scenario where:
  - the gateway process cwd is Hermes home
  - `TERMINAL_CWD` points at the intended project directory
  - Codex session cwd correctly resolves to the project directory

## How to Test

1. Run the Codex app-server integration tests:

   ```bash
   pytest tests/run_agent/test_codex_app_server_integration.py -q
   ```

2. Run the runtime cwd resolver tests:

   ```bash
   pytest tests/agent/test_runtime_cwd.py -q
   ```

3. Confirm both test suites pass:
   - `tests/run_agent/test_codex_app_server_integration.py`: 16 passed
   - `tests/agent/test_runtime_cwd.py`: 15 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A