### PR TITLE
fix(update): run hermes update inside managed virtualenv

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7929,7 +7929,7 @@ def _recover_core_update_marker_locked() -> None:
 
         uv_bin = ensure_uv()
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_update_target_venv_dir())}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
@@ -8012,7 +8012,7 @@ def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     except Exception:
         uv_bin = None
     if uv_bin:
-        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        env = {**os.environ, "VIRTUAL_ENV": str(_update_target_venv_dir())}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)
             env.pop("PYTHONHOME", None)
@@ -8059,13 +8059,167 @@ def _run_install_with_heartbeat(
         t.join(timeout=0.2)
 
 
+_UPDATE_VENV_REEXEC_ENV = "HERMES_UPDATE_VENV_REEXEC"
+
+
 def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _venv_python_path(venv_dir: Path) -> Path:
+    """Return the platform-specific Python executable path for a venv."""
+    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+    return scripts / ("python.exe" if _is_windows() else "python")
+
+
+def _python_belongs_to_venv(python_executable: str | Path, venv_dir: Path) -> bool:
+    """Return True when ``python_executable`` is inside ``venv_dir``.
+
+    Check the lexical path before resolving it because POSIX venv Python
+    executables commonly symlink to the system interpreter.
+    """
+    try:
+        Path(python_executable).expanduser().absolute().relative_to(
+            venv_dir.expanduser().absolute()
+        )
+        return True
+    except (OSError, ValueError):
+        pass
+
+    try:
+        Path(python_executable).resolve().relative_to(venv_dir.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _candidate_update_venvs(project_root: Path = PROJECT_ROOT) -> list[Path]:
+    """Return candidate Hermes-managed venvs in project-preferred order."""
+    candidates = [project_root / ".venv", project_root / "venv"]
+    try:
+        if (
+            project_root.resolve() == PROJECT_ROOT.resolve()
+            and (project_root / ".git").is_dir()
+        ):
+            from hermes_constants import get_hermes_home
+
+            hermes_home = get_hermes_home()
+            candidates.extend(
+                [
+                    hermes_home / "hermes-agent" / ".venv",
+                    hermes_home / "hermes-agent" / "venv",
+                ]
+            )
+    except Exception:
+        pass
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            key = candidate.expanduser().resolve()
+        except OSError:
+            key = candidate.expanduser().absolute()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate)
+    return unique
+
+
+def _select_update_venv(project_root: Path = PROJECT_ROOT) -> tuple[Path, Path] | None:
+    """Find the venv Python that should drive ``hermes update``."""
+    candidates: list[tuple[Path, Path]] = []
+    for venv_dir in _candidate_update_venvs(project_root):
+        python = _venv_python_path(venv_dir)
+        if python.is_file():
+            candidates.append((venv_dir, python))
+
+    # Keep the active managed venv even when a co-located .venv exists.
+    for venv_dir, python in candidates:
+        if _python_belongs_to_venv(sys.executable, venv_dir):
+            return venv_dir, python
+
+    return candidates[0] if candidates else None
+
+
+def _update_target_venv_dir(project_root: Path = PROJECT_ROOT) -> Path:
+    """Return the venv directory update subprocesses should mutate."""
+    selected = _select_update_venv(project_root)
+    if selected is not None:
+        return selected[0]
+    return project_root / "venv"
+
+
+def _venv_python_can_import_hermes_cli(venv_python: Path) -> bool:
+    """Return True when ``venv_python`` can import Hermes outside the CWD."""
+    probe_env = {**os.environ}
+    probe_env.pop("PYTHONPATH", None)
+    try:
+        result = subprocess.run(
+            [str(venv_python), "-P", "-c", "import hermes_cli.main"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=probe_env,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _maybe_reexec_update_in_managed_venv(args) -> bool:
+    """Re-exec ``hermes update`` inside the selected managed venv."""
+    if getattr(args, "check", False):
+        return False
+
+    selected = _select_update_venv(PROJECT_ROOT)
+    if selected is None:
+        return False
+
+    venv_dir, venv_python = selected
+    if _python_belongs_to_venv(sys.executable, venv_dir):
+        return False
+
+    if os.environ.get(_UPDATE_VENV_REEXEC_ENV):
+        print(
+            "✗ Hermes update re-exec was requested, but this process is "
+            "still not running inside the expected virtual environment."
+        )
+        print(f"  Expected venv: {venv_dir}")
+        print(f"  Current Python: {sys.executable}")
+        print("  Run `hermes doctor` or reinstall Hermes.")
+        sys.exit(1)
+
+    if not _venv_python_can_import_hermes_cli(venv_python):
+        print(
+            "⚠ Skipping Hermes update venv re-exec because the selected "
+            "virtual environment cannot import hermes_cli."
+        )
+        print(f"  Selected venv: {venv_dir}")
+        print("  Continuing with the current Python process.")
+        return False
+
+    scripts_dir = venv_dir / ("Scripts" if _is_windows() else "bin")
+    env = {**os.environ, _UPDATE_VENV_REEXEC_ENV: "1", "VIRTUAL_ENV": str(venv_dir)}
+    env.pop("PYTHONPATH", None)
+    env["PATH"] = f"{scripts_dir}{os.pathsep}{env.get('PATH', '')}"
+    cmd = [str(venv_python), "-P", "-m", "hermes_cli.main", *sys.argv[1:]]
+    print(f"Re-running update inside Hermes virtual environment: {venv_dir}")
+    if _is_windows():
+        try:
+            result = subprocess.run(cmd, env=env, check=False)
+        except OSError as exc:
+            print(f"✗ Failed to re-run update inside Hermes virtual environment: {exc}")
+            sys.exit(1)
+        sys.exit(result.returncode)
+    os.execvpe(str(venv_python), cmd, env)
+
+
 def _venv_scripts_dir() -> Path | None:
-    """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+    """Return the active update venv's Scripts/bin directory when present."""
+    venv_dir = _update_target_venv_dir(PROJECT_ROOT)
     if not venv_dir.is_dir():
         return None
     from hermes_constants import venv_bin_dir
@@ -9184,6 +9338,9 @@ def cmd_update(args):
             branch_explicit=bool(getattr(args, "branch", None)),
         )
         return
+
+    if install_method == "git":
+        _maybe_reexec_update_in_managed_venv(args)
 
     gateway_mode = getattr(args, "gateway", False)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8068,7 +8068,9 @@ def _is_windows() -> bool:
 
 def _venv_python_path(venv_dir: Path) -> Path:
     """Return the platform-specific Python executable path for a venv."""
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+    from hermes_constants import venv_bin_dir
+
+    scripts = venv_bin_dir(venv_dir, windows=_is_windows())
     return scripts / ("python.exe" if _is_windows() else "python")
 
 
@@ -8128,7 +8130,15 @@ def _candidate_update_venvs(project_root: Path = PROJECT_ROOT) -> list[Path]:
 
 
 def _select_update_venv(project_root: Path = PROJECT_ROOT) -> tuple[Path, Path] | None:
-    """Find the venv Python that should drive ``hermes update``."""
+    """Find the venv Python that should drive ``hermes update``.
+
+    Keep the active candidate when Hermes is already running from one. This
+    avoids switching an update from a managed ``venv`` into a co-located
+    development ``.venv``. Otherwise, use the stable project-preferred order:
+    ``.venv``, then ``venv``. Profile-aware ``$HERMES_HOME/hermes-agent``
+    candidates are included only for git checkouts, as a fallback for
+    worktrees that share the main install's environment.
+    """
     candidates: list[tuple[Path, Path]] = []
     for venv_dir in _candidate_update_venvs(project_root):
         python = _venv_python_path(venv_dir)
@@ -8201,7 +8211,9 @@ def _maybe_reexec_update_in_managed_venv(args) -> bool:
         print("  Continuing with the current Python process.")
         return False
 
-    scripts_dir = venv_dir / ("Scripts" if _is_windows() else "bin")
+    from hermes_constants import venv_bin_dir
+
+    scripts_dir = venv_bin_dir(venv_dir, windows=_is_windows())
     env = {**os.environ, _UPDATE_VENV_REEXEC_ENV: "1", "VIRTUAL_ENV": str(venv_dir)}
     env.pop("PYTHONPATH", None)
     env["PATH"] = f"{scripts_dir}{os.pathsep}{env.get('PATH', '')}"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -907,7 +907,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_m()._update_target_venv_dir())}
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -2793,7 +2793,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = _m()._update_target_venv_dir()
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
@@ -2871,7 +2871,7 @@ def _detect_venv_python_processes(
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = _m()._update_target_venv_dir()
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -2996,7 +2996,7 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = _m()._update_target_venv_dir()
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -4138,7 +4138,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # recreated before dependencies can be installed into it.
                 venv_python_missing = not (
                     venv_python_path(
-                        _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
+                        _m()._update_target_venv_dir(), windows=_m()._is_windows()
                     )
                 ).exists()
                 if venv_python_missing and repair_uv:
@@ -4149,7 +4149,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         check=False,
                     )
                 if repair_uv:
-                    repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+                    repair_env = {
+                        **os.environ,
+                        "VIRTUAL_ENV": str(_m()._update_target_venv_dir()),
+                    }
                     _m()._install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )
@@ -4335,7 +4338,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m()._update_target_venv_dir())}
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -71,6 +71,25 @@ def _patch_managed_uv(request):
         yield
 
 
+@pytest.fixture(autouse=True)
+def _skip_update_venv_reexec():
+    """Keep existing cmd_update tests focused on update behavior, not exec()."""
+    with patch("hermes_cli.main._maybe_reexec_update_in_managed_venv", return_value=False):
+        yield
+
+
+def test_cmd_update_does_not_reexec_for_non_git_installs(mock_args):
+    from hermes_cli import main as hm
+
+    with patch("hermes_cli.config.detect_install_method", return_value="pip"), patch.object(
+        hm, "_maybe_reexec_update_in_managed_venv"
+    ) as maybe_reexec, patch.object(hm, "_cmd_update_impl") as update_impl:
+        cmd_update(mock_args)
+
+    maybe_reexec.assert_not_called()
+    update_impl.assert_called_once_with(mock_args, gateway_mode=False)
+
+
 class TestCmdUpdateNpmLockfileCache:
     @staticmethod
     def _cache_file(hermes_root, project_root):

--- a/tests/hermes_cli/test_update_venv_reexec.py
+++ b/tests/hermes_cli/test_update_venv_reexec.py
@@ -1,0 +1,291 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+def _make_venv(root: Path, name: str = "venv") -> tuple[Path, Path]:
+    venv = root / name
+    scripts = venv / ("Scripts" if sys.platform == "win32" else "bin")
+    scripts.mkdir(parents=True)
+    python = scripts / ("python.exe" if sys.platform == "win32" else "python")
+    python.write_text("", encoding="utf-8")
+    return venv, python
+
+
+def test_select_update_venv_prefers_dotvenv(tmp_path):
+    dotvenv, dotvenv_python = _make_venv(tmp_path, ".venv")
+    _make_venv(tmp_path, "venv")
+
+    selected = cli_main._select_update_venv(tmp_path)
+
+    assert selected == (dotvenv, dotvenv_python)
+
+
+def test_select_update_venv_uses_venv_when_dotvenv_missing(tmp_path):
+    venv, python = _make_venv(tmp_path, "venv")
+
+    selected = cli_main._select_update_venv(tmp_path)
+
+    assert selected == (venv, python)
+
+
+def test_update_target_venv_follows_dotvenv_preference(tmp_path):
+    dotvenv, python = _make_venv(tmp_path, ".venv")
+    _make_venv(tmp_path, "venv")
+
+    with patch.object(sys, "executable", str(python)):
+        assert cli_main._update_target_venv_dir(tmp_path) == dotvenv
+
+
+def test_venv_scripts_dir_uses_selected_dotvenv_on_windows(tmp_path):
+    dotvenv = tmp_path / ".venv"
+    scripts = dotvenv / "Scripts"
+    scripts.mkdir(parents=True)
+    python = scripts / "python.exe"
+    python.write_text("", encoding="utf-8")
+    _make_venv(tmp_path, "venv")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ), patch.object(sys, "executable", str(python)):
+        assert cli_main._venv_scripts_dir() == scripts
+
+
+def test_select_update_venv_returns_none_without_usable_python(tmp_path):
+    (tmp_path / "venv" / "bin").mkdir(parents=True)
+
+    assert cli_main._select_update_venv(tmp_path) is None
+
+
+def test_candidate_venvs_skip_hermes_home_fallback_for_non_git_project(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    fallback_venv, _fallback_python = _make_venv(hermes_home / "hermes-agent", "venv")
+    project_root = tmp_path / "site-packages" / "hermes-agent"
+    project_root.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch.object(cli_main, "PROJECT_ROOT", project_root):
+        candidates = cli_main._candidate_update_venvs(project_root)
+
+    assert fallback_venv not in candidates
+
+
+def test_python_belongs_to_expected_venv(tmp_path):
+    venv, python = _make_venv(tmp_path, "venv")
+    other_python = tmp_path / "outside" / "python"
+    other_python.parent.mkdir()
+    other_python.write_text("", encoding="utf-8")
+
+    assert cli_main._python_belongs_to_venv(python, venv)
+    assert not cli_main._python_belongs_to_venv(other_python, venv)
+
+
+def test_python_belongs_to_venv_does_not_follow_posix_symlink_out(tmp_path):
+    venv = tmp_path / "venv"
+    scripts = venv / "bin"
+    scripts.mkdir(parents=True)
+    real_python = tmp_path / "system" / "python"
+    real_python.parent.mkdir()
+    real_python.write_text("", encoding="utf-8")
+    symlinked_python = scripts / "python"
+    try:
+        symlinked_python.symlink_to(real_python)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not available on this filesystem")
+
+    assert symlinked_python.resolve() == real_python
+    assert cli_main._python_belongs_to_venv(symlinked_python, venv)
+
+
+def test_maybe_reexec_skips_when_already_in_expected_venv(tmp_path):
+    venv, python = _make_venv(tmp_path, "venv")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        sys, "executable", str(python)
+    ), patch.object(os, "execvpe") as execvpe:
+        assert cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False)) is False
+
+    execvpe.assert_not_called()
+
+
+def test_venv_python_can_import_hermes_cli_uses_safe_env(tmp_path, monkeypatch):
+    _venv, python = _make_venv(tmp_path, "venv")
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "shadow"))
+
+    with patch.object(
+        cli_main.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess([], 0),
+    ) as run:
+        assert cli_main._venv_python_can_import_hermes_cli(python) is True
+
+    assert run.call_args.args[0] == [
+        str(python),
+        "-P",
+        "-c",
+        "import hermes_cli.main",
+    ]
+    assert "PYTHONPATH" not in run.call_args.kwargs["env"]
+
+
+def test_venv_python_can_import_hermes_cli_returns_false_on_probe_error(tmp_path):
+    _venv, python = _make_venv(tmp_path, "venv")
+
+    with patch.object(cli_main.subprocess, "run", side_effect=OSError("nope")):
+        assert cli_main._venv_python_can_import_hermes_cli(python) is False
+
+
+def test_maybe_reexec_uses_expected_venv_python(tmp_path, monkeypatch, capsys):
+    venv, python = _make_venv(tmp_path, "venv")
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
+    monkeypatch.delenv(cli_main._UPDATE_VENV_REEXEC_ENV, raising=False)
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "shadow"))
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        sys, "executable", str(system_python)
+    ), patch.object(sys, "argv", ["hermes", "update", "--yes", "--branch", "main"]), patch.object(
+        cli_main, "_venv_python_can_import_hermes_cli", return_value=True
+    ), patch.object(os, "execvpe") as execvpe:
+        execvpe.side_effect = RuntimeError("stop exec")
+        with pytest.raises(RuntimeError, match="stop exec"):
+            cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False))
+
+    exe, cmd, env = execvpe.call_args.args
+    assert exe == str(python)
+    assert cmd == [
+        str(python),
+        "-P",
+        "-m",
+        "hermes_cli.main",
+        "update",
+        "--yes",
+        "--branch",
+        "main",
+    ]
+    assert env[cli_main._UPDATE_VENV_REEXEC_ENV] == "1"
+    assert env["VIRTUAL_ENV"] == str(venv)
+    assert "PYTHONPATH" not in env
+    scripts_name = "Scripts" if cli_main._is_windows() else "bin"
+    assert env["PATH"].split(os.pathsep)[0] == str(venv / scripts_name)
+    assert str(venv) in capsys.readouterr().out
+
+
+def test_maybe_reexec_skips_venv_that_cannot_import_hermes_cli(
+    tmp_path, monkeypatch, capsys
+):
+    _venv, _python = _make_venv(tmp_path, "venv")
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
+    monkeypatch.delenv(cli_main._UPDATE_VENV_REEXEC_ENV, raising=False)
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        sys, "executable", str(system_python)
+    ), patch.object(
+        cli_main, "_venv_python_can_import_hermes_cli", return_value=False
+    ) as can_import, patch.object(os, "execvpe") as execvpe:
+        assert cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False)) is False
+
+    can_import.assert_called_once()
+    execvpe.assert_not_called()
+    assert "cannot import hermes_cli" in capsys.readouterr().out
+
+
+def test_maybe_reexec_on_windows_waits_for_child_and_exits(tmp_path, monkeypatch):
+    venv = tmp_path / "venv"
+    scripts = venv / "Scripts"
+    scripts.mkdir(parents=True)
+    python = scripts / "python.exe"
+    python.write_text("", encoding="utf-8")
+    system_python = tmp_path / "system" / "python.exe"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
+    monkeypatch.delenv(cli_main._UPDATE_VENV_REEXEC_ENV, raising=False)
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "shadow"))
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ), patch.object(sys, "executable", str(system_python)), patch.object(
+        sys, "argv", ["hermes", "update", "--yes"]
+    ), patch.object(
+        cli_main, "_venv_python_can_import_hermes_cli", return_value=True
+    ), patch.object(
+        cli_main.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess([], 7),
+    ) as run, patch.object(os, "execvpe") as execvpe:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False))
+
+    assert excinfo.value.code == 7
+    execvpe.assert_not_called()
+    cmd = run.call_args.args[0]
+    env = run.call_args.kwargs["env"]
+    assert cmd == [str(python), "-P", "-m", "hermes_cli.main", "update", "--yes"]
+    assert env["VIRTUAL_ENV"] == str(venv)
+    assert "PYTHONPATH" not in env
+    assert env["PATH"].split(os.pathsep)[0] == str(scripts)
+
+
+def test_maybe_reexec_on_windows_reports_launch_failure(tmp_path, monkeypatch, capsys):
+    venv = tmp_path / "venv"
+    scripts = venv / "Scripts"
+    scripts.mkdir(parents=True)
+    python = scripts / "python.exe"
+    python.write_text("", encoding="utf-8")
+    system_python = tmp_path / "system" / "python.exe"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
+    monkeypatch.delenv(cli_main._UPDATE_VENV_REEXEC_ENV, raising=False)
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ), patch.object(sys, "executable", str(system_python)), patch.object(
+        sys, "argv", ["hermes", "update"]
+    ), patch.object(
+        cli_main, "_venv_python_can_import_hermes_cli", return_value=True
+    ), patch.object(
+        cli_main.subprocess, "run", side_effect=OSError("boom")
+    ), patch.object(os, "execvpe") as execvpe:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False))
+
+    assert excinfo.value.code == 1
+    execvpe.assert_not_called()
+    assert "Failed to re-run update" in capsys.readouterr().out
+
+
+def test_maybe_reexec_guard_fails_instead_of_looping(tmp_path, monkeypatch, capsys):
+    _venv, _python = _make_venv(tmp_path, "venv")
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
+    monkeypatch.setenv(cli_main._UPDATE_VENV_REEXEC_ENV, "1")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        sys, "executable", str(system_python)
+    ), patch.object(os, "execvpe") as execvpe:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False))
+
+    assert excinfo.value.code == 1
+    execvpe.assert_not_called()
+    assert "still not running inside" in capsys.readouterr().out
+
+
+def test_maybe_reexec_skips_update_check(tmp_path):
+    _make_venv(tmp_path, "venv")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(os, "execvpe") as execvpe:
+        assert cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=True)) is False
+
+    execvpe.assert_not_called()

--- a/tests/hermes_cli/test_update_venv_reexec.py
+++ b/tests/hermes_cli/test_update_venv_reexec.py
@@ -19,13 +19,27 @@ def _make_venv(root: Path, name: str = "venv") -> tuple[Path, Path]:
     return venv, python
 
 
-def test_select_update_venv_prefers_dotvenv(tmp_path):
+def test_select_update_venv_prefers_dotvenv_when_current_python_is_external(tmp_path):
     dotvenv, dotvenv_python = _make_venv(tmp_path, ".venv")
     _make_venv(tmp_path, "venv")
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir()
+    system_python.write_text("", encoding="utf-8")
 
-    selected = cli_main._select_update_venv(tmp_path)
+    with patch.object(sys, "executable", str(system_python)):
+        selected = cli_main._select_update_venv(tmp_path)
 
     assert selected == (dotvenv, dotvenv_python)
+
+
+def test_select_update_venv_prefers_active_candidate_over_dotvenv(tmp_path):
+    _make_venv(tmp_path, ".venv")
+    venv, venv_python = _make_venv(tmp_path, "venv")
+
+    with patch.object(sys, "executable", str(venv_python)):
+        selected = cli_main._select_update_venv(tmp_path)
+
+    assert selected == (venv, venv_python)
 
 
 def test_select_update_venv_uses_venv_when_dotvenv_missing(tmp_path):
@@ -106,6 +120,18 @@ def test_python_belongs_to_venv_does_not_follow_posix_symlink_out(tmp_path):
 
 def test_maybe_reexec_skips_when_already_in_expected_venv(tmp_path):
     venv, python = _make_venv(tmp_path, "venv")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        sys, "executable", str(python)
+    ), patch.object(os, "execvpe") as execvpe:
+        assert cli_main._maybe_reexec_update_in_managed_venv(SimpleNamespace(check=False)) is False
+
+    execvpe.assert_not_called()
+
+
+def test_maybe_reexec_skips_when_active_venv_is_not_first_candidate(tmp_path):
+    _make_venv(tmp_path, ".venv")
+    _venv, python = _make_venv(tmp_path, "venv")
 
     with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
         sys, "executable", str(python)


### PR DESCRIPTION
## Summary

- re-execute `hermes update` inside a valid Hermes-managed virtual environment before update work begins
- prefer the currently active valid environment when both `venv` and `.venv` exist, avoiding an update of the wrong installation
- retain project and profile-aware fallback discovery for managed shared-venv worktrees
- cover POSIX and Windows interpreter selection, recursion protection, and safe re-exec behavior

## Scope

This is intentionally limited to `hermes update`; it does not redesign other entrypoints, gateway service generation, installers, or global environment management.

## Validation

- rebased onto `4281151ae859241351ba14d8c7682dc67ff4c126` on 2026-07-11; current head: `afbfc687f92cd4c8fda12970b0dcd697c0f78556`
- `.venv/bin/python -m pytest -q tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_venv_reexec.py` - 47 passed
- `.venv/bin/ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_venv_reexec.py` and `git diff --check upstream/main...HEAD` passed