### PR TITLE
fix(email): skip IMAP ID when unsupported

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -70,9 +70,27 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
 
     Required by 163/NetEase mailbox after LOGIN: without it, every UID
     SEARCH/FETCH returns ``BYE Unsafe Login`` and disconnects.  Other
-    IMAP servers either honor it silently or reject the unknown command;
-    we swallow failures so non-supporting servers keep working.
+    IMAP servers either advertise and honor it, omit the capability, or
+    reject the unknown command.  When capabilities are known and omit ID,
+    skip the command so imaplib does not desynchronize the next command.
     """
+    capabilities = getattr(imap, "capabilities", None)
+    if capabilities:
+        if isinstance(capabilities, bytes):
+            capability_items = capabilities.decode("ascii", errors="ignore").split()
+        elif isinstance(capabilities, str):
+            capability_items = capabilities.split()
+        elif isinstance(capabilities, (list, tuple, set, frozenset)):
+            capability_items = [
+                item.decode("ascii", errors="ignore") if isinstance(item, bytes) else str(item)
+                for item in capabilities
+            ]
+        else:
+            capability_items = []
+        if capability_items and "ID" not in {item.upper() for item in capability_items}:
+            logger.debug("[Email] IMAP server does not advertise ID capability; skipping")
+            return
+
     try:
         try:
             from hermes_cli import __version__ as _hermes_version

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1192,14 +1192,36 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
             "LOGIN — the polling path opens a fresh IMAP connection.",
         )
 
-    def test_send_imap_id_swallows_errors_for_non_supporting_servers(self):
-        """Servers that reject ID must not break the connection."""
+    def test_send_imap_id_swallows_errors_when_capabilities_unknown(self):
+        """Without a capability list, ID remains best-effort and never fatal."""
         from gateway.platforms.email import _send_imap_id
 
         mock_imap = MagicMock()
         mock_imap.xatom.side_effect = Exception("BAD command unknown: ID")
 
         _send_imap_id(mock_imap)
+        mock_imap.xatom.assert_called_once()
+
+    def test_send_imap_id_skips_when_capability_omits_id(self):
+        """Known capabilities without ID must not send a command that can desync imaplib."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = (b"IMAP4REV1", b"UIDPLUS")
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.xatom.assert_not_called()
+
+    def test_send_imap_id_sends_when_capability_includes_id(self):
+        """Servers that advertise RFC 2971 ID still get the NetEase compatibility command."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = (b"IMAP4REV1", b"ID", b"UIDPLUS")
+
+        _send_imap_id(mock_imap)
+
         mock_imap.xatom.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- Skip RFC 2971 `ID` when the IMAP server has a known capability list that does not advertise `ID`.
- Preserve NetEase/163 compatibility by still sending best-effort `ID` when capabilities are unknown or explicitly include `ID`.
- Add regression coverage for unsupported, supported, and unknown-capability IMAP ID paths.

Fixes #39856.

## Verification
- `.venv/bin/python -m py_compile gateway/platforms/email.py tests/gateway/test_email.py`
- `.venv/bin/python -m pytest tests/gateway/test_email.py -q -o addopts= --tb=short`
- `.venv/bin/python -m pytest tests/gateway/test_email.py::TestImapIdExtensionForNetEase -q -o addopts= --tb=short`
- `/opt/homebrew/bin/ruff check gateway/platforms/email.py tests/gateway/test_email.py`
- `git diff --check`
