### PR TITLE
fix(agent): parse OpenRouter output token errors

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -955,10 +955,34 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     Anthropic's API returns errors like:
       "max_tokens: 32768 > context_window: 200000 - input_tokens: 190000 = available_tokens: 10000"
 
+    OpenRouter-compatible providers may return:
+      "maximum context length is 256000 tokens ... (5683 of text input,
+       13410 of tool input, 262000 in the output)"
+
     Returns the number of output tokens that would fit (e.g. 10000 above), or None if
     the error does not look like a max_tokens-too-large error.
     """
     error_lower = error_msg.lower()
+
+    # OpenRouter/Nous format: the response says how much of the request is
+    # text input, tool input, and output. The output cap is too large when
+    # text + tools fits but text + tools + requested output exceeds the window.
+    openrouter_match = re.search(
+        r'maximum\s+context\s+length\s+is\s+([\d,]+).*?'
+        r'([\d,]+)\s+of\s+text\s+input.*?'
+        r'([\d,]+)\s+of\s+tool\s+input.*?'
+        r'([\d,]+)\s+in\s+the\s+output',
+        error_lower,
+        re.DOTALL,
+    )
+    if openrouter_match:
+        max_context = int(openrouter_match.group(1).replace(',', ''))
+        text_input = int(openrouter_match.group(2).replace(',', ''))
+        tool_input = int(openrouter_match.group(3).replace(',', ''))
+        requested_output = int(openrouter_match.group(4).replace(',', ''))
+        available = max_context - text_input - tool_input
+        if available >= 1 and requested_output > available:
+            return available
 
     # Must look like an output-cap error, not a prompt-length error.
     is_output_cap_error = (

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -74,6 +74,19 @@ class TestParseAvailableOutputTokens:
         msg = "max_tokens: 9999 > context_window: 10000 - input_tokens: 9999 = available_tokens: 1"
         assert self._parse(msg) == 1
 
+    def test_openrouter_nous_output_tokens_format(self):
+        msg = (
+            "Error code: 400 - {"
+            '"status": 400, '
+            '"message": "This endpoint\'s maximum context length is 256000 tokens. '
+            "However, you requested about 281093 tokens "
+            "(5683 of text input, 13410 of tool input, 262000 in the output). "
+            'Please reduce the length of either one."'
+            "}"
+        )
+
+        assert self._parse(msg) == 236907
+
     # ── Should NOT detect (returns None) ─────────────────────────────────
 
     def test_prompt_too_long_is_not_output_cap_error(self):


### PR DESCRIPTION
## Summary
- parse OpenRouter/Nous `N in the output` context errors as output-cap errors
- compute the available output budget from context length minus text/tool input
- add regression coverage using the Nous error format from #38652

Fixes #38652

## Tests
- `python -m pytest tests/test_ctx_halving_fix.py::TestParseAvailableOutputTokens::test_openrouter_nous_output_tokens_format -q -o addopts= --tb=short`
  - failed before the fix with `None == 236907`
  - passes after the fix
- `python -m pytest tests/test_ctx_halving_fix.py -q -o addopts= --tb=short`
- `python -m py_compile agent/model_metadata.py tests/test_ctx_halving_fix.py`
- `ruff check agent/model_metadata.py tests/test_ctx_halving_fix.py`
- `git diff --check`