### PR TITLE
fix(tools): accept file_path/file_content aliases in write_file & skill_manage

### DIFF
--- a/tests/tools/test_write_file_param_aliases.py
+++ b/tests/tools/test_write_file_param_aliases.py
@@ -1,0 +1,145 @@
+"""Cross-tool parameter-name aliases for file-writing tools.
+
+The standalone ``write_file`` tool names its arguments ``path`` / ``content``,
+while ``skill_manage(action="write_file")`` names the same two arguments
+``file_path`` / ``file_content``. Models routinely carry one tool's naming
+across to the other, which previously rejected a fully-formed call (the content
+was present under the wrong key) and cost a wasted turn. These tests pin the
+alias behaviour so the synonyms are accepted interchangeably.
+"""
+
+import json
+from unittest.mock import patch
+
+import tools.file_tools as file_tools
+import tools.skill_manager_tool as smt
+from tools.registry import registry
+
+
+# ---------------------------------------------------------------------------
+# write_file tool: accept file_path / file_content as aliases
+# ---------------------------------------------------------------------------
+
+def _capturing_write_file_tool():
+    captured = {}
+
+    def _stub(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"ok": True})
+
+    return captured, _stub
+
+
+def test_write_file_accepts_file_content_alias():
+    """The exact failure from the field: {path, file_content} must succeed."""
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        out = file_tools._handle_write_file(
+            {"path": "/tmp/x.txt", "file_content": "hello"}, task_id="t"
+        )
+    assert json.loads(out) == {"ok": True}
+    assert captured["path"] == "/tmp/x.txt"
+    assert captured["content"] == "hello"
+
+
+def test_write_file_accepts_file_path_alias():
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {"file_path": "/tmp/y.txt", "content": "data"}, task_id="t"
+        )
+    assert captured["path"] == "/tmp/y.txt"
+    assert captured["content"] == "data"
+
+
+def test_write_file_canonical_names_win_over_aliases():
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {
+                "path": "/canon", "file_path": "/alias",
+                "content": "canon", "file_content": "alias",
+            },
+            task_id="t",
+        )
+    assert captured["path"] == "/canon"
+    assert captured["content"] == "canon"
+
+
+def test_write_file_empty_string_content_preserved():
+    """Empty content is a valid write (truncate); the alias path must not
+    misread '' as missing and fall back."""
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {"path": "/tmp/empty.txt", "content": "", "file_content": "SHOULD_NOT_WIN"},
+            task_id="t",
+        )
+    assert captured["content"] == ""
+
+
+def test_write_file_truly_missing_content_still_errors():
+    out = file_tools._handle_write_file({"path": "/tmp/x.txt"}, task_id="t")
+    assert "missing required field 'content'" in out
+
+
+def test_write_file_truly_missing_path_still_errors():
+    out = file_tools._handle_write_file({"content": "data"}, task_id="t")
+    assert "missing required field 'path'" in out
+
+
+# ---------------------------------------------------------------------------
+# skill_manage write_file action: accept path / content as aliases
+# ---------------------------------------------------------------------------
+
+def test_skill_manage_write_file_accepts_content_alias():
+    """file_content omitted, `content` supplied -> falls back to content."""
+    captured = {}
+
+    def _stub(name, file_path, file_content):
+        captured.update(name=name, file_path=file_path, file_content=file_content)
+        return {"success": True, "message": "ok"}
+
+    with patch.object(smt, "_write_file", _stub):
+        smt.skill_manage(
+            action="write_file", name="myskill",
+            content="BODY", file_path="references/a.md", file_content=None,
+        )
+    assert captured["file_path"] == "references/a.md"
+    assert captured["file_content"] == "BODY"
+
+
+def test_skill_manage_write_file_accepts_path_alias_via_handler():
+    """The registry handler maps the model's `path` -> file_path."""
+    captured = {}
+
+    def _stub(name, file_path, file_content):
+        captured.update(name=name, file_path=file_path, file_content=file_content)
+        return {"success": True, "message": "ok"}
+
+    entry = registry.get_entry("skill_manage")
+    assert entry is not None, "skill_manage not registered"
+    with patch.object(smt, "_write_file", _stub):
+        entry.handler({
+            "action": "write_file", "name": "myskill",
+            "path": "references/b.md", "content": "DATA",
+        })
+    assert captured["file_path"] == "references/b.md"
+    assert captured["file_content"] == "DATA"
+
+
+def test_skill_manage_write_file_canonical_file_names_still_work():
+    captured = {}
+
+    def _stub(name, file_path, file_content):
+        captured.update(name=name, file_path=file_path, file_content=file_content)
+        return {"success": True, "message": "ok"}
+
+    entry = registry.get_entry("skill_manage")
+    with patch.object(smt, "_write_file", _stub):
+        entry.handler({
+            "action": "write_file", "name": "myskill",
+            "file_path": "references/c.md", "file_content": "CANON",
+        })
+    assert captured["file_path"] == "references/c.md"
+    assert captured["file_content"] == "CANON"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,25 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    # Accept `file_path`/`file_content` as aliases for `path`/`content`. The
+    # skill_manage tool's write_file action uses the `file_*` names, so models
+    # routinely carry that naming across to this tool (and vice versa) — a
+    # cross-tool footgun that otherwise rejects a fully-formed call and costs a
+    # wasted turn. Treat the synonyms as equivalent; the canonical names win
+    # when both are present.
+    path = args.get("path")
+    if not path:
+        path = args.get("file_path")
+    content = args.get("content")
+    if content is None:
+        content = args.get("file_content")
+
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if content is None:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1508,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -851,6 +851,11 @@ def skill_manage(
         result = _delete_skill(name, absorbed_into=absorbed_into)
 
     elif action == "write_file":
+        # Fall back to the `content` param (used by create/edit) when a model
+        # supplies the standalone write_file tool's `content` name instead of
+        # `file_content`. See the handler-level alias for `path`/`file_path`.
+        if file_content is None:
+            file_content = content
         if not file_path:
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
         if file_content is None:
@@ -1024,7 +1029,11 @@ registry.register(
         name=args.get("name", ""),
         content=args.get("content"),
         category=args.get("category"),
-        file_path=args.get("file_path"),
+        # Accept `path`/`file_path` and `content`/`file_content` interchangeably:
+        # the standalone write_file tool uses the short names, so models carry
+        # that naming across to skill_manage. `file_*` wins when both are set;
+        # the write_file action below also falls back to `content`.
+        file_path=args.get("file_path") or args.get("path"),
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),


### PR DESCRIPTION
## What does this PR do?

The standalone `write_file` tool names its arguments `path`/`content`, while `skill_manage(action="write_file")` names the same two arguments `file_path`/`file_content`. Models routinely carry one tool's naming across to the other, which rejects a **fully-formed** call (the content is present, just under the wrong key) and costs a wasted turn — the error even misdiagnoses it as a dropped argument.

This makes the names synonyms in both directions, so a misnamed-but-complete call succeeds instead of erroring.

## Related Issue

Fixes #35736

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` — `_handle_write_file` accepts `file_path`/`file_content` as aliases for `path`/`content`. Canonical names win when both are present; an empty-string `content` (a valid truncate) is preserved — only `None` falls back, so this isn't an `or`-based collapse.
- `tools/skill_manager_tool.py` — the `skill_manage` registry handler maps `path`→`file_path`; the `write_file` action falls back to the create/edit `content` param when `file_content` is omitted. (`content`→`file_content` is mapped only inside the `write_file` branch, since `content` legitimately means the SKILL.md body for `create`/`edit`.)
- `tests/tools/test_write_file_param_aliases.py` — new tests: both alias directions, canonical-wins-over-alias, empty-string content preserved, and genuinely-missing args still error.

## How to Test

Pre-fix repro: `skill_manage(action="write_file", name="x", file_path="references/a.md", content="...")` (passing `content` instead of `file_content`) returns `{"error": "file_content is required for 'write_file'."}` and the file is never written. Same class of failure hits `write_file` when a model sends `{path, file_content}`.

With this PR:
1. `scripts/run_tests.sh tests/tools/test_write_file_param_aliases.py` — 9 tests pass.
2. `test_write_file_accepts_file_content_alias` covers the exact #35736 shape (`{path, file_content}`); `test_skill_manage_write_file_accepts_content_alias` covers the reverse.
3. `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py` — existing 86 tests still pass (no regression).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites via `scripts/run_tests.sh` and all pass (full suite running locally + CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5, Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — handler-level alias only; no docs, config keys, or tool schemas changed