### PR TITLE
fix(agent): continue preflight compression when tokens decrease but message count is unchanged

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -656,12 +656,32 @@ def run_conversation(
             # context windows (each pass summarises the middle N turns).
             for _pass in range(3):
                 _orig_len = len(messages)
+                _orig_preflight_tokens = _preflight_tokens
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
+                # Check if compression actually reduced something.
+                # Message count reduction is the primary signal, but
+                # compression can also succeed by shrinking tool-result
+                # content without removing message rows — so re-estimate
+                # tokens and treat a material token reduction as success
+                # too (mirrors the context_overflow recovery path).
                 if len(messages) >= _orig_len:
-                    break  # Cannot compress further
+                    _preflight_tokens = estimate_request_tokens_rough(
+                        messages,
+                        system_prompt=active_system_prompt or "",
+                        tools=agent.tools or None,
+                    )
+                    if _preflight_tokens >= _orig_preflight_tokens:
+                        break  # Cannot compress further
+                    logger.info(
+                        "%sPreflight compression: message count unchanged (%d) "
+                        "but tokens reduced ~%s → ~%s — continuing",
+                        agent.log_prefix, len(messages),
+                        f"{_orig_preflight_tokens:,}",
+                        f"{_preflight_tokens:,}",
+                    )
                 # Compression created a new session — clear the history
                 # reference so _flush_messages_to_session_db writes ALL
                 # compressed messages to the new session's SQLite, not

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -744,6 +744,72 @@ class TestPreflightCompression:
         # Smaller estimate must not overwrite the larger tracked value.
         assert agent.context_compressor.last_prompt_tokens == 160_000
 
+    def test_preflight_continues_when_tokens_decrease_but_message_count_unchanged(self, agent):
+        """Compression that reduces tokens without removing messages must continue.
+
+        Regression for #39550 — the preflight loop used to break when
+        ``len(messages) >= _orig_len`` even if compression materially reduced
+        the estimated token count (e.g. shrinking tool-result content).
+        This caused a false ``Context length exceeded`` error and auto-reset.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 1_000_000
+        agent.context_compressor.threshold_tokens = 50_000
+
+        # Build a large history that exceeds the threshold.
+        big_history = []
+        for i in range(30):
+            big_history.append({"role": "user", "content": f"Message {i} with padding" * 10})
+            big_history.append({"role": "assistant", "content": f"Response {i} with padding" * 10})
+
+        ok_resp = _mock_response(content="After compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        compress_call_count = 0
+        estimate_call_count = 0
+
+        def _compress_shrink_tokens(msgs, *args, **kwargs):
+            """Simulate compression that keeps message count but shrinks content."""
+            nonlocal compress_call_count
+            compress_call_count += 1
+            shrunk = [{"role": m["role"], "content": m["content"][:20]} for m in msgs]
+            return shrunk, agent._cached_system_prompt
+
+        def _mock_estimate(msgs, **kwargs):
+            nonlocal estimate_call_count
+            estimate_call_count += 1
+            if estimate_call_count == 1:
+                # Initial preflight estimate — above threshold
+                return 200_000
+            elif estimate_call_count in (2, 3):
+                # After pass 1: tokens reduced but still above threshold.
+                # Call 2 is from the unchanged-message-count path,
+                # call 3 is from the shared should_compress re-check.
+                # Old code would have broken at call 2 (same message count).
+                # New code sees tokens decreased and continues.
+                return 70_000
+            else:
+                # After pass 2: now below threshold — loop exits naturally.
+                return 30_000
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_mock_estimate),
+            patch.object(agent, "_compress_context", side_effect=_compress_shrink_tokens),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        # Compression must have run at least twice — old code would break
+        # after pass 1 (same message count), new code continues.
+        assert compress_call_count >= 2, (
+            f"Expected >= 2 compression passes (tokens shrink, count unchanged), "
+            f"got {compress_call_count} — old code would have broken after pass 1"
+        )
+        assert result["completed"] is True
+        assert result["final_response"] == "After compression"
+
 
 class TestToolResultPreflightCompression:
     """Compression should trigger when tool results push context past the threshold."""


### PR DESCRIPTION
## Problem

Preflight compression uses `len(messages) >= _orig_len` as the sole stop condition in the multi-pass loop. When compression successfully reduces token usage (e.g. by shrinking tool-result content) without removing message rows, the loop breaks early and reports a false `Context length exceeded` error, causing the gateway to auto-reset a perfectly viable session.

This is the exact scenario reported in #39550: compression saved ~105K tokens (36%) but the 220 message count was unchanged, so the session was auto-reset despite being well within the 1M context window.

## Root Cause

`agent/conversation_loop.py` line 663:
```python
if len(messages) >= _orig_len:
    break  # Cannot compress further
```

This only checks message count. The context_overflow path (~line 3100) already has the correct dual check:
```python
if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
```

## Fix

Re-estimate tokens after compression using `estimate_request_tokens_rough()` when message count is unchanged. Continue the compression loop if tokens decreased materially, and log the reduction. This mirrors the existing context_overflow logic.

## Test

Added `test_preflight_continues_when_tokens_decrease_but_message_count_unchanged` — simulates compression that shrinks content without removing message rows, verifying the loop continues and the session completes successfully.

Closes #39550