### PR TITLE
fix(desktop): IME composition prevents send button from switching to arrow

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1229,6 +1229,27 @@ export function ChatBar({
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={() => {
           composingRef.current = false
+
+          // After IME composition ends, the editor DOM has the final
+          // committed text but the assistant-ui composer state may not
+          // reflect it yet — the input handler bailed during composition.
+          // Use setTimeout to defer the sync past the current event cycle
+          // so React's automatic batching doesn't swallow the state update
+          // and the send-button icon (microphone vs. up-arrow) switches
+          // immediately, even when the post-composition input event is
+          // late or swallowed by the browser.
+          setTimeout(() => {
+            const editor = editorRef.current
+
+            if (editor) {
+              const text = composerPlainText(editor)
+
+              if (text !== draftRef.current) {
+                draftRef.current = text
+                aui.composer().setText(text)
+              }
+            }
+          }, 0)
         }}
         onCompositionStart={() => {
           composingRef.current = true


### PR DESCRIPTION
## Summary

Fix CJK IME composition causing the send button to stay as microphone icon instead of switching to the up-arrow after Chinese/Japanese/Korean input.

## Root Cause

The `onCompositionEnd` handler only set `composingRef.current = false` without syncing the composer state with the final DOM content. As a result, `draft` stays empty, `hasComposerPayload` remains false, and the button stays as voice/microphone icon.

## Fix

Added state sync logic in `onCompositionEnd` that reads the final committed text from the editor DOM and pushes it to `aui.composer().setText()`. The sync is wrapped in `setTimeout(0)` to avoid React 18 automatic batching swallowing the state update.

## Test Plan

- [ ] Type Chinese characters using IME in Hermes Desktop -> verify send button switches to up-arrow immediately
- [ ] Type English text normally -> no regression
- [ ] Start a voice conversation -> no regression on microphone button