### PR TITLE
fix(security): make sudo password cache one-shot

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -88,6 +88,24 @@ def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_interactive_sudo_password_is_not_cached_after_prompt(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False, raising=False)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_prompt_for_sudo_password",
+        lambda timeout_seconds=45: "prompt-pass",
+    )
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo -S -p '' whoami"
+    assert sudo_stdin == "prompt-pass\n"
+    assert terminal_tool._get_cached_sudo_password() == ""
 
 
 def test_cached_sudo_password_isolated_by_session_key(monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -149,7 +149,7 @@ def _check_disk_usage_warning():
         return False
 
 
-# Interactive sudo password cache.
+# Interactive sudo password one-shot cache.
 #
 # Scope the cache to the active session when a session key is available, then
 # fall back to callback identity (ACP / CLI interactive callbacks), then the
@@ -229,8 +229,15 @@ def _get_cached_sudo_password() -> str:
         return _sudo_password_cache.get(scope, "")
 
 
+def _pop_cached_sudo_password() -> str:
+    """Consume and clear the cached sudo password for the current scope."""
+    scope = _get_sudo_password_cache_scope()
+    with _sudo_password_cache_lock:
+        return _sudo_password_cache.pop(scope, "")
+
+
 def _set_cached_sudo_password(password: str) -> None:
-    """Persist a sudo password for the current scope."""
+    """Store a sudo password for the current scope until next sudo use."""
     scope = _get_sudo_password_cache_scope()
     with _sudo_password_cache_lock:
         if password:
@@ -793,7 +800,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     sudo_password = (
         os.environ.get("SUDO_PASSWORD", "")
         if has_configured_password
-        else _get_cached_sudo_password()
+        else _pop_cached_sudo_password()
     )
 
     # Local hosts with sudoers NOPASSWD should not be forced through the
@@ -807,8 +814,6 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
     if not has_configured_password and not sudo_password and env_var_enabled("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
-        if sudo_password:
-            _set_cached_sudo_password(sudo_password)
 
     if has_configured_password or sudo_password:
         # Trailing newline is required: sudo -S reads one line for the password.


### PR DESCRIPTION
## Bug
Current main can keep an interactively prompted sudo password in the process cache after the command that requested it has been rewritten.

## Impact
A later sudo rewrite in the same cache scope can reuse that password without another prompt, increasing credential residency inside the running Hermes process.

## Fix
This PR makes the interactive sudo password cache one-shot: cached values are popped before use, and newly prompted values are used for the current rewrite without being stored afterward. Explicit `SUDO_PASSWORD` environment behavior is unchanged.

## Regression test
Adds coverage that:
- a cached sudo password is consumed and cleared after one rewrite
- an interactively prompted password is not retained in `_sudo_password_cache`

## Validation
`PYTHONUTF8=1; uv run --with pytest python -m pytest -q -o addopts='' tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_security.py tests/tools/test_terminal_tool_semantics.py tests/tools/test_terminal_tool_sudo_semantics.py`

Refs #30102