### PR TITLE
fix(install): ship and resolve whatsapp-bridge in wheel and sdist installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,15 @@
 graft skills
 graft optional-skills
 graft locales
+# WhatsApp Baileys bridge (Node.js) for sdist builds — Homebrew and other
+# downstream packagers build the wheel from the sdist, so the bridge sources
+# must be in the tarball. The wheel itself is covered by
+# [tool.setuptools.data-files] in pyproject.toml. Without this the sdist drops
+# bridge.js and the gateway WhatsApp adapter fatals with whatsapp_bridge_missing.
+graft scripts/whatsapp-bridge
+# Never ship a developer's locally-installed node_modules (created by the
+# bridge's runtime `npm install`) — it would bloat the sdist by 10s of MB.
+prune scripts/whatsapp-bridge/node_modules
 # Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
 # PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -29,7 +29,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from hermes_constants import get_hermes_dir
+from hermes_constants import get_bundled_whatsapp_bridge_dir, get_hermes_dir
 
 logger = logging.getLogger(__name__)
 
@@ -244,8 +244,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 4096
     DEFAULT_REPLY_PREFIX = "⚕ *Hermes Agent*\n────────────\n"
     
-    # Default bridge location relative to the hermes-agent install
-    _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
+    # Default bridge location. Resolved via get_bundled_whatsapp_bridge_dir()
+    # so it is found in packaged (wheel/sdist) installs too — the bridge ships
+    # as setuptools data-files and does NOT land next to this module's
+    # ``parents[2]`` in a wheel. A user-set ``bridge_script`` in config.extra
+    # still overrides this default in __init__.
+    _DEFAULT_BRIDGE_DIR = get_bundled_whatsapp_bridge_dir()
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_bundled_whatsapp_bridge_dir
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -1456,7 +1456,7 @@ def run_doctor(args):
     if _npm_bin:
         npm_dirs = [
             (PROJECT_ROOT, "Browser tools (agent-browser)"),
-            (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge"),
+            (get_bundled_whatsapp_bridge_dir(), "WhatsApp bridge"),
         ]
         for npm_dir, label in npm_dirs:
             if not (npm_dir / "node_modules").exists():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2287,8 +2287,10 @@ def cmd_whatsapp(args):
             print("  ⚠ No allowlist — the agent will respond to ALL incoming messages")
 
     # ── Step 4: Install bridge dependencies ──────────────────────────────
-    project_root = Path(__file__).resolve().parents[1]
-    bridge_dir = project_root / "scripts" / "whatsapp-bridge"
+    # Resolve via the shared helper so the bridge is found in packaged
+    # (wheel/sdist) installs, not only editable/git checkouts.
+    from hermes_constants import get_bundled_whatsapp_bridge_dir
+    bridge_dir = get_bundled_whatsapp_bridge_dir()
     bridge_script = bridge_dir / "bridge.js"
 
     if not bridge_script.exists():

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -221,6 +221,43 @@ def get_bundled_skills_dir(default: Path | None = None) -> Path:
     return get_hermes_home() / "skills"
 
 
+def get_bundled_whatsapp_bridge_dir(default: Path | None = None) -> Path:
+    """Return the bundled WhatsApp (Baileys) Node.js bridge directory.
+
+    The bridge under ``scripts/whatsapp-bridge`` is a bare data directory (no
+    ``__init__.py``), so — like ``locales/`` — it is invisible to
+    ``packages.find`` and to ``package-data``. It ships as setuptools
+    ``data-files`` (wheel) / ``MANIFEST.in`` graft (sdist), which means its
+    install location differs by install type. Resolution order, first existing
+    wins:
+
+        1. ``HERMES_WHATSAPP_BRIDGE_DIR`` env var (Nix/Homebrew wrapper or
+           explicit override).
+        2. Wheel-installed ``<sysconfig data|purelib|platlib>/scripts/whatsapp-bridge``
+           — where setuptools ``data-files`` extract on a ``pip install``.
+        3. Caller-supplied ``default`` (rarely needed).
+        4. ``<repo-root>/scripts/whatsapp-bridge`` — source checkouts and
+           ``pip install -e .``, where this top-level module sits at the repo
+           root next to ``scripts/``.
+
+    Falling through to the source-style path (even when it is missing) keeps
+    callers' "bridge script missing at <path>" diagnostics informative instead
+    of returning ``None``. Without this resolution, packaged installs raised
+    ``whatsapp_bridge_missing`` because the gateway adapter looked for the
+    bridge at ``<site-packages>/scripts/whatsapp-bridge`` — a location
+    ``data-files`` never populate.
+    """
+    override = os.getenv("HERMES_WHATSAPP_BRIDGE_DIR", "").strip()
+    if override:
+        return Path(override)
+    packaged = _get_packaged_data_dir("scripts/whatsapp-bridge")
+    if packaged is not None:
+        return packaged
+    if default is not None:
+        return default
+    return Path(__file__).resolve().parent / "scripts" / "whatsapp-bridge"
+
+
 def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     """Resolve a Hermes subdirectory with backward compatibility.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,20 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 # venv) drop the catalogs and gateway/CLI commands surface raw i18n keys like
 # `gateway.reset.header_default` (#27632, #35374, #23943).
 locales = ["locales/*.yaml"]
+# WhatsApp Baileys bridge (Node.js). scripts/whatsapp-bridge/ is a bare data
+# directory (no __init__.py), so — like locales/ above — it is neither a
+# package (packages.find) nor package-data (which attaches to a package).
+# data-files ships it in the wheel; MANIFEST.in `graft scripts/whatsapp-bridge`
+# ships it in the sdist. The gateway WhatsApp adapter, `hermes whatsapp`
+# pairing, and `hermes doctor` all resolve it via
+# hermes_constants.get_bundled_whatsapp_bridge_dir(), which checks this
+# data-files location. Without it, sealed installs (pip wheel, Homebrew) drop
+# bridge.js and the adapter fatals with `whatsapp_bridge_missing` — WhatsApp
+# works in editable/git checkouts but not in packaged installs.
+"scripts/whatsapp-bridge" = [
+  "scripts/whatsapp-bridge/*.js",
+  "scripts/whatsapp-bridge/*.json",
+]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -226,3 +226,40 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     # Every on-disk catalog has the .yaml extension the globs above match.
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
+
+
+def test_whatsapp_bridge_ships_in_both_wheel_and_sdist():
+    """Regression test: gateway WhatsApp adapter `whatsapp_bridge_missing` on packaged installs.
+
+    scripts/whatsapp-bridge/ is a bare Node.js data directory (no __init__.py),
+    so — like locales/ — it is invisible to packages.find and to package-data
+    (which attaches to a package). It must be declared as setuptools data-files
+    (wheel) AND grafted in MANIFEST.in (sdist; Homebrew and other downstream
+    packagers build the wheel from the sdist). Without both, sealed installs
+    drop bridge.js and the gateway WhatsApp adapter — plus `hermes whatsapp`
+    pairing and `hermes doctor` — can't find it via
+    get_bundled_whatsapp_bridge_dir(), even though editable/git checkouts work.
+    Mirrors test_locale_catalogs_ship_in_both_wheel_and_sdist.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    data_files = data["tool"]["setuptools"].get("data-files", {})
+    bridge_globs = data_files.get("scripts/whatsapp-bridge")
+    assert bridge_globs, (
+        "pyproject [tool.setuptools.data-files] must declare "
+        '"scripts/whatsapp-bridge" so the wheel ships the Node.js bridge'
+    )
+    # bridge.js + allowlist.js (*.js) and package.json + package-lock.json
+    # (*.json) are all required at runtime, so both globs must be present.
+    assert any(g.endswith("*.js") for g in bridge_globs), bridge_globs
+    assert any(g.endswith("*.json") for g in bridge_globs), bridge_globs
+
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "graft scripts/whatsapp-bridge" in manifest, (
+        "MANIFEST.in must `graft scripts/whatsapp-bridge` so the sdist ships the bridge"
+    )
+
+    # The runtime files the globs above must actually match on disk. bridge.js
+    # imports ./allowlist.js; npm install needs package.json + package-lock.json.
+    bridge_dir = REPO_ROOT / "scripts" / "whatsapp-bridge"
+    for required in ("bridge.js", "allowlist.js", "package.json", "package-lock.json"):
+        assert (bridge_dir / required).is_file(), f"missing bridge asset: {required}"

--- a/tests/test_whatsapp_bridge_resolution.py
+++ b/tests/test_whatsapp_bridge_resolution.py
@@ -1,0 +1,87 @@
+"""Unit tests for hermes_constants.get_bundled_whatsapp_bridge_dir().
+
+Shipping the bridge in the wheel/sdist (test_packaging_metadata.py) is only half
+the fix: the runtime must also *find* it. In a wheel install the gateway adapter
+module lives at ``<site-packages>/gateway/platforms/whatsapp.py``, so the old
+``parents[2]/scripts/whatsapp-bridge`` resolved to ``<site-packages>/scripts/...``
+— a location setuptools data-files never populate (they land under the interpreter
+``data`` scheme, i.e. ``sys.prefix``). These tests pin the resolution order so the
+packaged-install path can't silently regress to the source-only behavior.
+"""
+
+from pathlib import Path
+
+import hermes_constants
+from hermes_constants import get_bundled_whatsapp_bridge_dir
+
+
+def test_env_var_override_wins(tmp_path, monkeypatch):
+    custom = tmp_path / "custom-bridge"
+    custom.mkdir()
+    monkeypatch.setenv("HERMES_WHATSAPP_BRIDGE_DIR", str(custom))
+    assert get_bundled_whatsapp_bridge_dir() == custom
+
+
+def test_env_var_empty_string_ignored(tmp_path, monkeypatch):
+    """An empty override must fall through to the normal resolution chain."""
+    monkeypatch.setenv("HERMES_WHATSAPP_BRIDGE_DIR", "")
+    # No packaged dir on a source checkout, so we land on the source path.
+    result = get_bundled_whatsapp_bridge_dir()
+    assert result.name == "whatsapp-bridge"
+    assert result.parent.name == "scripts"
+
+
+def test_packaged_data_dir_used_when_present(tmp_path, monkeypatch):
+    """Wheel install: data-files land under a sysconfig scheme, not site-packages.
+
+    Simulate that by pointing the ``data`` scheme at a tmp prefix that contains
+    ``scripts/whatsapp-bridge`` and asserting the resolver finds it there rather
+    than the source-tree fallback.
+    """
+    monkeypatch.delenv("HERMES_WHATSAPP_BRIDGE_DIR", raising=False)
+    prefix = tmp_path / "prefix"
+    packaged = prefix / "scripts" / "whatsapp-bridge"
+    packaged.mkdir(parents=True)
+
+    real_get_path = hermes_constants.sysconfig.get_path
+
+    def fake_get_path(scheme, *args, **kwargs):
+        if scheme == "data":
+            return str(prefix)
+        return real_get_path(scheme, *args, **kwargs)
+
+    monkeypatch.setattr(hermes_constants.sysconfig, "get_path", fake_get_path)
+    assert get_bundled_whatsapp_bridge_dir() == packaged
+
+
+def test_env_var_wins_over_packaged(tmp_path, monkeypatch):
+    """Explicit override beats an installed data-files dir."""
+    prefix = tmp_path / "prefix"
+    (prefix / "scripts" / "whatsapp-bridge").mkdir(parents=True)
+    override = tmp_path / "override"
+    override.mkdir()
+    monkeypatch.setenv("HERMES_WHATSAPP_BRIDGE_DIR", str(override))
+    monkeypatch.setattr(
+        hermes_constants.sysconfig, "get_path",
+        lambda scheme, *a, **k: str(prefix) if scheme == "data" else None,
+    )
+    assert get_bundled_whatsapp_bridge_dir() == override
+
+
+def test_source_fallback_points_at_repo_scripts(monkeypatch):
+    """Source/editable install: resolve next to this top-level module (repo root)."""
+    monkeypatch.delenv("HERMES_WHATSAPP_BRIDGE_DIR", raising=False)
+    # Force the packaged lookup to find nothing so we exercise the fallback.
+    monkeypatch.setattr(hermes_constants, "_get_packaged_data_dir", lambda name: None)
+    result = get_bundled_whatsapp_bridge_dir()
+    expected = Path(hermes_constants.__file__).resolve().parent / "scripts" / "whatsapp-bridge"
+    assert result == expected
+    # In this repo checkout the bridge actually exists at the resolved path.
+    assert (result / "bridge.js").is_file()
+
+
+def test_caller_default_used_when_nothing_else(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_WHATSAPP_BRIDGE_DIR", raising=False)
+    monkeypatch.setattr(hermes_constants, "_get_packaged_data_dir", lambda name: None)
+    fallback = tmp_path / "explicit-default"
+    assert get_bundled_whatsapp_bridge_dir(default=fallback) == fallback

--- a/tests/test_wheel_whatsapp_bridge_e2e.py
+++ b/tests/test_wheel_whatsapp_bridge_e2e.py
@@ -1,0 +1,138 @@
+"""End-to-end: a built wheel/sdist, installed without a source tree, must let
+get_bundled_whatsapp_bridge_dir() resolve the Node.js bridge — not point at a
+nonexistent path.
+
+This is the test that proves the gateway WhatsApp adapter stops failing with
+`whatsapp_bridge_missing` on packaged installs. Metadata unit tests
+(test_packaging_metadata.py) prove the data-files glob and MANIFEST graft are
+declared; the unit tests (test_whatsapp_bridge_resolution.py) pin the resolution
+order with mocks; this proves the runtime actually finds bridge.js after a real
+build + install, the way the locales e2e (test_wheel_locales_e2e.py) does for
+i18n catalogs.
+
+Assumption: ``import hermes_constants`` needs only the stdlib (it imports os,
+sys, sysconfig, contextvars, pathlib — nothing third-party), so the wheel can be
+installed --no-deps. If hermes_constants ever gains a top-level non-stdlib
+import, this test must install that dep too.
+
+Marked `integration` because it shells out to `uv build` + `venv` + `pip` and
+takes ~15-30s. Run with: pytest -m integration tests/test_wheel_whatsapp_bridge_e2e.py
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import tarfile
+import venv
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    """Cross-platform path to a venv's interpreter (Scripts on Windows, bin elsewhere)."""
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI wheel build + venv + pip can exceed it
+def test_installed_wheel_resolves_whatsapp_bridge(tmp_path):
+    # 1. Build the wheel from the current tree.
+    wheel_dir = tmp_path / "wheel"
+    build = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(wheel_dir), "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert build.returncode == 0, f"uv build failed:\n{build.stderr}"
+    wheels = glob.glob(str(wheel_dir / "*.whl"))
+    assert wheels, "no wheel produced"
+    wheel = wheels[0]
+
+    # 2. Fresh venv, install the wheel WITHOUT deps (the resolver needs only
+    #    stdlib). --force-reinstall guards against pip's same-version no-op.
+    venv_dir = tmp_path / "venv"
+    venv.create(venv_dir, with_pip=True)
+    vpy = _venv_python(venv_dir)
+    subprocess.run(
+        [str(vpy), "-m", "pip", "install", "-q", "--no-deps", "--force-reinstall", wheel],
+        check=True,
+        timeout=300,
+    )
+
+    # 3. From a directory that is NOT the source tree, with a clean env (no
+    #    PYTHONPATH leaking the repo, no HERMES_WHATSAPP_BRIDGE_DIR override),
+    #    resolve the bridge dir and confirm the runtime files are really there.
+    probe = (
+        "import hermes_constants as hc;"
+        "import sys;"
+        "d = hc.get_bundled_whatsapp_bridge_dir();"
+        "print(repr(str(d)));"
+        "ok = (d / 'bridge.js').is_file() and (d / 'allowlist.js').is_file();"
+        "sys.exit(0 if ok else 1)"
+    )
+    env = {
+        k: v for k, v in os.environ.items()
+        if k not in ("PYTHONPATH", "HERMES_WHATSAPP_BRIDGE_DIR")
+    }
+    env["PATH"] = f"{venv_dir / ('Scripts' if sys.platform == 'win32' else 'bin')}{os.pathsep}{env['PATH']}"
+    env["VIRTUAL_ENV"] = str(venv_dir)
+    run = subprocess.run(
+        [str(vpy), "-c", probe],
+        cwd=str(tmp_path),  # NOT the repo root
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert run.returncode == 0, (
+        "installed wheel could not resolve the WhatsApp bridge (bridge.js missing "
+        "at the resolved path):\n"
+        f"stdout: {run.stdout}\nstderr: {run.stderr}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI sdist build can exceed it
+def test_built_sdist_ships_whatsapp_bridge(tmp_path):
+    """The sdist must carry scripts/whatsapp-bridge/ too.
+
+    The wheel is covered above; the sdist is the form Homebrew and other distro
+    packagers build the wheel from. MANIFEST.in `graft scripts/whatsapp-bridge`
+    is what puts the bridge in the tarball — a stale graft would pass the
+    metadata unit test (which only inspects the declaration) while the artifact
+    regresses. This inspects the real tarball so that path can't rot silently.
+    """
+    sdist_dir = tmp_path / "sdist"
+    build = subprocess.run(
+        ["uv", "build", "--sdist", "--out-dir", str(sdist_dir), "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert build.returncode == 0, f"uv build --sdist failed:\n{build.stderr}"
+    tarballs = glob.glob(str(sdist_dir / "*.tar.gz"))
+    assert tarballs, "no sdist produced"
+
+    with tarfile.open(tarballs[0]) as tf:
+        names = tf.getnames()
+        bridge = [m for m in names if "/scripts/whatsapp-bridge/" in m]
+
+    # The runtime-critical files must be in the tarball; node_modules must not.
+    for required in ("bridge.js", "allowlist.js", "package.json", "package-lock.json"):
+        assert any(m.endswith(f"/scripts/whatsapp-bridge/{required}") for m in bridge), (
+            f"sdist missing scripts/whatsapp-bridge/{required}; shipped: {bridge[:8]}"
+        )
+    assert not any("/node_modules/" in m for m in bridge), (
+        f"sdist must not ship the bridge's node_modules: {[m for m in bridge if '/node_modules/' in m][:5]}"
+    )


### PR DESCRIPTION


### What

Packaged installs (`pip install` wheel, and the sdist that Homebrew /
distro packagers build from) shipped **none** of
`scripts/whatsapp-bridge/`. At runtime the gateway WhatsApp adapter
resolved the bridge via
`Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"`,
found nothing, and died with a non-retryable `whatsapp_bridge_missing`
fatal error. WhatsApp worked in editable/git checkouts but was completely
broken in any packaged install ("works in dev, fatals in prod").

This PR ships the bridge **and** makes the runtime actually find it:

- **Ship it:** `scripts/whatsapp-bridge/*.js` + `*.json` via
  `[tool.setuptools.data-files]` (wheel) and `graft scripts/whatsapp-bridge`
  + `prune .../node_modules` in `MANIFEST.in` (sdist). Same dual-channel
  pattern as `locales/`.
- **Resolve it:** new `hermes_constants.get_bundled_whatsapp_bridge_dir()`
  (mirrors `get_bundled_skills_dir()` / `_get_packaged_data_dir()`), wired
  into all three resolution sites — the gateway adapter, `hermes whatsapp`
  pairing, and `hermes doctor`.

### Why packaging alone is not enough

`data-files` extract under the interpreter **`data` scheme**
(`sys.prefix`), *not* `site-packages`. A fix that only added the packaging
entries would ship `bridge.js` to `<prefix>/scripts/whatsapp-bridge` while
the adapter kept looking at `<site-packages>/scripts/whatsapp-bridge` — the
metadata test would pass while the runtime stayed broken. The resolver must
consult `sysconfig.get_path(scheme)` for `("data", "purelib", "platlib")`,
exactly as `agent/i18n.py::_locales_dir()` already does for i18n catalogs.
That gap is what the dedicated e2e wheel-install test guards against.

### Changes

- `hermes_constants.py` — add `get_bundled_whatsapp_bridge_dir()`
  (env override → sysconfig data/purelib/platlib → caller default →
  source path).
- `gateway/platforms/whatsapp.py` — `_DEFAULT_BRIDGE_DIR` via the helper.
- `hermes_cli/main.py` — `hermes whatsapp` pairing via the helper.
- `hermes_cli/doctor.py` — diagnostics npm-audit path via the helper.
- `pyproject.toml` / `MANIFEST.in` — ship the bridge in wheel + sdist.
- Tests: metadata regression (`test_packaging_metadata.py`), resolver unit
  tests (`test_whatsapp_bridge_resolution.py`), and a cross-platform e2e
  build+install test (`test_wheel_whatsapp_bridge_e2e.py`).

### How to test

```bash
# Fast (metadata + resolver order):
scripts/run_tests.sh tests/test_packaging_metadata.py \
  tests/test_whatsapp_bridge_resolution.py -q

# E2E (real uv build + fresh-venv install; proves runtime resolution):
pytest -m integration tests/test_wheel_whatsapp_bridge_e2e.py
```

Manual verification on a built wheel: `bridge.js` / `allowlist.js` /
`package.json` / `package-lock.json` land under
`…data/data/scripts/whatsapp-bridge/`; the sdist ships the bridge without
`node_modules`; a `--no-deps` wheel install in a clean venv resolves the
bridge with `bridge.js` present.

### Notes / scope

- No new dependencies; no dependency-pin changes.
- One logical change (ship + resolve the bundled bridge); does not touch
  the bridge's runtime `npm install` behavior. Known pre-existing
  limitation: a read-only system-wide install prefix can't host the runtime
  `npm install` into the bridge dir — orthogonal to this fix and unchanged.