### PR TITLE
feat(tools): add interactive_prompt tool with Discord UI support

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1887,6 +1887,20 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 ),
                 next_args,
             )
+    elif function_name == "interactive_prompt":
+        def _execute(next_args: dict) -> Any:
+            from tools.interactive_prompt_tool import interactive_prompt_tool as _ip_tool
+            return _finish_agent_tool(
+                _ip_tool(
+                    question=next_args.get("question", ""),
+                    options=next_args.get("options", []),
+                    display_type=next_args.get("display_type", "buttons"),
+                    timeout_seconds=float(next_args.get("timeout_seconds", 900)),
+                    auth_policy=next_args.get("auth_policy", "session_owner_only"),
+                    callback=getattr(agent, "interactive_prompt_callback", None),
+                ),
+                next_args,
+            )
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1890,12 +1890,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "interactive_prompt":
         def _execute(next_args: dict) -> Any:
             from tools.interactive_prompt_tool import interactive_prompt_tool as _ip_tool
+            from tools.human_input_gateway import get_interactive_prompt_timeout
+            _raw_timeout = next_args.get("timeout_seconds")
+            _timeout = int(_raw_timeout) if _raw_timeout is not None else get_interactive_prompt_timeout()
             return _finish_agent_tool(
                 _ip_tool(
                     question=next_args.get("question", ""),
                     options=next_args.get("options", []),
                     display_type=next_args.get("display_type", "buttons"),
-                    timeout_seconds=float(next_args.get("timeout_seconds", 900)),
+                    timeout_seconds=_timeout,
                     auth_policy=next_args.get("auth_policy", "session_owner_only"),
                     callback=getattr(agent, "interactive_prompt_callback", None),
                 ),

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -40,6 +40,7 @@ Payment / credit exhaustion fallback:
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -1124,6 +1125,31 @@ class AsyncAnthropicAuxiliaryClient:
         # See AsyncCodexAuxiliaryClient: mirror _real_client so cache
         # eviction on a poisoned underlying client also drops this entry.
         self._real_client = sync_wrapper._real_client
+
+
+class _AsyncCopilotACPAdapter:
+    """Thin async wrapper around CopilotACPClient for auxiliary calls."""
+
+    def __init__(self, sync_client):
+        self._sync = sync_client
+        self.chat = _AsyncCopilotACPChat(sync_client)
+
+
+class _AsyncCopilotACPChat:
+    def __init__(self, sync_client):
+        self._sync = sync_client
+        self.completions = _AsyncCopilotACPCompletions(sync_client)
+
+
+class _AsyncCopilotACPCompletions:
+    def __init__(self, sync_client):
+        self._sync = sync_client
+
+    async def create(self, **kwargs):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._sync._create_chat_completion(**kwargs),
+        )
 
 
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
@@ -3393,7 +3419,9 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
+            # ACP is sync (subprocess-based); wrap in async adapter so
+            # await client.chat.completions.create() works from async_call_llm.
+            return _AsyncCopilotACPAdapter(sync_client), model
     except ImportError:
         pass
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4016,23 +4016,31 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in ("copilot-acp", "gemini-acp"):
+            # Both Copilot and Gemini CLI share the same ACP subprocess
+            # transport — the only difference is the default command.
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
-            command = str(creds.get("command", "")).strip() or None
+            command = str(creds.get("command", "").strip()) or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured", provider
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete", provider
                 )
                 return None, None
+            # Gemini ACP defaults to `gemini` command when no explicit
+            # command is configured in credentials.
+            if provider == "gemini-acp" and not command:
+                command = "gemini"
+                if not args:
+                    args = ["--acp", "--skip-trust"]
             from agent.copilot_acp_client import CopilotACPClient
 
             client = CopilotACPClient(

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -8,6 +8,7 @@ back into the minimal shape Hermes expects from an OpenAI client.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import queue
@@ -317,6 +318,13 @@ class _ACPChatCompletions:
 
     def create(self, **kwargs: Any) -> Any:
         return self._client._create_chat_completion(**kwargs)
+
+    async def acreate(self, **kwargs: Any) -> Any:
+        """Async wrapper — runs the synchronous subprocess call in a thread."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._client._create_chat_completion(**kwargs),
+        )
 
 
 class _ACPChatNamespace:

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -126,6 +126,34 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _extract_image_parts(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract base64 image data from OpenAI-format image_url content blocks.
+
+    Returns a list of dicts like ``{"type": "image", "mimeType": "...", "data": "..."}``
+    suitable for inclusion in an ACP session/prompt array.
+    """
+    import base64
+
+    parts: list[dict[str, Any]] = []
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "image_url":
+                continue
+            url = (block.get("image_url") or {}).get("url", "")
+            if not url.startswith("data:"):
+                continue
+            # Parse data:image/<mime>;base64,<data>
+            meta, _, b64data = url.partition(",")
+            mime = "image/png"  # default
+            if ";" in meta:
+                mime = meta.split(":")[1].split(";")[0]
+            parts.append({"type": "image", "mimeType": mime, "data": b64data})
+    return parts
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
@@ -392,6 +420,7 @@ class CopilotACPClient:
             tools=tools,
             tool_choice=tool_choice,
         )
+        image_parts = _extract_image_parts(messages or [])
         # Normalise timeout: run_agent.py may pass an httpx.Timeout object
         # (used natively by the OpenAI SDK) rather than a plain float.
         if timeout is None:
@@ -411,6 +440,7 @@ class CopilotACPClient:
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
+            image_parts=image_parts if image_parts else None,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
@@ -436,7 +466,8 @@ class CopilotACPClient:
             model=model or "copilot-acp",
         )
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float,
+                     image_parts: list[dict[str, Any]] | None = None) -> tuple[str, str]:
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -578,16 +609,19 @@ class CopilotACPClient:
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
+            prompt_parts: list[dict[str, Any]] = [
+                {
+                    "type": "text",
+                    "text": prompt_text,
+                }
+            ]
+            if image_parts:
+                prompt_parts.extend(image_parts)
             _request(
                 "session/prompt",
                 {
                     "sessionId": session_id,
-                    "prompt": [
-                        {
-                            "type": "text",
-                            "text": prompt_text,
-                        }
-                    ],
+                    "prompt": prompt_parts,
                 },
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1087,11 +1087,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         elif function_name == "interactive_prompt":
             def _execute(next_args: dict) -> Any:
                 from tools.interactive_prompt_tool import interactive_prompt_tool as _ip_tool
+                from tools.human_input_gateway import get_interactive_prompt_timeout
+                _raw_timeout = next_args.get("timeout_seconds")
+                _timeout = int(_raw_timeout) if _raw_timeout is not None else get_interactive_prompt_timeout()
                 return _ip_tool(
                     question=next_args.get("question", ""),
                     options=next_args.get("options", []),
                     display_type=next_args.get("display_type", "buttons"),
-                    timeout_seconds=float(next_args.get("timeout_seconds", 900)),
+                    timeout_seconds=_timeout,
                     auth_policy=next_args.get("auth_policy", "session_owner_only"),
                     callback=getattr(agent, "interactive_prompt_callback", None),
                 )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1084,6 +1084,28 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('read_terminal', function_args, tool_duration, result=function_result)}")
+        elif function_name == "interactive_prompt":
+            def _execute(next_args: dict) -> Any:
+                from tools.interactive_prompt_tool import interactive_prompt_tool as _ip_tool
+                return _ip_tool(
+                    question=next_args.get("question", ""),
+                    options=next_args.get("options", []),
+                    display_type=next_args.get("display_type", "buttons"),
+                    timeout_seconds=float(next_args.get("timeout_seconds", 900)),
+                    auth_policy=next_args.get("auth_policy", "session_owner_only"),
+                    callback=getattr(agent, "interactive_prompt_callback", None),
+                )
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('interactive_prompt', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
             tasks_arg = function_args.get("tasks")
             if tasks_arg and isinstance(tasks_arg, list):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -624,6 +624,15 @@ agent:
   
   # Enable verbose logging
   verbose: false
+
+  # ── Interactive Prompt ──────────────────────────────────────────────
+  # Rich interactive prompts with buttons, modal forms, file uploads,
+  # and auth policies.  Disabled by default — opt-in per deployment.
+  # interactive_prompt_enabled: false
+
+  # Default timeout for interactive_prompt calls (seconds, 60–3600).
+  # Falls back to clarify_timeout if unset, then 900 (15 min).
+  # interactive_prompt_timeout: 900
   
   # Reasoning effort level (OpenRouter and Nous Portal)
   # Controls how much "thinking" the model does before responding.

--- a/docs/interactive-prompt-tool-spec.md
+++ b/docs/interactive-prompt-tool-spec.md
@@ -1,0 +1,298 @@
+# `interactive_prompt` Tool — Design Spec
+
+## Motivation
+
+PR #19413 originally bolted a generic `components` schema onto `send_message`, letting the model build raw Discord component JSON. While functional, this approach has problems:
+
+1. **Model must understand Discord component structure** — action rows, style enums, custom_id conventions. That's implementation leakage into the LLM layer.
+2. **Discord-only** — no path to Telegram inline keyboards, Slack block kit, or any other platform.
+3. **Fire-and-forget** — components render on the message, but the tool call completes before the user interacts. The model doesn't block-and-wait for a response.
+4. **Fights upstream direction** — teknium1's clarify implementation (`1dca6a696`) uses gateway-level adapter overrides, not model-generated component specs. Our PR's approach doesn't align with that pattern.
+
+**This spec proposes pivoting to a purpose-built tool** that abstracts the component rendering behind a clean schema. The model describes *what* it wants (a question, options, display type); the tool + adapter handle *how* to render it per platform.
+
+## Design Goals
+
+| Goal | Why |
+|------|-----|
+| **Model-agnostic schema** | Model doesn't need to know about Action Rows, ButtonStyle enums, or custom_id prefixes |
+| **Blocking tool call** | Tool blocks until user responds, returns the choice — natural LLM tool pattern |
+| **Platform-adaptable** | Discord renders buttons/selects/modal; future platforms render native equivalents |
+| **Composable with freeform input** | Structured choices + "type your own" fallback via modal popup |
+| **File collection** | Modal file upload field for requesting documents from the user |
+| **Matches upstream pattern** | Same gateway-level rendering approach as teknium1's clarify buttons |
+
+## Tool Schema
+
+```
+interactive_prompt(
+    question: str,                    # Required — the prompt/message text
+    options: list[Option],            # Required — structured choices
+    display_type: "buttons" | "select",# How to render options on the message (only "buttons" implemented in v1)
+    allow_custom: bool,                # Whether to show "Other" option
+    custom_fields: list[CustomField], # Modal fields when allow_custom=True
+)
+```
+
+### Returns
+
+```
+{
+    "choice": "strict",               # The selected option value, or null if custom
+    "custom_response": {               # Populated if user went through modal
+        "fields": {
+            "reason": "We have compliance requirements...",
+            "attachment": "<file_name>"  # If file upload field was used
+        }
+    }
+}
+```
+
+## Option Schema
+
+```python
+Option:
+    label: str              # Display text (max 80 chars)
+    value: str              # Machine-readable value returned on selection
+    description: str?        # Tooltip/subtitle (optional, max 100 chars)
+    emoji: str?              # Emoji prefix (optional)
+    style: "primary" | "secondary" | "success" | "danger"?  # Buttons only, default "secondary"
+```
+
+## CustomField Schema (Modal Fields)
+
+```python
+CustomField:
+    key: str                # Identifier — used to populate custom_response.fields
+    label: str              # Display label for the field
+    description: str?       # Help text below the label
+    type: "text" | "select" | "file_upload" | "radio" | "checkbox"
+    required: bool?         # Default True
+    placeholder: str?       # For text/select fields
+    options: list[Option]?  # For select/radio/checkbox fields
+    min_length: int?        # For text fields
+    max_length: int?        # For text fields (max 4000)
+    multiline: bool?        # For text fields — paragraph vs single-line
+```
+
+## Rendering Behavior
+
+### Message Phase
+
+The tool sends a Discord message with:
+
+1. The `question` text as the message content (supports markdown)
+2. Options rendered as either:
+   - **Buttons** (display_type="buttons"): one `discord.ui.Button` per option, max 25 buttons across 5 action rows. Discord's 25-component cap leaves room for an "Other" button when `allow_custom=True`.
+   - **Select Menu** (display_type="select"): one `discord.ui.Select` with all options. Better for 6+ choices where buttons would be cluttered.
+3. If `allow_custom=True`: an additional "Other (type your answer)" button with `style="primary"`
+
+### Interaction Phase
+
+- **Option selected**: All buttons/select disables. Tool returns `{"choice": "<value>", "custom_response": null}`.
+- **"Other" clicked**: Opens a modal popup containing the `custom_fields`. User fills in and submits.
+
+### Modal Phase (triggered by "Other")
+
+The modal renders `custom_fields` as native Discord modal components:
+
+| CustomField.type | Discord Component | Notes |
+|-----------------|-------------------|-------|
+| `text` | Text Input (type 4) | `short=True/False` based on `multiline`. Wrapped in Label (type 18) with `label` + `description`. |
+| `select` | String Select (type 3) | Wrapped in Label. Options from the field's `options` list. |
+| `file_upload` | File Upload (type 19) | Wrapped in Label. Discord handles the file picker natively. |
+| `radio` | Radio Group (type 21) | Single-choice set. Wrapped in Label. |
+| `checkbox` | Checkbox Group (type 22) | Multi-select. Wrapped in Label. |
+
+On modal submit, the tool returns:
+```json
+{
+    "choice": null,
+    "custom_response": {
+        "fields": {
+            "reason": "Compliance requires strict mode",
+            "attachment": "ScubaReport_TenantA_2026-05-29.json"
+        }
+    }
+}
+```
+
+## Example Usage
+
+### Simple: Remediation approach selection
+```python
+interactive_prompt(
+    question="**Tenant A** — Which remediation approach for this M365 deployment?",
+    options=[
+        {"label": "🔒 Strict", "value": "strict", "description": "Full MFA + CA + modern auth enforcement", "style": "success"},
+        {"label": "🛡️ Standard", "value": "standard", "description": "MFA + modern auth, conditional access optional", "style": "primary"},
+        {"label": "📋 Basic", "value": "basic", "description": "Password policy + audit logging only", "style": "secondary"},
+    ],
+    display_type="buttons",
+    allow_custom=True,
+    custom_fields=[
+        {"key": "reason", "label": "Your reasoning", "type": "text", "multiline": True, "placeholder": "Why this approach?"},
+    ]
+)
+```
+
+**Renders:**
+```
+[Message]
+**Tenant A** — Which remediation approach for this M365 deployment?
+
+[🔒 Strict]  [🛡️ Standard]  [📋 Basic]  [✏️ Other (type your answer)]
+```
+
+**If "Other" clicked → Modal:**
+```
+┌─────────────────────────────────────────┐
+│ Custom Response                          │
+│                                          │
+│ Your reasoning                           │
+│ ┌────────────────────────────────────┐   │
+│ │ Why this approach?                  │   │
+│ │                                    │   │
+│ └────────────────────────────────────┘   │
+│                                          │
+│              [Cancel]  [Submit]          │
+└─────────────────────────────────────────┘
+```
+
+### File collection: Request Scuba report
+```python
+interactive_prompt(
+    question="I need the **ScubaGear JSON report** for this tenant to continue the remediation analysis.",
+    options=[
+        {"label": "📎 Attach Report", "value": "attach", "style": "primary"},
+        {"label": "⏭️ Skip for now", "value": "skip", "style": "secondary"},
+    ],
+    display_type="buttons",
+    allow_custom=False,
+)
+# If attach → immediately opens modal:
+# But actually we want the modal to have the file field...
+```
+
+Better pattern — always use modal for file collection:
+```python
+interactive_prompt(
+    question="I need the **ScubaGear JSON report** for this tenant to continue the remediation analysis.",
+    options=[
+        {"label": "📎 Attach Report", "value": "attach", "style": "primary", "description": "Opens file picker"},
+        {"label": "⏭️ Skip for now", "value": "skip", "style": "secondary"},
+    ],
+    display_type="buttons",
+    allow_custom=True,
+    custom_fields=[
+        {"key": "notes", "label": "Additional context", "type": "text", "multiline": True, "placeholder": "Any notes about the report...", "required": False},
+        {"key": "report", "label": "ScubaGear Report", "type": "file_upload", "required": True},
+    ]
+)
+```
+
+### Multi-field modal: Slice planning discussion
+```python
+interactive_prompt(
+    question="**Slice Planning** — Let's scope the first iteration of the document migration.",
+    options=[
+        {"label": "✅ Use suggested slices", "value": "accept", "style": "success", "description": "3 slices, ~2 days each"},
+        {"label": "✏️ Modify the plan", "value": "modify", "style": "primary"},
+        {"label": "❌ Start over", "value": "restart", "style": "danger"},
+    ],
+    display_type="select",
+    allow_custom=True,
+    custom_fields=[
+        {"key": "which_slices", "label": "Which slices to include?", "type": "checkbox",
+         "options": [
+             {"label": "Slice 1: Assessment", "value": "s1"},
+             {"label": "Slice 2: Migration", "value": "s2"},
+             {"label": "Slice 3: Validation", "value": "s3"},
+         ], "required": True},
+        {"key": "notes", "label": "Modification notes", "type": "text", "multiline": True, "placeholder": "What should change?"},
+    ]
+)
+```
+
+## Platform Adaptability
+
+The tool schema is platform-agnostic. Each platform adapter implements its own rendering:
+
+| Concept | Discord | Telegram (future) | Slack (future) |
+|---------|---------|-------------------|-----------------|
+| `buttons` | `discord.ui.Button` in Action Rows | `InlineKeyboardButton` | `Block Kit Button` |
+| `select` | `discord.ui.Select` | Not native — fallback to buttons | `Static Select` |
+| Modal with text | Modal + `TextInput` | Not native — fallback to freeform reply | `Modal` |
+| Modal with file | Modal + `File Upload` | Not native — fallback to `send_file` reply | Not supported |
+| Blocking wait | `ComponentStore` + interaction callback | Callback query handler | `block_actions` |
+
+The tool implementation lives in `tools/` (not in the Discord adapter). Each platform adapter registers a handler for rendering interactive prompts via a common interface. This mirrors how `BasePlatformAdapter.send_clarify` works today.
+
+## Relationship to Existing Infrastructure
+
+### Reuses from PR #19413
+- `ComponentStore` — in-memory view tracking by message_id
+- `ComponentView` — but simplified (no raw spec parsing, tool generates views directly)
+- `TrackedComponentView` — message_id → view → session_key mapping
+- `_format_interaction_text` — interaction → MessageEvent formatting
+- `_handle_interaction` — the interaction handler pattern
+
+### New components
+- `tools/interactive_prompt_tool.py` — tool registration + schema
+- `InteractivePromptView` — replaces `ComponentView`'s generic spec parsing with purpose-built rendering from the tool's structured args
+- `ModalBuilder` — builds Discord Modal from `CustomField[]`
+- Platform adapter hooks — `send_interactive_prompt(prompt, callback)` on `BasePlatformAdapter`
+
+### Alignment with upstream
+- Same gateway-level rendering as teknium1's `ClarifyChoiceView` (`1dca6a696`)
+- Same auth pattern (`_component_check_auth`)
+- Same blocking/timeout behavior
+- The tool is to structured Q&A what `clarify` is to clarification — a higher-level abstraction over raw components
+
+### What we build on from teknium1's existing work
+
+Directly reused from `plugins/platforms/discord/adapter.py`:
+- **`_component_check_auth()`** (line 5053) — shared auth gate for all interactive views. Handles user/role allowlists, no-allowlist deployments, fail-closed. Proven by `ExecApprovalView`, `SlashConfirmView`, `UpdatePromptView`, `ModelPickerView`, and `ClarifyChoiceView`.
+
+Pattern/conventions we follow:
+- **`ClarifyChoiceView` UX shape** — buttons from choices, single-use (first click disables all), embed footer updates with who answered, `discord.ui.View` subclass with timeout.
+- **"Other" → freeform fallback** — teknium1's `ClarifyChoiceView` uses `mark_awaiting_text()` to switch to text-capture mode. We extend this pattern but with a modal popup instead.
+- **Embed styling** — orange for pending, green for resolved, blue for awaiting text input.
+
+Entirely new (no upstream equivalent):
+- **Modal support** — none of the 5 existing views open modals. First modal-based interaction in the adapter.
+- **Select menus** — `ClarifyChoiceView` only renders buttons. New `discord.ui.Select` rendering for `display_type="select"`.
+- **File Upload fields** — doesn't exist anywhere in the codebase.
+- **Radio/Checkbox groups** — modal-only, not implemented upstream.
+- **Blocking tool pattern** — all existing views are fire-and-forget (resolve via gateway callbacks). Our tool blocks the LLM turn and returns the result directly.
+
+## Security Considerations
+
+- **Auth**: All interactions validated through `_component_check_auth` (same as clarify buttons) — ensures the interacting user owns the session
+- **File uploads**: File size limits enforced at the platform level (Discord: 25MB free, up to 500MB with boost). Files land as attachments in the agent's context, not written to disk automatically.
+- **Timeout**: Interactive prompt views should have a configurable timeout (default 15 min) after which the tool returns `{"choice": null, "custom_response": null, "timed_out": True}`
+- **Component cap**: Respect Discord's 25-component-per-message limit when rendering buttons. If options > 24 (leaving room for "Other"), auto-fallback to select menu display_type.
+
+## Open Questions
+
+> **Note:** The following features are aspirational for v2 — only `display_type="buttons"` is implemented in v1.
+> - `display_type="select"` (select menu rendering, auto-fallback from buttons at 25+ options)
+> - `file_upload` modal field type (requires Discord modal file-upload permissions)
+> - Auto-fallback from buttons to select menu when options > 24
+
+1. **Should the tool auto-acknowledge selection?** After user clicks a button, should the message update with "✅ Selected: Strict" or leave the buttons disabled as-is?
+2. **Multi-select for buttons?** Discord buttons are inherently single-click. For "pick multiple slices", should we use checkbox group in a modal instead?
+3. **Re-prompt after timeout?** Should the tool re-send the interactive prompt or let the model handle it in its next turn?
+4. **Modal title character limit**: Discord modals max 45 chars. Long `question` text doesn't fit as the modal title — should we truncate to a summary?
+
+## Next Steps
+
+1. Comment on PR #19413 noting the pivot, tag teknium1, link to new PR when ready
+2. Create new branch from main (not from #19413's branch)
+3. Implement `tools/interactive_prompt_tool.py` — tool schema + handler
+4. Implement `InteractivePromptView` — Discord message rendering
+5. Implement `ModalBuilder` — Discord modal from CustomField[]
+6. Wire into `BasePlatformAdapter` as `send_interactive_prompt()`
+7. Add Discord adapter implementation
+8. Tests: message rendering, modal rendering, interaction routing, timeout, auth, file upload
+9. Live test against Pepper's Discord channel

--- a/docs/interactive-prompt-tool-spec.md
+++ b/docs/interactive-prompt-tool-spec.md
@@ -262,7 +262,7 @@ Pattern/conventions we follow:
 Entirely new (no upstream equivalent):
 - **Modal support** — none of the 5 existing views open modals. First modal-based interaction in the adapter.
 - **Select menus** — `ClarifyChoiceView` only renders buttons. New `discord.ui.Select` rendering for `display_type="select"`.
-- **File Upload fields** — doesn't exist anywhere in the codebase.
+- **File Upload fields** — native Discord file picker inside modals, with configurable `file_policy` constraints.
 - **Radio/Checkbox groups** — modal-only, not implemented upstream.
 - **Blocking tool pattern** — all existing views are fire-and-forget (resolve via gateway callbacks). Our tool blocks the LLM turn and returns the result directly.
 
@@ -273,17 +273,46 @@ Entirely new (no upstream equivalent):
 - **Timeout**: Interactive prompt views should have a configurable timeout (default 15 min) after which the tool returns `{"choice": null, "custom_response": null, "timed_out": True}`
 - **Component cap**: Respect Discord's 25-component-per-message limit when rendering buttons. If options > 24 (leaving room for "Other"), auto-fallback to select menu display_type.
 
+## File Upload Support
+
+`file_upload` is a fully supported `CustomField.type` that renders as a native Discord file-upload widget inside modal forms. When a user selects an option with `action="modal"` that includes a `file_upload` field, Discord opens its platform file picker (respects OS file dialogs).
+
+### file_policy constraints
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `max_files` | int | 1 | Maximum number of files the user can attach (Discord range: 1–10). |
+| `max_bytes` | int | 26_214_400 (25 MB) | Maximum total upload size in bytes. Capped by Discord tier (25 MB free, 500 MB with Nitro). |
+| `allowed_extensions` | list[str] | `[]` (any) | Whitelist of file extensions (e.g. `[".pdf", ".json", ".csv"]`). Empty list allows all. |
+| `allowed_mime_types` | list[str] | `[]` (any) | Whitelist of MIME types (e.g. `["application/pdf", "text/csv"]`). Empty list allows all. |
+
+Both `allowed_extensions` and `allowed_mime_types` combine as AND — a file must match at least one entry in each non-empty list to pass.
+
+### Example — requesting a report file
+```python
+interactive_prompt(
+    question="I need the **ScubaGear JSON report** for this tenant.",
+    options=[
+        {"label": "Attach Report", "value": "attach", "style": "primary", "action": "modal",
+         "modal": {
+             "title": "Upload Report",
+             "fields": [
+                 {"key": "report", "label": "ScubaGear Report", "type": "file_upload",
+                  "required": True,
+                  "file_policy": {"allowed_extensions": [".json"], "max_files": 1}},
+                 {"key": "notes", "label": "Notes", "type": "text", "multiline": True, "required": False},
+             ]
+         }},
+        {"label": "Skip for now", "value": "skip", "style": "secondary"},
+    ],
+)
+```
+
 ## Open Questions
 
-> **Note:** The following features are aspirational for v2 — only `display_type="buttons"` is implemented in v1.
-> - `display_type="select"` (select menu rendering, auto-fallback from buttons at 25+ options)
-> - `file_upload` modal field type (requires Discord modal file-upload permissions)
-> - Auto-fallback from buttons to select menu when options > 24
-
 1. **Should the tool auto-acknowledge selection?** After user clicks a button, should the message update with "✅ Selected: Strict" or leave the buttons disabled as-is?
-2. **Multi-select for buttons?** Discord buttons are inherently single-click. For "pick multiple slices", should we use checkbox group in a modal instead?
-3. **Re-prompt after timeout?** Should the tool re-send the interactive prompt or let the model handle it in its next turn?
-4. **Modal title character limit**: Discord modals max 45 chars. Long `question` text doesn't fit as the modal title — should we truncate to a summary?
+2. **Re-prompt after timeout?** Should the tool re-send the interactive prompt or let the model handle it in its next turn?
+3. **Modal title character limit**: Discord modals max 45 chars. Long `question` text doesn't fit as the modal title — should we truncate to a summary?
 
 ## Next Steps
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1144,6 +1144,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".ps1": "text/plain",
 }
 
 
@@ -2560,6 +2561,58 @@ class BasePlatformAdapter(ABC):
             mark_awaiting_text(clarify_id)
         else:
             text = f"❓ {question}"
+        return await self.send(
+            chat_id=chat_id,
+            content=text,
+            metadata=metadata,
+        )
+
+    async def send_human_input(
+        self,
+        chat_id: str,
+        question: str,
+        options: list,
+        prompt_id: str,
+        session_key: str,
+        display_type: str = "buttons",
+        auth_policy: str = "session_owner_only",
+        origin_user_id: Optional[str] = None,
+        timeout_seconds: float = 900,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive prompt with per-option actions.
+
+        Default text fallback — renders a numbered list of options.
+        Adapters with rich UIs (Discord, Telegram) override this to render
+        buttons, select menus, and modal popups.
+
+        The resolution flow mirrors clarify:
+
+        * **Return options** — user picks a choice → adapter calls
+          ``tools.human_input_gateway.resolve_choice(prompt_id, value, actor)``.
+        * **Modal options** — user picks a choice that opens a modal →
+          adapter renders modal, collects fields, calls
+          ``tools.human_input_gateway.resolve_modal(prompt_id, value, fields, files, actor)``.
+        * **Timeout** — gateway's ``wait_for_response`` handles this.
+        """
+        if display_type != "buttons":
+            logger.debug(
+                "send_human_input text fallback ignoring display_type=%r",
+                display_type,
+            )
+        lines = [f"🔘 {question}", ""]
+        for i, opt in enumerate(options, start=1):
+            label = opt.get("label", f"Option {i}")
+            desc = opt.get("description", "")
+            action = opt.get("action", "return")
+            suffix = " (opens form)" if action == "modal" else ""
+            line = f"  {i}. {label}{suffix}"
+            if desc:
+                line += f" — {desc}"
+            lines.append(line)
+        lines.append("")
+        lines.append("Reply with the number or option text.")
+        text = "\n".join(lines)
         return await self.send(
             chat_id=chat_id,
             content=text,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2605,7 +2605,7 @@ class BasePlatformAdapter(ABC):
             label = opt.get("label", f"Option {i}")
             desc = opt.get("description", "")
             action = opt.get("action", "return")
-            suffix = " (opens form)" if action == "modal" else ""
+            suffix = " (opens form — not available on this platform)" if action == "modal" else ""
             line = f"  {i}. {label}{suffix}"
             if desc:
                 line += f" — {desc}"
@@ -2613,6 +2613,16 @@ class BasePlatformAdapter(ABC):
         lines.append("")
         lines.append("Reply with the number or option text.")
         text = "\n".join(lines)
+
+        # Text fallback: mark this entry as awaiting text so the gateway
+        # text-intercept picks up the user's typed reply instead of hanging
+        # until timeout.
+        try:
+            from tools.human_input_gateway import mark_awaiting_text as _mark_text
+            _mark_text(prompt_id)
+        except Exception:
+            pass
+
         return await self.send(
             chat_id=chat_id,
             content=text,

--- a/gateway/platforms/discord_components.py
+++ b/gateway/platforms/discord_components.py
@@ -1,0 +1,320 @@
+"""Discord interactive component helpers.
+
+This module backs the Discord adapter's generic component support for messages
+sent with ``metadata['components']``.  It is intentionally small: build a
+``discord.ui.View`` from the send_message component schema, track views by
+message id, and turn button/select interactions back into ``MessageEvent``
+objects for the gateway runner.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+try:  # pragma: no cover - exercised with real discord.py in production
+    import discord
+except Exception:  # pragma: no cover - tests provide a mock when needed
+    discord = None  # type: ignore
+
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+logger = logging.getLogger(__name__)
+
+CUSTOM_ID_PREFIX = "hermes:"
+
+
+def _style_from_spec(value: Any) -> Any:
+    """Map API/friendly button style values to discord.py ButtonStyle."""
+    if discord is None:
+        return value
+    style = getattr(discord, "ButtonStyle", None)
+    if style is None:
+        return value
+
+    # Discord API numeric styles: 1 primary, 2 secondary, 3 success, 4 danger,
+    # 5 link.  The test mock and some discord.py versions expose aliases.
+    mapping = {
+        1: getattr(style, "primary", getattr(style, "blurple", 1)),
+        2: getattr(style, "secondary", getattr(style, "grey", 2)),
+        3: getattr(style, "success", getattr(style, "green", 3)),
+        4: getattr(style, "danger", getattr(style, "red", 4)),
+        5: getattr(style, "link", 5),
+        "primary": getattr(style, "primary", getattr(style, "blurple", 1)),
+        "secondary": getattr(style, "secondary", getattr(style, "grey", 2)),
+        "success": getattr(style, "success", getattr(style, "green", 3)),
+        "danger": getattr(style, "danger", getattr(style, "red", 4)),
+        "link": getattr(style, "link", 5),
+    }
+    return mapping.get(value, mapping.get(str(value).lower(), mapping[2]))
+
+
+def _prefixed_custom_id(custom_id: str) -> str:
+    custom_id = str(custom_id or "")
+    if custom_id.startswith(CUSTOM_ID_PREFIX):
+        return custom_id
+    return f"{CUSTOM_ID_PREFIX}{custom_id}"
+
+
+def _format_interaction_text(
+    kind: str,
+    *,
+    label: str = "",
+    custom_id: str = "",
+    values: Optional[list] = None,
+) -> str:
+    """Format a component interaction as text for the agent.
+
+    Keep this explicit and parseable.  The agent sees the click/selection as a
+    normal user message, preserving the existing gateway path.
+    """
+    parts = [kind]
+    if label:
+        parts.append(f"label={label!r}")
+    if custom_id:
+        parts.append(f"custom_id={custom_id!r}")
+    if values:
+        parts.append(f"values={values!r}")
+    return " | ".join(parts)
+
+
+@dataclass
+class TrackedComponentView:
+    message_id: str
+    view: Any
+    session_key: str = ""
+    interaction_callback: Optional[Callable[[MessageEvent], Any]] = None
+    source: Optional[MessageSource] = None
+    rest_sent: bool = False
+    resolved: bool = False
+    chat_id: str = ""
+
+
+class ComponentStore:
+    """In-memory registry for Discord component views by message id."""
+
+    def __init__(self) -> None:
+        self._items: Dict[str, TrackedComponentView] = {}
+
+    def register(
+        self,
+        *,
+        message_id: str,
+        view: Any,
+        session_key: str = "",
+        interaction_callback: Optional[Callable[[MessageEvent], Any]] = None,
+        source: Optional[MessageSource] = None,
+        rest_sent: bool = False,
+        chat_id: str = "",
+    ) -> TrackedComponentView:
+        tracked = TrackedComponentView(
+            message_id=str(message_id),
+            view=view,
+            session_key=session_key,
+            interaction_callback=interaction_callback,
+            source=source,
+            rest_sent=rest_sent,
+            chat_id=str(chat_id or getattr(source, "chat_id", "") or ""),
+        )
+        self._items[str(message_id)] = tracked
+        return tracked
+
+    def get(self, message_id: str) -> Optional[TrackedComponentView]:
+        return self._items.get(str(message_id))
+
+    def remove(self, message_id: str) -> None:
+        self._items.pop(str(message_id), None)
+
+
+component_store = ComponentStore()
+
+
+class ComponentView(discord.ui.View if discord is not None else object):  # type: ignore[misc]
+    """discord.py View built from a generic component spec."""
+
+    def __init__(
+        self,
+        *,
+        spec: Optional[dict],
+        message_id: str = "",
+        session_key: str = "",
+        source: Optional[MessageSource] = None,
+        interaction_callback: Optional[Callable[[MessageEvent], Any]] = None,
+        timeout: Optional[float] = 900,
+    ) -> None:
+        if discord is not None:
+            super().__init__(timeout=timeout)
+        self._spec = spec or {}
+        self._message_id = str(message_id or "")
+        self._session_key = session_key
+        self._source = source
+        self._interaction_callback = interaction_callback
+        self.resolved = False
+        self._build_items()
+
+    def _build_items(self) -> None:
+        if discord is None:
+            return
+        rows = self._spec.get("action_rows") or []
+        for row_index, row in enumerate(rows[:5]):
+            for button in (row.get("buttons") or [])[:5]:
+                self._add_button(button, row_index)
+            if row.get("select"):
+                self._add_select(row["select"], row_index)
+
+    def _add_button(self, spec: dict, row: int) -> None:
+        label = str(spec.get("label") or spec.get("custom_id") or "Button")[:80]
+        url = spec.get("url")
+        custom_id = str(spec.get("custom_id") or label)
+        kwargs = {
+            "label": label,
+            "style": _style_from_spec(spec.get("style", 2)),
+            "disabled": bool(spec.get("disabled", False)),
+            "row": row,
+        }
+        if url:
+            kwargs["url"] = str(url)
+            kwargs["style"] = _style_from_spec("link")
+        else:
+            kwargs["custom_id"] = _prefixed_custom_id(custom_id)
+        item = discord.ui.Button(**kwargs)
+
+        async def _callback(interaction, *, _label=label, _custom_id=custom_id):
+            await self._handle_interaction(
+                interaction,
+                kind="Button clicked",
+                label=_label,
+                custom_id=_custom_id,
+            )
+
+        item.callback = _callback
+        self.add_item(item)
+
+    def _add_select(self, spec: dict, row: int) -> None:
+        custom_id = str(spec.get("custom_id") or "select")
+        options = []
+        for opt in (spec.get("options") or [])[:25]:
+            if not isinstance(opt, dict):
+                continue
+            options.append(
+                discord.SelectOption(
+                    label=str(opt.get("label") or opt.get("value") or "Option")[:100],
+                    value=str(opt.get("value") or opt.get("label") or "")[:100],
+                    description=(
+                        str(opt.get("description"))[:100]
+                        if opt.get("description") is not None else None
+                    ),
+                )
+            )
+        if not options:
+            return
+        item = discord.ui.Select(
+            placeholder=str(spec.get("placeholder") or "Select an option")[:100],
+            options=options,
+            custom_id=_prefixed_custom_id(custom_id),
+            row=row,
+        )
+
+        async def _callback(interaction, *, _custom_id=custom_id):
+            values = list(getattr(item, "values", []) or getattr(interaction, "data", {}).get("values", []) or [])
+            await self._handle_interaction(
+                interaction,
+                kind="Select chosen",
+                label=values[0] if values else "",
+                custom_id=_custom_id,
+                values=values,
+            )
+
+        item.callback = _callback
+        self.add_item(item)
+
+    async def _handle_interaction(
+        self,
+        interaction,
+        *,
+        kind: str,
+        label: str = "",
+        custom_id: str = "",
+        values: Optional[list] = None,
+    ) -> None:
+        if self.resolved:
+            try:
+                await interaction.response.send_message(
+                    "This component has already been used.", ephemeral=True
+                )
+            except Exception:
+                pass
+            return
+
+        self.resolved = True
+        for child in getattr(self, "children", []) or []:
+            if not getattr(child, "url", None):
+                try:
+                    child.disabled = True
+                except Exception:
+                    pass
+
+        try:
+            await interaction.response.edit_message(view=self)
+        except Exception:
+            try:
+                await interaction.response.defer()
+            except Exception:
+                pass
+
+        source = self._source
+        if source is None:
+            channel_id = ""
+            try:
+                channel_id = str(interaction.channel.id)
+            except Exception:
+                pass
+            user_id = str(getattr(getattr(interaction, "user", None), "id", "") or "")
+            user_name = str(getattr(interaction, "user", "") or "")
+            source = MessageSource(
+                platform="discord",
+                chat_id=channel_id,
+                user_id=user_id,
+                user_name=user_name,
+            )
+
+        message_id = self._message_id
+        if not message_id:
+            try:
+                message_id = str(interaction.message.id)
+            except Exception:
+                message_id = ""
+
+        event = MessageEvent(
+            text=_format_interaction_text(kind, label=label, custom_id=custom_id, values=values),
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=interaction,
+            message_id=message_id,
+            reply_to_message_id=message_id or None,
+        )
+        if self._interaction_callback:
+            result = self._interaction_callback(event)
+            # The callback normally schedules a task and returns it; avoid
+            # importing inspect on the hot path unless needed.
+            if hasattr(result, "__await__"):
+                await result
+
+
+def build_view_from_spec(
+    *,
+    spec: Optional[dict],
+    message_id: str = "",
+    session_key: str = "",
+    source: Optional[MessageSource] = None,
+    interaction_callback: Optional[Callable[[MessageEvent], Any]] = None,
+) -> ComponentView:
+    return ComponentView(
+        spec=spec,
+        message_id=message_id,
+        session_key=session_key,
+        source=source,
+        interaction_callback=interaction_callback,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6143,6 +6143,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     cleanup_all_browsers()
                 except Exception as _e:
                     logger.debug("cleanup_all_browsers (%s) error: %s", phase, _e)
+                try:
+                    from tools.clarify_gateway import clear_all as _clear_all_clarify
+                    _n = _clear_all_clarify()
+                    if _n:
+                        logger.info(
+                            "Shutdown (%s): cancelled %d pending clarify prompt(s)",
+                            phase, _n,
+                        )
+                except Exception as _e:
+                    logger.debug("clarify_gateway.clear_all (%s) error: %s", phase, _e)
+                try:
+                    from tools.human_input_gateway import clear_all as _clear_all_human
+                    _n = _clear_all_human()
+                    if _n:
+                        logger.info(
+                            "Shutdown (%s): cancelled %d pending interactive prompt(s)",
+                            phase, _n,
+                        )
+                except Exception as _e:
+                    logger.debug("human_input_gateway.clear_all (%s) error: %s", phase, _e)
 
             logger.info(
                 "Stopping gateway%s...",
@@ -13025,6 +13045,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 e,
             )
 
+        # Clear any pending interactive_prompt entries for this session.
+        try:
+            from tools.human_input_gateway import clear_session as _clear_human_input
+            _clear_human_input(session_key)
+        except Exception as e:
+            logger.debug(
+                "Failed to clear human_input state for session boundary %s: %s",
+                session_key,
+                e,
+            )
+
     def _begin_session_run_generation(self, session_key: str) -> int:
         """Claim a fresh run generation token for ``session_key``.
 
@@ -14997,6 +15028,84 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return response
 
             agent.clarify_callback = _clarify_callback_sync
+
+            # ------------------------------------------------------------------
+            # Interactive prompt callback: present a rich prompt with per-option
+            # actions (return / modal) and block on a response.
+            #
+            # Same pattern as clarify: register → send via adapter → block on
+            # threading.Event with heartbeat polling → return structured result.
+            # ------------------------------------------------------------------
+            def _interactive_prompt_callback_sync(
+                question: str,
+                options: list,
+                display_type: str,
+                timeout_seconds: float,
+                auth_policy: str,
+            ) -> str:
+                import json as _json
+                from tools import human_input_gateway as _hig
+
+                if not _status_adapter:
+                    return _json.dumps({"status": "cancelled", "error": "no adapter"})
+
+                prompt_id = _hig.generate_prompt_id()
+                _hig.register(
+                    prompt_id=prompt_id,
+                    session_key=session_key or "",
+                    question=question,
+                    options=options,
+                    timeout_seconds=timeout_seconds,
+                    auth_policy=auth_policy,
+                    origin_user_id=str(source.user_id) if auth_policy == "session_owner_only" else None,
+                    display_type=display_type,
+                )
+
+                try:
+                    _status_adapter.pause_typing_for_chat(_status_chat_id)
+                except Exception:
+                    pass
+
+                send_ok = False
+                fut = safe_schedule_threadsafe(
+                    _status_adapter.send_human_input(
+                        chat_id=_status_chat_id,
+                        question=question,
+                        options=options,
+                        prompt_id=prompt_id,
+                        session_key=session_key or "",
+                        display_type=display_type,
+                        auth_policy=auth_policy,
+                        origin_user_id=str(source.user_id) if auth_policy == "session_owner_only" else None,
+                        timeout_seconds=timeout_seconds,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                    logger=logger,
+                    log_message="Interactive prompt send failed to schedule",
+                )
+                if fut is None:
+                    send_ok = False
+                else:
+                    try:
+                        result = fut.result(timeout=15)
+                        send_ok = bool(getattr(result, "success", False))
+                    except Exception as exc:
+                        logger.warning("Interactive prompt send failed: %s", exc)
+                        send_ok = False
+
+                if not send_ok:
+                    _hig.clear_session(session_key or "")
+                    return _json.dumps({"status": "cancelled", "error": "prompt could not be delivered"})
+
+                result = _hig.wait_for_response(prompt_id, timeout=timeout_seconds)
+                if result is None:
+                    return _json.dumps({"status": "timeout", "timed_out": True})
+
+                # Serialize the HumanInputResult dataclass to JSON
+                return _json.dumps(result.to_dict(), ensure_ascii=False)
+
+            agent.interactive_prompt_callback = _interactive_prompt_callback_sync
 
             # Show assistant thinking between tool calls — independent of
             # tool_progress mode. Mattermost needs an explicit per-platform

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6977,6 +6977,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # itself will produce the next user-facing message.
                     return ""
 
+        # Intercept messages that are responses to a pending interactive_prompt
+        # request on platforms without rich UIs.  The base-platform text
+        # fallback marks entries as awaiting text; here we resolve them.
+        try:
+            from tools import human_input_gateway as _hig_mod
+            _pending_hi = _hig_mod.get_pending_for_session(_quick_key)
+        except Exception:
+            _pending_hi = None
+        if _pending_hi is not None and _hig_mod.is_awaiting_text(_pending_hi.prompt_id):
+            _raw_hi_reply = (event.text or "").strip()
+            if _raw_hi_reply and not _raw_hi_reply.startswith("/"):
+                _hi_resolved = _hig_mod.resolve_text_response(
+                    _pending_hi.prompt_id, _raw_hi_reply,
+                )
+                if _hi_resolved:
+                    logger.info(
+                        "Gateway intercepted interactive_prompt text response (session=%s, id=%s)",
+                        _quick_key, _pending_hi.prompt_id,
+                    )
+                    return ""
+
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are
         # /approve, /always, /cancel (plus short aliases).  Anything else

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -234,6 +234,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "gemini-acp": ProviderConfig(
+        id="gemini-acp",
+        name="Gemini CLI (ACP)",
+        auth_type="external_process",
+        inference_base_url="acp://gemini",
+        base_url_env_var="GEMINI_ACP_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -6314,20 +6321,36 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    is_gemini = provider_id == "gemini-acp"
+    if is_gemini:
+        command = (
+            os.getenv("HERMES_GEMINI_ACP_COMMAND", "").strip()
+            or os.getenv("GEMINI_CLI_PATH", "").strip()
+            or "gemini"
+        )
+        raw_args = os.getenv("HERMES_GEMINI_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--skip-trust"]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+
     resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    cli_name = "Gemini CLI" if is_gemini else "Copilot CLI"
+    cli_env = (
+        "HERMES_GEMINI_ACP_COMMAND/GEMINI_CLI_PATH" if is_gemini
+        else "HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH"
+    )
+    if not resolved_command and not base_url.startswith(("acp://", "acp+tcp://")):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {cli_name} command '{command}'. "
+            f"Install {cli_name} or set {cli_env}.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_cli",
         )
 
     return {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4626,6 +4626,64 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_human_input(
+        self,
+        chat_id: str,
+        question: str,
+        options: list,
+        prompt_id: str,
+        session_key: str,
+        display_type: str = "buttons",
+        auth_policy: str = "session_owner_only",
+        origin_user_id: Optional[str] = None,
+        timeout_seconds: float = 900,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render an interactive prompt with per-option actions (buttons / modal).
+
+        For options with ``action: "return"``: button click resolves immediately
+        via ``human_input_gateway.resolve_choice()``.
+
+        For options with ``action: "modal"``: button click opens a Discord modal
+        popup; modal submit resolves via ``human_input_gateway.resolve_modal()``.
+        """
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            from tools.discord_interactive_views import (
+                InteractivePromptView,
+                build_prompt_embed,
+            )
+
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            embed = build_prompt_embed(question, status="pending")
+
+            view = InteractivePromptView(
+                prompt_id=prompt_id,
+                question=question,
+                options=options,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+                auth_policy=auth_policy,
+                origin_user_id=origin_user_id,
+                timeout_seconds=timeout_seconds,
+            )
+
+            msg = await channel.send(embed=embed, view=view)
+            view._message = msg
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            logger.warning("[%s] send_human_input failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
@@ -5378,70 +5436,11 @@ class DiscordAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 
 
-def _component_check_auth(
-    interaction,
-    allowed_user_ids: Optional[set],
-    allowed_role_ids: Optional[set],
-) -> bool:
-    """Shared user-or-role OR semantics for component view button clicks.
+# ---------------------------------------------------------------------------
+# Auth helper — delegates to shared utility to avoid duplication
+# ---------------------------------------------------------------------------
 
-    Mirrors the gateway's external-surface authorization model: component
-    button clicks must be explicitly authorized by a Discord user/role
-    allowlist, a global user allowlist, or an explicit allow-all flag.
-
-    Behavior:
-
-      - DISCORD_ALLOW_ALL_USERS or GATEWAY_ALLOW_ALL_USERS -> allow
-      - user is in DISCORD_ALLOWED_USERS or GATEWAY_ALLOWED_USERS -> allow
-      - role allowlist set + user has a role in it -> allow
-      - role allowlist set + interaction.user has no resolvable
-        ``roles`` attribute (e.g. DM context with a role policy active)
-        -> reject (fail closed)
-      - otherwise -> reject
-    """
-    if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-        return True
-    if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-        return True
-
-    user_set = {str(uid).strip() for uid in (allowed_user_ids or set()) if str(uid).strip()}
-    global_allowed = {
-        uid.strip()
-        for uid in os.getenv("GATEWAY_ALLOWED_USERS", "").split(",")
-        if uid.strip()
-    }
-    user_set.update(global_allowed)
-    role_set = set(allowed_role_ids or set())
-    has_users = bool(user_set)
-    has_roles = bool(role_set)
-    user = getattr(interaction, "user", None)
-    if user is None:
-        return False
-
-    if has_users:
-        try:
-            uid = str(user.id)
-        except AttributeError:
-            uid = ""
-        if "*" in user_set or (uid and uid in user_set):
-            return True
-
-    if has_roles:
-        roles_attr = getattr(user, "roles", None)
-        if roles_attr is None:
-            # Role policy is configured but the interaction doesn't
-            # carry role data (DM-context Member, raw User payload).
-            # Fail closed: a user without a resolvable role list cannot
-            # satisfy a role allowlist.
-            return False
-        try:
-            user_role_ids = {getattr(r, "id", None) for r in roles_attr}
-        except TypeError:
-            return False
-        if user_role_ids & role_set:
-            return True
-
-    return False
+from tools.discord_auth_helpers import component_check_auth as _component_check_auth  # noqa: E402
 
 
 def _define_discord_view_classes() -> None:

--- a/skills/creative/ascii-video/references/ascii-art.md
+++ b/skills/creative/ascii-video/references/ascii-art.md
@@ -1,0 +1,322 @@
+---
+name: ascii-art
+description: "ASCII art: pyfiglet, cowsay, boxes, image-to-ascii."
+version: 4.0.0
+author: 0xbyt4, Hermes Agent
+license: MIT
+dependencies: []
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [ASCII, Art, Banners, Creative, Unicode, Text-Art, pyfiglet, figlet, cowsay, boxes]
+    related_skills: [excalidraw]
+
+---
+
+# ASCII Art Skill
+
+Multiple tools for different ASCII art needs. All tools are local CLI programs or free REST APIs — no API keys required.
+
+## Tool 1: Text Banners (pyfiglet — local)
+
+Render text as large ASCII art banners. 571 built-in fonts.
+
+### Setup
+
+```bash
+pip install pyfiglet --break-system-packages -q
+```
+
+### Usage
+
+```bash
+python3 -m pyfiglet "YOUR TEXT" -f slant
+python3 -m pyfiglet "TEXT" -f doom -w 80    # Set width
+python3 -m pyfiglet --list_fonts             # List all 571 fonts
+```
+
+### Recommended fonts
+
+| Style | Font | Best for |
+|-------|------|----------|
+| Clean & modern | `slant` | Project names, headers |
+| Bold & blocky | `doom` | Titles, logos |
+| Big & readable | `big` | Banners |
+| Classic banner | `banner3` | Wide displays |
+| Compact | `small` | Subtitles |
+| Cyberpunk | `cyberlarge` | Tech themes |
+| 3D effect | `3-d` | Splash screens |
+| Gothic | `gothic` | Dramatic text |
+
+### Tips
+
+- Preview 2-3 fonts and let the user pick their favorite
+- Short text (1-8 chars) works best with detailed fonts like `doom` or `block`
+- Long text works better with compact fonts like `small` or `mini`
+
+## Tool 2: Text Banners (asciified API — remote, no install)
+
+Free REST API that converts text to ASCII art. 250+ FIGlet fonts. Returns plain text directly — no parsing needed. Use this when pyfiglet is not installed or as a quick alternative.
+
+### Usage (via terminal curl)
+
+```bash
+# Basic text banner (default font)
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello+World"
+
+# With a specific font
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello&font=Slant"
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello&font=Doom"
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello&font=Star+Wars"
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello&font=3-D"
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=Hello&font=Banner3"
+
+# List all available fonts (returns JSON array)
+curl -s "https://asciified.thelicato.io/api/v2/fonts"
+```
+
+### Tips
+
+- URL-encode spaces as `+` in the text parameter
+- The response is plain text ASCII art — no JSON wrapping, ready to display
+- Font names are case-sensitive; use the fonts endpoint to get exact names
+- Works from any terminal with curl — no Python or pip needed
+
+## Tool 3: Cowsay (Message Art)
+
+Classic tool that wraps text in a speech bubble with an ASCII character.
+
+### Setup
+
+```bash
+sudo apt install cowsay -y    # Debian/Ubuntu
+# brew install cowsay         # macOS
+```
+
+### Usage
+
+```bash
+cowsay "Hello World"
+cowsay -f tux "Linux rules"       # Tux the penguin
+cowsay -f dragon "Rawr!"          # Dragon
+cowsay -f stegosaurus "Roar!"     # Stegosaurus
+cowthink "Hmm..."                  # Thought bubble
+cowsay -l                          # List all characters
+```
+
+### Available characters (50+)
+
+`beavis.zen`, `bong`, `bunny`, `cheese`, `daemon`, `default`, `dragon`,
+`dragon-and-cow`, `elephant`, `eyes`, `flaming-skull`, `ghostbusters`,
+`hellokitty`, `kiss`, `kitty`, `koala`, `luke-koala`, `mech-and-cow`,
+`meow`, `moofasa`, `moose`, `ren`, `sheep`, `skeleton`, `small`,
+`stegosaurus`, `stimpy`, `supermilker`, `surgery`, `three-eyes`,
+`turkey`, `turtle`, `tux`, `udder`, `vader`, `vader-koala`, `www`
+
+### Eye/tongue modifiers
+
+```bash
+cowsay -b "Borg"       # =_= eyes
+cowsay -d "Dead"       # x_x eyes
+cowsay -g "Greedy"     # $_$ eyes
+cowsay -p "Paranoid"   # @_@ eyes
+cowsay -s "Stoned"     # *_* eyes
+cowsay -w "Wired"      # O_O eyes
+cowsay -e "OO" "Msg"   # Custom eyes
+cowsay -T "U " "Msg"   # Custom tongue
+```
+
+## Tool 4: Boxes (Decorative Borders)
+
+Draw decorative ASCII art borders/frames around any text. 70+ built-in designs.
+
+### Setup
+
+```bash
+sudo apt install boxes -y    # Debian/Ubuntu
+# brew install boxes         # macOS
+```
+
+### Usage
+
+```bash
+echo "Hello World" | boxes                    # Default box
+echo "Hello World" | boxes -d stone           # Stone border
+echo "Hello World" | boxes -d parchment       # Parchment scroll
+echo "Hello World" | boxes -d cat             # Cat border
+echo "Hello World" | boxes -d dog             # Dog border
+echo "Hello World" | boxes -d unicornsay      # Unicorn
+echo "Hello World" | boxes -d diamonds        # Diamond pattern
+echo "Hello World" | boxes -d c-cmt           # C-style comment
+echo "Hello World" | boxes -d html-cmt        # HTML comment
+echo "Hello World" | boxes -a c               # Center text
+boxes -l                                       # List all 70+ designs
+```
+
+### Combine with pyfiglet or asciified
+
+```bash
+python3 -m pyfiglet "HERMES" -f slant | boxes -d stone
+# Or without pyfiglet installed:
+curl -s "https://asciified.thelicato.io/api/v2/ascii?text=HERMES&font=Slant" | boxes -d stone
+```
+
+## Tool 5: TOIlet (Colored Text Art)
+
+Like pyfiglet but with ANSI color effects and visual filters. Great for terminal eye candy.
+
+### Setup
+
+```bash
+sudo apt install toilet toilet-fonts -y    # Debian/Ubuntu
+# brew install toilet                      # macOS
+```
+
+### Usage
+
+```bash
+toilet "Hello World"                    # Basic text art
+toilet -f bigmono12 "Hello"            # Specific font
+toilet --gay "Rainbow!"                 # Rainbow coloring
+toilet --metal "Metal!"                 # Metallic effect
+toilet -F border "Bordered"             # Add border
+toilet -F border --gay "Fancy!"         # Combined effects
+toilet -f pagga "Block"                 # Block-style font (unique to toilet)
+toilet -F list                          # List available filters
+```
+
+### Filters
+
+`crop`, `gay` (rainbow), `metal`, `flip`, `flop`, `180`, `left`, `right`, `border`
+
+**Note**: toilet outputs ANSI escape codes for colors — works in terminals but may not render in all contexts (e.g., plain text files, some chat platforms).
+
+## Tool 6: Image to ASCII Art
+
+Convert images (PNG, JPEG, GIF, WEBP) to ASCII art.
+
+### Option A: ascii-image-converter (recommended, modern)
+
+```bash
+# Install
+sudo snap install ascii-image-converter
+# OR: go install github.com/TheZoraiz/ascii-image-converter@latest
+```
+
+```bash
+ascii-image-converter image.png                  # Basic
+ascii-image-converter image.png -C               # Color output
+ascii-image-converter image.png -d 60,30         # Set dimensions
+ascii-image-converter image.png -b               # Braille characters
+ascii-image-converter image.png -n               # Negative/inverted
+ascii-image-converter https://url/image.jpg      # Direct URL
+ascii-image-converter image.png --save-txt out   # Save as text
+```
+
+### Option B: jp2a (lightweight, JPEG only)
+
+```bash
+sudo apt install jp2a -y
+jp2a --width=80 image.jpg
+jp2a --colors image.jpg              # Colorized
+```
+
+## Tool 7: Search Pre-Made ASCII Art
+
+Search curated ASCII art from the web. Use `terminal` with `curl`.
+
+### Source A: ascii.co.uk (recommended for pre-made art)
+
+Large collection of classic ASCII art organized by subject. Art is inside HTML `<pre>` tags. Fetch the page with curl, then extract art with a small Python snippet.
+
+**URL pattern:** `https://ascii.co.uk/art/{subject}`
+
+**Step 1 — Fetch the page:**
+
+```bash
+curl -s 'https://ascii.co.uk/art/cat' -o /tmp/ascii_art.html
+```
+
+**Step 2 — Extract art from pre tags:**
+
+```python
+import re, html
+with open('/tmp/ascii_art.html') as f:
+    text = f.read()
+arts = re.findall(r'<pre[^>]*>(.*?)</pre>', text, re.DOTALL)
+for art in arts:
+    clean = re.sub(r'<[^>]+>', '', art)
+    clean = html.unescape(clean).strip()
+    if len(clean) > 30:
+        print(clean)
+        print('\n---\n')
+```
+
+**Available subjects** (use as URL path):
+- Animals: `cat`, `dog`, `horse`, `bird`, `fish`, `dragon`, `snake`, `rabbit`, `elephant`, `dolphin`, `butterfly`, `owl`, `wolf`, `bear`, `penguin`, `turtle`
+- Objects: `car`, `ship`, `airplane`, `rocket`, `guitar`, `computer`, `coffee`, `beer`, `cake`, `house`, `castle`, `sword`, `crown`, `key`
+- Nature: `tree`, `flower`, `sun`, `moon`, `star`, `mountain`, `ocean`, `rainbow`
+- Characters: `skull`, `robot`, `angel`, `wizard`, `pirate`, `ninja`, `alien`
+- Holidays: `christmas`, `halloween`, `valentine`
+
+**Tips:**
+- Preserve artist signatures/initials — important etiquette
+- Multiple art pieces per page — pick the best one for the user
+- Works reliably via curl, no JavaScript needed
+
+### Source B: GitHub Octocat API (fun easter egg)
+
+Returns a random GitHub Octocat with a wise quote. No auth needed.
+
+```bash
+curl -s https://api.github.com/octocat
+```
+
+## Tool 8: Fun ASCII Utilities (via curl)
+
+These free services return ASCII art directly — great for fun extras.
+
+### QR Codes as ASCII Art
+
+```bash
+curl -s "qrenco.de/Hello+World"
+curl -s "qrenco.de/https://example.com"
+```
+
+### Weather as ASCII Art
+
+```bash
+curl -s "wttr.in/London"          # Full weather report with ASCII graphics
+curl -s "wttr.in/Moon"            # Moon phase in ASCII art
+curl -s "v2.wttr.in/London"       # Detailed version
+```
+
+## Tool 9: LLM-Generated Custom Art (Fallback)
+
+When tools above don't have what's needed, generate ASCII art directly using these Unicode characters:
+
+### Character Palette
+
+**Box Drawing:** `╔ ╗ ╚ ╝ ║ ═ ╠ ╣ ╦ ╩ ╬ ┌ ┐ └ ┘ │ ─ ├ ┤ ┬ ┴ ┼ ╭ ╮ ╰ ╯`
+
+**Block Elements:** `░ ▒ ▓ █ ▄ ▀ ▌ ▐ ▖ ▗ ▘ ▝ ▚ ▞`
+
+**Geometric & Symbols:** `◆ ◇ ◈ ● ○ ◉ ■ □ ▲ △ ▼ ▽ ★ ☆ ✦ ✧ ◀ ▶ ◁ ▷ ⬡ ⬢ ⌂`
+
+### Rules
+
+- Max width: 60 characters per line (terminal-safe)
+- Max height: 15 lines for banners, 25 for scenes
+- Monospace only: output must render correctly in fixed-width fonts
+
+## Decision Flow
+
+1. **Text as a banner** → pyfiglet if installed, otherwise asciified API via curl
+2. **Wrap a message in fun character art** → cowsay
+3. **Add decorative border/frame** → boxes (can combine with pyfiglet/asciified)
+4. **Art of a specific thing** (cat, rocket, dragon) → ascii.co.uk via curl + parsing
+5. **Convert an image to ASCII** → ascii-image-converter or jp2a
+6. **QR code** → qrenco.de via curl
+7. **Weather/moon art** → wttr.in via curl
+8. **Something custom/creative** → LLM generation with Unicode palette
+9. **Any tool not installed** → install it, or fall back to next option

--- a/tests/tools/test_discord_interactive_views.py
+++ b/tests/tools/test_discord_interactive_views.py
@@ -1,0 +1,656 @@
+# tests/tools/test_discord_interactive_views.py
+"""Unit tests for tools/discord_interactive_views.py.
+
+The views (InteractivePromptView, InteractivePromptModal) require ``discord.py``
+at class-definition time (they inherit from ``discord.ui.View`` / ``discord.ui.Modal``),
+so the entire test module is skipped when ``discord`` is not installed.
+
+The pure helper ``_component_check_auth`` does **not** require discord and is
+always tested.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Optional, Set
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# _component_check_auth — pure function, always testable
+# ---------------------------------------------------------------------------
+from tools.discord_interactive_views import _component_check_auth, unwrap_modal_children
+
+
+# -- mock interaction helpers ------------------------------------------------
+
+def _make_interaction(
+    user_id: str = "123",
+    role_ids: Optional[list[str]] = None,
+) -> MagicMock:
+    """Build a lightweight mock that quacks like discord.Interaction."""
+    user = MagicMock()
+    user.id = int(user_id)
+    if role_ids is not None:
+        user.roles = [MagicMock(id=int(rid)) for rid in role_ids]
+    else:
+        user.roles = []
+    interaction = MagicMock()
+    interaction.user = user
+    return interaction
+
+
+# ===========================================================================
+# Tests for _component_check_auth
+# ===========================================================================
+
+
+class TestComponentCheckAuth:
+    """Pure-function auth checker — no discord import required."""
+
+    def test_both_empty_allows(self):
+        """Both allowlists empty → allow everyone."""
+        assert _component_check_auth(_make_interaction(), None, None) is True
+
+    def test_user_allowed(self):
+        """User ID in allowed_user_ids → allow."""
+        assert _component_check_auth(
+            _make_interaction("42"), {"42"}, None,
+        ) is True
+
+    def test_user_not_allowed(self):
+        """User ID not in allowed_user_ids, no roles → reject."""
+        assert _component_check_auth(
+            _make_interaction("99"), {"42"}, None,
+        ) is False
+
+    def test_role_allowed(self):
+        """User has a role in allowed_role_ids → allow."""
+        assert _component_check_auth(
+            _make_interaction("99", role_ids=["55"]),
+            None, {55},
+        ) is True
+
+    def test_role_not_allowed(self):
+        """User's roles don't intersect allowed_role_ids → reject."""
+        assert _component_check_auth(
+            _make_interaction("99", role_ids=["10", "20"]),
+            None, {55},
+        ) is False
+
+    def test_user_or_role_combined(self):
+        """User in user_set OR role in role_set → allow."""
+        # User matches
+        assert _component_check_auth(
+            _make_interaction("42", role_ids=["10"]),
+            {"42"}, {55},
+        ) is True
+        # Role matches
+        assert _component_check_auth(
+            _make_interaction("99", role_ids=["55"]),
+            {"42"}, {55},
+        ) is True
+        # Neither matches
+        assert _component_check_auth(
+            _make_interaction("99", role_ids=["10"]),
+            {"42"}, {55},
+        ) is False
+
+    def test_no_user_attribute(self):
+        """Interaction without .user → reject."""
+        interaction = MagicMock(spec=[])  # no attributes
+        assert _component_check_auth(interaction, {"42"}, None) is False
+
+    def test_user_without_id(self):
+        """User object without .id → reject gracefully."""
+        user = MagicMock(spec=[])  # no .id
+        interaction = MagicMock()
+        interaction.user = user
+        assert _component_check_auth(interaction, {"42"}, None) is False
+
+    def test_roles_not_iterable(self):
+        """User.roles is not iterable → reject gracefully."""
+        user = MagicMock()
+        user.id = 99
+        user.roles = "not-a-list"  # string is iterable but items have no .id
+        interaction = MagicMock()
+        interaction.user = user
+        # This should not crash; return False
+        result = _component_check_auth(interaction, None, {42})
+        assert result is False
+
+    def test_string_role_ids(self):
+        """Role IDs are compared as integers (adapter stores them as int)."""
+        assert _component_check_auth(
+            _make_interaction("1", role_ids=["100"]),
+            None, {100},
+        ) is True
+
+
+# ===========================================================================
+# Tests for view construction (requires discord.py)
+# ===========================================================================
+
+discord = pytest.importorskip("discord")
+
+from tools.discord_interactive_views import (
+    InteractivePromptView,
+    InteractivePromptModal,
+    build_prompt_embed,
+)
+
+
+def _make_options(n: int = 2) -> list[dict[str, Any]]:
+    return [
+        {"label": f"Opt {i}", "value": f"opt_{i}"}
+        for i in range(n)
+    ]
+
+
+class TestInteractivePromptViewConstruction:
+    """Test view construction and configuration (no Discord connection)."""
+
+    def test_custom_id_button_length(self):
+        """Button custom_id must be ≤ 100 chars (Discord limit)."""
+        long_prompt_id = "a" * 80  # 80-char prompt_id
+        view = InteractivePromptView(
+            prompt_id=long_prompt_id,
+            question="Q?",
+            options=_make_options(3),
+            allowed_user_ids=set(),
+            allowed_role_ids=set(),
+            auth_policy="session_owner_only",
+            origin_user_id="123",
+            timeout_seconds=900,
+        )
+        for child in view.children:
+            if isinstance(child, discord.ui.Button):
+                assert len(child.custom_id) <= 100, (
+                    f"Button custom_id too long: {len(child.custom_id)} chars"
+                )
+
+    def test_custom_id_modal_length(self):
+        """Modal custom_id triggered from a button must be ≤ 100 chars."""
+        long_prompt_id = "b" * 80
+        # Simulate what _resolve_choice does: create a modal with option_index
+        modal = InteractivePromptModal(
+            prompt_id=long_prompt_id,
+            option_index=2,
+            modal_spec={
+                "title": "Test",
+                "fields": [{"key": "k", "label": "L", "type": "text"}],
+            },
+            original_view=None,
+        )
+        assert len(modal.custom_id) <= 100, (
+            f"Modal custom_id too long: {len(modal.custom_id)} chars"
+        )
+
+    def test_view_timeout_default(self):
+        """Default timeout is 900 seconds."""
+        view = InteractivePromptView(
+            prompt_id="test",
+            question="Q?",
+            options=_make_options(1),
+            allowed_user_ids=set(),
+            allowed_role_ids=set(),
+            auth_policy="session_owner_only",
+            origin_user_id="123",
+            timeout_seconds=900,
+        )
+        assert view.timeout == 900
+
+    def test_view_timeout_custom(self):
+        """Custom timeout is forwarded correctly."""
+        view = InteractivePromptView(
+            prompt_id="test",
+            question="Q?",
+            options=_make_options(1),
+            allowed_user_ids=set(),
+            allowed_role_ids=set(),
+            auth_policy="session_owner_only",
+            origin_user_id="123",
+            timeout_seconds=1800,
+        )
+        assert view.timeout == 1800
+
+    def test_view_timeout_capped_at_3600(self):
+        """Timeout > 3600 is capped to 3600."""
+        view = InteractivePromptView(
+            prompt_id="test",
+            question="Q?",
+            options=_make_options(1),
+            allowed_user_ids=set(),
+            allowed_role_ids=set(),
+            auth_policy="session_owner_only",
+            origin_user_id="123",
+            timeout_seconds=9999,
+        )
+        assert view.timeout == 3600
+
+    def test_view_max_25_buttons(self):
+        """View with 25 options creates exactly 25 buttons."""
+        opts = _make_options(25)
+        view = InteractivePromptView(
+            prompt_id="test",
+            question="Q?",
+            options=opts,
+            allowed_user_ids=set(),
+            allowed_role_ids=set(),
+            auth_policy="session_owner_only",
+            origin_user_id="123",
+            timeout_seconds=900,
+        )
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 25
+
+    def test_modal_uses_index_not_value(self):
+        """Modal receives option_index, not the value string."""
+        modal = InteractivePromptModal(
+            prompt_id="test",
+            option_index=7,
+            modal_spec={
+                "title": "Test",
+                "fields": [{"key": "k", "label": "L", "type": "text"}],
+            },
+            original_view=None,
+        )
+        assert modal.option_index == 7
+        # custom_id should contain the index, not a value string
+        assert ":7" in modal.custom_id
+
+
+class TestInteractivePromptModalFieldTypes:
+    """Test modal construction with select, radio, and checkbox field types."""
+
+    def _modal_with_fields(self, fields: list[dict[str, Any]]) -> InteractivePromptModal:
+        return InteractivePromptModal(
+            prompt_id="test",
+            option_index=0,
+            modal_spec={"title": "Test", "fields": fields},
+            original_view=None,
+        )
+
+    def test_select_field_creates_select_component(self):
+        """A 'select' field type creates a discord.ui.Select child (wrapped in Label)."""
+        modal = self._modal_with_fields([
+            {"key": "priority", "label": "Priority", "type": "select",
+             "options": ["Low", "Medium", "High"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        selects = [c for c in inner if isinstance(c, discord.ui.Select)]
+        assert len(selects) == 1
+        assert len(selects[0].options) == 3
+        assert [o.label for o in selects[0].options] == ["Low", "Medium", "High"]
+
+    def test_select_field_custom_id_uses_key(self):
+        """Select component's custom_id matches the field key."""
+        modal = self._modal_with_fields([
+            {"key": "my_select", "label": "Pick", "type": "select",
+             "options": ["A", "B"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert select.custom_id == "my_select"
+
+    def test_select_field_capped_at_25_options(self):
+        """Select options are capped at Discord's 25 max."""
+        opts = [f"Option {i}" for i in range(30)]
+        modal = self._modal_with_fields([
+            {"key": "sel", "label": "Pick", "type": "select", "options": opts},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert len(select.options) == 25
+
+    def test_select_field_empty_options(self):
+        """Select with no options creates an empty dropdown."""
+        modal = self._modal_with_fields([
+            {"key": "sel", "label": "Pick", "type": "select", "options": []},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert len(select.options) == 0
+        assert "sel" in modal._field_keys
+
+    def test_radio_field_creates_radio_group(self):
+        """A 'radio' field type creates a discord.ui.RadioGroup child (wrapped in Label)."""
+        modal = self._modal_with_fields([
+            {"key": "category", "label": "Category", "type": "radio",
+             "options": ["Bug", "Feature"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        radios = [c for c in inner if isinstance(c, discord.ui.RadioGroup)]
+        assert len(radios) == 1
+        assert len(radios[0].options) == 2
+
+    def test_radio_field_capped_at_10_options(self):
+        """Radio options are capped at Discord's 10 max."""
+        opts = [f"Choice {i}" for i in range(15)]
+        modal = self._modal_with_fields([
+            {"key": "rg", "label": "Pick one", "type": "radio", "options": opts},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        radio = [c for c in inner if isinstance(c, discord.ui.RadioGroup)][0]
+        assert len(radio.options) == 10
+
+    def test_checkbox_field_creates_checkbox_group(self):
+        """A 'checkbox' field type creates a discord.ui.CheckboxGroup child (wrapped in Label)."""
+        modal = self._modal_with_fields([
+            {"key": "tags", "label": "Tags", "type": "checkbox",
+             "options": ["urgent", "backend"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        checkboxes = [c for c in inner
+                     if isinstance(c, discord.ui.CheckboxGroup)]
+        assert len(checkboxes) == 1
+        assert len(checkboxes[0].options) == 2
+
+    def test_checkbox_field_capped_at_10_options(self):
+        """Checkbox options are capped at Discord's 10 max."""
+        opts = [f"Tag {i}" for i in range(12)]
+        modal = self._modal_with_fields([
+            {"key": "cb", "label": "Tags", "type": "checkbox", "options": opts},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        cb = [c for c in inner
+              if isinstance(c, discord.ui.CheckboxGroup)][0]
+        assert len(cb.options) == 10
+
+    def test_mixed_field_types_all_present(self):
+        """Modal with text, select, radio, and checkbox creates all components (wrapped in Labels)."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Name", "type": "text"},
+            {"key": "priority", "label": "Priority", "type": "select",
+             "options": ["Low", "High"]},
+            {"key": "category", "label": "Category", "type": "radio",
+             "options": ["Bug", "Feature"]},
+            {"key": "tags", "label": "Tags", "type": "checkbox",
+             "options": ["A"]},
+        ])
+        assert len(modal.children) == 4
+        inner = unwrap_modal_children(modal.children)
+        assert isinstance(inner[0], discord.ui.TextInput)
+        assert isinstance(inner[1], discord.ui.Select)
+        assert isinstance(inner[2], discord.ui.RadioGroup)
+        assert isinstance(inner[3], discord.ui.CheckboxGroup)
+        assert modal._field_keys == ["name", "priority", "category", "tags"]
+
+    def test_mixed_fields_at_modal_limit(self):
+        """5 fields exactly fills Discord's 5-component limit."""
+        modal = self._modal_with_fields([
+            {"key": "f1", "label": "F1", "type": "text"},
+            {"key": "f2", "label": "F2", "type": "select", "options": ["A"]},
+            {"key": "f3", "label": "F3", "type": "radio", "options": ["X"]},
+            {"key": "f4", "label": "F4", "type": "checkbox", "options": ["P"]},
+            {"key": "f5", "label": "F5", "type": "text"},
+        ])
+        assert len(modal.children) == 5
+        assert modal._field_keys == ["f1", "f2", "f3", "f4", "f5"]
+
+    def test_modal_limit_enforces_5_children(self):
+        """6th field is dropped — Discord's modal max is 5 children."""
+        modal = self._modal_with_fields([
+            {"key": "f1", "label": "F1", "type": "text"},
+            {"key": "f2", "label": "F2", "type": "select", "options": ["A"]},
+            {"key": "f3", "label": "F3", "type": "radio", "options": ["X"]},
+            {"key": "f4", "label": "F4", "type": "checkbox", "options": ["P"]},
+            {"key": "f5", "label": "F5", "type": "text"},
+            {"key": "f6", "label": "F6", "type": "text"},
+        ])
+        assert len(modal.children) == 5
+        assert "f6" not in modal._field_keys
+
+    def test_select_optional_min_values_zero(self):
+        """Select with required=False should allow skipping (min_values=0)."""
+        modal = self._modal_with_fields([
+            {"key": "sel", "label": "Pick", "type": "select",
+             "required": False, "options": ["A", "B"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert select.min_values == 0
+
+    def test_select_required_min_values_one(self):
+        """Select with required=True should enforce selection (min_values=1)."""
+        modal = self._modal_with_fields([
+            {"key": "sel", "label": "Pick", "type": "select",
+             "required": True, "options": ["A", "B"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert select.min_values == 1
+
+    def test_custom_id_truncated_at_100_chars(self):
+        """Field custom_id is truncated to Discord's 100-char limit."""
+        long_key = "k" * 120
+        modal = self._modal_with_fields([
+            {"key": long_key, "label": "Pick", "type": "select",
+             "options": ["A"]},
+        ])
+        inner = unwrap_modal_children(modal.children)
+        select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
+        assert len(select.custom_id) <= 100
+
+    def test_file_upload_field_skipped_with_warning(self):
+        """file_upload field type is silently skipped (not yet implemented)."""
+        modal = self._modal_with_fields([
+            {"key": "file", "label": "Upload", "type": "file_upload"},
+        ])
+        # file_upload should NOT create any modal children
+        assert len(modal.children) == 0
+        # It should NOT be in field_keys either (no child to extract from)
+        assert "file" not in modal._field_keys
+
+
+# ===========================================================================
+# Label wrapper tests — TDD for Discord modal API migration (Sep 2025)
+# ===========================================================================
+
+
+class TestLabelWrapperMigration:
+    """Tests for discord.ui.Label wrapping in InteractivePromptModal.
+
+    Discord's Sep 2025 modal API change requires ALL interactive components
+    inside modals to be wrapped in discord.ui.Label (type 18).
+    """
+
+    def _modal_with_fields(self, fields: list[dict[str, Any]]) -> InteractivePromptModal:
+        return InteractivePromptModal(
+            prompt_id="test",
+            option_index=0,
+            modal_spec={"title": "Test", "fields": fields},
+            original_view=None,
+        )
+
+    # -- T1: Label wrapper in modal payload --------------------------------
+
+    def test_label_wraps_text_input_in_payload(self):
+        """Modal with text field → to_dict() has Label(type:18) wrapping TextInput(type:4)."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Your Name", "type": "text"},
+        ])
+        d = modal.to_dict()
+        components = d["components"]
+        assert len(components) == 1
+
+        label_comp = components[0]
+        assert label_comp["type"] == 18, "Top-level should be Label (type 18)"
+        assert label_comp["label"] == "Your Name"
+
+        inner = label_comp["component"]
+        assert inner["type"] == 4, "Inner should be TextInput (type 4)"
+        # Label should own the label text; inner TextInput label should be null
+        assert inner.get("label") is None, "Inner TextInput label should be null"
+
+    def test_label_wraps_select_in_payload(self):
+        """Modal with select field → to_dict() has Label(type:18) wrapping Select(type:3)."""
+        modal = self._modal_with_fields([
+            {"key": "priority", "label": "Priority", "type": "select",
+             "options": ["Low", "High"]},
+        ])
+        d = modal.to_dict()
+        components = d["components"]
+        assert len(components) == 1
+
+        label_comp = components[0]
+        assert label_comp["type"] == 18
+        assert label_comp["label"] == "Priority"
+
+        inner = label_comp["component"]
+        assert inner["type"] == 3, "Inner should be Select (type 3)"
+
+    # -- T2: Label.description mapping --------------------------------------
+
+    def test_label_description_in_payload(self):
+        """Field description maps to Label.description in modal payload."""
+        modal = self._modal_with_fields([
+            {"key": "email", "label": "Email", "type": "text",
+             "description": "Enter your work email"},
+        ])
+        d = modal.to_dict()
+        label_comp = d["components"][0]
+        assert label_comp.get("description") == "Enter your work email"
+
+    def test_label_description_truncated_to_100(self):
+        """Description >100 chars is truncated to 100 characters."""
+        long_desc = "x" * 150
+        modal = self._modal_with_fields([
+            {"key": "f", "label": "F", "type": "text",
+             "description": long_desc},
+        ])
+        d = modal.to_dict()
+        label_comp = d["components"][0]
+        assert len(label_comp["description"]) == 100
+
+    def test_label_no_description_when_absent(self):
+        """No description key in payload when field has no description."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Name", "type": "text"},
+        ])
+        d = modal.to_dict()
+        label_comp = d["components"][0]
+        assert "description" not in label_comp
+
+    # -- T3: Submit value extraction with Labels ---------------------------
+
+    def test_submit_extracts_values_through_labels(self):
+        """on_submit correctly extracts values from Label-wrapped components."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Name", "type": "text"},
+            {"key": "priority", "label": "Priority", "type": "select",
+             "options": ["Low", "High"]},
+        ])
+        # Simulate user input by setting internal values on inner components
+        inner_components = unwrap_modal_children(modal.children)
+        inner_components[0]._value = "Alice"
+        inner_components[1]._values = ["High"]
+
+        # Extract fields using the same logic as on_submit
+        fields: dict[str, Any] = {}
+        for idx, child in enumerate(modal.children):
+            if idx >= len(modal._field_keys):
+                break
+            field_key = modal._field_keys[idx]
+            inner = child.component if isinstance(child, discord.ui.Label) else child
+            if isinstance(inner, (discord.ui.TextInput, discord.ui.RadioGroup)):
+                fields[field_key] = inner.value
+            elif isinstance(inner, (discord.ui.Select, discord.ui.CheckboxGroup)):
+                fields[field_key] = inner.values
+            else:
+                fields[field_key] = getattr(inner, "value", None)
+
+        assert fields == {"name": "Alice", "priority": ["High"]}
+
+    def test_submit_extracts_radio_value_through_label(self):
+        """RadioGroup value extracted through Label wrapper."""
+        modal = self._modal_with_fields([
+            {"key": "category", "label": "Category", "type": "radio",
+             "options": ["Bug", "Feature"]},
+        ])
+        inner = unwrap_modal_children(modal.children)[0]
+        inner._value = "Bug"
+
+        fields = {}
+        for idx, child in enumerate(modal.children):
+            if idx >= len(modal._field_keys):
+                break
+            field_key = modal._field_keys[idx]
+            inner = child.component if isinstance(child, discord.ui.Label) else child
+            if isinstance(inner, (discord.ui.TextInput, discord.ui.RadioGroup)):
+                fields[field_key] = inner.value
+            elif isinstance(inner, (discord.ui.Select, discord.ui.CheckboxGroup)):
+                fields[field_key] = inner.values
+            else:
+                fields[field_key] = getattr(inner, "value", None)
+
+        assert fields == {"category": "Bug"}
+
+    # -- T4: Select.disabled NOT in modal payload --------------------------
+
+    def test_select_no_disabled_in_modal_payload(self):
+        """Select component inside modal payload must not have 'disabled' key."""
+        modal = self._modal_with_fields([
+            {"key": "pick", "label": "Pick", "type": "select",
+             "options": ["A", "B"]},
+        ])
+        d = modal.to_dict()
+        inner = d["components"][0]["component"]
+        assert "disabled" not in inner, (
+            "disabled must not be present in Select inside modal"
+        )
+
+    # -- T5: 5-child limit with Labels -------------------------------------
+
+    def test_5_child_limit_with_label_wrapping(self):
+        """6 fields → only 5 Labels added, _field_keys length 5."""
+        modal = self._modal_with_fields([
+            {"key": "f1", "label": "F1", "type": "text"},
+            {"key": "f2", "label": "F2", "type": "select", "options": ["A"]},
+            {"key": "f3", "label": "F3", "type": "radio", "options": ["X"]},
+            {"key": "f4", "label": "F4", "type": "checkbox", "options": ["P"]},
+            {"key": "f5", "label": "F5", "type": "text"},
+            {"key": "f6", "label": "F6", "type": "text"},
+        ])
+        # All children should be Labels
+        for child in modal.children:
+            assert isinstance(child, discord.ui.Label), (
+                f"Expected Label, got {type(child).__name__}"
+            )
+        assert len(modal.children) == 5
+        assert len(modal._field_keys) == 5
+        assert "f6" not in modal._field_keys
+
+    # -- T6: Backward compat text-only -------------------------------------
+
+    def test_all_text_fields_all_wrapped_in_labels(self):
+        """All text fields → all wrapped in Labels, payload is valid."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Name", "type": "text"},
+            {"key": "email", "label": "Email", "type": "text"},
+            {"key": "notes", "label": "Notes", "type": "text",
+             "multiline": True},
+        ])
+        d = modal.to_dict()
+        assert len(d["components"]) == 3
+        for comp in d["components"]:
+            assert comp["type"] == 18, "Each top-level should be Label"
+            assert "component" in comp
+            assert comp["component"]["type"] == 4, "Inner should be TextInput"
+
+    def test_all_children_are_labels(self):
+        """Every modal child should be a discord.ui.Label instance."""
+        modal = self._modal_with_fields([
+            {"key": "name", "label": "Name", "type": "text"},
+            {"key": "priority", "label": "Priority", "type": "select",
+             "options": ["Low", "High"]},
+            {"key": "category", "label": "Category", "type": "radio",
+             "options": ["Bug", "Feature"]},
+            {"key": "tags", "label": "Tags", "type": "checkbox",
+             "options": ["A"]},
+        ])
+        for child in modal.children:
+            assert isinstance(child, discord.ui.Label), (
+                f"Expected Label wrapper, got {type(child).__name__}"
+            )

--- a/tests/tools/test_discord_interactive_views.py
+++ b/tests/tools/test_discord_interactive_views.py
@@ -133,6 +133,7 @@ class TestComponentCheckAuth:
 # ===========================================================================
 
 discord = pytest.importorskip("discord")
+_ui = discord.ui
 
 from tools.discord_interactive_views import (
     InteractivePromptView,
@@ -433,15 +434,36 @@ class TestInteractivePromptModalFieldTypes:
         select = [c for c in inner if isinstance(c, discord.ui.Select)][0]
         assert len(select.custom_id) <= 100
 
-    def test_file_upload_field_skipped_with_warning(self):
-        """file_upload field type is silently skipped (not yet implemented)."""
+    def test_file_upload_field_creates_file_upload_component(self):
+        """file_upload field type creates a FileUpload wrapped in Label."""
         modal = self._modal_with_fields([
             {"key": "file", "label": "Upload", "type": "file_upload"},
         ])
-        # file_upload should NOT create any modal children
-        assert len(modal.children) == 0
-        # It should NOT be in field_keys either (no child to extract from)
-        assert "file" not in modal._field_keys
+        assert len(modal.children) == 1
+        label = modal.children[0]
+        assert isinstance(label, _ui.Label)
+        assert label.text == "Upload"
+        assert isinstance(label.component, _ui.FileUpload)
+        assert label.component.custom_id == "file"
+        assert label.component.required is False
+        assert label.component.max_values == 1
+        assert "file" in modal._field_keys
+
+    def test_file_upload_with_file_policy(self):
+        """file_policy.max_files and min_files are forwarded to FileUpload."""
+        modal = self._modal_with_fields([
+            {
+                "key": "files",
+                "label": "Reports",
+                "type": "file_upload",
+                "required": True,
+                "file_policy": {"max_files": 5, "min_files": 1},
+            },
+        ])
+        fu = modal.children[0].component
+        assert fu.required is True
+        assert fu.max_values == 5
+        assert fu.min_values == 1
 
 
 # ===========================================================================

--- a/tests/tools/test_human_input_gateway.py
+++ b/tests/tools/test_human_input_gateway.py
@@ -1,0 +1,339 @@
+"""Tests for tools/human_input_gateway.py - Shared blocking primitive for human input.
+
+Covers: register, wait_for_response, resolve_choice, resolve_modal,
+clear_session, session isolation, custom_id helpers, and timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from tools.human_input_gateway import (
+    HumanInputResult,
+    ActorInfo,
+    FileResult,
+    generate_prompt_id,
+    make_component_custom_id,
+    make_modal_custom_id,
+    parse_custom_id,
+    register,
+    wait_for_response,
+    resolve_choice,
+    resolve_modal,
+    get_entry,
+    get_option_by_index,
+    has_pending,
+    clear_session,
+    register_notify,
+    unregister_notify,
+    get_notify,
+)
+
+
+def _clear_state():
+    """Reset module-level state between tests."""
+    from tools.human_input_gateway import _reset_for_testing
+    _reset_for_testing()
+
+
+_SIMPLE_OPTIONS = [
+    {"label": "Yes", "value": "yes"},
+    {"label": "No", "value": "no"},
+]
+
+_MODAL_OPTIONS = [
+    {
+        "label": "Submit report",
+        "value": "submit",
+        "action": "modal",
+        "modal": {
+            "title": "Report Details",
+            "fields": [
+                {"key": "title", "label": "Title"},
+                {"key": "notes", "label": "Notes"},
+            ],
+        },
+    },
+]
+
+
+class TestCustomIdHelpers:
+    """Tests for custom_id encode/decode helpers."""
+
+    def test_component_roundtrip(self):
+        pid = "abc123"
+        aid = "opt_0"
+        cid = make_component_custom_id(pid, aid)
+        assert len(cid) <= 100
+        parsed = parse_custom_id(cid)
+        assert parsed == ("ip", pid, aid)
+
+    def test_modal_roundtrip(self):
+        pid = "abc123"
+        aid = "opt_1"
+        cid = make_modal_custom_id(pid, aid)
+        parsed = parse_custom_id(cid)
+        assert parsed == ("ip-modal", pid, aid)
+
+    def test_parse_invalid_prefix(self):
+        assert parse_custom_id("garbage") is None
+        assert parse_custom_id("hp_opt_0") is None
+
+    def test_parse_custom_id_with_colon_in_value(self):
+        """Values containing colons should be preserved after split(":", 3)."""
+        pid = "abc123"
+        aid = "foo:bar:baz"
+        cid = make_component_custom_id(pid, aid)
+        parsed = parse_custom_id(cid)
+        assert parsed == ("ip", pid, "foo:bar:baz")
+
+    def test_generate_prompt_id_unique(self):
+        ids = {generate_prompt_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestRegisterAndWait:
+    """Core register/wait mechanics."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_resolve_choice_unblocks_wait(self):
+        """resolve_choice unblocks wait_for_response."""
+        register("p1", "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        def resolver():
+            time.sleep(0.05)
+            resolve_choice(
+                "p1", "yes",
+                actor=ActorInfo(platform="test", user_id="u1", display_name="T"),
+            )
+
+        threading.Thread(target=resolver).start()
+        result = wait_for_response("p1", timeout=2.0)
+        assert result is not None
+        assert result.status == "selected"
+        assert result.choice == "yes"
+        assert result.actor.display_name == "T"
+
+    def test_resolve_modal_unblocks_wait(self):
+        """resolve_modal unblocks wait_for_response with fields + files."""
+        register("p2", "sk2", "Submit?", _MODAL_OPTIONS, timeout_seconds=900)
+
+        files = [
+            FileResult(
+                field_key="attachment",
+                attachment_id="att_1",
+                filename="doc.pdf",
+                content_type="application/pdf",
+                size=2048,
+                cached_path="/tmp/doc.pdf",
+            )
+        ]
+
+        def resolver():
+            time.sleep(0.05)
+            resolve_modal(
+                "p2",
+                choice_value="submit",
+                fields={"title": "My Report", "notes": "See attached"},
+                files=files,
+                actor=ActorInfo(platform="test", user_id="u1", display_name="T"),
+            )
+
+        threading.Thread(target=resolver).start()
+        result = wait_for_response("p2", timeout=2.0)
+        assert result is not None
+        assert result.status == "submitted"
+        assert result.choice == "submit"
+        assert result.fields["title"] == "My Report"
+        assert result.files[0].filename == "doc.pdf"
+
+    def test_timeout_returns_timeout_result(self):
+        """wait_for_response returns a timeout HumanInputResult on timeout."""
+        register("p3", "sk3", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        result = wait_for_response("p3", timeout=0.2)
+        assert result is not None
+        assert result.status == "timeout"
+        assert result.timed_out is True
+
+    def test_resolve_unknown_id_is_noop(self):
+        """resolve_choice on unknown prompt_id returns False."""
+        assert resolve_choice("nonexistent", "x") is False
+
+    def test_resolve_modal_unknown_id_is_noop(self):
+        """resolve_modal on unknown prompt_id returns False."""
+        assert resolve_modal("nonexistent", "x", {}, []) is False
+
+
+class TestSessionManagement:
+    """Session index, clear_session, has_pending."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_has_pending(self):
+        register("p1", "sk1", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        assert has_pending("sk1") is True
+        assert has_pending("other") is False
+
+    def test_clear_session_unblocks_wait(self):
+        """clear_session cancels pending entries and unblocks waiters."""
+        register("p1", "sk1", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        def waiter():
+            return wait_for_response("p1", timeout=10.0)
+
+        with ThreadPoolExecutor(1) as pool:
+            fut = pool.submit(waiter)
+            time.sleep(0.05)
+            cancelled = clear_session("sk1")
+            assert cancelled == 1
+            result = fut.result(timeout=2.0)
+            # clear_session resolves with cancelled status
+            assert result is not None
+            assert result.status == "cancelled"
+
+    def test_clear_session_isolation(self):
+        """Clearing one session doesn't affect another."""
+        register("p1", "sk_a", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        register("p2", "sk_b", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        cleared = clear_session("sk_a")
+        assert cleared == 1
+        assert has_pending("sk_b") is True
+        assert has_pending("sk_a") is False
+
+    def test_session_index_isolation(self):
+        """Entries from different sessions don't leak."""
+        register("pA", "alpha", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        register("pB", "beta", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        assert has_pending("alpha") is True
+        assert has_pending("beta") is True
+
+
+class TestGetHelpers:
+    """get_entry and get_option_by_index."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_get_entry_returns_entry(self):
+        register("p1", "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        entry = get_entry("p1")
+        assert entry is not None
+        assert entry.prompt_id == "p1"
+
+    def test_get_entry_unknown_returns_none(self):
+        assert get_entry("nonexistent") is None
+
+    def test_get_option_by_index(self):
+        register("p1", "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        opt = get_option_by_index("p1", 0)
+        assert opt is not None
+        assert opt["value"] == "yes"
+
+    def test_get_option_out_of_range(self):
+        register("p1", "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        assert get_option_by_index("p1", 99) is None
+
+    def test_get_option_unknown_prompt(self):
+        assert get_option_by_index("nonexistent", 0) is None
+
+
+class TestNotifyCallbacks:
+    """register_notify / unregister_notify / get_notify."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_register_and_get_notify(self):
+        cb = lambda entry: None
+        register_notify("sk1", cb)
+        assert get_notify("sk1") is cb
+
+    def test_get_notify_unknown_session(self):
+        assert get_notify("nonexistent") is None
+
+    def test_unregister_notify_clears_pending(self):
+        """unregister_notify calls clear_session to unwind threads."""
+        register("p1", "sk1", "Q?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        def waiter():
+            return wait_for_response("p1", timeout=10.0)
+
+        with ThreadPoolExecutor(1) as pool:
+            fut = pool.submit(waiter)
+            time.sleep(0.05)
+            register_notify("sk1", lambda e: None)
+            unregister_notify("sk1")
+            result = fut.result(timeout=2.0)
+            assert result is not None
+            assert result.status == "cancelled"
+
+    def test_register_overwrites_previous(self):
+        cb1 = lambda e: None
+        cb2 = lambda e: None
+        register_notify("sk1", cb1)
+        register_notify("sk1", cb2)
+        assert get_notify("sk1") is cb2
+
+    def test_modal_custom_id_within_discord_limit(self):
+        """Modal custom_id must never exceed Discord's 100-char limit."""
+        pid = "x" * 16  # max prompt_id length from generate_prompt_id
+        for idx in (0, 9, 24):  # single-digit, double-digit, max index
+            cid = f"hermes:ip-modal:{pid}:{idx}"
+            assert len(cid) <= 100, f"custom_id too long ({len(cid)}): {cid}"
+
+
+class TestHumanInputResultToDict:
+    """Tests for HumanInputResult.to_dict() serialization."""
+
+    def test_minimal_result(self):
+        r = HumanInputResult(status="timeout", timed_out=True)
+        d = r.to_dict()
+        assert d == {"status": "timeout", "choice": None, "timed_out": True}
+
+    def test_full_result(self):
+        r = HumanInputResult(
+            status="submitted",
+            choice="opt_1",
+            timed_out=False,
+            actor=ActorInfo(platform="discord", user_id="123", display_name="TestUser"),
+            fields={"name": "Alice", "reason": "debug"},
+            files=[
+                FileResult(
+                    field_key="attachment",
+                    attachment_id="att_001",
+                    filename="log.txt",
+                    content_type="text/plain",
+                    size=1024,
+                    cached_path="/tmp/log.txt",
+                )
+            ],
+        )
+        d = r.to_dict()
+        assert d["status"] == "submitted"
+        assert d["choice"] == "opt_1"
+        assert d["timed_out"] is False
+        assert d["actor"] == {
+            "platform": "discord",
+            "user_id": "123",
+            "display_name": "TestUser",
+        }
+        assert d["fields"] == {"name": "Alice", "reason": "debug"}
+        assert len(d["files"]) == 1
+        assert d["files"][0]["field_key"] == "attachment"
+        assert d["files"][0]["filename"] == "log.txt"
+        assert d["files"][0]["size"] == 1024
+
+    def test_optional_fields_omitted(self):
+        """Actor/fields/files should be absent from dict when None."""
+        r = HumanInputResult(status="selected", choice="yes", timed_out=False)
+        d = r.to_dict()
+        assert "actor" not in d
+        assert "fields" not in d
+        assert "files" not in d

--- a/tests/tools/test_interactive_prompt_integration.py
+++ b/tests/tools/test_interactive_prompt_integration.py
@@ -1,0 +1,573 @@
+"""Integration tests for interactive_prompt: tool → gateway → mock adapter.
+
+Exercises the full wiring path that a real gateway session would follow:
+  1. Tool handler validates + calls callback
+  2. Callback registers in human_input_gateway, calls adapter.send_human_input()
+  3. A resolver thread simulates the user clicking a button
+  4. Result flows back through the gateway to the tool handler
+
+No real Discord connections — adapter is mocked.
+
+Result schema (from HumanInputResult.to_dict()):
+  {
+    "status": "selected" | "submitted" | "timeout" | "cancelled",
+    "choice": "value_of_clicked_option" | None,
+    "timed_out": bool,
+    "actor": {"platform", "user_id", "display_name"} | None,
+    "fields": {"field_key": "value", ...} | None,   # modal only
+    "files": [...] | None,                            # modal with uploads
+  }
+"""
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.human_input_gateway import (
+    ActorInfo,
+    HumanInputResult,
+    _reset_for_testing,
+    clear_session,
+    generate_prompt_id,
+    register,
+    resolve_choice,
+    resolve_modal,
+    wait_for_response,
+)
+from tools.interactive_prompt_tool import interactive_prompt_tool
+
+
+def _clear_state():
+    """Reset gateway module state between tests."""
+    _reset_for_testing()
+
+
+_SIMPLE_OPTIONS = [
+    {"label": "Yes", "value": "yes"},
+    {"label": "No", "value": "no"},
+]
+
+_MODAL_OPTIONS = [
+    {
+        "label": "Provide details",
+        "value": "details",
+        "action": "modal",
+        "modal": {
+            "title": "Details",
+            "fields": [
+                {"key": "reason", "label": "Reason", "type": "text"},
+            ],
+        },
+    },
+]
+
+_ACTOR = ActorInfo(platform="discord", user_id="123", display_name="Tester")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock callbacks that mimic gateway/run.py's _interactive_prompt_callback_sync
+# ---------------------------------------------------------------------------
+
+def _make_callback_that_resolves_choice(delay: float = 0.05):
+    """Build a mock adapter callback that simulates a button click."""
+    resolved_event = threading.Event()
+
+    def callback(question, options, display_type, timeout_seconds, auth_policy):
+        prompt_id = generate_prompt_id()
+        register(
+            prompt_id=prompt_id,
+            session_key="test-session",
+            question=question,
+            options=options,
+            timeout_seconds=timeout_seconds,
+            auth_policy=auth_policy,
+        )
+
+        def _resolve():
+            time.sleep(delay)
+            resolve_choice(prompt_id, options[0]["value"], actor=_ACTOR)
+            resolved_event.set()
+
+        threading.Thread(target=_resolve, daemon=True).start()
+
+        result = wait_for_response(prompt_id, timeout=timeout_seconds)
+        if result is None:
+            return {"status": "timeout", "timed_out": True}
+        return result.to_dict()
+
+    return callback, resolved_event
+
+
+def _make_callback_that_resolves_modal(delay: float = 0.05):
+    """Callback that resolves via modal submission."""
+    resolved_event = threading.Event()
+
+    def callback(question, options, display_type, timeout_seconds, auth_policy):
+        prompt_id = generate_prompt_id()
+        register(
+            prompt_id=prompt_id,
+            session_key="test-session",
+            question=question,
+            options=options,
+            timeout_seconds=timeout_seconds,
+            auth_policy=auth_policy,
+        )
+
+        def _resolve():
+            time.sleep(delay)
+            resolve_modal(
+                prompt_id,
+                options[0]["value"],
+                fields={"reason": "because reasons"},
+                actor=_ACTOR,
+            )
+            resolved_event.set()
+
+        threading.Thread(target=_resolve, daemon=True).start()
+
+        result = wait_for_response(prompt_id, timeout=timeout_seconds)
+        if result is None:
+            return {"status": "timeout", "timed_out": True}
+        return result.to_dict()
+
+    return callback, resolved_event
+
+
+def _make_callback_that_times_out(timeout_to_use: float = 1.0):
+    """Callback that never resolves — simulates user ignoring the prompt."""
+
+    def callback(question, options, display_type, timeout_seconds, auth_policy):
+        prompt_id = generate_prompt_id()
+        register(
+            prompt_id=prompt_id,
+            session_key="test-session-timeout",
+            question=question,
+            options=options,
+            timeout_seconds=timeout_to_use,
+            auth_policy=auth_policy,
+        )
+        result = wait_for_response(prompt_id, timeout=timeout_to_use)
+        if result is None:
+            return {"status": "timeout", "timed_out": True}
+        return result.to_dict()
+
+    return callback
+
+
+def _make_callback_that_fails_send():
+    """Callback that simulates the adapter failing to deliver the prompt."""
+
+    def callback(question, options, display_type, timeout_seconds, auth_policy):
+        prompt_id = generate_prompt_id()
+        register(
+            prompt_id=prompt_id,
+            session_key="test-session-fail",
+            question=question,
+            options=options,
+            timeout_seconds=timeout_seconds,
+            auth_policy=auth_policy,
+        )
+        # Simulate send failure — clear session (mirrors gateway/run.py)
+        clear_session("test-session-fail")
+        return {"status": "cancelled", "error": "prompt could not be delivered"}
+
+    return callback
+
+
+# =========================================================================
+# Integration tests
+# =========================================================================
+
+
+class TestChoiceRoundTrip:
+    """Full round-trip: tool → callback → gateway → resolve → result."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_choice_round_trip(self):
+        """Button click resolves through the full tool→gateway path."""
+        cb, event = _make_callback_that_resolves_choice()
+
+        result_str = interactive_prompt_tool(
+            question="Continue?",
+            options=_SIMPLE_OPTIONS,
+            display_type="buttons",
+            timeout_seconds=10,
+            auth_policy="session_owner_only",
+            callback=cb,
+        )
+
+        assert event.wait(timeout=5), "Resolver thread never fired"
+        result = json.loads(result_str)
+        assert result["status"] == "selected"
+        assert result["choice"] == "yes"
+        assert result["timed_out"] is False
+        assert result["actor"]["user_id"] == "123"
+        assert result["actor"]["display_name"] == "Tester"
+        assert result["actor"]["platform"] == "discord"
+
+    def test_choice_result_is_valid_json(self):
+        """Verify the JSON string is parseable and has required keys."""
+        cb, _ = _make_callback_that_resolves_choice()
+
+        result_str = interactive_prompt_tool(
+            question="Continue?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        # Required keys from HumanInputResult.to_dict()
+        assert "status" in result
+        assert "choice" in result
+        assert "timed_out" in result
+        assert "actor" in result
+
+    def test_second_option_choice(self):
+        """Clicking 'No' returns the correct value."""
+        resolved_event = threading.Event()
+
+        def cb(question, options, display_type, timeout_seconds, auth_policy):
+            pid = generate_prompt_id()
+            register(prompt_id=pid, session_key="test-s2", question=question,
+                     options=options, timeout_seconds=timeout_seconds, auth_policy=auth_policy)
+
+            def _r():
+                time.sleep(0.05)
+                resolve_choice(pid, options[1]["value"], actor=_ACTOR)
+                resolved_event.set()
+
+            threading.Thread(target=_r, daemon=True).start()
+            r = wait_for_response(pid, timeout=timeout_seconds)
+            return r.to_dict() if r else {"status": "timeout", "timed_out": True}
+
+        result_str = interactive_prompt_tool(
+            question="Continue?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert result["choice"] == "no"
+
+
+class TestModalRoundTrip:
+    """Full round-trip via modal submission."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_modal_round_trip(self):
+        """Modal submission resolves through the full tool→gateway path."""
+        cb, event = _make_callback_that_resolves_modal()
+
+        result_str = interactive_prompt_tool(
+            question="Tell me more?",
+            options=_MODAL_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        assert event.wait(timeout=5), "Resolver thread never fired"
+        result = json.loads(result_str)
+        assert result["status"] == "submitted"
+        assert result["choice"] == "details"
+        assert result["fields"]["reason"] == "because reasons"
+
+    def test_modal_actor_preserved(self):
+        """Actor info from the resolver survives serialization."""
+        cb, _ = _make_callback_that_resolves_modal()
+
+        result_str = interactive_prompt_tool(
+            question="Details?",
+            options=_MODAL_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert result["actor"]["user_id"] == "123"
+        assert result["actor"]["display_name"] == "Tester"
+
+
+class TestTimeoutPath:
+    """Timeout flows through the full integration path."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_timeout_returns_timeout_result(self):
+        """No user response → tool returns timeout JSON."""
+        cb = _make_callback_that_times_out(timeout_to_use=0.5)
+
+        result_str = interactive_prompt_tool(
+            question="Will timeout?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=60,  # Tool-level high, gateway-level 0.5 wins
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert result["status"] == "timeout"
+        assert result["timed_out"] is True
+
+
+class TestSendFailure:
+    """Adapter send failures propagate correctly."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_send_failure_returns_cancelled(self):
+        """Adapter fails to send → tool returns cancelled JSON."""
+        cb = _make_callback_that_fails_send()
+
+        result_str = interactive_prompt_tool(
+            question="Will fail?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert result["status"] == "cancelled"
+        assert "could not be delivered" in result["error"]
+
+
+class TestValidationStillWorks:
+    """Ensure input validation still fires even with a valid callback."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_empty_question_with_callback(self):
+        """Validation rejects empty question before calling callback."""
+        cb = MagicMock(side_effect=Exception("Should not be called"))
+
+        result_str = interactive_prompt_tool(
+            question="",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert "error" in result
+        cb.assert_not_called()
+
+    def test_no_options_with_callback(self):
+        """Validation rejects missing options before calling callback."""
+        cb = MagicMock(side_effect=Exception("Should not be called"))
+
+        result_str = interactive_prompt_tool(
+            question="Hello?",
+            options=None,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert "error" in result
+        cb.assert_not_called()
+
+    def test_too_many_options_with_callback(self):
+        """Validation rejects >25 options before calling callback."""
+        cb = MagicMock(side_effect=Exception("Should not be called"))
+        too_many = [{"label": f"Opt{i}", "value": f"opt{i}"} for i in range(26)]
+
+        result_str = interactive_prompt_tool(
+            question="Too many?",
+            options=too_many,
+            timeout_seconds=10,
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert "error" in result
+        cb.assert_not_called()
+
+
+class TestNoCallback:
+    """Tool gracefully handles missing callback (non-gateway context)."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_no_callback_returns_error(self):
+        """Without callback, tool returns context-not-available error."""
+        result_str = interactive_prompt_tool(
+            question="Hello?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=None,
+        )
+
+        result = json.loads(result_str)
+        assert "error" in result
+        assert "not available" in result["error"].lower()
+
+
+class TestCallbackException:
+    """Exceptions from the callback are caught and returned as errors."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_callback_exception_returns_error(self):
+        """Callback raises → tool returns error JSON."""
+        def bad_callback(question, options, display_type, timeout_seconds, auth_policy):
+            raise RuntimeError("Adapter exploded")
+
+        result_str = interactive_prompt_tool(
+            question="Will crash?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            callback=bad_callback,
+        )
+
+        result = json.loads(result_str)
+        assert "error" in result
+        assert "Adapter exploded" in result["error"]
+
+
+class TestResetForTesting:
+    """_reset_for_testing() clears all gateway state."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_reset_clears_registered_prompts(self):
+        """After reset, registered prompts are gone."""
+        prompt_id = generate_prompt_id()
+        register(
+            prompt_id=prompt_id,
+            session_key="test-session-reset",
+            question="Reset?",
+            options=_SIMPLE_OPTIONS,
+            timeout_seconds=10,
+            auth_policy="session_owner_only",
+        )
+
+        from tools.human_input_gateway import get_entry
+        assert get_entry(prompt_id) is not None
+
+        _reset_for_testing()
+
+        assert get_entry(prompt_id) is None
+
+
+class TestRegistryLambda:
+    """Test the registry lambda wiring (tool dispatch path)."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_registry_passes_args_correctly(self):
+        """Verify the registry lambda maps args to handler params."""
+        from tools.registry import registry
+
+        entry = registry._tools.get("interactive_prompt")
+        assert entry is not None, "interactive_prompt not registered"
+
+        cb, event = _make_callback_that_resolves_choice()
+
+        result_str = entry.handler(
+            {
+                "question": "From registry?",
+                "options": _SIMPLE_OPTIONS,
+                "display_type": "buttons",
+                # timeout_seconds omitted → config default via `or`
+            },
+            callback=cb,
+        )
+
+        result = json.loads(result_str)
+        assert result["status"] == "selected"
+        assert result["choice"] == "yes"
+
+    def test_registry_schema_has_required_fields(self):
+        """Schema is present and has the right function name."""
+        from tools.registry import registry
+
+        entry = registry._tools.get("interactive_prompt")
+        schema = entry.schema
+        assert schema["name"] == "interactive_prompt"
+        assert "question" in schema["parameters"]["properties"]
+        assert "options" in schema["parameters"]["properties"]
+
+
+class TestConcurrentSessions:
+    """Multiple concurrent prompts don't interfere."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_two_concurrent_prompts_isolated(self):
+        """Two simultaneous prompts resolve independently."""
+        barrier = threading.Barrier(2, timeout=5)
+
+        def make_cb(session_key):
+            def callback(question, options, display_type, timeout_seconds, auth_policy):
+                prompt_id = generate_prompt_id()
+                register(
+                    prompt_id=prompt_id,
+                    session_key=session_key,
+                    question=question,
+                    options=options,
+                    timeout_seconds=timeout_seconds,
+                    auth_policy=auth_policy,
+                )
+
+                def _resolve():
+                    barrier.wait()  # Ensure both are registered before resolving
+                    time.sleep(0.05)
+                    actor = ActorInfo(platform="discord", user_id=session_key,
+                                      display_name=session_key)
+                    resolve_choice(prompt_id, options[0]["value"], actor=actor)
+
+                threading.Thread(target=_resolve, daemon=True).start()
+                result = wait_for_response(prompt_id, timeout=timeout_seconds)
+                return result.to_dict() if result else {"status": "timeout"}
+
+            return callback
+
+        # Run both in parallel threads
+        r1_holder = [None]
+        r2_holder = [None]
+
+        def run1():
+            r1_holder[0] = interactive_prompt_tool(
+                question="Prompt 1?",
+                options=_SIMPLE_OPTIONS,
+                timeout_seconds=10,
+                callback=make_cb("session-A"),
+            )
+
+        def run2():
+            r2_holder[0] = interactive_prompt_tool(
+                question="Prompt 2?",
+                options=_SIMPLE_OPTIONS,
+                timeout_seconds=10,
+                callback=make_cb("session-B"),
+            )
+
+        t1 = threading.Thread(target=run1)
+        t2 = threading.Thread(target=run2)
+        t1.start()
+        t2.start()
+        t1.join(timeout=15)
+        t2.join(timeout=15)
+
+        j1 = json.loads(r1_holder[0])
+        j2 = json.loads(r2_holder[0])
+        assert j1["status"] == "selected"
+        assert j2["status"] == "selected"
+        # Different choice values = isolated sessions
+        assert j1["actor"]["user_id"] == "session-A"
+        assert j2["actor"]["user_id"] == "session-B"

--- a/tests/tools/test_interactive_prompt_review_fixes.py
+++ b/tests/tools/test_interactive_prompt_review_fixes.py
@@ -1,0 +1,660 @@
+"""Test cases for 7 code-review findings fixed on feat/interactive-prompt-tool branch.
+
+Covers:
+  Finding 1 (P1) — Double-JSON-encoding prevention
+  Finding 2 (P1) — Text-fallback non-rich platform resolution
+  Finding 3 (P2) — Config-aware timeout in intercepted path
+  Finding 4 (P2) — _finish_agent_tool wrapping
+  Finding 5 (P2) — Profile-aware upload cache path
+  Finding 6 (P2) — Per-policy auth checks
+  Finding 7 (P3) — Runtime argument validation
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import textwrap
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.human_input_gateway import (
+    HumanInputResult,
+    ActorInfo,
+    _reset_for_testing,
+    generate_prompt_id,
+    register,
+    resolve_text_response,
+    mark_awaiting_text,
+    is_awaiting_text,
+    get_pending_for_session,
+    wait_for_response,
+)
+
+
+def _clear_state():
+    """Reset gateway module state between tests."""
+    _reset_for_testing()
+
+
+_SIMPLE_OPTIONS = [
+    {"label": "Yes", "value": "yes"},
+    {"label": "No", "value": "no"},
+    {"label": "Maybe", "value": "maybe"},
+]
+
+
+# =============================================================================
+# Finding 1 (P1) — Double-JSON-encoding
+# =============================================================================
+
+
+class TestFinding1DoubleJSONEncoding:
+    """Verify the tool detects and passes through already-valid JSON strings
+    from production-shaped gateway callbacks, avoiding double-encoding."""
+
+    def test_json_string_callback_passed_through(self):
+        """A callback returning json.dumps(dict) should produce a string that
+        json.loads() parses to a dict — NOT a nested JSON string."""
+        payload = {"status": "selected", "choice": "yes"}
+
+        def json_callback(q, opts, dt, ts, ap):
+            return json.dumps(payload)
+
+        result_str = _call_tool(callback=json_callback)
+        parsed = json.loads(result_str)
+        assert isinstance(parsed, dict)
+        assert parsed["status"] == "selected"
+        assert parsed["choice"] == "yes"
+
+    def test_dict_callback_backward_compat(self):
+        """A callback returning a plain dict should still work (backward compat)."""
+        def dict_callback(q, opts, dt, ts, ap):
+            return {"status": "selected", "choice": "yes", "timed_out": False}
+
+        result_str = _call_tool(callback=dict_callback)
+        parsed = json.loads(result_str)
+        assert isinstance(parsed, dict)
+        assert parsed["choice"] == "yes"
+
+    def test_non_json_string_callback_serialized(self):
+        """A callback returning a non-JSON string should be serialized as JSON."""
+        def string_callback(q, opts, dt, ts, ap):
+            return "hello"
+
+        result_str = _call_tool(callback=string_callback)
+        parsed = json.loads(result_str)
+        assert parsed == "hello"
+
+    def test_human_input_result_still_works(self):
+        """HumanInputResult objects are still serialized correctly."""
+        def hir_callback(q, opts, dt, ts, ap):
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        result_str = _call_tool(callback=hir_callback)
+        parsed = json.loads(result_str)
+        assert parsed["status"] == "selected"
+        assert parsed["choice"] == "yes"
+
+    def test_json_list_string_re_serialized(self):
+        """A callback returning a JSON-encoded list (not a dict) gets
+        re-serialized — the pass-through only applies to JSON dicts."""
+        def json_callback(q, opts, dt, ts, ap):
+            return json.dumps([1, 2, 3])
+
+        result_str = _call_tool(callback=json_callback)
+        # json.loads("[1,2,3]") is a list, not a dict, so the tool falls
+        # through to json.dumps(result) which re-serializes the string.
+        # Final result: json.dumps("[1, 2, 3]") → '"[1, 2, 3]"'
+        parsed = json.loads(result_str)
+        assert isinstance(parsed, str)
+        assert json.loads(parsed) == [1, 2, 3]
+
+
+# =============================================================================
+# Finding 2 (P1) — Text-fallback non-rich platform resolution
+# =============================================================================
+
+
+class TestFinding2TextFallbackResolution:
+    """Test the new text-fallback functions: get_pending_for_session(),
+    mark_awaiting_text(), is_awaiting_text(), resolve_text_response()."""
+
+    def setup_method(self):
+        _clear_state()
+
+    def test_resolve_by_numeric_index(self):
+        """resolve_text_response with '2' resolves with the 2nd option's value."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        mark_awaiting_text(pid)
+        assert is_awaiting_text(pid) is True
+
+        resolved = resolve_text_response(pid, "2")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        assert entry.status == "selected"
+        assert entry.choice == "no"  # index 2 (1-based) → _SIMPLE_OPTIONS[1] → "no"
+
+    def test_resolve_by_label_match(self):
+        """resolve_text_response with 'Yes' matches the label."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        resolved = resolve_text_response(pid, "Yes")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        assert entry.choice == "yes"
+
+    def test_resolve_by_case_insensitive_label(self):
+        """resolve_text_response matches labels case-insensitively."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        resolved = resolve_text_response(pid, "MAYBE")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        assert entry.choice == "maybe"
+
+    def test_resolve_custom_text_fallback(self):
+        """resolve_text_response with 'custom text' uses raw text as choice."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        resolved = resolve_text_response(pid, "custom text")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        assert entry.choice == "custom text"
+
+    def test_modal_option_resolved_via_text_gets_raw_text(self):
+        """A modal option resolved via text fallback gets the raw text,
+        not the option value (can't collect modal fields via text)."""
+        modal_options = [
+            {"label": "Submit form", "value": "submit_form", "action": "modal",
+             "modal": {"title": "Form", "fields": [{"key": "name", "label": "Name"}]}},
+        ]
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Form?", modal_options, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        # Try to resolve by matching the label — should fall back to raw text
+        # because the matched option is a modal action
+        resolved = resolve_text_response(pid, "Submit form")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        # The modal option match triggers fallback to raw text
+        assert entry.choice == "Submit form"
+
+    def test_modal_option_resolved_by_index_gets_raw_text(self):
+        """A modal option resolved by numeric index gets the raw text index."""
+        modal_options = [
+            {"label": "Submit form", "value": "submit_form", "action": "modal",
+             "modal": {"title": "Form", "fields": [{"key": "name", "label": "Name"}]}},
+        ]
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Form?", modal_options, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        resolved = resolve_text_response(pid, "1")
+        assert resolved is True
+
+        entry = _get_entry_result(pid)
+        # Numeric index 1 → matches modal option → falls back to raw text "1"
+        assert entry.choice == "1"
+
+    def test_get_pending_for_session_returns_none_when_empty(self):
+        """get_pending_for_session returns None when no entries exist."""
+        assert get_pending_for_session("nonexistent_session") is None
+
+    def test_get_pending_for_session_returns_oldest_pending(self):
+        """get_pending_for_session returns the first unresolved entry."""
+        pid1 = generate_prompt_id()
+        pid2 = generate_prompt_id()
+        register(pid1, "sk1", "Q1?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        register(pid2, "sk1", "Q2?", _SIMPLE_OPTIONS, timeout_seconds=900)
+
+        entry = get_pending_for_session("sk1")
+        assert entry is not None
+        assert entry.prompt_id == pid1  # oldest first
+
+    def test_resolve_text_response_returns_false_for_already_resolved(self):
+        """resolve_text_response returns False for already-resolved entries."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        mark_awaiting_text(pid)
+
+        # First resolution succeeds
+        assert resolve_text_response(pid, "1") is True
+        # Second resolution on same entry should fail
+        assert resolve_text_response(pid, "2") is False
+
+    def test_mark_awaiting_text_returns_false_for_unknown(self):
+        """mark_awaiting_text returns False for unknown prompt_id."""
+        assert mark_awaiting_text("nonexistent") is False
+
+    def test_is_awaiting_text_false_by_default(self):
+        """is_awaiting_text returns False for entries not marked."""
+        pid = generate_prompt_id()
+        register(pid, "sk1", "Pick?", _SIMPLE_OPTIONS, timeout_seconds=900)
+        assert is_awaiting_text(pid) is False
+
+
+# =============================================================================
+# Finding 3 (P2) — Config-aware timeout
+# =============================================================================
+
+
+class TestFinding3ConfigAwareTimeout:
+    """Verify get_interactive_prompt_timeout reads from config correctly."""
+
+    def test_returns_configured_timeout(self):
+        """When agent.interactive_prompt_timeout is set, return it."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"agent": {"interactive_prompt_timeout": 600}}):
+            from tools.human_input_gateway import get_interactive_prompt_timeout
+            assert get_interactive_prompt_timeout() == 600
+
+    def test_falls_back_to_clarify_timeout(self):
+        """When interactive_prompt_timeout is absent, falls back to clarify_timeout."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"agent": {"clarify_timeout": 300}}):
+            from tools.human_input_gateway import get_interactive_prompt_timeout
+            assert get_interactive_prompt_timeout() == 300
+
+    def test_returns_default_when_no_config(self):
+        """When no config keys are set, returns 900 (default)."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            from tools.human_input_gateway import get_interactive_prompt_timeout
+            assert get_interactive_prompt_timeout() == 900
+
+    def test_returns_default_on_exception(self):
+        """Config load failure → returns 900 (safe default)."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("boom")):
+            from tools.human_input_gateway import get_interactive_prompt_timeout
+            assert get_interactive_prompt_timeout() == 900
+
+    def test_intercepted_path_imports_timeout_function(self):
+        """Verify the intercepted path in agent_runtime_helpers.py imports
+        get_interactive_prompt_timeout and uses it."""
+        import agent.agent_runtime_helpers
+        # The intercepted function is named invoke_tool
+        func = agent.agent_runtime_helpers.invoke_tool
+        src = inspect.getsource(func)
+        assert "interactive_prompt" in src
+        assert "get_interactive_prompt_timeout" in src
+        assert "_timeout = int(_raw_timeout) if _raw_timeout is not None else get_interactive_prompt_timeout()" in src
+
+
+# =============================================================================
+# Finding 4 (P2) — _finish_agent_tool wrapping
+# =============================================================================
+
+
+class TestFinding4FinishAgentToolWrapping:
+    """Verify the interactive_prompt branch uses _finish_agent_tool."""
+
+    def test_interactive_prompt_branch_uses_finish_agent_tool(self):
+        """The interactive_prompt branch in invoke_tool wraps
+        the call in _finish_agent_tool."""
+        import agent.agent_runtime_helpers
+        func = agent.agent_runtime_helpers.invoke_tool
+        src = inspect.getsource(func)
+
+        # Verify interactive_prompt is in the same function
+        assert 'function_name == "interactive_prompt"' in src
+        # Verify _finish_agent_tool is used in the function
+        assert 'return _finish_agent_tool(' in src, (
+            "Expected _finish_agent_tool wrapping in invoke_tool"
+        )
+
+
+# =============================================================================
+# Finding 5 (P2) — Profile-aware upload cache path
+# =============================================================================
+
+
+class TestFinding5ProfileAwareUploadCache:
+    """Verify discord_interactive_views.py uses get_hermes_home() instead of
+    hardcoded ~/.hermes."""
+
+    def test_file_contains_get_hermes_home(self):
+        """File should use get_hermes_home() for cache path construction."""
+        path = _find_discord_views_file()
+        content = open(path).read()
+        assert "get_hermes_home" in content, (
+            "discord_interactive_views.py should use get_hermes_home()"
+        )
+
+    def test_file_does_not_contain_hardcoded_expanduser(self):
+        """File should NOT contain hardcoded expanduser('~/.hermes/cache/uploads')."""
+        path = _find_discord_views_file()
+        content = open(path).read()
+        assert 'expanduser("~/.hermes/cache/uploads")' not in content, (
+            "Should not use hardcoded expanduser('~/.hermes/cache/uploads')"
+        )
+
+    def test_file_does_not_contain_hardcoded_hermes_cache(self):
+        """File should NOT contain hardcoded '~/.hermes/cache' path literal."""
+        path = _find_discord_views_file()
+        content = open(path).read()
+        # It should NOT have a raw string "~/.hermes/cache" without get_hermes_home
+        # Check there's no construction like os.path.expanduser("~/.hermes/cache")
+        assert '"~/.hermes/cache"' not in content or "get_hermes_home()" in content, (
+            "Cache path should use get_hermes_home() not hardcoded ~/.hermes"
+        )
+
+    def test_upload_cache_uses_get_hermes_home(self):
+        """The cache_dir construction uses os.path.join(get_hermes_home(), 'cache', 'uploads')."""
+        path = _find_discord_views_file()
+        content = open(path).read()
+        assert 'os.path.join(get_hermes_home(), "cache", "uploads")' in content, (
+            "Cache dir should be constructed with get_hermes_home()"
+        )
+
+
+# =============================================================================
+# Finding 6 (P2) — Per-policy auth checks
+# =============================================================================
+
+discord = pytest.importorskip("discord")
+
+from tools.discord_interactive_views import InteractivePromptView
+from tools.discord_auth_helpers import component_check_auth
+
+
+def _make_mock_interaction(
+    user_id: str = "123",
+    role_ids: list = None,
+):
+    """Build a lightweight mock that quacks like discord.Interaction."""
+    user = MagicMock()
+    user.id = int(user_id)
+    if role_ids is not None:
+        user.roles = [MagicMock(id=int(rid)) for rid in role_ids]
+    else:
+        user.roles = []
+    interaction = MagicMock()
+    interaction.user = user
+    return interaction
+
+
+def _make_view(
+    policy: str = "session_owner_only",
+    allowed_user_ids: set = None,
+    allowed_role_ids: set = None,
+    origin_user_id: str = None,
+) -> InteractivePromptView:
+    """Build an InteractivePromptView for testing auth checks."""
+    return InteractivePromptView(
+        prompt_id="test_prompt_id_123",
+        question="Test question?",
+        options=[{"label": "Opt 1", "value": "opt_1"}],
+        allowed_user_ids=allowed_user_ids or set(),
+        allowed_role_ids=allowed_role_ids or set(),
+        auth_policy=policy,
+        origin_user_id=origin_user_id,
+        timeout_seconds=900,
+    )
+
+
+class TestFinding6PerPolicyAuthChecks:
+    """Verify per-policy auth checks enforce the correct allowlist semantics."""
+
+    def test_any_allowed_user_matching_user_is_allowed(self):
+        """any_allowed_user: user in user allowlist → allowed."""
+        view = _make_view(
+            policy="any_allowed_user",
+            allowed_user_ids={"42", "99"},
+        )
+        interaction = _make_mock_interaction(user_id="42")
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_user_matching_role_only_is_rejected(self):
+        """any_allowed_user: user matches role allowlist only → rejected
+        (roles are ignored for any_allowed_user)."""
+        view = _make_view(
+            policy="any_allowed_user",
+            allowed_user_ids={"42"},
+            allowed_role_ids={"55"},
+        )
+        # User 99 has role 55 but is NOT in user allowlist
+        interaction = _make_mock_interaction(user_id="99", role_ids=["55"])
+        assert view._check_auth(interaction) is False
+
+    def test_any_allowed_user_no_user_allowlist_allows_all(self):
+        """any_allowed_user: empty user allowlist → allow everyone (no-restriction deployment)."""
+        view = _make_view(
+            policy="any_allowed_user",
+            allowed_user_ids=set(),
+        )
+        interaction = _make_mock_interaction(user_id="99")
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_role_matching_role_is_allowed(self):
+        """any_allowed_role: user has a role in role allowlist → allowed."""
+        view = _make_view(
+            policy="any_allowed_role",
+            allowed_role_ids={55, 77},
+        )
+        interaction = _make_mock_interaction(user_id="99", role_ids=["55"])
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_role_matching_user_only_is_rejected(self):
+        """any_allowed_role: user matches user allowlist only → rejected
+        (user IDs are ignored for any_allowed_role)."""
+        view = _make_view(
+            policy="any_allowed_role",
+            allowed_user_ids={"42"},
+            allowed_role_ids={55},
+        )
+        # User 42 is in user allowlist but NOT in role allowlist
+        interaction = _make_mock_interaction(user_id="42", role_ids=["10"])
+        assert view._check_auth(interaction) is False
+
+    def test_any_allowed_role_no_role_allowlist_allows_all(self):
+        """any_allowed_role: empty role allowlist → allow everyone."""
+        view = _make_view(
+            policy="any_allowed_role",
+            allowed_role_ids=set(),
+        )
+        interaction = _make_mock_interaction(user_id="99")
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_user_or_role_user_match(self):
+        """any_allowed_user_or_role: user matches user allowlist → allowed."""
+        view = _make_view(
+            policy="any_allowed_user_or_role",
+            allowed_user_ids={"42"},
+            allowed_role_ids={55},
+        )
+        interaction = _make_mock_interaction(user_id="42")
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_user_or_role_role_match(self):
+        """any_allowed_user_or_role: user has matching role → allowed."""
+        view = _make_view(
+            policy="any_allowed_user_or_role",
+            allowed_user_ids={"42"},
+            allowed_role_ids={55},
+        )
+        interaction = _make_mock_interaction(user_id="99", role_ids=["55"])
+        assert view._check_auth(interaction) is True
+
+    def test_any_allowed_user_or_role_no_match_rejected(self):
+        """any_allowed_user_or_role: neither user nor role matches → rejected."""
+        view = _make_view(
+            policy="any_allowed_user_or_role",
+            allowed_user_ids={"42"},
+            allowed_role_ids={55},
+        )
+        interaction = _make_mock_interaction(user_id="99", role_ids=["10"])
+        assert view._check_auth(interaction) is False
+
+    def test_session_owner_only_correct_user(self):
+        """session_owner_only: matching origin_user_id → allowed."""
+        view = _make_view(
+            policy="session_owner_only",
+            origin_user_id="42",
+        )
+        interaction = _make_mock_interaction(user_id="42")
+        assert view._check_auth(interaction) is True
+
+    def test_session_owner_only_wrong_user(self):
+        """session_owner_only: different user → rejected."""
+        view = _make_view(
+            policy="session_owner_only",
+            origin_user_id="42",
+        )
+        interaction = _make_mock_interaction(user_id="99")
+        assert view._check_auth(interaction) is False
+
+
+# =============================================================================
+# Finding 7 (P3) — Runtime argument validation
+# =============================================================================
+
+
+class TestFinding7RuntimeArgumentValidation:
+    """Verify runtime argument validation and clamping."""
+
+    def test_display_type_carousel_rejected(self):
+        """display_type='carousel' → tool_error with 'Unsupported display_type'."""
+        def mock_cb(*a, **kw):
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+        result_str = _call_tool(display_type="carousel", callback=mock_cb)
+        assert "Unsupported display_type" in result_str
+        assert "carousel" in result_str
+
+    def test_auth_policy_anyone_rejected(self):
+        """auth_policy='anyone' → tool_error with 'Unsupported auth_policy'."""
+        def mock_cb(*a, **kw):
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+        result_str = _call_tool(auth_policy="anyone", callback=mock_cb)
+        assert "Unsupported auth_policy" in result_str
+        assert "anyone" in result_str
+
+    def test_timeout_10_clamped_to_60(self):
+        """timeout_seconds=10 → clamped to 60 (minimum)."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=10, callback=capture_cb)
+        assert captured[0] == 60
+
+    def test_timeout_5000_clamped_to_3600(self):
+        """timeout_seconds=5000 → clamped to 3600 (maximum)."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=5000, callback=capture_cb)
+        assert captured[0] == 3600
+
+    def test_timeout_none_defaults_to_900(self):
+        """timeout_seconds=None → defaults to 900."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=None, callback=capture_cb)
+        assert captured[0] == 900
+
+    def test_timeout_within_range_unchanged(self):
+        """timeout_seconds=300 → passed through unchanged."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=300, callback=capture_cb)
+        assert captured[0] == 300
+
+    def test_timeout_exactly_60_accepted(self):
+        """timeout_seconds=60 (minimum) → accepted as-is."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=60, callback=capture_cb)
+        assert captured[0] == 60
+
+    def test_timeout_exactly_3600_accepted(self):
+        """timeout_seconds=3600 (maximum) → accepted as-is."""
+        captured = []
+
+        def capture_cb(q, opts, dt, ts, ap):
+            captured.append(ts)
+            return HumanInputResult(status="selected", choice="yes", timed_out=False)
+
+        _call_tool(timeout_seconds=3600, callback=capture_cb)
+        assert captured[0] == 3600
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _call_tool(
+    question="Pick one",
+    options=None,
+    display_type="buttons",
+    timeout_seconds=900,
+    auth_policy="session_owner_only",
+    callback=None,
+):
+    """Shorthand to call interactive_prompt_tool with defaults."""
+    from tools.interactive_prompt_tool import interactive_prompt_tool
+    return interactive_prompt_tool(
+        question=question,
+        options=options or _SIMPLE_OPTIONS,
+        display_type=display_type,
+        timeout_seconds=timeout_seconds,
+        auth_policy=auth_policy,
+        callback=callback,
+    )
+
+
+def _get_entry_result(prompt_id: str):
+    """Get the result from a resolved entry (wait_for_response cleans up,
+    so we need to get it from the entry before cleanup if possible,
+    or access the internal entry directly)."""
+    from tools.human_input_gateway import _entries, _lock
+    with _lock:
+        entry = _entries.get(prompt_id)
+    if entry and entry.result:
+        return entry.result
+    # If already cleaned up, the event should have the result
+    # We need to re-register and check; instead, use a workaround:
+    # Since resolve_text_response sets result before event.set(),
+    # and we're calling right after, the entry might still be there
+    # but the _resolved flag prevents wait_for_response from seeing it.
+    # We already set result above, so return what we got.
+    return None
+
+
+def _find_discord_views_file():
+    """Find the discord_interactive_views.py file path."""
+    import tools.discord_interactive_views as mod
+    return inspect.getfile(mod)

--- a/tests/tools/test_interactive_prompt_tool.py
+++ b/tests/tools/test_interactive_prompt_tool.py
@@ -1,0 +1,446 @@
+"""Tests for tools/interactive_prompt_tool.py - Rich interactive prompts."""
+
+import json
+from typing import Dict, Any, List
+from unittest.mock import patch
+
+from tools.interactive_prompt_tool import (
+    interactive_prompt_tool,
+    check_interactive_prompt_requirements,
+    MAX_OPTIONS,
+    MAX_LABEL_LEN,
+    MAX_VALUE_LEN,
+    MAX_DESC_LEN,
+    MAX_MODAL_TITLE_LEN,
+    MAX_MODAL_FIELDS,
+    MIN_MODAL_FIELDS,
+    MAX_QUESTION_LEN,
+    INTERACTIVE_PROMPT_SCHEMA,
+)
+from tools.human_input_gateway import HumanInputResult, ActorInfo, FileResult
+
+
+def _make_options(n: int, action: str = "return") -> List[Dict[str, Any]]:
+    """Build N minimal option dicts for testing."""
+    opts = []
+    for i in range(n):
+        opt: Dict[str, Any] = {
+            "label": f"Option {i}",
+            "value": f"opt_{i}",
+        }
+        if action == "modal":
+            opt["action"] = "modal"
+            opt["modal"] = {
+                "title": f"Modal {i}",
+                "fields": [
+                    {"key": "name", "label": "Name"},
+                ],
+            }
+        opts.append(opt)
+    return opts
+
+
+class TestInteractivePromptBasics:
+    """Basic functionality tests for interactive_prompt_tool."""
+
+    def test_simple_return_option(self):
+        """Should return JSON with the user's choice for a return option."""
+        def mock_cb(q, opts, dt, ts, ap):
+            return HumanInputResult(
+                status="resolved",
+                choice="opt_0",
+                timed_out=False,
+                actor=ActorInfo(platform="test", user_id="u1", display_name="Tester"),
+            )
+
+        result = json.loads(interactive_prompt_tool(
+            "Pick one",
+            options=_make_options(3),
+            callback=mock_cb,
+        ))
+        assert result["status"] == "resolved"
+        assert result["choice"] == "opt_0"
+        assert result["timed_out"] is False
+        assert result["actor"]["display_name"] == "Tester"
+
+    def test_modal_option_with_fields(self):
+        """Should return fields from a modal response."""
+        def mock_cb(q, opts, dt, ts, ap):
+            return HumanInputResult(
+                status="resolved",
+                choice="opt_0",
+                timed_out=False,
+                actor=ActorInfo(platform="test", user_id="u1", display_name="Tester"),
+                fields={"name": "Alice"},
+            )
+
+        result = json.loads(interactive_prompt_tool(
+            "Fill in",
+            options=_make_options(2, action="modal"),
+            callback=mock_cb,
+        ))
+        assert result["fields"]["name"] == "Alice"
+
+    def test_modal_option_with_files(self):
+        """Should return file metadata from a modal file upload."""
+        def mock_cb(q, opts, dt, ts, ap):
+            return HumanInputResult(
+                status="resolved",
+                choice="opt_0",
+                timed_out=False,
+                actor=ActorInfo(platform="test", user_id="u1", display_name="Tester"),
+                files=[
+                    FileResult(
+                        field_key="document",
+                        attachment_id="att_123",
+                        filename="report.pdf",
+                        content_type="application/pdf",
+                        size=4096,
+                        cached_path="/tmp/report.pdf",
+                    )
+                ],
+            )
+
+        result = json.loads(interactive_prompt_tool(
+            "Upload",
+            options=_make_options(1, action="modal"),
+            callback=mock_cb,
+        ))
+        assert result["files"][0]["filename"] == "report.pdf"
+        assert result["files"][0]["size"] == 4096
+
+    def test_empty_question_returns_error(self):
+        """Should return error for empty question."""
+        result = json.loads(interactive_prompt_tool(
+            "",
+            options=_make_options(1),
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_whitespace_only_question_returns_error(self):
+        """Should return error for whitespace-only question."""
+        result = json.loads(interactive_prompt_tool(
+            "   \n\t  ",
+            options=_make_options(1),
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+
+    def test_question_too_long_returns_error(self):
+        """Should reject questions exceeding MAX_QUESTION_LEN."""
+        long_q = "x" * (MAX_QUESTION_LEN + 1)
+        result = json.loads(interactive_prompt_tool(
+            long_q,
+            options=_make_options(1),
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "too long" in result["error"].lower()
+
+    def test_question_at_max_length_is_accepted(self):
+        """Questions at exactly MAX_QUESTION_LEN should pass validation."""
+        q = "y" * MAX_QUESTION_LEN
+        result = json.loads(interactive_prompt_tool(
+            q,
+            options=_make_options(1),
+            callback=lambda *a: HumanInputResult(
+                status="selected",
+                choice="opt_0",
+                timed_out=False,
+                actor=ActorInfo(platform="test", user_id="u1", display_name="T"),
+            ),
+        ))
+        assert "status" in result
+
+    def test_no_options_returns_error(self):
+        """Should return error when no options provided."""
+        result = json.loads(interactive_prompt_tool(
+            "Question?",
+            options=[],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "non-empty" in result["error"].lower()
+
+    def test_no_callback_returns_error(self):
+        """Should return error when no callback is provided."""
+        result = json.loads(interactive_prompt_tool(
+            "Question?",
+            options=_make_options(1),
+        ))
+        assert "error" in result
+        assert "not available" in result["error"].lower()
+
+
+class TestInteractivePromptOptionsValidation:
+    """Tests for options parameter validation."""
+
+    def test_options_not_list_returns_error(self):
+        """Non-list options should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options="not a list",  # type: ignore
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "list" in result["error"].lower()
+
+    def test_too_many_options_returns_error(self):
+        """Options exceeding MAX_OPTIONS should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Pick",
+            options=_make_options(MAX_OPTIONS + 1),
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "too many" in result["error"].lower()
+
+    def test_option_not_dict_returns_error(self):
+        """Non-dict option should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=["not a dict"],  # type: ignore
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "must be a dict" in result["error"].lower()
+
+    def test_option_missing_label_returns_error(self):
+        """Option without label should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"value": "x"}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "label" in result["error"].lower()
+
+    def test_option_missing_value_returns_error(self):
+        """Option without value should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"label": "My Option"}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "value" in result["error"].lower()
+
+    def test_option_label_too_long(self):
+        """Option label exceeding MAX_LABEL_LEN should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"label": "x" * (MAX_LABEL_LEN + 1), "value": "v"}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "label" in result["error"].lower()
+
+    def test_option_value_too_long(self):
+        """Option value exceeding MAX_VALUE_LEN should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"label": "L", "value": "x" * (MAX_VALUE_LEN + 1)}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "value" in result["error"].lower()
+
+    def test_option_description_too_long(self):
+        """Option description exceeding MAX_DESC_LEN should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"label": "L", "value": "v", "description": "d" * (MAX_DESC_LEN + 1)}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "description" in result["error"].lower()
+
+
+class TestInteractivePromptModalValidation:
+    """Tests for modal action validation."""
+
+    def test_modal_missing_modal_object(self):
+        """Modal action without modal dict should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{"label": "L", "value": "v", "action": "modal"}],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "modal" in result["error"].lower()
+
+    def test_modal_missing_title(self):
+        """Modal without title should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{
+                "label": "L", "value": "v", "action": "modal",
+                "modal": {"fields": [{"key": "k", "label": "K"}]},
+            }],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "title" in result["error"].lower()
+
+    def test_modal_title_too_long(self):
+        """Modal title exceeding MAX_MODAL_TITLE_LEN should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{
+                "label": "L", "value": "v", "action": "modal",
+                "modal": {
+                    "title": "T" * (MAX_MODAL_TITLE_LEN + 1),
+                    "fields": [{"key": "k", "label": "K"}],
+                },
+            }],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "title" in result["error"].lower()
+
+    def test_modal_fields_not_list(self):
+        """Modal with non-list fields should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{
+                "label": "L", "value": "v", "action": "modal",
+                "modal": {"title": "T", "fields": "not a list"},
+            }],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "fields" in result["error"].lower()
+
+    def test_modal_too_many_fields(self):
+        """Modal exceeding MAX_MODAL_FIELDS should return error."""
+        fields = [{"key": f"f{i}", "label": f"F{i}"} for i in range(MAX_MODAL_FIELDS + 1)]
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{
+                "label": "L", "value": "v", "action": "modal",
+                "modal": {"title": "T", "fields": fields},
+            }],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "fields" in result["error"].lower()
+
+    def test_modal_too_few_fields(self):
+        """Modal with fewer than MIN_MODAL_FIELDS should return error."""
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=[{
+                "label": "L", "value": "v", "action": "modal",
+                "modal": {"title": "T", "fields": []},
+            }],
+            callback=lambda *a: "ignored",
+        ))
+        assert "error" in result
+        assert "fields" in result["error"].lower()
+
+
+class TestInteractivePromptCallbackHandling:
+    """Tests for callback error handling."""
+
+    def test_callback_exception_returns_error(self):
+        """Should return error if callback raises exception."""
+        def failing_cb(q, opts, dt, ts, ap):
+            raise RuntimeError("User cancelled")
+
+        result = json.loads(interactive_prompt_tool(
+            "Q?",
+            options=_make_options(1),
+            callback=failing_cb,
+        ))
+        assert "error" in result
+        assert "Failed to get user input" in result["error"]
+
+    def test_callback_receives_stripped_question(self):
+        """Callback should receive trimmed question."""
+        received = []
+
+        def mock_cb(q, opts, dt, ts, ap):
+            received.append(q)
+            return HumanInputResult(status="resolved", choice="x", timed_out=False)
+
+        interactive_prompt_tool(
+            "  Question with spaces  \n",
+            options=_make_options(1),
+            callback=mock_cb,
+        )
+        assert received[0] == "Question with spaces"
+
+    def test_callback_receives_display_type(self):
+        """Callback should receive the display_type parameter."""
+        received = []
+
+        def mock_cb(q, opts, dt, ts, ap):
+            received.append(dt)
+            return HumanInputResult(status="resolved", choice="x", timed_out=False)
+
+        interactive_prompt_tool(
+            "Q?", options=_make_options(1),
+            display_type="buttons", callback=mock_cb,
+        )
+        assert received[0] == "buttons"
+
+    def test_callback_dict_result(self):
+        """Should handle callback returning a plain dict (fallback path)."""
+        def dict_cb(q, opts, dt, ts, ap):
+            return {"status": "ok", "data": "something"}
+
+        result = json.loads(interactive_prompt_tool(
+            "Q?", options=_make_options(1), callback=dict_cb,
+        ))
+        assert result["status"] == "ok"
+        assert result["data"] == "something"
+
+
+class TestCheckRequirements:
+    """Tests for the feature-flag requirements check."""
+
+    def test_disabled_by_default(self):
+        """Tool is disabled when config key is absent."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert check_interactive_prompt_requirements() is False
+
+    def test_enabled_when_config_true(self):
+        """Tool is enabled when agent.interactive_prompt_enabled=True."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"agent": {"interactive_prompt_enabled": True}}):
+            assert check_interactive_prompt_requirements() is True
+
+    def test_disabled_when_config_false(self):
+        """Tool is disabled when agent.interactive_prompt_enabled=False."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"agent": {"interactive_prompt_enabled": False}}):
+            assert check_interactive_prompt_requirements() is False
+
+    def test_falls_back_on_exception(self):
+        """Config load failure → disabled (safe default)."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("boom")):
+            assert check_interactive_prompt_requirements() is False
+
+
+class TestSchema:
+    """Tests for the OpenAI function-calling schema."""
+
+    def test_schema_name(self):
+        assert INTERACTIVE_PROMPT_SCHEMA["name"] == "interactive_prompt"
+
+    def test_schema_has_description(self):
+        assert "description" in INTERACTIVE_PROMPT_SCHEMA
+        assert len(INTERACTIVE_PROMPT_SCHEMA["description"]) > 50
+
+    def test_schema_question_required(self):
+        assert "question" in INTERACTIVE_PROMPT_SCHEMA["parameters"]["required"]
+
+    def test_schema_options_required(self):
+        assert "options" in INTERACTIVE_PROMPT_SCHEMA["parameters"]["required"]
+
+    def test_schema_display_type_enum(self):
+        props = INTERACTIVE_PROMPT_SCHEMA["parameters"]["properties"]
+        assert "buttons" in props["display_type"]["enum"]
+        assert "select" not in props["display_type"]["enum"]

--- a/tests/tools/test_interactive_prompt_tool.py
+++ b/tests/tools/test_interactive_prompt_tool.py
@@ -444,3 +444,99 @@ class TestSchema:
         props = INTERACTIVE_PROMPT_SCHEMA["parameters"]["properties"]
         assert "buttons" in props["display_type"]["enum"]
         assert "select" not in props["display_type"]["enum"]
+
+
+# ===========================================================================
+# file_policy validation tests
+# ===========================================================================
+
+
+class TestFilePolicyValidation:
+    """Validation guardrails for file_policy on file_upload fields."""
+
+    def _call(self, options):
+        from tools.interactive_prompt_tool import interactive_prompt_tool
+        return interactive_prompt_tool(
+            question="Upload test",
+            options=options,
+            callback=lambda *a, **kw: None,
+        )
+
+    def _file_upload_field(self, **policy_kwargs):
+        field = {"key": "f", "label": "File", "type": "file_upload"}
+        if policy_kwargs:
+            field["file_policy"] = policy_kwargs
+        return {
+            "label": "Upload",
+            "value": "upload",
+            "action": "modal",
+            "modal": {"title": "Upload", "fields": [field]},
+        }
+
+    def test_valid_file_policy_passes(self):
+        """Valid file_policy constraints are accepted."""
+        result = self._call([
+            self._file_upload_field(
+                max_files=5, max_bytes=10_000_000,
+                allowed_extensions=[".pdf", ".png"],
+            ),
+        ])
+        # callback returns None → "result" is json.dumps(None) = "null"
+        assert json.loads(result) is None
+
+    def test_valid_file_policy_no_policy_passes(self):
+        """file_upload field with no file_policy is accepted."""
+        result = self._call([
+            self._file_upload_field(),
+        ])
+        assert json.loads(result) is None
+
+    def test_max_files_zero_rejected(self):
+        result = self._call([self._file_upload_field(max_files=0)])
+        assert "max_files" in result
+        assert "1–10" in result
+
+    def test_max_files_eleven_rejected(self):
+        result = self._call([self._file_upload_field(max_files=11)])
+        assert "max_files" in result
+        assert "1–10" in result
+
+    def test_max_files_negative_rejected(self):
+        result = self._call([self._file_upload_field(max_files=-1)])
+        assert "max_files" in result
+
+    def test_max_bytes_zero_rejected(self):
+        result = self._call([self._file_upload_field(max_bytes=0)])
+        assert "max_bytes" in result
+
+    def test_max_bytes_negative_rejected(self):
+        result = self._call([self._file_upload_field(max_bytes=-100)])
+        assert "max_bytes" in result
+
+    def test_allowed_extensions_without_dot_rejected(self):
+        result = self._call([self._file_upload_field(allowed_extensions=["pdf"])])
+        assert "allowed_extensions" in result
+        assert "starting with" in result
+
+    def test_allowed_extensions_string_rejected(self):
+        result = self._call([self._file_upload_field(allowed_extensions=".pdf")])
+        assert "allowed_extensions" in result
+
+    def test_allowed_extensions_valid(self):
+        result = self._call([
+            self._file_upload_field(allowed_extensions=[".pdf", ".docx"]),
+        ])
+        assert json.loads(result) is None
+
+    def test_file_policy_ignored_for_non_file_fields(self):
+        """file_policy on a text field doesn't cause validation errors."""
+        field = {
+            "key": "name", "label": "Name", "type": "text",
+            "file_policy": {"max_files": 999},
+        }
+        opt = {
+            "label": "Text", "value": "text", "action": "modal",
+            "modal": {"title": "T", "fields": [field]},
+        }
+        result = self._call([opt])
+        assert json.loads(result) is None

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -224,6 +224,27 @@ def clear_session(session_key: str) -> int:
     return cancelled
 
 
+def clear_all() -> int:
+    """Cancel every pending clarify across all sessions.
+
+    Called during gateway shutdown so blocked agent threads resolve
+    immediately instead of hanging until their timeout.
+    Returns the total number of entries cancelled.
+    """
+    with _lock:
+        all_ids = list(_entries.keys())
+        _session_index.clear()
+        entries = [_entries.pop(cid, None) for cid in all_ids]
+    cancelled = 0
+    for entry in entries:
+        if entry is None:
+            continue
+        entry.response = ""
+        entry.event.set()
+        cancelled += 1
+    return cancelled
+
+
 # =========================================================================
 # Config
 # =========================================================================

--- a/tools/discord_auth_helpers.py
+++ b/tools/discord_auth_helpers.py
@@ -1,0 +1,63 @@
+"""Shared auth helpers for Discord component views.
+
+Extracted from ``plugins.platforms.discord.adapter._component_check_auth``
+and ``tools.discord_interactive_views._component_check_auth`` to eliminate
+duplication.  Both modules import this via alias to preserve the private
+``_component_check_auth`` name at their existing call sites.
+"""
+
+from typing import Any, Optional
+
+
+def component_check_auth(
+    interaction: Any,
+    allowed_user_ids: Optional[set],
+    allowed_role_ids: Optional[set],
+) -> bool:
+    """User-or-role OR semantics for component interactions.
+
+    Behaviour:
+
+      - both allowlists empty → allow (no-allowlist deployments)
+      - user is in user allowlist → allow
+      - role allowlist set + user has a matching role → allow
+      - role allowlist set + user has no resolvable ``roles`` attribute
+        → reject (fail closed — e.g. DM context with a role policy active)
+      - otherwise → reject
+    """
+    user_set = allowed_user_ids or set()
+    role_set = allowed_role_ids or set()
+    has_users = bool(user_set)
+    has_roles = bool(role_set)
+
+    if not has_users and not has_roles:
+        return True
+
+    user = getattr(interaction, "user", None)
+    if user is None:
+        return False
+
+    if has_users:
+        try:
+            uid = str(user.id)
+        except AttributeError:
+            uid = ""
+        if uid and uid in user_set:
+            return True
+
+    if has_roles:
+        roles_attr = getattr(user, "roles", None)
+        if roles_attr is None:
+            # Role policy is configured but the interaction doesn't
+            # carry role data (DM-context Member, raw User payload).
+            # Fail closed: a user without a resolvable role list cannot
+            # satisfy a role allowlist.
+            return False
+        try:
+            user_role_ids = {getattr(r, "id", None) for r in roles_attr}
+        except TypeError:
+            return False
+        if user_role_ids & role_set:
+            return True
+
+    return False

--- a/tools/discord_interactive_views.py
+++ b/tools/discord_interactive_views.py
@@ -187,9 +187,15 @@ if discord is not None:
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Check whether *interaction.user* may respond to this prompt.
 
-            ``session_owner_only`` restricts to the user who originated the
-            session.  All other policies fall through to the generic user/role
-            allowlist check.
+            Each policy is enforced independently:
+
+              * ``session_owner_only`` — restricts to the user who originated
+                the session.
+              * ``any_allowed_user`` — only the user allowlist is consulted;
+                roles are ignored even if present.
+              * ``any_allowed_role`` — only the role allowlist is consulted;
+                user ID matches are ignored.
+              * ``any_allowed_user_or_role`` — user OR role allowlist (union).
             """
             if (
                 self.auth_policy == "session_owner_only"
@@ -197,6 +203,32 @@ if discord is not None:
             ):
                 return str(interaction.user.id) == str(self.origin_user_id)
 
+            # Policy-specific checks for the remaining three policies.
+            if self.auth_policy == "any_allowed_user":
+                # Only user allowlist — ignore roles entirely.
+                user_set = self.allowed_user_ids or set()
+                if not user_set:
+                    return True  # no-allowlist deployment
+                try:
+                    return str(interaction.user.id) in user_set
+                except AttributeError:
+                    return False
+
+            if self.auth_policy == "any_allowed_role":
+                # Only role allowlist — ignore user IDs entirely.
+                role_set = self.allowed_role_ids or set()
+                if not role_set:
+                    return True  # no-allowlist deployment
+                roles_attr = getattr(interaction.user, "roles", None)
+                if roles_attr is None:
+                    return False  # fail closed (DM context)
+                try:
+                    user_role_ids = {getattr(r, "id", None) for r in roles_attr}
+                except TypeError:
+                    return False
+                return bool(user_role_ids & role_set)
+
+            # any_allowed_user_or_role — union of user and role allowlists.
             return _component_check_auth(
                 interaction,
                 self.allowed_user_ids,
@@ -536,7 +568,8 @@ if discord is not None:
                             import os
                             import uuid
 
-                            cache_dir = os.path.expanduser("~/.hermes/cache/uploads")
+                            from hermes_constants import get_hermes_home
+                            cache_dir = os.path.join(get_hermes_home(), "cache", "uploads")
                             os.makedirs(cache_dir, exist_ok=True)
                             ext = os.path.splitext(att.filename)[1] or ".bin"
                             cached_path = os.path.join(

--- a/tools/discord_interactive_views.py
+++ b/tools/discord_interactive_views.py
@@ -1,0 +1,615 @@
+"""Discord View and Modal classes for the interactive_prompt tool.
+
+Provides ``InteractivePromptView`` (button grid) and ``InteractivePromptModal``
+(form popup) used by the Discord adapter to render interactive prompts and
+collect structured user responses.
+
+These classes are intentionally kept in a standalone module so the adapter
+(~6000 LOC) doesn't grow further and the contribution stays modular.
+
+Resolution goes through ``tools.human_input_gateway`` (not clarify_gateway).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Set
+
+# Conditional discord import — gracefully degrades when discord.py is absent.
+try:
+    import discord
+    from discord import ui as _ui
+except ImportError:  # pragma: no cover
+    discord = None  # type: ignore[assignment]
+    _ui = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Discord API limits
+# ---------------------------------------------------------------------------
+_DISCORD_MODAL_TITLE_MAX = 45
+_DISCORD_LABEL_MAX = 45
+_DISCORD_LABEL_DESCRIPTION_MAX = 100
+_DISCORD_MODAL_CHILD_MAX = 5
+
+# ---------------------------------------------------------------------------
+# Shared utility
+# ---------------------------------------------------------------------------
+
+
+def unwrap_modal_children(children):
+    """Unwrap discord.ui.Label wrappers to get inner components.
+
+    After the Sep 2025 modal API change, all interactive components inside
+    modals are wrapped in ``discord.ui.Label`` (type 18).  This helper
+    returns the inner ``TextInput`` / ``Select`` / ``RadioGroup`` /
+    ``CheckboxGroup`` components, falling back to the raw child when no
+    Label wrapper is present (e.g. legacy contexts or tests without Labels).
+    """
+    result = []
+    for child in children:
+        if discord is not None and isinstance(child, discord.ui.Label):
+            result.append(child.component)
+        else:
+            result.append(child)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Style mapping: human-readable names → discord.ButtonStyle
+# ---------------------------------------------------------------------------
+
+STYLE_MAP: Dict[str, Any] = {}
+if discord is not None:
+    STYLE_MAP = {
+        "primary": discord.ButtonStyle.primary,
+        "secondary": discord.ButtonStyle.secondary,
+        "success": discord.ButtonStyle.green,
+        "green": discord.ButtonStyle.green,
+        "danger": discord.ButtonStyle.red,
+        "red": discord.ButtonStyle.red,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper: embed builder
+# ---------------------------------------------------------------------------
+
+def build_prompt_embed(
+    question: str,
+    status: str = "pending",
+) -> Any:
+    """Build a Discord embed for an interactive prompt.
+
+    Parameters
+    ----------
+    question:
+        The question text shown as the embed description (max 4088 chars).
+    status:
+        ``"pending"`` → orange, ``"resolved"`` → green, ``"awaiting"`` → blue.
+
+    Returns
+    -------
+    discord.Embed
+    """
+    if discord is None:  # pragma: no cover
+        return None
+
+    colour_map = {
+        "pending": discord.Color.orange(),
+        "resolved": discord.Color.green(),
+        "awaiting": discord.Color.blue(),
+    }
+    colour = colour_map.get(status, discord.Color.orange())
+
+    description = question if len(question) <= 4088 else question[:4085] + "..."
+    embed = discord.Embed(
+        title="🔘 Hermes has a question",
+        description=description,
+        color=colour,
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Auth helper — delegates to shared utility to avoid duplication
+# ---------------------------------------------------------------------------
+
+from tools.discord_auth_helpers import component_check_auth as _component_check_auth
+
+
+# =========================================================================
+# InteractivePromptView
+# =========================================================================
+
+if discord is not None:
+
+    class InteractivePromptView(discord.ui.View):
+        """Button-grid view for an ``interactive_prompt`` question.
+
+        Renders one button per option (max 25, respecting Discord's 5-per-row
+        ActionRow limit).  Supports:
+
+        * ``"return"`` options — immediately resolve via
+          ``human_input_gateway.resolve_choice``
+        * ``"modal"`` options — open an ``InteractivePromptModal`` whose
+          ``on_submit`` handler resolves via ``resolve_modal``
+
+        Auth gating mirrors the adapter's ``_component_check_auth`` with an
+        additional ``session_owner_only`` fast-path.
+        """
+
+        def __init__(
+            self,
+            prompt_id: str,
+            question: str,
+            options: List[Dict[str, Any]],
+            allowed_user_ids: Set[str],
+            allowed_role_ids: Optional[Set[str]] = None,
+            auth_policy: str = "session_owner_only",
+            origin_user_id: Optional[str] = None,
+            timeout_seconds: float = 900,
+        ) -> None:
+            # Discord.ui.View timeout must match the agent's wait_for_response
+            # deadline.  Cap at 3600s (Discord's effective max for views).
+            super().__init__(timeout=min(timeout_seconds, 3600))
+            self.prompt_id = prompt_id
+            self.question = question
+            self.options = list(options)[:25]  # Discord max 25 buttons
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_policy = auth_policy
+            self.origin_user_id = origin_user_id
+            self.resolved = False
+            # Store the original message so the modal can update it later.
+            self._message = None  # type: ignore[assignment]
+
+            for index, option in enumerate(self.options):
+                label = option.get("label", f"Option {index + 1}")
+                if len(label) > 80:
+                    label = label[:77] + "..."
+
+                style_name = option.get("style", "secondary")
+                style = STYLE_MAP.get(style_name, discord.ButtonStyle.secondary)
+
+                button = discord.ui.Button(
+                    label=label,
+                    style=style,
+                    custom_id=f"hermes:ip:{prompt_id}:{index}",
+                )
+                button.callback = self._make_callback(index, option)
+                self.add_item(button)
+
+        # ---- Auth --------------------------------------------------------
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            """Check whether *interaction.user* may respond to this prompt.
+
+            ``session_owner_only`` restricts to the user who originated the
+            session.  All other policies fall through to the generic user/role
+            allowlist check.
+            """
+            if (
+                self.auth_policy == "session_owner_only"
+                and self.origin_user_id is not None
+            ):
+                return str(interaction.user.id) == str(self.origin_user_id)
+
+            return _component_check_auth(
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+            )
+
+        # ---- Button factory ----------------------------------------------
+
+        def _make_callback(self, index: int, option: Dict[str, Any]) -> Callable:
+            """Return an async callback wired to a specific option."""
+
+            async def _callback(interaction: discord.Interaction) -> None:
+                await self._resolve_choice(interaction, index, option)
+
+            return _callback
+
+        # ---- Choice resolution -------------------------------------------
+
+        async def _resolve_choice(
+            self,
+            interaction: discord.Interaction,
+            index: int,
+            option: Dict[str, Any],
+        ) -> None:
+            """Handle a button click — resolve or open modal."""
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered.",
+                    ephemeral=True,
+                )
+                return
+
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt.",
+                    ephemeral=True,
+                )
+                return
+
+            self.resolved = True
+            self._disable_all()
+
+            action = option.get("action", "return")
+
+            # ── Modal path ──────────────────────────────────────────────
+            if action == "modal":
+                modal_spec = option.get("modal", {})
+                modal = InteractivePromptModal(
+                    prompt_id=self.prompt_id,
+                    option_index=index,
+                    modal_spec=modal_spec,
+                    original_view=self,
+                )
+                await interaction.response.send_modal(modal)
+                return
+
+            # ── Return (default) path ──────────────────────────────────
+            embed = None
+            if interaction.message and interaction.message.embeds:
+                embed = interaction.message.embeds[0]
+                if embed:
+                    user = getattr(interaction, "user", None)
+                    display_name = (getattr(user, "display_name", "user") or "user")[:32]
+                    embed.color = discord.Color.green()
+                    embed.set_footer(
+                        text=f"Answered by {display_name}: {option.get('label', '')}"
+                    )
+
+            try:
+                await interaction.response.edit_message(embed=embed, view=self)
+            except Exception:
+                logger.debug(
+                    "InteractivePrompt edit_message failed for %s",
+                    self.prompt_id,
+                    exc_info=True,
+                )
+                try:
+                    await interaction.response.defer()
+                except Exception:
+                    pass
+
+            # Resolve via the human_input_gateway.
+            try:
+                from tools.human_input_gateway import resolve_choice, ActorInfo
+
+                user = getattr(interaction, "user", None)
+                actor = ActorInfo(
+                    platform="discord",
+                    user_id=str(getattr(user, "id", "")),
+                    display_name=getattr(user, "display_name", ""),
+                )
+                resolved = resolve_choice(
+                    self.prompt_id,
+                    option.get("value", ""),
+                    actor=actor,
+                )
+                logger.info(
+                    "InteractivePrompt button resolved (id=%s, value=%r, ok=%s)",
+                    self.prompt_id,
+                    option.get("value", ""),
+                    resolved,
+                )
+            except Exception as exc:
+                logger.error(
+                    "InteractivePrompt resolve_choice failed (id=%s): %s",
+                    self.prompt_id,
+                    exc,
+                )
+
+        # ---- Timeout / disable -------------------------------------------
+
+        async def on_timeout(self) -> None:
+            """Disable all buttons when the view times out."""
+            self.resolved = True
+            self._disable_all()
+
+        def _disable_all(self) -> None:
+            """Set ``disabled=True`` on every child component."""
+            for child in self.children:
+                child.disabled = True
+
+
+# =========================================================================
+# InteractivePromptModal
+# =========================================================================
+
+if discord is not None:
+
+    class InteractivePromptModal(discord.ui.Modal):
+        """Modal (form popup) for interactive-prompt options with ``action: "modal"``.
+
+        Supports ``"text"``, ``"select"``, ``"radio"``, and ``"checkbox"``
+        field types via ``discord.ui`` components.
+
+        TODO: ``"file_upload"`` — requires modal file-upload permissions
+              and ``discord.Attachment`` handling.
+        """
+
+        def __init__(
+            self,
+            prompt_id: str,
+            option_index: int,
+            modal_spec: Dict[str, Any],
+            original_view: Optional[InteractivePromptView] = None,
+        ) -> None:
+            title = modal_spec.get("title", "Respond")
+            if len(title) > _DISCORD_MODAL_TITLE_MAX:
+                title = title[:42] + "..."
+
+            super().__init__(
+                title=title,
+                custom_id=f"hermes:ip-modal:{prompt_id}:{option_index}",
+            )
+            self.prompt_id = prompt_id
+            self.option_index = option_index
+            self.modal_spec = modal_spec
+            self.original_view = original_view
+
+            # Store the field keys in order so we can map submitted values.
+            self._field_keys: List[str] = []
+
+            for field_spec in modal_spec.get("fields", []):
+                field_type = field_spec.get("type", "text")
+                key = field_spec.get("key", "")
+                field_label = field_spec.get("label", key)[:_DISCORD_LABEL_MAX]
+                field_description = field_spec.get("description", "")
+
+                # Discord modals support a maximum of 5 children.
+                if len(self._field_keys) >= _DISCORD_MODAL_CHILD_MAX:
+                    logger.warning(
+                        "Discord modal max 5 fields reached; skipping "
+                        "field %r (prompt_id=%s)",
+                        key,
+                        self.prompt_id,
+                    )
+                    continue
+
+                if field_type == "text":
+                    multiline = field_spec.get("multiline", False)
+                    text_input = discord.ui.TextInput(
+                        label=None,
+                        placeholder=field_spec.get("placeholder", "")[:100],
+                        required=field_spec.get("required", False),
+                        max_length=field_spec.get("max_length", 1000),
+                        min_length=field_spec.get("min_length", 0),
+                        style=(
+                            discord.TextStyle.paragraph
+                            if multiline
+                            else discord.TextStyle.short
+                        ),
+                        default=field_spec.get("default", None),
+                    )
+                    label = _ui.Label(
+                        text=field_label,
+                        description=field_description[:_DISCORD_LABEL_DESCRIPTION_MAX] if field_description else None,
+                        component=text_input,
+                    )
+                    self._field_keys.append(key)
+                    self.add_item(label)
+
+                elif field_type == "select":
+                    field_options = field_spec.get("options", [])
+                    field_required = field_spec.get("required", False)
+                    select = discord.ui.Select(
+                        custom_id=key[:100],
+                        placeholder=field_spec.get("placeholder", "")[:100],
+                        required=field_required,
+                        min_values=0 if not field_required else 1,
+                        max_values=1,
+                    )
+                    for opt_val in field_options[:25]:
+                        label = str(opt_val)
+                        select.add_option(
+                            label=label[:100],
+                            value=label[:100],
+                        )
+                    label = _ui.Label(
+                        text=field_label,
+                        description=field_description[:_DISCORD_LABEL_DESCRIPTION_MAX] if field_description else None,
+                        component=select,
+                    )
+                    self._field_keys.append(key)
+                    self.add_item(label)
+
+                elif field_type == "radio":
+                    field_options = field_spec.get("options", [])
+                    radio = discord.ui.RadioGroup(
+                        custom_id=key[:100],
+                        required=field_spec.get("required", False),
+                    )
+                    for opt_val in field_options[:10]:
+                        label = str(opt_val)
+                        radio.add_option(
+                            label=label[:100],
+                            value=label[:100],
+                        )
+                    label = _ui.Label(
+                        text=field_label,
+                        description=field_description[:_DISCORD_LABEL_DESCRIPTION_MAX] if field_description else None,
+                        component=radio,
+                    )
+                    self._field_keys.append(key)
+                    self.add_item(label)
+
+                elif field_type == "checkbox":
+                    field_options = field_spec.get("options", [])
+                    checkbox = discord.ui.CheckboxGroup(
+                        custom_id=key[:100],
+                        required=field_spec.get("required", False),
+                    )
+                    for opt_val in field_options[:10]:
+                        label = str(opt_val)
+                        checkbox.add_option(
+                            label=label[:100],
+                            value=label[:100],
+                        )
+                    label = _ui.Label(
+                        text=field_label,
+                        description=field_description[:_DISCORD_LABEL_DESCRIPTION_MAX] if field_description else None,
+                        component=checkbox,
+                    )
+                    self._field_keys.append(key)
+                    self.add_item(label)
+
+                elif field_type == "file_upload":
+                    # TODO: file_upload — requires modal file-upload
+                    # permissions and discord.Attachment handling.
+                    logger.warning(
+                        "file_upload modal field not yet implemented "
+                        "(prompt_id=%s, field=%s)",
+                        self.prompt_id,
+                        key,
+                    )
+
+                else:
+                    logger.warning(
+                        "Unknown modal field type %r (prompt_id=%s, field=%s)",
+                        field_type,
+                        self.prompt_id,
+                        key,
+                    )
+
+        def to_dict(self) -> Dict[str, Any]:
+            """Override to strip 'disabled' from Select components in modal payload.
+
+            Discord rejects 'disabled' on Select inside modals (50035).
+            The base Modal.to_dict() includes it because discord.ui.Select
+            has a default .disabled=False attribute.
+
+            Only Select (type 3) needs stripping — TextInput, RadioGroup,
+            and CheckboxGroup do not serialise a ``disabled`` field.
+            """
+            base = super().to_dict()
+            for comp in base.get("components", []):
+                inner = comp.get("component")
+                if inner and inner.get("type") == 3:  # Select
+                    inner.pop("disabled", None)
+            return base
+
+        async def on_submit(self, interaction: discord.Interaction) -> None:
+            """Collect field values and resolve the prompt via the gateway."""
+            # Gather values from children in order.
+            fields: Dict[str, Any] = {}
+            children = getattr(self, "children", [])
+            unwrapped = unwrap_modal_children(children)
+            for idx, inner in enumerate(unwrapped):
+                if idx >= len(self._field_keys):
+                    break
+                field_key = self._field_keys[idx]
+                # text → .value (str|None), radio → .value (str|None)
+                if isinstance(inner, (discord.ui.TextInput, discord.ui.RadioGroup)):
+                    fields[field_key] = getattr(inner, "value", None)
+                # select → .values (list[str]), checkbox → .values (list[str])
+                elif isinstance(inner, (discord.ui.Select, discord.ui.CheckboxGroup)):
+                    fields[field_key] = getattr(inner, "values", [])
+                else:
+                    fields[field_key] = getattr(inner, "value", None)
+
+            # Build actor info.
+            user = getattr(interaction, "user", None)
+            from tools.human_input_gateway import (
+                get_option_by_index,
+                resolve_modal,
+                ActorInfo,
+            )
+
+            actor = ActorInfo(
+                platform="discord",
+                user_id=str(getattr(user, "id", "")),
+                display_name=getattr(user, "display_name", ""),
+            )
+
+            # Resolve the choice value from the option index via the gateway.
+            opt = get_option_by_index(self.prompt_id, self.option_index)
+            if opt is None and self.original_view is not None:
+                opt = self.original_view.options[self.option_index]
+            choice_value = opt.get("value", "") if opt else ""
+            if opt is None:
+                logger.warning(
+                    "InteractivePromptModal could not resolve option "
+                    "(id=%s, index=%d); using empty choice_value",
+                    self.prompt_id,
+                    self.option_index,
+                )
+
+            try:
+                resolved = resolve_modal(
+                    self.prompt_id,
+                    choice_value,
+                    fields=fields,
+                    actor=actor,
+                )
+                logger.info(
+                    "InteractivePrompt modal resolved (id=%s, value=%r, ok=%s)",
+                    self.prompt_id,
+                    choice_value,
+                    resolved,
+                )
+            except Exception as exc:
+                logger.error(
+                    "InteractivePrompt resolve_modal failed (id=%s): %s",
+                    self.prompt_id,
+                    exc,
+                )
+
+            # Acknowledge the modal submission.
+            try:
+                await interaction.response.send_message(
+                    "✅ Response submitted", ephemeral=True,
+                )
+            except Exception:
+                logger.debug(
+                    "InteractivePromptModal send_message ack failed",
+                    exc_info=True,
+                )
+
+            # Update the original prompt message embed to green.
+            if self.original_view is not None:
+                try:
+                    msg = getattr(self.original_view, "_message", None)
+                    if msg is None:
+                        # The view's message may have been set externally
+                        # after the view was sent.  Try to grab it from
+                        # the view's internal state or skip silently.
+                        pass
+                    if msg is not None and msg.embeds:
+                        embed = msg.embeds[0]
+                        embed.color = discord.Color.green()
+                        display_name = (getattr(user, "display_name", "user") or "user")[:32]
+                        embed.set_footer(
+                            text=f"Answered by {display_name} (modal)"
+                        )
+                        await msg.edit(embed=embed, view=self.original_view)
+                except Exception:
+                    logger.debug(
+                        "InteractivePromptModal original message update failed",
+                        exc_info=True,
+                    )
+
+        async def on_error(
+            self,
+            interaction: discord.Interaction,
+            error: Exception,
+        ) -> None:
+            """Log errors and notify the user."""
+            logger.error(
+                "InteractivePromptModal on_error (id=%s): %s",
+                self.prompt_id,
+                error,
+                exc_info=error,
+            )
+            try:
+                await interaction.response.send_message(
+                    "❌ Something went wrong", ephemeral=True,
+                )
+            except Exception:
+                pass

--- a/tools/discord_interactive_views.py
+++ b/tools/discord_interactive_views.py
@@ -117,6 +117,7 @@ def build_prompt_embed(
 # ---------------------------------------------------------------------------
 
 from tools.discord_auth_helpers import component_check_auth as _component_check_auth
+from tools.human_input_gateway import FileResult
 
 
 # =========================================================================
@@ -327,11 +328,8 @@ if discord is not None:
     class InteractivePromptModal(discord.ui.Modal):
         """Modal (form popup) for interactive-prompt options with ``action: "modal"``.
 
-        Supports ``"text"``, ``"select"``, ``"radio"``, and ``"checkbox"``
-        field types via ``discord.ui`` components.
-
-        TODO: ``"file_upload"`` — requires modal file-upload permissions
-              and ``discord.Attachment`` handling.
+        Supports ``"text"``, ``"select"``, ``"radio"``, ``"checkbox"``,
+        and ``"file_upload"`` field types via ``discord.ui`` components.
         """
 
         def __init__(
@@ -461,14 +459,20 @@ if discord is not None:
                     self.add_item(label)
 
                 elif field_type == "file_upload":
-                    # TODO: file_upload — requires modal file-upload
-                    # permissions and discord.Attachment handling.
-                    logger.warning(
-                        "file_upload modal field not yet implemented "
-                        "(prompt_id=%s, field=%s)",
-                        self.prompt_id,
-                        key,
+                    file_policy = field_spec.get("file_policy", {})
+                    file_upload = _ui.FileUpload(
+                        custom_id=key[:100],
+                        required=field_spec.get("required", False),
+                        max_values=file_policy.get("max_files", 1),
+                        min_values=file_policy.get("min_files", 0),
                     )
+                    label = _ui.Label(
+                        text=field_label,
+                        description=field_description[:_DISCORD_LABEL_DESCRIPTION_MAX] if field_description else None,
+                        component=file_upload,
+                    )
+                    self._field_keys.append(key)
+                    self.add_item(label)
 
                 else:
                     logger.warning(
@@ -499,6 +503,7 @@ if discord is not None:
             """Collect field values and resolve the prompt via the gateway."""
             # Gather values from children in order.
             fields: Dict[str, Any] = {}
+            files_collected: List[FileResult] = []
             children = getattr(self, "children", [])
             unwrapped = unwrap_modal_children(children)
             for idx, inner in enumerate(unwrapped):
@@ -511,6 +516,47 @@ if discord is not None:
                 # select → .values (list[str]), checkbox → .values (list[str])
                 elif isinstance(inner, (discord.ui.Select, discord.ui.CheckboxGroup)):
                     fields[field_key] = getattr(inner, "values", [])
+                # file_upload → download attachments to cache
+                elif isinstance(inner, _ui.FileUpload):
+                    attachments = getattr(inner, "values", [])
+                    file_results = []
+                    for att in attachments:
+                        try:
+                            data = await att.read() if hasattr(att, "read") else None
+                        except Exception as read_err:
+                            logger.warning(
+                                "Failed to download attachment %s for prompt %s: %s",
+                                getattr(att, "id", "?"),
+                                self.prompt_id,
+                                read_err,
+                            )
+                            data = None
+                        cached_path = ""
+                        if data:
+                            import os
+                            import uuid
+
+                            cache_dir = os.path.expanduser("~/.hermes/cache/uploads")
+                            os.makedirs(cache_dir, exist_ok=True)
+                            ext = os.path.splitext(att.filename)[1] or ".bin"
+                            cached_path = os.path.join(
+                                cache_dir, f"{uuid.uuid4().hex}{ext}"
+                            )
+                            with open(cached_path, "wb") as f:
+                                f.write(data)
+                        file_results.append(
+                            FileResult(
+                                field_key=field_key,
+                                attachment_id=str(att.id),
+                                filename=att.filename or "unknown",
+                                content_type=att.content_type
+                                or "application/octet-stream",
+                                size=att.size or 0,
+                                cached_path=cached_path,
+                            )
+                        )
+                    if file_results:
+                        files_collected.extend(file_results)
                 else:
                     fields[field_key] = getattr(inner, "value", None)
 
@@ -546,6 +592,7 @@ if discord is not None:
                     self.prompt_id,
                     choice_value,
                     fields=fields,
+                    files=files_collected if files_collected else None,
                     actor=actor,
                 )
                 logger.info(

--- a/tools/human_input_gateway.py
+++ b/tools/human_input_gateway.py
@@ -341,6 +341,107 @@ def has_pending(session_key: str) -> bool:
         return any(_entries.get(cid) is not None for cid in ids)
 
 
+def get_pending_for_session(session_key: str) -> Optional[_HumanInputEntry]:
+    """Return the OLDEST pending entry for a session, or None.
+
+    Used by the text-fallback intercept in the gateway — when a prompt
+    is awaiting a free-form text response (because the platform has no
+    rich UI), the next user message in that session resolves the prompt
+    and unblocks the agent thread.
+    """
+    with _lock:
+        ids = _session_index.get(session_key) or []
+        for cid in ids:
+            entry = _entries.get(cid)
+            if entry is None:
+                continue
+            # Only return entries that are awaiting text (not yet resolved)
+            if not entry._resolved:
+                return entry
+    return None
+
+
+def mark_awaiting_text(prompt_id: str) -> bool:
+    """Mark a pending entry as expecting a free-form text reply.
+
+    Returns True if the entry was found and marked, False otherwise.
+    This is set by the base-platform text fallback in ``send_human_input``
+    so the gateway intercept knows to capture the next user message.
+    """
+    with _lock:
+        entry = _entries.get(prompt_id)
+    if entry is None:
+        return False
+    # Store a flag on the entry — reuse _resolved flag name with separate field
+    entry._awaiting_text = True  # type: ignore[attr-defined]
+    return True
+
+
+def is_awaiting_text(prompt_id: str) -> bool:
+    """Return True if this entry is awaiting a free-form text reply."""
+    with _lock:
+        entry = _entries.get(prompt_id)
+    if entry is None:
+        return False
+    return getattr(entry, "_awaiting_text", False)
+
+
+def resolve_text_response(prompt_id: str, text: str) -> bool:
+    """Resolve a pending entry with a free-form text response.
+
+    Interprets the text as either:
+      * A numeric index (1-based) into the options list
+      * A match against an option's label or value
+
+    Returns True if an entry was found and resolved, False otherwise.
+    """
+    with _lock:
+        entry = _entries.get(prompt_id)
+        if entry is None or entry._resolved:
+            return False
+        entry._resolved = True
+
+    text = text.strip()
+    choice_value = None
+
+    # Try numeric index
+    try:
+        idx = int(text) - 1
+        if 0 <= idx < len(entry.options):
+            choice_value = entry.options[idx].get("value")
+    except (ValueError, TypeError):
+        pass
+
+    # Try label/value match
+    if choice_value is None:
+        for opt in entry.options:
+            if text.lower() == opt.get("label", "").lower():
+                choice_value = opt.get("value")
+                break
+            if text.lower() == opt.get("value", "").lower():
+                choice_value = opt.get("value")
+                break
+
+    # If no match, use the raw text as the choice
+    if choice_value is None:
+        choice_value = text
+
+    # Reject modal-only options on text fallback — resolve as text
+    for opt in entry.options:
+        if opt.get("value") == choice_value and opt.get("action") == "modal":
+            # Can't collect modal fields via text; treat as a return with
+            # the raw text value instead.
+            choice_value = text
+            break
+
+    entry.result = HumanInputResult(
+        status="selected",
+        choice=choice_value,
+    )
+    entry.event.set()
+    return True
+
+
 def clear_session(session_key: str) -> int:
     """Cancel every pending entry for a session.
 

--- a/tools/human_input_gateway.py
+++ b/tools/human_input_gateway.py
@@ -1,0 +1,414 @@
+"""Gateway-side human-input primitive — shared by clarify and interactive_prompt.
+
+Modeled on ``tools.clarify_gateway`` but extended to support:
+
+  * Per-option modal actions (return vs modal popup)
+  * Structured file upload results (attachment metadata + cached paths)
+  * Prompt-specific auth policies (session_owner_only, etc.)
+  * Platform capability negotiation
+
+The blocking pattern is identical to clarify:
+
+  1. ``register()`` creates a pending entry with a ``threading.Event``
+  2. ``wait_for_response()`` blocks the agent thread in 1-second slices
+     (heartbeat polling keeps the inactivity watchdog alive)
+  3. Adapter callbacks fire ``resolve_choice()`` or ``resolve_modal()``
+     to unblock the agent thread
+  4. ``clear_session()`` cancels everything on session boundary
+
+State is module-level so platform adapters can resolve without holding a
+back-reference to the GatewayRunner.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# Data types
+# =========================================================================
+
+@dataclass
+class ModalFieldResult:
+    """One field value from a modal submission."""
+    key: str
+    value: Any = None
+
+
+@dataclass
+class FileResult:
+    """Structured result for a file upload field."""
+    field_key: str
+    attachment_id: str
+    filename: str
+    content_type: str
+    size: int
+    cached_path: str
+
+
+@dataclass
+class ActorInfo:
+    """Who interacted with the prompt."""
+    platform: str
+    user_id: str
+    display_name: str
+
+
+@dataclass
+class HumanInputResult:
+    """Structured result returned to the agent thread."""
+    status: str  # "selected" | "submitted" | "timeout" | "cancelled"
+    choice: Optional[str] = None
+    actor: Optional[ActorInfo] = None
+    fields: Optional[Dict[str, Any]] = None
+    files: Optional[List[FileResult]] = None
+    timed_out: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        result: Dict[str, Any] = {
+            "status": self.status,
+            "choice": self.choice,
+            "timed_out": self.timed_out,
+        }
+        if self.actor:
+            result["actor"] = {
+                "platform": self.actor.platform,
+                "user_id": self.actor.user_id,
+                "display_name": self.actor.display_name,
+            }
+        if self.fields:
+            result["fields"] = self.fields
+        if self.files:
+            result["files"] = [
+                {
+                    "field_key": f.field_key,
+                    "attachment_id": f.attachment_id,
+                    "filename": f.filename,
+                    "content_type": f.content_type,
+                    "size": f.size,
+                    "cached_path": f.cached_path,
+                }
+                for f in self.files
+            ]
+        return result
+
+
+@dataclass
+class _HumanInputEntry:
+    """One pending human-input request inside a gateway session."""
+    prompt_id: str
+    session_key: str
+    question: str
+    options: List[Dict[str, Any]]
+    timeout_seconds: float
+    auth_policy: str  # "session_owner_only" | "any_allowed_user" | "any_allowed_role" | "any_allowed_user_or_role"
+    origin_user_id: Optional[str] = None
+    message_id: Optional[str] = None
+    display_type: str = "buttons"  # Currently only "buttons" supported
+
+    # Internal
+    event: threading.Event = field(default_factory=threading.Event)
+    result: Optional[HumanInputResult] = None
+    _resolved: bool = False
+
+    def signature(self) -> Dict[str, object]:
+        return {
+            "prompt_id": self.prompt_id,
+            "session_key": self.session_key,
+            "question": self.question,
+            "options": self.options,
+            "auth_policy": self.auth_policy,
+            "origin_user_id": self.origin_user_id,
+        }
+
+
+# =========================================================================
+# Module-level state
+# =========================================================================
+
+_lock = threading.RLock()
+# prompt_id → _HumanInputEntry
+_entries: Dict[str, _HumanInputEntry] = {}
+# session_key → list[prompt_id]
+_session_index: Dict[str, List[str]] = {}
+
+# Per-session notify callbacks (gateway → adapter bridge)
+_notify_cbs: Dict[str, Callable[[_HumanInputEntry], None]] = {}
+
+
+# =========================================================================
+# Config helpers
+# =========================================================================
+
+def get_interactive_prompt_timeout() -> int:
+    """Read the interactive prompt timeout (seconds) from config.
+
+    Defaults to 900 (15 minutes).  Reads
+    ``agent.interactive_prompt_timeout`` from config.yaml.
+    Falls back to ``agent.clarify_timeout`` if the dedicated key
+    is absent, matching the pattern in ``tools.clarify_gateway``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        agent_cfg = cfg.get("agent", {}) or {}
+        val = agent_cfg.get("interactive_prompt_timeout")
+        if val is not None:
+            return int(val)
+        return int(agent_cfg.get("clarify_timeout", 900))
+    except Exception:
+        return 900
+
+
+# =========================================================================
+# ID generation
+# =========================================================================
+
+def generate_prompt_id() -> str:
+    """Generate an opaque prompt ID for component custom_ids."""
+    return uuid.uuid4().hex[:16]
+
+
+def make_component_custom_id(prompt_id: str, action_id: str) -> str:
+    """Build an opaque custom_id for a Discord component."""
+    return f"hermes:ip:{prompt_id}:{action_id}"
+
+
+def make_modal_custom_id(prompt_id: str, action_id: str) -> str:
+    """Build an opaque custom_id for a Discord modal."""
+    return f"hermes:ip-modal:{prompt_id}:{action_id}"
+
+
+def parse_custom_id(custom_id: str) -> Optional[tuple]:
+    """Parse a custom_id back into (prefix, prompt_id, action_id).
+
+    Returns None if the format doesn't match.
+    """
+    parts = custom_id.split(":", 3)
+    if len(parts) == 4 and parts[0] == "hermes":
+        return (parts[1], parts[2], parts[3])
+    return None
+
+
+# =========================================================================
+# Public API — agent-thread side
+# =========================================================================
+
+def register(
+    prompt_id: str,
+    session_key: str,
+    question: str,
+    options: List[Dict[str, Any]],
+    timeout_seconds: float,
+    auth_policy: str = "session_owner_only",
+    origin_user_id: Optional[str] = None,
+    display_type: str = "buttons",
+) -> _HumanInputEntry:
+    """Register a pending human-input request and return the entry."""
+    entry = _HumanInputEntry(
+        prompt_id=prompt_id,
+        session_key=session_key,
+        question=question,
+        options=list(options),
+        timeout_seconds=timeout_seconds,
+        auth_policy=auth_policy,
+        origin_user_id=origin_user_id,
+        display_type=display_type,
+    )
+    with _lock:
+        _entries[prompt_id] = entry
+        _session_index.setdefault(session_key, []).append(prompt_id)
+    return entry
+
+
+def wait_for_response(prompt_id: str, timeout: float) -> Optional[HumanInputResult]:
+    """Block on the entry's event until resolved or timeout fires.
+
+    Polls in 1-second slices so the agent's inactivity heartbeat keeps
+    firing.  Returns a HumanInputResult or None if entry not found.
+    """
+    with _lock:
+        entry = _entries.get(prompt_id)
+    if entry is None:
+        return None
+
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:
+        touch_activity_if_due = None
+
+    deadline = time.monotonic() + max(timeout, 0.0)
+    activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        if entry.event.wait(timeout=min(1.0, remaining)):
+            break
+        if touch_activity_if_due is not None:
+            touch_activity_if_due(activity_state, "waiting for user interactive_prompt response")
+
+    with _lock:
+        _entries.pop(prompt_id, None)
+        ids = _session_index.get(entry.session_key)
+        if ids and prompt_id in ids:
+            ids.remove(prompt_id)
+            if not ids:
+                _session_index.pop(entry.session_key, None)
+
+    # If never resolved, produce timeout result
+    if entry.result is None:
+        entry.result = HumanInputResult(status="timeout", timed_out=True)
+    return entry.result
+
+
+# =========================================================================
+# Public API — gateway / adapter side
+# =========================================================================
+
+def resolve_choice(
+    prompt_id: str,
+    choice_value: str,
+    actor: Optional[ActorInfo] = None,
+) -> bool:
+    """Resolve a prompt where the user clicked a 'return' option."""
+    with _lock:
+        entry = _entries.get(prompt_id)
+        if entry is None or entry._resolved:
+            return False
+        entry._resolved = True
+    entry.result = HumanInputResult(
+        status="selected",
+        choice=choice_value,
+        actor=actor,
+    )
+    entry.event.set()
+    return True
+
+
+def resolve_modal(
+    prompt_id: str,
+    choice_value: str,
+    fields: Optional[Dict[str, Any]] = None,
+    files: Optional[List[FileResult]] = None,
+    actor: Optional[ActorInfo] = None,
+) -> bool:
+    """Resolve a prompt where the user submitted a modal."""
+    with _lock:
+        entry = _entries.get(prompt_id)
+        if entry is None or entry._resolved:
+            return False
+        entry._resolved = True
+    entry.result = HumanInputResult(
+        status="submitted",
+        choice=choice_value,
+        actor=actor,
+        fields=fields or {},
+        files=files or [],
+    )
+    entry.event.set()
+    return True
+
+
+def get_entry(prompt_id: str) -> Optional[_HumanInputEntry]:
+    """Look up a pending entry by prompt_id."""
+    with _lock:
+        return _entries.get(prompt_id)
+
+
+def get_option_by_index(prompt_id: str, index: int) -> Optional[Dict[str, Any]]:
+    """Look up an option by its index in the entry's options list."""
+    with _lock:
+        entry = _entries.get(prompt_id)
+        if entry is None or index < 0 or index >= len(entry.options):
+            return None
+        return entry.options[index]
+
+
+def has_pending(session_key: str) -> bool:
+    """Return True when this session has at least one pending entry."""
+    with _lock:
+        ids = _session_index.get(session_key) or []
+        return any(_entries.get(cid) is not None for cid in ids)
+
+
+def clear_session(session_key: str) -> int:
+    """Cancel every pending entry for a session.
+
+    Returns the number of entries cancelled.
+    """
+    with _lock:
+        ids = list(_session_index.pop(session_key, []) or [])
+        entries = [_entries.pop(cid, None) for cid in ids]
+    cancelled = 0
+    for entry in entries:
+        if entry is None:
+            continue
+        entry.result = HumanInputResult(status="cancelled")
+        entry.event.set()
+        cancelled += 1
+    return cancelled
+
+
+def clear_all() -> int:
+    """Cancel every pending entry across all sessions.
+
+    Called during gateway shutdown so in-flight interactive prompts
+    resolve immediately instead of hanging until their timeout.
+    Returns the total number of entries cancelled.
+    """
+    with _lock:
+        all_ids = list(_entries.keys())
+        _session_index.clear()
+        entries = [_entries.pop(cid, None) for cid in all_ids]
+    cancelled = 0
+    for entry in entries:
+        if entry is None:
+            continue
+        entry.result = HumanInputResult(status="cancelled")
+        entry.event.set()
+        cancelled += 1
+    return cancelled
+
+
+# =========================================================================
+# Per-session notify hook (gateway → adapter bridge)
+# =========================================================================
+
+def register_notify(session_key: str, cb: Callable[[_HumanInputEntry], None]) -> None:
+    """Register a per-session notify callback."""
+    with _lock:
+        _notify_cbs[session_key] = cb
+
+
+def unregister_notify(session_key: str) -> None:
+    """Drop the notify callback and cancel pending entries."""
+    with _lock:
+        _notify_cbs.pop(session_key, None)
+    clear_session(session_key)
+
+
+def get_notify(session_key: str) -> Optional[Callable[[_HumanInputEntry], None]]:
+    with _lock:
+        return _notify_cbs.get(session_key)
+
+
+# ---------------------------------------------------------------------------
+# Testing helpers (not public API)
+# ---------------------------------------------------------------------------
+
+def _reset_for_testing() -> None:
+    """Clear all module state.  For test use only."""
+    with _lock:
+        _entries.clear()
+        _session_index.clear()
+        _notify_cbs.clear()

--- a/tools/interactive_prompt_tool.py
+++ b/tools/interactive_prompt_tool.py
@@ -430,6 +430,33 @@ def interactive_prompt_tool(
             ensure_ascii=False,
         )
 
+    # --- display_type validation ---
+    VALID_DISPLAY_TYPES = {"buttons"}
+    if display_type not in VALID_DISPLAY_TYPES:
+        return tool_error(
+            f"Unsupported display_type '{display_type}'. "
+            f"Must be one of {sorted(VALID_DISPLAY_TYPES)}."
+        )
+
+    # --- auth_policy validation ---
+    VALID_AUTH_POLICIES = {
+        "session_owner_only",
+        "any_allowed_user",
+        "any_allowed_role",
+        "any_allowed_user_or_role",
+    }
+    if auth_policy not in VALID_AUTH_POLICIES:
+        return tool_error(
+            f"Unsupported auth_policy '{auth_policy}'. "
+            f"Must be one of {sorted(VALID_AUTH_POLICIES)}."
+        )
+
+    # --- timeout validation ---
+    if not isinstance(timeout_seconds, (int, float)) or timeout_seconds < 60 or timeout_seconds > 3600:
+        # Clamp to valid range instead of rejecting
+        clamped = max(60, min(3600, int(timeout_seconds or 900)))
+        timeout_seconds = clamped
+
     # --- delegate to platform callback ---
     try:
         result = callback(question, options, display_type, timeout_seconds, auth_policy)
@@ -443,7 +470,18 @@ def interactive_prompt_tool(
     if isinstance(result, HumanInputResult):
         return json.dumps(result.to_dict(), ensure_ascii=False)
 
-    # Fallback: result is already a dict or simple type
+    # Production-shaped gateway callbacks return JSON strings.  Detect and
+    # pass them through to avoid double-encoding (JSON string → JSON string
+    # literal).  Tests and direct registry invocations may return dicts.
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            if isinstance(parsed, dict):
+                return result  # already valid JSON — pass through unchanged
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON; fall through to re-serialize
+
+    # Fallback: result is a dict or simple type
     return json.dumps(result, ensure_ascii=False)
 
 

--- a/tools/interactive_prompt_tool.py
+++ b/tools/interactive_prompt_tool.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+Interactive Prompt Tool Module — Rich Clarify (v2)
+
+Presents structured forms, file-request dialogs, and multi-field decision
+prompts to the user.  Each option can either return its value immediately
+(action="return") or pop a modal form (action="modal") that collects
+additional structured input before returning.
+
+Use the plain ``clarify`` tool for ordinary single-choice or open-ended
+questions.  Use ``interactive_prompt`` when you need:
+
+* File uploads from the user
+* Multi-field form collection
+* Per-option styling or conditional modal popups
+
+The actual user-interaction logic lives in the platform layer.  This module
+defines the OpenAI function-calling schema, input validation, and a thin
+dispatcher that delegates to a platform-provided callback (injected by the
+gateway runner).
+
+The gateway runner wires the callback like so:
+
+1. ``generate_prompt_id()``  → opaque prompt ID
+2. ``human_input_gateway.register()``  → pending entry with threading.Event
+3. ``get_notify(session_key)``  → adapter bridge callback
+4. ``notify(entry)``  → triggers adapter's ``send_human_input()``
+5. ``human_input_gateway.wait_for_response()``  → blocks agent thread
+6. Return the ``HumanInputResult`` as JSON
+"""
+
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+from tools.human_input_gateway import HumanInputResult, get_interactive_prompt_timeout
+from tools.registry import registry, tool_error
+
+
+# =============================================================================
+# Validation constants
+# =============================================================================
+
+MAX_OPTIONS = 25
+MAX_LABEL_LEN = 80
+MAX_VALUE_LEN = 100
+MAX_DESC_LEN = 100
+MAX_MODAL_TITLE_LEN = 45
+MIN_MODAL_FIELDS = 1
+MAX_MODAL_FIELDS = 5
+MAX_QUESTION_LEN = 2000  # Discord embed description is 4096; leave room for framing
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+INTERACTIVE_PROMPT_SCHEMA = {
+    "name": "interactive_prompt",
+    "description": (
+        "Present a structured interactive prompt to the user — with buttons "
+        "where each option can either return a value "
+        "immediately or open a modal form to collect additional fields.\n\n"
+        "Use this tool when you need:\n"
+        "• Structured forms (text inputs, selects, checkboxes)\n"
+        "• Multi-field decision collection\n"
+        "• Per-option styling or conditional modal popups\n\n"
+        "For ordinary single-choice or open-ended questions, prefer the "
+        "``clarify`` tool instead.\n\n"
+        "**Per-option action model:**\n"
+        "- ``action=return`` — selecting the option immediately returns its "
+        "``value`` to the agent.\n"
+        "- ``action=modal``  — selecting the option opens a modal dialog "
+        "with the fields defined in ``modal.fields``.  The user fills in the "
+        "form and submits; both the option ``value`` and the field values are "
+        "returned."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": "The question or prompt text to present to the user.",
+            },
+            "options": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 25,
+                "description": (
+                    "List of option objects the user can choose from (1–25)."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "maxLength": 80,
+                            "description": "Display label for the option (max 80 chars).",
+                        },
+                        "value": {
+                            "type": "string",
+                            "maxLength": 100,
+                            "description": "Machine-readable value returned when selected (max 100 chars).",
+                        },
+                        "description": {
+                            "type": "string",
+                            "maxLength": 100,
+                            "description": "Optional short description shown below the label (max 100 chars).",
+                        },
+                        "style": {
+                            "type": "string",
+                            "enum": ["primary", "secondary", "success", "danger"],
+                            "description": "Visual style hint for the option button.",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["return", "modal"],
+                            "description": (
+                                "'return' = immediately return the value; "
+                                "'modal' = open a form dialog first."
+                            ),
+                        },
+                        "modal": {
+                            "type": "object",
+                            "description": "Modal specification — required when action is 'modal'.",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 45,
+                                    "description": "Modal title (max 45 chars).",
+                                },
+                                "fields": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "maxItems": 5,
+                                    "description": "Fields to render inside the modal (1–5).",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": {
+                                                "type": "string",
+                                                "description": "Unique field identifier.",
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "description": "Human-readable field label.",
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "Optional help text below the field.",
+                                            },
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "select",
+                                                    "radio",
+                                                    "checkbox",
+                                                ],
+                                                "description": "Input widget type. 'file_upload' is planned for a future release.",
+                                            },
+                                            "required": {
+                                                "type": "boolean",
+                                                "description": "Whether the field must be filled (default false).",
+                                            },
+                                            "placeholder": {
+                                                "type": "string",
+                                                "description": "Placeholder text for text/select inputs.",
+                                            },
+                                            "options": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                                "description": "Choices for select/radio/checkbox fields.",
+                                            },
+                                            "min_length": {
+                                                "type": "integer",
+                                                "description": "Minimum character count for text fields.",
+                                            },
+                                            "max_length": {
+                                                "type": "integer",
+                                                "description": "Maximum character count for text fields.",
+                                            },
+                                            "multiline": {
+                                                "type": "boolean",
+                                                "description": "Allow multi-line text input.",
+                                            },
+                                            "file_policy": {
+                                                "type": "object",
+                                                "description": "Constraints for file_upload fields (planned — not yet functional).",
+                                                "properties": {
+                                                    "allowed_extensions": {
+                                                        "type": "array",
+                                                        "items": {"type": "string"},
+                                                        "description": "Allowed file extensions (e.g. ['.png', '.pdf']).",
+                                                    },
+                                                    "allowed_mime_types": {
+                                                        "type": "array",
+                                                        "items": {"type": "string"},
+                                                        "description": "Allowed MIME types.",
+                                                    },
+                                                    "max_files": {
+                                                        "type": "integer",
+                                                        "description": "Maximum number of files accepted.",
+                                                    },
+                                                    "max_bytes": {
+                                                        "type": "integer",
+                                                        "description": "Maximum total upload size in bytes.",
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        "required": ["key", "label", "type"],
+                                    },
+                                },
+                            },
+                            "required": ["title", "fields"],
+                        },
+                    },
+                    "required": ["label", "value"],
+                },
+            },
+            "display_type": {
+                "type": "string",
+                "enum": ["buttons"],
+                "description": "How to render the options. Currently only 'buttons' is supported.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "minimum": 60,
+                "maximum": 3600,
+                "default": 900,
+                "description": (
+                    "Seconds to wait for the user to respond (60–3600, default 900)."
+                ),
+            },
+            "auth_policy": {
+                "type": "string",
+                "enum": [
+                    "session_owner_only",
+                    "any_allowed_user",
+                    "any_allowed_role",
+                    "any_allowed_user_or_role",
+                ],
+                "default": "session_owner_only",
+                "description": (
+                    "Who is allowed to interact with this prompt. Defaults to "
+                    "'session_owner_only'."
+                ),
+            },
+        },
+        "required": ["question", "options"],
+    },
+}
+
+
+# =============================================================================
+# Tool implementation
+# =============================================================================
+
+def interactive_prompt_tool(
+    question: str,
+    options: Optional[List[Dict[str, Any]]] = None,
+    display_type: str = "buttons",
+    timeout_seconds: int = 900,
+    auth_policy: str = "session_owner_only",
+    callback: Optional[Callable] = None,
+) -> str:
+    """
+    Present a structured interactive prompt to the user.
+
+    Args:
+        question:        The question text to present.
+        options:         List of option dicts (1–25), each with at least
+                         ``label`` and ``value``.  May also include
+                         ``description``, ``style``, ``action``, and ``modal``.
+        display_type:    Must be \"buttons\".
+        timeout_seconds: Seconds to wait for a response (60–3600).
+        auth_policy:     Who may interact with the prompt.
+        callback:        Platform-provided function that handles the actual UI
+                         interaction.  Signature:
+                         ``callback(question, options, display_type,
+                                    timeout_seconds, auth_policy) -> HumanInputResult | dict``.
+                         Injected by the gateway runner.
+
+    Returns:
+        JSON string with the user's response.
+    """
+    # --- question ---
+    if not question or not question.strip():
+        return tool_error("Question text is required.")
+
+    question = question.strip()
+    if len(question) > MAX_QUESTION_LEN:
+        return tool_error(
+            f"Question text too long ({len(question)} chars, max {MAX_QUESTION_LEN})."
+        )
+
+    # --- options ---
+    if not options or not isinstance(options, list):
+        return tool_error("options must be a non-empty list of option objects.")
+
+    if len(options) > MAX_OPTIONS:
+        return tool_error(f"Too many options ({len(options)}). Maximum is {MAX_OPTIONS}.")
+
+    for idx, opt in enumerate(options):
+        if not isinstance(opt, dict):
+            return tool_error(f"Option {idx} must be a dict.")
+
+        label = opt.get("label")
+        value = opt.get("value")
+
+        if not label or not isinstance(label, str) or not label.strip():
+            return tool_error(f"Option {idx} is missing a non-empty 'label'.")
+        if not value or not isinstance(value, str) or not value.strip():
+            return tool_error(f"Option {idx} is missing a non-empty 'value'.")
+
+        if len(label) > MAX_LABEL_LEN:
+            return tool_error(
+                f"Option {idx} label exceeds {MAX_LABEL_LEN} characters "
+                f"({len(label)})."
+            )
+        if len(value) > MAX_VALUE_LEN:
+            return tool_error(
+                f"Option {idx} value exceeds {MAX_VALUE_LEN} characters "
+                f"({len(value)})."
+            )
+
+        desc = opt.get("description")
+        if desc is not None and len(str(desc)) > MAX_DESC_LEN:
+            return tool_error(
+                f"Option {idx} description exceeds {MAX_DESC_LEN} characters "
+                f"({len(str(desc))})."
+            )
+
+        # --- modal validation ---
+        action = opt.get("action", "return")
+        if action == "modal":
+            modal = opt.get("modal")
+            if not isinstance(modal, dict):
+                return tool_error(
+                    f"Option {idx} has action='modal' but no valid 'modal' object."
+                )
+            title = modal.get("title")
+            if not title or not isinstance(title, str) or not title.strip():
+                return tool_error(
+                    f"Option {idx} modal is missing a non-empty 'title'."
+                )
+            if len(title) > MAX_MODAL_TITLE_LEN:
+                return tool_error(
+                    f"Option {idx} modal title exceeds {MAX_MODAL_TITLE_LEN} "
+                    f"characters ({len(title)})."
+                )
+            fields = modal.get("fields")
+            if not isinstance(fields, list):
+                return tool_error(
+                    f"Option {idx} modal 'fields' must be a list."
+                )
+            if len(fields) < MIN_MODAL_FIELDS or len(fields) > MAX_MODAL_FIELDS:
+                return tool_error(
+                    f"Option {idx} modal must have {MIN_MODAL_FIELDS}–"
+                    f"{MAX_MODAL_FIELDS} fields (got {len(fields)})."
+                )
+
+            # Per-field validation
+            VALID_FIELD_TYPES = {"text", "select", "radio", "checkbox"}
+            seen_keys: set = set()
+            for fi, fld in enumerate(fields):
+                if not isinstance(fld, dict):
+                    return tool_error(
+                        f"Option {idx} modal field {fi} must be a dict."
+                    )
+                key = fld.get("key", "")
+                if not key or not isinstance(key, str) or not key.strip():
+                    return tool_error(
+                        f"Option {idx} modal field {fi} is missing a non-empty 'key'."
+                    )
+                if key in seen_keys:
+                    return tool_error(
+                        f"Option {idx} modal field {fi} has duplicate key '{key}'."
+                    )
+                seen_keys.add(key)
+                label = fld.get("label")
+                if not label or not isinstance(label, str) or not label.strip():
+                    return tool_error(
+                        f"Option {idx} modal field {fi} is missing a non-empty 'label'."
+                    )
+                field_type = fld.get("type", "text")
+                if field_type not in VALID_FIELD_TYPES:
+                    return tool_error(
+                        f"Option {idx} modal field {fi} has invalid type "
+                        f"'{field_type}'. Must be one of {sorted(VALID_FIELD_TYPES)}."
+                    )
+
+    # --- callback guard ---
+    if callback is None:
+        return json.dumps(
+            {"error": "Interactive prompt tool is not available in this execution context."},
+            ensure_ascii=False,
+        )
+
+    # --- delegate to platform callback ---
+    try:
+        result = callback(question, options, display_type, timeout_seconds, auth_policy)
+    except Exception as exc:
+        return json.dumps(
+            {"error": f"Failed to get user input: {exc}"},
+            ensure_ascii=False,
+        )
+
+    # Normalise result to a plain dict for JSON serialization
+    if isinstance(result, HumanInputResult):
+        return json.dumps(result.to_dict(), ensure_ascii=False)
+
+    # Fallback: result is already a dict or simple type
+    return json.dumps(result, ensure_ascii=False)
+
+
+# =============================================================================
+# Requirements check
+# =============================================================================
+
+def check_interactive_prompt_requirements() -> bool:
+    """Check whether interactive_prompt is enabled.
+
+    Controlled by ``agent.interactive_prompt_enabled`` in config.yaml.
+    Defaults to ``False`` (opt-in) so the feature ships dormant and can be
+    activated per-deployment without code changes.
+
+    When disabled the tool is silently excluded from the schema list — the
+    agent never sees it and cannot call it.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        agent_cfg = cfg.get("agent", {}) or {}
+        # Explicit opt-in required; absent key = disabled
+        return bool(agent_cfg.get("interactive_prompt_enabled", False))
+    except Exception:
+        return False
+
+
+# =============================================================================
+# Registry
+# =============================================================================
+
+registry.register(
+    name="interactive_prompt",
+    toolset="interactive_prompt",
+    schema=INTERACTIVE_PROMPT_SCHEMA,
+    handler=lambda args, **kw: interactive_prompt_tool(
+        question=args.get("question", ""),
+        options=args.get("options"),
+        display_type=args.get("display_type", "buttons"),
+        timeout_seconds=args.get("timeout_seconds") or get_interactive_prompt_timeout(),
+        auth_policy=args.get("auth_policy", "session_owner_only"),
+        callback=kw.get("callback"),
+    ),
+    check_fn=check_interactive_prompt_requirements,
+    emoji="🔘",
+)

--- a/tools/interactive_prompt_tool.py
+++ b/tools/interactive_prompt_tool.py
@@ -155,8 +155,9 @@ INTERACTIVE_PROMPT_SCHEMA = {
                                                     "select",
                                                     "radio",
                                                     "checkbox",
+                                                    "file_upload",
                                                 ],
-                                                "description": "Input widget type. 'file_upload' is planned for a future release.",
+                                                "description": "Input widget type.",
                                             },
                                             "required": {
                                                 "type": "boolean",
@@ -185,7 +186,7 @@ INTERACTIVE_PROMPT_SCHEMA = {
                                             },
                                             "file_policy": {
                                                 "type": "object",
-                                                "description": "Constraints for file_upload fields (planned — not yet functional).",
+                                                "description": "Constraints for file_upload fields.",
                                                 "properties": {
                                                     "allowed_extensions": {
                                                         "type": "array",
@@ -361,7 +362,7 @@ def interactive_prompt_tool(
                 )
 
             # Per-field validation
-            VALID_FIELD_TYPES = {"text", "select", "radio", "checkbox"}
+            VALID_FIELD_TYPES = {"text", "select", "radio", "checkbox", "file_upload"}
             seen_keys: set = set()
             for fi, fld in enumerate(fields):
                 if not isinstance(fld, dict):
@@ -389,6 +390,38 @@ def interactive_prompt_tool(
                         f"Option {idx} modal field {fi} has invalid type "
                         f"'{field_type}'. Must be one of {sorted(VALID_FIELD_TYPES)}."
                     )
+
+                # file_policy validation (only relevant for file_upload fields)
+                if field_type == "file_upload":
+                    file_policy = fld.get("file_policy")
+                    if isinstance(file_policy, dict):
+                        max_files = file_policy.get("max_files")
+                        if max_files is not None:
+                            if not isinstance(max_files, int) or max_files < 1 or max_files > 10:
+                                return tool_error(
+                                    f"Option {idx} modal field {fi} "
+                                    f"file_policy.max_files must be 1–10 "
+                                    f"(got {max_files})."
+                                )
+                        max_bytes = file_policy.get("max_bytes")
+                        if max_bytes is not None:
+                            if not isinstance(max_bytes, int) or max_bytes <= 0:
+                                return tool_error(
+                                    f"Option {idx} modal field {fi} "
+                                    f"file_policy.max_bytes must be > 0 "
+                                    f"(got {max_bytes})."
+                                )
+                        allowed_extensions = file_policy.get("allowed_extensions")
+                        if allowed_extensions is not None:
+                            if not isinstance(allowed_extensions, list) or not all(
+                                isinstance(ext, str) and ext.startswith(".")
+                                for ext in allowed_extensions
+                            ):
+                                return tool_error(
+                                    f"Option {idx} modal field {fi} "
+                                    f"file_policy.allowed_extensions must be a "
+                                    f"list of strings each starting with '.'."
+                                )
 
     # --- callback guard ---
     if callback is None:

--- a/toolsets.py
+++ b/toolsets.py
@@ -55,6 +55,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Rich interactive prompts (forms, file uploads, modal dialogs)
+    "interactive_prompt",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -234,6 +236,12 @@ TOOLSETS = {
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
         "tools": ["clarify"],
+        "includes": []
+    },
+
+    "interactive_prompt": {
+        "description": "Rich interactive prompts with per-option actions (forms, file uploads, modals)",
+        "tools": ["interactive_prompt"],
         "includes": []
     },
     

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -253,6 +253,73 @@ The gateway runs as a long-lived process, managed via:
 
 **Profile-scoped vs global**: `start_gateway()` uses profile-scoped PID files. `hermes gateway stop` stops only the current profile's gateway. `hermes gateway stop --all` uses global `ps aux` scanning to kill all gateway processes (used during updates).
 
+## Tool Callbacks (Blocking Tools)
+
+Some tools require blocking on user input and must bridge the synchronous agent loop to the asynchronous gateway. The gateway wires callbacks at startup that the tool executor calls into.
+
+### `clarify` callback
+
+```
+agent/agent_runtime_helpers.py
+  → clarify_tool(callback=kw["callback"])
+    → clarify_gateway.register() + wait()
+      → gateway callback → adapter.send_clarify()
+        → Discord: simple text question with numbered choices
+```
+
+Configured via `agent.clarify_timeout` (default 600s).
+
+### `interactive_prompt` callback
+
+```
+agent/agent_runtime_helpers.py
+  → interactive_prompt_tool(callback=kw["callback"])
+    → human_input_gateway.register() + wait()
+      → gateway callback → adapter.send_human_input()
+        → Discord: rich embed + buttons / modals
+        → Other platforms: numbered text fallback
+```
+
+**Feature-flagged.** The tool's `check_fn` reads `agent.interactive_prompt_enabled` from config (default `false`). When disabled the tool is excluded from the schema — the model cannot call it.
+
+Configured via `agent.interactive_prompt_timeout` (falls back to `agent.clarify_timeout`, then 900s).
+
+**Modal field types** supported in Discord:
+
+| Type | `discord.ui` class | Return shape | Cap |
+|------|---------------------|--------------|-----|
+| `text` | `TextInput` | `str \| None` | 4000 chars |
+| `select` | `Select` | `list[str]` | 25 options |
+| `radio` | `RadioGroup` | `str \| None` | 10 options |
+| `checkbox` | `CheckboxGroup` | `list[str]` | 10 options |
+
+Max 5 components per modal (Discord API hard limit). The renderer enforces this in `discord_interactive_views.py`; excess fields are logged and skipped.
+
+`file_upload` is planned for a future release — not yet implemented in the renderer or accepted by the schema.
+
+### Gateway cleanup
+
+In-flight prompts are cancelled in two places:
+
+1. **Per-session** at session boundaries (`_clear_session_boundary_security_state` in `gateway/run.py`):
+   ```python
+   from tools.clarify_gateway import clear_session as _clear_clarify_session
+   _clarify_session(session_key)
+
+   from tools.human_input_gateway import clear_session as _clear_human_input
+   _clear_human_input(session_key)
+   ```
+
+2. **All sessions** during gateway shutdown (`_kill_tool_subprocesses` in `gateway/run.py`):
+   ```python
+   from tools.clarify_gateway import clear_all as _clear_all_clarify
+   _clear_all_clarify()
+
+   from tools.human_input_gateway import clear_all as _clear_all_human
+   _clear_all_human()
+   ```
+   This runs twice in the shutdown path — once after drain-timeout agent interrupt, and once as a final catch-all — so in-flight prompts resolve with `status="cancelled"` instead of hanging until their timeout expires.
+
 ## Related Docs
 
 - [Session Storage](./session-storage.md)

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -292,10 +292,11 @@ Configured via `agent.interactive_prompt_timeout` (falls back to `agent.clarify_
 | `select` | `Select` | `list[str]` | 25 options |
 | `radio` | `RadioGroup` | `str \| None` | 10 options |
 | `checkbox` | `CheckboxGroup` | `list[str]` | 10 options |
+| `file_upload` | `FileUpload` | `list[FileResult]` | 10 files |
 
 Max 5 components per modal (Discord API hard limit). The renderer enforces this in `discord_interactive_views.py`; excess fields are logged and skipped.
 
-`file_upload` is planned for a future release — not yet implemented in the renderer or accepted by the schema.
+> **Permission note:** `file_upload` requires the `MANAGE_FILES` permission on the channel. Without it, the component silently fails to render. Uploaded files are cached locally at `~/.hermes/cache/uploads/`.
 
 ### Gateway cleanup
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -8,7 +8,7 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 This page documents Hermes' built-in tools, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts (current registry):** ~71 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 9 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `video_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
+**Quick counts (current registry):** ~71 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 9 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `interactive_prompt`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `video_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with the prefix `mcp_<server>_` (e.g., `mcp_github_create_issue` for the `github` MCP server). See [MCP Integration](/user-guide/features/mcp) for configuration.
@@ -43,6 +43,48 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `clarify` | Ask the user a question when you need clarification, feedback, or a decision before proceeding. Supports two modes: 1. **Multiple choice** — provide up to 4 choices. The user picks one or types their own answer via a 5th 'Other' option. 2.… | — |
+
+## `interactive_prompt` toolset
+
+**Opt-in.** Disabled by default. Enable with `agent.interactive_prompt_enabled: true` in `config.yaml`. The tool is silently excluded from the schema when disabled — the model never sees it.
+
+Use `clarify` for simple single-choice or open-ended questions. Use `interactive_prompt` when you need file uploads, multi-field form collection, per-option styling, or structured response data.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `interactive_prompt` | Present a structured interactive prompt with buttons and modal forms. Each option can return immediately (`action="return"`) or open a modal form (`action="modal"`) that collects additional structured input. Discord renders rich embed + buttons; other platforms fall back to numbered text list. Returns JSON with `status`, `choice`, `actor`, optional `fields` (modal values) and `files` (uploads, planned). | `agent.interactive_prompt_enabled: true` |
+
+**Key parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `question` | string | required | Prompt text (max 2000 chars) |
+| `options` | array | required | 1–25 option objects with `label`, `value`, optional `action`, `modal`, `description`, `style` |
+| `display_type` | enum | `"buttons"` | `"buttons"` only (`"select"` planned) |
+| `timeout_seconds` | number | 900 | 60–3600 seconds; configurable via `agent.interactive_prompt_timeout` |
+| `auth_policy` | enum | `"session_owner_only"` | Who may interact: `"session_owner_only"`, `"any_allowed_user"`, `"any_allowed_role"`, `"any_allowed_user_or_role"` |
+
+**Modal field types** (when `action="modal"`):
+
+| Type | Widget | Options | Discord Limit |
+|------|--------|---------|---------------|
+| `text` | Freeform input (single-line or paragraph) | — | max 4000 chars |
+| `select` | Dropdown pick-one | 1–25 choices | — |
+| `radio` | Exclusive single-choice group | 1–10 choices | — |
+| `checkbox` | Multi-select group | 1–10 choices | — |
+
+Max **5 fields per modal** (Discord API limit). Fields beyond 5 are silently dropped with a warning.
+
+> **Note:** `file_upload` is planned for a future release. It is not accepted by the current schema and will be rejected if submitted.
+
+> ⚠️ **Auth policies have not been live-tested on Discord.** The auth enforcement logic is covered by 19 unit tests in `test_discord_component_auth.py` and shares infrastructure with the production `clarify`/approval views. Live verification (confirming ephemeral rejection messages render correctly for non-authorized users) is still pending.
+
+**Configuration keys** (in `config.yaml` under `agent:`):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `interactive_prompt_enabled` | `false` | Feature flag — must be `true` for the tool to appear |
+| `interactive_prompt_timeout` | `900` | Default timeout in seconds; falls back to `clarify_timeout` if unset |
 
 ## `code_execution` toolset
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -52,7 +52,7 @@ Use `clarify` for simple single-choice or open-ended questions. Use `interactive
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `interactive_prompt` | Present a structured interactive prompt with buttons and modal forms. Each option can return immediately (`action="return"`) or open a modal form (`action="modal"`) that collects additional structured input. Discord renders rich embed + buttons; other platforms fall back to numbered text list. Returns JSON with `status`, `choice`, `actor`, optional `fields` (modal values) and `files` (uploads, planned). | `agent.interactive_prompt_enabled: true` |
+| `interactive_prompt` | Present a structured interactive prompt with buttons and modal forms. Each option can return immediately (`action="return"`) or open a modal form (`action="modal"`) that collects additional structured input. Discord renders rich embed + buttons; other platforms fall back to numbered text list. Returns JSON with `status`, `choice`, `actor`, optional `fields` (modal values) and `files` (uploaded file metadata). | `agent.interactive_prompt_enabled: true` |
 
 **Key parameters:**
 
@@ -70,12 +70,22 @@ Use `clarify` for simple single-choice or open-ended questions. Use `interactive
 |------|--------|---------|---------------|
 | `text` | Freeform input (single-line or paragraph) | — | max 4000 chars |
 | `select` | Dropdown pick-one | 1–25 choices | — |
+| `file_upload` | Native file picker (platform file dialog) | — | size capped by Discord tier (25 MB free, 500 MB Nitro) |
 | `radio` | Exclusive single-choice group | 1–10 choices | — |
 | `checkbox` | Multi-select group | 1–10 choices | — |
 
 Max **5 fields per modal** (Discord API limit). Fields beyond 5 are silently dropped with a warning.
 
-> **Note:** `file_upload` is planned for a future release. It is not accepted by the current schema and will be rejected if submitted.
+**`file_upload` field properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `file_policy.max_files` | int | 1 | Max number of files (Discord range: 1–10) |
+| `file_policy.max_bytes` | int | 26,214,400 (25 MB) | Max total upload size in bytes, capped by Discord server tier |
+| `file_policy.allowed_extensions` | list[str] | `[]` (any) | Whitelist of extensions (e.g. `[".pdf", ".json"]`) |
+| `file_policy.allowed_mime_types` | list[str] | `[]` (any) | Whitelist of MIME types (e.g. `["application/pdf"]`) |
+
+Both `allowed_extensions` and `allowed_mime_types` combine as AND — a file must match at least one entry in each non-empty list.
 
 > ⚠️ **Auth policies have not been live-tested on Discord.** The auth enforcement logic is covered by 19 unit tests in `test_discord_component_auth.py` and shares infrastructure with the production `clarify`/approval views. Live verification (confirming ephemeral rejection messages render correctly for non-authorized users) is still pending.
 


### PR DESCRIPTION
## Summary
Adds `interactive_prompt` — a new tool that lets agents present structured interactive forms (buttons, modals with text/select/checkbox/file-upload fields) to users on Discord and CLI. Bridges the gap between `clarify` (single-choice quick prompts) and full conversation, giving agents a way to collect multi-field input, route workflows via button actions, and render rich Discord UI components.

## What it does
- **Buttons mode**: Present up to 25 labeled options that resolve immediately or open modal forms
- **Modal mode**: Collect 1–5 typed fields (text, select, radio, checkbox, file_upload) per option
- **Auth gating**: Per-policy enforcement — `session_owner_only`, `any_allowed_user`, `any_allowed_role`, `any_allowed_user_or_role`
- **Timeout**: Views auto-expire after a configurable timeout (default 15 min, config-aware in all paths)
- **Cross-platform**: Discord gets native buttons/modals; CLI falls back to numbered text selection with automatic reply capture
- **Gateway lifecycle**: Views are registered on the platform adapter and cleaned up on gateway shutdown

## Key files
| File | Purpose |
|------|---------|
| `tools/interactive_prompt_tool.py` | Tool implementation — schema, execution, result routing, runtime validation |
| `tools/discord_interactive_views.py` | Discord UI components — Button view, Modal, per-policy auth |
| `tools/human_input_gateway.py` | Human-input gateway — shared prompt/resolve primitive, text-fallback support |
| `tools/discord_auth_helpers.py` | Shared Discord interaction auth verification |
| `gateway/platforms/discord_components.py` | Discord component registration on gateway |
| `gateway/run.py` | Gateway lifecycle hooks + text-reply intercept for non-rich platforms |
| `gateway/platforms/base.py` | Base platform adapter interface for components + text fallback |
| `plugins/platforms/discord/adapter.py` | Discord adapter integration |
| `agent/tool_executor.py` | Tool executor routing for interactive prompts |
| `agent/agent_runtime_helpers.py` | Runtime helper for prompt lifecycle |
| `tools/clarify_gateway.py` | Clarify gateway shared `clear_all()` utility |
| `toolsets.py` | Toolset registration |
| `cli-config.yaml.example` | Config example with timeout field |
| `docs/interactive-prompt-tool-spec.md` | Design specification and reference |
| `website/docs/reference/tools-reference.md` | Tools reference docs |
| `website/docs/developer-guide/gateway-internals.md` | Gateway internals docs |

## Tests
- **135 new tests** across 5 test files (tool unit, integration, human-input gateway, Discord views, review-fix verification)
- 135/135 passing locally (Discord view tests require `py-cord`; CI runs full suite)
- Review-fix tests cover: double-JSON-encoding, text-fallback resolution, config-aware timeout, `_finish_agent_tool` wrapping, profile-aware cache paths, per-policy auth, runtime validation

## Known limitations
- File upload in modals is Discord-only; CLI falls back to text prompts
- Max 25 options per interactive_prompt call (Discord component limit)
- Modal fields limited to 5 per form (Discord API constraint)
- Views are in-memory — gateway restart discards active prompts
