### PR TITLE
fix(streaming): add None-safety guards in codex + chat-completions paths

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1780,7 +1780,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if agent._interrupt_requested:
                 break
 
-            if not chunk.choices:
+            if chunk.choices is None or not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model
                 # Usage comes in the final chunk with empty choices
@@ -1788,7 +1788,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     usage_obj = chunk.usage
                 continue
 
-            delta = chunk.choices[0].delta
+            _choices0 = chunk.choices[0]
+            if _choices0 is None:
+                logger.warning(
+                    "Chat completions stream: chunk.choices[0] is None, skipping. Chunk type=%s",
+                    type(chunk).__name__,
+                )
+                continue
+            delta = _choices0.delta
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
@@ -1986,6 +1993,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             except Exception:
                 pass
             for event in stream:
+                # Guard: None events would crash `in` operator on event_type below.
+                if event is None:
+                    continue
                 # Update stale-stream timer on every event so the
                 # outer poll loop knows data is flowing.  Without
                 # this, the detector kills healthy long-running

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -281,6 +281,10 @@ def _consume_codex_event_stream(
     saw_terminal = False
 
     for event in event_iter:
+        # Guard: backend can emit None events. Skip rather than crash on
+        # attribute access or `in` operator below.
+        if event is None:
+            continue
         if on_event is not None:
             try:
                 on_event(event)


### PR DESCRIPTION
## Summary

Add defensive `None` guards to streaming event loops to prevent crashes when backends emit `None` events or `None` choice objects.

## Problem

Three crash paths in the streaming infrastructure can be triggered by backends that emit `None` events (observed on `chatgpt.com/backend-api/codex` and similar proxies, May 2026):

1. **`agent/codex_runtime.py:_consume_codex_event_stream`** — `for event in event_iter:` followed by `event_type = _event_field(event, "type", "")` and `"output_text.delta" in event_type`. When `event` is `None`, the `in` operator raises `TypeError: argument of type 'NoneType' is not iterable`.

2. **`agent/chat_completion_helpers.py:interruptible_streaming_api_call` (chat-completions branch)** — `if not chunk.choices:` does not catch `chunk.choices is None`, and `delta = chunk.choices[0].delta` raises `AttributeError: 'NoneType' object has no attribute 'delta'` when `chunk.choices[0]` is `None`.

3. **Same file, Anthropic branch (`_call_anthropic`)** — same `event is None` vulnerability as #1.

## Fix

Minimal 16-line patch adding `if event is None: continue` (or its choice-equivalent) at the top of each iteration. Real events still flow through; `None` events are silently skipped.

## Context

This was originally an autostash from 2026-05-27 (`stash@{0}`) of an earlier defensive patch targeting the then-inline streaming code. Upstream subsequently refactored:

- `_run_codex_stream` was extracted from `run_agent.py` into `agent/codex_runtime.py`
- `interruptible_streaming_api_call` was extracted from `run_agent.py` into `agent/chat_completion_helpers.py`

The refactor moved the code paths but did not carry the defensive patches forward — the new locations remained vulnerable to the same `None`-event crashes. This PR reapplies the guard intent to the new module locations.

## Test plan

- Synthetic iterators yielding `[None, real_event, None, terminal_event]` produce the expected collected deltas and a `status="completed"` final response.
- All four `chunk.choices` edge cases (`None` / `[]` / `[None]` / `[real]`) handled correctly.
- `py_compile` clean on all four affected files (`codex_runtime.py`, `chat_completion_helpers.py`, `auxiliary_client.py`, `run_agent.py`).
- Module imports succeed with no `NameError` or `SyntaxError`.

## Diff

```diff
 agent/chat_completion_helpers.py | 14 ++++++++++++--
 agent/codex_runtime.py           |  4 ++++
 2 files changed, 16 insertions(+), 2 deletions(-)
```
