### PR TITLE
fix: harden tool output handling

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1131,7 +1131,7 @@ def handle_function_call(
                     error_message=error_message,
                 )
                 for hook_result in hook_results:
-                    if isinstance(hook_result, str):
+                    if isinstance(hook_result, str) and hook_result:
                         result = hook_result
                         break
         except Exception as _hook_err:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -97,6 +97,25 @@ class TestHandleFunctionCall:
             ),
         ]
 
+    def test_empty_transform_hook_result_does_not_blank_tool_output(self):
+        """Empty-string transform hooks should be treated as no-op.
+
+        A plugin hook may accidentally return "" while observing a tool call;
+        that must not replace non-empty tool output with a blank result.
+        """
+        def fake_invoke_hook(hook_name, **kwargs):
+            if hook_name == "transform_tool_result":
+                return [""]
+            return []
+
+        with (
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
+            patch("hermes_cli.plugins.invoke_hook", fake_invoke_hook),
+        ):
+            result = handle_function_call("web_search", {"q": "test"}, task_id="t1")
+
+        assert result == '{"ok":true}'
+
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):
         """Regression: post_tool_call and transform_tool_result hooks must
         receive a non-negative integer ``duration_ms`` kwarg measuring

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -77,6 +77,14 @@ def test_result_ignores_non_string_hook_returns(monkeypatch):
     assert out == '{"output": "original"}'
 
 
+def test_result_ignores_empty_string_hook_return(monkeypatch):
+    out = _run_handle_function_call(
+        monkeypatch,
+        invoke_hook=lambda hook_name, **kw: ["", None],
+    )
+    assert out == '{"output": "original"}'
+
+
 def test_first_valid_string_return_replaces_result(monkeypatch):
     out = _run_handle_function_call(
         monkeypatch,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3736,6 +3736,118 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
     server._sessions.pop(sid, None)
 
 
+
+
+def test_slash_worker_replaces_previous_worker_for_same_session_key(monkeypatch):
+    """Creating a replacement slash worker must close the abandoned prior one.
+
+    TUI resume/new churn can build more than one in-memory session object for
+    the same persisted session key. Without this guard each object owns a
+    persistent slash_worker subprocess and stale workers accumulate.
+    """
+    import io
+
+    procs = []
+
+    class _FakeProc:
+        def __init__(self, *args, **kwargs):
+            self.stdin = io.StringIO()
+            self.stdout = io.StringIO()
+            self.stderr = io.StringIO()
+            self._returncode = None
+            self.terminated = False
+            self.killed = False
+            procs.append(self)
+
+        def poll(self):
+            return self._returncode
+
+        def terminate(self):
+            self.terminated = True
+            self._returncode = -15
+
+        def wait(self, timeout=None):
+            return self._returncode
+
+        def kill(self):
+            self.killed = True
+            self._returncode = -9
+
+    monkeypatch.setattr(server.subprocess, "Popen", _FakeProc)
+    monkeypatch.setattr(server, "_slash_workers_by_key", {})
+
+    first = server._SlashWorker("same-session", "gpt-5.5")
+    second = server._SlashWorker("same-session", "gpt-5.5")
+
+    try:
+        assert procs[0].stdin.closed is True
+        assert procs[0].terminated is True
+        assert first._closed is True
+        assert second._closed is False
+        assert server._slash_workers_by_key["same-session"] == [second]
+
+        second.close()
+        second.close()
+        assert procs[1].stdin.closed is True
+        assert procs[1].terminated is True
+        assert second._closed is True
+        assert "same-session" not in server._slash_workers_by_key
+    finally:
+        second.close()
+
+
+
+def test_slash_worker_cleans_up_subprocess_when_startup_fails(monkeypatch):
+    """If worker startup fails after Popen, the child process must not leak."""
+    import io
+
+    import pytest
+
+    procs = []
+
+    class _FakeProc:
+        def __init__(self, *args, **kwargs):
+            self.stdin = io.StringIO()
+            self.stdout = io.StringIO()
+            self.stderr = io.StringIO()
+            self._returncode = None
+            self.terminated = False
+            self.killed = False
+            procs.append(self)
+
+        def poll(self):
+            return self._returncode
+
+        def terminate(self):
+            self.terminated = True
+            self._returncode = -15
+
+        def wait(self, timeout=None):
+            return self._returncode
+
+        def kill(self):
+            self.killed = True
+            self._returncode = -9
+
+    class _BrokenThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(server.subprocess, "Popen", _FakeProc)
+    monkeypatch.setattr(server.threading, "Thread", _BrokenThread)
+    monkeypatch.setattr(server, "_slash_workers_by_key", {})
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        server._SlashWorker("startup-fails", "gpt-5.5")
+
+    assert len(procs) == 1
+    assert procs[0].stdin.closed is True
+    assert procs[0].terminated is True
+    assert "startup-fails" not in server._slash_workers_by_key
+
 def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     fake_mod = types.ModuleType("hermes_state")
 
@@ -4669,6 +4781,10 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
 
 def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    # Pin Linux so empty browser candidates produce the no-executable branch.
+    # On macOS manual_chrome_debug_command falls back to an `open -a` command
+    # even when get_chrome_debug_candidates() is empty.
+    monkeypatch.setattr("platform.system", lambda: "Linux")
     emitted: list[tuple[str, dict]] = []
     monkeypatch.setattr(
         server,

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -432,6 +432,43 @@ class TestShellFileOpsHelpers:
         assert result.content == "alpha\n"
 
 
+    def test_read_file_reports_malformed_stat_output(self, mock_env):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/a.py")
+
+        assert result.error is not None
+        assert "expected byte count" in result.error
+        assert result.total_lines == 0
+        assert result.content == ""
+
+    def test_read_file_reports_malformed_line_count(self, mock_env):
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": "12\n", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": "print('ok')\n", "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": "print('ok')\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/a.py")
+
+        assert result.error is not None
+        assert "expected line count" in result.error
+        assert result.file_size == 12
+        assert result.content == ""
+
+
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""
 
@@ -448,6 +485,21 @@ class TestSearchPathValidation:
         result = ops.search("pattern", path="/nonexistent/path")
         assert result.error is not None
         assert "not found" in result.error.lower() or "Path not found" in result.error
+
+    def test_search_reports_malformed_path_probe(self, mock_env):
+        """search() should fail loudly if the path probe returns blank stdout."""
+        def side_effect(command, **kwargs):
+            if "test -e" in command:
+                return {"output": "", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.search("pattern", path="/maybe/path")
+        assert result.error is not None
+        assert "expected exists/not_found" in result.error
+        assert result.total_count == 0
 
     def test_search_nonexistent_path_files_mode(self, mock_env):
         """search(target='files') should also return error for bad paths."""

--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -105,3 +105,29 @@ def test_get_active_env_honours_rl_override():
         terminal_tool.clear_task_env_overrides("rl-42")
         terminal_tool._active_environments.pop("default", None)
         terminal_tool._active_environments.pop("rl-42", None)
+
+
+
+def test_cleanup_vm_collapses_session_id_before_clearing_shared_env(monkeypatch):
+    class DummyEnv:
+        persist = False
+        def __init__(self):
+            self.cleaned = False
+        def cleanup(self):
+            self.cleaned = True
+
+    env = DummyEnv()
+    terminal_tool._active_environments["default"] = env
+    terminal_tool._creation_locks["default"] = object()
+    cleared = []
+
+    import tools.file_tools as file_tools
+    monkeypatch.setattr(file_tools, "clear_file_ops_cache", lambda tid: cleared.append(tid))
+
+    terminal_tool.cleanup_vm("sess-123e4567-e89b-12d3")
+
+    assert env.cleaned is True
+    assert "default" not in terminal_tool._active_environments
+    assert "default" not in terminal_tool._creation_locks
+    assert "default" in cleared
+    assert "sess-123e4567-e89b-12d3" in cleared

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -88,6 +88,17 @@ def test_terminal_output_ignores_invalid_hook_results(monkeypatch, tmp_path):
     assert result["output"] == "plain output"
 
 
+def test_terminal_output_ignores_empty_string_hook_result(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=lambda hook_name, **kwargs: ["", None],
+    )
+
+    assert result["output"] == "plain output"
+
+
 def test_terminal_output_uses_first_valid_string_from_hooks(monkeypatch, tmp_path):
     result, _mock_env = _run_terminal(
         monkeypatch,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -915,7 +915,13 @@ class ShellFileOperations(FileOperations):
         try:
             file_size = int(stat_output.strip())
         except ValueError:
-            file_size = 0
+            return ReadResult(
+                error=(
+                    f"Failed to read file metadata for {path}: expected byte count "
+                    f"from wc -c, got {stat_output!r}. The terminal backend may "
+                    "have returned empty or malformed stdout."
+                )
+            )
         
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
@@ -967,7 +973,14 @@ class ShellFileOperations(FileOperations):
         try:
             total_lines = int(wc_output.strip())
         except ValueError:
-            total_lines = 0
+            return ReadResult(
+                error=(
+                    f"Failed to read line count for {path}: expected line count "
+                    f"from wc -l, got {wc_output!r}. The terminal backend may "
+                    "have returned empty or malformed stdout."
+                ),
+                file_size=file_size,
+            )
         
         # Check if truncated
         truncated = total_lines > end_line
@@ -1050,7 +1063,13 @@ class ShellFileOperations(FileOperations):
         try:
             file_size = int(stat_output.strip())
         except ValueError:
-            file_size = 0
+            return ReadResult(
+                error=(
+                    f"Failed to read file metadata for {path}: expected byte count "
+                    f"from wc -c, got {stat_output!r}. The terminal backend may "
+                    "have returned empty or malformed stdout."
+                )
+            )
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
         sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
@@ -1830,6 +1849,15 @@ class ShellFileOperations(FileOperations):
         
         # Validate that the path exists before searching
         check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
+        if "exists" not in check.stdout and "not_found" not in check.stdout:
+            return SearchResult(
+                error=(
+                    f"Could not validate search path {path}: expected exists/not_found "
+                    f"probe output, got {check.stdout!r}. The terminal backend may "
+                    "have returned empty or malformed stdout."
+                ),
+                total_count=0,
+            )
         if "not_found" in check.stdout:
             # Try to suggest nearby paths
             parent = os.path.dirname(path) or "."

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1477,6 +1477,14 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
+    # Normal agent-turn task_ids are per-turn UUIDs, but terminal/file/code
+    # environments are deliberately collapsed to the shared ``default`` key by
+    # _resolve_container_task_id().  Resolve here too; otherwise per-turn
+    # cleanup_vm(uuid) pops a non-existent UUID entry and leaves a wedged
+    # ``default`` environment + ShellFileOperations cache alive indefinitely.
+    original_task_id = task_id
+    task_id = _resolve_container_task_id(task_id)
+
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.
@@ -1484,15 +1492,22 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     with _env_lock:
         env = _active_environments.pop(task_id, None)
         _last_activity.pop(task_id, None)
+        if env is None and original_task_id != task_id:
+            env = _active_environments.pop(original_task_id, None)
+            _last_activity.pop(original_task_id, None)
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
         _creation_locks.pop(task_id, None)
+        if original_task_id != task_id:
+            _creation_locks.pop(original_task_id, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
         clear_file_ops_cache(task_id)
+        if original_task_id != task_id:
+            clear_file_ops_cache(original_task_id)
     except ImportError:
         pass
 
@@ -2323,7 +2338,7 @@ def terminal_tool(
                     env_type=env_type,
                 )
                 for hook_result in hook_results:
-                    if isinstance(hook_result, str):
+                    if isinstance(hook_result, str) and hook_result:
                         output = hook_result
                         break
             except Exception:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -203,10 +203,45 @@ sys.stdout = sys.stderr
 _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 
 
+_slash_worker_registry_lock = threading.Lock()
+_slash_workers_by_key: dict[str, list["_SlashWorker"]] = {}
+
+
+def _replace_registered_slash_worker(session_key: str, worker: "_SlashWorker") -> list["_SlashWorker"]:
+    """Register ``worker`` as the sole slash worker for ``session_key``.
+
+    The TUI can create multiple in-memory session objects for the same persisted
+    Hermes session (resume/new/branch/compression flows). Each session object
+    used to spawn its own persistent slash-worker subprocess, and abandoned
+    session objects left those children alive until gateway shutdown. Keep at
+    most one worker per session key inside this gateway process; slash commands
+    are serialized by the worker itself and a replacement is cheap.
+    """
+    with _slash_worker_registry_lock:
+        previous = [w for w in _slash_workers_by_key.get(session_key, []) if w is not worker]
+        _slash_workers_by_key[session_key] = [worker]
+    return previous
+
+
+def _unregister_slash_worker(session_key: str, worker: "_SlashWorker") -> None:
+    with _slash_worker_registry_lock:
+        workers = _slash_workers_by_key.get(session_key)
+        if not workers:
+            return
+        remaining = [w for w in workers if w is not worker]
+        if remaining:
+            _slash_workers_by_key[session_key] = remaining
+        else:
+            _slash_workers_by_key.pop(session_key, None)
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
     def __init__(self, session_key: str, model: str):
+        self.session_key = session_key
+        self._closed = False
+        self._close_lock = threading.Lock()
         self._lock = threading.Lock()
         self._seq = 0
         self.stderr_tail: list[str] = []
@@ -232,8 +267,18 @@ class _SlashWorker:
             cwd=os.getcwd(),
             env=os.environ.copy(),
         )
-        threading.Thread(target=self._drain_stdout, daemon=True).start()
-        threading.Thread(target=self._drain_stderr, daemon=True).start()
+        try:
+            threading.Thread(target=self._drain_stdout, daemon=True).start()
+            threading.Thread(target=self._drain_stderr, daemon=True).start()
+
+            for previous in _replace_registered_slash_worker(session_key, self):
+                try:
+                    previous.close()
+                except Exception:
+                    pass
+        except Exception:
+            self.close()
+            raise
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
@@ -276,13 +321,33 @@ class _SlashWorker:
             )
 
     def close(self):
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        _unregister_slash_worker(self.session_key, self)
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+        except Exception:
+            pass
         try:
             if self.proc.poll() is None:
                 self.proc.terminate()
-                self.proc.wait(timeout=1)
+                self.proc.wait(timeout=2)
         except Exception:
             try:
                 self.proc.kill()
+                self.proc.wait(timeout=2)
+            except Exception as exc:
+                self.stderr_tail = (
+                    self.stderr_tail + [f"failed to reap slash worker after kill: {exc}"]
+                )[-80:]
+        for stream_name in ("stdout", "stderr"):
+            try:
+                stream = getattr(self.proc, stream_name, None)
+                if stream:
+                    stream.close()
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

This hardens Hermes tool-result handling so transient or malformed backend output does not masquerade as authoritative empty results.

- Treat empty `transform_tool_result` hook responses as no-ops instead of replacing valid tool output with `""`.
- Return explicit `ReadResult` / `SearchResult` errors when file/search backend probes produce malformed stdout (`wc -c`, `wc -l`, path existence probe), rather than silently reporting zero-byte files or misleading path state.
- Clean up shared terminal environment aliases so collapsed task IDs and original task IDs both release env/file-op cache state.
- Prevent stale TUI slash-worker subprocess leaks by keeping one registered worker per session key, closing replaced workers, and making worker close/startup failure cleanup more defensive.
- Pin a browser-launch test to Linux for the no-executable branch, avoiding macOS `open -a` fallback behavior.

## Why

In long-lived/runtime-instrumented sessions, blank or malformed backend stdout can otherwise make Hermes believe real files are empty or valid tool output disappeared. That is dangerous for agent correctness because subsequent reads/patches may be based on false state.

This PR changes those cases to fail loudly with diagnostic errors instead of silently zeroing metadata.

## Test plan

- `git diff --check`
- Added-lines security scan for hardcoded secrets, shell injection, eval/exec, pickle, and SQL format patterns
- Claude Code independent review: PASS, no blockers
- Targeted pytest suite:

```text
333 passed, 1 warning in 16.20s
```

Command run:

```bash
venv/bin/python -m pytest \
  tests/test_model_tools.py \
  tests/test_transform_tool_result_hook.py \
  tests/tools/test_file_operations.py \
  tests/tools/test_terminal_output_transform_hook.py \
  tests/tools/test_shared_container_task_id.py \
  tests/test_tui_gateway_server.py \
  tests/tools/test_docker_environment.py::test_cleanup_vm_default_honors_persist_mode \
  tests/tools/test_docker_environment.py::test_cleanup_vm_force_remove_tears_down_persist_container \
  -q -o 'addopts=' --tb=short
```
