### PR TITLE
Fix cron liveness during context compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+import threading
+import time
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +41,68 @@ from typing import Any, Optional, Tuple
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
+
+_COMPRESSION_ACTIVITY_HEARTBEAT_SECONDS = 30.0
+
+
+def _start_compression_activity_heartbeat(agent: Any) -> tuple[threading.Event | None, threading.Thread | None]:
+    """Keep the agent activity tracker warm while compression is running.
+
+    Cron/gateway watchdogs rely on ``agent._touch_activity()`` to distinguish
+    "still working" from "wedged". Tool execution and main-model API calls
+    already emit heartbeats, but context compression runs synchronously in the
+    agent loop and can spend tens of seconds inside an auxiliary summarizer with
+    no activity updates at all. That makes a healthy post-tool compaction phase
+    look like an idle hang, which is exactly the #5209 shape.
+    """
+    interval = _COMPRESSION_ACTIVITY_HEARTBEAT_SECONDS
+    if interval <= 0 or not hasattr(agent, "_touch_activity"):
+        return None, None
+
+    started_at = time.monotonic()
+    stop = threading.Event()
+
+    def _beat() -> None:
+        while not stop.wait(interval):
+            try:
+                elapsed = int(time.monotonic() - started_at)
+                agent._touch_activity(
+                    f"context compression running ({elapsed}s)"
+                )
+            except Exception:
+                # Activity heartbeats are best-effort; compression itself
+                # must continue even if the tracker is unavailable.
+                return
+
+    try:
+        agent._touch_activity("context compression started")
+    except Exception:
+        return None, None
+
+    thread = threading.Thread(
+        target=_beat,
+        daemon=True,
+        name="compression-activity-heartbeat",
+    )
+    thread.start()
+    return stop, thread
+
+
+def _stop_compression_activity_heartbeat(
+    agent: Any,
+    stop: threading.Event | None,
+    thread: threading.Thread | None,
+) -> None:
+    """Tear down the compression heartbeat thread and mark completion."""
+    if stop is not None:
+        stop.set()
+    if thread is not None:
+        thread.join(timeout=0.5)
+    if hasattr(agent, "_touch_activity"):
+        try:
+            agent._touch_activity("context compression finished")
+        except Exception:
+            pass
 
 
 def _compression_lock_holder(agent: Any) -> str:
@@ -429,17 +493,21 @@ def compress_context(
         except Exception:
             pass
 
+    _heartbeat_stop, _heartbeat_thread = _start_compression_activity_heartbeat(agent)
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
-    except TypeError:
-        # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
+        try:
+            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        except TypeError:
+            # Plugin context engine with strict signature that doesn't accept
+            # focus_topic / force — fall back to calling without them.
+            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
     except BaseException:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.
         _release_lock()
         raise
+    finally:
+        _stop_compression_activity_heartbeat(agent, _heartbeat_stop, _heartbeat_thread)
 
     # If compression aborted (aux LLM failed to produce a usable summary)
     # the compressor returns the input messages unchanged.  Surface the

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -11,6 +11,7 @@ import pytest
 
 
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -438,6 +439,48 @@ class TestPreflightCompression:
         assert events[0][0] == "lifecycle"
         assert "Compacting context" in events[0][1]
         assert events[1] == ("compress", "started")
+
+    def test_compress_context_touches_activity_while_summary_runs(self, agent, monkeypatch):
+        """Long compression work must keep cron/gateway inactivity trackers warm."""
+        import agent.conversation_compression as compression_mod
+
+        monkeypatch.setattr(
+            compression_mod,
+            "_COMPRESSION_ACTIVITY_HEARTBEAT_SECONDS",
+            0.02,
+        )
+
+        saw_running_heartbeat = threading.Event()
+        original_touch = agent._touch_activity
+
+        def _record_touch(desc):
+            original_touch(desc)
+            if "context compression running" in desc:
+                saw_running_heartbeat.set()
+
+        agent._touch_activity = _record_touch
+
+        def _slow_compress(messages, current_tokens=None, focus_topic=None, force=False):
+            threading.Event().wait(0.08)
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_slow_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            compressed, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+        assert new_system_prompt == "new system prompt"
+        assert saw_running_heartbeat.is_set(), (
+            "compression should emit activity heartbeats while the summary call is still running"
+        )
+        assert agent.get_activity_summary()["last_activity_desc"] == "context compression finished"
 
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""


### PR DESCRIPTION
## Summary
- keep the cron activity tracker alive while context compression is running
- touch activity before compression starts, periodically during long-running compression, and when it finishes
- add regression coverage for compression heartbeats during direct context compaction

## Root cause
Cron's inactivity watchdog in `cron/scheduler.py` only knows a run is alive when `AIAgent` updates its activity tracker via `_touch_activity()`. Tool execution and main-model API calls already did that, but synchronous post-tool context compression did not. When a cron run entered context compression after tool work, the scheduler could see a long quiet period before `run_conversation()` returned its terminal result, misclassify the run as hung, and time it out before delivery ever started.

## Testing
- `HOME=$PWD/.tmp-test-home scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/cron/test_cron_inactivity_timeout.py`

## Why this complements #18011
#18011 improves cron timeout cleanup once a run has already hung. This change prevents a healthy post-tool compression phase from looking idle in the first place, so the scheduler keeps waiting for the terminal result instead of false-timing out the job.
