### PR TITLE
fix(tools): accept file_path/file_content aliases in the write_file tool

### DIFF
--- a/tests/tools/test_write_file_arg_aliases.py
+++ b/tests/tools/test_write_file_arg_aliases.py
@@ -1,0 +1,81 @@
+"""The write_file tool accepts file_path/file_content as aliases for path/content.
+
+skill_manage(action="write_file") names the same two arguments file_path/
+file_content, while the standalone write_file tool uses path/content. Models
+routinely carry one tool's naming across to the other, which previously rejected
+a fully-formed call (the content was present, just under the wrong key) and cost
+a wasted turn. These tests pin the alias behaviour. See issue #39964.
+"""
+
+import json
+from unittest.mock import patch
+
+import tools.file_tools as file_tools
+
+
+def _capturing_write_file_tool():
+    captured = {}
+
+    def _stub(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"ok": True})
+
+    return captured, _stub
+
+
+def test_write_file_accepts_file_content_alias():
+    """The reported failure: {path, file_content} must succeed."""
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        out = file_tools._handle_write_file(
+            {"path": "/tmp/x.txt", "file_content": "hello"}, task_id="t"
+        )
+    assert json.loads(out) == {"ok": True}
+    assert captured["path"] == "/tmp/x.txt"
+    assert captured["content"] == "hello"
+
+
+def test_write_file_accepts_file_path_alias():
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {"file_path": "/tmp/y.txt", "content": "data"}, task_id="t"
+        )
+    assert captured["path"] == "/tmp/y.txt"
+    assert captured["content"] == "data"
+
+
+def test_write_file_canonical_names_win_over_aliases():
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {
+                "path": "/canon", "file_path": "/alias",
+                "content": "canon", "file_content": "alias",
+            },
+            task_id="t",
+        )
+    assert captured["path"] == "/canon"
+    assert captured["content"] == "canon"
+
+
+def test_write_file_empty_string_content_preserved():
+    """Empty content is a valid write (truncate); the alias path must not
+    misread '' as missing and fall back to file_content."""
+    captured, stub = _capturing_write_file_tool()
+    with patch.object(file_tools, "write_file_tool", stub):
+        file_tools._handle_write_file(
+            {"path": "/tmp/empty.txt", "content": "", "file_content": "SHOULD_NOT_WIN"},
+            task_id="t",
+        )
+    assert captured["content"] == ""
+
+
+def test_write_file_truly_missing_content_still_errors():
+    out = file_tools._handle_write_file({"path": "/tmp/x.txt"}, task_id="t")
+    assert "missing required field 'content'" in out
+
+
+def test_write_file_truly_missing_path_still_errors():
+    out = file_tools._handle_write_file({"content": "data"}, task_id="t")
+    assert "missing required field 'path'" in out

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,25 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    # Accept `file_path`/`file_content` as aliases for `path`/`content`. The
+    # skill_manage tool's write_file action uses the `file_*` names, so models
+    # routinely carry that naming across to this tool (and vice versa) — a
+    # cross-tool footgun that otherwise rejects a fully-formed call and costs a
+    # wasted turn. Treat the synonyms as equivalent; the canonical names win
+    # when both are present.
+    path = args.get("path")
+    if not path:
+        path = args.get("file_path")
+    content = args.get("content")
+    if content is None:
+        content = args.get("file_content")
+
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if content is None:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1508,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
## What does this PR do?

The standalone `write_file` tool names its arguments `path`/`content`, while `skill_manage(action="write_file")` names the same two arguments `file_path`/`file_content`. Models routinely carry the `file_*` naming across to the `write_file` tool, so a **fully-formed** call (`{path, file_content}`) is rejected as `missing required field 'content'` — even though the content is present, just under the wrong key. The error even misdiagnoses it as a dropped-argument bug, sending the model into a wasted retry.

This accepts `file_path`/`file_content` as aliases for `path`/`content` so a complete-but-misnamed call succeeds. It is the standalone-tool counterpart to #35741 (which fixes the same footgun on `skill_manage` for #35736); this PR deliberately does **not** touch `skill_manage`, to stay focused.

## Related Issue

Fixes #39964

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` — `_handle_write_file` resolves `file_path`→`path` and `file_content`→`content` as aliases. Canonical names win when both are present; an empty-string `content` (a valid truncate) is preserved — only `None` falls back, so this is not an `or`-based collapse.
- `tests/tools/test_write_file_arg_aliases.py` — new tests: both alias directions, canonical-wins-over-alias, empty-string content preserved, genuinely-missing args still error.

## How to Test

Pre-fix repro: `write_file({"path": "/tmp/out.txt", "file_content": "hello"})` returns `{"error": "write_file: missing required field 'content'. ..."}` and nothing is written.

With this PR:
1. `scripts/run_tests.sh tests/tools/test_write_file_arg_aliases.py` — 6 tests pass.
2. `test_write_file_accepts_file_content_alias` covers the reported shape.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single file + test)
- [x] I've run the affected tests via `scripts/run_tests.sh` and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5, Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — handler-level alias only; no docs, config keys, or tool schemas changed