### PR TITLE
fix(cron): give completed cron sessions a human-readable title

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1933,6 +1933,29 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _VAR_MAP[_var_name].set("")
         if _session_db:
             try:
+                # Give the cron session a clean, human-readable title instead of
+                # leaving it NULL (the dashboard then falls back to rendering the
+                # raw cron prompt, e.g. "[IMPORTANT: You are ru...", as the title
+                # for every run). Format: "⏰ <job name> · <Mon DD YYYY>".
+                # Collisions (same job same day) and the 100-char cap are handled
+                # defensively; failures are non-fatal.
+                try:
+                    _title_date = _hermes_now().strftime("%b %d %Y")
+                    _base_title = f"\u23f0 {job_name} \u00b7 {_title_date}"
+                    _base_title = _base_title[:100]
+                    for _candidate in (
+                        _base_title,
+                        f"{_base_title[:92]} {_hermes_now().strftime('%H:%M')}",
+                        f"{_base_title[:89]} {_hermes_now().strftime('%H:%M:%S')}",
+                    ):
+                        try:
+                            if _session_db.set_session_title(_cron_session_id, _candidate):
+                                break
+                        except ValueError:
+                            # Title-in-use collision — try the next, more specific candidate.
+                            continue
+                except (Exception, KeyboardInterrupt) as e:
+                    logger.debug("Job '%s': failed to set session title: %s", job_id, e)
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)

--- a/tests/cron/test_cron_session_titles.py
+++ b/tests/cron/test_cron_session_titles.py
@@ -1,0 +1,86 @@
+"""Regression test for cron session titles.
+
+A finished cron run used to leave its session title NULL, so the desktop /
+dashboard fell back to rendering the raw cron prompt (e.g.
+"[IMPORTANT: You are ru...") as the title for every run. The scheduler now
+stamps a clean "⏰ <job name> · <Mon DD YYYY>" title on completion, retrying
+with a more specific (time-stamped) candidate when the same job completes
+twice in one day and hits the unique-title constraint.
+
+These tests exercise the title-generation + collision-retry contract directly
+against a real SessionDB, which is the integration point the scheduler relies
+on (set_session_title raising ValueError on a duplicate title).
+"""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    store = SessionDB(tmp_path / "sessions.db")
+    yield store
+    store.close()
+
+
+def _candidates(job_name: str, when: datetime.datetime):
+    """Mirror the scheduler's candidate ladder for a fixed timestamp."""
+    base = f"\u23f0 {job_name} \u00b7 {when.strftime('%b %d %Y')}"[:100]
+    return [
+        base,
+        f"{base[:92]} {when.strftime('%H:%M')}",
+        f"{base[:89]} {when.strftime('%H:%M:%S')}",
+    ]
+
+
+def _apply_title(db, session_id, candidates):
+    """Mirror the scheduler's set-with-retry loop; return the title that stuck."""
+    for candidate in candidates:
+        try:
+            if db.set_session_title(session_id, candidate):
+                return candidate
+        except ValueError:
+            continue
+    return None
+
+
+def test_cron_title_is_human_readable(db):
+    sid = db.create_session("cron-1", "cron")
+    when = datetime.datetime(2026, 6, 5, 9, 0, 0)
+
+    title = _apply_title(db, sid, _candidates("Daily Briefing", when))
+
+    assert title == "\u23f0 Daily Briefing \u00b7 Jun 05 2026"
+    assert db.get_session_title(sid) == title
+    # Never the raw-prompt fallback.
+    assert not title.startswith("[")
+
+
+def test_same_job_same_day_falls_back_to_timestamped_candidate(db):
+    when = datetime.datetime(2026, 6, 5, 9, 0, 0)
+    sid_a = db.create_session("cron-a", "cron")
+    sid_b = db.create_session("cron-b", "cron")
+
+    first = _apply_title(db, sid_a, _candidates("Daily Briefing", when))
+    second = _apply_title(db, sid_b, _candidates("Daily Briefing", when))
+
+    # Both got a title, and they differ (the second escalated to include HH:MM).
+    assert first and second
+    assert first != second
+    assert second.endswith("09:00")
+    assert db.get_session_title(sid_a) == first
+    assert db.get_session_title(sid_b) == second
+
+
+def test_long_job_name_is_capped_to_max_title_length(db):
+    sid = db.create_session("cron-long", "cron")
+    when = datetime.datetime(2026, 6, 5, 9, 0, 0)
+
+    title = _apply_title(db, sid, _candidates("X" * 300, when))
+
+    assert title is not None
+    assert len(title) <= SessionDB.MAX_TITLE_LENGTH


### PR DESCRIPTION
A finished cron run left its session title NULL, so the desktop and dashboard fell back to rendering the raw cron prompt (e.g. "[IMPORTANT: You are ru...") as the title for every scheduled run, which is noisy and leaks prompt internals into the session list.

On completion the scheduler now stamps a clean title: "⏰ <job name> · <Mon DD YYYY>". When the same job completes more than once in a day it would collide with the unique-title constraint, so it retries with progressively more specific candidates (append HH:MM, then HH:MM:SS). The base title is capped at MAX_TITLE_LENGTH (100), and the whole block is best-effort: any failure is logged at debug and never breaks job teardown (it runs just before end_session in the cleanup path).

Tests: tests/cron/test_cron_session_titles.py covers the happy path, the same-job-same-day collision fallback to a timestamped candidate, and the long-job-name length cap.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

