### PR TITLE
fix(kanban): resolve worker skill probe against platform default home

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6560,10 +6560,16 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     omitting the flag only drops the supplementary pattern library.
     """
     from pathlib import Path as _Path
+    from hermes_constants import get_default_hermes_root
 
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    # An unset HERMES_HOME means the worker falls back to the platform-native
+    # default root home (``~/.hermes`` on POSIX, ``%LOCALAPPDATA%\hermes`` on
+    # native Windows), which ships the bundled skill. Resolve it through the
+    # same helper the rest of this module uses (see ``kanban_home``) rather than
+    # hardcoding ``Path.home() / ".hermes"`` — that POSIX-only path is an empty
+    # husk on native Windows, so the probe would scan the wrong directory and
+    # silently drop ``--skills kanban-worker``.
+    base = _Path(hermes_home) if hermes_home else get_default_hermes_root()
     skills_root = base / "skills"
     if not skills_root.is_dir():
         return False

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+import hermes_constants
 from hermes_cli import kanban_db as kb
 
 
@@ -4287,3 +4288,79 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Worker skill probe — platform-aware default home resolution
+# ---------------------------------------------------------------------------
+
+
+def _make_kanban_worker_skill(home: Path) -> None:
+    """Create the bundled kanban-worker SKILL.md under ``<home>/skills/devops/``."""
+    skill = home / "skills" / "devops" / "kanban-worker" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text("---\nname: kanban-worker\n---\n", encoding="utf-8")
+
+
+def test_worker_skill_probe_resolves_platform_default_on_windows(tmp_path, monkeypatch):
+    """With HERMES_HOME unset on native Windows, the probe resolves the bundled
+    skill under %LOCALAPPDATA%\\hermes — not the POSIX ~/.hermes husk.
+
+    Regression: the None fallback previously hardcoded ``Path.home()/".hermes"``,
+    which on native Windows points at an empty husk, so the probe returned False
+    and the dispatcher silently dropped ``--skills kanban-worker``.
+    """
+    local_appdata = tmp_path / "LocalAppData"
+    user_home = tmp_path / "Home"
+    user_home.mkdir()
+    # Skill ships under the platform-native root only.
+    _make_kanban_worker_skill(local_appdata / "hermes")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    assert kb._kanban_worker_skill_available(None) is True
+
+
+def test_worker_skill_probe_ignores_posix_husk_on_windows(tmp_path, monkeypatch):
+    """On native Windows the probe must NOT consult ~/.hermes — a leftover skill
+    in that husk is invisible to a worker that resolves %LOCALAPPDATA%\\hermes."""
+    local_appdata = tmp_path / "LocalAppData"
+    # Platform-native root exists with an (empty) skills dir: the probe scans
+    # here and must find nothing rather than reaching into the husk.
+    (local_appdata / "hermes" / "skills").mkdir(parents=True)
+    user_home = tmp_path / "Home"
+    # Skill present ONLY in the POSIX husk the worker never reads on Windows.
+    _make_kanban_worker_skill(user_home / ".hermes")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    assert kb._kanban_worker_skill_available(None) is False
+
+
+def test_worker_skill_probe_resolves_posix_default_when_home_unset(tmp_path, monkeypatch):
+    """On POSIX, the unset-HERMES_HOME fallback still resolves ~/.hermes."""
+    user_home = tmp_path / "Home"
+    _make_kanban_worker_skill(user_home / ".hermes")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+
+    assert kb._kanban_worker_skill_available(None) is True
+
+
+def test_worker_skill_probe_honors_explicit_home(tmp_path, monkeypatch):
+    """An explicit hermes_home is scanned directly, independent of platform."""
+    explicit = tmp_path / "profiles" / "coder"
+    _make_kanban_worker_skill(explicit)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    assert kb._kanban_worker_skill_available(str(explicit)) is True
+    # A home without the skill resolves False.
+    assert kb._kanban_worker_skill_available(str(tmp_path / "empty")) is False


### PR DESCRIPTION
## What & why

`_kanban_worker_skill_available()` decides whether the kanban dispatcher
injects `--skills kanban-worker` into a spawned worker. When the probe is
called with `hermes_home=None`, it fell back to a hardcoded
`Path.home() / ".hermes"`:

```python
base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
```

This is wrong on **native Windows**, where the canonical Hermes home is
`%LOCALAPPDATA%\hermes` (see `hermes_constants._get_platform_default_hermes_home`),
not `%USERPROFILE%\.hermes` (an empty husk). It also violates the hardline
rule against hardcoding `Path.home() / ".hermes"` (AGENTS.md → *Rules for
profile-safe code #1*; *Known Pitfalls → DO NOT hardcode `~/.hermes` paths*).

**Reachability:** the `None` branch is hit when `_default_spawn()` calls
`resolve_profile_env()` for a non-existent named profile (raises
`FileNotFoundError`, so `HERMES_HOME` is never written to the child env —
`kanban_db.py:6652-6659`) **and** the dispatcher process itself has no
`HERMES_HOME` in its environment. `env.get("HERMES_HOME")` is then `None`
and the probe scans the wrong directory.

**Impact:** on native Windows the bundled skill lives under
`%LOCALAPPDATA%\hermes\skills\devops\kanban-worker\`, but the probe looked
under `%USERPROFILE%\.hermes\skills\…` → returns `False` →
`--skills kanban-worker` is silently dropped, so dispatched workers lose the
pattern library (silent graceful-degradation regression).

## Fix

Replace the hardcoded fallback with `get_default_hermes_root()` — the same
platform-aware helper this module already uses in `kanban_home()` and at
`kanban_db.py:7480`. When `HERMES_HOME` is unset (the precondition for the
`None` branch), it returns the platform-native default root, matching what
the worker actually resolves. It is also side-effect-free (no warning
emission, unlike `get_hermes_home()`).

```python
from hermes_constants import get_default_hermes_root
base = _Path(hermes_home) if hermes_home else get_default_hermes_root()
```

The misleading inline comment (which claimed the fallback is `~/.hermes`)
is updated to state the platform-native behavior.

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k worker_skill_probe
```

Adds 4 regression tests in `tests/hermes_cli/test_kanban_db.py`:

- `test_worker_skill_probe_resolves_platform_default_on_windows` — with
  `HERMES_HOME` unset on simulated win32, the skill under
  `%LOCALAPPDATA%\hermes` resolves (`True`). **Fails on the old code** (it
  scanned the empty `~/.hermes` husk).
- `test_worker_skill_probe_ignores_posix_husk_on_windows` — a skill present
  only in `~/.hermes` is not consulted on win32 (`False`).
- `test_worker_skill_probe_resolves_posix_default_when_home_unset` — POSIX
  fallback still resolves `~/.hermes` (`True`).
- `test_worker_skill_probe_honors_explicit_home` — an explicit `hermes_home`
  is scanned directly, independent of platform.

The existing integration test `test_default_spawn_auto_loads_kanban_worker_skill`
still passes.

## Platforms tested


  `test_default_spawn_auto_loads_kanban_worker_skill` pass; `ruff check`
  clean. (Other pre-existing failures in the suite on native Windows are
  unrelated POSIX-only tests — `os.symlink` privilege, `os.waitpid` zombie
  reaping, `_resolve_hermes_argv` shim resolution.)
- Behavior on Linux/macOS is unchanged: the fallback still resolves
  `~/.hermes`.

## Related

- Follows the profile-safe path rule and the cross-platform `HERMES_HOME`
  resolution established in #18594 / #3575.