### PR TITLE
fix(oneshot): populate fallback chain in -z mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -313,6 +313,12 @@ def _run_agent(
         platform="cli",
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
+        # Fallback provider chain (config.yaml `fallback_providers`). Without
+        # this, oneshot builds an agent with an empty `_fallback_chain`, so a
+        # primary that fails with rate-limit/overload/connection errors yields
+        # empty stdout instead of failing over. Mirrors how `hermes chat` and
+        # the gateway construct the agent.
+        fallback_model=cfg.get("fallback_providers"),
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction


### PR DESCRIPTION
## Problem
`hermes -z` (oneshot) builds `AIAgent` without passing `fallback_model`, so `_fallback_chain` is empty. When the primary provider fails with rate-limit/overload/connection errors, oneshot prints empty stdout instead of failing over to the configured `fallback_providers`. `hermes chat` and the gateway both pass the chain, so only oneshot is affected.

## Fix
Pass `fallback_model=cfg.get("fallback_providers")` to the `AIAgent` constructor in `hermes_cli/oneshot.py` (cfg is already loaded in scope). Malformed entries are filtered by `AIAgent` as in the chat/gateway paths.

## Testing
With a primary provider returning 429, `hermes -z "..."` now returns the fallback provider's answer instead of empty output. Verified end-to-end against a 3-provider chain (anthropic → openai-codex → google-gemini-cli).