### PR TITLE
feat(delegate): explicit preloaded skills for subagents

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5310,6 +5310,7 @@ class AIAgent:
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
+            skills=function_args.get("skills"),
             toolsets=function_args.get("toolsets"),
             tasks=function_args.get("tasks"),
             max_iterations=function_args.get("max_iterations"),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -285,6 +285,7 @@ AUTHOR_MAP = {
     "aman@abacus.ai": "Aman113114-IITD",
     "octavio.turra@gmail.com": "octavioturra",
     "524706+Twanislas@users.noreply.github.com": "Twanislas",
+    "loicnico96@gmail.com": "loicnico96",
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "kchuang1015@users.noreply.github.com": "kchuang1015",
     "maheshthedev@gmail.com": "MaheshtheDev",

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -16,6 +16,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from run_agent import AIAgent
+
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -2135,6 +2137,23 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
+
+    def test_skills_forwarded(self):
+        """The agent-loop dispatch helper must pass through top-level skills."""
+        parent = object.__new__(AIAgent)
+        with patch("tools.delegate_tool.delegate_task", return_value='{"ok":true}') as mock_delegate:
+            result = AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "skills": ["hermes-agent", "git-workflow-maintenance"],
+                },
+            )
+
+        self.assertEqual(result, '{"ok":true}')
+        _, kwargs = mock_delegate.call_args
+        self.assertEqual(kwargs["skills"], ["hermes-agent", "git-workflow-maintenance"])
+        self.assertIs(kwargs["parent_agent"], parent)
 
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,12 +69,14 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertIn("skills", props)
         self.assertIn("toolsets", props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+        self.assertIn("skills", props["tasks"]["items"]["properties"])
 
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
@@ -142,6 +144,62 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+
+class TestDelegateSkills(unittest.TestCase):
+    @patch("agent.skill_commands.build_preloaded_skills_prompt")
+    @patch("run_agent.AIAgent")
+    def test_build_child_agent_appends_canonical_skill_prompt(
+        self, MockAgent, mock_build_preloaded_skills_prompt
+    ):
+        mock_build_preloaded_skills_prompt.return_value = (
+            "SKILL PROMPT BLOCK",
+            ["hermes-agent"],
+            [],
+        )
+        parent = _make_mock_parent(depth=0)
+        MockAgent.return_value = MagicMock()
+
+        _build_child_agent(
+            task_index=0,
+            goal="Use the loaded skill",
+            context="child context",
+            skills=["hermes-agent"],
+            toolsets=None,
+            model=None,
+            max_iterations=10,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+        _, kwargs = MockAgent.call_args
+        self.assertIn("Use the loaded skill", kwargs["ephemeral_system_prompt"])
+        self.assertIn("SKILL PROMPT BLOCK", kwargs["ephemeral_system_prompt"])
+        mock_build_preloaded_skills_prompt.assert_called_once_with(
+            ["hermes-agent"], task_id=None
+        )
+
+    @patch("agent.skill_commands.build_preloaded_skills_prompt")
+    def test_delegate_task_fails_when_preloaded_skill_missing(
+        self, mock_build_preloaded_skills_prompt
+    ):
+        mock_build_preloaded_skills_prompt.return_value = (
+            "",
+            [],
+            ["missing-skill"],
+        )
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(
+                goal="Use the loaded skill",
+                skills=["missing-skill"],
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("missing-skill", result["error"])
 
 
 class TestStripBlockedTools(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3151,11 +3151,7 @@ DELEGATE_TASK_SCHEMA = {
             "skills": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": (
-                    "Optional skill names to preload into this subagent using "
-                    "the same canonical skill-loading path as CLI --skills. "
-                    "If any named skill cannot be resolved, delegate_task fails."
-                ),
+                "description": "Optional skill names to preload.",
             },
             "tasks": {
                 "type": "array",
@@ -3170,7 +3166,7 @@ DELEGATE_TASK_SCHEMA = {
                         "skills": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Skill names to preload for this specific task. Missing skills are a hard error.",
+                            "description": "Optional skill names for this specific task to preload.",
                         },
                         "toolsets": {
                             "type": "array",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -663,6 +663,30 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+def _build_delegate_skills_prompt(skill_identifiers: Optional[List[str]]) -> str:
+    """Resolve delegated skills through the canonical preload pipeline.
+
+    Delegate subagents should load skills the same way normal CLI preloads do,
+    not through a delegate-specific filesystem scan. Missing skills are treated
+    as a hard error for parity with other preloaded-skill entrypoints.
+    """
+    if not skill_identifiers:
+        return ""
+
+    from agent.skill_commands import build_preloaded_skills_prompt
+
+    prompt_text, _loaded_names, missing = build_preloaded_skills_prompt(
+        skill_identifiers, task_id=None
+    )
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(
+            f"Unknown skill(s): {missing_list}. Delegated skill preloading fails "
+            "closed when any requested skill cannot be resolved."
+        )
+    return prompt_text
+
+
 def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
@@ -1047,6 +1071,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    skills: Optional[List[str]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1135,6 +1160,9 @@ def _build_child_agent(
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
     )
+    skills_prompt = _build_delegate_skills_prompt(skills)
+    if skills_prompt:
+        child_prompt = f"{child_prompt}\n\n{skills_prompt}"
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -2124,6 +2152,7 @@ def _recover_tasks_from_json_string(
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
+    skills: Optional[List[str]] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
@@ -2137,8 +2166,8 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, skills, toolsets, role)
+      - Batch:  provide tasks array [{goal, context, skills, toolsets, role}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -2232,7 +2261,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "skills": skills,
+                "toolsets": toolsets,
+                "role": top_role,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2277,6 +2312,7 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
+                skills=t.get("skills") if "skills" in t else skills,
                 toolsets=t.get("toolsets") or toolsets,
                 model=creds["model"],
                 max_iterations=effective_max_iter,
@@ -2299,6 +2335,8 @@ def delegate_task(
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
+    except ValueError as exc:
+        return tool_error(str(exc))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -3110,6 +3148,15 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional skill names to preload into this subagent using "
+                    "the same canonical skill-loading path as CLI --skills. "
+                    "If any named skill cannot be resolved, delegate_task fails."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3119,6 +3166,11 @@ DELEGATE_TASK_SCHEMA = {
                         "context": {
                             "type": "string",
                             "description": "Task-specific context",
+                        },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Skill names to preload for this specific task. Missing skills are a hard error.",
                         },
                         "toolsets": {
                             "type": "array",
@@ -3223,6 +3275,7 @@ registry.register(
     handler=lambda args, **kw: delegate_task(
         goal=args.get("goal"),
         context=args.get("context"),
+        skills=args.get("skills"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -14,10 +14,12 @@ The `delegate_task` tool spawns child AIAgent instances with isolated context, r
 delegate_task(
     goal="Debug why tests fail",
     context="Error: assertion in test_foo.py line 42",
+    skills=["systematic-debugging"],
     toolsets=["terminal", "file"]
 )
 ```
 
+Top-level `skills` is also optional. When present, Hermes preloads those skills into the child through the same canonical loading path used by CLI `--skills`, and missing skill names fail the delegation call instead of being ignored.
 ## Parallel Batch
 
 Up to 3 concurrent subagents by default (configurable, no hard ceiling):


### PR DESCRIPTION
## What does this PR do?

Add preloadable `skills` to `delegate_task` tool.

This is a rather minor improvement over asking delegate to load the skill, the biggest gain being explicitness.
- slightly more efficient than having the agent instruct "Load skill X, then ..."
- fails if skill does not exist, rather than silently spawning a confused delegate

My example use case: "peer-review" skill that tells agents to do delegate_task reviews before commit, with specialized reviewer skills like "security-reviewer" based on areas touched. This is better expressed if the agent can explicitly bind a particular specialized reviewer skill to a particular delegate.

## Related Issue

#3631 exists but does ad hoc skill resolution from filesystem instead of reusing the established skill-loading system (which among others means it doesn't get counted in stats, etc.)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `skills` in `delegate_tool` schema, both top-level and per-task
- Preload skills using the existing `build_preloaded_skills_prompt`
- Fail if any requested skill does not exist

## How to Test

Variations of "Delegate to a subagent with skill X and tell it to reply whether it has it preloaded."

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<img width="1041" height="639" alt="image" src="https://github.com/user-attachments/assets/408dc6b8-9b39-4806-a7b4-7d95a70cef24" />