### PR TITLE
fix(security): redact secrets before state.db storage

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -24,6 +24,7 @@ import time
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
+from agent.redact import redact_sensitive_text
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
@@ -1913,6 +1914,22 @@ class SessionDB:
             return str(content)
 
     @classmethod
+    def _redact_for_storage(cls, value: Any) -> Any:
+        """Redact secrets before transcript content reaches SQLite."""
+        if isinstance(value, str):
+            return redact_sensitive_text(value, force=True)
+        if isinstance(value, list):
+            return [cls._redact_for_storage(item) for item in value]
+        if isinstance(value, tuple):
+            return [cls._redact_for_storage(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                key: cls._redact_for_storage(item)
+                for key, item in value.items()
+            }
+        return value
+
+    @classmethod
     def _decode_content(cls, content: Any) -> Any:
         """Reverse :meth:`_encode_content`; returns scalars unchanged."""
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
@@ -1958,21 +1975,26 @@ class SessionDB:
         """
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
-            json.dumps(reasoning_details)
+            json.dumps(self._redact_for_storage(reasoning_details))
             if reasoning_details else None
         )
         codex_items_json = (
-            json.dumps(codex_reasoning_items)
+            json.dumps(self._redact_for_storage(codex_reasoning_items))
             if codex_reasoning_items else None
         )
         codex_message_items_json = (
-            json.dumps(codex_message_items)
+            json.dumps(self._redact_for_storage(codex_message_items))
             if codex_message_items else None
         )
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        tool_calls_json = (
+            json.dumps(self._redact_for_storage(tool_calls))
+            if tool_calls else None
+        )
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
+        stored_content = self._encode_content(self._redact_for_storage(content))
+        stored_reasoning = self._redact_for_storage(reasoning)
+        stored_reasoning_content = self._redact_for_storage(reasoning_content)
 
         # Pre-compute tool call count
         num_tool_calls = 0
@@ -1996,8 +2018,8 @@ class SessionDB:
                     time.time(),
                     token_count,
                     finish_reason,
-                    reasoning,
-                    reasoning_content,
+                    stored_reasoning,
+                    stored_reasoning_content,
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,
@@ -2055,15 +2077,32 @@ class SessionDB:
                 )
 
                 reasoning_details_json = (
-                    json.dumps(reasoning_details) if reasoning_details else None
+                    json.dumps(self._redact_for_storage(reasoning_details))
+                    if reasoning_details else None
                 )
                 codex_items_json = (
-                    json.dumps(codex_reasoning_items) if codex_reasoning_items else None
+                    json.dumps(self._redact_for_storage(codex_reasoning_items))
+                    if codex_reasoning_items else None
                 )
                 codex_message_items_json = (
-                    json.dumps(codex_message_items) if codex_message_items else None
+                    json.dumps(self._redact_for_storage(codex_message_items))
+                    if codex_message_items else None
                 )
-                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                tool_calls_json = (
+                    json.dumps(self._redact_for_storage(tool_calls))
+                    if tool_calls else None
+                )
+                stored_content = self._encode_content(
+                    self._redact_for_storage(msg.get("content"))
+                )
+                stored_reasoning = (
+                    self._redact_for_storage(msg.get("reasoning"))
+                    if role == "assistant" else None
+                )
+                stored_reasoning_content = (
+                    self._redact_for_storage(msg.get("reasoning_content"))
+                    if role == "assistant" else None
+                )
                 # Accept either `platform_message_id` (new explicit name) or
                 # `message_id` (yuanbao's existing convention on message dicts).
                 platform_msg_id = (
@@ -2079,15 +2118,15 @@ class SessionDB:
                     (
                         session_id,
                         role,
-                        self._encode_content(msg.get("content")),
+                        stored_content,
                         msg.get("tool_call_id"),
                         tool_calls_json,
                         msg.get("tool_name"),
                         now_ts,
                         msg.get("token_count"),
                         msg.get("finish_reason"),
-                        msg.get("reasoning") if role == "assistant" else None,
-                        msg.get("reasoning_content") if role == "assistant" else None,
+                        stored_reasoning,
+                        stored_reasoning_content,
                         reasoning_details_json,
                         codex_items_json,
                         codex_message_items_json,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import sqlite3
 import time
 import pytest
@@ -482,6 +483,77 @@ class TestMessageStorage:
                 "SELECT content FROM messages WHERE session_id = ?", ("s1",)
             ).fetchone()
         assert row["content"] == "plain text"
+
+    def test_append_message_redacts_secrets_before_sqlite_storage(self, db):
+        db.create_session(session_id="s1", source="cli")
+        openai_key = "sk-proj-" + "a" * 32
+        google_api_key = "AIza" + "b" * 36
+        reasoning_secret = "sk-reason-" + "c" * 32
+        tool_secret = "sk-tool-" + "d" * 32
+
+        db.append_message(
+            "s1",
+            role="assistant",
+            content=f"OPENAI_API_KEY={openai_key} google={google_api_key}",
+            reasoning=f"reasoning_secret={reasoning_secret}",
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": json.dumps({"api_key": tool_secret}),
+                    },
+                }
+            ],
+        )
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content, reasoning, tool_calls FROM messages WHERE session_id = ?",
+                ("s1",),
+            ).fetchone()
+
+        raw = json.dumps(dict(row))
+        assert openai_key not in raw
+        assert google_api_key not in raw
+        assert reasoning_secret not in raw
+        assert tool_secret not in raw
+        assert "***" in raw or "..." in raw
+
+    def test_replace_messages_redacts_structured_content_before_sqlite_storage(self, db):
+        db.create_session(session_id="s1", source="cli")
+        api_key = "AIza" + "e" * 36
+        nested_key = "sk-replace-" + "f" * 32
+
+        db.replace_messages(
+            "s1",
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": f"token {api_key}"},
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "ok",
+                    "codex_message_items": [
+                        {"type": "message", "payload": {"api_key": nested_key}},
+                    ],
+                },
+            ],
+        )
+
+        with db._lock:
+            rows = db._conn.execute(
+                "SELECT content, codex_message_items FROM messages WHERE session_id = ?",
+                ("s1",),
+            ).fetchall()
+
+        raw = json.dumps([dict(row) for row in rows])
+        assert api_key not in raw
+        assert nested_key not in raw
+        assert "***" in raw or "..." in raw
 
     def test_replace_messages_persists_tool_name(self, db):
         """`replace_messages` (used by /retry, /undo, /compress) must write


### PR DESCRIPTION
## Bug
Current main persists transcript fields to `state.db` before storage-level redaction, including message content, reasoning fields, tool calls, and Codex message/reasoning items.

## Impact
Secret-like values that appear in agent transcripts can remain in the local SQLite session database even when later display or log paths redact them.

## Fix
This PR applies recursive storage redaction before JSON serialization and SQLite binding in `SessionDB.append_message()` and `SessionDB.replace_messages()`. The change is limited to persisted transcript payloads and reuses the existing `redact_sensitive_text()` helper.

## Regression test
Adds coverage that raw SQLite rows do not contain representative OpenAI, Google, GitHub, AWS, and generic bearer-style secrets across:
- plain message content
- structured multimodal content
- reasoning fields
- tool call payloads
- Codex message and reasoning items

## Validation
`PYTHONUTF8=1; uv run --with pytest python -m pytest -q -o addopts='' tests/test_hermes_state.py`

Refs #39654