### PR TITLE
fix(gateway): strip gateway guard in Windows restart helper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4040,10 +4040,21 @@ class GatewayRunner:
                 _CREATE_NEW_PROCESS_GROUP = 0x00000200
                 _DETACHED_PROCESS = 0x00000008
                 _CREATE_NO_WINDOW = 0x08000000
+                env = dict(os.environ)
+                # The helper is spawned by the gateway process, whose env
+                # contains _HERMES_GATEWAY=1.  `hermes gateway restart` has a
+                # self-targeting guard for that marker; if we inherit it here,
+                # the replacement command refuses to run and /restart silently
+                # leaves the gateway stopped.  Strip only the guard marker so
+                # HERMES_HOME/profile/PATH and credentials still flow through.
+                env.pop("_HERMES_GATEWAY", None)
                 subprocess.Popen(
                     cmd,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    env=env,
+                    close_fds=True,
                     creationflags=_CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS | _CREATE_NO_WINDOW,
                 )
                 """

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 import subprocess
 from datetime import datetime
@@ -182,6 +183,7 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     runner, _adapter = make_restart_runner()
     popen_calls = []
 
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None)
@@ -202,6 +204,38 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_strips_gateway_guard_from_child_env(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["C:/Hermes/hermes.exe"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[:3] == [gateway_run.sys.executable, "-c", cmd[2]]
+    watcher_source = cmd[2]
+    assert "env.pop(\"_HERMES_GATEWAY\", None)" in watcher_source
+    assert "env=env" in watcher_source
+    assert "stdin=subprocess.DEVNULL" in watcher_source
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+    # The parent gateway's environment still contains the guard in this test;
+    # the generated watcher must remove it before invoking `hermes gateway restart`.
+    assert os.environ["_HERMES_GATEWAY"] == "1"
 
 
 # ── Shutdown notification tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #39969.

This fixes a Windows gateway `/restart` failure where the detached restart helper inherited `_HERMES_GATEWAY=1` from the old gateway process. The replacement `hermes gateway restart` command then hit the gateway self-targeting guard and refused to run, leaving the gateway stopped.

## Changes

- Strip only `_HERMES_GATEWAY` from the Windows detached restart helper environment.
- Preserve the rest of the environment so `HERMES_HOME`, profile, PATH, venv, and credentials continue to work.
- Detach helper stdio explicitly, including `stdin=subprocess.DEVNULL`.
- Add a regression test that asserts the Windows watcher removes the guard before invoking the replacement restart command.

## Verification

Targeted test run on Windows:

```text
PYTHONPATH="$(pwd)" uv run --with pytest --with pytest-asyncio --with pytest-xdist --with pyyaml pytest tests/gateway/test_restart_drain.py -q -o 'addopts='
..................                                                       [100%]
18 passed in 2.66s
```

Live affected install recovered after restart:

```text
✓ Scheduled Task registered: Hermes_Gateway
✓ Gateway process running (PID: 9344)
```

QQBot messages were delivered again after the gateway came back up.

## Risk

Low. The change is scoped to the generated Windows detached restart helper. It removes only the internal self-targeting guard from the helper's child environment and leaves all runtime configuration intact.
