### PR TITLE
fix(file-sync): retry immediately after failed sync

### DIFF
--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -223,6 +223,22 @@ class TestRateLimiting:
             mgr.sync()
         assert upload.call_count == 1
 
+    def test_failed_sync_does_not_start_rate_limit_window(self, tmp_files):
+        mgr = FileSyncManager(
+            get_files_fn=_make_get_files(tmp_files),
+            upload_fn=MagicMock(side_effect=RuntimeError("upload failed")),
+            delete_fn=MagicMock(),
+            sync_interval=10.0,
+        )
+
+        mgr.sync(force=True)
+
+        good_upload = MagicMock()
+        mgr._upload_fn = good_upload
+        mgr.sync()
+
+        assert good_upload.call_count == 3, "failed sync should not suppress the next retry"
+
 
 class TestEdgeCases:
     def test_empty_file_list(self):

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -207,7 +207,6 @@ class FileSyncManager:
         except Exception as exc:
             self._synced_files = prev_files
             self._pushed_hashes = prev_hashes
-            self._last_sync_time = time.monotonic()
             logger.warning("file_sync: sync failed, rolled back state: %s", exc)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep failed `FileSyncManager.sync()` cycles from advancing the rate-limit clock
- preserve rollback semantics so the next non-forced sync retries immediately
- add a regression test for failed-sync retry behavior

Fixes #39945

## Tests
- `python -m pytest tests/tools/test_file_sync.py::TestRateLimiting::test_failed_sync_does_not_start_rate_limit_window -q -o addopts= --tb=short`
  - failed before the fix with `good_upload.call_count == 0`
  - passes after the fix
- `python -m pytest tests/tools/test_file_sync.py -q -o addopts= --tb=short`
- `python -m py_compile tools/environments/file_sync.py tests/tools/test_file_sync.py`
- `ruff check tools/environments/file_sync.py tests/tools/test_file_sync.py`
- `git diff --check`