### PR TITLE
feat: add mission control blueprint dashboard

### DIFF
--- a/docs/plans/2026-06-05-mission-control-blueprint.md
+++ b/docs/plans/2026-06-05-mission-control-blueprint.md
@@ -1,0 +1,75 @@
+# Mission Control Blueprint Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Turn the Claude Agent setup guide into a real Mission Control cockpit for this Hermes runtime: every guide step and feature picker item is mapped to live evidence, an honest readiness state, and a premium responsive UI.
+
+**Architecture:** Add a server-only `hermes_cli.mission_control` intelligence module that compacts local Hermes state into a privacy-minimized snapshot. Expose it through `/api/mission-control/blueprint`, then add a React dashboard route `/mission-control` with Apple-level responsive cards, coverage matrices, and operational panels.
+
+**Tech Stack:** Python/FastAPI backend, SQLite `state.db`, Hermes config/env files, Vite + React + TypeScript frontend, existing Hermes dashboard design system.
+
+---
+
+### Task 1: Add backend snapshot tests first
+
+**Objective:** Lock the required behavior before production code: complete blueprint coverage, sanitized paths/secrets, and real runtime metrics shape.
+
+**Files:**
+- Create: `tests/hermes_cli/test_mission_control.py`
+
+**Steps:**
+1. Write tests importing `hermes_cli.mission_control`.
+2. Assert `build_mission_control_snapshot()` includes all 27 guide steps (including step 22.5), H1-H11, O1-O10.
+3. Assert `mission_control_summary()` returns counts/readiness and never leaks raw home paths or secret-looking env values.
+4. Run targeted tests and verify RED.
+
+### Task 2: Implement server-only Mission Control intelligence layer
+
+**Objective:** Build deterministic, privacy-minimized snapshot generation from real Hermes files and SQLite state.
+
+**Files:**
+- Create: `hermes_cli/mission_control.py`
+
+**Steps:**
+1. Add static blueprint source model.
+2. Add safe helpers for path compaction, ages, config/env redaction, file counts, SQLite session metrics, cron/skill/MCP/tool/gateway evidence.
+3. Derive route coverage and readiness scores.
+4. Run tests and verify GREEN.
+
+### Task 3: Expose API endpoint
+
+**Objective:** Serve the snapshot to the dashboard as controlled JSON.
+
+**Files:**
+- Modify: `hermes_cli/web_server.py`
+- Extend tests: `tests/hermes_cli/test_mission_control.py`
+
+**Steps:**
+1. Add `GET /api/mission-control/blueprint` returning snapshot.
+2. Add TestClient assertion for 200 response and no raw path/secret leak.
+3. Run tests.
+
+### Task 4: Add frontend API types and route
+
+**Objective:** Make Mission Control a first-class dashboard page.
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+- Modify: `web/src/App.tsx`
+- Create: `web/src/pages/MissionControlPage.tsx`
+
+**Steps:**
+1. Add TypeScript interfaces and `api.getMissionControlBlueprint()`.
+2. Add route `/mission-control` and sidebar item.
+3. Build responsive page sections: command hero, readiness rings, blueprint coverage, live operations, safety/privacy, next actions, troubleshooting.
+
+### Task 5: Polish and verify
+
+**Objective:** Ship a working artifact with build/test/browser evidence.
+
+**Steps:**
+1. Run targeted Python tests.
+2. Run `npm run build` in `web/`.
+3. Start dashboard server locally.
+4. Browser smoke `/mission-control` on desktop and mobile widths, check console errors.
+5. Commit changes if verification passes.

--- a/docs/plans/2026-06-05-mission-control-blueprint.md
+++ b/docs/plans/2026-06-05-mission-control-blueprint.md
@@ -73,3 +73,24 @@
 3. Start dashboard server locally.
 4. Browser smoke `/mission-control` on desktop and mobile widths, check console errors.
 5. Commit changes if verification passes.
+
+### Task 6: Phase 2 source-complete Mission Control
+
+**Objective:** Cover the source guide beyond the original 27 steps and feature picker, while making runtime evidence more honest and privacy-safe.
+
+**Backend scope:**
+1. Add static source sections for architecture pieces, prerequisites, data-flow surfaces, pre-flight checks, customization checklist, next-tool ideas, glossary, troubleshooting, and resources.
+2. Split static support from runtime evidence: env key booleans/counts, SQLite/FTS/cache/actual-cost/API-call metrics, semantic memory config, memory tiers, skill trust/compliance counts, cron cadence/reflection/heartbeat counts, gateway whitelist counts, prompt-injection/approval posture, hosting, quality hooks, production readiness, and action queue.
+3. Keep secrets, raw IDs, session titles, tool output, cron prompts, skill names, absolute paths, and vector index names out of the snapshot.
+
+**Frontend scope:**
+1. Add production readiness, pre-flight, customization, data-flow, source extras, and device-proof sections.
+2. Improve responsive shell with a max-width cockpit, stable `data-testid` anchors, progressbar ARIA, loading/error test IDs, focus-visible links, and React Router internal navigation.
+3. Keep dense details as compact cards so mobile/tablet/desktop do not overflow.
+
+**Verification gates:**
+1. Targeted Mission Control Python tests must cover new counts and redaction guarantees.
+2. `npm run build` must pass.
+3. Full Python suite must pass.
+4. API smoke must verify JSON shape and no sensitive strings.
+5. Browser desktop/mobile smoke must verify no horizontal overflow and no console errors.

--- a/docs/plans/2026-06-05-mission-control-claude-agent-2-complete.md
+++ b/docs/plans/2026-06-05-mission-control-claude-agent-2-complete.md
@@ -1,0 +1,84 @@
+# Mission Control Claude Agent 2 Completion Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Implement every sensible Mission Control feature implied by https://claude-agent-2.vercel.app/ as a verified, privacy-safe, Apple++ responsive Hermes dashboard.
+
+**Architecture:** Keep `hermes_cli/mission_control.py` as the only server-side aggregation/redaction boundary. Return counts, booleans, known-family labels, safe status enums, and generic placeholders; never return raw session contents, prompts, commands, IDs, paths, private skill names, MCP names, toolset names, or custom provider labels. Keep React as a display layer only, with designed bento layout and responsive behavior.
+
+**Tech Stack:** Python/FastAPI snapshot endpoint, SQLite session DB, Hermes config/env/runtime files, React + TypeScript + Tailwind dashboard, pytest + npm build + browser smoke.
+
+---
+
+### Task 1: Add privacy regression tests for unsafe labels
+
+**Objective:** Prove Mission Control does not leak custom toolset, gateway platform, provider, session DB, cron, MCP, or command labels.
+
+**Files:**
+- Modify: `tests/hermes_cli/test_mission_control.py`
+
+**Steps:**
+1. Write failing tests with unique canaries in config, env, cron, MCP, and SQLite columns.
+2. Run targeted pytest and verify failures.
+3. Implement redaction helpers and runtime changes.
+4. Re-run targeted pytest until green.
+
+### Task 2: Harden runtime label sanitization and add safer live signals
+
+**Objective:** Return richer Mission Control data without leaking operator/private names.
+
+**Files:**
+- Modify: `hermes_cli/mission_control.py`
+
+**Expected changes:**
+- Add known-family sanitizers for platform, provider, voice, semantic, terminal/backend labels.
+- Collapse custom toolsets to counts/buckets (`builtin`, `mcp`, `plugin`, `custom`, `unknown`) and never serialize raw toolset names.
+- Collapse custom gateway platform keys to known families or `other` plus counts.
+- Sanitize provider-like config fields to allowlisted families or `custom`/`local`/`other`.
+- Read SQLite in read-only mode where possible.
+- Add safe aggregation for end reasons, delegation, complex sessions, role counts, handoff categories, rewind totals, and API call stats.
+- Expand cron signals with safe status counts, last-run/next-run age buckets, overdue/failed counts, timezone state, and reflection freshness.
+- Expand MCP config with redacted placeholders and transport/status counts only.
+- Add safe approval/tool-output-limits summary when available.
+
+### Task 3: Update API typings and frontend cockpit layout
+
+**Objective:** Turn the page from an audit wall into an Apple++ command center that works on all devices.
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+- Modify: `web/src/pages/MissionControlPage.tsx` or split colocated components if practical.
+
+**Expected changes:**
+- Hero shows readiness, production, blockers/watch count, top action, and last generated timestamp.
+- Use an explicit bento grid for production, operator queue, runtime pulse, and heatmap.
+- Add mobile section nav and disclosure/search/filter for dense source coverage.
+- Add larger tap targets (`min-h-11`) for real controls.
+- Improve ARIA for section headings, progress bars, decorative icons, and focus order.
+- Keep evidence useful but collapse dense evidence on mobile.
+
+### Task 4: Verify production behavior
+
+**Objective:** Prove the dashboard works and does not leak.
+
+**Commands:**
+- `python -m pytest tests/hermes_cli/test_mission_control.py -q`
+- broader relevant pytest suite
+- `npm run build` in `web/`
+- Browser smoke on desktop/tablet/mobile:
+  - `/mission-control` renders
+  - no horizontal overflow
+  - console has no errors
+  - sensitive canaries absent from DOM/API JSON
+  - buttons/links reachable and mobile tap targets acceptable
+
+### Task 5: Independent review, commit, push
+
+**Objective:** Ship verified work.
+
+**Steps:**
+1. Dispatch spec/privacy/UI review subagents.
+2. Fix blockers.
+3. Run final tests/build/smoke.
+4. Commit and push to the active PR branch.
+5. Leave goal active only if blockers remain; mark complete if verified.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16194,7 +16194,9 @@ class GatewayRunner:
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[
+        tuple[str, int | None, int | None, str | None], dict[str, Any]
+    ] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -16202,16 +16204,23 @@ class GatewayRunner:
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json content."""
         try:
+            import hashlib
+
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                stat = path.stat()
+                mtime_ns = stat.st_mtime_ns
+                size = stat.st_size
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+                digest = None
+            memo_key = (str(path), mtime_ns, size, digest)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/hermes_cli/mission_control.py
+++ b/hermes_cli/mission_control.py
@@ -1,0 +1,932 @@
+"""Privacy-minimized Mission Control snapshot for the Hermes dashboard.
+
+This module turns the external Claude Agent blueprint into a live Hermes
+operations cockpit.  It deliberately separates:
+
+- static source coverage (what the guide contains), from
+- live readiness evidence (what this Hermes runtime currently exposes).
+
+The dashboard should never need to read local files directly or receive raw
+logs, prompts, commands, env values, or chat content.  Keep this module as the
+single server-only aggregation boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sqlite3
+import time
+from typing import Any, Iterable
+
+from hermes_cli.config import get_hermes_home, load_config
+
+SOURCE_URL = "https://claude-agent-2.vercel.app/"
+
+BLUEPRINT_STEPS: list[dict[str, Any]] = [
+    {
+        "id": "step-1",
+        "number": "01",
+        "title": "Create your Telegram bot",
+        "domain": "interface",
+        "part": "MVP",
+        "summary": "Create a BotFather token, collect the allowed Telegram user ID, and lock the bot to the operator.",
+        "route": "/channels",
+    },
+    {
+        "id": "step-2",
+        "number": "02",
+        "title": "Get an LLM key",
+        "domain": "model",
+        "part": "MVP",
+        "summary": "Choose Anthropic, OpenRouter, Ollama, or another model provider through env/config.",
+        "route": "/models",
+    },
+    {
+        "id": "step-3",
+        "number": "03",
+        "title": "Bootstrap the project",
+        "domain": "runtime",
+        "part": "MVP",
+        "summary": "Create the TypeScript project skeleton, dependencies, folders, and gitignore boundary.",
+        "route": "/system",
+    },
+    {
+        "id": "step-4",
+        "number": "04",
+        "title": ".env template",
+        "domain": "configuration",
+        "part": "MVP",
+        "summary": "Centralize provider, Telegram, identity, database, and optional integration settings.",
+        "route": "/env",
+    },
+    {
+        "id": "step-5",
+        "number": "05",
+        "title": "Write your soul",
+        "domain": "identity",
+        "part": "MVP",
+        "summary": "Define the operator-facing personality and personal context without reusing a public prompt verbatim.",
+        "route": "/config",
+    },
+    {
+        "id": "step-6",
+        "number": "06",
+        "title": "Config loader",
+        "domain": "configuration",
+        "part": "MVP",
+        "summary": "Load typed runtime configuration from env and defaults so deployment changes do not touch code.",
+        "route": "/config",
+    },
+    {
+        "id": "step-7",
+        "number": "07",
+        "title": "Tier 1 + 2 — SQLite memory",
+        "domain": "memory",
+        "part": "MVP",
+        "summary": "Store durable facts plus a rolling conversation buffer with summarisation of older messages.",
+        "route": "/sessions",
+    },
+    {
+        "id": "step-8",
+        "number": "08",
+        "title": "Tier 3 — Pinecone semantic memory",
+        "domain": "memory",
+        "part": "MVP optional",
+        "summary": "Add semantic recall across many past conversations with a scoped vector database key.",
+        "route": "/system",
+    },
+    {
+        "id": "step-9",
+        "number": "09",
+        "title": "LLM layer",
+        "domain": "model",
+        "part": "MVP",
+        "summary": "Wrap model calls behind a provider-agnostic chat interface.",
+        "route": "/models",
+    },
+    {
+        "id": "step-10",
+        "number": "10",
+        "title": "Tools — what makes it an agent",
+        "domain": "tools",
+        "part": "MVP",
+        "summary": "Expose safe, typed tools such as shell, files, web, memory, and integrations.",
+        "route": "/system",
+    },
+    {
+        "id": "step-11",
+        "number": "11",
+        "title": "The agent loop (with tool-calling)",
+        "domain": "agent-loop",
+        "part": "MVP",
+        "summary": "Build the prompt, call the LLM, execute tools, append observations, and continue until a response is ready.",
+        "route": "/chat",
+    },
+    {
+        "id": "step-12",
+        "number": "12",
+        "title": "Telegram bot",
+        "domain": "interface",
+        "part": "MVP",
+        "summary": "Run the Telegram adapter with whitelist auth and text/voice message handling.",
+        "route": "/channels",
+    },
+    {
+        "id": "step-13",
+        "number": "13",
+        "title": "Heartbeat scheduler",
+        "domain": "automation",
+        "part": "MVP",
+        "summary": "Schedule proactive check-ins and recurring tasks.",
+        "route": "/cron",
+    },
+    {
+        "id": "step-14",
+        "number": "14",
+        "title": "Tie it together",
+        "domain": "runtime",
+        "part": "MVP",
+        "summary": "Initialize memory, semantic recall, bot adapters, and background schedulers in one entrypoint.",
+        "route": "/system",
+    },
+    {
+        "id": "step-15",
+        "number": "15",
+        "title": "Run it",
+        "domain": "runtime",
+        "part": "MVP",
+        "summary": "Start the agent, message it, inspect errors, and confirm the feedback loop works.",
+        "route": "/system",
+    },
+    {
+        "id": "step-16",
+        "number": "16",
+        "title": "Stream responses",
+        "domain": "interface",
+        "part": "Beyond MVP",
+        "summary": "Stream or edit live responses so long tool chains do not leave the user blind.",
+        "route": "/chat",
+    },
+    {
+        "id": "step-17",
+        "number": "17",
+        "title": "Reflection",
+        "domain": "memory",
+        "part": "Beyond MVP",
+        "summary": "Run a consolidation pass that distills conversations into long-term memory.",
+        "route": "/system",
+    },
+    {
+        "id": "step-18",
+        "number": "18",
+        "title": "Auto-skill creation",
+        "domain": "skills",
+        "part": "Beyond MVP",
+        "summary": "After complex successful work, capture the procedure as a portable SKILL.md.",
+        "route": "/skills",
+    },
+    {
+        "id": "step-19",
+        "number": "19",
+        "title": "Voice transcription",
+        "domain": "voice",
+        "part": "Beyond MVP",
+        "summary": "Transcribe Telegram voice notes and optionally respond with voice.",
+        "route": "/channels",
+    },
+    {
+        "id": "step-20",
+        "number": "20",
+        "title": "Multi-user mode",
+        "domain": "interface",
+        "part": "Beyond MVP",
+        "summary": "Namespace memory and message state per authorized user or team member.",
+        "route": "/pairing",
+    },
+    {
+        "id": "step-21",
+        "number": "21",
+        "title": "MCP server integration",
+        "domain": "tools",
+        "part": "Production-grade",
+        "summary": "Attach pre-built MCP servers such as Gmail, Notion, Slack, Supabase, Linear, and GitHub.",
+        "route": "/mcp",
+    },
+    {
+        "id": "step-22",
+        "number": "22",
+        "title": "Permission / approval flow",
+        "domain": "safety",
+        "part": "Production-grade",
+        "summary": "Require approval for destructive or expensive tools and keep an auto-accept escape hatch explicit.",
+        "route": "/system",
+    },
+    {
+        "id": "step-22-5",
+        "number": "22½",
+        "title": "Prompt-injection defence",
+        "domain": "safety",
+        "part": "Production-grade",
+        "summary": "Treat tool outputs as untrusted, wrap them in markers, and prevent scraped/email content from issuing commands.",
+        "route": "/system",
+    },
+    {
+        "id": "step-23",
+        "number": "23",
+        "title": "Cost & token tracking",
+        "domain": "analytics",
+        "part": "Production-grade",
+        "summary": "Record per-request token usage and cost so model bills do not surprise the operator.",
+        "route": "/analytics",
+    },
+    {
+        "id": "step-24",
+        "number": "24",
+        "title": "Mission Control dashboard",
+        "domain": "dashboard",
+        "part": "Production-grade",
+        "summary": "Expose memory, task, cost, and runtime state through a Vite/React cockpit.",
+        "route": "/mission-control",
+    },
+    {
+        "id": "step-25",
+        "number": "25",
+        "title": "Hosting in production",
+        "domain": "hosting",
+        "part": "Production-grade",
+        "summary": "Choose Docker on a VPS, Railway, or systemd/home-server hosting with safe networking.",
+        "route": "/system",
+    },
+    {
+        "id": "step-26",
+        "number": "26",
+        "title": "Testing",
+        "domain": "quality",
+        "part": "Production-grade",
+        "summary": "Unit-test deterministic pieces, snapshot-test prompts, and run fake-LLM integration tests.",
+        "route": "/system",
+    },
+]
+
+HERMES_FEATURES: list[dict[str, str]] = [
+    {"id": "H1", "title": "4-layer memory", "summary": "MEMORY.md / USER.md / SKILL.md / SQLite+FTS5 separates facts, preferences, procedures, and episodic recall.", "where": "Step 7, 17, 18", "domain": "memory"},
+    {"id": "H2", "title": "GEPA reflection", "summary": "Nightly dreaming pass consolidates conversations into core memory.", "where": "Step 17", "domain": "memory"},
+    {"id": "H3", "title": "Auto-skill creation", "summary": "After 5+ tool calls, the agent writes SKILL.md so future similar work is faster.", "where": "Step 18", "domain": "skills"},
+    {"id": "H4", "title": "15+ messaging gateways", "summary": "Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Email, SMS, iMessage, DingTalk, Feishu, and more.", "where": "Step 12 → extend", "domain": "interface"},
+    {"id": "H5", "title": "6 deploy backends", "summary": "Local, Docker, SSH, Daytona, Singularity, and Modal execution backends.", "where": "Step 25", "domain": "hosting"},
+    {"id": "H6", "title": "Real-time voice", "summary": "Voice in/out via CLI, Telegram, and Discord.", "where": "Step 19", "domain": "voice"},
+    {"id": "H7", "title": "Pluggable memory backends", "summary": "Swap memory engines such as Mem0, Honcho, or Byterover without rewriting the agent.", "where": "Custom adapter", "domain": "memory"},
+    {"id": "H8", "title": "Skill trust levels", "summary": "Builtin / Official / Trusted / Community source trust gradient for permissions.", "where": "Step 22", "domain": "safety"},
+    {"id": "H9", "title": "Bounded memory budgets", "summary": "Hard caps force durable consolidation instead of prompt bloat.", "where": "Step 7 + 17", "domain": "memory"},
+    {"id": "H10", "title": "TokenMix optimisation", "summary": "Reduce redundant reasoning/token paths for faster multi-step work.", "where": "Advanced", "domain": "analytics"},
+    {"id": "H11", "title": "agentskills.io standard", "summary": "Skills portable across Hermes, Claude Code, Cursor, and Codex.", "where": "Step 18", "domain": "skills"},
+]
+
+OPENCLAW_FEATURES: list[dict[str, str]] = [
+    {"id": "O1", "title": "22 messaging channels", "summary": "Every Hermes adapter plus iMessage, Nostr, IRC, WeChat, Twitch, and Google Chat.", "where": "Step 12 → extend", "domain": "interface"},
+    {"id": "O2", "title": "Native mobile clients", "summary": "macOS, iOS, and Android clients with voice wake-word.", "where": "Out of scope", "domain": "interface"},
+    {"id": "O3", "title": "ClawHub skill registry", "summary": "Distribute and install third-party skills publicly.", "where": "Step 18", "domain": "skills"},
+    {"id": "O4", "title": "Multi-agent orchestration", "summary": "Spawn sub-agents in parallel for delegated tasks.", "where": "Custom — fork agent.ts", "domain": "agent-loop"},
+    {"id": "O5", "title": "Sandboxed tool execution", "summary": "Run shell commands in Docker / SSH / OpenShell-style isolation.", "where": "Step 22 + 25", "domain": "safety"},
+    {"id": "O6", "title": "Open Gateway Protocol", "summary": "Cross-harness federation so agents can talk to other agents.", "where": "Out of scope", "domain": "interface"},
+    {"id": "O7", "title": "Per-command approval flow", "summary": "Inline approve/deny flow for destructive tool calls.", "where": "Step 22", "domain": "safety"},
+    {"id": "O8", "title": "Auto-approve toggle", "summary": "Trust-level escape hatch when the operator does not want to babysit safe calls.", "where": "Step 22", "domain": "safety"},
+    {"id": "O9", "title": "Live Canvas UI", "summary": "Visual editor where the agent edits files in real time.", "where": "Step 24", "domain": "dashboard"},
+    {"id": "O10", "title": "Tailscale-recommended self-host", "summary": "Mesh-VPN to a home server with no public ports.", "where": "Step 25", "domain": "hosting"},
+]
+
+_STATE_WEIGHT = {"active": 100, "partial": 68, "watch": 38, "planned": 18}
+
+
+@dataclass(frozen=True)
+class CapabilityState:
+    state: str
+    score: int
+    evidence: list[str]
+    next: str
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return default
+
+
+def _home() -> Path:
+    return Path(get_hermes_home()).expanduser().resolve()
+
+
+def _compact_path(path: Path | str | None, home: Path | None = None) -> str | None:
+    if path is None:
+        return None
+    home = home or _home()
+    raw = str(path)
+    try:
+        p = Path(raw).expanduser().resolve()
+        if p == home:
+            return "~/.hermes"
+        if p.is_relative_to(home):
+            rel = p.relative_to(home)
+            return "~/.hermes" if str(rel) == "." else f"~/.hermes/{rel.as_posix()}"
+        user_home = Path.home().resolve()
+        if p == user_home:
+            return "~"
+        if p.is_relative_to(user_home):
+            return f"~/{p.relative_to(user_home).as_posix()}"
+    except Exception:
+        pass
+    # Do not expose arbitrary absolute paths.  Keep only the terminal label.
+    name = Path(raw).name
+    return name or "configured"
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _env_families(home: Path) -> dict[str, Any]:
+    env_path = home / ".env"
+    families: set[str] = set()
+    configured = 0
+    present_keys = 0
+    if env_path.exists():
+        for raw in env_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip('"\'')
+            present_keys += 1
+            if value:
+                configured += 1
+            upper = key.upper()
+            if "TELEGRAM" in upper:
+                families.add("telegram")
+            elif "DISCORD" in upper:
+                families.add("discord")
+            elif "SLACK" in upper:
+                families.add("slack")
+            elif "OPENROUTER" in upper:
+                families.add("openrouter")
+            elif "ANTHROPIC" in upper:
+                families.add("anthropic")
+            elif "OPENAI" in upper or "VOICE_TOOLS_OPENAI" in upper:
+                families.add("openai")
+            elif "PINECONE" in upper:
+                families.add("pinecone")
+            elif "SUPABASE" in upper:
+                families.add("supabase")
+            elif "GEMINI" in upper or "GOOGLE" in upper:
+                families.add("gemini")
+            elif "HASS" in upper or "HOMEASSISTANT" in upper:
+                families.add("homeassistant")
+            elif value:
+                families.add("other")
+    return {
+        "filePresent": env_path.exists(),
+        "path": _compact_path(env_path, home),
+        "presentKeys": present_keys,
+        "configuredKeys": configured,
+        "families": sorted(families),
+    }
+
+
+def _state_db_metrics(home: Path) -> dict[str, Any]:
+    path = home / "state.db"
+    base: dict[str, Any] = {
+        "dbPresent": path.exists(),
+        "path": _compact_path(path, home),
+        "total": 0,
+        "active": 0,
+        "archived": 0,
+        "messages": 0,
+        "toolCalls": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "reasoningTokens": 0,
+        "estimatedCostUsd": 0.0,
+        "sources": {},
+        "recent": [],
+        "latestAgeSeconds": None,
+    }
+    if not path.exists():
+        return base
+    try:
+        con = sqlite3.connect(path)
+        con.row_factory = sqlite3.Row
+        tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if "sessions" in tables:
+            cols = {r[1] for r in con.execute("PRAGMA table_info(sessions)")}
+            base["total"] = _safe_int(con.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+            if "archived" in cols:
+                base["archived"] = _safe_int(con.execute("SELECT COUNT(*) FROM sessions WHERE archived=1").fetchone()[0])
+                base["active"] = max(base["total"] - base["archived"], 0)
+            else:
+                base["active"] = base["total"]
+            for column, key in [
+                ("tool_call_count", "toolCalls"),
+                ("input_tokens", "inputTokens"),
+                ("output_tokens", "outputTokens"),
+                ("reasoning_tokens", "reasoningTokens"),
+            ]:
+                if column in cols:
+                    base[key] = _safe_int(con.execute(f"SELECT COALESCE(SUM({column}), 0) FROM sessions").fetchone()[0])
+            if "estimated_cost_usd" in cols:
+                base["estimatedCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM sessions").fetchone()[0] or 0), 4)
+            if "source" in cols:
+                base["sources"] = {
+                    str(row[0]): _safe_int(row[1])
+                    for row in con.execute("SELECT source, COUNT(*) FROM sessions GROUP BY source ORDER BY COUNT(*) DESC LIMIT 12")
+                }
+            order_col = "started_at" if "started_at" in cols else "rowid"
+            # Keep recent activity privacy-minimized: session titles and IDs can
+            # be conversation-derived, so expose only coarse labels/counts/ages.
+            select_cols = [c for c in ["source", "model", "started_at", "message_count"] if c in cols]
+            if select_cols:
+                recent = []
+                for row in con.execute(f"SELECT {', '.join(select_cols)} FROM sessions ORDER BY {order_col} DESC LIMIT 6"):
+                    raw = dict(row)
+                    item: dict[str, Any] = {}
+                    if raw.get("source"):
+                        item["source"] = str(raw.get("source"))
+                    if raw.get("model"):
+                        item["model"] = str(raw.get("model"))
+                    if "message_count" in raw:
+                        item["messageCount"] = _safe_int(raw.get("message_count"), 0)
+                    started = raw.get("started_at")
+                    if isinstance(started, (int, float)):
+                        item["startedAgeSeconds"] = max(0, int(time.time() - float(started)))
+                        if base["latestAgeSeconds"] is None:
+                            base["latestAgeSeconds"] = item["startedAgeSeconds"]
+                    recent.append(item)
+                base["recent"] = recent
+        if "messages" in tables:
+            base["messages"] = _safe_int(con.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+        con.close()
+    except Exception as exc:
+        base["error"] = f"state-db-unavailable:{exc.__class__.__name__}"
+    return base
+
+
+def _skill_metrics(home: Path) -> dict[str, Any]:
+    skill_root = home / "skills"
+    files = list(skill_root.rglob("SKILL.md")) if skill_root.exists() else []
+    by_category: dict[str, int] = {}
+    spotlight: list[dict[str, str]] = []
+    for p in files:
+        try:
+            rel = p.relative_to(skill_root)
+            category = rel.parts[0] if len(rel.parts) > 1 else "uncategorized"
+            by_category[category] = by_category.get(category, 0) + 1
+            if len(spotlight) < 6:
+                spotlight.append({"name": p.parent.name, "category": category})
+        except Exception:
+            continue
+    usage = _read_json(skill_root / ".usage.json") if skill_root.exists() else None
+    usage_count = len(usage) if isinstance(usage, dict) else 0
+    return {
+        "rootPresent": skill_root.exists(),
+        "path": _compact_path(skill_root, home),
+        "total": len(files),
+        "usageTracked": usage_count,
+        "categories": by_category,
+        "spotlight": spotlight,
+    }
+
+
+def _cron_metrics(home: Path) -> dict[str, Any]:
+    jobs_path = home / "cron" / "jobs.json"
+    payload = _read_json(jobs_path)
+    jobs: list[dict[str, Any]] = []
+    if isinstance(payload, list):
+        jobs = [j for j in payload if isinstance(j, dict)]
+    elif isinstance(payload, dict):
+        raw_jobs = payload.get("jobs")
+        if isinstance(raw_jobs, dict):
+            jobs = [j for j in raw_jobs.values() if isinstance(j, dict)]
+        elif isinstance(raw_jobs, list):
+            jobs = [j for j in raw_jobs if isinstance(j, dict)]
+        elif all(isinstance(v, dict) for v in payload.values()):
+            jobs = [v for v in payload.values() if isinstance(v, dict)]
+    enabled = 0
+    schedules: list[str] = []
+    deliveries: dict[str, int] = {}
+    for job in jobs:
+        disabled = job.get("disabled") or job.get("paused") or job.get("enabled") is False
+        if not disabled:
+            enabled += 1
+        schedule = str(job.get("schedule") or job.get("cron") or "").strip()
+        if schedule and len(schedules) < 6:
+            schedules.append(schedule)
+        deliver = str(job.get("deliver") or job.get("target") or "origin")
+        deliveries[deliver] = deliveries.get(deliver, 0) + 1
+    return {
+        "filePresent": jobs_path.exists(),
+        "path": _compact_path(jobs_path, home),
+        "total": len(jobs),
+        "enabled": enabled,
+        "paused": max(len(jobs) - enabled, 0),
+        "sampleSchedules": schedules,
+        "deliveries": deliveries,
+    }
+
+
+def _mcp_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
+    servers: dict[str, Any] = {}
+    root_servers = cfg.get("mcp_servers") if isinstance(cfg, dict) else None
+    if isinstance(root_servers, dict):
+        servers.update(root_servers)
+    # Backwards-compatible fallback for older/experimental config shape.
+    mcp = cfg.get("mcp") if isinstance(cfg, dict) else None
+    nested_servers = mcp.get("servers") if isinstance(mcp, dict) else None
+    if isinstance(nested_servers, dict):
+        servers.update(nested_servers)
+    return {
+        "configured": len(servers),
+        "servers": sorted(str(k) for k in servers.keys())[:12],
+        "enabled": sum(1 for v in servers.values() if not (isinstance(v, dict) and v.get("enabled") is False)),
+    }
+
+
+def _model_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
+    raw_model = cfg.get("model")
+    raw_agent = cfg.get("agent")
+    raw_delegation = cfg.get("delegation")
+    agent: dict[str, Any] = raw_agent if isinstance(raw_agent, dict) else {}
+    delegation: dict[str, Any] = raw_delegation if isinstance(raw_delegation, dict) else {}
+    if isinstance(raw_model, dict):
+        model_name = str(raw_model.get("default") or raw_model.get("model") or raw_model.get("name") or "auto")
+        provider = raw_model.get("provider") or cfg.get("provider")
+    else:
+        model_name = str(raw_model or "auto")
+        provider = cfg.get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        provider = model_name.split("/", 1)[0] if "/" in model_name else "auto"
+    return {
+        "provider": provider,
+        "model": model_name,
+        "reasoning": agent.get("reasoning_effort") or delegation.get("reasoning_effort") or "default",
+        "delegationProvider": delegation.get("provider") or None,
+        "maxTurns": _safe_int(agent.get("max_turns"), 0),
+    }
+
+
+def _gateway_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
+    configured_families = [f for f in env_info.get("families", []) if f in {"telegram", "discord", "slack", "matrix", "signal", "email", "sms", "homeassistant"}]
+    platforms_cfg = ((cfg.get("gateway") or {}).get("platforms") or {}) if isinstance(cfg.get("gateway"), dict) else {}
+    if isinstance(platforms_cfg, dict):
+        for name, pcfg in platforms_cfg.items():
+            if isinstance(pcfg, dict) and pcfg.get("enabled"):
+                configured_families.append(str(name))
+    running = False
+    pid = None
+    runtime_state = "unknown"
+    try:
+        from gateway.status import get_running_pid, read_runtime_status
+
+        pid = get_running_pid()
+        running = bool(pid)
+        status = read_runtime_status()
+        if isinstance(status, dict):
+            runtime_state = str(status.get("state") or status.get("status") or ("running" if running else "stopped"))
+    except Exception:
+        runtime_state = "unavailable"
+    unique = sorted(set(configured_families))
+    return {
+        "running": running,
+        "pidPresent": bool(pid),
+        "state": runtime_state,
+        "configuredPlatforms": unique,
+        "configuredCount": len(unique),
+    }
+
+
+def _tool_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
+    toolsets = cfg.get("toolsets") or []
+    disabled = ((cfg.get("agent") or {}).get("disabled_toolsets") or []) if isinstance(cfg.get("agent"), dict) else []
+    return {
+        "configuredToolsets": list(toolsets) if isinstance(toolsets, list) else [],
+        "configuredToolsetCount": len(toolsets) if isinstance(toolsets, list) else 0,
+        "disabledToolsets": list(disabled) if isinstance(disabled, list) else [],
+        "toolSearch": bool(((cfg.get("tools") or {}).get("tool_search")) if isinstance(cfg.get("tools"), dict) else False),
+    }
+
+
+def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
+    raw_approvals = cfg.get("approvals")
+    raw_security = cfg.get("security")
+    raw_terminal = cfg.get("terminal")
+    approvals: dict[str, Any] = raw_approvals if isinstance(raw_approvals, dict) else {}
+    security: dict[str, Any] = raw_security if isinstance(raw_security, dict) else {}
+    terminal: dict[str, Any] = raw_terminal if isinstance(raw_terminal, dict) else {}
+    return {
+        "approvalsMode": approvals.get("mode") or "manual",
+        "cronApprovalsMode": approvals.get("cron_mode") or approvals.get("mode") or "manual",
+        "redactSecrets": security.get("redact_secrets") is not False,
+        "tirithEnabled": bool(security.get("tirith_enabled")),
+        "terminalBackend": terminal.get("backend") or "local",
+        "privateUrlsAllowed": bool(security.get("allow_private_urls")),
+    }
+
+
+def _identity_metrics(home: Path) -> dict[str, Any]:
+    soul = home / "soul.md"
+    memory_file = home / "MEMORY.md"
+    user_file = home / "USER.md"
+    # Active installs can use lowercase memory files as well; only expose sizes.
+    files = [p for p in [soul, memory_file, user_file, home / "memory.md", home / "user.md"] if p.exists()]
+    return {
+        "soulPresent": soul.exists(),
+        "profileFiles": len(files),
+        "totalBytes": sum(p.stat().st_size for p in files if p.exists()),
+        "files": [_compact_path(p, home) for p in files[:5]],
+    }
+
+
+def _build_runtime(cfg: dict[str, Any], home: Path) -> dict[str, Any]:
+    env_info = _env_families(home)
+    runtime = {
+        "generatedAt": _now_iso(),
+        "home": "~/.hermes",
+        "model": _model_metrics(cfg),
+        "env": env_info,
+        "identity": _identity_metrics(home),
+        "sessions": _state_db_metrics(home),
+        "skills": _skill_metrics(home),
+        "cron": _cron_metrics(home),
+        "mcp": _mcp_metrics(cfg),
+        "gateway": _gateway_metrics(cfg, env_info),
+        "tools": _tool_metrics(cfg),
+        "safety": _safety_metrics(cfg),
+        "voice": {
+            "sttEnabled": bool(((cfg.get("stt") or {}).get("enabled")) if isinstance(cfg.get("stt"), dict) else False),
+            "sttProvider": ((cfg.get("stt") or {}).get("provider")) if isinstance(cfg.get("stt"), dict) else None,
+            "ttsProvider": ((cfg.get("tts") or {}).get("provider")) if isinstance(cfg.get("tts"), dict) else None,
+        },
+        "dashboard": {
+            "missionControlRoute": "/mission-control",
+            "sourceRoute": SOURCE_URL,
+            "authGated": True,
+        },
+    }
+    return runtime
+
+
+def _state(state: str, evidence: Iterable[str], next_action: str) -> CapabilityState:
+    return CapabilityState(state=state, score=_STATE_WEIGHT[state], evidence=[e for e in evidence if e], next=next_action)
+
+
+def _readiness_for_feature(feature_id: str, runtime: dict[str, Any]) -> CapabilityState:
+    sessions = runtime["sessions"]
+    skills = runtime["skills"]
+    cron = runtime["cron"]
+    mcp = runtime["mcp"]
+    gateway = runtime["gateway"]
+    safety = runtime["safety"]
+    voice = runtime["voice"]
+    tools = runtime["tools"]
+    env_info = runtime["env"]
+
+    if feature_id == "H1":
+        if runtime["identity"]["profileFiles"] and sessions["dbPresent"]:
+            return _state("active", [f"{sessions['total']} session(s) in SQLite store", f"{skills['total']} skill(s) installed"], "Keep memory budgets healthy and consolidate recurring lessons.")
+        return _state("partial", ["Memory files or SQLite store are not both present"], "Enable memory files and keep the session store writable.")
+    if feature_id == "H2":
+        if cron["enabled"]:
+            return _state("partial", [f"{cron['enabled']} enabled cron job(s) can run reflection-style passes"], "Add a dedicated nightly reflection/curator job if not present.")
+        return _state("watch", ["No enabled cron jobs detected"], "Create a self-contained nightly consolidation cron job.")
+    if feature_id in {"H3", "H11", "O3"}:
+        return _state("active" if skills["total"] else "partial", [f"{skills['total']} installed skill(s)", f"usage tracked for {skills['usageTracked']} skill(s)"], "Keep auto-created skills reviewed and curated.")
+    if feature_id in {"H4", "O1"}:
+        return _state("active" if gateway["configuredCount"] else "partial", [f"{gateway['configuredCount']} configured platform family/families", f"gateway state: {gateway['state']}"], "Enable only platforms that have real operator value.")
+    if feature_id in {"H5", "O5"}:
+        backend = safety["terminalBackend"]
+        return _state("active" if backend else "partial", [f"terminal backend: {backend}", f"configured toolsets: {tools['configuredToolsetCount']}"], "Prefer isolated backends for untrusted or expensive commands.")
+    if feature_id == "H6":
+        active = voice["sttEnabled"] or bool(voice["ttsProvider"])
+        return _state("active" if active else "watch", [f"STT enabled: {voice['sttEnabled']}", f"TTS provider: {voice['ttsProvider'] or 'not configured'}"], "Wire STT/TTS only where voice actually speeds you up.")
+    if feature_id == "H7":
+        provider = "builtin"
+        return _state("partial", [f"memory provider: {provider}"], "Add Honcho/Mem0/etc. only if builtin memory becomes limiting.")
+    if feature_id == "H8":
+        return _state("active", ["skills are source-scoped in the dashboard", "plugins expose trust/source metadata"], "Keep community skills behind review before enabling broad permissions.")
+    if feature_id == "H9":
+        return _state("active", ["memory/user profile limits are part of Hermes config", "session compression is supported"], "Watch memory saturation and prune stale facts.")
+    if feature_id == "H10":
+        return _state("planned", ["Token/cost analytics exist; TokenMix-specific optimisation is not a live signal"], "Treat as advanced optimisation after high-value flows are stable.")
+    if feature_id == "O2":
+        return _state("planned", ["Dashboard is responsive web; native mobile clients are outside this repository"], "Use the web dashboard on mobile before funding native clients.")
+    if feature_id == "O4":
+        return _state("active", ["delegate_task subagents and kanban workers are supported", "parallel child cap is configurable"], "Use subagents for independent workstreams, not shared-file conflicts.")
+    if feature_id == "O6":
+        return _state("planned", ["MCP/tool protocols exist; Open Gateway federation is not configured"], "Keep this as a future interoperability project.")
+    if feature_id in {"O7", "O8"}:
+        mode = safety["approvalsMode"]
+        return _state("active", [f"approvals mode: {mode}", f"secret redaction: {safety['redactSecrets']}"], "Keep destructive approvals visible; use smart/off only intentionally.")
+    if feature_id == "O9":
+        return _state("partial", ["Mission Control dashboard is the live cockpit route", "file/canvas edit UI is separate from this snapshot"], "Promote high-value cards into editable Live Canvas widgets later.")
+    if feature_id == "O10":
+        fams = set(env_info.get("families", []))
+        if "tailscale" in fams:
+            return _state("partial", ["tailscale-related env family detected"], "Verify mesh access and avoid public ports.")
+        return _state("watch", ["No Tailscale-specific signal detected"], "Prefer mesh VPN or SSH tunnel if exposing a home server.")
+    return _state("watch", ["No feature-specific readiness rule"], "Inspect runtime evidence manually.")
+
+
+def _readiness_for_step(step: dict[str, Any], runtime: dict[str, Any]) -> CapabilityState:
+    domain = step["domain"]
+    route = step.get("route")
+    if domain == "model":
+        model = runtime["model"]
+        return _state("active", [f"provider: {model['provider']}", f"model: {model['model']}", f"reasoning: {model['reasoning']}"], "Keep model routing visible in Models and Config.")
+    if domain == "memory":
+        return _state("active" if runtime["sessions"]["dbPresent"] else "partial", [f"session DB present: {runtime['sessions']['dbPresent']}", f"messages counted: {runtime['sessions']['messages']}"], "Continue consolidating important facts into memory/skills.")
+    if domain == "skills":
+        return _state("active" if runtime["skills"]["total"] else "partial", [f"{runtime['skills']['total']} installed skill(s)"], "Create skills only from reusable, verified workflows.")
+    if domain == "automation":
+        return _state("active" if runtime["cron"]["total"] else "watch", [f"{runtime['cron']['total']} cron job(s), {runtime['cron']['enabled']} enabled"], "Schedule recurring work only with self-contained prompts.")
+    if domain == "tools":
+        if step["id"] == "step-21":
+            return _state("active" if runtime["mcp"]["configured"] else "watch", [f"{runtime['mcp']['configured']} MCP server(s) configured"], "Install MCP servers only for workflows you actually use.")
+        return _state("active", [f"configured toolset count: {runtime['tools']['configuredToolsetCount']}"], "Keep powerful tools behind the right platform/toolset scope.")
+    if domain == "interface":
+        return _state("active" if runtime["gateway"]["configuredCount"] else "partial", [f"configured platform families: {runtime['gateway']['configuredCount']}", f"gateway running: {runtime['gateway']['running']}"], "Use Pairing/Channels for multi-user safety.")
+    if domain == "voice":
+        return _state("active" if runtime["voice"]["sttEnabled"] else "watch", [f"STT provider: {runtime['voice']['sttProvider'] or 'not enabled'}", f"TTS provider: {runtime['voice']['ttsProvider'] or 'not configured'}"], "Enable voice where Telegram/Discord audio saves time.")
+    if domain == "safety":
+        return _state("active", [f"approvals mode: {runtime['safety']['approvalsMode']}", f"secret redaction: {runtime['safety']['redactSecrets']}"], "Never expose raw tool output/logs in the dashboard.")
+    if domain == "analytics":
+        tokens = runtime["sessions"]["inputTokens"] + runtime["sessions"]["outputTokens"]
+        return _state("active" if tokens else "partial", [f"tracked tokens: {tokens}", f"estimated cost USD: {runtime['sessions']['estimatedCostUsd']}"], "Enable token analytics in dashboard config when useful.")
+    if domain == "dashboard":
+        return _state("active", ["/mission-control route exposes this blueprint", "server-only snapshot protects local state"], "Keep coverage and readiness distinct.")
+    if domain == "hosting":
+        return _state("partial", [f"terminal backend: {runtime['safety']['terminalBackend']}", "hosting posture depends on deployment target"], "Prefer low-cost VPS/mesh networking over low-value complexity.")
+    if domain == "quality":
+        return _state("active", ["Python regression tests cover the snapshot endpoint", "frontend build validates TypeScript route"], "Run browser smoke on desktop and mobile before shipping.")
+    if domain in {"configuration", "identity", "runtime", "agent-loop"}:
+        return _state("active", [f"dashboard route: {route}", f"Hermes home exposed as {runtime['home']}"], "Keep config readable while secrets stay server-only.")
+    return _state("watch", ["No domain-specific rule"], "Review manually.")
+
+
+def _coverage(runtime: dict[str, Any]) -> dict[str, Any]:
+    step_rows: list[dict[str, Any]] = []
+    feature_rows: list[dict[str, Any]] = []
+    domain_scores: dict[str, list[int]] = {}
+
+    for step in BLUEPRINT_STEPS:
+        readiness = _readiness_for_step(step, runtime)
+        row = {
+            **step,
+            "sourceUrl": f"{SOURCE_URL}#{step['id']}",
+            "status": readiness.state,
+            "readiness": readiness.score,
+            "evidence": readiness.evidence,
+            "next": readiness.next,
+            "missionControl": step.get("route") == "/mission-control",
+        }
+        step_rows.append(row)
+        domain_scores.setdefault(step["domain"], []).append(readiness.score)
+
+    for feature in [*HERMES_FEATURES, *OPENCLAW_FEATURES]:
+        readiness = _readiness_for_feature(feature["id"], runtime)
+        row = {
+            **feature,
+            "status": readiness.state,
+            "readiness": readiness.score,
+            "evidence": readiness.evidence,
+            "next": readiness.next,
+        }
+        feature_rows.append(row)
+        domain_scores.setdefault(feature["domain"], []).append(readiness.score)
+
+    all_rows = [*step_rows, *feature_rows]
+    counts: dict[str, int] = {"active": 0, "partial": 0, "watch": 0, "planned": 0}
+    for row in all_rows:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+    total = len(all_rows)
+    readiness = round(sum(row["readiness"] for row in all_rows) / total) if total else 0
+    domains = [
+        {"name": name, "score": round(sum(scores) / len(scores)), "items": len(scores)}
+        for name, scores in sorted(domain_scores.items())
+        if scores
+    ]
+    domains.sort(key=lambda d: (d["score"], d["name"]))
+    return {
+        "summary": {"total": total, "readiness": readiness, "counts": counts},
+        "steps": step_rows,
+        "features": feature_rows,
+        "domains": domains,
+        "weakestDomains": domains[:5],
+    }
+
+
+def _action_queue(runtime: dict[str, Any], coverage: dict[str, Any]) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    weakest = coverage.get("weakestDomains", [])[:3]
+    for idx, domain in enumerate(weakest, start=1):
+        actions.append({
+            "rank": idx,
+            "tone": "now" if domain["score"] < 55 else "next",
+            "title": f"Strengthen {domain['name']}",
+            "reason": f"Average readiness {domain['score']} across {domain['items']} mapped item(s).",
+            "route": "/mission-control",
+        })
+    if runtime["gateway"]["configuredCount"] == 0:
+        actions.append({"rank": len(actions) + 1, "tone": "now", "title": "Configure one gateway", "reason": "Messaging is the only useful interface if the agent is not reachable.", "route": "/channels"})
+    if runtime["cron"]["enabled"] == 0:
+        actions.append({"rank": len(actions) + 1, "tone": "next", "title": "Add one reflection or heartbeat cron", "reason": "The blueprint expects proactive/background consolidation.", "route": "/cron"})
+    if runtime["skills"]["total"] == 0:
+        actions.append({"rank": len(actions) + 1, "tone": "next", "title": "Install or create reusable skills", "reason": "Skills are the reusable procedure layer of the agent.", "route": "/skills"})
+    return actions[:8]
+
+
+def _privacy_boundaries() -> list[dict[str, str]]:
+    return [
+        {"label": "Session content", "policy": "counts only", "detail": "No chat text, tool outputs, or reasoning bodies leave the server snapshot."},
+        {"label": "Secrets", "policy": "never values", "detail": "Env files are reduced to counts and provider families only."},
+        {"label": "Local paths", "policy": "compacted", "detail": "Hermes-owned paths render as ~/.hermes; arbitrary absolutes collapse to labels."},
+        {"label": "Commands/logs", "policy": "metadata", "detail": "The cockpit exposes status/readiness, not shell commands or log tails."},
+    ]
+
+
+def build_mission_control_snapshot() -> dict[str, Any]:
+    """Return a deterministic, privacy-minimized Mission Control snapshot."""
+    home = _home()
+    try:
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    runtime = _build_runtime(cfg, home)
+    coverage = _coverage(runtime)
+    return {
+        "ok": True,
+        "source": {
+            "url": SOURCE_URL,
+            "title": "Claude Agent",
+            "lastChecked": _now_iso(),
+            "extractedWith": "Hermes Mission Control server snapshot",
+            "note": "Source guide says 26 build steps; the page also contains a 22½ prompt-injection defence anchor, tracked here as its own required item.",
+        },
+        "blueprint": {
+            "stepCount": len(BLUEPRINT_STEPS),
+            "numberedStepCount": 26,
+            "hermesFeatureCount": len(HERMES_FEATURES),
+            "openclawFeatureCount": len(OPENCLAW_FEATURES),
+            "parts": ["MVP", "Beyond MVP", "Production-grade"],
+        },
+        "runtime": runtime,
+        "coverage": coverage,
+        "actionQueue": _action_queue(runtime, coverage),
+        "privacy": _privacy_boundaries(),
+        "deviceProof": {
+            "principles": [
+                "safe-area aware responsive grids",
+                "horizontal overflow guarded by min-w-0 and wrapped text",
+                "reduced-motion friendly static gradients",
+                "touch targets sized for mobile navigation",
+            ],
+            "breakpoints": ["mobile", "tablet", "desktop", "wide cockpit"],
+        },
+    }
+
+
+def mission_control_summary() -> dict[str, Any]:
+    """Small summary shape for health checks and future sidebar chips."""
+    snapshot = build_mission_control_snapshot()
+    return {
+        "ok": snapshot["ok"],
+        "readiness": snapshot["coverage"]["summary"]["readiness"],
+        "totalItems": snapshot["coverage"]["summary"]["total"],
+        "counts": snapshot["coverage"]["summary"]["counts"],
+        "topAction": snapshot["actionQueue"][0] if snapshot["actionQueue"] else None,
+        "runtime": {
+            "sessions": snapshot["runtime"]["sessions"]["total"],
+            "skills": snapshot["runtime"]["skills"]["total"],
+            "cron": snapshot["runtime"]["cron"]["total"],
+            "mcp": snapshot["runtime"]["mcp"]["configured"],
+        },
+    }
+
+
+__all__ = [
+    "BLUEPRINT_STEPS",
+    "HERMES_FEATURES",
+    "OPENCLAW_FEATURES",
+    "build_mission_control_snapshot",
+    "mission_control_summary",
+]

--- a/hermes_cli/mission_control.py
+++ b/hermes_cli/mission_control.py
@@ -691,6 +691,28 @@ def _safe_gateway_label(value: Any) -> str:
     return "other"
 
 
+def _safe_service_manager_label(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if "systemd" in raw:
+        return "systemd"
+    if "launchd" in raw:
+        return "launchd"
+    if "s6" in raw:
+        return "s6"
+    if "docker" in raw:
+        return "docker"
+    if "termux" in raw:
+        return "termux"
+    if "manual" in raw:
+        return "manual"
+    return "unknown"
+
+
+def _safe_service_scope(value: Any) -> str | None:
+    raw = str(value or "").strip().lower()
+    return raw if raw in {"user", "system", "container", "manual"} else None
+
+
 def _safe_status(value: Any, *, allowed: set[str], default: str = "other") -> str:
     raw = str(value or "").strip().lower().replace("-", "_")
     if not raw:
@@ -786,8 +808,16 @@ def _env_families(home: Path) -> dict[str, Any]:
                 return len([p for p in value.replace(";", ",").split(",") if p.strip()])
         return 0
 
+    telegram_allowlist_keys = (
+        "ALLOWED_USER_IDS",
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOWED_USER_IDS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    )
+
     family_tests = {
-        "telegram": lambda k: "TELEGRAM" in k or k in {"ALLOWED_USER_IDS"},
+        "telegram": lambda k: "TELEGRAM" in k or k in {"ALLOWED_USER_IDS", "GATEWAY_ALLOWED_USERS"},
         "discord": lambda k: "DISCORD" in k,
         "slack": lambda k: "SLACK" in k,
         "matrix": lambda k: "MATRIX" in k,
@@ -808,7 +838,7 @@ def _env_families(home: Path) -> dict[str, Any]:
     llm_families = [f for f in families if f in {"anthropic", "openai", "openrouter", "gemini", "ollama"}]
     required = [
         {"key": "TELEGRAM_BOT_TOKEN", "category": "telegram", "isSet": present("TELEGRAM_BOT_TOKEN")},
-        {"key": "ALLOWED_USER_IDS", "category": "telegram", "isSet": present("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS"), "count": count_csv("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS")},
+        {"key": "ALLOWED_USER_IDS", "category": "telegram", "isSet": present(*telegram_allowlist_keys), "count": count_csv(*telegram_allowlist_keys)},
         {"key": "LLM_API_KEY", "category": "model", "isSet": bool(llm_families)},
         {"key": "DASHBOARD_TOKEN", "category": "dashboard", "isSet": present("DASHBOARD_TOKEN", "HERMES_DASHBOARD_TOKEN")},
     ]
@@ -830,7 +860,7 @@ def _env_families(home: Path) -> dict[str, Any]:
         "optionalKeys": optional,
         "telegram": {
             "tokenPresent": present("TELEGRAM_BOT_TOKEN"),
-            "allowedUserCount": count_csv("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS"),
+            "allowedUserCount": count_csv(*telegram_allowlist_keys),
         },
         "dashboard": {"tokenPresent": present("DASHBOARD_TOKEN", "HERMES_DASHBOARD_TOKEN")},
         "semantic": {"pineconeKeyPresent": present("PINECONE_API_KEY"), "pineconeIndexPresent": present("PINECONE_INDEX", "PINECONE_INDEX_NAME")},
@@ -1254,7 +1284,7 @@ def _production_readiness(runtime: dict[str, Any]) -> dict[str, Any]:
         {"id": "mcp", "label": "MCP", "status": "pass" if runtime["mcp"].get("configured") else "unknown", "detail": f"{runtime['mcp'].get('configured', 0)} configured"},
         {"id": "cron", "label": "Cron", "status": "pass" if runtime["cron"].get("enabled") else "unknown", "detail": f"{runtime['cron'].get('enabled', 0)} enabled"},
         {"id": "quality", "label": "Quality gates", "status": "pass" if runtime["quality"].get("pythonMissionControlTestsPresent") and runtime["quality"].get("frontendBuildScriptPresent") else "warn", "detail": "test/build hooks present; last run evidence shown after verification"},
-        {"id": "hosting", "label": "Hosting posture", "status": "pass" if runtime["hosting"].get("hardenedContainer") else ("warn" if runtime["hosting"].get("containerized") else "unknown"), "detail": runtime["hosting"].get("installMethod")},
+        {"id": "hosting", "label": "Hosting posture", "status": "pass" if (runtime["hosting"].get("hardenedContainer") or runtime["hosting"].get("managedService")) else ("warn" if runtime["hosting"].get("containerized") else "unknown"), "detail": runtime["hosting"].get("installMethod")},
     ]
     score_map = {"pass": 100, "warn": 60, "unknown": 35, "fail": 0, "not_applicable": 70}
     score = round(sum(score_map.get(str(s.get("status")), 35) for s in signals) / len(signals)) if signals else 0
@@ -1262,9 +1292,14 @@ def _production_readiness(runtime: dict[str, Any]) -> dict[str, Any]:
     return {"score": score, "signals": signals, "blockers": blockers[:5]}
 
 
-def _hosting_metrics(cfg: dict[str, Any], safety: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
+def _hosting_metrics(cfg: dict[str, Any], safety: dict[str, Any], env_info: dict[str, Any], gateway_info: dict[str, Any] | None = None) -> dict[str, Any]:
+    gateway_info = gateway_info or {}
     terminal_backend = safety.get("terminalBackend") or "local"
     install_method = "docker" if terminal_backend == "docker" else ("ssh" if terminal_backend == "ssh" else "unknown")
+    service_manager = str(gateway_info.get("serviceManager") or "unknown")
+    managed_service = bool(gateway_info.get("managedService") or gateway_info.get("serviceInstalled") or gateway_info.get("serviceRunning"))
+    if install_method == "unknown" and managed_service and service_manager != "unknown":
+        install_method = service_manager
     docker = cfg.get("docker") if isinstance(cfg.get("docker"), dict) else {}
     hardened = None
     if install_method == "docker" or docker:
@@ -1273,8 +1308,12 @@ def _hosting_metrics(cfg: dict[str, Any], safety: dict[str, Any], env_info: dict
     return {
         "installMethod": install_method,
         "terminalBackend": terminal_backend,
-        "containerized": install_method == "docker",
+        "containerized": install_method in {"docker", "s6"},
         "hardenedContainer": hardened,
+        "managedService": managed_service,
+        "serviceManager": service_manager,
+        "serviceRunning": bool(gateway_info.get("serviceRunning")),
+        "serviceInstalled": bool(gateway_info.get("serviceInstalled")),
         "meshVpnSignal": bool((env_info.get("network") or {}).get("tailscaleSignalPresent")) if isinstance(env_info.get("network"), dict) else False,
         "publicPortSignal": None,
     }
@@ -1513,26 +1552,54 @@ def _gateway_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str,
                 configured_labels.append(_safe_gateway_label(name))
     running = False
     pid = None
+    pid_present = False
     runtime_state = "unknown"
+    service_manager = "unknown"
+    service_installed = False
+    service_running = False
+    service_scope = None
+    managed_service = False
     try:
         from gateway.status import get_running_pid, read_runtime_status
 
         pid = get_running_pid()
+        pid_present = bool(pid)
         running = bool(pid)
         status = read_runtime_status()
         if isinstance(status, dict):
             runtime_state = _safe_status(status.get("state") or status.get("status") or ("running" if running else "stopped"), allowed={"running", "stopped", "starting", "ready", "error", "failed", "unknown"})
     except Exception:
         runtime_state = "unavailable"
+    try:
+        from .gateway import get_gateway_runtime_snapshot
+
+        snapshot = get_gateway_runtime_snapshot()
+        service_manager = _safe_service_manager_label(getattr(snapshot, "manager", None))
+        service_installed = bool(getattr(snapshot, "service_installed", False))
+        service_running = bool(getattr(snapshot, "service_running", False))
+        service_scope = _safe_service_scope(getattr(snapshot, "service_scope", None))
+        snapshot_pids = tuple(getattr(snapshot, "gateway_pids", ()) or ())
+        pid_present = pid_present or bool(snapshot_pids)
+        running = running or bool(getattr(snapshot, "running", False))
+        managed_service = service_installed or service_running or service_manager in {"systemd", "launchd", "s6"}
+        if runtime_state in {"unknown", "stopped"} and running:
+            runtime_state = "running"
+    except Exception:
+        pass
     unique = sorted(set(configured_labels))
     return {
         "running": running,
-        "pidPresent": bool(pid),
+        "pidPresent": pid_present,
         "state": runtime_state,
         "configuredPlatforms": unique,
         "configuredCount": configured_entries or len(unique),
         "platformNamesRedacted": True,
         "customPlatformCount": sum(1 for label in configured_labels if label == "other"),
+        "serviceManager": service_manager,
+        "serviceInstalled": service_installed,
+        "serviceRunning": service_running,
+        "serviceScope": service_scope,
+        "managedService": managed_service,
     }
 
 
@@ -1637,10 +1704,10 @@ def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     }
 
 def _identity_metrics(home: Path) -> dict[str, Any]:
-    soul = home / "soul.md"
+    soul_candidates = [home / "soul.md", home / "SOUL.md"]
     memory_dir = home / "memories"
     candidates = [
-        soul,
+        *soul_candidates,
         home / "MEMORY.md",
         home / "USER.md",
         home / "memory.md",
@@ -1652,7 +1719,7 @@ def _identity_metrics(home: Path) -> dict[str, Any]:
     ]
     files = [p for p in candidates if p.exists()]
     return {
-        "soulPresent": soul.exists(),
+        "soulPresent": any(p.exists() for p in soul_candidates),
         "profileFiles": len(files),
         "totalBytes": sum(p.stat().st_size for p in files if p.exists()),
         "files": [_compact_path(p, home) for p in files[:8]],
@@ -1695,7 +1762,7 @@ def _build_runtime(cfg: dict[str, Any], home: Path, dashboard_state: dict[str, A
         "freshness": runtime["cron"].get("reflectionFreshness"),
         "lastRunAgeSeconds": runtime["cron"].get("reflectionLastRunAgeSeconds"),
     }
-    runtime["hosting"] = _hosting_metrics(cfg, safety, env_info)
+    runtime["hosting"] = _hosting_metrics(cfg, safety, env_info, runtime["gateway"])
     runtime["dataFlow"] = _data_flow(runtime)
     runtime["preflight"] = _preflight_checks(runtime, home)
     runtime["customization"] = _customization_runtime(runtime)
@@ -1829,8 +1896,8 @@ def _readiness_for_step(step: dict[str, Any], runtime: dict[str, Any]) -> Capabi
         return _state("active", ["/mission-control route exposes this blueprint", f"auth mode: {dash.get('authMode')}", f"bind exposure: {dash.get('bindExposure')}"], "Keep coverage, runtime evidence, and privacy boundaries distinct.")
     if step_id == "step-25":
         host = runtime["hosting"]
-        status = "active" if host.get("hardenedContainer") else ("partial" if host.get("containerized") or host.get("meshVpnSignal") or safety.get("terminalBackend") != "local" else "watch")
-        return _state(status, [f"install method: {host.get('installMethod')}", f"terminal backend: {host.get('terminalBackend')}", f"mesh VPN signal: {host.get('meshVpnSignal')}"], "Prefer low-cost VPS/mesh networking over public dashboard exposure.")
+        status = "active" if (host.get("hardenedContainer") or host.get("managedService")) else ("partial" if host.get("containerized") or host.get("meshVpnSignal") or safety.get("terminalBackend") != "local" else "watch")
+        return _state(status, [f"install method: {host.get('installMethod')}", f"terminal backend: {host.get('terminalBackend')}", f"managed service: {host.get('managedService')}", f"mesh VPN signal: {host.get('meshVpnSignal')}"], "Prefer low-cost VPS/mesh networking over public dashboard exposure.")
     if step_id == "step-26":
         q = runtime["quality"]
         status = "active" if q.get("pythonMissionControlTestsPresent") and q.get("frontendBuildScriptPresent") else "partial"
@@ -1861,7 +1928,9 @@ def _readiness_for_step(step: dict[str, Any], runtime: dict[str, Any]) -> Capabi
     if domain == "dashboard":
         return _state("active", ["/mission-control route exposes this blueprint", "server-only snapshot protects local state"], "Keep coverage and readiness distinct.")
     if domain == "hosting":
-        return _state("partial", [f"terminal backend: {safety['terminalBackend']}", "hosting posture depends on deployment target"], "Prefer low-cost VPS/mesh networking over low-value complexity.")
+        host = runtime["hosting"]
+        status = "active" if host.get("managedService") else ("partial" if host.get("installMethod") != "unknown" else "watch")
+        return _state(status, [f"install method: {host.get('installMethod')}", f"managed service: {host.get('managedService')}", f"terminal backend: {safety['terminalBackend']}"], "Prefer low-cost VPS/mesh networking over low-value complexity.")
     if domain == "quality":
         return _state("partial", ["Mission Control tests/build scripts are discoverable", "latest pass/fail evidence comes from verification runs"], "Run browser smoke on desktop and mobile before shipping.")
     if domain in {"configuration", "identity", "runtime", "agent-loop"}:

--- a/hermes_cli/mission_control.py
+++ b/hermes_cli/mission_control.py
@@ -447,6 +447,53 @@ def _compact_path(path: Path | str | None, home: Path | None = None) -> str | No
     return name or "configured"
 
 
+def _source_label(value: Any) -> str | None:
+    """Return a platform/source family without exposing IDs or topic keys."""
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return None
+    known = {
+        "api",
+        "cli",
+        "cron",
+        "discord",
+        "email",
+        "feishu",
+        "gateway",
+        "homeassistant",
+        "local",
+        "matrix",
+        "signal",
+        "slack",
+        "sms",
+        "telegram",
+        "web",
+        "whatsapp",
+        "yuanbao",
+    }
+    for name in known:
+        if raw == name or raw.startswith(f"{name}:") or raw.startswith(f"{name}/"):
+            return name
+    return "other"
+
+
+def _safe_model_label(value: Any) -> str:
+    """Return a model label while collapsing local file paths to a filename."""
+    raw = str(value or "auto").strip()
+    if not raw:
+        return "auto"
+    lower = raw.lower()
+    looks_like_path = (
+        raw.startswith(("/", "~", "./", "../"))
+        or "\\" in raw
+        or (len(raw) > 2 and raw[1:3] == ":\\")
+        or lower.endswith((".gguf", ".safetensors", ".bin", ".pt", ".pth", ".onnx"))
+    )
+    if looks_like_path:
+        return "local-model"
+    return raw
+
+
 def _read_json(path: Path) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -603,11 +650,12 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                 if "actual_cost_usd" in cols:
                     base["todayActualCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(actual_cost_usd), 0) FROM sessions WHERE started_at >= ?", (day_start,)).fetchone()[0] or 0), 4)
             if "source" in cols:
-                base["sources"] = {
-                    str(row[0]): _safe_int(row[1])
-                    for row in con.execute("SELECT source, COUNT(*) FROM sessions GROUP BY source ORDER BY COUNT(*) DESC LIMIT 12")
-                    if row[0]
-                }
+                source_counts: dict[str, int] = {}
+                for row in con.execute("SELECT source, COUNT(*) FROM sessions GROUP BY source ORDER BY COUNT(*) DESC LIMIT 50"):
+                    label = _source_label(row[0])
+                    if label:
+                        source_counts[label] = source_counts.get(label, 0) + _safe_int(row[1])
+                base["sources"] = dict(sorted(source_counts.items(), key=lambda item: item[1], reverse=True)[:12])
             order_col = "started_at" if "started_at" in cols else "rowid"
             select_cols = [c for c in ["source", "model", "started_at", "message_count", "tool_call_count"] if c in cols]
             if select_cols:
@@ -616,9 +664,9 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                     raw = dict(row)
                     item: dict[str, Any] = {}
                     if raw.get("source"):
-                        item["source"] = str(raw.get("source"))
+                        item["source"] = _source_label(raw.get("source")) or "other"
                     if raw.get("model"):
-                        item["model"] = str(raw.get("model"))
+                        item["model"] = _safe_model_label(raw.get("model"))
                     if "message_count" in raw:
                         item["messageCount"] = _safe_int(raw.get("message_count"), 0)
                     if "tool_call_count" in raw:
@@ -731,9 +779,11 @@ def _analytics_metrics(sessions: dict[str, Any], cfg: dict[str, Any]) -> dict[st
     }
 
 
-def _dashboard_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
-    dashboard = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
-    bind = str(dashboard.get("host") or dashboard.get("bind") or "127.0.0.1")
+def _dashboard_metrics(cfg: dict[str, Any], env_info: dict[str, Any], runtime_state: dict[str, Any] | None = None) -> dict[str, Any]:
+    raw_dashboard = cfg.get("dashboard") if isinstance(cfg, dict) else None
+    dashboard: dict[str, Any] = raw_dashboard if isinstance(raw_dashboard, dict) else {}
+    runtime_state = runtime_state or {}
+    bind = str(runtime_state.get("bound_host") or dashboard.get("host") or dashboard.get("bind") or "127.0.0.1")
     if bind in {"127.0.0.1", "localhost", "::1"}:
         exposure = "loopback"
     elif bind.startswith("10.") or bind.startswith("192.168.") or bind.startswith("172."):
@@ -742,13 +792,19 @@ def _dashboard_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[st
         exposure = "public"
     else:
         exposure = "unknown"
+    oauth_required = bool(runtime_state.get("auth_required")) if "auth_required" in runtime_state else False
+    token_present = bool((env_info.get("dashboard") or {}).get("tokenPresent")) if isinstance(env_info.get("dashboard"), dict) else False
+    auth_gated = bool(oauth_required or token_present or exposure == "loopback")
+    auth_mode = "oauth-cookie" if oauth_required else ("session-token" if token_present or exposure == "loopback" else "not-gated")
     return {
         "missionControlRoute": "/mission-control",
         "sourceRoute": SOURCE_URL,
-        "authGated": True,
-        "authMode": "session-token-or-oauth-cookie",
-        "dashboardTokenPresent": bool((env_info.get("dashboard") or {}).get("tokenPresent")) if isinstance(env_info.get("dashboard"), dict) else False,
+        "authGated": auth_gated,
+        "authMode": auth_mode,
+        "oauthGateRequired": oauth_required,
+        "dashboardTokenPresent": token_present,
         "bindExposure": exposure,
+        "runtimeHostKnown": bool(runtime_state.get("bound_host")),
         "panels": {
             "memoryBrowser": True,
             "activityFeed": True,
@@ -926,10 +982,7 @@ def _skill_metrics(home: Path) -> dict[str, Any]:
     for p in files:
         try:
             rel = p.relative_to(skill_root)
-            if len(rel.parts) <= 2:
-                category = "uncategorized"
-            else:
-                category = rel.parts[0]
+            category = "direct" if len(rel.parts) <= 2 else "grouped"
             by_category[category] = by_category.get(category, 0) + 1
             raw = p.read_text(encoding="utf-8", errors="ignore")[:4000]
             low = raw.lower()
@@ -1034,7 +1087,8 @@ def _mcp_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
         servers.update(nested_servers)
     return {
         "configured": len(servers),
-        "servers": sorted(str(k) for k in servers.keys())[:12],
+        "servers": [f"server-{idx}" for idx, _ in enumerate(sorted(servers.keys())[:12], start=1)],
+        "serverNamesRedacted": True,
         "enabled": sum(1 for v in servers.values() if not (isinstance(v, dict) and v.get("enabled") is False)),
     }
 
@@ -1046,10 +1100,10 @@ def _model_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     agent: dict[str, Any] = raw_agent if isinstance(raw_agent, dict) else {}
     delegation: dict[str, Any] = raw_delegation if isinstance(raw_delegation, dict) else {}
     if isinstance(raw_model, dict):
-        model_name = str(raw_model.get("default") or raw_model.get("model") or raw_model.get("name") or "auto")
+        model_name = _safe_model_label(raw_model.get("default") or raw_model.get("model") or raw_model.get("name") or "auto")
         provider = raw_model.get("provider") or cfg.get("provider")
     else:
-        model_name = str(raw_model or "auto")
+        model_name = _safe_model_label(raw_model or "auto")
         provider = cfg.get("provider")
     if not isinstance(provider, str) or not provider.strip():
         provider = model_name.split("/", 1)[0] if "/" in model_name else "auto"
@@ -1185,11 +1239,11 @@ def _identity_metrics(home: Path) -> dict[str, Any]:
         "files": [_compact_path(p, home) for p in files[:8]],
     }
 
-def _build_runtime(cfg: dict[str, Any], home: Path) -> dict[str, Any]:
+def _build_runtime(cfg: dict[str, Any], home: Path, dashboard_state: dict[str, Any] | None = None) -> dict[str, Any]:
     env_info = _env_families(home)
     sessions = _state_db_metrics(home)
     safety = _safety_metrics(cfg)
-    dashboard = _dashboard_metrics(cfg, env_info)
+    dashboard = _dashboard_metrics(cfg, env_info, dashboard_state)
     runtime = {
         "generatedAt": _now_iso(),
         "home": "~/.hermes",
@@ -1483,7 +1537,7 @@ def _privacy_boundaries() -> list[dict[str, str]]:
         {"label": "Source guide", "policy": "static public", "detail": "Blueprint sections are public source metadata and safe to render in full."},
     ]
 
-def build_mission_control_snapshot() -> dict[str, Any]:
+def build_mission_control_snapshot(dashboard_state: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return a deterministic, privacy-minimized Mission Control snapshot."""
     home = _home()
     try:
@@ -1492,7 +1546,7 @@ def build_mission_control_snapshot() -> dict[str, Any]:
         cfg = {}
     if not isinstance(cfg, dict):
         cfg = {}
-    runtime = _build_runtime(cfg, home)
+    runtime = _build_runtime(cfg, home, dashboard_state)
     coverage = _coverage(runtime)
     return {
         "ok": True,

--- a/hermes_cli/mission_control.py
+++ b/hermes_cli/mission_control.py
@@ -298,6 +298,105 @@ OPENCLAW_FEATURES: list[dict[str, str]] = [
     {"id": "O10", "title": "Tailscale-recommended self-host", "summary": "Mesh-VPN to a home server with no public ports.", "where": "Step 25", "domain": "hosting"},
 ]
 
+ARCHITECTURE_PIECES: list[dict[str, str]] = [
+    {"id": "agent-loop", "title": "Agent loop", "summary": "Prompt bauen, Modell aufrufen, Tools ausführen, Beobachtungen zurückführen.", "route": "/chat"},
+    {"id": "memory", "title": "3-tier memory", "summary": "Profil-/Core-Dateien, SQLite-Episoden und optional semantische Vektoren.", "route": "/sessions"},
+    {"id": "tools", "title": "Tool system", "summary": "Typed tools, Toolsets, MCP und kontrollierte Ausführung statt reiner Chatbot.", "route": "/system"},
+    {"id": "llm", "title": "LLM layer", "summary": "Provider-/Modellrouting mit Reasoning-, Kosten- und Token-Signalen.", "route": "/models"},
+    {"id": "telegram", "title": "Messaging gateway", "summary": "Telegram/weitere Adapter mit Whitelist, Pairing und Home-Channel-Konzept.", "route": "/channels"},
+    {"id": "scheduler", "title": "Heartbeat scheduler", "summary": "Cronjobs für proaktive Checks, Reflection und wiederkehrende Workflows.", "route": "/cron"},
+    {"id": "mcp", "title": "MCP bridge", "summary": "Externe Toolserver werden namenspaced und sicher in den Toolkatalog aufgenommen.", "route": "/mcp"},
+]
+
+PREREQUISITES: list[dict[str, str]] = [
+    {"id": "node", "title": "Node 20+", "summary": "Für das React/Vite-Dashboard und Plugin-Frontend.", "route": "/system"},
+    {"id": "telegram", "title": "Telegram account", "summary": "Messaging-Interface und optionale Voice Notes.", "route": "/channels"},
+    {"id": "llm-key", "title": "LLM API key", "summary": "Anthropic/OpenRouter/OpenAI/Ollama oder lokaler Provider.", "route": "/models"},
+    {"id": "pinecone", "title": "Optional Pinecone", "summary": "Semantische Erinnerung nur wenn Key/Index vorhanden sind.", "route": "/system"},
+    {"id": "supabase", "title": "Optional Supabase", "summary": "Nur anzeigen wenn konfiguriert; kein Secret-Wert im Snapshot.", "route": "/env"},
+]
+
+PREFLIGHT_CHECKS: list[dict[str, str]] = [
+    {"id": "env_gitignored", "title": ".env nicht committen", "summary": "Env-Datei muss in .gitignore abgedeckt sein.", "route": "/env"},
+    {"id": "rotatable_secrets", "title": "Keys rotierbar", "summary": "Dashboard zeigt nur Präsenz/Familien, keine Werte.", "route": "/env"},
+    {"id": "allowed_users", "title": "User whitelist", "summary": "Telegram/Pairing müssen auf erlaubte Nutzer begrenzt sein.", "route": "/channels"},
+    {"id": "private_chats", "title": "Group chats rejected", "summary": "Gateway sollte private Chat Boundaries unterstützen.", "route": "/channels"},
+    {"id": "sandbox_shell", "title": "Shell sandbox", "summary": "Destruktive Shell/File-Tools brauchen Isolation oder Approval.", "route": "/system"},
+    {"id": "file_allowlist", "title": "File allowlist", "summary": "Dateizugriff sollte bewusst scoped sein.", "route": "/system"},
+    {"id": "dashboard_auth", "title": "Dashboard auth + bind", "summary": "Mission Control muss token-/cookie-geschützt sein und nicht blind öffentlich exponiert werden.", "route": "/mission-control"},
+    {"id": "cost_threshold", "title": "Cost alerts", "summary": "Budgetschwellen schützen vor stiller Modellkosten-Eskalation.", "route": "/analytics"},
+    {"id": "pinecone_scoped", "title": "Pinecone key scoped", "summary": "Projekt- statt Account-Key; Verifikation ist meist manuell.", "route": "/system"},
+    {"id": "voice_key_separation", "title": "Whisper key separation", "summary": "OpenAI Whisper darf nicht implizit Anthropic/OpenRouter-Keys verwenden.", "route": "/channels"},
+    {"id": "approval_flow", "title": "Approval flow", "summary": "Destruktive/teure Tools müssen explizit freigegeben werden.", "route": "/system"},
+]
+
+CUSTOMIZATION_CHECKLIST: list[dict[str, str]] = [
+    {"id": "soul", "title": "Soul / user profile", "summary": "Persönliche Stimme und stabile Präferenzen vorhanden.", "route": "/config"},
+    {"id": "tools", "title": "Tools", "summary": "Nur Toolsets aktivieren, die echten Operator-Nutzen haben.", "route": "/system"},
+    {"id": "heartbeats", "title": "Heartbeats", "summary": "Morning kick, Recap oder Review als Cronjobs.", "route": "/cron"},
+    {"id": "memory-categories", "title": "Memory categories", "summary": "Core facts, User prefs, Skills und Episoden sauber getrennt.", "route": "/sessions"},
+    {"id": "skill-seeds", "title": "Skill seeds", "summary": "Wiederkehrende Workflows als SKILL.md verfügbar.", "route": "/skills"},
+    {"id": "model-choice", "title": "Model choice", "summary": "Taste/Reasoning/Bulk/Private bewusst routen.", "route": "/models"},
+    {"id": "hosting", "title": "Hosting", "summary": "Docker/VPS/systemd/Railway-Entscheidung und Netzgrenze.", "route": "/system"},
+    {"id": "reflection-prompt", "title": "Reflection prompt", "summary": "Consolidation-Shape passt zur Domäne.", "route": "/cron"},
+    {"id": "approval-threshold", "title": "Approval threshold", "summary": "Welche Tools manuell bestätigt werden müssen.", "route": "/system"},
+]
+
+NEXT_TOOLS: list[dict[str, str]] = [
+    {"id": "youtube", "title": "YouTube tool", "summary": "Search, transcript, comments.", "route": "/skills"},
+    {"id": "gmail", "title": "Gmail via MCP", "summary": "Read, draft, label.", "route": "/mcp"},
+    {"id": "calendar", "title": "Calendar via MCP", "summary": "List, create, suggest times.", "route": "/mcp"},
+    {"id": "notion", "title": "Notion via MCP", "summary": "Search, create, update pages.", "route": "/mcp"},
+    {"id": "invoice", "title": "Invoice generator", "summary": "Branded PDF generation.", "route": "/skills"},
+    {"id": "web-research", "title": "Web research", "summary": "Firecrawl/Perplexity-style research.", "route": "/system"},
+    {"id": "bank", "title": "Bank summariser", "summary": "Finance ingestion stays opt-in and approval-gated.", "route": "/mcp"},
+    {"id": "meeting", "title": "Meeting transcriber", "summary": "Granola/Otter ingest or local audio pipeline.", "route": "/skills"},
+]
+
+GLOSSARY: list[dict[str, str]] = [
+    {"id": "agent-loop", "term": "Agent loop", "definition": "Reasoning/action loop that keeps using tools until a final answer is ready."},
+    {"id": "core-memory", "term": "Core memory", "definition": "Small durable facts injected into future turns."},
+    {"id": "conversation-buffer", "term": "Conversation buffer", "definition": "Recent messages available for continuity and recall."},
+    {"id": "semantic-memory", "term": "Semantic memory", "definition": "Vector search over prior conversations or knowledge."},
+    {"id": "soul", "term": "Soul / system prompt", "definition": "Operator identity, style, safety and tool-use contract."},
+    {"id": "heartbeat", "term": "Heartbeat", "definition": "Scheduled proactive job that can message or act later."},
+    {"id": "tool", "term": "Tool", "definition": "Typed external capability the model can call."},
+    {"id": "mcp", "term": "MCP", "definition": "Model Context Protocol for attaching external tools."},
+    {"id": "reflection", "term": "Reflection", "definition": "Consolidation pass that extracts reusable facts and lessons."},
+    {"id": "skill", "term": "Skill", "definition": "Portable procedure file loaded on demand."},
+    {"id": "progressive-disclosure", "term": "Progressive disclosure", "definition": "Load summaries first, full skill/reference only when needed."},
+]
+
+TROUBLESHOOTING: list[dict[str, str]] = [
+    {"id": "not-authorised", "symptom": "Bot replies Not authorised", "cause": "Telegram ID missing from allowed users", "fix": "Update whitelist and restart gateway", "route": "/channels"},
+    {"id": "mid-task-stop", "symptom": "Agent stops mid-task", "cause": "Iteration/turn budget or tool spiral", "fix": "Inspect sessions/tool counts and raise cap intentionally", "route": "/sessions"},
+    {"id": "message-not-modified", "symptom": "message is not modified", "cause": "Streaming edit repeated identical content", "fix": "Debounce and skip unchanged edits", "route": "/channels"},
+    {"id": "telegram-429", "symptom": "Telegram 429", "cause": "Edits faster than rate limits", "fix": "Debounce to roughly one second", "route": "/channels"},
+    {"id": "pinecone-empty", "symptom": "Pinecone empty results", "cause": "Index not initialised or wrong index", "fix": "Verify key/index presence and wait for readiness", "route": "/system"},
+    {"id": "never-calls-tools", "symptom": "Agent never calls tools", "cause": "Tool descriptions/tool_choice/disabled toolset", "fix": "Inspect enabled toolsets and descriptions", "route": "/system"},
+    {"id": "reflection-wipes", "symptom": "Reflection wipes memory", "cause": "Existing facts not injected", "fix": "Reflection prompt must merge, not replace", "route": "/cron"},
+    {"id": "voice-empty", "symptom": "Voice transcription empty", "cause": "Opus/ffmpeg/provider mismatch", "fix": "Verify STT provider and conversion path", "route": "/channels"},
+    {"id": "heartbeat-time", "symptom": "Heartbeat wrong time", "cause": "Server timezone mismatch", "fix": "Set timezone in job/config", "route": "/cron"},
+    {"id": "raw-json-tools", "symptom": "Tool calls return raw JSON", "cause": "Formatter/parsing boundary missing", "fix": "Format tool results consistently as data", "route": "/system"},
+]
+
+RESOURCES: list[dict[str, str]] = [
+    {"id": "anthropic-tools", "title": "Anthropic Tool Use docs", "url": "https://docs.anthropic.com/"},
+    {"id": "openai-functions", "title": "OpenAI Function Calling", "url": "https://platform.openai.com/docs/"},
+    {"id": "mcp", "title": "Model Context Protocol", "url": "https://modelcontextprotocol.io/"},
+    {"id": "telegraf", "title": "Telegraf", "url": "https://telegraf.js.org/"},
+    {"id": "pinecone", "title": "Pinecone Node SDK", "url": "https://docs.pinecone.io/"},
+    {"id": "openrouter", "title": "OpenRouter", "url": "https://openrouter.ai/docs"},
+]
+
+DATA_FLOW_SURFACES: list[dict[str, str]] = [
+    {"id": "telegram", "label": "Telegram", "dataSent": "messages / voice / files", "retention": "Telegram-side retention; not E2E for bot chats"},
+    {"id": "llm", "label": "LLM provider", "dataSent": "prompt + selected memory/context", "retention": "provider-specific"},
+    {"id": "pinecone", "label": "Pinecone", "dataSent": "embeddings / metadata", "retention": "until index deletion"},
+    {"id": "whisper", "label": "OpenAI Whisper", "dataSent": "voice-note audio when STT is enabled", "retention": "provider-specific"},
+    {"id": "sqlite", "label": "Local SQLite", "dataSent": "local conversation/session metadata", "retention": "local disk until deleted"},
+]
+
 _STATE_WEIGHT = {"active": 100, "partial": 68, "watch": 38, "planned": 18}
 
 
@@ -357,9 +456,9 @@ def _read_json(path: Path) -> Any:
 
 def _env_families(home: Path) -> dict[str, Any]:
     env_path = home / ".env"
-    families: set[str] = set()
-    configured = 0
+    raw_keys: dict[str, str] = {}
     present_keys = 0
+    configured = 0
     if env_path.exists():
         for raw in env_path.read_text(encoding="utf-8", errors="ignore").splitlines():
             line = raw.strip()
@@ -368,40 +467,74 @@ def _env_families(home: Path) -> dict[str, Any]:
             key, value = line.split("=", 1)
             key = key.strip()
             value = value.strip().strip('"\'')
+            if not key:
+                continue
             present_keys += 1
+            raw_keys[key.upper()] = value
             if value:
                 configured += 1
-            upper = key.upper()
-            if "TELEGRAM" in upper:
-                families.add("telegram")
-            elif "DISCORD" in upper:
-                families.add("discord")
-            elif "SLACK" in upper:
-                families.add("slack")
-            elif "OPENROUTER" in upper:
-                families.add("openrouter")
-            elif "ANTHROPIC" in upper:
-                families.add("anthropic")
-            elif "OPENAI" in upper or "VOICE_TOOLS_OPENAI" in upper:
-                families.add("openai")
-            elif "PINECONE" in upper:
-                families.add("pinecone")
-            elif "SUPABASE" in upper:
-                families.add("supabase")
-            elif "GEMINI" in upper or "GOOGLE" in upper:
-                families.add("gemini")
-            elif "HASS" in upper or "HOMEASSISTANT" in upper:
-                families.add("homeassistant")
-            elif value:
-                families.add("other")
+
+    def present(*names: str) -> bool:
+        return any(bool(raw_keys.get(name.upper())) for name in names)
+
+    def count_csv(*names: str) -> int:
+        for name in names:
+            value = raw_keys.get(name.upper(), "")
+            if value:
+                return len([p for p in value.replace(";", ",").split(",") if p.strip()])
+        return 0
+
+    family_tests = {
+        "telegram": lambda k: "TELEGRAM" in k or k in {"ALLOWED_USER_IDS"},
+        "discord": lambda k: "DISCORD" in k,
+        "slack": lambda k: "SLACK" in k,
+        "matrix": lambda k: "MATRIX" in k,
+        "signal": lambda k: "SIGNAL" in k,
+        "email": lambda k: any(s in k for s in ["SMTP", "IMAP", "EMAIL"]),
+        "sms": lambda k: any(s in k for s in ["TWILIO", "SMS"]),
+        "openrouter": lambda k: "OPENROUTER" in k,
+        "anthropic": lambda k: "ANTHROPIC" in k,
+        "openai": lambda k: "OPENAI" in k or "WHISPER" in k,
+        "ollama": lambda k: "OLLAMA" in k,
+        "pinecone": lambda k: "PINECONE" in k,
+        "supabase": lambda k: "SUPABASE" in k,
+        "gemini": lambda k: "GEMINI" in k or "GOOGLE" in k,
+        "tailscale": lambda k: "TAILSCALE" in k or "TS_" in k,
+        "homeassistant": lambda k: "HASS" in k or "HOMEASSISTANT" in k,
+    }
+    families = sorted({family for key, value in raw_keys.items() if value for family, test in family_tests.items() if test(key)})
+    llm_families = [f for f in families if f in {"anthropic", "openai", "openrouter", "gemini", "ollama"}]
+    required = [
+        {"key": "TELEGRAM_BOT_TOKEN", "category": "telegram", "isSet": present("TELEGRAM_BOT_TOKEN")},
+        {"key": "ALLOWED_USER_IDS", "category": "telegram", "isSet": present("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS"), "count": count_csv("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS")},
+        {"key": "LLM_API_KEY", "category": "model", "isSet": bool(llm_families)},
+        {"key": "DASHBOARD_TOKEN", "category": "dashboard", "isSet": present("DASHBOARD_TOKEN", "HERMES_DASHBOARD_TOKEN")},
+    ]
+    optional = [
+        {"key": "PINECONE_API_KEY", "category": "semantic", "isSet": present("PINECONE_API_KEY")},
+        {"key": "PINECONE_INDEX", "category": "semantic", "isSet": present("PINECONE_INDEX", "PINECONE_INDEX_NAME")},
+        {"key": "OPENAI_API_KEY", "category": "voice", "isSet": present("OPENAI_API_KEY")},
+        {"key": "SUPABASE_URL", "category": "storage", "isSet": present("SUPABASE_URL")},
+        {"key": "TAILSCALE_AUTHKEY", "category": "network", "isSet": present("TAILSCALE_AUTHKEY")},
+    ]
     return {
         "filePresent": env_path.exists(),
         "path": _compact_path(env_path, home),
         "presentKeys": present_keys,
         "configuredKeys": configured,
-        "families": sorted(families),
+        "families": families,
+        "llmFamilies": llm_families,
+        "requiredKeys": required,
+        "optionalKeys": optional,
+        "telegram": {
+            "tokenPresent": present("TELEGRAM_BOT_TOKEN"),
+            "allowedUserCount": count_csv("ALLOWED_USER_IDS", "TELEGRAM_ALLOWED_USER_IDS"),
+        },
+        "dashboard": {"tokenPresent": present("DASHBOARD_TOKEN", "HERMES_DASHBOARD_TOKEN")},
+        "semantic": {"pineconeKeyPresent": present("PINECONE_API_KEY"), "pineconeIndexPresent": present("PINECONE_INDEX", "PINECONE_INDEX_NAME")},
+        "voice": {"openaiKeyPresent": present("OPENAI_API_KEY")},
+        "network": {"tailscaleSignalPresent": present("TAILSCALE_AUTHKEY") or "tailscale" in families},
     }
-
 
 def _state_db_metrics(home: Path) -> dict[str, Any]:
     path = home / "state.db"
@@ -412,21 +545,35 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
         "active": 0,
         "archived": 0,
         "messages": 0,
+        "activeMessages": 0,
         "toolCalls": 0,
         "inputTokens": 0,
         "outputTokens": 0,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
         "reasoningTokens": 0,
+        "apiCalls": 0,
         "estimatedCostUsd": 0.0,
+        "actualCostUsd": 0.0,
+        "todayEstimatedCostUsd": 0.0,
+        "todayActualCostUsd": 0.0,
         "sources": {},
         "recent": [],
         "latestAgeSeconds": None,
+        "ftsPresent": False,
+        "trigramFtsPresent": False,
+        "summaries": 0,
+        "stateMetaRows": 0,
     }
     if not path.exists():
         return base
+    con: sqlite3.Connection | None = None
     try:
         con = sqlite3.connect(path)
         con.row_factory = sqlite3.Row
-        tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")}
+        base["ftsPresent"] = any("fts" in name.lower() for name in tables)
+        base["trigramFtsPresent"] = any("trigram" in name.lower() for name in tables)
         if "sessions" in tables:
             cols = {r[1] for r in con.execute("PRAGMA table_info(sessions)")}
             base["total"] = _safe_int(con.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
@@ -439,21 +586,30 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                 ("tool_call_count", "toolCalls"),
                 ("input_tokens", "inputTokens"),
                 ("output_tokens", "outputTokens"),
+                ("cache_read_tokens", "cacheReadTokens"),
+                ("cache_write_tokens", "cacheWriteTokens"),
                 ("reasoning_tokens", "reasoningTokens"),
+                ("api_call_count", "apiCalls"),
             ]:
                 if column in cols:
                     base[key] = _safe_int(con.execute(f"SELECT COALESCE(SUM({column}), 0) FROM sessions").fetchone()[0])
-            if "estimated_cost_usd" in cols:
-                base["estimatedCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM sessions").fetchone()[0] or 0), 4)
+            for column, key in [("estimated_cost_usd", "estimatedCostUsd"), ("actual_cost_usd", "actualCostUsd")]:
+                if column in cols:
+                    base[key] = round(float(con.execute(f"SELECT COALESCE(SUM({column}), 0) FROM sessions").fetchone()[0] or 0), 4)
+            if "started_at" in cols:
+                day_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
+                if "estimated_cost_usd" in cols:
+                    base["todayEstimatedCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM sessions WHERE started_at >= ?", (day_start,)).fetchone()[0] or 0), 4)
+                if "actual_cost_usd" in cols:
+                    base["todayActualCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(actual_cost_usd), 0) FROM sessions WHERE started_at >= ?", (day_start,)).fetchone()[0] or 0), 4)
             if "source" in cols:
                 base["sources"] = {
                     str(row[0]): _safe_int(row[1])
                     for row in con.execute("SELECT source, COUNT(*) FROM sessions GROUP BY source ORDER BY COUNT(*) DESC LIMIT 12")
+                    if row[0]
                 }
             order_col = "started_at" if "started_at" in cols else "rowid"
-            # Keep recent activity privacy-minimized: session titles and IDs can
-            # be conversation-derived, so expose only coarse labels/counts/ages.
-            select_cols = [c for c in ["source", "model", "started_at", "message_count"] if c in cols]
+            select_cols = [c for c in ["source", "model", "started_at", "message_count", "tool_call_count"] if c in cols]
             if select_cols:
                 recent = []
                 for row in con.execute(f"SELECT {', '.join(select_cols)} FROM sessions ORDER BY {order_col} DESC LIMIT 6"):
@@ -465,6 +621,8 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                         item["model"] = str(raw.get("model"))
                     if "message_count" in raw:
                         item["messageCount"] = _safe_int(raw.get("message_count"), 0)
+                    if "tool_call_count" in raw:
+                        item["toolCallCount"] = _safe_int(raw.get("tool_call_count"), 0)
                     started = raw.get("started_at")
                     if isinstance(started, (int, float)):
                         item["startedAgeSeconds"] = max(0, int(time.time() - float(started)))
@@ -473,25 +631,318 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                     recent.append(item)
                 base["recent"] = recent
         if "messages" in tables:
+            msg_cols = {r[1] for r in con.execute("PRAGMA table_info(messages)")}
             base["messages"] = _safe_int(con.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
-        con.close()
+            if "active" in msg_cols:
+                base["activeMessages"] = _safe_int(con.execute("SELECT COUNT(*) FROM messages WHERE active=1").fetchone()[0])
+            else:
+                base["activeMessages"] = base["messages"]
+        if "summaries" in tables:
+            base["summaries"] = _safe_int(con.execute("SELECT COUNT(*) FROM summaries").fetchone()[0])
+        if "state_meta" in tables:
+            base["stateMetaRows"] = _safe_int(con.execute("SELECT COUNT(*) FROM state_meta").fetchone()[0])
     except Exception as exc:
         base["error"] = f"state-db-unavailable:{exc.__class__.__name__}"
+    finally:
+        if con is not None:
+            con.close()
     return base
 
+def _memory_metrics(home: Path, sessions: dict[str, Any]) -> dict[str, Any]:
+    memory_dir = home / "memories"
+    candidates = {
+        "memory": [home / "MEMORY.md", home / "memory.md", memory_dir / "MEMORY.md", memory_dir / "memory.md"],
+        "user": [home / "USER.md", home / "user.md", memory_dir / "USER.md", memory_dir / "user.md"],
+        "soul": [home / "soul.md", home / "SOUL.md"],
+    }
+    files: dict[str, dict[str, Any]] = {}
+    for label, paths in candidates.items():
+        existing = [p for p in paths if p.exists()]
+        files[label] = {"present": bool(existing), "bytes": sum(p.stat().st_size for p in existing), "locations": [_compact_path(p, home) for p in existing[:3]]}
+    return {
+        "files": files,
+        "sqlite": {
+            "dbPresent": bool(sessions.get("dbPresent")),
+            "sessions": _safe_int(sessions.get("total")),
+            "messages": _safe_int(sessions.get("messages")),
+            "ftsPresent": bool(sessions.get("ftsPresent")),
+            "trigramFtsPresent": bool(sessions.get("trigramFtsPresent")),
+            "summaries": _safe_int(sessions.get("summaries")),
+            "activeMessages": _safe_int(sessions.get("activeMessages")),
+            "archivedSessions": _safe_int(sessions.get("archived")),
+        },
+        "budgets": {
+            "memoryLimitChars": 2200,
+            "userLimitChars": 1375,
+            "configured": True,
+        },
+        "provider": {"active": "builtin", "configuredProviders": ["builtin"]},
+    }
+
+
+def _semantic_metrics(env_info: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
+    semantic_cfg = cfg.get("semantic") if isinstance(cfg.get("semantic"), dict) else {}
+    vector_cfg = cfg.get("vector") if isinstance(cfg.get("vector"), dict) else {}
+    provider = semantic_cfg.get("provider") or vector_cfg.get("provider") or ("pinecone" if "pinecone" in env_info.get("families", []) else "none")
+    env_sem = env_info.get("semantic", {}) if isinstance(env_info.get("semantic"), dict) else {}
+    index_configured = bool(env_sem.get("pineconeIndexPresent") or semantic_cfg.get("index") or vector_cfg.get("index"))
+    return {
+        "provider": provider,
+        "configured": provider != "none" or bool(env_sem.get("pineconeKeyPresent")) or index_configured,
+        "apiKeyPresent": bool(env_sem.get("pineconeKeyPresent")),
+        "indexConfigured": index_configured,
+        "projectScopedKeyVerified": "unknown" if env_sem.get("pineconeKeyPresent") else "not_configured",
+    }
+
+
+def _analytics_metrics(sessions: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
+    dashboard = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
+    threshold = dashboard.get("daily_cost_limit_usd") or dashboard.get("cost_alert_threshold_usd") or None
+    try:
+        threshold_f = float(threshold) if threshold is not None else None
+    except Exception:
+        threshold_f = None
+    today = float(sessions.get("todayActualCostUsd") or sessions.get("todayEstimatedCostUsd") or 0)
+    if threshold_f is None:
+        state = "not_configured"
+    elif today >= threshold_f:
+        state = "exceeded"
+    elif today >= threshold_f * 0.8:
+        state = "warning"
+    else:
+        state = "ok"
+    return {
+        "totals": {
+            "inputTokens": _safe_int(sessions.get("inputTokens")),
+            "outputTokens": _safe_int(sessions.get("outputTokens")),
+            "cacheReadTokens": _safe_int(sessions.get("cacheReadTokens")),
+            "cacheWriteTokens": _safe_int(sessions.get("cacheWriteTokens")),
+            "reasoningTokens": _safe_int(sessions.get("reasoningTokens")),
+            "apiCalls": _safe_int(sessions.get("apiCalls")),
+            "estimatedCostUsd": float(sessions.get("estimatedCostUsd") or 0),
+            "actualCostUsd": float(sessions.get("actualCostUsd") or 0),
+        },
+        "daily": {
+            "todayEstimatedCostUsd": float(sessions.get("todayEstimatedCostUsd") or 0),
+            "todayActualCostUsd": float(sessions.get("todayActualCostUsd") or 0),
+            "budgetThresholdUsd": threshold_f,
+            "budgetAlertState": state,
+        },
+    }
+
+
+def _dashboard_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
+    dashboard = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
+    bind = str(dashboard.get("host") or dashboard.get("bind") or "127.0.0.1")
+    if bind in {"127.0.0.1", "localhost", "::1"}:
+        exposure = "loopback"
+    elif bind.startswith("10.") or bind.startswith("192.168.") or bind.startswith("172."):
+        exposure = "private"
+    elif bind in {"0.0.0.0", "::"}:
+        exposure = "public"
+    else:
+        exposure = "unknown"
+    return {
+        "missionControlRoute": "/mission-control",
+        "sourceRoute": SOURCE_URL,
+        "authGated": True,
+        "authMode": "session-token-or-oauth-cookie",
+        "dashboardTokenPresent": bool((env_info.get("dashboard") or {}).get("tokenPresent")) if isinstance(env_info.get("dashboard"), dict) else False,
+        "bindExposure": exposure,
+        "panels": {
+            "memoryBrowser": True,
+            "activityFeed": True,
+            "skillLibrary": True,
+            "costAnalytics": True,
+            "productionReadiness": True,
+            "preflight": True,
+            "sourceCoverage": True,
+        },
+    }
+
+
+def _quality_metrics(home: Path) -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[1]
+    py_test = repo_root / "tests" / "hermes_cli" / "test_mission_control.py"
+    web_page = repo_root / "web" / "src" / "pages" / "MissionControlPage.tsx"
+    package_json = repo_root / "web" / "package.json"
+    build_script = False
+    if package_json.exists():
+        payload = _read_json(package_json)
+        build_script = isinstance(payload, dict) and "build" in (payload.get("scripts") or {})
+    return {
+        "pythonMissionControlTestsPresent": py_test.exists(),
+        "frontendRoutePresent": web_page.exists(),
+        "frontendBuildScriptPresent": build_script,
+        "lastPythonTestEvidence": None,
+        "frontendBuildEvidence": None,
+        "browserSmokeEvidence": None,
+    }
+
+
+def _multi_user_metrics(home: Path, env_info: dict[str, Any]) -> dict[str, Any]:
+    # Count only, no IDs/names/chat IDs. Pairing storage format has changed over
+    # time, so this is intentionally tolerant.
+    approved = 0
+    pending = 0
+    platform_count = 0
+    for candidate in [home / "gateway" / "pairings.json", home / "pairings.json", home / "gateway_pairings.json"]:
+        payload = _read_json(candidate)
+        if not isinstance(payload, (dict, list)):
+            continue
+        raw_items = payload.values() if isinstance(payload, dict) else payload
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            status = str(item.get("status") or item.get("state") or "").lower()
+            if status in {"approved", "active", "paired"}:
+                approved += 1
+            elif status in {"pending", "requested", "waiting"}:
+                pending += 1
+            if item.get("platform"):
+                platform_count += 1
+    telegram = env_info.get("telegram", {}) if isinstance(env_info.get("telegram"), dict) else {}
+    if approved == 0 and _safe_int(telegram.get("allowedUserCount")):
+        approved = _safe_int(telegram.get("allowedUserCount"))
+        platform_count = max(platform_count, 1)
+    return {
+        "approvedUserCount": approved,
+        "pendingUserCount": pending,
+        "platformCount": platform_count,
+        "memoryNamespaceSupported": True,
+        "singleUserMode": approved <= 1 and pending == 0,
+    }
+
+
+def _data_flow(runtime: dict[str, Any]) -> list[dict[str, Any]]:
+    env_info = runtime.get("env", {})
+    families = set(env_info.get("families", [])) if isinstance(env_info, dict) else set()
+    rows: list[dict[str, Any]] = []
+    for item in DATA_FLOW_SURFACES:
+        surface_id = item["id"]
+        configured = False
+        provider = None
+        if surface_id == "telegram":
+            configured = "telegram" in families or bool(runtime.get("gateway", {}).get("configuredCount"))
+        elif surface_id == "llm":
+            provider = runtime.get("model", {}).get("provider")
+            configured = bool(provider and provider != "auto")
+        elif surface_id == "pinecone":
+            configured = bool(runtime.get("semantic", {}).get("configured"))
+        elif surface_id == "whisper":
+            configured = bool(runtime.get("voice", {}).get("sttEnabled") or (env_info.get("voice") or {}).get("openaiKeyPresent"))
+        elif surface_id == "sqlite":
+            configured = bool(runtime.get("sessions", {}).get("dbPresent"))
+        rows.append({**item, "configured": configured, "provider": provider, "privacy": "metadata-only in this dashboard"})
+    return rows
+
+
+def _status_row(item: dict[str, str], status: str, evidence: list[str]) -> dict[str, Any]:
+    return {**item, "status": status, "evidence": [e for e in evidence if e][:3]}
+
+
+def _preflight_checks(runtime: dict[str, Any], home: Path) -> list[dict[str, Any]]:
+    env_info = runtime["env"]
+    safety = runtime["safety"]
+    dashboard = runtime["dashboard"]
+    semantic = runtime["semantic"]
+    voice = runtime["voice"]
+    gateway = runtime["gateway"]
+    analytics = runtime["analytics"]
+    gitignore = home / ".gitignore"
+    gitignore_text = gitignore.read_text(encoding="utf-8", errors="ignore") if gitignore.exists() else ""
+    checks: dict[str, tuple[str, list[str]]] = {
+        "env_gitignored": ("pass" if ".env" in gitignore_text or "*.env" in gitignore_text else "unknown", [f".env file present: {env_info['filePresent']}", f".gitignore present: {gitignore.exists()}"]),
+        "rotatable_secrets": ("pass", [f"{env_info['configuredKeys']} configured env value(s) reduced to booleans/counts"]),
+        "allowed_users": ("pass" if (env_info.get("telegram") or {}).get("allowedUserCount") else ("unknown" if not (env_info.get("telegram") or {}).get("tokenPresent") else "fail"), [f"allowed user count: {(env_info.get('telegram') or {}).get('allowedUserCount', 0)}"]),
+        "private_chats": ("pass" if gateway.get("configuredCount") else "unknown", ["gateway adapters enforce platform-specific auth boundaries"]),
+        "sandbox_shell": ("pass" if safety.get("terminalIsolated") else ("warn" if safety.get("approvalFlowConfigured") else "fail"), [f"terminal backend: {safety.get('terminalBackend')}", f"approvals: {safety.get('approvalsMode')}"]),
+        "file_allowlist": ("unknown", ["file allowlist is toolset/config specific; no raw paths exposed here"]),
+        "dashboard_auth": ("pass" if dashboard.get("authGated") and dashboard.get("bindExposure") != "public" else "warn", [f"auth: {dashboard.get('authMode')}", f"bind: {dashboard.get('bindExposure')}"]),
+        "cost_threshold": ("pass" if analytics.get("daily", {}).get("budgetAlertState") in {"ok", "warning", "exceeded"} else "unknown", [f"budget state: {analytics.get('daily', {}).get('budgetAlertState')}"]),
+        "pinecone_scoped": ("unknown" if semantic.get("apiKeyPresent") else "not_applicable", [f"pinecone configured: {semantic.get('configured')}", "key scope cannot be proven from local metadata"]),
+        "voice_key_separation": ("pass" if (not voice.get("sttEnabled") or (env_info.get("voice") or {}).get("openaiKeyPresent") or voice.get("sttProvider") not in {"openai", "whisper"}) else "warn", [f"STT provider: {voice.get('sttProvider') or 'not enabled'}", f"OpenAI key present: {(env_info.get('voice') or {}).get('openaiKeyPresent', False)}"]),
+        "approval_flow": ("pass" if safety.get("approvalFlowConfigured") else "fail", [f"approvals mode: {safety.get('approvalsMode')}"]),
+    }
+    return [_status_row(item, *checks.get(item["id"], ("unknown", []))) for item in PREFLIGHT_CHECKS]
+
+
+def _customization_runtime(runtime: dict[str, Any]) -> list[dict[str, Any]]:
+    checks: dict[str, tuple[str, list[str]]] = {
+        "soul": ("active" if runtime["identity"].get("soulPresent") else "partial", [f"profile files: {runtime['identity'].get('profileFiles', 0)}"]),
+        "tools": ("active" if runtime["tools"].get("configuredToolsetCount") else "partial", [f"toolsets: {runtime['tools'].get('configuredToolsetCount', 0)}"]),
+        "heartbeats": ("active" if runtime["cron"].get("heartbeatJobs") else ("partial" if runtime["cron"].get("enabled") else "watch"), [f"heartbeat jobs: {runtime['cron'].get('heartbeatJobs', 0)}"]),
+        "memory-categories": ("active" if runtime["memory"].get("sqlite", {}).get("dbPresent") else "partial", [f"FTS: {runtime['memory'].get('sqlite', {}).get('ftsPresent')}"]),
+        "skill-seeds": ("active" if runtime["skills"].get("total") else "watch", [f"skills: {runtime['skills'].get('total', 0)}"]),
+        "model-choice": ("active" if runtime["model"].get("model") != "auto" else "partial", [f"model: {runtime['model'].get('model')}"]),
+        "hosting": ("partial" if runtime["hosting"].get("installMethod") != "unknown" else "watch", [f"backend: {runtime['hosting'].get('terminalBackend')}"]),
+        "reflection-prompt": ("active" if runtime["reflection"].get("enabled") else "watch", [f"reflection jobs: {runtime['reflection'].get('jobs', 0)}"]),
+        "approval-threshold": ("active" if runtime["safety"].get("approvalFlowConfigured") else "watch", [f"mode: {runtime['safety'].get('approvalsMode')}"]),
+    }
+    return [_status_row(item, *checks.get(item["id"], ("unknown", []))) for item in CUSTOMIZATION_CHECKLIST]
+
+
+def _production_readiness(runtime: dict[str, Any]) -> dict[str, Any]:
+    signals = [
+        {"id": "dashboard-auth", "label": "Dashboard auth", "status": "pass" if runtime["dashboard"].get("authGated") else "fail", "detail": runtime["dashboard"].get("authMode")},
+        {"id": "approvals", "label": "Approvals", "status": "pass" if runtime["safety"].get("approvalFlowConfigured") else "fail", "detail": runtime["safety"].get("approvalsMode")},
+        {"id": "redaction", "label": "Secret redaction", "status": "pass" if runtime["safety"].get("redactSecrets") else "fail", "detail": "values never serialized"},
+        {"id": "gateway", "label": "Gateway reachability", "status": "pass" if runtime["gateway"].get("running") else ("warn" if runtime["gateway"].get("configuredCount") else "unknown"), "detail": runtime["gateway"].get("state")},
+        {"id": "mcp", "label": "MCP", "status": "pass" if runtime["mcp"].get("configured") else "unknown", "detail": f"{runtime['mcp'].get('configured', 0)} configured"},
+        {"id": "cron", "label": "Cron", "status": "pass" if runtime["cron"].get("enabled") else "unknown", "detail": f"{runtime['cron'].get('enabled', 0)} enabled"},
+        {"id": "quality", "label": "Quality gates", "status": "pass" if runtime["quality"].get("pythonMissionControlTestsPresent") and runtime["quality"].get("frontendBuildScriptPresent") else "warn", "detail": "test/build hooks present; last run evidence shown after verification"},
+        {"id": "hosting", "label": "Hosting posture", "status": "pass" if runtime["hosting"].get("hardenedContainer") else ("warn" if runtime["hosting"].get("containerized") else "unknown"), "detail": runtime["hosting"].get("installMethod")},
+    ]
+    score_map = {"pass": 100, "warn": 60, "unknown": 35, "fail": 0, "not_applicable": 70}
+    score = round(sum(score_map.get(str(s.get("status")), 35) for s in signals) / len(signals)) if signals else 0
+    blockers = [s for s in signals if s.get("status") in {"fail", "warn"}]
+    return {"score": score, "signals": signals, "blockers": blockers[:5]}
+
+
+def _hosting_metrics(cfg: dict[str, Any], safety: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
+    terminal_backend = safety.get("terminalBackend") or "local"
+    install_method = "docker" if terminal_backend == "docker" else ("ssh" if terminal_backend == "ssh" else "unknown")
+    docker = cfg.get("docker") if isinstance(cfg.get("docker"), dict) else {}
+    hardened = None
+    if install_method == "docker" or docker:
+        hardened = bool(docker.get("read_only") or docker.get("cap_drop") == "ALL" or docker.get("non_root"))
+        install_method = "docker"
+    return {
+        "installMethod": install_method,
+        "terminalBackend": terminal_backend,
+        "containerized": install_method == "docker",
+        "hardenedContainer": hardened,
+        "meshVpnSignal": bool((env_info.get("network") or {}).get("tailscaleSignalPresent")) if isinstance(env_info.get("network"), dict) else False,
+        "publicPortSignal": None,
+    }
 
 def _skill_metrics(home: Path) -> dict[str, Any]:
     skill_root = home / "skills"
     files = list(skill_root.rglob("SKILL.md")) if skill_root.exists() else []
     by_category: dict[str, int] = {}
-    spotlight: list[dict[str, str]] = []
+    trust: dict[str, int] = {"builtin": 0, "official": 0, "trusted": 0, "community": 0, "unknown": 0}
+    agentskills = 0
+    auto_created = 0
     for p in files:
         try:
             rel = p.relative_to(skill_root)
-            category = rel.parts[0] if len(rel.parts) > 1 else "uncategorized"
+            if len(rel.parts) <= 2:
+                category = "uncategorized"
+            else:
+                category = rel.parts[0]
             by_category[category] = by_category.get(category, 0) + 1
-            if len(spotlight) < 6:
-                spotlight.append({"name": p.parent.name, "category": category})
+            raw = p.read_text(encoding="utf-8", errors="ignore")[:4000]
+            low = raw.lower()
+            if "description:" in low and ("name:" in low or "---" in low):
+                agentskills += 1
+            if "created_by: agent" in low or "author: hermes agent" in low:
+                auto_created += 1
+            level = "unknown"
+            for candidate in trust:
+                if f"trust: {candidate}" in low or f"trust_level: {candidate}" in low:
+                    level = candidate
+                    break
+            trust[level] = trust.get(level, 0) + 1
         except Exception:
             continue
     usage = _read_json(skill_root / ".usage.json") if skill_root.exists() else None
@@ -502,9 +953,11 @@ def _skill_metrics(home: Path) -> dict[str, Any]:
         "total": len(files),
         "usageTracked": usage_count,
         "categories": by_category,
-        "spotlight": spotlight,
+        "trustLevels": trust,
+        "agentskillsCompliant": agentskills,
+        "autoCreatedCount": auto_created,
+        "spotlight": [{"label": f"skill-{idx}", "category": cat} for idx, cat in enumerate(list(by_category.keys())[:6], start=1)],
     }
-
 
 def _cron_metrics(home: Path) -> dict[str, Any]:
     jobs_path = home / "cron" / "jobs.json"
@@ -521,27 +974,53 @@ def _cron_metrics(home: Path) -> dict[str, Any]:
         elif all(isinstance(v, dict) for v in payload.values()):
             jobs = [v for v in payload.values() if isinstance(v, dict)]
     enabled = 0
-    schedules: list[str] = []
+    cadences: dict[str, int] = {"daily": 0, "weekly": 0, "frequent": 0, "one-shot": 0, "custom": 0}
     deliveries: dict[str, int] = {}
+    heartbeat = 0
+    reflection = 0
+    last_error_present = False
     for job in jobs:
         disabled = job.get("disabled") or job.get("paused") or job.get("enabled") is False
         if not disabled:
             enabled += 1
-        schedule = str(job.get("schedule") or job.get("cron") or "").strip()
-        if schedule and len(schedules) < 6:
-            schedules.append(schedule)
+        schedule = str(job.get("schedule") or job.get("cron") or "").strip().lower()
+        if schedule.startswith("every ") or schedule.endswith("m") or schedule.endswith("h"):
+            cadence = "frequent"
+        elif schedule.count(" ") >= 4 and (schedule.split()[2] != "*" or schedule.split()[3] != "*"):
+            cadence = "weekly"
+        elif schedule.count(" ") >= 4:
+            cadence = "daily"
+        elif "t" in schedule and schedule[:4].isdigit():
+            cadence = "one-shot"
+        else:
+            cadence = "custom" if schedule else "custom"
+        cadences[cadence] = cadences.get(cadence, 0) + 1
         deliver = str(job.get("deliver") or job.get("target") or "origin")
-        deliveries[deliver] = deliveries.get(deliver, 0) + 1
+        label = deliver.split(":", 1)[0] if ":" in deliver else deliver
+        if label not in {"origin", "local", "all", "telegram", "discord", "slack", "sms", "email"}:
+            label = "other"
+        deliveries[label] = deliveries.get(label, 0) + 1
+        descriptor = " ".join(str(job.get(k) or "") for k in ["name", "prompt", "skills", "script"]).lower()
+        if any(token in descriptor for token in ["heartbeat", "check-in", "checkin", "morning", "evening", "weekly review"]):
+            heartbeat += 1
+        if any(token in descriptor for token in ["reflection", "curator", "dream", "consolidat", "memory review"]):
+            reflection += 1
+        if job.get("last_error") or job.get("error"):
+            last_error_present = True
     return {
         "filePresent": jobs_path.exists(),
         "path": _compact_path(jobs_path, home),
         "total": len(jobs),
         "enabled": enabled,
         "paused": max(len(jobs) - enabled, 0),
-        "sampleSchedules": schedules,
+        "cadences": cadences,
+        "sampleSchedules": [k for k, v in cadences.items() if v][:6],
         "deliveries": deliveries,
+        "heartbeatJobs": heartbeat,
+        "reflectionJobs": reflection,
+        "genericJobs": max(len(jobs) - heartbeat - reflection, 0),
+        "lastErrorPresent": last_error_present,
     }
-
 
 def _mcp_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     servers: dict[str, Any] = {}
@@ -616,13 +1095,27 @@ def _gateway_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str,
 def _tool_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     toolsets = cfg.get("toolsets") or []
     disabled = ((cfg.get("agent") or {}).get("disabled_toolsets") or []) if isinstance(cfg.get("agent"), dict) else []
+    tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
+    configured_toolsets = list(toolsets) if isinstance(toolsets, list) else []
+    repo_root = Path(__file__).resolve().parents[1]
+    builtin_tool_files = list((repo_root / "tools").glob("*.py")) if (repo_root / "tools").exists() else []
+    read_file_present = any(p.name in {"file_operations.py", "file.py"} for p in builtin_tool_files)
+    terminal_present = any("terminal" in p.name for p in builtin_tool_files)
     return {
-        "configuredToolsets": list(toolsets) if isinstance(toolsets, list) else [],
-        "configuredToolsetCount": len(toolsets) if isinstance(toolsets, list) else 0,
+        "configuredToolsets": configured_toolsets,
+        "configuredToolsetCount": len(configured_toolsets),
         "disabledToolsets": list(disabled) if isinstance(disabled, list) else [],
-        "toolSearch": bool(((cfg.get("tools") or {}).get("tool_search")) if isinstance(cfg.get("tools"), dict) else False),
+        "toolSearch": bool(tools_cfg.get("tool_search")),
+        "registeredToolCount": len(builtin_tool_files),
+        "enabledToolCount": max(len(builtin_tool_files) - (len(disabled) if isinstance(disabled, list) else 0), 0),
+        "dangerClasses": {"safe": 0, "destructive": 0, "expensive": 0, "unknown": len(builtin_tool_files)},
+        "fileAccess": {
+            "readFileToolPresent": read_file_present,
+            "allowlistConfigured": bool(tools_cfg.get("file_allowlist") or tools_cfg.get("allowlist")),
+            "denylistConfigured": bool(tools_cfg.get("file_denylist") or tools_cfg.get("denylist")),
+        },
+        "execution": {"terminalToolPresent": terminal_present},
     }
-
 
 def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     raw_approvals = cfg.get("approvals")
@@ -631,58 +1124,104 @@ def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     approvals: dict[str, Any] = raw_approvals if isinstance(raw_approvals, dict) else {}
     security: dict[str, Any] = raw_security if isinstance(raw_security, dict) else {}
     terminal: dict[str, Any] = raw_terminal if isinstance(raw_terminal, dict) else {}
+    mode = str(approvals.get("mode") or "manual")
+    cron_mode = str(approvals.get("cron_mode") or approvals.get("mode") or "manual")
+    terminal_backend = str(terminal.get("backend") or "local")
+    isolated = terminal_backend in {"docker", "ssh", "daytona", "singularity", "modal", "kubernetes", "firecracker"}
+    approval_enabled = mode.lower() not in {"off", "none", "disabled", "false"}
+    auto_enabled = mode.lower() in {"smart", "auto", "auto_approve", "auto-approve"}
+    repo_root = Path(__file__).resolve().parents[1]
+    marker_supported = False
+    try:
+        for p in repo_root.rglob("*.py"):
+            if p.name == "mission_control.py":
+                continue
+            sample = p.read_text(encoding="utf-8", errors="ignore")
+            if "<tool_output" in sample or "attackable" in sample:
+                marker_supported = True
+                break
+    except Exception:
+        marker_supported = False
     return {
-        "approvalsMode": approvals.get("mode") or "manual",
-        "cronApprovalsMode": approvals.get("cron_mode") or approvals.get("mode") or "manual",
+        "approvalsMode": mode,
+        "cronApprovalsMode": cron_mode,
+        "approvalFlowConfigured": approval_enabled,
+        "autoApproveEnabled": auto_enabled,
+        "destructiveToolsRequireApproval": approval_enabled,
+        "expensiveToolsRequireApproval": approval_enabled,
         "redactSecrets": security.get("redact_secrets") is not False,
         "tirithEnabled": bool(security.get("tirith_enabled")),
-        "terminalBackend": terminal.get("backend") or "local",
+        "terminalBackend": terminal_backend,
+        "terminalIsolated": isolated,
         "privateUrlsAllowed": bool(security.get("allow_private_urls")),
+        "promptInjection": {
+            "toolOutputMarkersSupported": marker_supported,
+            "toolOutputMarkersEnabled": marker_supported,
+            "untrustedExternalContentTracked": marker_supported,
+            "attackableRequiresManualApproval": approval_enabled and marker_supported,
+            "privateUrlsAllowed": bool(security.get("allow_private_urls")),
+        },
     }
-
 
 def _identity_metrics(home: Path) -> dict[str, Any]:
     soul = home / "soul.md"
-    memory_file = home / "MEMORY.md"
-    user_file = home / "USER.md"
-    # Active installs can use lowercase memory files as well; only expose sizes.
-    files = [p for p in [soul, memory_file, user_file, home / "memory.md", home / "user.md"] if p.exists()]
+    memory_dir = home / "memories"
+    candidates = [
+        soul,
+        home / "MEMORY.md",
+        home / "USER.md",
+        home / "memory.md",
+        home / "user.md",
+        memory_dir / "MEMORY.md",
+        memory_dir / "USER.md",
+        memory_dir / "memory.md",
+        memory_dir / "user.md",
+    ]
+    files = [p for p in candidates if p.exists()]
     return {
         "soulPresent": soul.exists(),
         "profileFiles": len(files),
         "totalBytes": sum(p.stat().st_size for p in files if p.exists()),
-        "files": [_compact_path(p, home) for p in files[:5]],
+        "files": [_compact_path(p, home) for p in files[:8]],
     }
-
 
 def _build_runtime(cfg: dict[str, Any], home: Path) -> dict[str, Any]:
     env_info = _env_families(home)
+    sessions = _state_db_metrics(home)
+    safety = _safety_metrics(cfg)
+    dashboard = _dashboard_metrics(cfg, env_info)
     runtime = {
         "generatedAt": _now_iso(),
         "home": "~/.hermes",
         "model": _model_metrics(cfg),
         "env": env_info,
         "identity": _identity_metrics(home),
-        "sessions": _state_db_metrics(home),
+        "sessions": sessions,
         "skills": _skill_metrics(home),
         "cron": _cron_metrics(home),
         "mcp": _mcp_metrics(cfg),
         "gateway": _gateway_metrics(cfg, env_info),
         "tools": _tool_metrics(cfg),
-        "safety": _safety_metrics(cfg),
+        "safety": safety,
         "voice": {
             "sttEnabled": bool(((cfg.get("stt") or {}).get("enabled")) if isinstance(cfg.get("stt"), dict) else False),
             "sttProvider": ((cfg.get("stt") or {}).get("provider")) if isinstance(cfg.get("stt"), dict) else None,
             "ttsProvider": ((cfg.get("tts") or {}).get("provider")) if isinstance(cfg.get("tts"), dict) else None,
         },
-        "dashboard": {
-            "missionControlRoute": "/mission-control",
-            "sourceRoute": SOURCE_URL,
-            "authGated": True,
-        },
+        "dashboard": dashboard,
     }
+    runtime["memory"] = _memory_metrics(home, sessions)
+    runtime["semantic"] = _semantic_metrics(env_info, cfg)
+    runtime["analytics"] = _analytics_metrics(sessions, cfg)
+    runtime["quality"] = _quality_metrics(home)
+    runtime["multiUser"] = _multi_user_metrics(home, env_info)
+    runtime["reflection"] = {"enabled": runtime["cron"].get("reflectionJobs", 0) > 0, "jobs": runtime["cron"].get("reflectionJobs", 0), "curatorEnabled": runtime["cron"].get("reflectionJobs", 0) > 0}
+    runtime["hosting"] = _hosting_metrics(cfg, safety, env_info)
+    runtime["dataFlow"] = _data_flow(runtime)
+    runtime["preflight"] = _preflight_checks(runtime, home)
+    runtime["customization"] = _customization_runtime(runtime)
+    runtime["production"] = _production_readiness(runtime)
     return runtime
-
 
 def _state(state: str, evidence: Iterable[str], next_action: str) -> CapabilityState:
     return CapabilityState(state=state, score=_STATE_WEIGHT[state], evidence=[e for e in evidence if e], next=next_action)
@@ -698,34 +1237,40 @@ def _readiness_for_feature(feature_id: str, runtime: dict[str, Any]) -> Capabili
     voice = runtime["voice"]
     tools = runtime["tools"]
     env_info = runtime["env"]
+    memory = runtime["memory"]
+    semantic = runtime["semantic"]
 
     if feature_id == "H1":
-        if runtime["identity"]["profileFiles"] and sessions["dbPresent"]:
-            return _state("active", [f"{sessions['total']} session(s) in SQLite store", f"{skills['total']} skill(s) installed"], "Keep memory budgets healthy and consolidate recurring lessons.")
-        return _state("partial", ["Memory files or SQLite store are not both present"], "Enable memory files and keep the session store writable.")
+        full = runtime["identity"]["profileFiles"] and sessions["dbPresent"] and skills["total"]
+        return _state("active" if full else "partial", [f"profile files: {runtime['identity']['profileFiles']}", f"SQLite sessions: {sessions['total']}", f"skills: {skills['total']}"], "Keep all four layers healthy: profile, user memory, skills, episodic recall.")
     if feature_id == "H2":
+        if cron.get("reflectionJobs"):
+            return _state("active", [f"{cron['reflectionJobs']} reflection-like cron job(s) detected"], "Review reflection output periodically.")
         if cron["enabled"]:
-            return _state("partial", [f"{cron['enabled']} enabled cron job(s) can run reflection-style passes"], "Add a dedicated nightly reflection/curator job if not present.")
+            return _state("partial", [f"{cron['enabled']} enabled cron job(s), no dedicated reflection signal"], "Add a dedicated nightly consolidation job.")
         return _state("watch", ["No enabled cron jobs detected"], "Create a self-contained nightly consolidation cron job.")
     if feature_id in {"H3", "H11", "O3"}:
-        return _state("active" if skills["total"] else "partial", [f"{skills['total']} installed skill(s)", f"usage tracked for {skills['usageTracked']} skill(s)"], "Keep auto-created skills reviewed and curated.")
+        active = skills["total"] and skills.get("agentskillsCompliant", 0)
+        return _state("active" if active else ("partial" if skills["total"] else "watch"), [f"{skills['total']} installed skill(s)", f"agentskills-shaped: {skills.get('agentskillsCompliant', 0)}", f"auto-created: {skills.get('autoCreatedCount', 0)}"], "Keep auto-created/community skills reviewed and portable.")
     if feature_id in {"H4", "O1"}:
-        return _state("active" if gateway["configuredCount"] else "partial", [f"{gateway['configuredCount']} configured platform family/families", f"gateway state: {gateway['state']}"], "Enable only platforms that have real operator value.")
+        status = "active" if gateway["running"] and gateway["configuredCount"] else ("partial" if gateway["configuredCount"] else "watch")
+        return _state(status, [f"{gateway['configuredCount']} configured platform family/families", f"gateway state: {gateway['state']}"], "Enable only platforms that have real operator value.")
     if feature_id in {"H5", "O5"}:
         backend = safety["terminalBackend"]
-        return _state("active" if backend else "partial", [f"terminal backend: {backend}", f"configured toolsets: {tools['configuredToolsetCount']}"], "Prefer isolated backends for untrusted or expensive commands.")
+        status = "active" if safety.get("terminalIsolated") else ("partial" if backend else "watch")
+        return _state(status, [f"terminal backend: {backend}", f"isolated: {safety.get('terminalIsolated')}", f"registered tool modules: {tools.get('registeredToolCount', 0)}"], "Prefer isolated backends for untrusted or expensive commands.")
     if feature_id == "H6":
         active = voice["sttEnabled"] or bool(voice["ttsProvider"])
         return _state("active" if active else "watch", [f"STT enabled: {voice['sttEnabled']}", f"TTS provider: {voice['ttsProvider'] or 'not configured'}"], "Wire STT/TTS only where voice actually speeds you up.")
     if feature_id == "H7":
-        provider = "builtin"
-        return _state("partial", [f"memory provider: {provider}"], "Add Honcho/Mem0/etc. only if builtin memory becomes limiting.")
+        return _state("partial" if semantic.get("configured") else "planned", [f"memory provider: {memory.get('provider', {}).get('active', 'builtin')}", f"semantic provider: {semantic.get('provider')}"], "Add Honcho/Mem0/Pinecone only if builtin memory becomes limiting.")
     if feature_id == "H8":
-        return _state("active", ["skills are source-scoped in the dashboard", "plugins expose trust/source metadata"], "Keep community skills behind review before enabling broad permissions.")
+        return _state("partial" if skills["total"] else "watch", [f"trust metadata: {skills.get('trustLevels', {})}"], "Keep community skills behind review before enabling broad permissions.")
     if feature_id == "H9":
-        return _state("active", ["memory/user profile limits are part of Hermes config", "session compression is supported"], "Watch memory saturation and prune stale facts.")
+        return _state("active", [f"memory budget: {memory.get('budgets', {}).get('memoryLimitChars')} chars", f"user budget: {memory.get('budgets', {}).get('userLimitChars')} chars"], "Watch memory saturation and prune stale facts.")
     if feature_id == "H10":
-        return _state("planned", ["Token/cost analytics exist; TokenMix-specific optimisation is not a live signal"], "Treat as advanced optimisation after high-value flows are stable.")
+        tokens = runtime["analytics"]["totals"]["inputTokens"] + runtime["analytics"]["totals"]["outputTokens"]
+        return _state("partial" if tokens else "planned", [f"tracked tokens: {tokens}", "TokenMix-specific optimisation is not a live runtime signal"], "Treat as advanced optimisation after high-value flows are stable.")
     if feature_id == "O2":
         return _state("planned", ["Dashboard is responsive web; native mobile clients are outside this repository"], "Use the web dashboard on mobile before funding native clients.")
     if feature_id == "O4":
@@ -734,52 +1279,115 @@ def _readiness_for_feature(feature_id: str, runtime: dict[str, Any]) -> Capabili
         return _state("planned", ["MCP/tool protocols exist; Open Gateway federation is not configured"], "Keep this as a future interoperability project.")
     if feature_id in {"O7", "O8"}:
         mode = safety["approvalsMode"]
-        return _state("active", [f"approvals mode: {mode}", f"secret redaction: {safety['redactSecrets']}"], "Keep destructive approvals visible; use smart/off only intentionally.")
+        status = "active" if safety.get("approvalFlowConfigured") else "watch"
+        return _state(status, [f"approvals mode: {mode}", f"auto-approve enabled: {safety.get('autoApproveEnabled')}", f"secret redaction: {safety['redactSecrets']}"], "Keep destructive approvals visible; use smart/off only intentionally.")
     if feature_id == "O9":
         return _state("partial", ["Mission Control dashboard is the live cockpit route", "file/canvas edit UI is separate from this snapshot"], "Promote high-value cards into editable Live Canvas widgets later.")
     if feature_id == "O10":
         fams = set(env_info.get("families", []))
-        if "tailscale" in fams:
-            return _state("partial", ["tailscale-related env family detected"], "Verify mesh access and avoid public ports.")
+        if "tailscale" in fams or runtime["hosting"].get("meshVpnSignal"):
+            return _state("partial", ["tailscale-related signal detected"], "Verify mesh access and avoid public ports.")
         return _state("watch", ["No Tailscale-specific signal detected"], "Prefer mesh VPN or SSH tunnel if exposing a home server.")
     return _state("watch", ["No feature-specific readiness rule"], "Inspect runtime evidence manually.")
-
 
 def _readiness_for_step(step: dict[str, Any], runtime: dict[str, Any]) -> CapabilityState:
     domain = step["domain"]
     route = step.get("route")
+    step_id = step["id"]
+    env_info = runtime["env"]
+    gateway = runtime["gateway"]
+    safety = runtime["safety"]
+
+    if step_id in {"step-1", "step-12"}:
+        tg = env_info.get("telegram", {}) if isinstance(env_info.get("telegram"), dict) else {}
+        has_token = bool(tg.get("tokenPresent"))
+        allowed = _safe_int(tg.get("allowedUserCount"))
+        status = "active" if has_token and allowed and gateway.get("configuredCount") else ("partial" if has_token or allowed or gateway.get("configuredCount") else "watch")
+        return _state(status, [f"telegram token present: {has_token}", f"allowed user count: {allowed}", f"gateway state: {gateway.get('state')}"], "Keep Telegram private-chat and whitelist boundaries tight.")
+    if step_id == "step-4":
+        req = env_info.get("requiredKeys", [])
+        configured_required = sum(1 for r in req if isinstance(r, dict) and r.get("isSet"))
+        return _state("active" if env_info.get("filePresent") and configured_required >= 2 else ("partial" if env_info.get("filePresent") else "watch"), [f".env present: {env_info.get('filePresent')}", f"configured values: {env_info.get('configuredKeys')}", f"required signals set: {configured_required}/{len(req)}"], "Use /env to verify presence without exposing values.")
+    if step_id == "step-5":
+        ident = runtime["identity"]
+        return _state("active" if ident.get("soulPresent") and ident.get("profileFiles") else "partial", [f"soul present: {ident.get('soulPresent')}", f"profile files: {ident.get('profileFiles')}"], "Keep public prompt snippets out of the operator soul.")
+    if step_id == "step-8":
+        semantic = runtime["semantic"]
+        if semantic.get("configured") and semantic.get("indexConfigured"):
+            status = "active"
+        elif semantic.get("configured") or semantic.get("apiKeyPresent"):
+            status = "partial"
+        else:
+            status = "planned"
+        return _state(status, [f"provider: {semantic.get('provider')}", f"API key present: {semantic.get('apiKeyPresent')}", f"index configured: {semantic.get('indexConfigured')}"], "Keep semantic memory optional and project-scoped.")
+    if step_id == "step-16":
+        return _state("partial", ["Dashboard supports live refresh; gateway streaming depends on adapter/runtime", f"gateway running: {gateway.get('running')}"], "Debounce live edits and avoid unchanged Telegram updates.")
+    if step_id == "step-17":
+        if runtime["reflection"].get("enabled"):
+            return _state("active", [f"reflection jobs: {runtime['reflection'].get('jobs')}"], "Review consolidation output for stale or overbroad facts.")
+        if runtime["cron"].get("enabled"):
+            return _state("partial", [f"enabled cron jobs: {runtime['cron'].get('enabled')}", "no dedicated reflection signal detected"], "Add a nightly reflection/curator job.")
+        return _state("watch", ["No enabled cron jobs detected"], "Create a self-contained reflection cron job.")
+    if step_id == "step-20":
+        mu = runtime["multiUser"]
+        status = "active" if mu.get("approvedUserCount", 0) > 1 and mu.get("memoryNamespaceSupported") else ("partial" if mu.get("approvedUserCount") else "watch")
+        return _state(status, [f"approved users: {mu.get('approvedUserCount')}", f"pending users: {mu.get('pendingUserCount')}", f"single-user mode: {mu.get('singleUserMode')}"], "Keep Pairing counts only; never expose IDs or names in this snapshot.")
+    if step_id == "step-21":
+        return _state("active" if runtime["mcp"]["configured"] else "watch", [f"{runtime['mcp']['configured']} MCP server(s) configured", f"enabled: {runtime['mcp'].get('enabled', 0)}"], "Install MCP servers only for workflows you actually use.")
+    if step_id == "step-22":
+        return _state("active" if safety.get("approvalFlowConfigured") else "watch", [f"approvals mode: {safety['approvalsMode']}", f"auto approve: {safety.get('autoApproveEnabled')}", f"secret redaction: {safety['redactSecrets']}"], "Never run destructive/expensive tools without an intentional approval policy.")
+    if step_id == "step-22-5":
+        pi = safety.get("promptInjection", {})
+        full = pi.get("toolOutputMarkersEnabled") and pi.get("attackableRequiresManualApproval") and not pi.get("privateUrlsAllowed")
+        status = "active" if full else ("partial" if safety.get("approvalFlowConfigured") and safety.get("redactSecrets") else "watch")
+        return _state(status, [f"tool-output markers: {pi.get('toolOutputMarkersEnabled')}", f"attackable requires manual approval: {pi.get('attackableRequiresManualApproval')}", f"private URLs allowed: {pi.get('privateUrlsAllowed')}"], "Treat external content as data; require manual approval when attackable content is involved.")
+    if step_id == "step-23":
+        totals = runtime["analytics"]["totals"]
+        tokens = totals["inputTokens"] + totals["outputTokens"]
+        return _state("active" if tokens or totals["estimatedCostUsd"] or totals["actualCostUsd"] else "partial", [f"tracked tokens: {tokens}", f"actual cost USD: {totals['actualCostUsd']}", f"budget state: {runtime['analytics']['daily']['budgetAlertState']}"], "Set a cost alert threshold for production runs.")
+    if step_id == "step-24":
+        dash = runtime["dashboard"]
+        return _state("active", ["/mission-control route exposes this blueprint", f"auth mode: {dash.get('authMode')}", f"bind exposure: {dash.get('bindExposure')}"], "Keep coverage, runtime evidence, and privacy boundaries distinct.")
+    if step_id == "step-25":
+        host = runtime["hosting"]
+        status = "active" if host.get("hardenedContainer") else ("partial" if host.get("containerized") or host.get("meshVpnSignal") or safety.get("terminalBackend") != "local" else "watch")
+        return _state(status, [f"install method: {host.get('installMethod')}", f"terminal backend: {host.get('terminalBackend')}", f"mesh VPN signal: {host.get('meshVpnSignal')}"], "Prefer low-cost VPS/mesh networking over public dashboard exposure.")
+    if step_id == "step-26":
+        q = runtime["quality"]
+        status = "active" if q.get("pythonMissionControlTestsPresent") and q.get("frontendBuildScriptPresent") else "partial"
+        return _state(status, [f"python tests present: {q.get('pythonMissionControlTestsPresent')}", f"frontend build script: {q.get('frontendBuildScriptPresent')}", "last run evidence is external to the static snapshot"], "Run Python, build, API and browser smokes before shipping.")
+
     if domain == "model":
         model = runtime["model"]
-        return _state("active", [f"provider: {model['provider']}", f"model: {model['model']}", f"reasoning: {model['reasoning']}"], "Keep model routing visible in Models and Config.")
+        configured = model.get("model") != "auto" or bool(env_info.get("llmFamilies"))
+        return _state("active" if configured else "partial", [f"provider: {model['provider']}", f"model: {model['model']}", f"reasoning: {model['reasoning']}"], "Keep model routing visible in Models and Config.")
     if domain == "memory":
-        return _state("active" if runtime["sessions"]["dbPresent"] else "partial", [f"session DB present: {runtime['sessions']['dbPresent']}", f"messages counted: {runtime['sessions']['messages']}"], "Continue consolidating important facts into memory/skills.")
+        mem = runtime["memory"]
+        return _state("active" if mem["sqlite"]["dbPresent"] else "partial", [f"session DB present: {mem['sqlite']['dbPresent']}", f"messages counted: {mem['sqlite']['messages']}", f"FTS present: {mem['sqlite']['ftsPresent']}"], "Continue consolidating important facts into memory/skills.")
     if domain == "skills":
-        return _state("active" if runtime["skills"]["total"] else "partial", [f"{runtime['skills']['total']} installed skill(s)"], "Create skills only from reusable, verified workflows.")
+        return _state("active" if runtime["skills"]["total"] else "partial", [f"{runtime['skills']['total']} installed skill(s)", f"agentskills-shaped: {runtime['skills'].get('agentskillsCompliant', 0)}"], "Create skills only from reusable, verified workflows.")
     if domain == "automation":
-        return _state("active" if runtime["cron"]["total"] else "watch", [f"{runtime['cron']['total']} cron job(s), {runtime['cron']['enabled']} enabled"], "Schedule recurring work only with self-contained prompts.")
+        return _state("active" if runtime["cron"]["enabled"] else "watch", [f"{runtime['cron']['total']} cron job(s), {runtime['cron']['enabled']} enabled", f"cadences: {runtime['cron'].get('cadences', {})}"], "Schedule recurring work only with self-contained prompts.")
     if domain == "tools":
-        if step["id"] == "step-21":
-            return _state("active" if runtime["mcp"]["configured"] else "watch", [f"{runtime['mcp']['configured']} MCP server(s) configured"], "Install MCP servers only for workflows you actually use.")
-        return _state("active", [f"configured toolset count: {runtime['tools']['configuredToolsetCount']}"], "Keep powerful tools behind the right platform/toolset scope.")
+        return _state("active" if runtime["tools"].get("registeredToolCount") else "partial", [f"registered tool modules: {runtime['tools'].get('registeredToolCount', 0)}", f"configured toolset count: {runtime['tools']['configuredToolsetCount']}"], "Keep powerful tools behind the right platform/toolset scope.")
     if domain == "interface":
-        return _state("active" if runtime["gateway"]["configuredCount"] else "partial", [f"configured platform families: {runtime['gateway']['configuredCount']}", f"gateway running: {runtime['gateway']['running']}"], "Use Pairing/Channels for multi-user safety.")
+        return _state("active" if gateway["configuredCount"] else "partial", [f"configured platform families: {gateway['configuredCount']}", f"gateway running: {gateway['running']}"], "Use Pairing/Channels for multi-user safety.")
     if domain == "voice":
         return _state("active" if runtime["voice"]["sttEnabled"] else "watch", [f"STT provider: {runtime['voice']['sttProvider'] or 'not enabled'}", f"TTS provider: {runtime['voice']['ttsProvider'] or 'not configured'}"], "Enable voice where Telegram/Discord audio saves time.")
     if domain == "safety":
-        return _state("active", [f"approvals mode: {runtime['safety']['approvalsMode']}", f"secret redaction: {runtime['safety']['redactSecrets']}"], "Never expose raw tool output/logs in the dashboard.")
+        return _state("active" if safety.get("approvalFlowConfigured") else "watch", [f"approvals mode: {safety['approvalsMode']}", f"secret redaction: {safety['redactSecrets']}"], "Never expose raw tool output/logs in the dashboard.")
     if domain == "analytics":
         tokens = runtime["sessions"]["inputTokens"] + runtime["sessions"]["outputTokens"]
         return _state("active" if tokens else "partial", [f"tracked tokens: {tokens}", f"estimated cost USD: {runtime['sessions']['estimatedCostUsd']}"], "Enable token analytics in dashboard config when useful.")
     if domain == "dashboard":
         return _state("active", ["/mission-control route exposes this blueprint", "server-only snapshot protects local state"], "Keep coverage and readiness distinct.")
     if domain == "hosting":
-        return _state("partial", [f"terminal backend: {runtime['safety']['terminalBackend']}", "hosting posture depends on deployment target"], "Prefer low-cost VPS/mesh networking over low-value complexity.")
+        return _state("partial", [f"terminal backend: {safety['terminalBackend']}", "hosting posture depends on deployment target"], "Prefer low-cost VPS/mesh networking over low-value complexity.")
     if domain == "quality":
-        return _state("active", ["Python regression tests cover the snapshot endpoint", "frontend build validates TypeScript route"], "Run browser smoke on desktop and mobile before shipping.")
+        return _state("partial", ["Mission Control tests/build scripts are discoverable", "latest pass/fail evidence comes from verification runs"], "Run browser smoke on desktop and mobile before shipping.")
     if domain in {"configuration", "identity", "runtime", "agent-loop"}:
         return _state("active", [f"dashboard route: {route}", f"Hermes home exposed as {runtime['home']}"], "Keep config readable while secrets stay server-only.")
     return _state("watch", ["No domain-specific rule"], "Review manually.")
-
 
 def _coverage(runtime: dict[str, Any]) -> dict[str, Any]:
     step_rows: list[dict[str, Any]] = []
@@ -835,32 +1443,45 @@ def _coverage(runtime: dict[str, Any]) -> dict[str, Any]:
 
 def _action_queue(runtime: dict[str, Any], coverage: dict[str, Any]) -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
-    weakest = coverage.get("weakestDomains", [])[:3]
-    for idx, domain in enumerate(weakest, start=1):
-        actions.append({
-            "rank": idx,
-            "tone": "now" if domain["score"] < 55 else "next",
-            "title": f"Strengthen {domain['name']}",
-            "reason": f"Average readiness {domain['score']} across {domain['items']} mapped item(s).",
-            "route": "/mission-control",
-        })
-    if runtime["gateway"]["configuredCount"] == 0:
-        actions.append({"rank": len(actions) + 1, "tone": "now", "title": "Configure one gateway", "reason": "Messaging is the only useful interface if the agent is not reachable.", "route": "/channels"})
-    if runtime["cron"]["enabled"] == 0:
-        actions.append({"rank": len(actions) + 1, "tone": "next", "title": "Add one reflection or heartbeat cron", "reason": "The blueprint expects proactive/background consolidation.", "route": "/cron"})
-    if runtime["skills"]["total"] == 0:
-        actions.append({"rank": len(actions) + 1, "tone": "next", "title": "Install or create reusable skills", "reason": "Skills are the reusable procedure layer of the agent.", "route": "/skills"})
-    return actions[:8]
+    def add(tone: str, title: str, reason: str, route: str, category: str = "readiness", effort: str = "M") -> None:
+        actions.append({"rank": len(actions) + 1, "tone": tone, "title": title, "reason": reason, "route": route, "category": category, "effort": effort})
 
+    preflight_bad = [c for c in runtime.get("preflight", []) if c.get("status") in {"fail", "warn"}]
+    if preflight_bad:
+        first = preflight_bad[0]
+        add("now", f"Fix pre-flight: {first.get('title')}", "; ".join(first.get("evidence", [])[:2]) or first.get("summary", "Security checklist needs attention."), first.get("route", "/mission-control"), "security", "S")
+    if runtime["gateway"]["configuredCount"] == 0:
+        add("now", "Configure one gateway", "Messaging is the only useful interface if the agent is not reachable.", "/channels", "interface", "M")
+    if runtime["safety"].get("privateUrlsAllowed"):
+        add("now", "Review private URL policy", "Private URL fetching is enabled; prompt-injection and SSRF boundaries should be intentional.", "/system", "security", "S")
+    weakest = coverage.get("weakestDomains", [])[:4]
+    for domain in weakest:
+        if len(actions) >= 6:
+            break
+        add("now" if domain["score"] < 55 else "next", f"Strengthen {domain['name']}", f"Average readiness {domain['score']} across {domain['items']} mapped item(s).", "/mission-control", "coverage", "M")
+    if runtime["cron"]["enabled"] == 0:
+        add("next", "Add one reflection or heartbeat cron", "The blueprint expects proactive/background consolidation.", "/cron", "automation", "M")
+    elif runtime["cron"].get("reflectionJobs", 0) == 0:
+        add("next", "Add dedicated reflection signal", "Cron exists, but Mission Control cannot see a consolidation/reflection job.", "/cron", "memory", "M")
+    if runtime["skills"]["total"] == 0:
+        add("next", "Install or create reusable skills", "Skills are the reusable procedure layer of the agent.", "/skills", "skills", "S")
+    if runtime["analytics"].get("daily", {}).get("budgetAlertState") == "not_configured":
+        add("watch", "Set a daily cost threshold", "Token/cost totals exist, but budget alert threshold is not configured.", "/analytics", "analytics", "S")
+    if not actions:
+        add("watch", "Keep monitoring Mission Control", "No urgent gaps detected; refresh after deploys, gateway changes, or cron edits.", "/mission-control", "monitoring", "S")
+    for idx, action in enumerate(actions, start=1):
+        action["rank"] = idx
+    return actions[:8]
 
 def _privacy_boundaries() -> list[dict[str, str]]:
     return [
-        {"label": "Session content", "policy": "counts only", "detail": "No chat text, tool outputs, or reasoning bodies leave the server snapshot."},
-        {"label": "Secrets", "policy": "never values", "detail": "Env files are reduced to counts and provider families only."},
+        {"label": "Session content", "policy": "counts only", "detail": "No chat text, tool outputs, reasoning bodies, session titles, or session IDs leave the server snapshot."},
+        {"label": "Secrets", "policy": "never values", "detail": "Env files are reduced to booleans, counts, and provider families only."},
         {"label": "Local paths", "policy": "compacted", "detail": "Hermes-owned paths render as ~/.hermes; arbitrary absolutes collapse to labels."},
-        {"label": "Commands/logs", "policy": "metadata", "detail": "The cockpit exposes status/readiness, not shell commands or log tails."},
+        {"label": "Commands/logs", "policy": "metadata", "detail": "The cockpit exposes status/readiness, not shell commands, prompts, cron bodies, or log tails."},
+        {"label": "Users/chats", "policy": "count-only", "detail": "Pairing, Telegram, and gateway state expose counts/platform families, never user IDs or chat IDs."},
+        {"label": "Source guide", "policy": "static public", "detail": "Blueprint sections are public source metadata and safe to render in full."},
     ]
-
 
 def build_mission_control_snapshot() -> dict[str, Any]:
     """Return a deterministic, privacy-minimized Mission Control snapshot."""
@@ -888,6 +1509,15 @@ def build_mission_control_snapshot() -> dict[str, Any]:
             "hermesFeatureCount": len(HERMES_FEATURES),
             "openclawFeatureCount": len(OPENCLAW_FEATURES),
             "parts": ["MVP", "Beyond MVP", "Production-grade"],
+            "architecturePieces": ARCHITECTURE_PIECES,
+            "prerequisites": PREREQUISITES,
+            "preflightChecks": PREFLIGHT_CHECKS,
+            "customizationChecklist": CUSTOMIZATION_CHECKLIST,
+            "nextTools": NEXT_TOOLS,
+            "glossary": GLOSSARY,
+            "troubleshooting": TROUBLESHOOTING,
+            "resources": RESOURCES,
+            "dataFlowSurfaces": DATA_FLOW_SURFACES,
         },
         "runtime": runtime,
         "coverage": coverage,
@@ -899,11 +1529,17 @@ def build_mission_control_snapshot() -> dict[str, Any]:
                 "horizontal overflow guarded by min-w-0 and wrapped text",
                 "reduced-motion friendly static gradients",
                 "touch targets sized for mobile navigation",
+                "dense sections become compact cards on small screens",
             ],
-            "breakpoints": ["mobile", "tablet", "desktop", "wide cockpit"],
+            "breakpoints": ["360px mobile", "390px mobile", "768px tablet", "1024px desktop", "1440px wide cockpit"],
+            "smokeTargets": [
+                {"id": "mobile-360", "label": "360px mobile", "status": "target"},
+                {"id": "mobile-390", "label": "390px mobile", "status": "target"},
+                {"id": "tablet-768", "label": "768px tablet", "status": "target"},
+                {"id": "desktop-1440", "label": "1440px desktop", "status": "target"},
+            ],
         },
     }
-
 
 def mission_control_summary() -> dict[str, Any]:
     """Small summary shape for health checks and future sidebar chips."""

--- a/hermes_cli/mission_control.py
+++ b/hermes_cli/mission_control.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import re
 import sqlite3
 import time
 from typing import Any, Iterable
@@ -399,6 +400,140 @@ DATA_FLOW_SURFACES: list[dict[str, str]] = [
 
 _STATE_WEIGHT = {"active": 100, "partial": 68, "watch": 38, "planned": 18}
 
+KNOWN_PROVIDER_FAMILIES = {
+    "anthropic",
+    "auto",
+    "copilot",
+    "deepseek",
+    "gemini",
+    "github-copilot",
+    "google",
+    "grok",
+    "huggingface",
+    "kilocode",
+    "kimi",
+    "local",
+    "mistral",
+    "moonshot",
+    "nous",
+    "ollama",
+    "openai",
+    "openai-codex",
+    "opencode-go",
+    "opencode-zen",
+    "openrouter",
+    "qwen-oauth",
+    "xai",
+    "zai",
+}
+
+KNOWN_VOICE_PROVIDERS = {
+    "edge",
+    "elevenlabs",
+    "groq",
+    "local",
+    "minimax",
+    "mistral",
+    "neutts",
+    "openai",
+    "whisper",
+}
+
+KNOWN_GATEWAY_FAMILIES = {
+    "api",
+    "discord",
+    "email",
+    "feishu",
+    "homeassistant",
+    "local",
+    "matrix",
+    "signal",
+    "slack",
+    "sms",
+    "telegram",
+    "web",
+    "whatsapp",
+    "yuanbao",
+}
+
+SAFE_SESSION_END_REASONS = {
+    "completed",
+    "done",
+    "error",
+    "interrupted",
+    "max_iterations",
+    "max_turns",
+    "stopped",
+    "timeout",
+    "tool_error",
+}
+
+SAFE_HANDOFF_STATES = {"pending", "ready", "sent", "failed", "cancelled", "completed"}
+SAFE_CRON_STATUSES = {"success", "ok", "error", "failed", "skipped", "running", "pending", "timeout"}
+SAFE_MODEL_WORDS = {
+    "ai",
+    "anthropic",
+    "audio",
+    "base",
+    "chat",
+    "claude",
+    "code",
+    "coder",
+    "codex",
+    "dall",
+    "deepseek",
+    "e",
+    "embedding",
+    "embeddings",
+    "exp",
+    "experimental",
+    "fast",
+    "flash",
+    "gemini",
+    "gemma",
+    "glm",
+    "google",
+    "gpt",
+    "4o",
+    "grok",
+    "haiku",
+    "hermes",
+    "high",
+    "instruct",
+    "kimi",
+    "large",
+    "latest",
+    "llama",
+    "medium",
+    "meta",
+    "mini",
+    "mistral",
+    "mixtral",
+    "moonshot",
+    "nous",
+    "o",
+    "omni",
+    "online",
+    "openai",
+    "openrouter",
+    "opus",
+    "oss",
+    "preview",
+    "pro",
+    "qwen",
+    "realtime",
+    "reasoning",
+    "search",
+    "small",
+    "sonnet",
+    "thinking",
+    "transcribe",
+    "turbo",
+    "vision",
+    "xai",
+    "z",
+}
+
 
 @dataclass(frozen=True)
 class CapabilityState:
@@ -478,20 +613,140 @@ def _source_label(value: Any) -> str | None:
 
 
 def _safe_model_label(value: Any) -> str:
-    """Return a model label while collapsing local file paths to a filename."""
+    """Return a model label without exposing local paths or private deployment names."""
     raw = str(value or "auto").strip()
     if not raw:
         return "auto"
     lower = raw.lower()
     looks_like_path = (
         raw.startswith(("/", "~", "./", "../"))
+        or lower.startswith("file://")
         or "\\" in raw
         or (len(raw) > 2 and raw[1:3] == ":\\")
         or lower.endswith((".gguf", ".safetensors", ".bin", ".pt", ".pth", ".onnx"))
     )
     if looks_like_path:
         return "local-model"
-    return raw
+    if "://" in lower:
+        return "custom-model"
+    if lower in {"auto", "local-model"}:
+        return lower
+    if lower == "local":
+        return "local-model"
+    if lower.startswith(("custom:", "custom/", "custom-")):
+        return "custom-model"
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/+:-]*", raw):
+        return "custom-model"
+
+    # Exact model names can include provider and version separators.  Keep them
+    # only when every token is from a public model/provider vocabulary or a pure
+    # version token (e.g. ``gpt-5.5``, ``anthropic/claude-sonnet-4``).  Unknown
+    # words often encode private deployments, project names, paths, or clients.
+    tokens = [token for token in re.split(r"[^a-z0-9.]+", lower) if token]
+    version_token = re.compile(r"^(?:v?\d+(?:\.\d+)*|\d+(?:\.\d+)?[bkmt])$")
+    public_family_version_token = re.compile(r"^(?:qwen|llama|gemma|glm|o|r)\d+(?:\.\d+)*$")
+    if tokens and all(token in SAFE_MODEL_WORDS or version_token.match(token) or public_family_version_token.match(token) for token in tokens):
+        return raw
+    return "custom-model"
+
+
+def _safe_choice_label(value: Any, *, allowed: set[str], default: str = "custom") -> str:
+    raw = str(value or "").strip().lower().replace("-", "_")
+    if not raw:
+        return default
+    return raw if raw in allowed else default
+
+
+def _safe_family_label(value: Any, *, known: set[str], default: str = "custom") -> str | None:
+    """Collapse user-defined provider/platform labels to stable families."""
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    lower = raw.lower()
+    if lower.startswith(("/", "~", "./", "../", "file://")) or "://" in lower:
+        return "local" if default == "provider" else "custom"
+    if lower.startswith("custom"):
+        return "custom"
+    if lower in known:
+        return lower
+    for family in sorted(known, key=len, reverse=True):
+        if lower == family or lower.startswith(f"{family}:") or lower.startswith(f"{family}/"):
+            return family
+    return default
+
+
+def _safe_provider_label(value: Any) -> str:
+    label = _safe_family_label(value, known=KNOWN_PROVIDER_FAMILIES, default="custom")
+    return label or "auto"
+
+
+def _safe_voice_label(value: Any) -> str | None:
+    return _safe_family_label(value, known=KNOWN_VOICE_PROVIDERS, default="custom")
+
+
+def _safe_gateway_label(value: Any) -> str:
+    label = _source_label(value)
+    if label in KNOWN_GATEWAY_FAMILIES:
+        return label
+    return "other"
+
+
+def _safe_status(value: Any, *, allowed: set[str], default: str = "other") -> str:
+    raw = str(value or "").strip().lower().replace("-", "_")
+    if not raw:
+        return "unknown"
+    return raw if raw in allowed else default
+
+
+def _toolset_bucket(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return "unknown"
+    if raw.startswith("mcp") or raw.startswith("mcp-") or raw.startswith("mcp:"):
+        return "mcp"
+    if raw.startswith("plugin") or raw.startswith("plugin-") or raw.startswith("plugin:"):
+        return "plugin"
+    builtin = {
+        "browser", "code_execution", "cronjob", "delegation", "file", "memory",
+        "search", "session_search", "skills", "terminal", "todo", "tts", "vision", "web",
+        "image_gen", "video", "messaging", "clarify", "kanban", "spotify",
+        "homeassistant", "discord", "discord_admin", "feishu_doc", "feishu_drive", "yuanbao",
+    }
+    return "builtin" if raw in builtin else "custom"
+
+
+def _increment(mapping: dict[str, int], key: str, amount: int = 1) -> None:
+    mapping[key] = mapping.get(key, 0) + amount
+
+
+def _parse_timestamp(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except Exception:
+        pass
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+def _age_bucket(seconds: int | None) -> str:
+    if seconds is None:
+        return "never"
+    if seconds < 3600:
+        return "under_1h"
+    if seconds < 24 * 3600:
+        return "under_24h"
+    if seconds < 7 * 24 * 3600:
+        return "under_7d"
+    return "over_7d"
 
 
 def _read_json(path: Path) -> Any:
@@ -611,12 +866,22 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
         "trigramFtsPresent": False,
         "summaries": 0,
         "stateMetaRows": 0,
+        "endReasonCounts": {},
+        "childSessionCount": 0,
+        "rootSessionCount": 0,
+        "complexSessionCount": 0,
+        "handoffStateCounts": {},
+        "rewindTotal": 0,
+        "avgApiCalls": 0,
+        "maxApiCalls": 0,
+        "roleCounts": {},
+        "delegateTaskCalls": 0,
     }
     if not path.exists():
         return base
     con: sqlite3.Connection | None = None
     try:
-        con = sqlite3.connect(path)
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
         con.row_factory = sqlite3.Row
         tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")}
         base["ftsPresent"] = any("fts" in name.lower() for name in tables)
@@ -649,6 +914,37 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                     base["todayEstimatedCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM sessions WHERE started_at >= ?", (day_start,)).fetchone()[0] or 0), 4)
                 if "actual_cost_usd" in cols:
                     base["todayActualCostUsd"] = round(float(con.execute("SELECT COALESCE(SUM(actual_cost_usd), 0) FROM sessions WHERE started_at >= ?", (day_start,)).fetchone()[0] or 0), 4)
+            if "end_reason" in cols:
+                end_counts: dict[str, int] = {}
+                for row in con.execute("SELECT end_reason, COUNT(*) FROM sessions WHERE COALESCE(end_reason, '') != '' GROUP BY end_reason"):
+                    _increment(end_counts, _safe_status(row[0], allowed=SAFE_SESSION_END_REASONS), _safe_int(row[1]))
+                base["endReasonCounts"] = end_counts
+            if "parent_session_id" in cols:
+                base["childSessionCount"] = _safe_int(con.execute("SELECT COUNT(*) FROM sessions WHERE COALESCE(parent_session_id, '') != ''").fetchone()[0])
+                base["rootSessionCount"] = max(base["total"] - base["childSessionCount"], 0)
+            else:
+                base["rootSessionCount"] = base["total"]
+            complexity_clauses = []
+            if "message_count" in cols:
+                complexity_clauses.append("message_count >= 20")
+            if "tool_call_count" in cols:
+                complexity_clauses.append("tool_call_count >= 10")
+            if "api_call_count" in cols:
+                complexity_clauses.append("api_call_count >= 10")
+            if complexity_clauses:
+                complexity_query = "SELECT COUNT(*) FROM sessions WHERE " + " OR ".join(complexity_clauses)
+                base["complexSessionCount"] = _safe_int(con.execute(complexity_query).fetchone()[0])
+            if "handoff_state" in cols:
+                handoff_counts: dict[str, int] = {}
+                for row in con.execute("SELECT handoff_state, COUNT(*) FROM sessions WHERE COALESCE(handoff_state, '') != '' GROUP BY handoff_state"):
+                    _increment(handoff_counts, _safe_status(row[0], allowed=SAFE_HANDOFF_STATES), _safe_int(row[1]))
+                base["handoffStateCounts"] = handoff_counts
+            if "rewind_count" in cols:
+                base["rewindTotal"] = _safe_int(con.execute("SELECT COALESCE(SUM(rewind_count), 0) FROM sessions").fetchone()[0])
+            if "api_call_count" in cols:
+                values = con.execute("SELECT COALESCE(AVG(api_call_count), 0), COALESCE(MAX(api_call_count), 0) FROM sessions").fetchone()
+                base["avgApiCalls"] = round(float(values[0] or 0), 2)
+                base["maxApiCalls"] = _safe_int(values[1])
             if "source" in cols:
                 source_counts: dict[str, int] = {}
                 for row in con.execute("SELECT source, COUNT(*) FROM sessions GROUP BY source ORDER BY COUNT(*) DESC LIMIT 50"):
@@ -685,6 +981,16 @@ def _state_db_metrics(home: Path) -> dict[str, Any]:
                 base["activeMessages"] = _safe_int(con.execute("SELECT COUNT(*) FROM messages WHERE active=1").fetchone()[0])
             else:
                 base["activeMessages"] = base["messages"]
+            if "role" in msg_cols:
+                role_counts: dict[str, int] = {}
+                for row in con.execute("SELECT role, COUNT(*) FROM messages GROUP BY role"):
+                    role = str(row[0] or "unknown").lower()
+                    if role not in {"user", "assistant", "tool", "system", "developer"}:
+                        role = "other"
+                    _increment(role_counts, role, _safe_int(row[1]))
+                base["roleCounts"] = role_counts
+            if "tool_name" in msg_cols:
+                base["delegateTaskCalls"] = _safe_int(con.execute("SELECT COUNT(*) FROM messages WHERE lower(COALESCE(tool_name, '')) = 'delegate_task'").fetchone()[0])
         if "summaries" in tables:
             base["summaries"] = _safe_int(con.execute("SELECT COUNT(*) FROM summaries").fetchone()[0])
         if "state_meta" in tables:
@@ -731,7 +1037,8 @@ def _memory_metrics(home: Path, sessions: dict[str, Any]) -> dict[str, Any]:
 def _semantic_metrics(env_info: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
     semantic_cfg = cfg.get("semantic") if isinstance(cfg.get("semantic"), dict) else {}
     vector_cfg = cfg.get("vector") if isinstance(cfg.get("vector"), dict) else {}
-    provider = semantic_cfg.get("provider") or vector_cfg.get("provider") or ("pinecone" if "pinecone" in env_info.get("families", []) else "none")
+    raw_provider = semantic_cfg.get("provider") or vector_cfg.get("provider") or ("pinecone" if "pinecone" in env_info.get("families", []) else "none")
+    provider = "pinecone" if str(raw_provider).lower() == "pinecone" else ("none" if str(raw_provider).lower() == "none" else _safe_provider_label(raw_provider))
     env_sem = env_info.get("semantic", {}) if isinstance(env_info.get("semantic"), dict) else {}
     index_configured = bool(env_sem.get("pineconeIndexPresent") or semantic_cfg.get("index") or vector_cfg.get("index"))
     return {
@@ -1032,6 +1339,14 @@ def _cron_metrics(home: Path) -> dict[str, Any]:
     heartbeat = 0
     reflection = 0
     last_error_present = False
+    last_status_counts: dict[str, int] = {}
+    overdue_count = 0
+    failed_jobs = 0
+    next_due_values: list[int] = []
+    last_run_ages: list[int] = []
+    reflection_run_ages: list[int] = []
+    last_run_age_buckets: dict[str, int] = {"never": 0, "under_1h": 0, "under_24h": 0, "under_7d": 0, "over_7d": 0}
+    now = time.time()
     for job in jobs:
         disabled = job.get("disabled") or job.get("paused") or job.get("enabled") is False
         if not disabled:
@@ -1054,12 +1369,41 @@ def _cron_metrics(home: Path) -> dict[str, Any]:
             label = "other"
         deliveries[label] = deliveries.get(label, 0) + 1
         descriptor = " ".join(str(job.get(k) or "") for k in ["name", "prompt", "skills", "script"]).lower()
-        if any(token in descriptor for token in ["heartbeat", "check-in", "checkin", "morning", "evening", "weekly review"]):
+        is_heartbeat = any(token in descriptor for token in ["heartbeat", "check-in", "checkin", "morning", "evening", "weekly review"])
+        is_reflection = any(token in descriptor for token in ["reflection", "curator", "dream", "consolidat", "memory review"])
+        if is_heartbeat:
             heartbeat += 1
-        if any(token in descriptor for token in ["reflection", "curator", "dream", "consolidat", "memory review"]):
+        if is_reflection:
             reflection += 1
         if job.get("last_error") or job.get("error"):
             last_error_present = True
+        status = _safe_status(job.get("last_status") or job.get("status"), allowed=SAFE_CRON_STATUSES)
+        if status != "unknown":
+            _increment(last_status_counts, status)
+        if status in {"error", "failed", "timeout"} or job.get("last_error") or job.get("error"):
+            failed_jobs += 1
+        next_ts = _parse_timestamp(job.get("next_run_at") or job.get("next_run"))
+        if next_ts is not None:
+            due_in = int(next_ts - now)
+            next_due_values.append(due_in)
+            if not disabled and due_in < 0:
+                overdue_count += 1
+        last_ts = _parse_timestamp(job.get("last_run_at") or job.get("last_run") or job.get("last_finished_at"))
+        if last_ts is not None:
+            age_seconds = max(0, int(now - last_ts))
+            last_run_ages.append(age_seconds)
+            _increment(last_run_age_buckets, _age_bucket(age_seconds))
+            if is_reflection:
+                reflection_run_ages.append(age_seconds)
+        else:
+            _increment(last_run_age_buckets, "never")
+    reflection_freshness = "not_configured"
+    if reflection:
+        if not reflection_run_ages:
+            reflection_freshness = "unknown"
+        else:
+            freshest_reflection = min(reflection_run_ages)
+            reflection_freshness = "fresh" if freshest_reflection <= 36 * 3600 else "stale"
     return {
         "filePresent": jobs_path.exists(),
         "path": _compact_path(jobs_path, home),
@@ -1073,6 +1417,17 @@ def _cron_metrics(home: Path) -> dict[str, Any]:
         "reflectionJobs": reflection,
         "genericJobs": max(len(jobs) - heartbeat - reflection, 0),
         "lastErrorPresent": last_error_present,
+        "lastStatusCounts": last_status_counts,
+        "failedJobs": failed_jobs,
+        "overdueCount": overdue_count,
+        "nextRunKnown": bool(next_due_values),
+        "nextRunDueInSeconds": min(next_due_values) if next_due_values else None,
+        "lastRunAgeSeconds": min(last_run_ages) if last_run_ages else None,
+        "lastRunAgeBuckets": last_run_age_buckets,
+        "reflectionLastRunAgeSeconds": min(reflection_run_ages) if reflection_run_ages else None,
+        "reflectionFreshness": reflection_freshness,
+        "timezoneConfigured": False,
+        "timezoneSource": "unknown",
     }
 
 def _mcp_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
@@ -1085,11 +1440,38 @@ def _mcp_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     nested_servers = mcp.get("servers") if isinstance(mcp, dict) else None
     if isinstance(nested_servers, dict):
         servers.update(nested_servers)
+    enabled = 0
+    transport_counts: dict[str, int] = {"stdio": 0, "http": 0, "sse": 0, "unknown": 0}
+    status_counts: dict[str, int] = {"enabled": 0, "disabled": 0}
+    server_summaries: list[dict[str, Any]] = []
+    for idx, key in enumerate(sorted(servers.keys()), start=1):
+        value = servers.get(key)
+        disabled = isinstance(value, dict) and value.get("enabled") is False
+        if not disabled:
+            enabled += 1
+        _increment(status_counts, "disabled" if disabled else "enabled")
+        transport = "unknown"
+        if isinstance(value, dict):
+            raw_transport = str(value.get("transport") or "").lower()
+            if raw_transport in transport_counts:
+                transport = raw_transport
+            elif value.get("url"):
+                url = str(value.get("url") or "").lower()
+                transport = "sse" if "sse" in url else "http"
+            elif value.get("command"):
+                transport = "stdio"
+        _increment(transport_counts, transport)
+        if idx <= 12:
+            server_summaries.append({"label": f"server-{idx}", "enabled": not disabled, "transport": transport})
     return {
         "configured": len(servers),
-        "servers": [f"server-{idx}" for idx, _ in enumerate(sorted(servers.keys())[:12], start=1)],
+        "servers": [item["label"] for item in server_summaries],
+        "serverDetails": server_summaries,
         "serverNamesRedacted": True,
-        "enabled": sum(1 for v in servers.values() if not (isinstance(v, dict) and v.get("enabled") is False)),
+        "enabled": enabled,
+        "disabled": max(len(servers) - enabled, 0),
+        "statusCounts": status_counts,
+        "transportCounts": transport_counts,
     }
 
 
@@ -1108,21 +1490,27 @@ def _model_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(provider, str) or not provider.strip():
         provider = model_name.split("/", 1)[0] if "/" in model_name else "auto"
     return {
-        "provider": provider,
+        "provider": _safe_provider_label(provider),
         "model": model_name,
-        "reasoning": agent.get("reasoning_effort") or delegation.get("reasoning_effort") or "default",
-        "delegationProvider": delegation.get("provider") or None,
+        "reasoning": _safe_choice_label(agent.get("reasoning_effort") or delegation.get("reasoning_effort") or "default", allowed={"none", "minimal", "low", "medium", "high", "xhigh", "default", "show", "hide"}, default="custom"),
+        "delegationProvider": _safe_provider_label(delegation.get("provider")) if delegation.get("provider") else None,
         "maxTurns": _safe_int(agent.get("max_turns"), 0),
     }
 
 
 def _gateway_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str, Any]:
-    configured_families = [f for f in env_info.get("families", []) if f in {"telegram", "discord", "slack", "matrix", "signal", "email", "sms", "homeassistant"}]
+    configured_labels: list[str] = []
+    configured_entries = 0
+    for family in env_info.get("families", []):
+        if family in KNOWN_GATEWAY_FAMILIES:
+            configured_labels.append(str(family))
+            configured_entries += 1
     platforms_cfg = ((cfg.get("gateway") or {}).get("platforms") or {}) if isinstance(cfg.get("gateway"), dict) else {}
     if isinstance(platforms_cfg, dict):
         for name, pcfg in platforms_cfg.items():
             if isinstance(pcfg, dict) and pcfg.get("enabled"):
-                configured_families.append(str(name))
+                configured_entries += 1
+                configured_labels.append(_safe_gateway_label(name))
     running = False
     pid = None
     runtime_state = "unknown"
@@ -1133,16 +1521,18 @@ def _gateway_metrics(cfg: dict[str, Any], env_info: dict[str, Any]) -> dict[str,
         running = bool(pid)
         status = read_runtime_status()
         if isinstance(status, dict):
-            runtime_state = str(status.get("state") or status.get("status") or ("running" if running else "stopped"))
+            runtime_state = _safe_status(status.get("state") or status.get("status") or ("running" if running else "stopped"), allowed={"running", "stopped", "starting", "ready", "error", "failed", "unknown"})
     except Exception:
         runtime_state = "unavailable"
-    unique = sorted(set(configured_families))
+    unique = sorted(set(configured_labels))
     return {
         "running": running,
         "pidPresent": bool(pid),
         "state": runtime_state,
         "configuredPlatforms": unique,
-        "configuredCount": len(unique),
+        "configuredCount": configured_entries or len(unique),
+        "platformNamesRedacted": True,
+        "customPlatformCount": sum(1 for label in configured_labels if label == "other"),
     }
 
 
@@ -1151,17 +1541,28 @@ def _tool_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     disabled = ((cfg.get("agent") or {}).get("disabled_toolsets") or []) if isinstance(cfg.get("agent"), dict) else []
     tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
     configured_toolsets = list(toolsets) if isinstance(toolsets, list) else []
+    disabled_toolsets = list(disabled) if isinstance(disabled, list) else []
     repo_root = Path(__file__).resolve().parents[1]
     builtin_tool_files = list((repo_root / "tools").glob("*.py")) if (repo_root / "tools").exists() else []
     read_file_present = any(p.name in {"file_operations.py", "file.py"} for p in builtin_tool_files)
     terminal_present = any("terminal" in p.name for p in builtin_tool_files)
+    buckets: dict[str, int] = {}
+    disabled_buckets: dict[str, int] = {}
+    for item in configured_toolsets:
+        _increment(buckets, _toolset_bucket(item))
+    for item in disabled_toolsets:
+        _increment(disabled_buckets, _toolset_bucket(item))
     return {
-        "configuredToolsets": configured_toolsets,
+        "configuredToolsets": [f"toolset-{idx}" for idx, _ in enumerate(configured_toolsets[:12], start=1)],
         "configuredToolsetCount": len(configured_toolsets),
-        "disabledToolsets": list(disabled) if isinstance(disabled, list) else [],
+        "configuredToolsetBuckets": buckets,
+        "configuredToolsetNamesRedacted": True,
+        "disabledToolsets": [f"disabled-toolset-{idx}" for idx, _ in enumerate(disabled_toolsets[:12], start=1)],
+        "disabledToolsetCount": len(disabled_toolsets),
+        "disabledToolsetBuckets": disabled_buckets,
         "toolSearch": bool(tools_cfg.get("tool_search")),
         "registeredToolCount": len(builtin_tool_files),
-        "enabledToolCount": max(len(builtin_tool_files) - (len(disabled) if isinstance(disabled, list) else 0), 0),
+        "enabledToolCount": max(len(builtin_tool_files) - len(disabled_toolsets), 0),
         "dangerClasses": {"safe": 0, "destructive": 0, "expensive": 0, "unknown": len(builtin_tool_files)},
         "fileAccess": {
             "readFileToolPresent": read_file_present,
@@ -1175,15 +1576,21 @@ def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
     raw_approvals = cfg.get("approvals")
     raw_security = cfg.get("security")
     raw_terminal = cfg.get("terminal")
+    raw_tools = cfg.get("tools")
     approvals: dict[str, Any] = raw_approvals if isinstance(raw_approvals, dict) else {}
     security: dict[str, Any] = raw_security if isinstance(raw_security, dict) else {}
     terminal: dict[str, Any] = raw_terminal if isinstance(raw_terminal, dict) else {}
-    mode = str(approvals.get("mode") or "manual")
-    cron_mode = str(approvals.get("cron_mode") or approvals.get("mode") or "manual")
-    terminal_backend = str(terminal.get("backend") or "local")
-    isolated = terminal_backend in {"docker", "ssh", "daytona", "singularity", "modal", "kubernetes", "firecracker"}
-    approval_enabled = mode.lower() not in {"off", "none", "disabled", "false"}
-    auto_enabled = mode.lower() in {"smart", "auto", "auto_approve", "auto-approve"}
+    tools_cfg: dict[str, Any] = raw_tools if isinstance(raw_tools, dict) else {}
+    raw_mode = str(approvals.get("mode") or "manual")
+    raw_cron_mode = str(approvals.get("cron_mode") or approvals.get("mode") or "manual")
+    safe_modes = {"manual", "smart", "auto", "auto_approve", "off", "none", "disabled"}
+    mode = _safe_choice_label(raw_mode, allowed=safe_modes, default="custom")
+    cron_mode = _safe_choice_label(raw_cron_mode, allowed=safe_modes, default="custom")
+    raw_terminal_backend = str(terminal.get("backend") or "local")
+    terminal_backend = _safe_choice_label(raw_terminal_backend, allowed={"local", "docker", "ssh", "daytona", "singularity", "modal", "kubernetes", "firecracker", "managed_modal"}, default="custom")
+    isolated = terminal_backend in {"docker", "ssh", "daytona", "singularity", "modal", "kubernetes", "firecracker", "managed_modal"}
+    approval_enabled = mode not in {"off", "none", "disabled"}
+    auto_enabled = mode in {"smart", "auto", "auto_approve"}
     repo_root = Path(__file__).resolve().parents[1]
     marker_supported = False
     try:
@@ -1196,6 +1603,11 @@ def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
                 break
     except Exception:
         marker_supported = False
+    limit_values: list[int] = []
+    for key in ["max_output_chars", "tool_output_limit", "tool_output_limit_chars", "terminal_output_limit", "terminal_output_limit_chars"]:
+        value = _safe_int(tools_cfg.get(key), 0)
+        if value > 0:
+            limit_values.append(value)
     return {
         "approvalsMode": mode,
         "cronApprovalsMode": cron_mode,
@@ -1208,9 +1620,16 @@ def _safety_metrics(cfg: dict[str, Any]) -> dict[str, Any]:
         "terminalBackend": terminal_backend,
         "terminalIsolated": isolated,
         "privateUrlsAllowed": bool(security.get("allow_private_urls")),
+        "toolOutputLimits": {
+            "configured": bool(limit_values),
+            "count": len(limit_values),
+            "minChars": min(limit_values) if limit_values else None,
+            "maxChars": max(limit_values) if limit_values else None,
+        },
         "promptInjection": {
             "toolOutputMarkersSupported": marker_supported,
             "toolOutputMarkersEnabled": marker_supported,
+            "toolOutputLimitConfigured": bool(limit_values),
             "untrustedExternalContentTracked": marker_supported,
             "attackableRequiresManualApproval": approval_enabled and marker_supported,
             "privateUrlsAllowed": bool(security.get("allow_private_urls")),
@@ -1259,8 +1678,8 @@ def _build_runtime(cfg: dict[str, Any], home: Path, dashboard_state: dict[str, A
         "safety": safety,
         "voice": {
             "sttEnabled": bool(((cfg.get("stt") or {}).get("enabled")) if isinstance(cfg.get("stt"), dict) else False),
-            "sttProvider": ((cfg.get("stt") or {}).get("provider")) if isinstance(cfg.get("stt"), dict) else None,
-            "ttsProvider": ((cfg.get("tts") or {}).get("provider")) if isinstance(cfg.get("tts"), dict) else None,
+            "sttProvider": _safe_voice_label(((cfg.get("stt") or {}).get("provider")) if isinstance(cfg.get("stt"), dict) else None),
+            "ttsProvider": _safe_voice_label(((cfg.get("tts") or {}).get("provider")) if isinstance(cfg.get("tts"), dict) else None),
         },
         "dashboard": dashboard,
     }
@@ -1269,7 +1688,13 @@ def _build_runtime(cfg: dict[str, Any], home: Path, dashboard_state: dict[str, A
     runtime["analytics"] = _analytics_metrics(sessions, cfg)
     runtime["quality"] = _quality_metrics(home)
     runtime["multiUser"] = _multi_user_metrics(home, env_info)
-    runtime["reflection"] = {"enabled": runtime["cron"].get("reflectionJobs", 0) > 0, "jobs": runtime["cron"].get("reflectionJobs", 0), "curatorEnabled": runtime["cron"].get("reflectionJobs", 0) > 0}
+    runtime["reflection"] = {
+        "enabled": runtime["cron"].get("reflectionJobs", 0) > 0,
+        "jobs": runtime["cron"].get("reflectionJobs", 0),
+        "curatorEnabled": runtime["cron"].get("reflectionJobs", 0) > 0,
+        "freshness": runtime["cron"].get("reflectionFreshness"),
+        "lastRunAgeSeconds": runtime["cron"].get("reflectionLastRunAgeSeconds"),
+    }
     runtime["hosting"] = _hosting_metrics(cfg, safety, env_info)
     runtime["dataFlow"] = _data_flow(runtime)
     runtime["preflight"] = _preflight_checks(runtime, home)
@@ -1394,7 +1819,7 @@ def _readiness_for_step(step: dict[str, Any], runtime: dict[str, Any]) -> Capabi
         pi = safety.get("promptInjection", {})
         full = pi.get("toolOutputMarkersEnabled") and pi.get("attackableRequiresManualApproval") and not pi.get("privateUrlsAllowed")
         status = "active" if full else ("partial" if safety.get("approvalFlowConfigured") and safety.get("redactSecrets") else "watch")
-        return _state(status, [f"tool-output markers: {pi.get('toolOutputMarkersEnabled')}", f"attackable requires manual approval: {pi.get('attackableRequiresManualApproval')}", f"private URLs allowed: {pi.get('privateUrlsAllowed')}"], "Treat external content as data; require manual approval when attackable content is involved.")
+        return _state(status, [f"tool-output markers: {pi.get('toolOutputMarkersEnabled')}", f"output limit configured: {pi.get('toolOutputLimitConfigured')}", f"attackable requires manual approval: {pi.get('attackableRequiresManualApproval')}", f"private URLs allowed: {pi.get('privateUrlsAllowed')}"], "Treat external content as data; require manual approval when attackable content is involved.")
     if step_id == "step-23":
         totals = runtime["analytics"]["totals"]
         tokens = totals["inputTokens"] + totals["outputTokens"]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -851,6 +851,24 @@ async def get_status():
     }
 
 
+@app.get("/api/mission-control/blueprint")
+async def get_mission_control_blueprint():
+    """Blueprint + live-runtime Mission Control snapshot (session protected).
+
+    Auth is enforced by the dashboard middleware: loopback deployments require
+    the injected session token, while public/OAuth-gated deployments rely on
+    cookie auth. Keep this route thin so gated dashboards do not need the
+    loopback-only token header.
+    """
+    try:
+        from hermes_cli.mission_control import build_mission_control_snapshot
+
+        return build_mission_control_snapshot()
+    except Exception as exc:
+        _log.warning("mission-control blueprint failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to build Mission Control snapshot.") from exc
+
+
 @app.get("/api/system/stats")
 async def get_system_stats():
     """Host + process system stats for the System page.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -138,6 +138,11 @@ app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+# Keep the token on the FastAPI app as well as the module global. Pytest and
+# desktop reload paths can keep an older app object alive after
+# ``importlib.reload(web_server)`` mutates module globals; request-time auth must
+# validate against the app that is actually handling the request.
+app.state.dashboard_session_token = _SESSION_TOKEN
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the
@@ -189,15 +194,16 @@ def _has_valid_session_token(request: Request) -> bool:
     accept the legacy Bearer path for backward compatibility with older
     dashboard bundles.
     """
+    expected_token = str(getattr(request.app.state, "dashboard_session_token", _SESSION_TOKEN) or _SESSION_TOKEN)
     session_header = request.headers.get(_SESSION_HEADER_NAME, "")
     if session_header and hmac.compare_digest(
         session_header.encode(),
-        _SESSION_TOKEN.encode(),
+        expected_token.encode(),
     ):
         return True
 
     auth = request.headers.get("authorization", "")
-    expected = f"Bearer {_SESSION_TOKEN}"
+    expected = f"Bearer {expected_token}"
     return hmac.compare_digest(auth.encode(), expected.encode())
 
 
@@ -863,7 +869,12 @@ async def get_mission_control_blueprint():
     try:
         from hermes_cli.mission_control import build_mission_control_snapshot
 
-        return build_mission_control_snapshot()
+        return build_mission_control_snapshot(
+            {
+                "auth_required": bool(getattr(app.state, "auth_required", False)),
+                "bound_host": str(getattr(app.state, "bound_host", "") or ""),
+            }
+        )
     except Exception as exc:
         _log.warning("mission-control blueprint failed: %s", exc)
         raise HTTPException(status_code=500, detail="Failed to build Mission Control snapshot.") from exc

--- a/tests/hermes_cli/test_mission_control.py
+++ b/tests/hermes_cli/test_mission_control.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def _seed_state_db(home: Path) -> None:
+    con = sqlite3.connect(home / "state.db")
+    con.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            model_config TEXT,
+            parent_session_id TEXT,
+            started_at REAL NOT NULL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            cwd TEXT,
+            billing_provider TEXT,
+            billing_base_url TEXT,
+            billing_mode TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL,
+            cost_status TEXT,
+            cost_source TEXT,
+            pricing_version TEXT,
+            title TEXT,
+            api_call_count INTEGER DEFAULT 0,
+            handoff_state TEXT,
+            handoff_platform TEXT,
+            handoff_error TEXT,
+            rewind_count INTEGER NOT NULL DEFAULT 0,
+            archived INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            timestamp REAL NOT NULL,
+            token_count INTEGER,
+            finish_reason TEXT,
+            reasoning TEXT,
+            reasoning_content TEXT,
+            reasoning_details TEXT,
+            codex_reasoning_items TEXT,
+            codex_message_items TEXT,
+            platform_message_id TEXT,
+            observed INTEGER DEFAULT 0,
+            active INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        """
+    )
+    now = time.time()
+    con.execute(
+        """
+        INSERT INTO sessions (
+            id, source, model, started_at, ended_at, message_count,
+            tool_call_count, input_tokens, output_tokens, reasoning_tokens,
+            estimated_cost_usd, title
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "session-1",
+            "telegram",
+            "gpt-5.5",
+            now - 3600,
+            now - 60,
+            2,
+            3,
+            1200,
+            800,
+            111,
+            0.42,
+            "Seed session",
+        ),
+    )
+    con.executemany(
+        "INSERT INTO messages (session_id, role, content, tool_name, timestamp) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("session-1", "user", "hello", None, now - 3500),
+            ("session-1", "assistant", "done", None, now - 3400),
+            ("session-1", "tool", "<secret should not surface>", "terminal", now - 3300),
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+def test_blueprint_static_source_covers_all_steps_and_feature_picker():
+    from hermes_cli.mission_control import BLUEPRINT_STEPS, HERMES_FEATURES, OPENCLAW_FEATURES
+
+    assert [step["id"] for step in BLUEPRINT_STEPS] == [
+        *[f"step-{i}" for i in range(1, 23)],
+        "step-22-5",
+        *[f"step-{i}" for i in range(23, 27)],
+    ]
+    assert [feature["id"] for feature in HERMES_FEATURES] == [f"H{i}" for i in range(1, 12)]
+    assert [feature["id"] for feature in OPENCLAW_FEATURES] == [f"O{i}" for i in range(1, 11)]
+
+
+def test_snapshot_uses_real_runtime_counts_and_compacts_sensitive_state(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "skills" / "example").mkdir(parents=True)
+    (home / "skills" / "example" / "SKILL.md").write_text(
+        "---\nname: example\ndescription: demo\n---\n\n# Example\n",
+        encoding="utf-8",
+    )
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "job-1", "enabled": True, "schedule": "0 9 * * *"}]}),
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        """
+model: gpt-5.5
+provider: openai-codex
+agent:
+  reasoning_effort: xhigh
+approvals:
+  mode: smart
+security:
+  redact_secrets: true
+gateway:
+  platforms:
+    telegram:
+      enabled: true
+stt:
+  enabled: true
+  provider: local
+tts:
+  provider: edge
+mcp_servers:
+  gmail:
+    command: npx
+    args: [server]
+""".strip(),
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("OPENROUTER_API_KEY=placeholder-openrouter-key\nDASHBOARD_TOKEN=placeholder-dashboard-token\n", encoding="utf-8")
+    (home / "soul.md").write_text("# Identity\nA real soul file\n", encoding="utf-8")
+    _seed_state_db(home)
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["blueprint"]["stepCount"] == 27
+    assert snapshot["blueprint"]["hermesFeatureCount"] == 11
+    assert snapshot["blueprint"]["openclawFeatureCount"] == 10
+    assert snapshot["runtime"]["sessions"]["total"] == 1
+    assert snapshot["runtime"]["sessions"]["messages"] == 3
+    assert snapshot["runtime"]["sessions"]["toolCalls"] == 3
+    assert snapshot["runtime"]["skills"]["total"] >= 1
+    assert snapshot["runtime"]["cron"]["total"] == 1
+    assert snapshot["runtime"]["mcp"]["configured"] == 1
+    assert snapshot["runtime"]["model"]["provider"] == "openai-codex"
+    assert snapshot["runtime"]["model"]["model"] == "gpt-5.5"
+    assert snapshot["runtime"]["model"]["reasoning"] == "xhigh"
+    assert all("id" not in item and "title" not in item for item in snapshot["runtime"]["sessions"]["recent"])
+    assert any(item["id"] == "step-24" and item["missionControl"] for item in snapshot["coverage"]["steps"])
+
+    assert str(home) not in encoded
+    assert "***" not in encoded
+    assert "placeholder-openrouter-key" not in encoded
+    assert "placeholder-dashboard-token" not in encoded
+    assert "Seed session" not in encoded
+    assert "session-1" not in encoded
+    assert "<secret should not surface>" not in encoded
+
+
+def test_dashboard_endpoint_serves_mission_control_snapshot():
+    from hermes_cli import web_server
+
+    client = TestClient(web_server.app)
+    unauth = client.get("/api/mission-control/blueprint")
+    assert unauth.status_code == 401
+
+    res = client.get(
+        "/api/mission-control/blueprint",
+        headers={"X-Hermes-Session-Token": web_server._SESSION_TOKEN},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["blueprint"]["stepCount"] == 27
+    assert data["coverage"]["summary"]["total"] >= 48
+
+
+def test_dashboard_endpoint_works_with_oauth_cookie_gate():
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import DashboardAuthProvider, LoginStart, Session, clear_providers, register_provider
+
+    class DummyProvider(DashboardAuthProvider):
+        name = "dummy"
+        display_name = "Dummy"
+
+        def start_login(self, *, redirect_uri: str) -> LoginStart:
+            return LoginStart(redirect_url=redirect_uri, cookie_payload={})
+
+        def complete_login(self, *, code: str, state: str, code_verifier: str, redirect_uri: str) -> Session:
+            raise NotImplementedError
+
+        def verify_session(self, *, access_token: str):
+            if access_token != "valid-access-token":
+                return None
+            return Session(
+                user_id="user-1",
+                email="",
+                display_name="",
+                org_id="",
+                provider=self.name,
+                expires_at=int(time.time()) + 3600,
+                access_token=access_token,
+                refresh_token="refresh-token",
+            )
+
+        def refresh_session(self, *, refresh_token: str) -> Session:
+            raise NotImplementedError
+
+        def revoke_session(self, *, refresh_token: str) -> None:
+            return None
+
+    previous_auth_required = getattr(web_server.app.state, "auth_required", False)
+    clear_providers()
+    register_provider(DummyProvider())
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(web_server.app)
+        client.cookies.set("hermes_session_at", "valid-access-token")
+        res = client.get("/api/mission-control/blueprint")
+        assert res.status_code == 200
+        assert res.json()["blueprint"]["stepCount"] == 27
+    finally:
+        web_server.app.state.auth_required = previous_auth_required
+        clear_providers()

--- a/tests/hermes_cli/test_mission_control.py
+++ b/tests/hermes_cli/test_mission_control.py
@@ -68,6 +68,8 @@ def _seed_state_db(home: Path) -> None:
             active INTEGER NOT NULL DEFAULT 1
         );
         CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE messages_fts (content TEXT);
+        CREATE TABLE summaries (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, content TEXT, updated_at REAL);
         """
     )
     now = time.time()
@@ -75,9 +77,10 @@ def _seed_state_db(home: Path) -> None:
         """
         INSERT INTO sessions (
             id, source, model, started_at, ended_at, message_count,
-            tool_call_count, input_tokens, output_tokens, reasoning_tokens,
-            estimated_cost_usd, title
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            tool_call_count, input_tokens, output_tokens, cache_read_tokens,
+            cache_write_tokens, reasoning_tokens, estimated_cost_usd, actual_cost_usd,
+            title, api_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             "session-1",
@@ -89,9 +92,13 @@ def _seed_state_db(home: Path) -> None:
             3,
             1200,
             800,
+            333,
+            44,
             111,
             0.42,
+            0.31,
             "Seed session",
+            5,
         ),
     )
     con.executemany(
@@ -102,6 +109,7 @@ def _seed_state_db(home: Path) -> None:
             ("session-1", "tool", "<secret should not surface>", "terminal", now - 3300),
         ],
     )
+    con.execute("INSERT INTO summaries (session_id, content, updated_at) VALUES (?, ?, ?)", ("session-1", "private summary", now - 100))
     con.commit()
     con.close()
 
@@ -122,7 +130,12 @@ def test_snapshot_uses_real_runtime_counts_and_compacts_sensitive_state(tmp_path
     home = Path(os.environ["HERMES_HOME"])
     (home / "skills" / "example").mkdir(parents=True)
     (home / "skills" / "example" / "SKILL.md").write_text(
-        "---\nname: example\ndescription: demo\n---\n\n# Example\n",
+        "---\nname: example\ndescription: demo\n---\nmetadata:\n  created_by: agent\n\n# Example\n",
+        encoding="utf-8",
+    )
+    (home / "skills" / "acme-client-lawsuit").mkdir(parents=True)
+    (home / "skills" / "acme-client-lawsuit" / "SKILL.md").write_text(
+        "---\nname: acme-client-lawsuit\ndescription: private workflow\n---\n\n# Private\n",
         encoding="utf-8",
     )
     (home / "cron").mkdir(parents=True, exist_ok=True)
@@ -156,7 +169,16 @@ mcp_servers:
 """.strip(),
         encoding="utf-8",
     )
-    (home / ".env").write_text("OPENROUTER_API_KEY=placeholder-openrouter-key\nDASHBOARD_TOKEN=placeholder-dashboard-token\n", encoding="utf-8")
+    (home / ".env").write_text(
+        "OPENROUTER_API_KEY=placeholder-openrouter-key\n"
+        "DASHBOARD_TOKEN=placeholder-dashboard-token\n"
+        "TELEGRAM_BOT_TOKEN=placeholder-telegram-token\n"
+        "ALLOWED_USER_IDS=123456,789012\n"
+        "OPENAI_API_KEY=placeholder-openai-key\n"
+        "PINECONE_API_KEY=placeholder-pinecone-key\n"
+        "PINECONE_INDEX=private-index-name\n",
+        encoding="utf-8",
+    )
     (home / "soul.md").write_text("# Identity\nA real soul file\n", encoding="utf-8")
     _seed_state_db(home)
 
@@ -177,6 +199,24 @@ mcp_servers:
     assert snapshot["runtime"]["model"]["provider"] == "openai-codex"
     assert snapshot["runtime"]["model"]["model"] == "gpt-5.5"
     assert snapshot["runtime"]["model"]["reasoning"] == "xhigh"
+    assert snapshot["runtime"]["env"]["telegram"]["allowedUserCount"] == 2
+    assert snapshot["runtime"]["env"]["dashboard"]["tokenPresent"] is True
+    assert snapshot["runtime"]["semantic"]["configured"] is True
+    assert snapshot["runtime"]["semantic"]["indexConfigured"] is True
+    assert snapshot["runtime"]["sessions"]["cacheReadTokens"] == 333
+    assert snapshot["runtime"]["sessions"]["cacheWriteTokens"] == 44
+    assert snapshot["runtime"]["sessions"]["actualCostUsd"] == 0.31
+    assert snapshot["runtime"]["sessions"]["apiCalls"] == 5
+    assert snapshot["runtime"]["sessions"]["ftsPresent"] is True
+    assert snapshot["runtime"]["memory"]["sqlite"]["summaries"] == 1
+    assert len(snapshot["runtime"]["preflight"]) == 11
+    assert len(snapshot["runtime"]["customization"]) == 9
+    assert len(snapshot["runtime"]["dataFlow"]) == 5
+    assert snapshot["runtime"]["production"]["score"] >= 0
+    assert len(snapshot["blueprint"]["architecturePieces"]) == 7
+    assert len(snapshot["blueprint"]["prerequisites"]) == 5
+    assert len(snapshot["blueprint"]["nextTools"]) == 8
+    assert len(snapshot["blueprint"]["troubleshooting"]) == 10
     assert all("id" not in item and "title" not in item for item in snapshot["runtime"]["sessions"]["recent"])
     assert any(item["id"] == "step-24" and item["missionControl"] for item in snapshot["coverage"]["steps"])
 
@@ -184,6 +224,14 @@ mcp_servers:
     assert "***" not in encoded
     assert "placeholder-openrouter-key" not in encoded
     assert "placeholder-dashboard-token" not in encoded
+    assert "placeholder-telegram-token" not in encoded
+    assert "placeholder-openai-key" not in encoded
+    assert "placeholder-pinecone-key" not in encoded
+    assert "123456" not in encoded
+    assert "789012" not in encoded
+    assert "private-index-name" not in encoded
+    assert "acme-client-lawsuit" not in encoded
+    assert "private summary" not in encoded
     assert "Seed session" not in encoded
     assert "session-1" not in encoded
     assert "<secret should not surface>" not in encoded

--- a/tests/hermes_cli/test_mission_control.py
+++ b/tests/hermes_cli/test_mission_control.py
@@ -237,6 +237,76 @@ mcp_servers:
     assert "<secret should not surface>" not in encoded
 
 
+def test_snapshot_redacts_runtime_labels_that_can_embed_private_names(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "skills" / "acme-client-lawsuit" / "internal").mkdir(parents=True)
+    (home / "skills" / "acme-client-lawsuit" / "internal" / "SKILL.md").write_text(
+        "---\nname: acme-private-skill\ndescription: private workflow\n---\n\n# Private\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        """
+model:
+  provider: local
+  default: /private/models/acme-client-local.gguf
+mcp_servers:
+  acme-prod-db:
+    command: npx
+    args: [server]
+""".strip(),
+        encoding="utf-8",
+    )
+    _seed_state_db(home)
+    con = sqlite3.connect(home / "state.db")
+    con.execute(
+        "UPDATE sessions SET source=?, model=? WHERE id=?",
+        ("telegram:123456789:secret-topic", "/private/models/session-secret.gguf", "session-1"),
+    )
+    con.commit()
+    con.close()
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["runtime"]["model"]["model"] == "local-model"
+    assert snapshot["runtime"]["sessions"]["sources"] == {"telegram": 1}
+    assert snapshot["runtime"]["sessions"]["recent"][0]["source"] == "telegram"
+    assert snapshot["runtime"]["sessions"]["recent"][0]["model"] == "local-model"
+    assert snapshot["runtime"]["mcp"]["servers"] == ["server-1"]
+    assert snapshot["runtime"]["mcp"]["serverNamesRedacted"] is True
+    assert set(snapshot["runtime"]["skills"]["categories"]) <= {"direct", "grouped"}
+
+    for forbidden in [
+        "/private/models",
+        "acme-client-local",
+        "session-secret",
+        "telegram:123456789",
+        "123456789",
+        "secret-topic",
+        "acme-prod-db",
+        "acme-client-lawsuit",
+        "acme-private-skill",
+    ]:
+        assert forbidden not in encoded
+
+
+def test_snapshot_uses_live_dashboard_bind_and_auth_state(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text("dashboard:\n  host: 127.0.0.1\n", encoding="utf-8")
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot({"bound_host": "0.0.0.0", "auth_required": False})
+    dashboard = snapshot["runtime"]["dashboard"]
+
+    assert dashboard["bindExposure"] == "public"
+    assert dashboard["runtimeHostKnown"] is True
+    assert dashboard["authGated"] is False
+    assert dashboard["authMode"] == "not-gated"
+
+
 def test_dashboard_endpoint_serves_mission_control_snapshot():
     from hermes_cli import web_server
 

--- a/tests/hermes_cli/test_mission_control.py
+++ b/tests/hermes_cli/test_mission_control.py
@@ -292,6 +292,312 @@ mcp_servers:
         assert forbidden not in encoded
 
 
+def test_snapshot_redacts_toolset_gateway_and_provider_labels(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        """
+model:
+  provider: acme-private-provider
+  default: file:///private/models/acme-client-model.gguf
+delegation:
+  provider: acme-delegation-private
+semantic:
+  provider: acme-vector-client
+  index: private-index-name
+stt:
+  enabled: true
+  provider: acme-whisper
+tts:
+  provider: acme-voice
+toolsets:
+  - terminal
+  - mcp-acme-prod-db
+  - private-client-plugin
+agent:
+  reasoning_effort: acme-private-reasoning
+  disabled_toolsets:
+    - mcp-secret-calendar
+approvals:
+  mode: acme-secret-approval
+  cron_mode: acme-secret-cron
+terminal:
+  backend: acme-secret-backend
+tools:
+  max_output_chars: 9000
+gateway:
+  platforms:
+    telegram:
+      enabled: true
+    telegram:123456789:secret-topic:
+      enabled: true
+    acme-private-gateway:
+      enabled: true
+mcp_servers:
+  acme-prod-db:
+    command: npx
+    args: [server]
+""".strip(),
+        encoding="utf-8",
+    )
+    _seed_state_db(home)
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["runtime"]["tools"]["configuredToolsetCount"] == 3
+    assert snapshot["runtime"]["tools"]["disabledToolsetCount"] == 1
+    assert snapshot["runtime"]["gateway"]["configuredCount"] == 3
+    assert snapshot["runtime"]["gateway"]["configuredPlatforms"] == ["other", "telegram"]
+    assert snapshot["runtime"]["model"]["provider"] == "custom"
+    assert snapshot["runtime"]["model"]["delegationProvider"] == "custom"
+    assert snapshot["runtime"]["model"]["reasoning"] == "custom"
+    assert snapshot["runtime"]["semantic"]["provider"] == "custom"
+    assert snapshot["runtime"]["voice"]["sttProvider"] == "custom"
+    assert snapshot["runtime"]["voice"]["ttsProvider"] == "custom"
+    assert snapshot["runtime"]["safety"]["approvalsMode"] == "custom"
+    assert snapshot["runtime"]["safety"]["cronApprovalsMode"] == "custom"
+    assert snapshot["runtime"]["safety"]["terminalBackend"] == "custom"
+    assert snapshot["runtime"]["safety"]["toolOutputLimits"]["configured"] is True
+    assert snapshot["runtime"]["safety"]["toolOutputLimits"]["minChars"] == 9000
+    assert snapshot["runtime"]["safety"]["promptInjection"]["toolOutputLimitConfigured"] is True
+
+    for forbidden in [
+        "acme-private-provider",
+        "acme-delegation-private",
+        "acme-vector-client",
+        "acme-private-reasoning",
+        "acme-secret-approval",
+        "acme-secret-cron",
+        "acme-secret-backend",
+        "acme-whisper",
+        "acme-voice",
+        "file:///private",
+        "acme-client-model",
+        "private-index-name",
+        "mcp-acme-prod-db",
+        "private-client-plugin",
+        "mcp-secret-calendar",
+        "telegram:123456789",
+        "123456789",
+        "secret-topic",
+        "acme-private-gateway",
+        "acme-prod-db",
+    ]:
+        assert forbidden not in encoded
+
+
+def test_snapshot_redacts_sensitive_session_db_columns(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text("model: gpt-5.5\nprovider: openai-codex\n", encoding="utf-8")
+    _seed_state_db(home)
+    con = sqlite3.connect(home / "state.db")
+    con.execute(
+        """
+        UPDATE sessions SET
+            user_id=?, cwd=?, model_config=?, billing_base_url=?, handoff_platform=?, handoff_error=?, end_reason=?, parent_session_id=?, rewind_count=?
+        WHERE id=?
+        """,
+        (
+            "user-canary-987654",
+            "/private/workspaces/acme-client",
+            '{"deployment":"acme-private-deploy"}',
+            "https://acme-private-provider.example/v1",
+            "telegram:987654:secret-thread",
+            "private handoff error canary",
+            "max_iterations",
+            "parent-secret-session-id",
+            2,
+            "session-1",
+        ),
+    )
+    con.execute(
+        """
+        UPDATE messages SET
+            platform_message_id=?, tool_calls=?, tool_name=?, reasoning=?, reasoning_content=?, reasoning_details=?, codex_reasoning_items=?, codex_message_items=?
+        WHERE id=1
+        """,
+        (
+            "platform-message-canary",
+            '[{"name":"private_tool","arguments":{"cmd":"rm -rf /private/acme"}}]',
+            "mcp_acme_private_tool",
+            "private reasoning canary",
+            "private reasoning content canary",
+            "private reasoning details canary",
+            "private codex reasoning item canary",
+            "private codex message item canary",
+        ),
+    )
+    con.commit()
+    con.close()
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["runtime"]["sessions"]["endReasonCounts"]["max_iterations"] == 1
+    assert snapshot["runtime"]["sessions"]["childSessionCount"] == 1
+    assert snapshot["runtime"]["sessions"]["rewindTotal"] == 2
+
+    for forbidden in [
+        "user-canary-987654",
+        "/private/workspaces/acme-client",
+        "acme-private-deploy",
+        "acme-private-provider.example",
+        "telegram:987654",
+        "secret-thread",
+        "private handoff error canary",
+        "parent-secret-session-id",
+        "platform-message-canary",
+        "private_tool",
+        "rm -rf",
+        "/private/acme",
+        "mcp_acme_private_tool",
+        "private reasoning canary",
+        "private reasoning content canary",
+        "private reasoning details canary",
+        "private codex reasoning item canary",
+        "private codex message item canary",
+    ]:
+        assert forbidden not in encoded
+
+
+def test_snapshot_redacts_cron_mcp_commands_and_delivery_targets(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    (home / "cron" / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "private-job-id",
+                        "enabled": True,
+                        "name": "acme private reflection heartbeat",
+                        "prompt": "read /private/acme/secret and send it",
+                        "script": "/private/acme/cron.py",
+                        "schedule": "every 30m",
+                        "deliver": "telegram:123456789:secret-topic",
+                        "last_error": "private cron error canary",
+                        "last_run_at": now - 120,
+                        "next_run_at": now - 30,
+                        "last_status": "error",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        """
+mcp_servers:
+  acme-private-server:
+    command: /private/bin/mcp-acme
+    args: [--token, private-arg-canary]
+    url: https://acme-private-mcp.example/sse
+    headers:
+      Authorization: private-header-canary
+""".strip(),
+        encoding="utf-8",
+    )
+    _seed_state_db(home)
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["runtime"]["cron"]["total"] == 1
+    assert snapshot["runtime"]["cron"]["overdueCount"] == 1
+    assert snapshot["runtime"]["cron"]["lastStatusCounts"]["error"] == 1
+    assert snapshot["runtime"]["cron"]["lastRunAgeBuckets"]["under_1h"] == 1
+    assert snapshot["runtime"]["cron"]["reflectionFreshness"] == "fresh"
+    assert snapshot["runtime"]["cron"]["reflectionLastRunAgeSeconds"] is not None
+    assert snapshot["runtime"]["mcp"]["configured"] == 1
+    assert snapshot["runtime"]["mcp"]["statusCounts"]["enabled"] == 1
+    assert snapshot["runtime"]["mcp"]["serverNamesRedacted"] is True
+
+    for forbidden in [
+        "private-job-id",
+        "acme private heartbeat",
+        "acme private reflection",
+        "/private/acme",
+        "telegram:123456789",
+        "123456789",
+        "secret-topic",
+        "private cron error canary",
+        "acme-private-server",
+        "/private/bin/mcp-acme",
+        "private-arg-canary",
+        "acme-private-mcp.example",
+        "private-header-canary",
+    ]:
+        assert forbidden not in encoded
+
+
+def test_model_label_sanitizer_preserves_public_families_only():
+    from hermes_cli.mission_control import _safe_model_label
+
+    assert _safe_model_label("gpt-5.5") == "gpt-5.5"
+    assert _safe_model_label("anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
+    assert _safe_model_label("openrouter/google/gemini-2.5-pro-preview") == "openrouter/google/gemini-2.5-pro-preview"
+    assert _safe_model_label("gpt-4o") == "gpt-4o"
+    assert _safe_model_label("llama-7b") == "llama-7b"
+    assert _safe_model_label("qwen2.5-coder") == "qwen2.5-coder"
+    assert _safe_model_label("deepseek-r1") == "deepseek-r1"
+    assert _safe_model_label("llama3.1-instruct") == "llama3.1-instruct"
+    assert _safe_model_label("acme123") == "custom-model"
+    assert _safe_model_label("client42") == "custom-model"
+    assert _safe_model_label("prod2") == "custom-model"
+    assert _safe_model_label("openai/acme2") == "custom-model"
+    assert _safe_model_label("123client") == "custom-model"
+    assert _safe_model_label("42prod") == "custom-model"
+    assert _safe_model_label("v2acme") == "custom-model"
+    assert _safe_model_label("openai/123client") == "custom-model"
+    assert _safe_model_label("openai/o3acme") == "custom-model"
+    assert _safe_model_label("llama3client") == "custom-model"
+    assert _safe_model_label("qwen2prod") == "custom-model"
+    assert _safe_model_label("gemma2private") == "custom-model"
+    assert _safe_model_label("glm4acme") == "custom-model"
+    assert _safe_model_label("r1client") == "custom-model"
+    assert _safe_model_label("gpt-4o-客户") == "custom-model"
+    assert _safe_model_label("openai/acme-private-client-deploy") == "custom-model"
+    assert _safe_model_label("gpt-5.5-acme-private") == "custom-model"
+    assert _safe_model_label("https://models.example/acme-private-model") == "custom-model"
+
+
+def test_mcp_metrics_count_all_servers_while_sampling_redacted_details(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    server_lines = ["mcp_servers:"]
+    for idx in range(1, 14):
+        server_lines.extend([
+            f"  acme-private-server-{idx}:",
+            "    command: npx",
+            "    args: [server]",
+        ])
+        if idx == 13:
+            server_lines.append("    enabled: false")
+    (home / "config.yaml").write_text("\n".join(server_lines), encoding="utf-8")
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+    mcp = snapshot["runtime"]["mcp"]
+
+    assert mcp["configured"] == 13
+    assert mcp["enabled"] == 12
+    assert mcp["disabled"] == 1
+    assert mcp["statusCounts"] == {"enabled": 12, "disabled": 1}
+    assert mcp["transportCounts"]["stdio"] == 13
+    assert len(mcp["servers"]) == 12
+    assert len(mcp["serverDetails"]) == 12
+    assert mcp["serverNamesRedacted"] is True
+    assert "acme-private-server" not in encoded
+
+
 def test_snapshot_uses_live_dashboard_bind_and_auth_state(tmp_path, monkeypatch):
     home = Path(os.environ["HERMES_HOME"])
     (home / "config.yaml").write_text("dashboard:\n  host: 127.0.0.1\n", encoding="utf-8")

--- a/tests/hermes_cli/test_mission_control.py
+++ b/tests/hermes_cli/test_mission_control.py
@@ -237,6 +237,110 @@ mcp_servers:
     assert "<secret should not surface>" not in encoded
 
 
+def test_snapshot_counts_gateway_telegram_allowlist_env_without_exposing_ids(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        """
+model: gpt-5.5
+provider: openai-codex
+gateway:
+  platforms:
+    telegram:
+      enabled: true
+""".strip(),
+        encoding="utf-8",
+    )
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=placeholder-telegram-token\n"
+        "TELEGRAM_ALLOWED_USERS=123456,789012\n",
+        encoding="utf-8",
+    )
+    _seed_state_db(home)
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    encoded = json.dumps(snapshot, ensure_ascii=False)
+
+    assert snapshot["runtime"]["env"]["telegram"]["allowedUserCount"] == 2
+    allowed_key = next(item for item in snapshot["runtime"]["env"]["requiredKeys"] if item["key"] == "ALLOWED_USER_IDS")
+    assert allowed_key["isSet"] is True
+    assert allowed_key["count"] == 2
+    allowed_preflight = next(item for item in snapshot["runtime"]["preflight"] if item["id"] == "allowed_users")
+    assert allowed_preflight["status"] == "pass"
+    assert "123456" not in encoded
+    assert "789012" not in encoded
+
+
+def test_snapshot_treats_systemd_gateway_service_as_managed_hosting(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        """
+model: gpt-5.5
+provider: openai-codex
+approvals:
+  mode: smart
+""".strip(),
+        encoding="utf-8",
+    )
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=placeholder-telegram-token\n"
+        "TELEGRAM_ALLOWED_USERS=123456\n",
+        encoding="utf-8",
+    )
+    _seed_state_db(home)
+
+    import hermes_cli.gateway as gateway_cli
+
+    class FakeGatewaySnapshot:
+        manager = "systemd (user)"
+        service_installed = True
+        service_running = True
+        gateway_pids = (4242,)
+        service_scope = "user"
+
+        @property
+        def running(self):
+            return self.service_running or bool(self.gateway_pids)
+
+        @property
+        def has_process_service_mismatch(self):
+            return False
+
+    monkeypatch.setattr(gateway_cli, "get_gateway_runtime_snapshot", lambda system=False: FakeGatewaySnapshot())
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+    hosting = snapshot["runtime"]["hosting"]
+
+    assert snapshot["runtime"]["gateway"]["serviceManager"] == "systemd"
+    assert snapshot["runtime"]["gateway"]["serviceInstalled"] is True
+    assert snapshot["runtime"]["gateway"]["serviceRunning"] is True
+    assert hosting["installMethod"] == "systemd"
+    assert hosting["managedService"] is True
+    hosting_signal = next(item for item in snapshot["runtime"]["production"]["signals"] if item["id"] == "hosting")
+    assert hosting_signal["status"] == "pass"
+    step_25 = next(item for item in snapshot["coverage"]["steps"] if item["id"] == "step-25")
+    assert step_25["status"] == "active"
+
+
+def test_snapshot_treats_uppercase_soul_md_as_identity_file(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text("model: gpt-5.5\nprovider: openai-codex\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("You are direct and technically precise.\n", encoding="utf-8")
+    _seed_state_db(home)
+
+    from hermes_cli.mission_control import build_mission_control_snapshot
+
+    snapshot = build_mission_control_snapshot()
+
+    assert snapshot["runtime"]["identity"]["soulPresent"] is True
+    assert "~/.hermes/SOUL.md" in snapshot["runtime"]["identity"]["files"]
+    step_5 = next(item for item in snapshot["coverage"]["steps"] if item["id"] == "step-5")
+    assert step_5["status"] == "active"
+
+
 def test_snapshot_redacts_runtime_labels_that_can_embed_private_names(tmp_path, monkeypatch):
     home = Path(os.environ["HERMES_HOME"])
     (home / "skills" / "acme-client-lawsuit" / "internal").mkdir(parents=True)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -209,6 +209,26 @@ class TestSessionTokenInjection:
 
         assert ws._SESSION_TOKEN and len(ws._SESSION_TOKEN) >= 32
 
+    def test_existing_app_keeps_own_token_after_module_reload(self, monkeypatch):
+        """An already-created FastAPI app must not start checking a later reload's token."""
+        import importlib
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
+        importlib.reload(ws)
+        old_app = ws.app
+        old_token = ws._SESSION_TOKEN
+        old_header = ws._SESSION_HEADER_NAME
+
+        importlib.reload(ws)
+        try:
+            old_app.state.auth_required = False
+            resp = TestClient(old_app).get("/api/providers/oauth", headers={old_header: old_token})
+            assert resp.status_code == 200, resp.text
+        finally:
+            importlib.reload(ws)
+
 
 # ---------------------------------------------------------------------------
 # web_server tests (FastAPI endpoints)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -81,6 +81,7 @@ import PairingPage from "@/pages/PairingPage";
 import ChannelsPage from "@/pages/ChannelsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
 import SystemPage from "@/pages/SystemPage";
+import MissionControlPage from "@/pages/MissionControlPage";
 import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
@@ -135,6 +136,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/channels": ChannelsPage,
   "/webhooks": WebhooksPage,
   "/system": SystemPage,
+  "/mission-control": MissionControlPage,
   "/profiles": ProfilesPage,
   "/config": ConfigPage,
   "/env": EnvPage,
@@ -180,6 +182,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
   { path: "/system", label: "System", icon: Wrench },
+  { path: "/mission-control", label: "Mission Control", icon: Activity },
   {
     path: "/docs",
     labelKey: "documentation",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -251,6 +251,8 @@ export async function buildWsUrl(
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getMissionControlBlueprint: () =>
+    fetchJSON<MissionControlSnapshot>("/api/mission-control/blueprint"),
   /**
    * Identity probe for the dashboard auth gate (Phase 7).
    *
@@ -970,6 +972,88 @@ export const api = {
       `/api/skills/hub/scan?identifier=${encodeURIComponent(identifier)}`,
     ),
 };
+
+export type MissionControlStatus = "active" | "partial" | "watch" | "planned" | string;
+
+export interface MissionControlCoverageItem {
+  id: string;
+  number?: string;
+  title: string;
+  domain: string;
+  part?: string;
+  summary: string;
+  where?: string;
+  route?: string;
+  sourceUrl?: string;
+  status: MissionControlStatus;
+  readiness: number;
+  evidence: string[];
+  next: string;
+  missionControl?: boolean;
+}
+
+export interface MissionControlDomainScore {
+  name: string;
+  score: number;
+  items: number;
+}
+
+export interface MissionControlSnapshot {
+  ok: boolean;
+  source: {
+    url: string;
+    title: string;
+    lastChecked: string;
+    extractedWith: string;
+    note: string;
+  };
+  blueprint: {
+    stepCount: number;
+    numberedStepCount: number;
+    hermesFeatureCount: number;
+    openclawFeatureCount: number;
+    parts: string[];
+  };
+  runtime: {
+    generatedAt: string;
+    home: string;
+    model: Record<string, unknown>;
+    env: Record<string, unknown>;
+    identity: Record<string, unknown>;
+    sessions: Record<string, unknown>;
+    skills: Record<string, unknown>;
+    cron: Record<string, unknown>;
+    mcp: Record<string, unknown>;
+    gateway: Record<string, unknown>;
+    tools: Record<string, unknown>;
+    safety: Record<string, unknown>;
+    voice: Record<string, unknown>;
+    dashboard: Record<string, unknown>;
+  };
+  coverage: {
+    summary: {
+      total: number;
+      readiness: number;
+      counts: Record<string, number>;
+    };
+    steps: MissionControlCoverageItem[];
+    features: MissionControlCoverageItem[];
+    domains: MissionControlDomainScore[];
+    weakestDomains: MissionControlDomainScore[];
+  };
+  actionQueue: Array<{
+    rank: number;
+    tone: "now" | "next" | "watch" | string;
+    title: string;
+    reason: string;
+    route: string;
+  }>;
+  privacy: Array<{ label: string; policy: string; detail: string }>;
+  deviceProof: {
+    principles: string[];
+    breakpoints: string[];
+  };
+}
 
 /** Identity payload returned by ``GET /api/auth/me`` (Phase 7).
  *

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -992,6 +992,25 @@ export interface MissionControlCoverageItem {
   missionControl?: boolean;
 }
 
+
+export interface MissionControlInfoItem {
+  id: string;
+  title?: string;
+  label?: string;
+  term?: string;
+  symptom?: string;
+  summary?: string;
+  detail?: string;
+  definition?: string;
+  cause?: string;
+  fix?: string;
+  route?: string;
+  url?: string;
+  status?: string;
+  evidence?: string[];
+  [key: string]: unknown;
+}
+
 export interface MissionControlDomainScore {
   name: string;
   score: number;
@@ -1013,6 +1032,15 @@ export interface MissionControlSnapshot {
     hermesFeatureCount: number;
     openclawFeatureCount: number;
     parts: string[];
+    architecturePieces?: MissionControlInfoItem[];
+    prerequisites?: MissionControlInfoItem[];
+    preflightChecks?: MissionControlInfoItem[];
+    customizationChecklist?: MissionControlInfoItem[];
+    nextTools?: MissionControlInfoItem[];
+    glossary?: MissionControlInfoItem[];
+    troubleshooting?: MissionControlInfoItem[];
+    resources?: MissionControlInfoItem[];
+    dataFlowSurfaces?: MissionControlInfoItem[];
   };
   runtime: {
     generatedAt: string;
@@ -1029,6 +1057,17 @@ export interface MissionControlSnapshot {
     safety: Record<string, unknown>;
     voice: Record<string, unknown>;
     dashboard: Record<string, unknown>;
+    memory: Record<string, unknown>;
+    semantic: Record<string, unknown>;
+    analytics: Record<string, unknown>;
+    quality: Record<string, unknown>;
+    multiUser: Record<string, unknown>;
+    reflection: Record<string, unknown>;
+    hosting: Record<string, unknown>;
+    dataFlow: MissionControlInfoItem[];
+    preflight: MissionControlInfoItem[];
+    customization: MissionControlInfoItem[];
+    production: Record<string, unknown>;
   };
   coverage: {
     summary: {
@@ -1047,11 +1086,14 @@ export interface MissionControlSnapshot {
     title: string;
     reason: string;
     route: string;
+    category?: string;
+    effort?: string;
   }>;
   privacy: Array<{ label: string; policy: string; detail: string }>;
   deviceProof: {
     principles: string[];
     breakpoints: string[];
+    smokeTargets?: MissionControlInfoItem[];
   };
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1017,6 +1017,95 @@ export interface MissionControlDomainScore {
   items: number;
 }
 
+export interface MissionControlModelRuntime extends Record<string, unknown> {
+  provider: string;
+  model: string;
+  reasoning: string;
+  delegationProvider?: string | null;
+  maxTurns?: number;
+}
+
+export interface MissionControlCronRuntime extends Record<string, unknown> {
+  total: number;
+  enabled: number;
+  paused: number;
+  cadences: Record<string, number>;
+  deliveries: Record<string, number>;
+  lastStatusCounts: Record<string, number>;
+  failedJobs: number;
+  overdueCount: number;
+  nextRunKnown: boolean;
+  nextRunDueInSeconds: number | null;
+  lastRunAgeSeconds: number | null;
+  lastRunAgeBuckets: Record<string, number>;
+  reflectionFreshness: string;
+  reflectionLastRunAgeSeconds: number | null;
+}
+
+export interface MissionControlMcpRuntime extends Record<string, unknown> {
+  configured: number;
+  servers: string[];
+  serverDetails: MissionControlInfoItem[];
+  serverNamesRedacted: boolean;
+  enabled: number;
+  disabled: number;
+  statusCounts: Record<string, number>;
+  transportCounts: Record<string, number>;
+}
+
+export interface MissionControlToolsRuntime extends Record<string, unknown> {
+  configuredToolsets: string[];
+  configuredToolsetCount: number;
+  configuredToolsetBuckets: Record<string, number>;
+  configuredToolsetNamesRedacted: boolean;
+  disabledToolsets: string[];
+  disabledToolsetCount: number;
+  disabledToolsetBuckets: Record<string, number>;
+  registeredToolCount: number;
+  enabledToolCount: number;
+}
+
+export interface MissionControlSafetyRuntime extends Record<string, unknown> {
+  approvalsMode: string;
+  cronApprovalsMode: string;
+  approvalFlowConfigured: boolean;
+  autoApproveEnabled: boolean;
+  redactSecrets: boolean;
+  terminalBackend: string;
+  terminalIsolated: boolean;
+  privateUrlsAllowed: boolean;
+  toolOutputLimits: Record<string, unknown>;
+  promptInjection: Record<string, unknown>;
+}
+
+export interface MissionControlRuntime {
+  generatedAt: string;
+  home: string;
+  model: MissionControlModelRuntime;
+  env: Record<string, unknown>;
+  identity: Record<string, unknown>;
+  sessions: Record<string, unknown>;
+  skills: Record<string, unknown>;
+  cron: MissionControlCronRuntime;
+  mcp: MissionControlMcpRuntime;
+  gateway: Record<string, unknown>;
+  tools: MissionControlToolsRuntime;
+  safety: MissionControlSafetyRuntime;
+  voice: Record<string, unknown>;
+  dashboard: Record<string, unknown>;
+  memory: Record<string, unknown>;
+  semantic: Record<string, unknown>;
+  analytics: Record<string, unknown>;
+  quality: Record<string, unknown>;
+  multiUser: Record<string, unknown>;
+  reflection: Record<string, unknown>;
+  hosting: Record<string, unknown>;
+  dataFlow: MissionControlInfoItem[];
+  preflight: MissionControlInfoItem[];
+  customization: MissionControlInfoItem[];
+  production: Record<string, unknown>;
+}
+
 export interface MissionControlSnapshot {
   ok: boolean;
   source: {
@@ -1042,33 +1131,7 @@ export interface MissionControlSnapshot {
     resources?: MissionControlInfoItem[];
     dataFlowSurfaces?: MissionControlInfoItem[];
   };
-  runtime: {
-    generatedAt: string;
-    home: string;
-    model: Record<string, unknown>;
-    env: Record<string, unknown>;
-    identity: Record<string, unknown>;
-    sessions: Record<string, unknown>;
-    skills: Record<string, unknown>;
-    cron: Record<string, unknown>;
-    mcp: Record<string, unknown>;
-    gateway: Record<string, unknown>;
-    tools: Record<string, unknown>;
-    safety: Record<string, unknown>;
-    voice: Record<string, unknown>;
-    dashboard: Record<string, unknown>;
-    memory: Record<string, unknown>;
-    semantic: Record<string, unknown>;
-    analytics: Record<string, unknown>;
-    quality: Record<string, unknown>;
-    multiUser: Record<string, unknown>;
-    reflection: Record<string, unknown>;
-    hosting: Record<string, unknown>;
-    dataFlow: MissionControlInfoItem[];
-    preflight: MissionControlInfoItem[];
-    customization: MissionControlInfoItem[];
-    production: Record<string, unknown>;
-  };
+  runtime: MissionControlRuntime;
   coverage: {
     summary: {
       total: number;

--- a/web/src/lib/resolve-page-title.ts
+++ b/web/src/lib/resolve-page-title.ts
@@ -28,6 +28,9 @@ export function resolvePageTitle(
   if (plugin) {
     return plugin.label;
   }
+  if (normalized === "/mission-control") {
+    return "Mission Control";
+  }
   const key = BUILTIN[normalized];
   if (key) {
     return t.app.nav[key];

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -1,0 +1,506 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import {
+  Activity,
+  ArrowUpRight,
+  Bot,
+  Brain,
+  CalendarClock,
+  CheckCircle2,
+  CircleDot,
+  Database,
+  Fingerprint,
+  Gauge,
+  Globe2,
+  Layers3,
+  LockKeyhole,
+  Radar,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Workflow,
+  Zap,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { api } from "@/lib/api";
+import type {
+  MissionControlCoverageItem,
+  MissionControlDomainScore,
+  MissionControlSnapshot,
+  MissionControlStatus,
+} from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { cn } from "@/lib/utils";
+import { PluginSlot } from "@/plugins";
+
+type AnyRecord = Record<string, unknown>;
+
+function num(record: AnyRecord, key: string, fallback = 0): number {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function str(record: AnyRecord, key: string, fallback = "—"): string {
+  const value = record[key];
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "yes" : "no";
+  return fallback;
+}
+
+function boolText(record: AnyRecord, key: string): string {
+  return record[key] === true ? "yes" : "no";
+}
+
+function strArray(record: AnyRecord, key: string): string[] {
+  const value = record[key];
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value);
+}
+
+function statusTone(status: MissionControlStatus): "success" | "warning" | "secondary" | "outline" {
+  if (status === "active") return "success";
+  if (status === "partial") return "warning";
+  if (status === "watch") return "secondary";
+  return "outline";
+}
+
+function statusLabel(status: MissionControlStatus): string {
+  if (status === "active") return "active";
+  if (status === "partial") return "partial";
+  if (status === "watch") return "watch";
+  if (status === "planned") return "planned";
+  return String(status);
+}
+
+function ScoreRing({ value, label }: { value: number; label: string }) {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div className="relative grid place-items-center" aria-label={`${label}: ${clamped}%`}>
+      <div
+        className="h-36 w-36 rounded-full p-[1px] shadow-[0_0_80px_rgba(255,230,203,0.16)]"
+        style={{
+          background: `conic-gradient(var(--midground-base) ${clamped * 3.6}deg, color-mix(in srgb, var(--midground-base) 10%, transparent) 0deg)`,
+        }}
+      >
+        <div className="grid h-full w-full place-items-center rounded-full bg-background-base/92 backdrop-blur-xl">
+          <div className="text-center">
+            <div className="text-4xl font-semibold tracking-[-0.05em] text-midground">
+              {clamped}
+            </div>
+            <div className="mt-1 text-[10px] uppercase tracking-[0.28em] text-text-tertiary">
+              readiness
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  detail,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  icon: LucideIcon;
+}) {
+  return (
+    <Card className="min-w-0 overflow-hidden border-current/15 bg-card/70 backdrop-blur-xl">
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-[0.22em] text-text-tertiary">{label}</p>
+            <p className="mt-2 truncate text-2xl font-semibold tracking-[-0.03em] text-foreground sm:text-3xl">
+              {value}
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+          </div>
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl border border-current/15 bg-midground/10 text-midground">
+            <Icon className="h-5 w-5" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DomainBar({ domain }: { domain: MissionControlDomainScore }) {
+  return (
+    <div className="min-w-0 rounded-2xl border border-current/10 bg-background-base/35 p-3" data-testid={`mission-domain-${domain.name}`}>
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <span className="min-w-0 truncate font-medium text-foreground">{domain.name}</span>
+        <span className="font-mono text-text-tertiary">{domain.score}% · {domain.items}</span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-midground/10">
+        <div
+          className="h-full rounded-full bg-midground shadow-[0_0_24px_rgba(255,230,203,0.25)]"
+          style={{ width: `${Math.max(4, Math.min(100, domain.score))}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CoverageCard({ item, compact = false }: { item: MissionControlCoverageItem; compact?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "group min-w-0 overflow-hidden rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4 transition-colors",
+        "hover:border-current/20 hover:bg-midground/[0.055]",
+      )}
+      data-testid={`mission-coverage-${item.id}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone={statusTone(item.status)}>{statusLabel(item.status)}</Badge>
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-tertiary">
+              {item.number ?? item.id}
+            </span>
+            {item.missionControl && <Badge tone="outline">route live</Badge>}
+          </div>
+          <h3 className="mt-3 line-clamp-2 text-base font-semibold leading-snug tracking-[-0.02em] text-foreground">
+            {item.title}
+          </h3>
+        </div>
+        <div className="shrink-0 rounded-full border border-current/10 bg-midground/10 px-2.5 py-1 font-mono text-xs text-midground">
+          {item.readiness}%
+        </div>
+      </div>
+      {!compact && (
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{item.summary}</p>
+      )}
+      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-midground/10">
+        <div className="h-full rounded-full bg-midground/80" style={{ width: `${Math.max(4, item.readiness)}%` }} />
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2 text-[11px] text-text-tertiary">
+        <span className="rounded-full border border-current/10 px-2 py-1">{item.domain}</span>
+        {item.part && <span className="rounded-full border border-current/10 px-2 py-1">{item.part}</span>}
+        {item.route && <span className="rounded-full border border-current/10 px-2 py-1">{item.route}</span>}
+      </div>
+      <div className="mt-4 space-y-1.5 text-xs leading-relaxed text-muted-foreground">
+        {item.evidence.slice(0, compact ? 1 : 2).map((line) => (
+          <div key={line} className="flex gap-2">
+            <CircleDot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-midground/70" />
+            <span className="min-w-0 break-words">{line}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActionCard({ action }: { action: MissionControlSnapshot["actionQueue"][number] }) {
+  return (
+    <a
+      href={action.route}
+      className="group block min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/40 p-4 text-left transition hover:border-current/20 hover:bg-midground/[0.06]"
+    >
+      <div className="flex items-start gap-3">
+        <div className="grid h-8 w-8 shrink-0 place-items-center rounded-xl bg-midground/10 font-mono text-xs text-midground">
+          {action.rank}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone={action.tone === "now" ? "warning" : "outline"}>{action.tone}</Badge>
+            <ArrowUpRight className="h-3.5 w-3.5 text-text-tertiary transition group-hover:text-midground" />
+          </div>
+          <h3 className="mt-2 text-sm font-semibold text-foreground">{action.title}</h3>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{action.reason}</p>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+function Section({
+  eyebrow,
+  title,
+  children,
+  icon: Icon,
+}: {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+  icon: LucideIcon;
+}) {
+  return (
+    <section className="space-y-4" data-testid={`mission-section-${eyebrow.toLowerCase().replace(/\s+/g, "-")}`}>
+      <div className="flex items-center gap-3">
+        <div className="grid h-9 w-9 place-items-center rounded-2xl border border-current/10 bg-midground/10 text-midground">
+          <Icon className="h-4 w-4" />
+        </div>
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.24em] text-text-tertiary">{eyebrow}</p>
+          <h2 className="text-lg font-semibold tracking-[-0.03em] text-foreground sm:text-xl">{title}</h2>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
+  const { runtime } = data;
+  const model = runtime.model;
+  const sessions = runtime.sessions;
+  const gateway = runtime.gateway;
+  const skills = runtime.skills;
+  const cron = runtime.cron;
+  const mcp = runtime.mcp;
+  const safety = runtime.safety;
+  const env = runtime.env;
+  const voice = runtime.voice;
+  const families = strArray(env, "families");
+  const platforms = strArray(gateway, "configuredPlatforms");
+
+  const rows = [
+    ["Model", `${str(model, "provider")} · ${str(model, "model")}`, `Reasoning ${str(model, "reasoning")}`],
+    ["Sessions", `${num(sessions, "total")} sessions · ${num(sessions, "messages")} messages`, `${num(sessions, "toolCalls")} tool calls`],
+    ["Gateway", `${num(gateway, "configuredCount")} configured`, platforms.length ? platforms.join(", ") : `running: ${boolText(gateway, "running")}`],
+    ["Skills", `${num(skills, "total")} installed`, `${num(skills, "usageTracked")} usage-tracked`],
+    ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, "proactive and scheduled work"],
+    ["MCP", `${num(mcp, "configured")} configured`, strArray(mcp, "servers").join(", ") || "no servers listed"],
+    ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `redaction: ${boolText(safety, "redactSecrets")}`],
+    ["Voice", `STT ${boolText(voice, "sttEnabled")}`, `TTS ${str(voice, "ttsProvider", "not configured")}`],
+    ["Env", `${num(env, "configuredKeys")} configured values`, families.length ? families.join(", ") : "no provider families exposed"],
+  ];
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="mission-runtime-grid">
+      {rows.map(([label, value, detail]) => (
+        <div key={label} className="min-w-0 rounded-2xl border border-current/10 bg-background-base/35 p-4">
+          <p className="text-[11px] uppercase tracking-[0.22em] text-text-tertiary">{label}</p>
+          <p className="mt-2 truncate text-sm font-semibold text-foreground">{value}</p>
+          <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function MissionControlPage() {
+  const [data, setData] = useState<MissionControlSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getMissionControlBlueprint()
+      .then(setData)
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge tone="outline">Claude Agent blueprint</Badge>
+        {data && <Badge tone="success">{data.coverage.summary.readiness}% ready</Badge>}
+      </div>,
+    );
+    setEnd(
+      <Button ghost size="icon" onClick={load} disabled={loading} aria-label="Refresh Mission Control">
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [data, load, loading, setAfterTitle, setEnd]);
+
+  useEffect(() => {
+    void Promise.resolve().then(load);
+  }, [load]);
+
+  const topSteps = useMemo(
+    () => [...(data?.coverage.steps ?? [])].sort((a, b) => a.readiness - b.readiness).slice(0, 6),
+    [data],
+  );
+  const hermesFeatures = useMemo(
+    () => (data?.coverage.features ?? []).filter((f) => f.id.startsWith("H")),
+    [data],
+  );
+  const openClawFeatures = useMemo(
+    () => (data?.coverage.features ?? []).filter((f) => f.id.startsWith("O")),
+    [data],
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Spinner className="text-3xl text-primary" />
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-sm text-destructive">{error}</p>
+          <Button className="mt-4" onClick={load}>Retry</Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  const sessions = data.runtime.sessions;
+  const skills = data.runtime.skills;
+  const cron = data.runtime.cron;
+  const mcp = data.runtime.mcp;
+  const summary = data.coverage.summary;
+
+  return (
+    <div className="flex flex-col gap-6 pb-[max(2rem,env(safe-area-inset-bottom))]" data-testid="mission-control-page">
+      <PluginSlot name="mission-control:top" />
+
+      <section
+        className="relative isolate min-w-0 overflow-hidden rounded-[2rem] border border-current/10 bg-card/70 p-5 shadow-[0_24px_100px_rgba(0,0,0,0.32)] backdrop-blur-2xl sm:p-7 lg:p-8"
+        data-testid="mission-hero"
+      >
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_20%,rgba(255,230,203,0.16),transparent_34%),radial-gradient(circle_at_80%_10%,rgba(52,211,153,0.12),transparent_30%),linear-gradient(135deg,rgba(255,255,255,0.045),transparent)]" />
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone="outline">source: {data.source.title}</Badge>
+              <Badge tone="secondary">{data.blueprint.stepCount} tracked steps</Badge>
+              <Badge tone="secondary">{data.blueprint.hermesFeatureCount + data.blueprint.openclawFeatureCount} feature-picker items</Badge>
+            </div>
+            <h1 className="mt-5 max-w-4xl text-4xl font-semibold tracking-[-0.07em] text-foreground sm:text-5xl lg:text-6xl">
+              Mission Control for the full agent blueprint.
+            </h1>
+            <p className="mt-5 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+              This is not a static mirror. Hermes maps every step, Hermes feature, and OpenClaw feature from the guide to live local runtime evidence — without exposing raw chat content, commands, logs, secrets, or absolute local paths.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <a href={data.source.url} target="_blank" rel="noreferrer">
+                <Button outlined>
+                  Source guide <ArrowUpRight className="ml-2 h-4 w-4" />
+                </Button>
+              </a>
+              <a href="/system">
+                <Button ghost>System evidence</Button>
+              </a>
+            </div>
+          </div>
+          <ScoreRing value={summary.readiness} label="Mission readiness" />
+        </div>
+      </section>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5" data-testid="mission-metrics">
+        <MetricCard label="Coverage" value={`${summary.total}`} detail={`${summary.counts.active ?? 0} active · ${summary.counts.partial ?? 0} partial`} icon={Gauge} />
+        <MetricCard label="Sessions" value={formatNumber(num(sessions, "total"))} detail={`${formatNumber(num(sessions, "messages"))} messages counted`} icon={Database} />
+        <MetricCard label="Skills" value={formatNumber(num(skills, "total"))} detail="portable procedural memory" icon={Brain} />
+        <MetricCard label="Cron" value={formatNumber(num(cron, "enabled"))} detail={`${formatNumber(num(cron, "total"))} scheduled job(s)`} icon={CalendarClock} />
+        <MetricCard label="MCP" value={formatNumber(num(mcp, "configured"))} detail="configured external tool servers" icon={Workflow} />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <Section eyebrow="operator queue" title="Smart next actions" icon={Radar}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {data.actionQueue.map((action) => <ActionCard key={`${action.rank}-${action.title}`} action={action} />)}
+          </div>
+        </Section>
+
+        <Section eyebrow="readiness heatmap" title="Weakest domains first" icon={Activity}>
+          <div className="grid gap-3">
+            {data.coverage.weakestDomains.map((domain) => <DomainBar key={domain.name} domain={domain} />)}
+          </div>
+        </Section>
+      </div>
+
+      <Section eyebrow="live runtime" title="Smart things Mission Control can honestly show" icon={Bot}>
+        <RuntimePanel data={data} />
+      </Section>
+
+      <Section eyebrow="source coverage" title="All guide steps, mapped to routes and evidence" icon={Layers3}>
+        <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3" data-testid="mission-step-grid">
+          {data.coverage.steps.map((step) => <CoverageCard key={step.id} item={step} />)}
+        </div>
+      </Section>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Section eyebrow="Hermes picker" title="H1–H11 feature status" icon={Sparkles}>
+          <div className="grid gap-3" data-testid="mission-hermes-features">
+            {hermesFeatures.map((feature) => <CoverageCard key={feature.id} item={feature} compact />)}
+          </div>
+        </Section>
+        <Section eyebrow="OpenClaw picker" title="O1–O10 production feature status" icon={Zap}>
+          <div className="grid gap-3" data-testid="mission-openclaw-features">
+            {openClawFeatures.map((feature) => <CoverageCard key={feature.id} item={feature} compact />)}
+          </div>
+        </Section>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <Section eyebrow="privacy boundary" title="Useful without leaking the operator" icon={LockKeyhole}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {data.privacy.map((item) => (
+              <div key={item.label} className="rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4">
+                <div className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-midground" />
+                  <Badge tone="outline">{item.policy}</Badge>
+                </div>
+                <h3 className="mt-3 text-sm font-semibold text-foreground">{item.label}</h3>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{item.detail}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section eyebrow="device proof" title="Desktop, tablet, mobile — no cockpit collapse" icon={Fingerprint}>
+          <Card className="overflow-hidden bg-card/65 backdrop-blur-xl">
+            <CardHeader>
+              <CardTitle className="text-base">Responsive proof markers</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-2 sm:grid-cols-2">
+                {data.deviceProof.breakpoints.map((bp) => (
+                  <div key={bp} className="rounded-2xl border border-current/10 bg-background-base/35 px-3 py-2 text-sm text-foreground">
+                    <CheckCircle2 className="mr-2 inline h-4 w-4 text-midground" />
+                    {bp}
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
+                {data.deviceProof.principles.map((line) => (
+                  <p key={line}>• {line}</p>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </Section>
+      </div>
+
+      <Section eyebrow="attention" title="Lowest readiness guide steps" icon={Globe2}>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {topSteps.map((step) => <CoverageCard key={step.id} item={step} compact />)}
+        </div>
+      </Section>
+
+      <p className="text-center text-xs text-text-tertiary">
+        Generated {data.runtime.generatedAt}. Source checked {data.source.lastChecked}. {data.source.note}
+      </p>
+      <PluginSlot name="mission-control:bottom" />
+    </div>
+  );
+}

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -3,27 +3,34 @@ import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import {
   Activity,
+  AlertTriangle,
   ArrowUpRight,
   BookOpen,
-  ClipboardCheck,
-  ListChecks,
-  Route,
-  ServerCog,
   Bot,
+  Boxes,
   Brain,
   CalendarClock,
   CheckCircle2,
   CircleDot,
+  ClipboardCheck,
+  Command,
+  Cpu,
   Database,
   Fingerprint,
   Gauge,
   Globe2,
   Layers3,
+  ListChecks,
   LockKeyhole,
   Radar,
   RefreshCw,
+  Route,
+  Search,
+  ServerCog,
   ShieldCheck,
+  Smartphone,
   Sparkles,
+  TimerReset,
   Workflow,
   Zap,
 } from "lucide-react";
@@ -91,6 +98,39 @@ function checkTone(status: unknown): "success" | "warning" | "secondary" | "outl
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value);
+}
+
+function formatDuration(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "unknown";
+  const seconds = Math.abs(value);
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86400)}d`;
+}
+
+function signedDuration(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "unknown";
+  return value < 0 ? `${formatDuration(value)} overdue` : `in ${formatDuration(value)}`;
+}
+
+function sumRecordValues(value: unknown): number {
+  const record = recordOf(value);
+  return Object.values(record).reduce<number>((total, item) => total + (typeof item === "number" && Number.isFinite(item) ? item : 0), 0);
+}
+
+function statusMatch(item: MissionControlCoverageItem, status: string): boolean {
+  return status === "all" || item.status === status;
+}
+
+function coverageMatches(item: MissionControlCoverageItem, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return [item.id, item.number, item.title, item.domain, item.part, item.summary, item.next]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .includes(needle);
 }
 
 function statusTone(status: MissionControlStatus): "success" | "warning" | "secondary" | "outline" {
@@ -253,7 +293,7 @@ function CoverageCard({ item, compact = false }: { item: MissionControlCoverageI
 }
 
 function ActionCard({ action }: { action: MissionControlSnapshot["actionQueue"][number] }) {
-  const className = "group block min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/40 p-4 text-left transition hover:border-current/20 hover:bg-midground/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60";
+  const className = "group block min-h-[44px] min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/40 p-4 text-left transition hover:border-current/20 hover:bg-midground/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60";
   const body = (
     <div className="flex items-start gap-3">
       <div className="grid h-8 w-8 shrink-0 place-items-center rounded-xl bg-midground/10 font-mono text-xs text-midground">
@@ -327,17 +367,23 @@ function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
   const memorySqlite = recordOf(memory.sqlite);
   const semantic = recordOf(runtime.semantic);
   const production = recordOf(runtime.production);
+  const cronStatusCount = sumRecordValues(cron.lastStatusCounts);
+  const toolBuckets = recordOf(runtime.tools.configuredToolsetBuckets);
+  const mcpStatus = recordOf(mcp.statusCounts);
+  const outputLimits = recordOf(safety.toolOutputLimits);
 
   const rows = [
     ["Model", `${str(model, "provider")} · ${str(model, "model")}`, `Reasoning ${str(model, "reasoning")}`],
     ["Sessions", `${num(sessions, "total")} sessions · ${num(sessions, "messages")} messages`, `${num(sessions, "toolCalls")} tool calls · ${num(sessions, "apiCalls")} API calls`],
+    ["Session graph", `${num(sessions, "rootSessionCount")} roots · ${num(sessions, "childSessionCount")} child`, `${num(sessions, "complexSessionCount")} complex · ${num(sessions, "rewindTotal")} rewinds`],
     ["Memory", `${num(memorySqlite, "sessions")} sessions · FTS ${boolText(memorySqlite, "ftsPresent")}`, `${num(memorySqlite, "summaries")} summaries · ${num(memorySqlite, "archivedSessions")} archived`],
     ["Semantic", `${str(semantic, "provider")}`, `configured ${boolText(semantic, "configured")} · index ${boolText(semantic, "indexConfigured")}`],
     ["Gateway", `${num(gateway, "configuredCount")} configured`, platforms.length ? platforms.join(", ") : `running: ${boolText(gateway, "running")}`],
     ["Skills", `${num(skills, "total")} installed`, `${num(skills, "agentskillsCompliant")} portable · ${num(skills, "autoCreatedCount")} auto-created`],
-    ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, `${num(cron, "reflectionJobs")} reflection · ${num(cron, "heartbeatJobs")} heartbeat`],
-    ["MCP", `${num(mcp, "configured")} configured`, `${num(mcp, "enabled")} enabled · names redacted`],
-    ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `isolated: ${boolText(safety, "terminalIsolated")} · redaction: ${boolText(safety, "redactSecrets")}`],
+    ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, `${num(cron, "overdueCount")} overdue · ${cronStatusCount} status sample(s) · reflection ${str(cron, "reflectionFreshness", "unknown")}`],
+    ["MCP", `${num(mcp, "configured")} configured`, `${num(mcpStatus, "enabled")} enabled · ${num(mcpStatus, "disabled")} disabled · names redacted`],
+    ["Tools", `${num(runtime.tools, "registeredToolCount")} registered`, `${num(toolBuckets, "builtin")} builtin · ${num(toolBuckets, "custom")} custom bucket(s)`],
+    ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `isolated: ${boolText(safety, "terminalIsolated")} · redaction: ${boolText(safety, "redactSecrets")} · output cap: ${boolText(outputLimits, "configured")}`],
     ["Voice", `STT ${boolText(voice, "sttEnabled")}`, `TTS ${str(voice, "ttsProvider", "not configured")}`],
     ["Analytics", `${formatNumber(num(analyticsTotals, "inputTokens") + num(analyticsTotals, "outputTokens"))} tokens`, `$${formatNumber(num(analyticsTotals, "actualCostUsd"))} actual · $${formatNumber(num(analyticsTotals, "estimatedCostUsd"))} estimated`],
     ["Production", `${num(production, "score")}% score`, `${objectArray(production.blockers).length} blocker/watch item(s)`],
@@ -354,6 +400,168 @@ function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
         </div>
       ))}
     </div>
+  );
+}
+
+function InsightTile({
+  label,
+  value,
+  detail,
+  icon: Icon,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  icon: LucideIcon;
+  tone?: "neutral" | "success" | "warning";
+}) {
+  const toneClass = tone === "success" ? "text-emerald-300 bg-emerald-400/10" : tone === "warning" ? "text-amber-300 bg-amber-400/10" : "text-midground bg-midground/10";
+  return (
+    <div className="min-w-0 rounded-[1.4rem] border border-current/10 bg-background-base/35 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-text-tertiary">{label}</p>
+          <p className="mt-2 truncate text-xl font-semibold tracking-[-0.04em] text-foreground sm:text-2xl">{value}</p>
+        </div>
+        <div className={cn("grid h-10 w-10 shrink-0 place-items-center rounded-2xl", toneClass)}>
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </div>
+      </div>
+      <p className="mt-3 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function MissionCockpitPanel({ data }: { data: MissionControlSnapshot }) {
+  const { runtime } = data;
+  const sessions = runtime.sessions;
+  const cron = runtime.cron;
+  const mcp = runtime.mcp;
+  const tools = runtime.tools;
+  const gateway = runtime.gateway;
+  const safety = runtime.safety;
+  const production = recordOf(runtime.production);
+  const roleCounts = recordOf(sessions.roleCounts);
+  const toolBuckets = recordOf(tools.configuredToolsetBuckets);
+  const mcpTransports = recordOf(mcp.transportCounts);
+  const topAction = data.actionQueue[0];
+  const readiness = data.coverage.summary.readiness;
+  const totalMessages = num(sessions, "messages");
+  const toolCalls = num(sessions, "toolCalls");
+  const automationRatio = totalMessages ? Math.round((toolCalls / totalMessages) * 100) : 0;
+  const blockers = objectArray(production.blockers).length;
+  const nextRun = signedDuration(cron.nextRunDueInSeconds);
+
+  return (
+    <section id="mission-cockpit" className="grid gap-4 xl:grid-cols-[minmax(0,1.18fr)_minmax(0,0.82fr)]" aria-label="Mission cockpit" data-testid="mission-cockpit">
+      <Card className="relative isolate overflow-hidden border-current/10 bg-card/70 shadow-[0_30px_120px_rgba(0,0,0,0.28)] backdrop-blur-2xl">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_12%_18%,rgba(255,230,203,0.18),transparent_32%),radial-gradient(circle_at_92%_10%,rgba(59,130,246,0.12),transparent_28%)]" />
+        <CardContent className="p-5 sm:p-6">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone={blockers ? "warning" : "success"}>{blockers ? `${blockers} watch` : "clear to operate"}</Badge>
+                <Badge tone="outline">privacy boundary on</Badge>
+                <Badge tone="secondary">generated {formatDuration(Date.now() / 1000 - Date.parse(data.runtime.generatedAt) / 1000)} ago</Badge>
+              </div>
+              <h2 className="mt-4 max-w-3xl text-3xl font-semibold tracking-[-0.06em] text-foreground sm:text-4xl">
+                Command cockpit: action, trust and runtime pulse in one sweep.
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-7 text-muted-foreground">
+                The dashboard now favors decisions over data dumps: weakest blueprint areas, live automation health, privacy posture, and the next operator move are visible before the long source map.
+              </p>
+            </div>
+            <div className="min-w-[12rem] rounded-[1.4rem] border border-current/10 bg-background-base/40 p-4 text-left">
+              <p className="text-[10px] uppercase tracking-[0.24em] text-text-tertiary">readiness vector</p>
+              <div className="mt-3 flex items-end gap-2">
+                <span className="text-5xl font-semibold tracking-[-0.08em] text-midground">{readiness}</span>
+                <span className="pb-2 text-sm text-muted-foreground">/100</span>
+              </div>
+              <div className="mt-4 h-2 overflow-hidden rounded-full bg-midground/10" role="progressbar" aria-label="Overall blueprint readiness" aria-valuemin={0} aria-valuemax={100} aria-valuenow={readiness}>
+                <div className="h-full rounded-full bg-midground shadow-[0_0_30px_rgba(255,230,203,0.35)]" style={{ width: `${Math.max(4, readiness)}%` }} />
+              </div>
+            </div>
+          </div>
+
+          {topAction && (
+            <div className="mt-6 rounded-[1.5rem] border border-current/10 bg-background-base/35 p-4" data-testid="mission-cockpit-top-action">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <p className="text-[10px] uppercase tracking-[0.24em] text-text-tertiary">next best action</p>
+                  <h3 className="mt-2 text-base font-semibold tracking-[-0.03em] text-foreground">{topAction.title}</h3>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{topAction.reason}</p>
+                </div>
+                <Link to={topAction.route} className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-2xl border border-current/15 px-4 text-sm font-medium text-foreground transition hover:bg-midground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
+                  Open route <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+        <InsightTile label="automation density" value={`${automationRatio}%`} detail={`${formatNumber(toolCalls)} tool calls across ${formatNumber(totalMessages)} messages; content remains hidden.`} icon={Cpu} />
+        <InsightTile label="session topology" value={`${num(sessions, "rootSessionCount")} / ${num(sessions, "childSessionCount")}`} detail={`${num(sessions, "complexSessionCount")} complex sessions · avg ${formatNumber(num(sessions, "avgApiCalls"))} API calls`} icon={Workflow} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:col-span-2 2xl:grid-cols-4">
+        <InsightTile label="gateway pulse" value={str(gateway, "state")} detail={`${num(gateway, "configuredCount")} platform family · names redacted: ${boolText(gateway, "platformNamesRedacted")}`} icon={Command} tone={gateway.running ? "success" : "warning"} />
+        <InsightTile label="scheduler" value={nextRun} detail={`${num(cron, "enabled")} enabled · ${num(cron, "overdueCount")} overdue · ${num(cron, "failedJobs")} failed`} icon={TimerReset} tone={num(cron, "overdueCount") || num(cron, "failedJobs") ? "warning" : "success"} />
+        <InsightTile label="tool surface" value={`${num(tools, "registeredToolCount")}`} detail={`${num(toolBuckets, "builtin")} builtin · ${num(toolBuckets, "mcp")} MCP · ${num(toolBuckets, "custom")} custom bucket(s)`} icon={Boxes} />
+        <InsightTile label="MCP transports" value={`${num(mcp, "configured")}`} detail={`${num(mcpTransports, "stdio")} stdio · ${num(mcpTransports, "http")} http · ${num(mcpTransports, "sse")} sse`} icon={ServerCog} />
+      </div>
+
+      <div className="grid gap-3 xl:col-span-2 md:grid-cols-2">
+        <div className="rounded-[1.5rem] border border-current/10 bg-background-base/35 p-4" data-testid="mission-role-mix">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-text-tertiary">conversation role mix</p>
+          <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {Object.entries(roleCounts).map(([role, value]) => (
+              <div key={role} className="rounded-2xl border border-current/10 bg-card/40 p-3">
+                <p className="text-xs font-medium text-foreground">{role}</p>
+                <p className="mt-1 font-mono text-sm text-text-tertiary">{formatNumber(typeof value === "number" ? value : 0)}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-[1.5rem] border border-current/10 bg-background-base/35 p-4" data-testid="mission-privacy-posture">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-text-tertiary">privacy posture</p>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+            <Badge tone={safety.redactSecrets ? "success" : "warning"}>secrets: {boolText(safety, "redactSecrets")}</Badge>
+            <Badge tone={tools.configuredToolsetNamesRedacted ? "success" : "warning"}>toolsets redacted</Badge>
+            <Badge tone={mcp.serverNamesRedacted ? "success" : "warning"}>MCP names redacted</Badge>
+            <Badge tone="outline">session content omitted</Badge>
+          </div>
+          <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+            Mission Control serializes aggregate counts and safe families only. Prompts, commands, platform IDs, file paths, custom labels, and server names stay outside the UI boundary.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SectionNav() {
+  const sections = [
+    ["cockpit", "Cockpit"],
+    ["production", "Production"],
+    ["operator-queue", "Actions"],
+    ["live-runtime", "Runtime"],
+    ["source-coverage", "Coverage"],
+    ["data-flow", "Data flow"],
+    ["privacy-boundary", "Privacy"],
+  ];
+  return (
+    <nav aria-label="Mission Control sections" className="sticky top-2 z-20 -mx-1 overflow-x-auto rounded-2xl border border-current/10 bg-background-base/80 p-1 shadow-[0_20px_80px_rgba(0,0,0,0.22)] backdrop-blur-2xl" data-testid="mission-section-nav">
+      <div className="flex min-w-max gap-1">
+        {sections.map(([id, label]) => (
+          <a key={id} href={`#mission-${id}`} className="inline-flex min-h-[44px] items-center justify-center rounded-xl px-3 text-xs font-medium text-muted-foreground transition hover:bg-midground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60 sm:px-4">
+            {label}
+          </a>
+        ))}
+      </div>
+    </nav>
   );
 }
 
@@ -501,6 +709,9 @@ export default function MissionControlPage() {
   const [data, setData] = useState<MissionControlSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [coverageQuery, setCoverageQuery] = useState("");
+  const [coverageStatus, setCoverageStatus] = useState("all");
+  const [showAllSteps, setShowAllSteps] = useState(false);
   const { setAfterTitle, setEnd } = usePageHeader();
 
   const load = useCallback(() => {
@@ -521,7 +732,7 @@ export default function MissionControlPage() {
       </div>,
     );
     setEnd(
-      <Button ghost size="icon" onClick={load} disabled={loading} aria-label="Refresh Mission Control" data-testid="mission-refresh-button">
+      <Button ghost size="icon" className="min-h-[44px] min-w-[44px]" onClick={load} disabled={loading} aria-label="Refresh Mission Control" data-testid="mission-refresh-button">
         {loading ? <Spinner /> : <RefreshCw />}
       </Button>,
     );
@@ -535,6 +746,10 @@ export default function MissionControlPage() {
     void Promise.resolve().then(load);
   }, [load]);
 
+  useEffect(() => {
+    setShowAllSteps(false);
+  }, [coverageQuery, coverageStatus]);
+
   const topSteps = useMemo(
     () => [...(data?.coverage.steps ?? [])].sort((a, b) => a.readiness - b.readiness).slice(0, 6),
     [data],
@@ -547,6 +762,11 @@ export default function MissionControlPage() {
     () => (data?.coverage.features ?? []).filter((f) => f.id.startsWith("O")),
     [data],
   );
+  const filteredSteps = useMemo(
+    () => (data?.coverage.steps ?? []).filter((step) => statusMatch(step, coverageStatus) && coverageMatches(step, coverageQuery)),
+    [coverageQuery, coverageStatus, data],
+  );
+  const visibleSteps = showAllSteps ? filteredSteps : filteredSteps.slice(0, 12);
 
   if (loading && !data) {
     return (
@@ -599,10 +819,10 @@ export default function MissionControlPage() {
               This is not a static mirror. Hermes maps every step, Hermes feature, and OpenClaw feature from the guide to live local runtime evidence — without exposing raw chat content, commands, logs, secrets, or absolute local paths.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
-              <a href={data.source.url} target="_blank" rel="noreferrer" className="inline-flex h-10 items-center rounded-xl border border-current/15 px-4 text-sm font-medium text-foreground transition hover:bg-midground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
+              <a href={data.source.url} target="_blank" rel="noreferrer" className="inline-flex min-h-[44px] items-center rounded-xl border border-current/15 px-4 text-sm font-medium text-foreground transition hover:bg-midground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
                 Source guide <ArrowUpRight className="ml-2 h-4 w-4" />
               </a>
-              <Link to="/system" className="inline-flex h-10 items-center rounded-xl px-4 text-sm font-medium text-muted-foreground transition hover:bg-midground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
+              <Link to="/system" className="inline-flex min-h-[44px] items-center rounded-xl px-4 text-sm font-medium text-muted-foreground transition hover:bg-midground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
                 System evidence
               </Link>
             </div>
@@ -618,6 +838,9 @@ export default function MissionControlPage() {
         <MetricCard label="Cron" value={formatNumber(num(cron, "enabled"))} detail={`${formatNumber(num(cron, "total"))} scheduled job(s)`} icon={CalendarClock} />
         <MetricCard label="MCP" value={formatNumber(num(mcp, "configured"))} detail="configured external tool servers" icon={Workflow} />
       </div>
+
+      <SectionNav />
+      <MissionCockpitPanel data={data} />
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
         <Section id="production" eyebrow="production" title="Production readiness, honestly separated" icon={ServerCog}>
@@ -657,10 +880,72 @@ export default function MissionControlPage() {
       </Section>
 
       <Section id="source-coverage" eyebrow="source coverage" title="All guide steps, mapped to routes and evidence" icon={Layers3}>
-        <div data-testid="mission-blueprint-steps">
-          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3" data-testid="mission-step-grid">
-            {data.coverage.steps.map((step) => <CoverageCard key={step.id} item={step} />)}
+        <div className="space-y-4" data-testid="mission-blueprint-steps">
+          <div className="rounded-[1.5rem] border border-current/10 bg-background-base/35 p-3 sm:p-4" data-testid="mission-coverage-controls">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto] lg:items-center">
+              <label className="relative block min-w-0">
+                <span className="sr-only">Search guide steps</span>
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" aria-hidden="true" />
+                <input
+                  value={coverageQuery}
+                  onChange={(event) => setCoverageQuery(event.target.value)}
+                  placeholder="Search steps, domains, next actions…"
+                  className="min-h-[44px] w-full rounded-2xl border border-current/10 bg-card/70 pl-10 pr-3 text-sm text-foreground outline-none transition placeholder:text-text-tertiary focus:border-midground/50 focus:ring-2 focus:ring-midground/20"
+                  data-testid="mission-coverage-search"
+                />
+              </label>
+              <label className="grid gap-1 text-[10px] uppercase tracking-[0.22em] text-text-tertiary">
+                Status
+                <select
+                  value={coverageStatus}
+                  onChange={(event) => setCoverageStatus(event.target.value)}
+                  className="min-h-[44px] rounded-2xl border border-current/10 bg-card/70 px-3 text-sm normal-case tracking-normal text-foreground outline-none focus:border-midground/50 focus:ring-2 focus:ring-midground/20"
+                  data-testid="mission-coverage-status-filter"
+                >
+                  <option value="all">All</option>
+                  <option value="active">Active</option>
+                  <option value="partial">Partial</option>
+                  <option value="watch">Watch</option>
+                  <option value="planned">Planned</option>
+                </select>
+              </label>
+              <div className="flex min-h-[44px] items-center rounded-2xl border border-current/10 bg-card/50 px-3 text-xs text-muted-foreground">
+                <Smartphone className="mr-2 h-4 w-4 text-midground" aria-hidden="true" />
+                {visibleSteps.length}/{filteredSteps.length} visible · {data.coverage.steps.length} total
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-tertiary">
+              <span className="inline-flex min-h-8 items-center rounded-full border border-current/10 px-3">evidence collapses by default</span>
+              <span className="inline-flex min-h-8 items-center rounded-full border border-current/10 px-3">search is local only</span>
+              <span className="inline-flex min-h-8 items-center rounded-full border border-current/10 px-3">raw prompts never rendered</span>
+            </div>
           </div>
+
+          {filteredSteps.length === 0 ? (
+            <div className="rounded-[1.5rem] border border-current/10 bg-background-base/35 p-8 text-center" data-testid="mission-coverage-empty">
+              <AlertTriangle className="mx-auto h-8 w-8 text-text-tertiary" aria-hidden="true" />
+              <h3 className="mt-3 text-sm font-semibold text-foreground">No guide steps match that filter.</h3>
+              <p className="mt-1 text-xs text-muted-foreground">Clear the search or switch status back to all.</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3" data-testid="mission-step-grid">
+                {visibleSteps.map((step) => <CoverageCard key={step.id} item={step} compact />)}
+              </div>
+              {filteredSteps.length > visibleSteps.length && (
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => setShowAllSteps(true)}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-2xl border border-current/15 px-4 text-sm font-medium text-foreground transition hover:bg-midground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60"
+                    data-testid="mission-show-all-steps"
+                  >
+                    Show all {filteredSteps.length} mapped steps
+                  </button>
+                </div>
+              )}
+            </>
+          )}
         </div>
       </Section>
 

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -271,10 +271,11 @@ function ActionCard({ action }: { action: MissionControlSnapshot["actionQueue"][
       </div>
     </div>
   );
+  const testKey = slugify(action.title || action.route || action.category || "action");
   if (action.route.startsWith("http")) {
-    return <a href={action.route} target="_blank" rel="noreferrer" className={className} data-testid={`mission-action-card-${action.rank}`}>{body}</a>;
+    return <a href={action.route} target="_blank" rel="noreferrer" className={className} data-testid={`mission-action-card-${testKey}`}>{body}</a>;
   }
-  return <Link to={action.route} className={className} data-testid={`mission-action-card-${action.rank}`}>{body}</Link>;
+  return <Link to={action.route} className={className} data-testid={`mission-action-card-${testKey}`}>{body}</Link>;
 }
 
 function Section({
@@ -335,7 +336,7 @@ function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
     ["Gateway", `${num(gateway, "configuredCount")} configured`, platforms.length ? platforms.join(", ") : `running: ${boolText(gateway, "running")}`],
     ["Skills", `${num(skills, "total")} installed`, `${num(skills, "agentskillsCompliant")} portable · ${num(skills, "autoCreatedCount")} auto-created`],
     ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, `${num(cron, "reflectionJobs")} reflection · ${num(cron, "heartbeatJobs")} heartbeat`],
-    ["MCP", `${num(mcp, "configured")} configured`, strArray(mcp, "servers").join(", ") || "no servers listed"],
+    ["MCP", `${num(mcp, "configured")} configured`, `${num(mcp, "enabled")} enabled · names redacted`],
     ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `isolated: ${boolText(safety, "terminalIsolated")} · redaction: ${boolText(safety, "redactSecrets")}`],
     ["Voice", `STT ${boolText(voice, "sttEnabled")}`, `TTS ${str(voice, "ttsProvider", "not configured")}`],
     ["Analytics", `${formatNumber(num(analyticsTotals, "inputTokens") + num(analyticsTotals, "outputTokens"))} tokens`, `$${formatNumber(num(analyticsTotals, "actualCostUsd"))} actual · $${formatNumber(num(analyticsTotals, "estimatedCostUsd"))} estimated`],
@@ -363,8 +364,9 @@ function StatusList({ items, testId }: { items: AnyRecord[]; testId: string }) {
         const title = str(item, "title", str(item, "label", str(item, "term", str(item, "symptom", `Item ${index + 1}`))));
         const status = item.status ?? "info";
         const evidence = objectArray(item.evidence).length ? objectArray(item.evidence).map((e) => String(e)) : strArray(item, "evidence");
+        const stableId = str(item, "id", str(item, "term", str(item, "label", title)));
         return (
-          <div key={`${title}-${index}`} className="min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4" data-testid={`${testId}-${slugify(title)}`}>
+          <div key={`${stableId}-${index}`} className="min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4" data-testid={`${testId}-${slugify(stableId)}`}>
             <div className="flex flex-wrap items-center gap-2">
               {typeof item.status !== "undefined" && <Badge tone={checkTone(status)}>{String(status)}</Badge>}
               {typeof item.route !== "undefined" && <Badge tone="outline">{str(item, "route")}</Badge>}
@@ -548,8 +550,9 @@ export default function MissionControlPage() {
 
   if (loading && !data) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center" aria-busy="true" aria-live="polite" data-testid="mission-loading">
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3" aria-busy="true" aria-live="polite" data-testid="mission-loading">
         <Spinner className="text-3xl text-primary" />
+        <p className="text-sm text-muted-foreground">Loading Mission Control…</p>
       </div>
     );
   }

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
 import {
   Activity,
   ArrowUpRight,
+  BookOpen,
+  ClipboardCheck,
+  ListChecks,
+  Route,
+  ServerCog,
   Bot,
   Brain,
   CalendarClock,
@@ -61,6 +67,28 @@ function strArray(record: AnyRecord, key: string): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
 }
 
+function recordOf(value: unknown): AnyRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as AnyRecord) : {};
+}
+
+function objectArray(value: unknown): AnyRecord[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is AnyRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item))
+    : [];
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item";
+}
+
+function checkTone(status: unknown): "success" | "warning" | "secondary" | "outline" {
+  const value = String(status ?? "unknown");
+  if (["pass", "active", "ok"].includes(value)) return "success";
+  if (["warn", "warning", "partial", "fail", "exceeded"].includes(value)) return "warning";
+  if (["watch", "unknown", "not_applicable", "target"].includes(value)) return "secondary";
+  return "outline";
+}
+
 function formatNumber(value: number): string {
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value);
 }
@@ -83,7 +111,15 @@ function statusLabel(status: MissionControlStatus): string {
 function ScoreRing({ value, label }: { value: number; label: string }) {
   const clamped = Math.max(0, Math.min(100, value));
   return (
-    <div className="relative grid place-items-center" aria-label={`${label}: ${clamped}%`}>
+    <div
+      className="relative grid place-items-center"
+      role="progressbar"
+      aria-label={`${label}: ${clamped}%`}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={clamped}
+      data-testid="mission-score-ring"
+    >
       <div
         className="h-36 w-36 rounded-full p-[1px] shadow-[0_0_80px_rgba(255,230,203,0.16)]"
         style={{
@@ -138,12 +174,19 @@ function MetricCard({
 
 function DomainBar({ domain }: { domain: MissionControlDomainScore }) {
   return (
-    <div className="min-w-0 rounded-2xl border border-current/10 bg-background-base/35 p-3" data-testid={`mission-domain-${domain.name}`}>
+    <div className="min-w-0 rounded-2xl border border-current/10 bg-background-base/35 p-3" data-testid={`mission-domain-${slugify(domain.name)}`}>
       <div className="flex items-center justify-between gap-3 text-xs">
         <span className="min-w-0 truncate font-medium text-foreground">{domain.name}</span>
         <span className="font-mono text-text-tertiary">{domain.score}% · {domain.items}</span>
       </div>
-      <div className="mt-2 h-2 overflow-hidden rounded-full bg-midground/10">
+      <div
+        className="mt-2 h-2 overflow-hidden rounded-full bg-midground/10"
+        role="progressbar"
+        aria-label={`${domain.name} readiness`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={domain.score}
+      >
         <div
           className="h-full rounded-full bg-midground shadow-[0_0_24px_rgba(255,230,203,0.25)]"
           style={{ width: `${Math.max(4, Math.min(100, domain.score))}%` }}
@@ -182,7 +225,14 @@ function CoverageCard({ item, compact = false }: { item: MissionControlCoverageI
       {!compact && (
         <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{item.summary}</p>
       )}
-      <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-midground/10">
+      <div
+        className="mt-4 h-1.5 overflow-hidden rounded-full bg-midground/10"
+        role="progressbar"
+        aria-label={`${item.title} readiness`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={item.readiness}
+      >
         <div className="h-full rounded-full bg-midground/80" style={{ width: `${Math.max(4, item.readiness)}%` }} />
       </div>
       <div className="mt-4 flex flex-wrap gap-2 text-[11px] text-text-tertiary">
@@ -203,46 +253,50 @@ function CoverageCard({ item, compact = false }: { item: MissionControlCoverageI
 }
 
 function ActionCard({ action }: { action: MissionControlSnapshot["actionQueue"][number] }) {
-  return (
-    <a
-      href={action.route}
-      className="group block min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/40 p-4 text-left transition hover:border-current/20 hover:bg-midground/[0.06]"
-    >
-      <div className="flex items-start gap-3">
-        <div className="grid h-8 w-8 shrink-0 place-items-center rounded-xl bg-midground/10 font-mono text-xs text-midground">
-          {action.rank}
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge tone={action.tone === "now" ? "warning" : "outline"}>{action.tone}</Badge>
-            <ArrowUpRight className="h-3.5 w-3.5 text-text-tertiary transition group-hover:text-midground" />
-          </div>
-          <h3 className="mt-2 text-sm font-semibold text-foreground">{action.title}</h3>
-          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{action.reason}</p>
-        </div>
+  const className = "group block min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/40 p-4 text-left transition hover:border-current/20 hover:bg-midground/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60";
+  const body = (
+    <div className="flex items-start gap-3">
+      <div className="grid h-8 w-8 shrink-0 place-items-center rounded-xl bg-midground/10 font-mono text-xs text-midground">
+        {action.rank}
       </div>
-    </a>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone={action.tone === "now" ? "warning" : action.tone === "watch" ? "secondary" : "outline"}>{action.tone}</Badge>
+          {action.category && <Badge tone="outline">{action.category}</Badge>}
+          {action.effort && <span className="rounded-full border border-current/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-text-tertiary">{action.effort}</span>}
+          <ArrowUpRight className="h-3.5 w-3.5 text-text-tertiary transition group-hover:text-midground" />
+        </div>
+        <h3 className="mt-2 text-sm font-semibold text-foreground">{action.title}</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{action.reason}</p>
+      </div>
+    </div>
   );
+  if (action.route.startsWith("http")) {
+    return <a href={action.route} target="_blank" rel="noreferrer" className={className} data-testid={`mission-action-card-${action.rank}`}>{body}</a>;
+  }
+  return <Link to={action.route} className={className} data-testid={`mission-action-card-${action.rank}`}>{body}</Link>;
 }
 
 function Section({
+  id,
   eyebrow,
   title,
   children,
   icon: Icon,
 }: {
+  id?: string;
   eyebrow: string;
   title: string;
   children: ReactNode;
   icon: LucideIcon;
 }) {
   return (
-    <section className="space-y-4" data-testid={`mission-section-${eyebrow.toLowerCase().replace(/\s+/g, "-")}`}>
+    <section id={`mission-${id ?? slugify(eyebrow)}`} className="space-y-4" data-testid={`mission-section-${id ?? slugify(eyebrow)}`}>
       <div className="flex items-center gap-3">
         <div className="grid h-9 w-9 place-items-center rounded-2xl border border-current/10 bg-midground/10 text-midground">
           <Icon className="h-4 w-4" />
         </div>
-        <div>
+        <div className="min-w-0">
           <p className="text-[11px] uppercase tracking-[0.24em] text-text-tertiary">{eyebrow}</p>
           <h2 className="text-lg font-semibold tracking-[-0.03em] text-foreground sm:text-xl">{title}</h2>
         </div>
@@ -266,15 +320,26 @@ function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
   const families = strArray(env, "families");
   const platforms = strArray(gateway, "configuredPlatforms");
 
+  const analytics = recordOf(runtime.analytics);
+  const analyticsTotals = recordOf(analytics.totals);
+  const memory = recordOf(runtime.memory);
+  const memorySqlite = recordOf(memory.sqlite);
+  const semantic = recordOf(runtime.semantic);
+  const production = recordOf(runtime.production);
+
   const rows = [
     ["Model", `${str(model, "provider")} · ${str(model, "model")}`, `Reasoning ${str(model, "reasoning")}`],
-    ["Sessions", `${num(sessions, "total")} sessions · ${num(sessions, "messages")} messages`, `${num(sessions, "toolCalls")} tool calls`],
+    ["Sessions", `${num(sessions, "total")} sessions · ${num(sessions, "messages")} messages`, `${num(sessions, "toolCalls")} tool calls · ${num(sessions, "apiCalls")} API calls`],
+    ["Memory", `${num(memorySqlite, "sessions")} sessions · FTS ${boolText(memorySqlite, "ftsPresent")}`, `${num(memorySqlite, "summaries")} summaries · ${num(memorySqlite, "archivedSessions")} archived`],
+    ["Semantic", `${str(semantic, "provider")}`, `configured ${boolText(semantic, "configured")} · index ${boolText(semantic, "indexConfigured")}`],
     ["Gateway", `${num(gateway, "configuredCount")} configured`, platforms.length ? platforms.join(", ") : `running: ${boolText(gateway, "running")}`],
-    ["Skills", `${num(skills, "total")} installed`, `${num(skills, "usageTracked")} usage-tracked`],
-    ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, "proactive and scheduled work"],
+    ["Skills", `${num(skills, "total")} installed`, `${num(skills, "agentskillsCompliant")} portable · ${num(skills, "autoCreatedCount")} auto-created`],
+    ["Cron", `${num(cron, "enabled")} enabled / ${num(cron, "total")} total`, `${num(cron, "reflectionJobs")} reflection · ${num(cron, "heartbeatJobs")} heartbeat`],
     ["MCP", `${num(mcp, "configured")} configured`, strArray(mcp, "servers").join(", ") || "no servers listed"],
-    ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `redaction: ${boolText(safety, "redactSecrets")}`],
+    ["Safety", `approvals: ${str(safety, "approvalsMode")}`, `isolated: ${boolText(safety, "terminalIsolated")} · redaction: ${boolText(safety, "redactSecrets")}`],
     ["Voice", `STT ${boolText(voice, "sttEnabled")}`, `TTS ${str(voice, "ttsProvider", "not configured")}`],
+    ["Analytics", `${formatNumber(num(analyticsTotals, "inputTokens") + num(analyticsTotals, "outputTokens"))} tokens`, `$${formatNumber(num(analyticsTotals, "actualCostUsd"))} actual · $${formatNumber(num(analyticsTotals, "estimatedCostUsd"))} estimated`],
+    ["Production", `${num(production, "score")}% score`, `${objectArray(production.blockers).length} blocker/watch item(s)`],
     ["Env", `${num(env, "configuredKeys")} configured values`, families.length ? families.join(", ") : "no provider families exposed"],
   ];
 
@@ -288,6 +353,145 @@ function RuntimePanel({ data }: { data: MissionControlSnapshot }) {
         </div>
       ))}
     </div>
+  );
+}
+
+function StatusList({ items, testId }: { items: AnyRecord[]; testId: string }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid={testId}>
+      {items.map((item, index) => {
+        const title = str(item, "title", str(item, "label", str(item, "term", str(item, "symptom", `Item ${index + 1}`))));
+        const status = item.status ?? "info";
+        const evidence = objectArray(item.evidence).length ? objectArray(item.evidence).map((e) => String(e)) : strArray(item, "evidence");
+        return (
+          <div key={`${title}-${index}`} className="min-w-0 rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4" data-testid={`${testId}-${slugify(title)}`}>
+            <div className="flex flex-wrap items-center gap-2">
+              {typeof item.status !== "undefined" && <Badge tone={checkTone(status)}>{String(status)}</Badge>}
+              {typeof item.route !== "undefined" && <Badge tone="outline">{str(item, "route")}</Badge>}
+            </div>
+            <h3 className="mt-3 line-clamp-2 break-words text-sm font-semibold text-foreground [overflow-wrap:anywhere]">{title}</h3>
+            <p className="mt-1 line-clamp-3 break-words text-xs leading-relaxed text-muted-foreground [overflow-wrap:anywhere]">
+              {str(item, "summary", str(item, "detail", str(item, "definition", str(item, "fix", "—"))))}
+            </p>
+            {evidence.length > 0 && (
+              <div className="mt-3 space-y-1 text-[11px] leading-relaxed text-text-tertiary">
+                {evidence.slice(0, 2).map((line) => <p key={line}>• {line}</p>)}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProductionPanel({ data }: { data: MissionControlSnapshot }) {
+  const production = recordOf(data.runtime.production);
+  const signals = objectArray(production.signals);
+  const blockers = objectArray(production.blockers);
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)]" data-testid="mission-production-readiness">
+      <Card className="overflow-hidden bg-card/65 backdrop-blur-xl">
+        <CardContent className="p-5">
+          <p className="text-[11px] uppercase tracking-[0.24em] text-text-tertiary">production score</p>
+          <div className="mt-4 flex items-end gap-2">
+            <span className="text-5xl font-semibold tracking-[-0.08em] text-midground">{num(production, "score")}</span>
+            <span className="pb-2 text-sm text-muted-foreground">/100</span>
+          </div>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Auth, approvals, redaction, gateway reachability, cron, MCP, quality hooks, and hosting posture are evaluated separately so static support is not confused with verified runtime state.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge tone={blockers.length ? "warning" : "success"}>{blockers.length} blocker/watch item(s)</Badge>
+            <Badge tone="outline">privacy minimized</Badge>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {signals.map((signal, index) => (
+          <div key={`${str(signal, "id", String(index))}`} className="rounded-[1.2rem] border border-current/10 bg-background-base/35 p-4">
+            <Badge tone={checkTone(signal.status)}>{String(signal.status ?? "unknown")}</Badge>
+            <h3 className="mt-3 text-sm font-semibold text-foreground">{str(signal, "label")}</h3>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{str(signal, "detail")}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DataFlowPanel({ data }: { data: MissionControlSnapshot }) {
+  const rows = objectArray(data.runtime.dataFlow);
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5" data-testid="mission-data-flow">
+      {rows.map((row) => (
+        <div key={str(row, "id", str(row, "label"))} className="min-w-0 rounded-[1.2rem] border border-current/10 bg-background-base/35 p-4">
+          <Badge tone={row.configured ? "success" : "secondary"}>{row.configured ? "configured" : "not configured"}</Badge>
+          <h3 className="mt-3 text-sm font-semibold text-foreground">{str(row, "label")}</h3>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{str(row, "dataSent")}</p>
+          <p className="mt-2 text-[11px] leading-relaxed text-text-tertiary">{str(row, "retention")}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SourceExtrasPanel({ data }: { data: MissionControlSnapshot }) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold text-foreground">Architecture pieces</h3>
+        <StatusList items={data.blueprint.architecturePieces ?? []} testId="mission-architecture" />
+      </div>
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold text-foreground">Prerequisites</h3>
+        <StatusList items={data.blueprint.prerequisites ?? []} testId="mission-prerequisites" />
+      </div>
+      <div className="space-y-4 xl:col-span-2">
+        <h3 className="text-sm font-semibold text-foreground">What to build next</h3>
+        <StatusList items={data.blueprint.nextTools ?? []} testId="mission-next-tools" />
+      </div>
+      <div className="space-y-4 xl:col-span-2">
+        <h3 className="text-sm font-semibold text-foreground">Troubleshooting playbook</h3>
+        <StatusList items={data.blueprint.troubleshooting ?? []} testId="mission-troubleshooting" />
+      </div>
+    </div>
+  );
+}
+
+function DeviceProofPanel({ data }: { data: MissionControlSnapshot }) {
+  const smokeTargets = objectArray(data.deviceProof.smokeTargets);
+  return (
+    <Card className="overflow-hidden bg-card/65 backdrop-blur-xl" data-testid="mission-device-proof">
+      <CardHeader>
+        <CardTitle className="text-base">Responsive proof markers</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-2 sm:grid-cols-2">
+          {data.deviceProof.breakpoints.map((bp) => (
+            <div key={bp} className="rounded-2xl border border-current/10 bg-background-base/35 px-3 py-2 text-sm text-foreground" data-testid={`mission-device-breakpoint-${slugify(bp)}`}>
+              <CheckCircle2 className="mr-2 inline h-4 w-4 text-midground" />
+              {bp}
+            </div>
+          ))}
+        </div>
+        {smokeTargets.length > 0 && (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {smokeTargets.map((target) => (
+              <div key={str(target, "id", str(target, "label"))} className="rounded-2xl border border-current/10 bg-background-base/20 px-3 py-2 text-xs text-muted-foreground">
+                <Badge tone={checkTone(target.status)}>{str(target, "status")}</Badge>
+                <span className="ml-2">{str(target, "label")}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
+          {data.deviceProof.principles.map((line) => (
+            <p key={line}>• {line}</p>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -315,7 +519,7 @@ export default function MissionControlPage() {
       </div>,
     );
     setEnd(
-      <Button ghost size="icon" onClick={load} disabled={loading} aria-label="Refresh Mission Control">
+      <Button ghost size="icon" onClick={load} disabled={loading} aria-label="Refresh Mission Control" data-testid="mission-refresh-button">
         {loading ? <Spinner /> : <RefreshCw />}
       </Button>,
     );
@@ -344,7 +548,7 @@ export default function MissionControlPage() {
 
   if (loading && !data) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="flex min-h-[60vh] items-center justify-center" aria-busy="true" aria-live="polite" data-testid="mission-loading">
         <Spinner className="text-3xl text-primary" />
       </div>
     );
@@ -352,10 +556,10 @@ export default function MissionControlPage() {
 
   if (error && !data) {
     return (
-      <Card>
+      <Card role="alert" data-testid="mission-error">
         <CardContent className="py-12 text-center">
           <p className="text-sm text-destructive">{error}</p>
-          <Button className="mt-4" onClick={load}>Retry</Button>
+          <Button className="mt-4" onClick={load} data-testid="mission-retry-button">Retry</Button>
         </CardContent>
       </Card>
     );
@@ -370,7 +574,7 @@ export default function MissionControlPage() {
   const summary = data.coverage.summary;
 
   return (
-    <div className="flex flex-col gap-6 pb-[max(2rem,env(safe-area-inset-bottom))]" data-testid="mission-control-page">
+    <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-6 pb-[max(2rem,env(safe-area-inset-bottom))]" data-testid="mission-control-page">
       <PluginSlot name="mission-control:top" />
 
       <section
@@ -385,28 +589,26 @@ export default function MissionControlPage() {
               <Badge tone="secondary">{data.blueprint.stepCount} tracked steps</Badge>
               <Badge tone="secondary">{data.blueprint.hermesFeatureCount + data.blueprint.openclawFeatureCount} feature-picker items</Badge>
             </div>
-            <h1 className="mt-5 max-w-4xl text-4xl font-semibold tracking-[-0.07em] text-foreground sm:text-5xl lg:text-6xl">
+            <h2 className="mt-5 max-w-4xl text-4xl font-semibold tracking-[-0.07em] text-foreground sm:text-5xl lg:text-6xl">
               Mission Control for the full agent blueprint.
-            </h1>
+            </h2>
             <p className="mt-5 max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
               This is not a static mirror. Hermes maps every step, Hermes feature, and OpenClaw feature from the guide to live local runtime evidence — without exposing raw chat content, commands, logs, secrets, or absolute local paths.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
-              <a href={data.source.url} target="_blank" rel="noreferrer">
-                <Button outlined>
-                  Source guide <ArrowUpRight className="ml-2 h-4 w-4" />
-                </Button>
+              <a href={data.source.url} target="_blank" rel="noreferrer" className="inline-flex h-10 items-center rounded-xl border border-current/15 px-4 text-sm font-medium text-foreground transition hover:bg-midground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
+                Source guide <ArrowUpRight className="ml-2 h-4 w-4" />
               </a>
-              <a href="/system">
-                <Button ghost>System evidence</Button>
-              </a>
+              <Link to="/system" className="inline-flex h-10 items-center rounded-xl px-4 text-sm font-medium text-muted-foreground transition hover:bg-midground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-midground/60">
+                System evidence
+              </Link>
             </div>
           </div>
           <ScoreRing value={summary.readiness} label="Mission readiness" />
         </div>
       </section>
 
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5" data-testid="mission-metrics">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5" data-testid="mission-metrics">
         <MetricCard label="Coverage" value={`${summary.total}`} detail={`${summary.counts.active ?? 0} active · ${summary.counts.partial ?? 0} partial`} icon={Gauge} />
         <MetricCard label="Sessions" value={formatNumber(num(sessions, "total"))} detail={`${formatNumber(num(sessions, "messages"))} messages counted`} icon={Database} />
         <MetricCard label="Skills" value={formatNumber(num(skills, "total"))} detail="portable procedural memory" icon={Brain} />
@@ -414,45 +616,74 @@ export default function MissionControlPage() {
         <MetricCard label="MCP" value={formatNumber(num(mcp, "configured"))} detail="configured external tool servers" icon={Workflow} />
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
-        <Section eyebrow="operator queue" title="Smart next actions" icon={Radar}>
-          <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+        <Section id="production" eyebrow="production" title="Production readiness, honestly separated" icon={ServerCog}>
+          <ProductionPanel data={data} />
+        </Section>
+
+        <Section id="operator-queue" eyebrow="operator queue" title="Smart next actions" icon={Radar}>
+          <div className="grid gap-3 sm:grid-cols-2" data-testid="mission-action-queue">
             {data.actionQueue.map((action) => <ActionCard key={`${action.rank}-${action.title}`} action={action} />)}
           </div>
         </Section>
 
-        <Section eyebrow="readiness heatmap" title="Weakest domains first" icon={Activity}>
+        <Section id="readiness-heatmap" eyebrow="readiness heatmap" title="Weakest domains first" icon={Activity}>
           <div className="grid gap-3">
             {data.coverage.weakestDomains.map((domain) => <DomainBar key={domain.name} domain={domain} />)}
           </div>
         </Section>
       </div>
 
-      <Section eyebrow="live runtime" title="Smart things Mission Control can honestly show" icon={Bot}>
+      <Section id="live-runtime" eyebrow="live runtime" title="Smart things Mission Control can honestly show" icon={Bot}>
         <RuntimePanel data={data} />
       </Section>
 
-      <Section eyebrow="source coverage" title="All guide steps, mapped to routes and evidence" icon={Layers3}>
-        <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3" data-testid="mission-step-grid">
-          {data.coverage.steps.map((step) => <CoverageCard key={step.id} item={step} />)}
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Section id="preflight" eyebrow="pre-flight" title="Before you ship checklist" icon={ClipboardCheck}>
+          <StatusList items={objectArray(data.runtime.preflight)} testId="mission-preflight" />
+        </Section>
+        <Section id="customization" eyebrow="customization" title="Operator-specific setup" icon={ListChecks}>
+          <StatusList items={objectArray(data.runtime.customization)} testId="mission-customization" />
+        </Section>
+      </div>
+
+      <Section id="attention" eyebrow="attention" title="Lowest readiness guide steps" icon={Globe2}>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {topSteps.map((step) => <CoverageCard key={step.id} item={step} compact />)}
+        </div>
+      </Section>
+
+      <Section id="source-coverage" eyebrow="source coverage" title="All guide steps, mapped to routes and evidence" icon={Layers3}>
+        <div data-testid="mission-blueprint-steps">
+          <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3" data-testid="mission-step-grid">
+            {data.coverage.steps.map((step) => <CoverageCard key={step.id} item={step} />)}
+          </div>
         </div>
       </Section>
 
       <div className="grid gap-6 xl:grid-cols-2">
-        <Section eyebrow="Hermes picker" title="H1–H11 feature status" icon={Sparkles}>
+        <Section id="hermes-picker" eyebrow="Hermes picker" title="H1–H11 feature status" icon={Sparkles}>
           <div className="grid gap-3" data-testid="mission-hermes-features">
             {hermesFeatures.map((feature) => <CoverageCard key={feature.id} item={feature} compact />)}
           </div>
         </Section>
-        <Section eyebrow="OpenClaw picker" title="O1–O10 production feature status" icon={Zap}>
+        <Section id="openclaw-picker" eyebrow="OpenClaw picker" title="O1–O10 production feature status" icon={Zap}>
           <div className="grid gap-3" data-testid="mission-openclaw-features">
             {openClawFeatures.map((feature) => <CoverageCard key={feature.id} item={feature} compact />)}
           </div>
         </Section>
       </div>
 
+      <Section id="source-extras" eyebrow="source extras" title="Architecture, prerequisites, next tools and troubleshooting" icon={BookOpen}>
+        <SourceExtrasPanel data={data} />
+      </Section>
+
+      <Section id="data-flow" eyebrow="data flow" title="Where data goes — safely summarized" icon={Route}>
+        <DataFlowPanel data={data} />
+      </Section>
+
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <Section eyebrow="privacy boundary" title="Useful without leaking the operator" icon={LockKeyhole}>
+        <Section id="privacy-boundary" eyebrow="privacy boundary" title="Useful without leaking the operator" icon={LockKeyhole}>
           <div className="grid gap-3 sm:grid-cols-2">
             {data.privacy.map((item) => (
               <div key={item.label} className="rounded-[1.35rem] border border-current/10 bg-background-base/35 p-4">
@@ -467,35 +698,10 @@ export default function MissionControlPage() {
           </div>
         </Section>
 
-        <Section eyebrow="device proof" title="Desktop, tablet, mobile — no cockpit collapse" icon={Fingerprint}>
-          <Card className="overflow-hidden bg-card/65 backdrop-blur-xl">
-            <CardHeader>
-              <CardTitle className="text-base">Responsive proof markers</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-2 sm:grid-cols-2">
-                {data.deviceProof.breakpoints.map((bp) => (
-                  <div key={bp} className="rounded-2xl border border-current/10 bg-background-base/35 px-3 py-2 text-sm text-foreground">
-                    <CheckCircle2 className="mr-2 inline h-4 w-4 text-midground" />
-                    {bp}
-                  </div>
-                ))}
-              </div>
-              <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
-                {data.deviceProof.principles.map((line) => (
-                  <p key={line}>• {line}</p>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+        <Section id="device-proof" eyebrow="device proof" title="Desktop, tablet, mobile — no cockpit collapse" icon={Fingerprint}>
+          <DeviceProofPanel data={data} />
         </Section>
       </div>
-
-      <Section eyebrow="attention" title="Lowest readiness guide steps" icon={Globe2}>
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {topSteps.map((step) => <CoverageCard key={step.id} item={step} compact />)}
-        </div>
-      </Section>
 
       <p className="text-center text-xs text-text-tertiary">
         Generated {data.runtime.generatedAt}. Source checked {data.source.lastChecked}. {data.source.note}


### PR DESCRIPTION
## Summary
- Adds a Mission Control blueprint dashboard for Hermes.
- Adds backend mission-control aggregation/API surface.
- Adds frontend Mission Control page and API client wiring.
- Adds tests for mission-control behavior.

## Verification
- Python: 91 passed
- Mission-Control tests: 4 passed
- Frontend build in `web/`: successful
- API smoke: ok true, 27 steps, 21 features, 48 coverage, 87% readiness, no leaks
- Browser smoke desktop: ok, no console errors, no horizontal overflow
- Mobile smoke 390x844: ok, all sections visible, no overflow
