### PR TITLE
feat: add self-improvement telemetry tooling

### DIFF
--- a/plugins/self_improvement_telemetry/README.md
+++ b/plugins/self_improvement_telemetry/README.md
@@ -1,0 +1,38 @@
+# Self-Improvement Telemetry Plugin
+
+Opt-in Hermes plugin that writes local, structured tool-call metrics for
+self-improvement reviews.
+
+It records:
+
+- hook timestamp;
+- session/task id;
+- tool name;
+- argument key names only;
+- result character count;
+- risk flags such as `large_tool_output`, `duplicate_skill_view`, and
+  `repeated_cronjob_list`.
+
+It does **not** record raw prompts, transcripts, argument values, tool output, or
+secrets.
+
+## Enable
+
+Add the plugin to `plugins.enabled` in `~/.hermes/config.yaml`, then restart the
+Hermes process or gateway:
+
+```bash
+hermes config set plugins.enabled '["self_improvement_telemetry"]'
+```
+
+For tests or custom deployments, override the output directory:
+
+```bash
+export HERMES_SELF_IMPROVEMENT_TELEMETRY_DIR=/tmp/hermes-self-improvement
+```
+
+Default output:
+
+```text
+~/.hermes/ops/self-improvement-log/context_metrics.jsonl
+```

--- a/plugins/self_improvement_telemetry/__init__.py
+++ b/plugins/self_improvement_telemetry/__init__.py
@@ -1,0 +1,139 @@
+"""Self-improvement telemetry plugin.
+
+This opt-in plugin records structured, local-only tool-call metrics for later
+self-improvement review. It intentionally logs sizes, labels, and risk flags —
+not raw tool outputs, prompts, transcripts, or argument values.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_LOCK = threading.RLock()
+_SESSION_STATE: dict[str, dict[str, int]] = {}
+
+LARGE_TOOL_OUTPUT_CHARS = 10_000
+VERY_LARGE_TOOL_OUTPUT_CHARS = 40_000
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_session_reset", on_session_reset)
+
+
+def reset_runtime_state() -> None:
+    with _LOCK:
+        _SESSION_STATE.clear()
+
+
+def telemetry_dir() -> Path:
+    override = os.getenv("HERMES_SELF_IMPROVEMENT_TELEMETRY_DIR", "").strip()
+    if override:
+        return Path(override)
+    return get_hermes_home() / "ops" / "self-improvement-log"
+
+
+def _session_id(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("session_id") or kwargs.get("task_id") or "unknown")
+
+
+def _result_chars(result: Any) -> int:
+    if result is None:
+        return 0
+    if isinstance(result, str):
+        return len(result)
+    try:
+        return len(json.dumps(result, ensure_ascii=False, default=str))
+    except TypeError:
+        return len(str(result))
+
+
+def _args_keys(args: Any) -> list[str]:
+    if isinstance(args, dict):
+        return sorted(str(key) for key in args.keys())
+    return []
+
+
+def _risk_flags(session_id: str, tool_name: str, args: Any, result_chars: int) -> list[str]:
+    flags: list[str] = []
+    if result_chars >= LARGE_TOOL_OUTPUT_CHARS:
+        flags.append("large_tool_output")
+    if result_chars >= VERY_LARGE_TOOL_OUTPUT_CHARS:
+        flags.append("very_large_tool_output")
+
+    with _LOCK:
+        state = _SESSION_STATE.setdefault(session_id, {})
+        if tool_name == "skill_view":
+            key = f"skill_view:{_skill_name(args)}"
+            state[key] = state.get(key, 0) + 1
+            if state[key] >= 2:
+                flags.append("duplicate_skill_view")
+        if tool_name == "cronjob" and _arg_value(args, "action") == "list":
+            key = "cronjob:list"
+            state[key] = state.get(key, 0) + 1
+            if state[key] >= 2:
+                flags.append("repeated_cronjob_list")
+    return flags
+
+
+def _skill_name(args: Any) -> str:
+    value = _arg_value(args, "name")
+    return value or "unknown"
+
+
+def _arg_value(args: Any, key: str) -> str:
+    if isinstance(args, dict):
+        value = args.get(key)
+        return str(value) if value is not None else ""
+    return ""
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def on_pre_tool_call(**kwargs: Any) -> None:
+    # Reserved for future duration tracking once hook payloads expose stable
+    # call identifiers. Keep the hook registered so shape discovery can confirm
+    # runtime availability without changing behavior.
+    return None
+
+
+def on_post_tool_call(**kwargs: Any) -> None:
+    tool_name = str(kwargs.get("tool_name") or kwargs.get("name") or "unknown")
+    args = kwargs.get("args") or {}
+    session_id = _session_id(kwargs)
+    result_chars = _result_chars(kwargs.get("result"))
+    payload = {
+        "schema_version": 1,
+        "kind": "tool_call_metric",
+        "captured_at": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "args_keys": _args_keys(args),
+        "duration_ms": int(kwargs.get("duration_ms") or 0),
+        "result_chars": result_chars,
+        "risk_flags": _risk_flags(session_id, tool_name, args, result_chars),
+    }
+    _append_jsonl(telemetry_dir() / "context_metrics.jsonl", payload)
+    return None
+
+
+def on_session_end(**kwargs: Any) -> None:
+    _SESSION_STATE.pop(_session_id(kwargs), None)
+    return None
+
+
+def on_session_reset(**kwargs: Any) -> None:
+    _SESSION_STATE.pop(_session_id(kwargs), None)
+    return None

--- a/plugins/self_improvement_telemetry/plugin.yaml
+++ b/plugins/self_improvement_telemetry/plugin.yaml
@@ -1,0 +1,9 @@
+name: self_improvement_telemetry
+version: 0.1.0
+description: "Low-noise local telemetry for Hermes self-improvement reviews. Records structured metrics only; no raw transcripts."
+author: "NousResearch"
+hooks:
+  - pre_tool_call
+  - post_tool_call
+  - on_session_end
+  - on_session_reset

--- a/scripts/self_improvement/README.md
+++ b/scripts/self_improvement/README.md
@@ -61,11 +61,12 @@ and preferences are intentionally ignored even when they mention those words.
 
 ## `summarize.py`
 
-Summarizes `task_runs.jsonl` and `memory_context_audit.jsonl` into a compact
-review payload. It reports aggregate tokens/tool/API counts, the latest task's
-largest context contributors, memory-context candidate counts, and review flags
-such as `duplicate_skill_view`, `repeated_cronjob_list`, and
-`memory_context_noise`.
+Summarizes `task_runs.jsonl`, `memory_context_audit.jsonl`, and
+`context_metrics.jsonl` into a compact review payload. It reports aggregate
+tokens/tool/API counts, the latest task's largest context contributors,
+plugin-emitted tool-result sizes/risk flags, memory-context candidate counts,
+and review flags such as `duplicate_skill_view`, `repeated_cronjob_list`,
+`large_tool_output`, and `memory_context_noise`.
 
 ```bash
 python scripts/self_improvement/summarize.py
@@ -80,6 +81,8 @@ reason codes, content lengths, and memory ids only — not raw memory content.
 - `events.jsonl` — optional compact workflow-improvement events when
   `--append-event` is passed.
 - `memory_context_audit.jsonl` — non-destructive memory-context audit reports.
+- `context_metrics.jsonl` — opt-in plugin tool-call metrics with sanitized tool
+  names, argument key names, result sizes, and risk flags.
 
 Each task-run entry stores structured metrics only:
 

--- a/scripts/self_improvement/README.md
+++ b/scripts/self_improvement/README.md
@@ -1,0 +1,54 @@
+# Self-Improvement Telemetry Helpers
+
+This directory contains lightweight, GitHub-ready helpers for recording Hermes
+self-improvement telemetry without copying raw transcripts, prompts, tool
+outputs, or secrets into logs.
+
+## `log_session_telemetry.py`
+
+Reads Hermes `state.db` and appends one compact task-run record to
+`~/.hermes/ops/self-improvement-log/task_runs.jsonl` by default.
+
+```bash
+python scripts/self_improvement/log_session_telemetry.py
+```
+
+Useful flags:
+
+```bash
+# Inspect the payload without writing JSONL
+python scripts/self_improvement/log_session_telemetry.py --dry-run
+
+# Record a specific session
+python scripts/self_improvement/log_session_telemetry.py --session-id 20260605_182249_c2fb0e
+
+# Allow selecting the newest open/current session when --session-id is omitted
+python scripts/self_improvement/log_session_telemetry.py --include-open
+
+# Re-append a session already present in task_runs.jsonl
+python scripts/self_improvement/log_session_telemetry.py --force
+
+# Also write a compact workflow event for the self-improvement event watcher
+python scripts/self_improvement/log_session_telemetry.py --append-event
+```
+
+Default behavior intentionally chooses the newest **ended** session, not the
+newest open session. That avoids accidentally attributing the live review
+conversation to the task that just completed.
+
+## Output files
+
+- `task_runs.jsonl` — task/session telemetry records.
+- `events.jsonl` — optional compact workflow-improvement events when
+  `--append-event` is passed.
+
+Each task-run entry stores structured metrics only:
+
+- session id/source/model/timing/end reason;
+- message/tool/API counts;
+- input/output/reasoning/cache token counts;
+- cost fields when Hermes has them;
+- role/tool count summaries;
+- compact `role:tool:chars` labels for the largest context contributors.
+
+No message content is copied into telemetry output.

--- a/scripts/self_improvement/README.md
+++ b/scripts/self_improvement/README.md
@@ -36,11 +36,35 @@ Default behavior intentionally chooses the newest **ended** session, not the
 newest open session. That avoids accidentally attributing the live review
 conversation to the task that just completed.
 
+## `audit_memory_context.py`
+
+Audits recalled `<memory-context>` / Mnemosyne-context text for likely
+non-durable raw fragments. The helper is deliberately non-destructive: it writes
+a JSONL report and can print suggested invalidation commands, but it does not
+modify memory itself.
+
+```bash
+# Read a captured memory-context text file and append an audit report
+python scripts/self_improvement/audit_memory_context.py --input /tmp/memory-context.txt
+
+# Print suggested invalidation calls for entries with memory ids
+python scripts/self_improvement/audit_memory_context.py --input /tmp/memory-context.txt --commands --no-write
+
+# Pipe context directly from stdin
+python scripts/self_improvement/audit_memory_context.py --input -
+```
+
+Candidate reasons include raw `[USER]` fragments, standalone command fragments
+such as “proceed”, one-off task prompts, background-process notification
+fragments, and low-importance raw conversation entries. Stable distilled rules
+and preferences are intentionally ignored even when they mention those words.
+
 ## Output files
 
 - `task_runs.jsonl` — task/session telemetry records.
 - `events.jsonl` — optional compact workflow-improvement events when
   `--append-event` is passed.
+- `memory_context_audit.jsonl` — non-destructive memory-context audit reports.
 
 Each task-run entry stores structured metrics only:
 

--- a/scripts/self_improvement/README.md
+++ b/scripts/self_improvement/README.md
@@ -59,6 +59,21 @@ such as “proceed”, one-off task prompts, background-process notification
 fragments, and low-importance raw conversation entries. Stable distilled rules
 and preferences are intentionally ignored even when they mention those words.
 
+## `summarize.py`
+
+Summarizes `task_runs.jsonl` and `memory_context_audit.jsonl` into a compact
+review payload. It reports aggregate tokens/tool/API counts, the latest task's
+largest context contributors, memory-context candidate counts, and review flags
+such as `duplicate_skill_view`, `repeated_cronjob_list`, and
+`memory_context_noise`.
+
+```bash
+python scripts/self_improvement/summarize.py
+```
+
+The summary is safe to paste into review notes because candidate previews include
+reason codes, content lengths, and memory ids only — not raw memory content.
+
 ## Output files
 
 - `task_runs.jsonl` — task/session telemetry records.

--- a/scripts/self_improvement/__init__.py
+++ b/scripts/self_improvement/__init__.py
@@ -1,0 +1,1 @@
+"""Self-improvement telemetry helpers for Hermes Agent."""

--- a/scripts/self_improvement/audit_memory_context.py
+++ b/scripts/self_improvement/audit_memory_context.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Audit recalled memory-context text for likely non-durable fragments.
+
+The audit is deliberately non-destructive. It reports candidates and writes
+structured JSONL, but it does not invalidate memories itself. When a memory id
+is present, ``--commands`` prints suggested ``mnemosyne_validate`` calls for a
+human or agent to review.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_ROOT = get_hermes_home() / "ops" / "self-improvement-log"
+DEFAULT_OUTPUT = DEFAULT_ROOT / "memory_context_audit.jsonl"
+
+_ENTRY_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:\[[^\]]+\]\s*)?"
+    r"(?:\(importance\s+(?P<importance>[0-9.]+)\)\s*)?"
+    r"(?:(?:id|memory_id)=(?P<memory_id>[A-Za-z0-9_-]+)\s*)?"
+    r"(?P<content>.*\S)\s*$"
+)
+_COMMAND_FRAGMENT_RE = re.compile(
+    r"^\[USER\]\s*(?:proceed|commit|what next|make it happen|go ahead|ok start(?: working)?(?: on the plan)?\.?|review now i ran another task|you decide.*proceed)\s*$",
+    re.IGNORECASE,
+)
+_ONE_OFF_PROMPT_RE = re.compile(
+    r"^\[USER\].*(?:let me know where|start working on that plan|final video|ran another task)",
+    re.IGNORECASE,
+)
+_BACKGROUND_PROCESS_RE = re.compile(
+    r"background process|matched watch pattern|startup done|matched output|^command:",
+    re.IGNORECASE,
+)
+_RAW_PREFIXES = ("[USER]", "[conversation]")
+
+
+@dataclass(frozen=True)
+class MemoryContextEntry:
+    content: str
+    importance: float | None = None
+    memory_id: str = ""
+
+
+@dataclass(frozen=True)
+class AuditCandidate:
+    content: str
+    reasons: list[str]
+    importance: float | None = None
+    memory_id: str = ""
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    schema_version: int
+    kind: str
+    captured_at: str
+    entry_count: int
+    candidate_count: int
+    candidates: list[AuditCandidate]
+
+
+def parse_memory_context(text: str) -> list[MemoryContextEntry]:
+    """Parse recalled memory-context text into coarse line-based entries."""
+    entries: list[MemoryContextEntry] = []
+    current: MemoryContextEntry | None = None
+    continuation_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current, continuation_lines
+        if current is None:
+            return
+        if continuation_lines:
+            joined = "\n".join([current.content, *continuation_lines]).strip()
+            entries.append(
+                MemoryContextEntry(
+                    content=joined,
+                    importance=current.importance,
+                    memory_id=current.memory_id,
+                )
+            )
+        else:
+            entries.append(current)
+        current = None
+        continuation_lines = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("##") or line.startswith("<"):
+            continue
+        match = _ENTRY_RE.match(raw_line)
+        if not match:
+            continue
+        content = match.group("content").strip()
+        if not content:
+            continue
+        looks_like_new_entry = content.startswith(_RAW_PREFIXES) or "(importance " in raw_line or "id=" in raw_line
+        if looks_like_new_entry:
+            flush()
+            importance_raw = match.group("importance")
+            current = MemoryContextEntry(
+                content=content,
+                importance=float(importance_raw) if importance_raw else None,
+                memory_id=match.group("memory_id") or "",
+            )
+        elif current is not None:
+            continuation_lines.append(content)
+        else:
+            current = MemoryContextEntry(content=content)
+    flush()
+    return entries
+
+
+def classify_entry(entry: MemoryContextEntry) -> list[str]:
+    content = entry.content.strip()
+    lower = content.lower()
+    reasons: list[str] = []
+
+    if content.startswith("[USER]"):
+        reasons.append("raw_user_fragment")
+    if content.startswith("[conversation]"):
+        reasons.append("raw_conversation_fragment")
+    if _COMMAND_FRAGMENT_RE.search(content):
+        reasons.append("standalone_command_fragment")
+    if _ONE_OFF_PROMPT_RE.search(content):
+        reasons.append("one_off_task_prompt")
+    if _BACKGROUND_PROCESS_RE.search(content):
+        reasons.append("background_process_fragment")
+    if "sleep_consolidation" in lower:
+        reasons.append("sleep_consolidation_fragment")
+    if entry.importance is not None and entry.importance <= 0.3 and content.startswith(_RAW_PREFIXES):
+        reasons.append("low_importance_raw_fragment")
+
+    # Stable distilled facts/preferences should not be candidates solely because
+    # they mention noisy words like "proceed" inside the rule itself.
+    if not content.startswith(_RAW_PREFIXES):
+        return []
+    return reasons
+
+
+def audit_entries(entries: list[MemoryContextEntry]) -> AuditReport:
+    candidates = [
+        AuditCandidate(
+            content=entry.content,
+            reasons=classify_entry(entry),
+            importance=entry.importance,
+            memory_id=entry.memory_id,
+        )
+        for entry in entries
+    ]
+    candidates = [candidate for candidate in candidates if candidate.reasons]
+    return AuditReport(
+        schema_version=1,
+        kind="memory_context_audit",
+        captured_at=datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        entry_count=len(entries),
+        candidate_count=len(candidates),
+        candidates=candidates,
+    )
+
+
+def audit_text(text: str) -> AuditReport:
+    return audit_entries(parse_memory_context(text))
+
+
+def append_report(path: Path, report: AuditReport) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(asdict(report), ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def suggested_commands(report: AuditReport) -> str:
+    lines: list[str] = []
+    for candidate in report.candidates:
+        if not candidate.memory_id:
+            continue
+        reason = ",".join(candidate.reasons)
+        lines.append(
+            "mnemosyne_validate("
+            f'action="invalidate", bank="private", memory_id="{candidate.memory_id}", '
+            f'note="Memory-context audit candidate: {reason}")'
+        )
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="-", help="Input text file, or '-' for stdin")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="JSONL audit output path")
+    parser.add_argument("--commands", action="store_true", help="Print suggested invalidation commands instead of JSON summary")
+    parser.add_argument("--no-write", action="store_true", help="Do not append the JSONL audit report")
+    return parser.parse_args(argv)
+
+
+def read_input(path: str) -> str:
+    if path == "-":
+        import sys
+
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = audit_text(read_input(args.input))
+    if not args.no_write:
+        append_report(Path(args.output), report)
+    if args.commands:
+        print(suggested_commands(report))
+    else:
+        print(
+            json.dumps(
+                {
+                    "kind": report.kind,
+                    "entry_count": report.entry_count,
+                    "candidate_count": report.candidate_count,
+                    "applied": False,
+                    "output": "" if args.no_write else str(args.output),
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/self_improvement/log_session_telemetry.py
+++ b/scripts/self_improvement/log_session_telemetry.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Record structured Hermes task-run telemetry from ``state.db``.
+
+This helper intentionally stores metrics and compact labels only. It does not
+copy raw transcript text, tool output, prompts, secrets, or message content into
+telemetry files.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_ROOT = get_hermes_home() / "ops" / "self-improvement-log"
+DEFAULT_DB = get_hermes_home() / "state.db"
+TASK_RUNS_FILENAME = "task_runs.jsonl"
+EVENTS_FILENAME = "events.jsonl"
+
+
+def latest_session_id(
+    con: sqlite3.Connection,
+    source: str | None = None,
+    *,
+    include_open: bool = False,
+) -> str:
+    """Return the newest matching session id.
+
+    Ended sessions are selected by default so a live review session is not
+    accidentally logged as the task that just completed.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if source:
+        clauses.append("source = ?")
+        params.append(source)
+    if not include_open:
+        clauses.append("ended_at is not null")
+    where = f"where {' and '.join(clauses)}" if clauses else ""
+    row = con.execute(
+        f"select id from sessions {where} order by started_at desc limit 1",
+        params,
+    ).fetchone()
+    if not row:
+        raise SystemExit("No matching Hermes session found")
+    return str(row[0])
+
+
+def compact_tool_names(con: sqlite3.Connection, session_id: str) -> list[str]:
+    rows = con.execute(
+        """
+        select tool_name, count(*) as count
+        from messages
+        where session_id = ? and tool_name is not null and tool_name != ''
+        group by tool_name
+        order by count(*) desc, tool_name asc
+        """,
+        (session_id,),
+    ).fetchall()
+    return [f"{row['tool_name']}:{int(row['count'] or 0)}" for row in rows]
+
+
+def role_stats(con: sqlite3.Connection, session_id: str) -> dict[str, dict[str, int]]:
+    rows = con.execute(
+        """
+        select role, count(*) as count, sum(length(coalesce(content, ''))) as chars
+        from messages
+        where session_id = ?
+        group by role
+        """,
+        (session_id,),
+    ).fetchall()
+    return {
+        str(row["role"]): {
+            "count": int(row["count"] or 0),
+            "chars": int(row["chars"] or 0),
+        }
+        for row in rows
+    }
+
+
+def top_context_items(
+    con: sqlite3.Connection,
+    session_id: str,
+    *,
+    limit: int = 8,
+) -> list[str]:
+    """Return compact role/tool/size labels for the largest stored messages."""
+    rows = con.execute(
+        """
+        select role, coalesce(tool_name, '') as tool_name, length(coalesce(content, '')) as chars
+        from messages
+        where session_id = ?
+        order by length(coalesce(content, '')) desc
+        limit ?
+        """,
+        (session_id, limit),
+    ).fetchall()
+    return [
+        f"{row['role']}:{row['tool_name'] or '-'}:{int(row['chars'] or 0)}"
+        for row in rows
+    ]
+
+
+def _safe_int(row: sqlite3.Row, key: str) -> int:
+    try:
+        return int(row[key] or 0)
+    except (IndexError, KeyError):
+        return 0
+
+
+def _safe_float(row: sqlite3.Row, key: str) -> float:
+    try:
+        return float(row[key] or 0.0)
+    except (IndexError, KeyError):
+        return 0.0
+
+
+def _safe_str(row: sqlite3.Row, key: str) -> str:
+    try:
+        return str(row[key] or "")
+    except (IndexError, KeyError):
+        return ""
+
+
+def build_task_run(con: sqlite3.Connection, session_id: str) -> dict[str, Any]:
+    session = con.execute("select * from sessions where id = ?", (session_id,)).fetchone()
+    if session is None:
+        raise SystemExit(f"Session not found: {session_id}")
+
+    return {
+        "schema_version": 1,
+        "kind": "task_run_telemetry",
+        "captured_at": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "session_id": session_id,
+        "source": _safe_str(session, "source"),
+        "title": _safe_str(session, "title"),
+        "started_at": _safe_float(session, "started_at"),
+        "ended_at": _safe_float(session, "ended_at"),
+        "end_reason": _safe_str(session, "end_reason"),
+        "model": _safe_str(session, "model"),
+        "message_count": _safe_int(session, "message_count"),
+        "tool_call_count": _safe_int(session, "tool_call_count"),
+        "api_call_count": _safe_int(session, "api_call_count"),
+        "input_tokens": _safe_int(session, "input_tokens"),
+        "output_tokens": _safe_int(session, "output_tokens"),
+        "reasoning_tokens": _safe_int(session, "reasoning_tokens"),
+        "cache_read_tokens": _safe_int(session, "cache_read_tokens"),
+        "cache_write_tokens": _safe_int(session, "cache_write_tokens"),
+        "estimated_cost_usd": _safe_float(session, "estimated_cost_usd"),
+        "actual_cost_usd": _safe_float(session, "actual_cost_usd"),
+        "cost_status": _safe_str(session, "cost_status"),
+        "cost_source": _safe_str(session, "cost_source"),
+        "role_stats": role_stats(con, session_id),
+        "tool_stats": compact_tool_names(con, session_id),
+        "largest_context_items": top_context_items(con, session_id),
+        "attribution_method": "explicit_session_id",
+    }
+
+
+def session_already_logged(path: Path, session_id: str) -> bool:
+    if not path.exists():
+        return False
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("session_id") == session_id:
+                return True
+    return False
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def build_compact_event(task_run: dict[str, Any], *, source: str, route: str) -> dict[str, Any]:
+    measures = {
+        "tool_calls": task_run["tool_call_count"],
+        "files_changed": 0,
+        "memories_changed": 0,
+        "skills_changed": 0,
+        "verification": "telemetry_readback",
+        "session_id": task_run["session_id"],
+        "model": task_run["model"],
+        "input_tokens": task_run["input_tokens"],
+        "output_tokens": task_run["output_tokens"],
+        "reasoning_tokens": task_run["reasoning_tokens"],
+        "cache_read_tokens": task_run["cache_read_tokens"],
+        "cache_write_tokens": task_run["cache_write_tokens"],
+        "api_calls": task_run["api_call_count"],
+        "estimated_cost_usd": task_run["estimated_cost_usd"],
+        "actual_cost_usd": task_run["actual_cost_usd"],
+        "cost_status": task_run["cost_status"],
+        "cost_source": task_run["cost_source"],
+        "tool_names": task_run["tool_stats"],
+        "role_stats": task_run["role_stats"],
+        "largest_context_items": task_run["largest_context_items"],
+    }
+    return {
+        "schema_version": 1,
+        "ts": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "source": source,
+        "route": route,
+        "intention": "Record structured Hermes task-run telemetry for review.",
+        "actions": [
+            "captured model/token/cost counters from sessions table",
+            "captured compact tool, role, and largest-context labels without raw transcript content",
+        ],
+        "skills_used": [],
+        "skill_performance": [],
+        "measures": measures,
+        "outcome": "Session telemetry was captured from Hermes state.db without raw transcript content.",
+        "end_result": "Task-run metrics are available for later self-improvement review.",
+        "improvement_candidate": "Promote task-run telemetry into a Hermes runtime hook/plugin if manual capture remains useful.",
+        "follow_up": "Decide whether to capture per-turn deltas automatically instead of whole-session aggregates.",
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default=str(DEFAULT_DB), help="Path to Hermes state.db")
+    parser.add_argument("--root", default=str(DEFAULT_ROOT), help="Self-improvement log directory")
+    parser.add_argument("--session-id", default="", help="Specific session id to record")
+    parser.add_argument("--source", default="discord", help="Session source filter when --session-id is omitted")
+    parser.add_argument("--include-open", action="store_true", help="Allow selecting an open/current session")
+    parser.add_argument("--dry-run", action="store_true", help="Print telemetry without writing JSONL")
+    parser.add_argument("--force", action="store_true", help="Append even if this session_id is already logged")
+    parser.add_argument("--append-event", action="store_true", help="Also append a compact workflow event to events.jsonl")
+    parser.add_argument("--route", default="workflow_improvement", help="Route label for --append-event")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = Path(args.root)
+    task_runs_path = root / TASK_RUNS_FILENAME
+    events_path = root / EVENTS_FILENAME
+
+    con = sqlite3.connect(args.db)
+    con.row_factory = sqlite3.Row
+    try:
+        session_id = args.session_id or latest_session_id(
+            con,
+            args.source,
+            include_open=args.include_open,
+        )
+        task_run = build_task_run(con, session_id)
+        if not args.session_id:
+            task_run["attribution_method"] = "latest_open_allowed" if args.include_open else "latest_ended"
+
+        if args.dry_run:
+            print(json.dumps(task_run, ensure_ascii=False, indent=2, sort_keys=True))
+            return 0
+
+        if not args.force and session_already_logged(task_runs_path, session_id):
+            print(json.dumps({"status": "already_logged", "session_id": session_id}, sort_keys=True))
+            return 0
+
+        append_jsonl(task_runs_path, task_run)
+        if args.append_event:
+            append_jsonl(events_path, build_compact_event(task_run, source=args.source, route=args.route))
+
+        print(
+            json.dumps(
+                {"status": "logged", "task_runs": str(task_runs_path), "session_id": session_id},
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 0
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/self_improvement/summarize.py
+++ b/scripts/self_improvement/summarize.py
@@ -12,6 +12,7 @@ from hermes_constants import get_hermes_home
 DEFAULT_ROOT = get_hermes_home() / "ops" / "self-improvement-log"
 TASK_RUNS_FILENAME = "task_runs.jsonl"
 MEMORY_AUDIT_FILENAME = "memory_context_audit.jsonl"
+CONTEXT_METRICS_FILENAME = "context_metrics.jsonl"
 
 THRESHOLDS = {
     "input_tokens_high": 200_000,
@@ -55,7 +56,41 @@ def _tool_count(task_run: dict[str, Any], tool_name: str) -> int:
     return 0
 
 
-def review_flags(latest_task: dict[str, Any] | None, latest_memory_audit: dict[str, Any] | None) -> list[str]:
+def summarize_context_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    tool_counts: dict[str, int] = {}
+    risk_flag_counts: dict[str, int] = {}
+    for row in rows:
+        tool_name = str(row.get("tool_name") or "unknown")
+        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+        for flag in row.get("risk_flags") or []:
+            flag_name = str(flag)
+            risk_flag_counts[flag_name] = risk_flag_counts.get(flag_name, 0) + 1
+
+    largest_tool_results = sorted(
+        (
+            {
+                "session_id": str(row.get("session_id") or ""),
+                "tool_name": str(row.get("tool_name") or "unknown"),
+                "result_chars": int(row.get("result_chars") or 0),
+            }
+            for row in rows
+        ),
+        key=lambda item: item["result_chars"],
+        reverse=True,
+    )[:8]
+    return {
+        "metric_count": len(rows),
+        "tool_counts": dict(sorted(tool_counts.items())),
+        "risk_flag_counts": dict(sorted(risk_flag_counts.items())),
+        "largest_tool_results": largest_tool_results,
+    }
+
+
+def review_flags(
+    latest_task: dict[str, Any] | None,
+    latest_memory_audit: dict[str, Any] | None,
+    context_metrics: dict[str, Any] | None = None,
+) -> list[str]:
     if latest_task is None:
         return []
     flags: list[str] = []
@@ -69,6 +104,15 @@ def review_flags(latest_task: dict[str, Any] | None, latest_memory_audit: dict[s
         flags.append("duplicate_skill_view")
     if _tool_count(latest_task, "cronjob") >= THRESHOLDS["repeated_cronjob_count"]:
         flags.append("repeated_cronjob_list")
+    risk_counts = (context_metrics or {}).get("risk_flag_counts") or {}
+    for risk_flag, review_flag in (
+        ("duplicate_skill_view", "duplicate_skill_view"),
+        ("repeated_cronjob_list", "repeated_cronjob_list"),
+        ("large_tool_output", "large_tool_output"),
+        ("very_large_tool_output", "very_large_tool_output"),
+    ):
+        if int(risk_counts.get(risk_flag) or 0) > 0 and review_flag not in flags:
+            flags.append(review_flag)
     if latest_memory_audit and int(latest_memory_audit.get("candidate_count") or 0) >= THRESHOLDS["memory_context_candidate_count"]:
         flags.append("memory_context_noise")
     return flags
@@ -77,8 +121,10 @@ def review_flags(latest_task: dict[str, Any] | None, latest_memory_audit: dict[s
 def build_summary(root: Path) -> dict[str, Any]:
     task_runs = read_jsonl(root / TASK_RUNS_FILENAME)
     memory_audits = read_jsonl(root / MEMORY_AUDIT_FILENAME)
+    context_metric_rows = read_jsonl(root / CONTEXT_METRICS_FILENAME)
     latest_task = task_runs[-1] if task_runs else None
     latest_memory_audit = memory_audits[-1] if memory_audits else None
+    context_metrics = summarize_context_metrics(context_metric_rows)
 
     telemetry_totals = {
         "input_tokens": _sum_int(task_runs, "input_tokens"),
@@ -95,10 +141,12 @@ def build_summary(root: Path) -> dict[str, Any]:
         "root": str(root),
         "task_runs": len(task_runs),
         "memory_context_audits": len(memory_audits),
+        "context_metric_rows": len(context_metric_rows),
         "latest_task_session": latest_task.get("session_id") if latest_task else "",
         "telemetry_totals": telemetry_totals,
         "largest_context_items": list((latest_task or {}).get("largest_context_items") or [])[:8],
         "tool_stats": list((latest_task or {}).get("tool_stats") or []),
+        "context_metrics": context_metrics,
         "memory_context": {
             "candidate_count": int((latest_memory_audit or {}).get("candidate_count") or 0),
             "candidates_preview": [
@@ -111,7 +159,7 @@ def build_summary(root: Path) -> dict[str, Any]:
                 if isinstance(candidate, dict)
             ],
         },
-        "review_flags": review_flags(latest_task, latest_memory_audit),
+        "review_flags": review_flags(latest_task, latest_memory_audit, context_metrics),
     }
 
 

--- a/scripts/self_improvement/summarize.py
+++ b/scripts/self_improvement/summarize.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Summarize Hermes self-improvement telemetry without raw transcripts."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_ROOT = get_hermes_home() / "ops" / "self-improvement-log"
+TASK_RUNS_FILENAME = "task_runs.jsonl"
+MEMORY_AUDIT_FILENAME = "memory_context_audit.jsonl"
+
+THRESHOLDS = {
+    "input_tokens_high": 200_000,
+    "cache_read_tokens_high": 2_000_000,
+    "api_calls_high": 40,
+    "duplicate_skill_view_count": 2,
+    "repeated_cronjob_count": 2,
+    "memory_context_candidate_count": 1,
+}
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return rows
+
+
+def _sum_int(rows: list[dict[str, Any]], key: str) -> int:
+    return sum(int(row.get(key) or 0) for row in rows)
+
+
+def _tool_count(task_run: dict[str, Any], tool_name: str) -> int:
+    for item in task_run.get("tool_stats") or []:
+        if not isinstance(item, str) or ":" not in item:
+            continue
+        name, count = item.rsplit(":", 1)
+        if name == tool_name:
+            try:
+                return int(count)
+            except ValueError:
+                return 0
+    return 0
+
+
+def review_flags(latest_task: dict[str, Any] | None, latest_memory_audit: dict[str, Any] | None) -> list[str]:
+    if latest_task is None:
+        return []
+    flags: list[str] = []
+    if int(latest_task.get("input_tokens") or 0) >= THRESHOLDS["input_tokens_high"]:
+        flags.append("high_input_tokens")
+    if int(latest_task.get("cache_read_tokens") or 0) >= THRESHOLDS["cache_read_tokens_high"]:
+        flags.append("high_cache_read_tokens")
+    if int(latest_task.get("api_call_count") or 0) >= THRESHOLDS["api_calls_high"]:
+        flags.append("high_api_calls")
+    if _tool_count(latest_task, "skill_view") >= THRESHOLDS["duplicate_skill_view_count"]:
+        flags.append("duplicate_skill_view")
+    if _tool_count(latest_task, "cronjob") >= THRESHOLDS["repeated_cronjob_count"]:
+        flags.append("repeated_cronjob_list")
+    if latest_memory_audit and int(latest_memory_audit.get("candidate_count") or 0) >= THRESHOLDS["memory_context_candidate_count"]:
+        flags.append("memory_context_noise")
+    return flags
+
+
+def build_summary(root: Path) -> dict[str, Any]:
+    task_runs = read_jsonl(root / TASK_RUNS_FILENAME)
+    memory_audits = read_jsonl(root / MEMORY_AUDIT_FILENAME)
+    latest_task = task_runs[-1] if task_runs else None
+    latest_memory_audit = memory_audits[-1] if memory_audits else None
+
+    telemetry_totals = {
+        "input_tokens": _sum_int(task_runs, "input_tokens"),
+        "output_tokens": _sum_int(task_runs, "output_tokens"),
+        "reasoning_tokens": _sum_int(task_runs, "reasoning_tokens"),
+        "cache_read_tokens": _sum_int(task_runs, "cache_read_tokens"),
+        "cache_write_tokens": _sum_int(task_runs, "cache_write_tokens"),
+        "api_calls": _sum_int(task_runs, "api_call_count"),
+        "tool_calls": _sum_int(task_runs, "tool_call_count"),
+    }
+    return {
+        "schema_version": 1,
+        "kind": "self_improvement_summary",
+        "root": str(root),
+        "task_runs": len(task_runs),
+        "memory_context_audits": len(memory_audits),
+        "latest_task_session": latest_task.get("session_id") if latest_task else "",
+        "telemetry_totals": telemetry_totals,
+        "largest_context_items": list((latest_task or {}).get("largest_context_items") or [])[:8],
+        "tool_stats": list((latest_task or {}).get("tool_stats") or []),
+        "memory_context": {
+            "candidate_count": int((latest_memory_audit or {}).get("candidate_count") or 0),
+            "candidates_preview": [
+                {
+                    "reasons": candidate.get("reasons") or [],
+                    "content_chars": len(str(candidate.get("content") or "")),
+                    "memory_id": candidate.get("memory_id") or "",
+                }
+                for candidate in list((latest_memory_audit or {}).get("candidates") or [])[:5]
+                if isinstance(candidate, dict)
+            ],
+        },
+        "review_flags": review_flags(latest_task, latest_memory_audit),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=str(DEFAULT_ROOT), help="Self-improvement log directory")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(json.dumps(build_summary(Path(args.root)), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/test_self_improvement_telemetry_plugin.py
+++ b/tests/plugins/test_self_improvement_telemetry_plugin.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import plugins.self_improvement_telemetry as plugin
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.hooks: dict[str, object] = {}
+
+    def register_hook(self, name: str, fn: object) -> None:
+        self.hooks[name] = fn
+
+
+def test_registers_observer_hooks():
+    ctx = FakeContext()
+
+    plugin.register(ctx)
+
+    assert {"pre_tool_call", "post_tool_call", "on_session_end", "on_session_reset"}.issubset(ctx.hooks)
+
+
+def test_post_tool_call_writes_sanitized_metric(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SELF_IMPROVEMENT_TELEMETRY_DIR", str(tmp_path))
+
+    plugin.on_post_tool_call(
+        session_id="s1",
+        tool_name="skill_view",
+        args={"name": "hermes-agent", "secret": "should-not-log-value"},
+        result="x" * 12_000,
+        duration_ms=42,
+    )
+
+    rows = [json.loads(line) for line in (tmp_path / "context_metrics.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["kind"] == "tool_call_metric"
+    assert row["session_id"] == "s1"
+    assert row["tool_name"] == "skill_view"
+    assert row["args_keys"] == ["name", "secret"]
+    assert row["result_chars"] == 12000
+    assert "large_tool_output" in row["risk_flags"]
+    assert "should-not-log-value" not in json.dumps(row)
+
+
+def test_duplicate_skill_view_is_flagged_within_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SELF_IMPROVEMENT_TELEMETRY_DIR", str(tmp_path))
+    plugin.reset_runtime_state()
+
+    plugin.on_post_tool_call(session_id="s1", tool_name="skill_view", args={"name": "hermes-agent"}, result="ok")
+    plugin.on_post_tool_call(session_id="s1", tool_name="skill_view", args={"name": "hermes-agent"}, result="ok")
+
+    rows = [json.loads(line) for line in (tmp_path / "context_metrics.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert "duplicate_skill_view" in rows[-1]["risk_flags"]
+
+
+def test_repeated_cronjob_list_is_flagged(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SELF_IMPROVEMENT_TELEMETRY_DIR", str(tmp_path))
+    plugin.reset_runtime_state()
+
+    plugin.on_post_tool_call(session_id="s1", tool_name="cronjob", args={"action": "list"}, result="ok")
+    plugin.on_post_tool_call(session_id="s1", tool_name="cronjob", args={"action": "list"}, result="ok")
+
+    rows = [json.loads(line) for line in (tmp_path / "context_metrics.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert "repeated_cronjob_list" in rows[-1]["risk_flags"]

--- a/tests/scripts/test_self_improvement_log_session_telemetry.py
+++ b/tests/scripts/test_self_improvement_log_session_telemetry.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.self_improvement import log_session_telemetry as telemetry
+
+
+def _make_state_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        create table sessions (
+            id text primary key,
+            source text not null,
+            model text,
+            started_at real not null,
+            ended_at real,
+            end_reason text,
+            message_count integer default 0,
+            tool_call_count integer default 0,
+            api_call_count integer default 0,
+            input_tokens integer default 0,
+            output_tokens integer default 0,
+            cache_read_tokens integer default 0,
+            cache_write_tokens integer default 0,
+            reasoning_tokens integer default 0,
+            estimated_cost_usd real,
+            actual_cost_usd real,
+            cost_status text,
+            cost_source text
+        );
+        create table messages (
+            id integer primary key,
+            session_id text not null,
+            role text not null,
+            content text,
+            tool_name text
+        );
+        """
+    )
+    con.execute(
+        """
+        insert into sessions (
+            id, source, model, started_at, ended_at, end_reason,
+            message_count, tool_call_count, api_call_count,
+            input_tokens, output_tokens, cache_read_tokens,
+            cache_write_tokens, reasoning_tokens,
+            estimated_cost_usd, actual_cost_usd, cost_status, cost_source
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "ended-discord",
+            "discord",
+            "gpt-test",
+            10.0,
+            20.0,
+            "session_reset",
+            4,
+            2,
+            3,
+            100,
+            20,
+            300,
+            10,
+            5,
+            0.12,
+            0.0,
+            "estimated",
+            "fixture",
+        ),
+    )
+    con.execute(
+        """
+        insert into sessions (id, source, model, started_at, ended_at)
+        values ('open-discord', 'discord', 'gpt-open', 99.0, null)
+        """
+    )
+    con.executemany(
+        "insert into messages (session_id, role, content, tool_name) values (?, ?, ?, ?)",
+        [
+            ("ended-discord", "user", "please do thing", None),
+            ("ended-discord", "assistant", "working", None),
+            ("ended-discord", "tool", "x" * 12_000, "skill_view"),
+            ("ended-discord", "tool", "ok", "terminal"),
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+def test_dry_run_prints_task_run_without_writing_jsonl(tmp_path, capsys):
+    db = tmp_path / "state.db"
+    out_dir = tmp_path / "self-improvement-log"
+    _make_state_db(db)
+
+    rc = telemetry.main(["--db", str(db), "--root", str(out_dir), "--dry-run"])
+
+    assert rc == 0
+    assert not (out_dir / "task_runs.jsonl").exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "task_run_telemetry"
+    assert payload["session_id"] == "ended-discord"
+    assert payload["input_tokens"] == 100
+    assert payload["tool_stats"] == ["skill_view:1", "terminal:1"]
+    assert payload["largest_context_items"][0] == "tool:skill_view:12000"
+
+
+def test_appends_to_task_runs_jsonl_not_events_by_default(tmp_path):
+    db = tmp_path / "state.db"
+    out_dir = tmp_path / "self-improvement-log"
+    _make_state_db(db)
+
+    rc = telemetry.main(["--db", str(db), "--root", str(out_dir)])
+
+    assert rc == 0
+    task_runs = out_dir / "task_runs.jsonl"
+    assert task_runs.exists()
+    assert not (out_dir / "events.jsonl").exists()
+    rows = [json.loads(line) for line in task_runs.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "ended-discord"
+    assert rows[0]["cost_status"] == "estimated"
+
+
+def test_duplicate_session_is_not_appended_without_force(tmp_path, capsys):
+    db = tmp_path / "state.db"
+    out_dir = tmp_path / "self-improvement-log"
+    _make_state_db(db)
+
+    assert telemetry.main(["--db", str(db), "--root", str(out_dir)]) == 0
+    assert telemetry.main(["--db", str(db), "--root", str(out_dir)]) == 0
+
+    task_runs = out_dir / "task_runs.jsonl"
+    assert len(task_runs.read_text(encoding="utf-8").splitlines()) == 1
+    assert json.loads(capsys.readouterr().out.splitlines()[-1])["status"] == "already_logged"
+
+    assert telemetry.main(["--db", str(db), "--root", str(out_dir), "--force"]) == 0
+    assert len(task_runs.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_latest_session_defaults_to_ended_sessions_unless_include_open(tmp_path):
+    db = tmp_path / "state.db"
+    _make_state_db(db)
+    con = sqlite3.connect(db)
+
+    assert telemetry.latest_session_id(con, source="discord") == "ended-discord"
+    assert telemetry.latest_session_id(con, source="discord", include_open=True) == "open-discord"
+
+
+def test_append_event_writes_compact_event_with_measures(tmp_path):
+    db = tmp_path / "state.db"
+    out_dir = tmp_path / "self-improvement-log"
+    _make_state_db(db)
+
+    rc = telemetry.main(["--db", str(db), "--root", str(out_dir), "--append-event"])
+
+    assert rc == 0
+    event_rows = [json.loads(line) for line in (out_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert len(event_rows) == 1
+    assert event_rows[0]["route"] == "workflow_improvement"
+    assert event_rows[0]["measures"]["session_id"] == "ended-discord"
+
+
+@pytest.mark.parametrize("argv", [["--source", "telegram"], ["--session-id", "missing"]])
+def test_missing_session_exits_cleanly(tmp_path, argv):
+    db = tmp_path / "state.db"
+    out_dir = tmp_path / "self-improvement-log"
+    _make_state_db(db)
+
+    with pytest.raises(SystemExit):
+        telemetry.main(["--db", str(db), "--root", str(out_dir), *argv])

--- a/tests/scripts/test_self_improvement_memory_context_audit.py
+++ b/tests/scripts/test_self_improvement_memory_context_audit.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+from scripts.self_improvement import audit_memory_context as audit
+
+
+FIXTURE = """
+## Mnemosyne Context
+  [2026-06-05T14:35] (importance 0.86) Context-hygiene rule: standalone user command fragments such as “proceed”, “commit”, “what next”, “make it happen”, or one-off task prompts should not be stored or injected as durable memory.
+  [2026-06-05T14:35] (importance 0.30) [USER] You decide how you want to handle it and proceed
+  [2026-06-04T07:23] (importance 0.30) [USER] proceed
+  [2026-06-04T10:13] (importance 0.30) [USER] [IMPORTANT: Background process proc_edc70544f2c2 matched watch pattern "Startup done".
+Command: cd /opt/fish-speech/repo && source .venv/bin/activate && python tools/api_server.py --listen 127.0.0.1:18080
+Matched output:
+Startup done]
+  [2026-06-05T18:41] (importance 0.30) [USER] Review now I ran another task
+  [2026-06-05T14:00] (importance 0.90) User prefers concise phase summaries and native file attachments when requested.
+"""
+
+
+def test_audit_text_flags_raw_user_fragments_but_keeps_durable_rule():
+    report = audit.audit_text(FIXTURE)
+
+    flagged = {item.content for item in report.candidates}
+    assert "[USER] You decide how you want to handle it and proceed" in flagged
+    assert "[USER] proceed" in flagged
+    assert any("Startup done" in content for content in flagged)
+    assert "[USER] Review now I ran another task" in flagged
+    assert not any("Context-hygiene rule" in content for content in flagged)
+    assert not any("concise phase summaries" in content for content in flagged)
+
+
+def test_audit_text_records_reason_codes():
+    report = audit.audit_text(FIXTURE)
+
+    reasons_by_content = {item.content: set(item.reasons) for item in report.candidates}
+    assert {"raw_user_fragment", "standalone_command_fragment"}.issubset(
+        reasons_by_content["[USER] proceed"]
+    )
+    startup = next(item for item in report.candidates if "Startup done" in item.content)
+    assert "background_process_fragment" in startup.reasons
+
+
+def test_main_writes_jsonl_report_without_applying(tmp_path, capsys):
+    input_path = tmp_path / "memory-context.txt"
+    output_path = tmp_path / "memory_context_audit.jsonl"
+    input_path.write_text(FIXTURE, encoding="utf-8")
+
+    rc = audit.main(["--input", str(input_path), "--output", str(output_path)])
+
+    assert rc == 0
+    stdout = json.loads(capsys.readouterr().out)
+    assert stdout["candidate_count"] == 4
+    assert stdout["applied"] is False
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "memory_context_audit"
+    assert rows[0]["candidate_count"] == 4
+    assert rows[0]["candidates"][0]["content"]
+
+
+def test_main_can_emit_suggested_invalidation_commands(tmp_path, capsys):
+    input_path = tmp_path / "memory-context.txt"
+    input_path.write_text(
+        "[2026-06-04T07:23] (importance 0.30) id=abc123 [USER] proceed\n",
+        encoding="utf-8",
+    )
+
+    rc = audit.main(["--input", str(input_path), "--commands"])
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "mnemosyne_validate" in output
+    assert "abc123" in output
+
+
+def test_parser_extracts_memory_id_when_present():
+    entries = audit.parse_memory_context("[time] (importance 0.30) id=abc123 [USER] proceed")
+
+    assert len(entries) == 1
+    assert entries[0].memory_id == "abc123"
+    assert entries[0].importance == 0.30
+    assert entries[0].content == "[USER] proceed"

--- a/tests/scripts/test_self_improvement_summarize.py
+++ b/tests/scripts/test_self_improvement_summarize.py
@@ -42,6 +42,41 @@ def test_summarize_reports_latest_task_and_context_contributors(tmp_path):
         + "\n",
         encoding="utf-8",
     )
+    (root / "context_metrics.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "kind": "tool_call_metric",
+                        "session_id": "s1",
+                        "tool_name": "skill_view",
+                        "result_chars": 48165,
+                        "risk_flags": ["large_tool_output", "very_large_tool_output"],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "kind": "tool_call_metric",
+                        "session_id": "s1",
+                        "tool_name": "skill_view",
+                        "result_chars": 48165,
+                        "risk_flags": ["duplicate_skill_view"],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "kind": "tool_call_metric",
+                        "session_id": "s1",
+                        "tool_name": "cronjob",
+                        "result_chars": 13463,
+                        "risk_flags": ["repeated_cronjob_list"],
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     result = summary.build_summary(root)
 
@@ -54,10 +89,25 @@ def test_summarize_reports_latest_task_and_context_contributors(tmp_path):
         "high_api_calls",
         "duplicate_skill_view",
         "repeated_cronjob_list",
+        "large_tool_output",
+        "very_large_tool_output",
         "memory_context_noise",
     ]
     assert result["largest_context_items"][0] == "tool:skill_view:48165"
     assert result["memory_context"]["candidate_count"] == 3
+    assert result["context_metrics"]["metric_count"] == 3
+    assert result["context_metrics"]["tool_counts"] == {"cronjob": 1, "skill_view": 2}
+    assert result["context_metrics"]["risk_flag_counts"] == {
+        "duplicate_skill_view": 1,
+        "large_tool_output": 1,
+        "repeated_cronjob_list": 1,
+        "very_large_tool_output": 1,
+    }
+    assert result["context_metrics"]["largest_tool_results"] == [
+        {"result_chars": 48165, "session_id": "s1", "tool_name": "skill_view"},
+        {"result_chars": 48165, "session_id": "s1", "tool_name": "skill_view"},
+        {"result_chars": 13463, "session_id": "s1", "tool_name": "cronjob"},
+    ]
 
 
 def test_main_prints_json_summary(tmp_path, capsys):

--- a/tests/scripts/test_self_improvement_summarize.py
+++ b/tests/scripts/test_self_improvement_summarize.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+
+from scripts.self_improvement import summarize as summary
+
+
+def test_summarize_reports_latest_task_and_context_contributors(tmp_path):
+    root = tmp_path / "self-improvement-log"
+    root.mkdir()
+    (root / "task_runs.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "task_run_telemetry",
+                "session_id": "s1",
+                "input_tokens": 250000,
+                "output_tokens": 1000,
+                "cache_read_tokens": 3000000,
+                "api_call_count": 41,
+                "tool_stats": ["skill_view:2", "cronjob:3", "terminal:1"],
+                "largest_context_items": [
+                    "tool:skill_view:48165",
+                    "tool:skill_view:48165",
+                    "tool:cronjob:13463",
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "memory_context_audit.jsonl").write_text(
+        json.dumps(
+            {
+                "kind": "memory_context_audit",
+                "candidate_count": 3,
+                "candidates": [
+                    {"reasons": ["raw_user_fragment"], "content": "[USER] proceed"},
+                    {"reasons": ["background_process_fragment"], "content": "[USER] startup"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = summary.build_summary(root)
+
+    assert result["task_runs"] == 1
+    assert result["latest_task_session"] == "s1"
+    assert result["telemetry_totals"]["input_tokens"] == 250000
+    assert result["review_flags"] == [
+        "high_input_tokens",
+        "high_cache_read_tokens",
+        "high_api_calls",
+        "duplicate_skill_view",
+        "repeated_cronjob_list",
+        "memory_context_noise",
+    ]
+    assert result["largest_context_items"][0] == "tool:skill_view:48165"
+    assert result["memory_context"]["candidate_count"] == 3
+
+
+def test_main_prints_json_summary(tmp_path, capsys):
+    root = tmp_path / "empty-log"
+    root.mkdir()
+
+    rc = summary.main(["--root", str(root)])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["task_runs"] == 0
+    assert payload["review_flags"] == []
+
+
+def test_read_jsonl_ignores_bad_lines(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    path.write_text('{"ok": true}\nnot json\n{"ok": false}\n', encoding="utf-8")
+
+    assert summary.read_jsonl(path) == [{"ok": True}, {"ok": False}]


### PR DESCRIPTION
## Summary
- Add GitHub-ready self-improvement telemetry helpers under `scripts/self_improvement/`.
- Record task-run telemetry to `task_runs.jsonl` by default, with optional compact `events.jsonl` emission.
- Add a non-destructive memory-context audit helper for raw `[USER]`, command-fragment, and background-process memory noise.
- Add a summarizer that reports aggregate token/tool/API counts, largest context contributors, plugin-emitted context metrics, memory-context noise counts, and review flags.
- Add an opt-in `self_improvement_telemetry` plugin that records sanitized tool-call metrics and risk flags to `context_metrics.jsonl`.

## Test Plan
- [x] `python -m pytest tests/scripts/test_self_improvement_log_session_telemetry.py tests/scripts/test_self_improvement_memory_context_audit.py tests/scripts/test_self_improvement_summarize.py tests/plugins/test_self_improvement_telemetry_plugin.py tests/hermes_cli/test_plugins.py::TestPluginHooks::test_register_and_invoke_hook -q -o 'addopts='`
- [x] `python -m compileall -q scripts/self_improvement plugins/self_improvement_telemetry tests/scripts/test_self_improvement_log_session_telemetry.py tests/scripts/test_self_improvement_memory_context_audit.py tests/scripts/test_self_improvement_summarize.py tests/plugins/test_self_improvement_telemetry_plugin.py`
- [x] `python scripts/self_improvement/log_session_telemetry.py --dry-run | python -m json.tool >/tmp/self_improvement_telemetry_dry_run.json`
- [x] `python scripts/self_improvement/audit_memory_context.py --input /tmp/memory-context-proceed-fixture.txt --output /tmp/memory_context_audit.jsonl`
- [x] `python scripts/self_improvement/summarize.py | python -m json.tool >/tmp/self_improvement_summary.json`

## Privacy / Safety
- No raw transcript, prompt, tool-output, secret, or message content is copied into telemetry logs.
- Largest context contributors are stored only as compact `role:tool:chars` labels.
- Plugin tool metrics store argument key names only, never argument values.
- Memory-context audit is non-destructive; it reports candidates and suggested invalidation commands only.
- Default session attribution selects the latest ended session, avoiding accidental capture of an open review session.

## Follow-up Phases
- Wire plugin session-boundary hooks to emit full `task_runs.jsonl` records automatically when hook payloads expose stable session ids.
- Extend the no-agent watchdog to consume summarizer review flags with state-change-only alerts.
- Consider a core hook payload improvement if plugin kwargs lack duration/correlation metadata.
