### PR TITLE
fix(cron): isolate profile home context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_hermes_home_override
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -225,6 +225,9 @@ _hermes_home: Path | None = None
 
 def _get_hermes_home() -> Path:
     """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
+    override = get_hermes_home_override()
+    if override:
+        return Path(override)
     return _hermes_home or get_hermes_home()
 
 
@@ -240,11 +243,11 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     """Temporarily run a job under a specific Hermes profile.
 
     Cron jobs are stored and scheduled by the profile running the scheduler, but
-    an individual job can opt into a different runtime profile. While active,
-    the scheduler's test/override hook and a context-local Hermes home override
-    both point at the resolved profile directory so _get_hermes_home(),
-    .env/config loading, script resolution, AIAgent construction, and downstream
-    get_hermes_home() callers agree on the same home.
+    an individual job can opt into a different runtime profile. While active, a
+    context-local Hermes home override points at the resolved profile directory
+    so _get_hermes_home(), .env/config loading, script resolution, AIAgent
+    construction, and downstream get_hermes_home() callers agree on the same
+    home without leaking into parallel cron worker threads.
 
     Some existing provider/config paths still load profile .env values through
     os.environ, so profile jobs also snapshot and restore the process
@@ -256,8 +259,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         yield None
         return
 
-    global _hermes_home
-    prior_override = _hermes_home
     env_snapshot = os.environ.copy()
 
     from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
@@ -278,7 +279,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     override_token = None
     try:
         override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
         logger.info(
             "Job '%s': using Hermes profile '%s' (%s)",
             job_id,
@@ -287,7 +287,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         )
         yield normalized_profile
     finally:
-        _hermes_home = prior_override
         if override_token is not None:
             reset_hermes_home_override(override_token)
         # Delta-based restore: remove added keys, restore changed keys.

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import contextvars
 
 import pytest
 
@@ -329,6 +330,22 @@ class TestRunJobProfileContext:
         assert success is True, error
         assert response.strip() == str(profile_home.resolve())
         assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
+    def test_profile_context_does_not_bleed_into_fresh_context(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        monkeypatch.setattr(sched, "_hermes_home", None)
+
+        with sched._job_profile_context("profile-job", "support"):
+            assert sched._get_hermes_home() == profile_home.resolve()
+
+            parallel_context = contextvars.Context()
+            assert parallel_context.run(sched._get_hermes_home) == root
+
         assert sched._get_hermes_home() == root
 
     def test_run_job_without_profile_leaves_hermes_home_untouched(


### PR DESCRIPTION
## Summary
- Make cron scheduler `_get_hermes_home()` prefer the context-local Hermes home override.
- Stop `_job_profile_context()` from mutating scheduler module-global `_hermes_home`, keeping that global only as the test/emergency hook.
- Add a regression test showing a profile job context does not bleed into a fresh parallel context.

Fixes #39886.

## Verification
- `.venv/bin/python -m py_compile cron/scheduler.py tests/cron/test_cron_profile.py tests/cron/test_scheduler.py tests/cron/test_parallel_pool.py`
- `.venv/bin/python -m pytest tests/cron/test_cron_profile.py tests/cron/test_parallel_pool.py tests/cron/test_scheduler.py::TestParallelTick -q -o addopts= --tb=short`
- `/opt/homebrew/bin/ruff check cron/scheduler.py tests/cron/test_cron_profile.py tests/cron/test_scheduler.py tests/cron/test_parallel_pool.py`
- `git diff --check`
