### PR TITLE
fix(file-sync): don't rate-limit retry after a failed sync cycle

### DIFF
--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -225,6 +225,42 @@ class TestRateLimiting:
             mgr.sync()
         assert upload.call_count == 1
 
+    def test_failed_sync_does_not_suppress_next_retry(self, tmp_files, monkeypatch):
+        """A failed sync must not advance the rate-limit clock.
+
+        Regression: the failure path used to set ``_last_sync_time`` on
+        rollback, so the next non-forced ``sync()`` within ``sync_interval``
+        hit the rate-limit guard and returned early — silently suppressing the
+        retry the rollback had just prepared and leaving the remote stale.
+        """
+        from tools.environments import file_sync
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(file_sync.time, "monotonic", lambda: clock["t"])
+
+        upload = MagicMock(side_effect=RuntimeError("transport down"))
+        mgr = FileSyncManager(
+            get_files_fn=_make_get_files(tmp_files),
+            upload_fn=upload,
+            delete_fn=MagicMock(),
+            sync_interval=10.0,
+        )
+
+        # First sync fails (forced bypasses the guard); state rolls back.
+        mgr.sync(force=True)
+        assert upload.call_count >= 1
+
+        # Transport recovers; advance the clock by LESS than the interval.
+        upload.reset_mock()
+        upload.side_effect = None
+        clock["t"] = 1002.0  # 2s later, < 10s interval
+
+        # The next non-forced cycle must retry, not be rate-limited away.
+        mgr.sync()
+        assert upload.call_count == 3, (
+            "a failed sync must not rate-limit the next retry"
+        )
+
 
 class TestEdgeCases:
     def test_empty_file_list(self):

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -232,7 +232,12 @@ class FileSyncManager:
         except Exception as exc:
             self._synced_files = prev_files
             self._pushed_hashes = prev_hashes
-            self._last_sync_time = time.monotonic()
+            # Do NOT advance _last_sync_time here: a failed cycle rolls state
+            # back so the next cycle can retry. Bumping the rate-limit clock on
+            # failure would make the next non-forced sync() return early (the
+            # guard above), suppressing that retry for up to _sync_interval and
+            # leaving the remote with stale files — contradicting this method's
+            # documented "next cycle retries everything" contract.
             logger.warning("file_sync: sync failed, rolled back state: %s", exc)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`FileSyncManager.sync()` (`tools/environments/file_sync.py`) is rate-limited to once per `_sync_interval` (default 5s) via `_last_sync_time`. Its docstring promises that on failure "state rolls back so the next cycle retries everything" — but the `except` handler also did `self._last_sync_time = time.monotonic()`, so the next non-forced `sync()` within the interval hit the rate-limit guard and returned early, **suppressing the very retry the rollback had just prepared**.

Because the non-forced `sync()` runs before every command on the SSH/Modal/Daytona backends, a single transient upload failure (network blip, dropped channel) left the remote with **stale files for the next command**, up to `_sync_interval`. Forced syncs bypass the guard, which is why the symptom was intermittent.

The fix removes the failure-path timestamp bump so the clock advances only on a successful or no-op cycle, matching the documented contract. The success path and the no-work path keep their `_last_sync_time` updates.

## Related Issue

Fixes #39945

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/file_sync.py` — remove `self._last_sync_time = time.monotonic()` from the `sync()` failure/rollback `except` block (with an explanatory comment).
- `tests/tools/test_file_sync.py` — add `TestRateLimiting::test_failed_sync_does_not_suppress_next_retry`, a regression test that patches `time.monotonic` for determinism and asserts a failed cycle does not rate-limit the next retry.

## How to Test

1. `pytest tests/tools/test_file_sync.py -q` — passes (16 tests).
2. Regression proof: temporarily restore the removed `self._last_sync_time = time.monotonic()` line in the `except` block and re-run the new test — it fails (`assert 0 == 3`, the retry is rate-limited away). With the line removed it passes (the retry uploads all files).
3. Full related suites: `pytest tests/tools/test_file_sync.py tests/tools/test_file_sync_back.py tests/tools/test_file_sync_perf.py -q` — 35 passed, 3 ssh-skipped.

## Infographic

<p align="center"><img src="https://v3b.fal.media/files/b/0a9d193c/ENthic0L4JefYUyAerdKY_9JjYjkxt.png" alt="file-sync retry fix infographic" width="640"></p>

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(file-sync):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_file_sync.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior now matches the existing docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure timing/control-flow logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A


