### PR TITLE
fix(mcp): show startup servers as connecting

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -650,6 +650,11 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                     f"[dim {dim}]{srv['name']}[/] [dim]({srv['transport']})[/] "
                     f"[dim {dim}]— disabled[/]"
                 )
+            elif srv.get("status") in {"connecting", "pending"}:
+                right_lines.append(
+                    f"[dim {dim}]{srv['name']}[/] [dim]({srv['transport']})[/] "
+                    f"[yellow]— connecting[/]"
+                )
             else:
                 right_lines.append(
                     f"[red]{srv['name']}[/] [dim]({srv['transport']})[/] "

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -167,3 +167,32 @@ def test_build_welcome_banner_disabled_mcp_shows_disabled_not_failed():
     assert "broken" in output
     assert "failed" in output
 
+
+def test_build_welcome_banner_pending_mcp_shows_connecting_not_failed():
+    """A pending MCP server renders as connecting while background startup runs."""
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=(["web"], [])),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(
+            tools.mcp_tool,
+            "get_mcp_status",
+            return_value=[
+                {"name": "slow", "transport": "stdio", "tools": 0,
+                 "connected": False, "disabled": False, "status": "pending"},
+            ],
+        ),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console, model="anthropic/test-model", cwd="/tmp/project",
+            tools=[{"function": {"name": "read_file"}}],
+            get_toolset_for_tool=lambda n: "file",
+        )
+
+    slow_line = next(
+        line for line in console.export_text().splitlines()
+        if "slow" in line
+    )
+    assert "connecting" in slow_line
+    assert "failed" not in slow_line

--- a/tests/tools/test_mcp_status.py
+++ b/tests/tools/test_mcp_status.py
@@ -1,0 +1,114 @@
+"""Tests for user-facing MCP server status snapshots."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_mcp_tool(name="ping"):
+    return SimpleNamespace(
+        name=name,
+        description=name,
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _make_mock_server(name, session=None, tools=None):
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask(name)
+    server.session = session
+    server._tools = tools or []
+    return server
+
+
+def _reset_mcp_status_state(mcp):
+    with mcp._lock:
+        mcp._servers.clear()
+        mcp._connecting_servers.clear()
+        mcp._failed_servers.clear()
+
+
+def test_configured_enabled_server_is_pending_before_discovery_attempt():
+    import tools.mcp_tool as mcp
+
+    fake_config = {"slow": {"command": "npx", "args": ["demo"]}}
+    _reset_mcp_status_state(mcp)
+
+    with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+         patch("tools.mcp_tool._load_mcp_config", return_value=fake_config):
+        status = mcp.get_mcp_status()
+
+    assert status == [{
+        "name": "slow",
+        "transport": "stdio",
+        "tools": 0,
+        "connected": False,
+        "disabled": False,
+        "status": "pending",
+    }]
+
+
+def test_register_mcp_servers_marks_connecting_then_failed():
+    import tools.mcp_tool as mcp
+
+    fake_config = {"broken": {"command": "npx", "args": ["bad"]}}
+    observed_statuses = []
+
+    async def fail_register(name, cfg):
+        observed_statuses.append(mcp.get_mcp_status()[0]["status"])
+        raise ConnectionError("cannot reach server")
+
+    _reset_mcp_status_state(mcp)
+    try:
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=fail_register), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+            mcp._ensure_mcp_loop()
+            mcp.register_mcp_servers(fake_config)
+            final_status = mcp.get_mcp_status()
+
+        assert observed_statuses == ["connecting"]
+        assert final_status[0]["status"] == "failed"
+        assert final_status[0]["connected"] is False
+        assert final_status[0]["disabled"] is False
+    finally:
+        _reset_mcp_status_state(mcp)
+
+
+def test_register_mcp_servers_clears_connecting_after_success():
+    import tools.mcp_tool as mcp
+
+    fake_config = {"ok": {"command": "npx", "args": ["good"]}}
+    observed_statuses = []
+
+    async def ok_register(name, cfg):
+        observed_statuses.append(mcp.get_mcp_status()[0]["status"])
+        server = _make_mock_server(
+            name,
+            session=MagicMock(),
+            tools=[_make_mcp_tool("ping")],
+        )
+        server._registered_tool_names = ["mcp_ok_ping"]
+        mcp._servers[name] = server
+        return ["mcp_ok_ping"]
+
+    _reset_mcp_status_state(mcp)
+    try:
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool._discover_and_register_server", side_effect=ok_register), \
+             patch("tools.mcp_tool._existing_tool_names", return_value=["mcp_ok_ping"]):
+            mcp._ensure_mcp_loop()
+            mcp.register_mcp_servers(fake_config)
+            final_status = mcp.get_mcp_status()
+
+        assert observed_statuses == ["connecting"]
+        assert final_status[0]["status"] == "connected"
+        assert final_status[0]["connected"] is True
+        assert final_status[0]["tools"] == 1
+        with mcp._lock:
+            assert "ok" not in mcp._connecting_servers
+            assert "ok" not in mcp._failed_servers
+    finally:
+        _reset_mcp_status_state(mcp)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1981,6 +1981,8 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 
 _servers: Dict[str, MCPServerTask] = {}
+_connecting_servers: set[str] = set()
+_failed_servers: set[str] = set()
 
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
@@ -3469,8 +3471,22 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     )
     with _lock:
         _servers[name] = server
+        _connecting_servers.discard(name)
+        _failed_servers.discard(name)
 
-    registered_names = _register_server_tools(name, server, config)
+    try:
+        registered_names = _register_server_tools(name, server, config)
+    except Exception:
+        with _lock:
+            if _servers.get(name) is server:
+                _servers.pop(name, None)
+            _connecting_servers.discard(name)
+            _failed_servers.add(name)
+        try:
+            await server.shutdown()
+        except Exception as exc:
+            logger.debug("MCP server '%s': shutdown after registration failure failed: %s", name, exc)
+        raise
     server._registered_tool_names = list(registered_names)
 
     transport_type = "HTTP" if "url" in config else "stdio"
@@ -3514,6 +3530,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             for k, v in servers.items()
             if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
         }
+        for srv_name in new_servers:
+            _connecting_servers.add(srv_name)
+            _failed_servers.discard(srv_name)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -3539,6 +3558,12 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             return_exceptions=True,
         )
         for name, result in zip(server_names, results):
+            with _lock:
+                _connecting_servers.discard(name)
+                if isinstance(result, BaseException):
+                    _failed_servers.add(name)
+                else:
+                    _failed_servers.discard(name)
             if isinstance(result, BaseException):
                 command = new_servers.get(name, {}).get("command")
                 logger.warning(
@@ -3560,6 +3585,13 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _set_interrupt(False)
     try:
         _run_on_mcp_loop(_discover_all, timeout=120)
+    except Exception:
+        with _lock:
+            for name in new_servers:
+                if name not in _servers:
+                    _connecting_servers.discard(name)
+                    _failed_servers.add(name)
+        raise
     finally:
         if _was_interrupted:
             _set_interrupt(True)
@@ -3651,8 +3683,10 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
 def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
-    Returns a list of dicts with keys: name, transport, tools, connected.
-    Includes both successfully connected servers and configured-but-failed ones.
+    Returns a list of dicts with keys: name, transport, tools, connected,
+    disabled, and status. Includes successfully connected servers, disabled
+    servers, servers whose discovery failed, and enabled servers whose
+    background discovery has not completed yet.
     """
     result: List[dict] = []
 
@@ -3663,6 +3697,8 @@ def get_mcp_status() -> List[dict]:
 
     with _lock:
         active_servers = dict(_servers)
+        connecting_servers = set(_connecting_servers)
+        failed_servers = set(_failed_servers)
 
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
@@ -3675,6 +3711,7 @@ def get_mcp_status() -> List[dict]:
                 "tools": len(server._registered_tool_names) if hasattr(server, "_registered_tool_names") else len(server._tools),
                 "connected": True,
                 "disabled": False,
+                "status": "connected",
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
@@ -3683,12 +3720,19 @@ def get_mcp_status() -> List[dict]:
             # A server with enabled: false is intentionally not connected — it is
             # disabled, not failed. Surface that distinction so consumers (banner,
             # TUI) can render "disabled" rather than an alarming "failed".
+            if not enabled:
+                status = "disabled"
+            elif name in failed_servers or not _MCP_AVAILABLE:
+                status = "failed"
+            else:
+                status = "connecting" if name in connecting_servers else "pending"
             result.append({
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
                 "disabled": not enabled,
+                "status": status,
             })
 
     return result
@@ -3769,6 +3813,9 @@ def shutdown_mcp_servers():
     """
     with _lock:
         servers_snapshot = list(_servers.values())
+        if not servers_snapshot:
+            _connecting_servers.clear()
+            _failed_servers.clear()
 
     # Fast path: nothing to shut down.
     if not servers_snapshot:
@@ -3787,6 +3834,8 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _connecting_servers.clear()
+            _failed_servers.clear()
 
     with _lock:
         loop = _mcp_loop

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -195,6 +195,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const skillEntries = Object.entries(info.skills).sort()
   const skillsTotal = flat(info.skills).length
   const skillsCatCount = skillEntries.length
+  const mcpConnectedCount = info.mcp_servers?.filter(s => s.connected).length ?? 0
 
   const skillsBody = () => {
     if (info.lazy && skillEntries.length === 0) {
@@ -254,6 +255,10 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
             <Text color={t.color.text}>
               {s.tools} tool{s.tools === 1 ? '' : 's'}
             </Text>
+          ) : s.disabled || s.status === 'disabled' ? (
+            <Text color={t.color.muted}>disabled</Text>
+          ) : s.status === 'connecting' || s.status === 'pending' ? (
+            <Text color={t.color.warn}>connecting</Text>
           ) : (
             <Text color={t.color.error}>failed</Text>
           )}
@@ -376,7 +381,7 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
               count={info.mcp_servers.length}
               onToggle={() => setMcpOpen(v => !v)}
               open={mcpOpen}
-              suffix="connected"
+              suffix={`${mcpConnectedCount} connected`}
               t={t}
               title="MCP Servers"
             />

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -138,7 +138,9 @@ export type SectionVisibility = Partial<Record<SectionName, DetailsMode>>
 
 export interface McpServerStatus {
   connected: boolean
+  disabled?: boolean
   name: string
+  status?: 'connected' | 'connecting' | 'disabled' | 'failed' | 'pending'
   tools: number
   transport: string
 }


### PR DESCRIPTION
## Summary
- track MCP servers that are actively discovering or have failed discovery
- expose a backward-compatible `status` field from `get_mcp_status()`
- render pending/connecting MCP servers as `connecting` in the CLI and TUI instead of red `failed`

Fixes #39901.

## Verification
- `.venv/bin/python -m py_compile tools/mcp_tool.py hermes_cli/banner.py tests/tools/test_mcp_status.py tests/hermes_cli/test_banner.py`
- `.venv/bin/python -m pytest tests/tools/test_mcp_status.py tests/hermes_cli/test_banner.py -q -o addopts= --tb=short`
- `.venv/bin/python -m pytest tests/hermes_cli/test_mcp_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/test_tui_gateway_server.py -q -o addopts= --tb=short -k "session_info_includes_mcp_servers or mcp_discovery"`
- `/opt/homebrew/bin/ruff check tools/mcp_tool.py hermes_cli/banner.py tests/tools/test_mcp_status.py tests/hermes_cli/test_banner.py`
- `npm exec eslint -- src/components/branding.tsx src/types.ts` from `ui-tui/`
- `git diff --check`

Note: `npm --prefix ui-tui run type-check` still fails before reaching these files due existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` child_process typing errors.