### PR TITLE
fix(desktop): continue reasoning across tool calls

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
+  appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
   renderMediaTags,
@@ -140,6 +141,19 @@ describe('renderMediaTags', () => {
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+})
+
+describe('appendReasoningPart', () => {
+  it('continues the previous reasoning block across an intervening tool call', () => {
+    const first = appendReasoningPart([], 'I should inspect ')
+    const withTool = upsertToolPart(first, { name: 'terminal', tool_id: 'tool-1' }, 'running')
+    const resumed = appendReasoningPart(withTool, 'the repo before editing.')
+
+    expect(resumed.map(part => part.type)).toEqual(['reasoning', 'tool-call'])
+    expect((resumed[0] as Extract<ChatMessagePart, { type: 'reasoning' }>).text).toBe(
+      'I should inspect the repo before editing.'
+    )
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -205,12 +205,15 @@ export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string)
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
   const next = [...parts]
-  const last = next.at(-1)
 
-  if (last?.type === 'reasoning') {
-    next[next.length - 1] = { ...last, text: `${last.text}${delta}` }
+  for (let index = next.length - 1; index >= 0; index -= 1) {
+    const part = next[index]
 
-    return next
+    if (part?.type === 'reasoning') {
+      next[index] = { ...part, text: `${part.text}${delta}` }
+
+      return next
+    }
   }
 
   next.push(reasoningPart(delta))


### PR DESCRIPTION
## Summary
- update `appendReasoningPart()` to continue the nearest prior reasoning part instead of requiring reasoning to be the final part
- add a desktop regression test covering reasoning → tool-call → reasoning streaming

## Why
When a tool call lands between reasoning deltas, the desktop stream currently creates a second `Thinking` block. Continuing the prior reasoning part keeps one continuous reasoning block while preserving the intervening tool-call part.

Fixes #39966.

## Verification
- `npm run test:ui -- src/lib/chat-messages.test.ts`
- `npx eslint src/lib/chat-messages.ts src/lib/chat-messages.test.ts`
- `npm run type-check`
- `git diff --check`