### PR TITLE
fix(feishu): remove outdated markdown table text-mode fallback

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -151,12 +151,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\s*\|)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4324,12 +4321,13 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # NOTE(2026-06-06): _MARKDOWN_TABLE_RE was removed because the Feishu API
+        # bug it worked around (post-type 'md' rendering blank on the client) was
+        # silently fixed between API doc versions v1.0.0.3025 and v1.0.0.3356.
+        # Sending table content as post now succeeds (code=0) and preserves other
+        # markdown formatting (**bold**, [links], `code`) that text mode strips.
+        # Tables still render as pipe characters, but other formatting works.
+        # Fall back to text only if nothing looks like markdown at all.
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
## Summary

Removes the `_MARKDOWN_TABLE_RE` workaround that forced table content to plain text and adds `(^\s*\|)` to `_MARKDOWN_HINT_RE` so pipe table syntax is routed to the Feishu post markdown pipeline.

## Root Cause

The `_MARKDOWN_TABLE_RE` pattern was a historical workaround for a Feishu API bug where `post`-type `md` elements containing markdown tables rendered as blank messages on the client. This caused messages with tables to lose **all** markdown formatting (bold, links, inline code) because they were force-downgraded to plain text (`msg_type=text`).

The Feishu API bug has been silently fixed between API doc versions v1.0.0.3025 and v1.0.0.3356. Sending table content as `post` type now returns code=0 (success) and renders correctly.

## Changes

**`gateway/platforms/feishu.py`**

1. **Removed `_MARKDOWN_TABLE_RE`** — The regex `^\|.*\|\n\|[-|: ]+\|` and its early-return check in `_build_outbound_payload()` are no longer needed.

2. **Added `(^\s*\|)` to `_MARKDOWN_HINT_RE`** — Pipe table rows (lines starting with `|`) are now recognized as markdown hints, so even table-only messages route through the `post` markdown pipeline. Previously they would have been caught by `_MARKDOWN_TABLE_RE` and sent as plain text.

3. **Updated comment** — Documents why the workaround was removed and references the API version change.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Table + **bold** + [links] + \`code\` | All formatting stripped to plain text | **bold** and [links] render; table shown as pipes |
| Table only (no other markdown) | Plain text with pipes | Post markdown — still pipes, but consistent path |
| No markdown at all | Plain text | Plain text (unchanged) |

Tables are still rendered as pipe characters (Feishu does not natively render pipe tables in the `md` tag), but other markdown elements now work correctly alongside tables.

## Testing

- 160/160 Feishu gateway tests pass (45 skipped due to optional deps)
- Direct API test: `msg_type=post` with pipe table content returns code=0 (no blank message)
- No regressions in text-only message handling

## Related

- Closes #38755
- References #27922 (native table rendering approach — more complex, different scope)
- References #38867 (similar fix, same approach)
- References #39510 (similar fix with DingTalk changes)