### PR TITLE
fix(cli): load dotenv from platform-native hermes home

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
+
+from hermes_constants import get_hermes_home
 from utils import atomic_replace
 
 
@@ -217,14 +219,22 @@ def load_hermes_dotenv(
     """Load Hermes environment files with user config taking precedence.
 
     Behavior:
-    - `~/.hermes/.env` overrides stale shell-exported values when present.
+    - the Hermes home `.env` overrides stale shell-exported values when present.
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+
+    When ``hermes_home`` is not supplied, the home directory is resolved via
+    :func:`hermes_constants.get_hermes_home` so the platform-native default is
+    honored — ``%LOCALAPPDATA%\\hermes`` on native Windows, ``~/.hermes`` on
+    POSIX. Hardcoding ``Path.home() / ".hermes"`` here made the loader read the
+    wrong location on Windows when ``HERMES_HOME`` was unset (e.g. spawned
+    subprocesses), so installer-written keys never loaded and provider auth
+    silently failed.
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    home_path = Path(hermes_home) if hermes_home else get_hermes_home()
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,36 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
 
 
+def test_user_env_loads_from_localappdata_home_on_windows_when_hermes_home_unset(
+    tmp_path, monkeypatch
+):
+    """On native Windows the default .env lives under %LOCALAPPDATA%\\hermes.
+
+    Regression: ``load_hermes_dotenv()`` hardcoded ``Path.home() / ".hermes"``
+    as its fallback, but the platform-native home on Windows is
+    ``%LOCALAPPDATA%\\hermes`` (see ``hermes_constants.get_hermes_home``). With
+    ``HERMES_HOME`` unset — as happens in spawned subprocesses and some shells
+    — the installer-written keys under ``%LOCALAPPDATA%\\hermes\\.env`` were
+    never loaded, so provider auth silently failed even though setup "worked".
+    """
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    local_appdata = tmp_path / "AppData" / "Local"
+    hermes_home = local_appdata / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / ".env").write_text(
+        "OPENAI_API_KEY=sk-from-localappdata\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv()
+
+    assert loaded == [hermes_home / ".env"]
+    assert os.getenv("OPENAI_API_KEY") == "sk-from-localappdata"
+
+
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()


### PR DESCRIPTION


## What & why

`load_hermes_dotenv()` failed to find the user's `.env` when
`HERMES_HOME` was not set in the process environment (spawned
subprocesses, older shells, some spawn paths). The installer writes
credentials to `%LOCALAPPDATA%\hermes\.env`, but the loader fell back
to `~/.hermes/.env`, so API keys were never loaded and providers
failed to authenticate — the "installed fine, but the model won't
run" symptom.

## Root cause

`hermes_cli/env_loader.py` hardcoded the fallback home:

```python
home_path = Path(
    hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes")
)
```

The single source of truth, `hermes_constants.get_hermes_home()`,
resolves the platform-native default (`%LOCALAPPDATA%\hermes` vs
`~/.hermes`). The two disagreed whenever `HERMES_HOME` was unset.
This is the exact pattern `AGENTS.md` and `tests/conftest.py` call
out as "a bug to fix at the callsite".

## The fix

Defer home resolution to the canonical resolver when no explicit
`hermes_home` is passed:

```python
home_path = Path(hermes_home) if hermes_home else get_hermes_home()
```

- Preserves the explicit-argument path used by `cli.py`,
  `run_agent.py`, and the existing tests.
- Fixes every no-arg caller at once (`hermes_cli/main.py`,
  `mcp_config.py`, `tools/mcp_tool.py`, `feishu_comment_rules.py`):
  resolution now honors the platform-native default, the
  `HERMES_HOME` env var, and the context-local profile override that
  the old expression silently ignored.
- `hermes_constants` is import-safe (stdlib-only) — no circular
  import.

## Tests

Added a regression test in
`tests/hermes_cli/test_env_loader.py`:

```python
def test_user_env_loads_from_localappdata_home_on_windows_when_hermes_home_unset(
    tmp_path, monkeypatch
):
    monkeypatch.delenv("HERMES_HOME", raising=False)
    monkeypatch.setattr(sys, "platform", "win32")

    local_appdata = tmp_path / "AppData" / "Local"
    hermes_home = local_appdata / "hermes"
    hermes_home.mkdir(parents=True)
    (hermes_home / ".env").write_text(
        "OPENAI_API_KEY=sk-from-localappdata\n", encoding="utf-8"
    )
    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
    monkeypatch.delenv("OPENAI_API_KEY", raising=False)

    loaded = load_hermes_dotenv()

    assert loaded == [hermes_home / ".env"]
    assert os.getenv("OPENAI_API_KEY") == "sk-from-localappdata"
```

It simulates the unset-`HERMES_HOME` default path, so it guards the
behavior independent of the host the suite runs on.

## Test results

```
$ scripts/run_tests.sh tests/hermes_cli/test_env_loader.py -q
.......                                                  [100%]
7 passed in 0.26s
```

Regression confirmed: against the pre-fix code the new test fails
with `assert [] == [.../hermes/.env]` (the loader looked at
`~/.hermes`, which has no `.env`); with the fix it passes.

## Scope / risk

Low. Only the unset-`HERMES_HOME` fallback branch changes; the
explicit-arg and `HERMES_HOME`-set paths are equivalent to before.
No public API change.