### PR TITLE
fix(desktop): scan backwards for reasoning part instead of only checking last element

### DIFF
--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -233,6 +233,22 @@ export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMes
 }
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  const next = [...parts]
+
+  // Find the last reasoning part in the array regardless of what part
+  // types sit between — mid-thought tool execution inserts tool-call
+  // parts that should not split one continuous reasoning sentence into
+  // separate "Thinking" blocks.
+  for (let i = next.length - 1; i >= 0; i--) {
+    const entry = next[i]
+
+    if (entry?.type === 'reasoning') {
+      next[i] = { ...entry, text: `${entry.text}${delta}` }
+
+      return next
+    }
+  }
+
   return appendStreamPart(parts, 'reasoning', delta).parts
 }
 


### PR DESCRIPTION
## Problem

When the model pauses its reasoning to make a tool call mid-thought, the desktop app splits one continuous reasoning sentence into two separate `Thinking` blocks.

## Fix

`appendReasoningPart()` now scans backwards from the end of the parts array to find the last `reasoning` part, instead of only checking `next.at(-1)`. Tool-call parts inserted mid-thought no longer split the reasoning block.

Fixes #39966
