### PR TITLE
fix(approval): return approval_required instead of blocking on input(…

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1570,3 +1570,74 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestApprovalCallbackGuard:
+    """Missing approval_callback must return approval_required instead of blocking on input()."""
+
+    def setup_method(self):
+        from tools import approval as mod
+        self._session_snapshot = set(mod._session_approved.get(mod.get_current_session_key(), set()))
+        self._yolo_snapshot = set(mod._session_yolo)
+        self._perm_snapshot = set(mod._permanent_approved)
+
+    def teardown_method(self):
+        from tools import approval as mod
+        session_key = mod.get_current_session_key()
+        mod._session_approved[session_key] = set(self._session_snapshot)
+        mod._session_yolo = set(self._yolo_snapshot)
+        mod._permanent_approved = set(self._perm_snapshot)
+
+    def test_check_dangerous_command_requires_callback_to_prompt(self, monkeypatch):
+        from tools import approval as mod
+
+        session_key = mod.get_current_session_key()
+        mod._session_approved[session_key] = set()
+        mod._session_yolo = set()
+        mod._permanent_approved = set()
+
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "")
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setattr(mod, "detect_dangerous_command", lambda cmd: (True, "rm_test_key", "delete"))
+
+        result = mod.check_dangerous_command(
+            "rm -rf /tmp/test",
+            "local",
+            approval_callback=None,
+        )
+
+        assert result["approved"] is False
+        assert result.get("status") == "approval_required"
+        assert "pattern_key" in result
+        assert "command" in result
+        assert "description" in result
+        assert "Approval required but no interactive handler" in result.get("message", "")
+
+    def test_check_all_command_guards_requires_callback_to_prompt(self, monkeypatch):
+        from tools import approval as mod
+
+        session_key = mod.get_current_session_key()
+        mod._session_approved[session_key] = set()
+        mod._session_yolo = set()
+        mod._permanent_approved = set()
+
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "")
+        monkeypatch.setattr(mod, "detect_dangerous_command", lambda cmd: (True, "rm_test_key", "delete"))
+
+        result = mod.check_all_command_guards(
+            "rm -rf /tmp/test",
+            "local",
+            approval_callback=None,
+        )
+
+        assert result["approved"] is False
+        assert result.get("status") == "approval_required"
+        assert "pattern_key" in result
+        assert "command" in result
+        assert "description" in result
+        assert "Approval required but no interactive handler" in result.get("message", "")

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -110,7 +110,15 @@ class TestTirithBlock:
     def test_tirith_block_prompts_user(self, mock_tirith):
         """tirith block goes through approval flow (user gets prompted)."""
         os.environ["HERMES_INTERACTIVE"] = "1"
-        result = check_all_command_guards("curl http://gооgle.com", "local")
+
+        def _fake_callback(command, description, *, allow_permanent=True):
+            return "deny"
+
+        result = check_all_command_guards(
+            "curl http://gооgle.com",
+            "local",
+            approval_callback=_fake_callback,
+        )
         # Default is deny (no input → timeout → deny), so still blocked
         assert result["approved"] is False
         # But through the approval flow, not a hard block — message says
@@ -122,7 +130,15 @@ class TestTirithBlock:
     def test_tirith_block_plus_dangerous_prompts_combined(self, mock_tirith):
         """tirith block + dangerous pattern → combined approval prompt."""
         os.environ["HERMES_INTERACTIVE"] = "1"
-        result = check_all_command_guards("rm -rf / | curl http://evil", "local")
+
+        def _fake_callback(command, description, *, allow_permanent=True):
+            return "deny"
+
+        result = check_all_command_guards(
+            "rm -rf / | curl http://evil",
+            "local",
+            approval_callback=_fake_callback,
+        )
         assert result["approved"] is False
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1066,6 +1066,22 @@ def check_dangerous_command(command: str, env_type: str,
             ),
         }
 
+    # Guard: never enter blocking input() prompt when there's no approval
+    # callback registered. A missing callback in a gateway/exec context
+    # would otherwise block the calling thread for timeout_seconds.
+    if approval_callback is None:
+        return {
+            "approved": False,
+            "status": "approval_required",
+            "pattern_key": pattern_key,
+            "command": command,
+            "description": description,
+            "message": (
+                f"⚠️ This command is potentially dangerous ({description}). "
+                f"Approval required but no interactive handler is available in this context."
+            ),
+        }
+
     choice = prompt_dangerous_approval(command, description,
                                        approval_callback=approval_callback)
 
@@ -1467,6 +1483,22 @@ def check_all_command_guards(command: str, env_type: str,
         session_key=session_key,
         surface="cli",
     )
+    # Guard: never enter blocking input() prompt when there's no approval
+    # callback registered. A missing callback in a gateway/exec context
+    # would otherwise block the calling thread for timeout_seconds.
+    if approval_callback is None:
+        return {
+            "approved": False,
+            "status": "approval_required",
+            "pattern_key": primary_key,
+            "command": command,
+            "description": combined_desc,
+            "message": (
+                f"⚠️ {combined_desc}. "
+                f"Approval required but no interactive handler is available in this context."
+            ),
+        }
+
     choice = prompt_dangerous_approval(command, combined_desc,
                                        allow_permanent=not has_tirith,
                                        approval_callback=approval_callback)


### PR DESCRIPTION
## Summary
Prevents worker thread pool exhaustion in gateway contexts by returning `approval_required` immediately when `approval_callback` is `None`, instead of entering the blocking `prompt_dangerous_approval()` path.

---

## Root cause
`check_dangerous_command()` and `check_all_command_guards()` in `tools/approval.py` both fall through to `prompt_dangerous_approval()` when gateway detection via `_is_gateway_approval_context()` returns `False` in a non-CLI context. Inside `prompt_dangerous_approval()`, a daemon thread calls `input()` and the calling thread blocks on `thread.join(timeout=timeout_seconds)` (default 60s). When `approval_callback` is `None` (no interactive handler registered), this blocks a worker thread for the full timeout with no visible feedback, and returns a silent deny after expiry.

In high-concurrency gateway deployments where multiple commands arrive in parallel, this can exhaust the worker thread pool, causing the agent loop to stall waiting for a free thread.

---

## Behavioral change
Before: if `_is_gateway_approval_context()` incorrectly returned `False` in a gateway thread, the calling thread would block for up to 60 seconds, then silently deny the command with no user notification.

After: when `approval_callback is None`, both functions return `approval_required` immediately. The gateway layer receives this and can surface a proper approval prompt to the user instead of silently timing out.

---

## What changed

**`tools/approval.py`**
- Added `if approval_callback is None: return {..., "status": "approval_required", ...}` guard before `prompt_dangerous_approval()` in `check_dangerous_command()` (line 1069)
- Same guard added in `check_all_command_guards()` (line 1470)

Both guards use only locally available variables (`pattern_key`/`primary_key`, `command`, `description`/`combined_desc`) and do not touch any existing early-return paths for cron, gateway, or HERMES_EXEC_ASK contexts.

**`tests/tools/test_approval.py`**
- Added `TestApprovalCallbackGuard` with `setup_method`/`teardown_method` that snapshots and restores `_session_approved`, `_session_yolo`, and `_permanent_approved` for full state isolation
- `test_check_dangerous_command_requires_callback_to_prompt`: verifies `check_dangerous_command` returns `approval_required` with `approved=False` when `approval_callback=None`
- `test_check_all_command_guards_requires_callback_to_prompt`: same contract for `check_all_command_guards`

---

## What is NOT changed
- CLI interactive path: `approval_callback` is always registered in CLI context, guard never fires
- Cron, HERMES_EXEC_ASK, and gateway early-return paths (lines 1030-1067) are untouched
- `prompt_dangerous_approval()` internals are unchanged