### PR TITLE
fix(cron): report active scripts dir in validation errors

### DIFF
--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -409,6 +409,20 @@ class TestCronjobToolScriptValidation:
         assert result["success"] is False
         assert "relative" in result["error"].lower() or "absolute" in result["error"].lower()
 
+    def test_absolute_script_error_mentions_active_scripts_dir(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script=str(cron_env / "scripts" / "monitor.py"),
+        ))
+        assert result["success"] is False
+        assert str(cron_env / "scripts") in result["error"]
+        assert "~/.hermes/scripts" not in result["error"]
+
     def test_create_with_tilde_script_rejected(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -393,20 +393,20 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     from hermes_constants import get_hermes_home
 
     raw = script.strip()
+    scripts_dir = get_hermes_home() / "scripts"
 
     # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
+    # Only relative paths within HERMES_HOME/scripts/ are allowed.
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to HERMES_HOME/scripts/ ({scripts_dir}). "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts in {scripts_dir} and use just the filename."
         )
 
     # Validate containment after resolution
     from tools.path_security import validate_within_dir
 
-    scripts_dir = get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
     if containment_error:


### PR DESCRIPTION
## Summary
- replace the hardcoded `~/.hermes/scripts/` cron script validation hint with the active `HERMES_HOME/scripts` path
- add a regression test for custom `HERMES_HOME` error messaging

## Why
When `HERMES_HOME` points somewhere other than `~/.hermes`, absolute or home-relative script validation errors pointed users and agents at the wrong scripts directory even though relative script resolution already uses `get_hermes_home() / "scripts"`.

Fixes #38693

## Tests
- `.venv/bin/python -m pytest tests/cron/test_cron_script.py::TestCronjobToolScriptValidation -q -o addopts= --tb=short`
- `.venv/bin/python -m pytest tests/cron/test_cron_script.py -q -o addopts= --tb=short`
- `.venv/bin/python -m py_compile tools/cronjob_tools.py tests/cron/test_cron_script.py`
- `/opt/homebrew/bin/ruff check tools/cronjob_tools.py tests/cron/test_cron_script.py`
- `git diff --check`