### PR TITLE
fix(desktop): sync contentEditable state before submit (#39872)

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -936,11 +936,13 @@ export function ChatBar({
   }
 
   const queueCurrentDraft = useCallback(() => {
-    if (!activeQueueSessionKey || (!draft.trim() && attachments.length === 0)) {
+    const currentDraft = draftRef.current
+
+    if (!activeQueueSessionKey || (!currentDraft.trim() && attachments.length === 0)) {
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: draft, attachments })) {
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: currentDraft, attachments })) {
       return false
     }
 
@@ -949,7 +951,7 @@ export function ChatBar({
     triggerHaptic('selection')
 
     return true
-  }, [activeQueueSessionKey, attachments, clearDraft, draft])
+  }, [activeQueueSessionKey, attachments, clearDraft])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.
@@ -1054,6 +1056,25 @@ export function ChatBar({
   }, [activeQueueSessionKey, editingQueuedPrompt, queueEdit]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const submitDraft = () => {
+    // Flush the live DOM content into draftRef before reading it.  When
+    // typing fast and pressing Enter immediately, the React state (`draft`)
+    // may not have committed yet — `draftRef` is updated synchronously in
+    // handleEditorInput, but as a safety net we also read the editor
+    // directly so we never submit stale, empty, or truncated text.
+    const editor = editorRef.current
+
+    if (editor) {
+      const liveText = composerPlainText(editor)
+
+      if (liveText !== draftRef.current) {
+        draftRef.current = liveText
+        aui.composer().setText(liveText)
+      }
+    }
+
+    const currentDraft = draftRef.current
+    const hasPayload = currentDraft.trim().length > 0 || attachments.length > 0
+
     if (queueEdit) {
       exitQueuedEdit('save')
     } else if (busy) {
@@ -1064,12 +1085,12 @@ export function ChatBar({
       // busy guard for commands that genuinely need an idle session (skill
       // /send directives).  Queuing them would make every slash command wait
       // for the current turn to finish, which is how the TUI never behaves.
-      if (!attachments.length && SLASH_COMMAND_RE.test(draft.trim())) {
-        const submitted = draft
+      if (!attachments.length && SLASH_COMMAND_RE.test(currentDraft.trim())) {
+        const submitted = currentDraft
         triggerHaptic('submit')
         clearDraft()
         void onSubmit(submitted)
-      } else if (hasComposerPayload) {
+      } else if (hasPayload) {
         queueCurrentDraft()
       } else {
         // Stop button: an explicit interrupt must actually halt the running
@@ -1081,10 +1102,10 @@ export function ChatBar({
         triggerHaptic('cancel')
         void Promise.resolve(onCancel())
       }
-    } else if (!hasComposerPayload && queuedPrompts.length > 0) {
+    } else if (!hasPayload && queuedPrompts.length > 0) {
       void drainNextQueued()
-    } else if (draft.trim() || attachments.length > 0) {
-      const submitted = draft
+    } else if (currentDraft.trim() || attachments.length > 0) {
+      const submitted = currentDraft
       triggerHaptic('submit')
       clearDraft()
       clearComposerAttachments()


### PR DESCRIPTION
## Fixes #39872

### Problem
The desktop composer uses a contentEditable div with a handleEditorInput callback that synchronously updates draftRef.current and calls aui.composer().setText(). However, submitDraft() and queueCurrentDraft() read from the React state variable draft (via useAuiState), which lags behind due to batched state updates. When typing fast and pressing Enter immediately, the submitted text is stale, empty, or truncated.

### Fix (apps/desktop/src/app/chat/composer/index.tsx, +30/-9)

1. submitDraft() - DOM flush before submit: Read live DOM via composerPlainText(editorRef.current) and reconcile with draftRef.current before submission. Replace reads of draft with currentDraft (from draftRef.current).

2. queueCurrentDraft() - read from ref instead of state: Changed to read draftRef.current instead of the stale draft React state variable. Removed draft from the useCallback dependency array.

### Testing
- The fix is minimal and targeted to the submit path only
- No changes to rendering or input handling logic