### PR TITLE
feat(skills): add post-merge PR verification workflow

### DIFF
--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-pr-workflow
-description: "GitHub PR lifecycle: branch, commit, open, CI, merge."
-version: 1.1.0
+description: "GitHub PR lifecycle: branch, CI, merge, post-merge verify."
+version: 1.2.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -276,6 +276,37 @@ When asked to auto-fix CI, follow this loop:
 
 ## 6. Merging
 
+### Pre-Merge Readiness Check
+
+Before merging, confirm the PR is actually ready — don't merge a red or stale
+branch. This is the proven pattern: check mergeability, review state, and that
+the branch is current with `main`.
+
+**With gh:**
+
+```bash
+# One JSON snapshot of everything that gates a merge.
+gh pr view <PR_NUMBER> --json \
+  state,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print('state            :', d['state'])
+print('mergeable        :', d['mergeable'])          # MERGEABLE / CONFLICTING / UNKNOWN
+print('mergeStateStatus :', d['mergeStateStatus'])   # CLEAN / BEHIND / BLOCKED / DIRTY
+print('reviewDecision   :', d['reviewDecision'] or '(none required)')
+ok = d['state']=='OPEN' and d['mergeable']=='MERGEABLE' and d['mergeStateStatus'] in ('CLEAN','HAS_HOOKS','UNSTABLE')
+print('READY            :', ok)
+"
+# Also confirm CI is green (Section 4) before merging.
+```
+
+If `mergeStateStatus` is `BEHIND`, update the branch first (`gh pr update-branch
+<PR_NUMBER>` or rebase locally). A stale branch silently reverts recent fixes on
+`main` when squashed — see the AGENTS.md pitfall on stale squash merges.
+
+### Squash Merge + Branch Cleanup
+
 **With gh:**
 
 ```bash
@@ -327,7 +358,66 @@ curl -s -X POST \
   -d "{\"query\": \"mutation { enablePullRequestAutoMerge(input: {pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH}) { clientMutationId } }\"}"
 ```
 
-## 7. Complete Workflow Example
+## 7. Post-Merge Verification
+
+Merging is not the finish line. The squash commit lands on the **base branch**,
+which kicks off a *fresh* set of CI / deploy runs — separate from the PR-branch
+checks you watched in Section 4. Verifying the merge means finding those
+base-branch runs **by the merge commit SHA**, watching them, and (for deploys)
+probing the live surface.
+
+### The Helper Script (recommended)
+
+`scripts/post_merge_verify.py` does the whole loop with `gh` and Python JSON
+parsing — no `jq`, no token handling, nothing secret printed:
+
+```bash
+PR=123
+
+# One-shot summary of base-branch runs for the merge commit
+python3 scripts/post_merge_verify.py $PR
+
+# Watch until those runs finish (15 min default), then probe the deploy
+python3 scripts/post_merge_verify.py $PR --watch \
+  --probe https://app.example.com/healthz
+
+# Machine-readable report for chaining
+python3 scripts/post_merge_verify.py $PR --watch --json
+```
+
+Exit codes: `0` runs (and probes) succeeded · `1` a run/probe failed · `2`
+PR not merged / `gh` missing · `3` still pending after `--timeout`. Pass
+`-R owner/repo` when not running inside the repo checkout.
+
+### Doing It By Hand
+
+If you can't run the script, the same steps with raw `gh`:
+
+```bash
+PR=123
+
+# 1. Get the merge commit SHA (empty until the PR is actually merged)
+SHA=$(gh pr view $PR --json mergeCommit -q .mergeCommit.oid)
+echo "merge commit: $SHA"
+
+# 2. Find base-branch workflow runs triggered by that exact commit
+gh api "repos/$OWNER/$REPO/actions/runs?head_sha=$SHA" \
+  | python3 -c "
+import sys, json
+for r in json.load(sys.stdin)['workflow_runs']:
+    print(f\"  [{r['conclusion'] or r['status']}] {r['name']}  {r['html_url']}\")"
+
+# 3. Watch a specific run to completion
+gh run watch <RUN_ID>
+
+# 4. Probe the deployment surface once runs are green
+curl -fsS -o /dev/null -w "%{http_code}\n" https://app.example.com/healthz
+```
+
+See `references/post-merge-verification.md` for the full rationale, the
+`mergeStateStatus` cheat sheet, and the gateway/deploy probe checklist.
+
+## 8. Complete Workflow Example
 
 ```bash
 # 1. Start from clean main
@@ -352,7 +442,10 @@ git push -u origin HEAD
 
 # 7. Monitor CI (see Section 4)
 
-# 8. Merge when green (see Section 6)
+# 8. Pre-merge readiness check, then squash merge (see Section 6)
+
+# 9. Verify the merge on the base branch (see Section 7)
+python3 scripts/post_merge_verify.py <PR_NUMBER> --watch
 ```
 
 ## Useful PR Commands Reference

--- a/skills/github/github-pr-workflow/references/post-merge-verification.md
+++ b/skills/github/github-pr-workflow/references/post-merge-verification.md
@@ -1,0 +1,86 @@
+# Post-Merge Verification
+
+Merging a PR is the *start* of the base-branch lifecycle, not the end. The squash
+commit that lands on `main` triggers a fresh, independent set of workflow runs —
+CI re-runs against the integrated tree, and deploy pipelines fire. The checks you
+watched on the PR branch (Section 4 of the skill) do **not** cover these. This
+reference documents the verification loop Hermes/Coop sessions should run after
+every merge.
+
+## Why base-branch runs differ from PR-branch runs
+
+- PR-branch checks run against the *merge preview* (your branch + a test merge).
+  Base-branch runs run against the *actual squash commit*.
+- Deploy workflows are almost always gated on `push` to `main`, so they only
+  exist after the merge.
+- A stale PR branch can pass its own checks yet break `main` once squashed — the
+  AGENTS.md "stale squash merge silently reverts fixes" pitfall. Base-branch runs
+  are where that shows up.
+
+The reliable key tying a merge to its runs is the **merge commit SHA**, exposed
+as `mergeCommit.oid` on the PR. Filter `actions/runs?head_sha=<SHA>` to get
+exactly the runs that commit produced.
+
+## Pre-merge `mergeStateStatus` cheat sheet
+
+`gh pr view N --json mergeable,mergeStateStatus,reviewDecision` returns the gate
+state. `mergeStateStatus` values:
+
+| Value | Meaning | Action |
+|-------|---------|--------|
+| `CLEAN` | Mergeable, all checks green | merge |
+| `UNSTABLE` | Mergeable, a non-required check is failing/pending | usually safe to merge; confirm the failing check isn't load-bearing |
+| `HAS_HOOKS` | Mergeable with pre-receive hooks | merge |
+| `BEHIND` | Branch is behind base | update branch first (`gh pr update-branch N`) |
+| `BLOCKED` | Required review or check not satisfied | resolve before merging |
+| `DIRTY` | Merge conflict | rebase/resolve |
+| `DRAFT` | PR is a draft | mark ready first |
+
+`mergeable` is the coarse signal (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`);
+`UNKNOWN` means GitHub is still computing — re-query after a few seconds.
+
+## The verification loop
+
+1. **Resolve the merge commit.** `SHA=$(gh pr view N --json mergeCommit -q .mergeCommit.oid)`.
+   Empty ⇒ the PR is not actually merged; stop.
+2. **Discover base-branch runs by SHA.** `gh api repos/$OWNER/$REPO/actions/runs?head_sha=$SHA`.
+3. **Classify.** failure if any run concluded `failure`/`timed_out`/`startup_failure`;
+   pending if any run is not `completed`; otherwise success.
+4. **Watch** the runs to completion (`gh run watch <id>`, or the script's `--watch`).
+5. **Probe deployment surfaces.** Once runs are green, GET the live health/probe
+   endpoints and confirm the expected status. A green deploy job does not prove
+   the app actually came up.
+
+`scripts/post_merge_verify.py` automates steps 1–5. It shells out to `gh` (which
+carries its own auth), parses JSON in Python (no `jq`), never reads or prints a
+token, and redacts token-shaped strings from any captured output defensively.
+
+## Deploy / probe checklist
+
+After CI is green on the base branch, verify the surface that actually changed:
+
+- **HTTP service** — GET a health endpoint (`/healthz`, `/api/status`) and assert
+  the status code. Prefer a probe that exercises a real code path over a static
+  `200`.
+- **Gateway / bot** — confirm the process reconnected (platform "online" state)
+  and that a `/status`-style command responds, rather than only checking the
+  deploy job's exit code.
+- **CLI / package** — install the freshly published artifact in a clean
+  environment and run `--version` / a smoke command.
+- **Static site / docs** — fetch a known URL and grep for content that only the
+  new build contains, to defeat CDN cache false-positives.
+
+Probe *after* runs succeed, not in parallel — a probe against a half-deployed
+surface produces misleading flakes.
+
+## Exit-code contract (`post_merge_verify.py`)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Merge verified — base-branch runs succeeded (and probes returned expected status) |
+| 1 | A run concluded in failure, or a probe failed |
+| 2 | Usage / environment error (`gh` missing, PR not merged, repo unresolved) |
+| 3 | Runs still pending after `--timeout` (only with `--watch`) |
+
+Wire these into automation: treat `1` as a rollback/alert trigger, `3` as
+"keep watching", and `2` as a setup bug.

--- a/skills/github/github-pr-workflow/scripts/post_merge_verify.py
+++ b/skills/github/github-pr-workflow/scripts/post_merge_verify.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Post-merge verification for a GitHub PR.
+
+After a PR is squash-merged into the base branch, the commit on the base branch
+triggers a fresh set of CI / deploy workflow runs. This helper finds those runs
+*by the PR's merge commit SHA*, summarizes them, optionally watches until they
+finish, and optionally probes deployment URLs for liveness.
+
+It shells out to `gh` (which carries its own auth) and parses JSON in Python —
+no `jq` dependency, and no token is ever read or printed by this script. Any
+captured text is passed through a redactor before display as defense-in-depth.
+
+Usage:
+    python post_merge_verify.py <pr_number> [-R owner/repo]
+    python post_merge_verify.py 123 --watch --timeout 900
+    python post_merge_verify.py 123 --probe https://app.example.com/healthz
+    python post_merge_verify.py 123 --watch --probe https://app.example.com --json
+
+Exit codes:
+    0  merge verified — runs succeeded (and probes, if given, returned expected status)
+    1  a run concluded in failure, or a probe failed
+    2  usage / environment error (gh missing, PR not merged, etc.)
+    3  still pending after --timeout (only with --watch)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Token shapes GitHub issues. We never print secrets, but redact defensively in
+# case a workflow/run name or URL ever echoes one back to us.
+_TOKEN_RE = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"
+)
+
+# Conclusions that mean "this run is finished and it went badly".
+_FAILURE_CONCLUSIONS = {"failure", "timed_out", "startup_failure", "stale"}
+# Conclusions that are terminal but not failures.
+_OK_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+
+class GhError(RuntimeError):
+    """Raised when a `gh` invocation fails or returns unparseable output."""
+
+
+def redact(text: str) -> str:
+    """Mask anything that looks like a GitHub token."""
+    return _TOKEN_RE.sub("***REDACTED***", text)
+
+
+def run_gh(args, *, timeout=60):
+    """Run `gh <args>` and return parsed stdout.
+
+    Returns parsed JSON when stdout looks like JSON, else the raw string.
+    Raises GhError on non-zero exit or a JSON parse failure on `--json` output.
+    """
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except FileNotFoundError as exc:  # gh not installed
+        raise GhError(
+            "GitHub CLI (`gh`) not found. Install it or use the curl fallback "
+            "documented in the github-pr-workflow skill."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GhError(f"`gh {' '.join(args)}` timed out after {timeout}s") from exc
+
+    if proc.returncode != 0:
+        raise GhError(redact((proc.stderr or proc.stdout or "").strip()))
+
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return out
+
+
+def _repo_args(repo):
+    """gh `-R owner/repo` flag list, or empty to let gh infer from cwd."""
+    return ["-R", repo] if repo else []
+
+
+def get_merge_info(pr_number, repo=None, *, _runner=run_gh):
+    """Return normalized merge metadata for a PR.
+
+    Keys: merged (bool), merge_commit (str|None), base (str), state, title, url.
+    """
+    data = _runner(
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            *_repo_args(repo),
+            "--json",
+            "number,state,mergedAt,mergeCommit,baseRefName,title,url",
+        ]
+    )
+    if not isinstance(data, dict):
+        raise GhError(f"Unexpected response for PR #{pr_number}")
+    merge_commit = (data.get("mergeCommit") or {}).get("oid")
+    # `gh` exposes no boolean `merged` field — derive it from state/mergedAt.
+    merged = data.get("state") == "MERGED" or bool(data.get("mergedAt"))
+    return {
+        "number": data.get("number"),
+        "merged": merged,
+        "merge_commit": merge_commit,
+        "base": data.get("baseRefName"),
+        "state": data.get("state"),
+        "title": data.get("title"),
+        "url": data.get("url"),
+    }
+
+
+def resolve_repo(repo=None, *, _runner=run_gh):
+    """Return owner/repo, resolving from the current dir via gh when not given."""
+    if repo:
+        return repo
+    data = _runner(["repo", "view", "--json", "nameWithOwner"])
+    if isinstance(data, dict) and data.get("nameWithOwner"):
+        return data["nameWithOwner"]
+    raise GhError("Could not resolve repository; pass -R owner/repo.")
+
+
+def parse_runs(payload):
+    """Normalize the `actions/runs` API payload into a flat list of run dicts.
+
+    Each item: name, status, conclusion, event, branch, sha, url, created_at.
+    Accepts either the raw API object ({"workflow_runs": [...]}) or a bare list.
+    """
+    if isinstance(payload, dict):
+        raw = payload.get("workflow_runs", [])
+    elif isinstance(payload, list):
+        raw = payload
+    else:
+        raw = []
+    runs = []
+    for r in raw:
+        runs.append(
+            {
+                "name": r.get("name") or r.get("display_title") or "(unnamed)",
+                "status": r.get("status"),
+                "conclusion": r.get("conclusion"),
+                "event": r.get("event"),
+                "branch": r.get("head_branch"),
+                "sha": r.get("head_sha"),
+                "url": r.get("html_url"),
+                "created_at": r.get("created_at"),
+            }
+        )
+    return runs
+
+
+def list_runs_for_sha(sha, repo, *, limit=30, _runner=run_gh):
+    """Fetch workflow runs whose head commit is `sha` (the merge commit)."""
+    payload = _runner(
+        [
+            "api",
+            f"repos/{repo}/actions/runs?head_sha={sha}&per_page={limit}",
+        ]
+    )
+    return parse_runs(payload)
+
+
+def classify_runs(runs):
+    """Reduce a list of runs to an overall state.
+
+    Returns one of: "none", "pending", "failure", "success".
+    - failure if any run finished in a failure conclusion
+    - pending if any run has not completed
+    - success if all runs completed without failure
+    """
+    if not runs:
+        return "none"
+    if any(r.get("conclusion") in _FAILURE_CONCLUSIONS for r in runs):
+        return "failure"
+    if any(r.get("status") != "completed" for r in runs):
+        return "pending"
+    return "success"
+
+
+_STATE_ICON = {"success": "✓", "failure": "✗", "pending": "·", "none": "?"}
+
+
+def format_summary(merge_info, runs):
+    """Build a human-readable, secret-free summary block."""
+    lines = []
+    pr = merge_info
+    head = f"PR #{pr.get('number')} → {pr.get('base')}"
+    if pr.get("title"):
+        head += f"  {pr['title']}"
+    lines.append(head)
+    lines.append(f"merge commit: {pr.get('merge_commit') or '(none)'}")
+    overall = classify_runs(runs)
+    lines.append(f"runs: {len(runs)}  overall: {overall} {_STATE_ICON[overall]}")
+    for r in runs:
+        state = r.get("conclusion") or r.get("status") or "?"
+        lines.append(f"  [{state}] {r['name']}  {r.get('url') or ''}")
+    return redact("\n".join(lines))
+
+
+def probe_url(url, *, timeout=10, expect_status=200, _opener=None):
+    """HTTP GET a deployment surface; return {url, ok, status, error}."""
+    opener = _opener or urllib.request.urlopen
+    req = urllib.request.Request(url, method="GET", headers={"User-Agent": "hermes-post-merge-verify"})
+    try:
+        with opener(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", None) or resp.getcode()
+        return {"url": url, "ok": status == expect_status, "status": status, "error": None}
+    except urllib.error.HTTPError as exc:
+        return {"url": url, "ok": exc.code == expect_status, "status": exc.code, "error": None}
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return {"url": url, "ok": False, "status": None, "error": redact(str(exc))}
+
+
+def watch_runs(sha, repo, *, timeout=900, interval=20, _runner=run_gh, _sleep=time.sleep, _clock=time.monotonic):
+    """Poll runs for `sha` until all complete or `timeout` seconds elapse.
+
+    Returns (runs, overall_state). overall_state may be "pending" on timeout.
+    """
+    deadline = _clock() + timeout
+    runs = []
+    while True:
+        runs = list_runs_for_sha(sha, repo, _runner=_runner)
+        state = classify_runs(runs)
+        if state in ("success", "failure", "none"):
+            return runs, state
+        if _clock() >= deadline:
+            return runs, "pending"
+        _sleep(interval)
+
+
+def build_arg_parser():
+    p = argparse.ArgumentParser(
+        prog="post_merge_verify.py", description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("pr_number", help="merged PR number")
+    p.add_argument("-R", "--repo", default=None, help="owner/repo (default: infer from cwd)")
+    p.add_argument("--watch", action="store_true", help="poll until base-branch runs finish")
+    p.add_argument("--timeout", type=int, default=900, help="watch timeout seconds (default 900)")
+    p.add_argument("--interval", type=int, default=20, help="watch poll interval seconds (default 20)")
+    p.add_argument("--probe", action="append", default=[], metavar="URL",
+                   help="deployment URL to GET after runs succeed (repeatable)")
+    p.add_argument("--expect-status", type=int, default=200, help="expected probe HTTP status (default 200)")
+    p.add_argument("--json", action="store_true", help="emit a JSON report instead of text")
+    return p
+
+
+def run(argv=None):
+    """Programmatic entry point. Returns (exit_code, report_dict)."""
+    args = build_arg_parser().parse_args(argv)
+    try:
+        repo = resolve_repo(args.repo)
+        merge_info = get_merge_info(args.pr_number, repo)
+    except GhError as exc:
+        return 2, {"error": str(exc)}
+
+    if not merge_info["merged"] or not merge_info["merge_commit"]:
+        return 2, {
+            "error": f"PR #{args.pr_number} is not merged (state={merge_info['state']}); "
+            "nothing to verify.",
+            "merge": merge_info,
+        }
+
+    sha = merge_info["merge_commit"]
+    try:
+        if args.watch:
+            runs, overall = watch_runs(
+                sha, repo, timeout=args.timeout, interval=args.interval
+            )
+        else:
+            runs = list_runs_for_sha(sha, repo)
+            overall = classify_runs(runs)
+    except GhError as exc:
+        return 2, {"error": str(exc), "merge": merge_info}
+
+    probes = []
+    if args.probe and overall != "failure":
+        probes = [probe_url(u, expect_status=args.expect_status) for u in args.probe]
+
+    report = {
+        "merge": merge_info,
+        "overall": overall,
+        "runs": runs,
+        "probes": probes,
+        "summary": format_summary(merge_info, runs),
+    }
+
+    if overall == "failure":
+        code = 1
+    elif overall == "pending":
+        code = 3
+    elif any(not p["ok"] for p in probes):
+        code = 1
+    else:
+        code = 0
+    return code, report
+
+
+def main(argv=None):
+    code, report = run(argv)
+    if "error" in report:
+        print(redact(report["error"]), file=sys.stderr)
+        if report.get("merge"):
+            print(report["summary"] if "summary" in report else "", file=sys.stderr)
+        return code
+
+    args_json = "--json" in (argv if argv is not None else sys.argv[1:])
+    if args_json:
+        # Drop the pre-rendered text summary from JSON output to avoid duplication.
+        out = {k: v for k, v in report.items() if k != "summary"}
+        print(json.dumps(out, indent=2))
+    else:
+        print(report["summary"])
+        for p in report.get("probes", []):
+            mark = "✓" if p["ok"] else "✗"
+            detail = f"status={p['status']}" if p["status"] is not None else f"error={p['error']}"
+            print(f"  probe [{mark}] {p['url']}  {detail}")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_github_pr_workflow_skill.py
+++ b/tests/skills/test_github_pr_workflow_skill.py
@@ -1,0 +1,343 @@
+"""Tests for the github-pr-workflow skill.
+
+Covers the post_merge_verify.py helper (pure functions + gh/probe wrappers via
+mocks, no network) and validates SKILL.md frontmatter + referenced-file links.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "github"
+    / "github-pr-workflow"
+)
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import post_merge_verify as pmv  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# redact
+# --------------------------------------------------------------------------- #
+class TestRedact:
+    def test_masks_classic_pat(self):
+        s = "token ghp_" + "A" * 36 + " here"
+        assert "ghp_" not in pmv.redact(s)
+        assert "***REDACTED***" in pmv.redact(s)
+
+    def test_masks_fine_grained_pat(self):
+        s = "github_pat_" + "B" * 30
+        assert pmv.redact(s) == "***REDACTED***"
+
+    def test_leaves_ordinary_text_untouched(self):
+        s = "PR #123 merged into main at deadbeef"
+        assert pmv.redact(s) == s
+
+
+# --------------------------------------------------------------------------- #
+# parse_runs
+# --------------------------------------------------------------------------- #
+class TestParseRuns:
+    def test_parses_api_object(self):
+        payload = {
+            "workflow_runs": [
+                {
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "event": "push",
+                    "head_branch": "main",
+                    "head_sha": "abc123",
+                    "html_url": "https://gh/run/1",
+                    "created_at": "2026-06-05T00:00:00Z",
+                }
+            ]
+        }
+        runs = pmv.parse_runs(payload)
+        assert len(runs) == 1
+        assert runs[0]["name"] == "CI"
+        assert runs[0]["conclusion"] == "success"
+        assert runs[0]["sha"] == "abc123"
+
+    def test_accepts_bare_list(self):
+        assert pmv.parse_runs([{"name": "X", "status": "queued"}])[0]["name"] == "X"
+
+    def test_unnamed_falls_back(self):
+        runs = pmv.parse_runs({"workflow_runs": [{"status": "completed"}]})
+        assert runs[0]["name"] == "(unnamed)"
+
+    def test_garbage_returns_empty(self):
+        assert pmv.parse_runs(None) == []
+        assert pmv.parse_runs("nope") == []
+
+
+# --------------------------------------------------------------------------- #
+# classify_runs
+# --------------------------------------------------------------------------- #
+class TestClassifyRuns:
+    def test_none(self):
+        assert pmv.classify_runs([]) == "none"
+
+    def test_failure_takes_precedence(self):
+        runs = [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "in_progress", "conclusion": None},
+            {"status": "completed", "conclusion": "failure"},
+        ]
+        assert pmv.classify_runs(runs) == "failure"
+
+    def test_pending_when_incomplete(self):
+        runs = [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "in_progress", "conclusion": None},
+        ]
+        assert pmv.classify_runs(runs) == "pending"
+
+    def test_success_all_completed(self):
+        runs = [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "skipped"},
+        ]
+        assert pmv.classify_runs(runs) == "success"
+
+    @pytest.mark.parametrize("bad", ["failure", "timed_out", "startup_failure", "stale"])
+    def test_failure_conclusions(self, bad):
+        assert pmv.classify_runs([{"status": "completed", "conclusion": bad}]) == "failure"
+
+
+# --------------------------------------------------------------------------- #
+# get_merge_info / resolve_repo (mocked runner)
+# --------------------------------------------------------------------------- #
+class TestGetMergeInfo:
+    def test_normalizes_merged_pr(self):
+        fake = {
+            "number": 7,
+            "state": "MERGED",
+            "merged": True,
+            "mergeCommit": {"oid": "cafe1234"},
+            "baseRefName": "main",
+            "title": "feat: thing",
+            "url": "https://gh/pr/7",
+        }
+        info = pmv.get_merge_info(7, "o/r", _runner=lambda *a, **k: fake)
+        assert info["merged"] is True
+        assert info["merge_commit"] == "cafe1234"
+        assert info["base"] == "main"
+
+    def test_open_pr_has_no_merge_commit(self):
+        fake = {"number": 7, "state": "OPEN", "merged": False, "mergeCommit": None,
+                "baseRefName": "main", "title": "t", "url": "u"}
+        info = pmv.get_merge_info(7, "o/r", _runner=lambda *a, **k: fake)
+        assert info["merged"] is False
+        assert info["merge_commit"] is None
+
+    def test_bad_response_raises(self):
+        with pytest.raises(pmv.GhError):
+            pmv.get_merge_info(7, "o/r", _runner=lambda *a, **k: "not a dict")
+
+
+class TestResolveRepo:
+    def test_passthrough_when_given(self):
+        assert pmv.resolve_repo("o/r", _runner=lambda *a, **k: pytest.fail("should not call")) == "o/r"
+
+    def test_infers_from_gh(self):
+        assert pmv.resolve_repo(None, _runner=lambda *a, **k: {"nameWithOwner": "a/b"}) == "a/b"
+
+    def test_raises_when_unresolvable(self):
+        with pytest.raises(pmv.GhError):
+            pmv.resolve_repo(None, _runner=lambda *a, **k: {})
+
+
+# --------------------------------------------------------------------------- #
+# run_gh (subprocess mocked)
+# --------------------------------------------------------------------------- #
+class TestRunGh:
+    def test_parses_json_stdout(self):
+        cp = mock.Mock(returncode=0, stdout='{"a": 1}', stderr="")
+        with mock.patch("subprocess.run", return_value=cp):
+            assert pmv.run_gh(["api", "x"]) == {"a": 1}
+
+    def test_returns_raw_string_when_not_json(self):
+        cp = mock.Mock(returncode=0, stdout="hello", stderr="")
+        with mock.patch("subprocess.run", return_value=cp):
+            assert pmv.run_gh(["x"]) == "hello"
+
+    def test_nonzero_raises_gherror_redacted(self):
+        cp = mock.Mock(returncode=1, stdout="", stderr="bad token ghp_" + "Z" * 36)
+        with mock.patch("subprocess.run", return_value=cp):
+            with pytest.raises(pmv.GhError) as exc:
+                pmv.run_gh(["x"])
+        assert "ghp_" not in str(exc.value)
+
+    def test_missing_gh_raises(self):
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError()):
+            with pytest.raises(pmv.GhError):
+                pmv.run_gh(["x"])
+
+
+# --------------------------------------------------------------------------- #
+# probe_url (urlopen mocked)
+# --------------------------------------------------------------------------- #
+class TestProbeUrl:
+    def _opener(self, status):
+        def _open(req, timeout=None):
+            cm = mock.MagicMock()
+            cm.__enter__.return_value = mock.Mock(status=status)
+            return cm
+        return _open
+
+    def test_ok_status(self):
+        r = pmv.probe_url("https://x", _opener=self._opener(200))
+        assert r["ok"] is True and r["status"] == 200
+
+    def test_unexpected_status(self):
+        r = pmv.probe_url("https://x", _opener=self._opener(503))
+        assert r["ok"] is False and r["status"] == 503
+
+    def test_custom_expect(self):
+        r = pmv.probe_url("https://x", expect_status=204, _opener=self._opener(204))
+        assert r["ok"] is True
+
+    def test_connection_error(self):
+        import urllib.error
+
+        def _open(req, timeout=None):
+            raise urllib.error.URLError("refused")
+
+        r = pmv.probe_url("https://x", _opener=_open)
+        assert r["ok"] is False and r["status"] is None and "refused" in r["error"]
+
+
+# --------------------------------------------------------------------------- #
+# watch_runs (runner + clock injected, no real sleep)
+# --------------------------------------------------------------------------- #
+class TestWatchRuns:
+    def test_returns_on_success(self):
+        seq = [
+            {"workflow_runs": [{"name": "CI", "status": "in_progress", "conclusion": None}]},
+            {"workflow_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+        ]
+        calls = {"n": 0}
+
+        def runner(args, **k):
+            i = min(calls["n"], len(seq) - 1)
+            calls["n"] += 1
+            return seq[i]
+
+        runs, state = pmv.watch_runs(
+            "sha", "o/r", interval=0, _runner=runner, _sleep=lambda s: None,
+        )
+        assert state == "success"
+        assert calls["n"] == 2
+
+    def test_timeout_returns_pending(self):
+        runner = lambda *a, **k: {"workflow_runs": [{"name": "CI", "status": "queued", "conclusion": None}]}
+        clock = iter([0, 0, 1000])  # start, first check, past-deadline check
+        runs, state = pmv.watch_runs(
+            "sha", "o/r", timeout=10, interval=0,
+            _runner=runner, _sleep=lambda s: None, _clock=lambda: next(clock),
+        )
+        assert state == "pending"
+
+
+# --------------------------------------------------------------------------- #
+# run() orchestration + exit codes
+# --------------------------------------------------------------------------- #
+class TestRunEntry:
+    def _patch(self, monkeypatch, merge_info, runs):
+        monkeypatch.setattr(pmv, "resolve_repo", lambda repo=None, **k: "o/r")
+        monkeypatch.setattr(pmv, "get_merge_info", lambda pr, repo, **k: merge_info)
+        monkeypatch.setattr(pmv, "list_runs_for_sha", lambda sha, repo, **k: runs)
+
+    def test_unmerged_pr_exit_2(self, monkeypatch):
+        self._patch(monkeypatch, {"merged": False, "merge_commit": None, "state": "OPEN"}, [])
+        code, report = pmv.run(["7"])
+        assert code == 2
+        assert "not merged" in report["error"]
+
+    def test_success_exit_0(self, monkeypatch):
+        mi = {"merged": True, "merge_commit": "sha", "state": "MERGED", "number": 7,
+              "base": "main", "title": "t", "url": "u"}
+        self._patch(monkeypatch, mi, [{"status": "completed", "conclusion": "success", "name": "CI"}])
+        code, report = pmv.run(["7"])
+        assert code == 0
+        assert report["overall"] == "success"
+
+    def test_failure_exit_1(self, monkeypatch):
+        mi = {"merged": True, "merge_commit": "sha", "state": "MERGED", "number": 7,
+              "base": "main", "title": "t", "url": "u"}
+        self._patch(monkeypatch, mi, [{"status": "completed", "conclusion": "failure", "name": "CI"}])
+        code, report = pmv.run(["7"])
+        assert code == 1
+
+    def test_probe_failure_exit_1(self, monkeypatch):
+        mi = {"merged": True, "merge_commit": "sha", "state": "MERGED", "number": 7,
+              "base": "main", "title": "t", "url": "u"}
+        self._patch(monkeypatch, mi, [{"status": "completed", "conclusion": "success", "name": "CI"}])
+        monkeypatch.setattr(pmv, "probe_url",
+                            lambda u, **k: {"url": u, "ok": False, "status": 500, "error": None})
+        code, report = pmv.run(["7", "--probe", "https://x"])
+        assert code == 1
+        assert report["probes"][0]["ok"] is False
+
+    def test_gh_missing_exit_2(self, monkeypatch):
+        def boom(repo=None, **k):
+            raise pmv.GhError("gh not found")
+        monkeypatch.setattr(pmv, "resolve_repo", boom)
+        code, report = pmv.run(["7"])
+        assert code == 2
+        assert "gh not found" in report["error"]
+
+
+# --------------------------------------------------------------------------- #
+# format_summary never leaks tokens
+# --------------------------------------------------------------------------- #
+def test_format_summary_redacts():
+    mi = {"number": 1, "base": "main", "title": "ghp_" + "Q" * 36, "merge_commit": "deadbeef"}
+    out = pmv.format_summary(mi, [{"name": "CI", "status": "completed", "conclusion": "success", "url": "u"}])
+    assert "ghp_" not in out
+    assert "deadbeef" in out
+
+
+# --------------------------------------------------------------------------- #
+# SKILL.md frontmatter + link validation
+# --------------------------------------------------------------------------- #
+class TestSkillDoc:
+    def _frontmatter(self):
+        text = (SKILL_DIR / "SKILL.md").read_text()
+        m = re.search(r"^description: (.*)$", text, re.MULTILINE)
+        return text, m
+
+    def test_description_under_60_chars(self):
+        _, m = self._frontmatter()
+        assert m, "no description field"
+        desc = m.group(1).strip().strip('"')
+        assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+        assert desc.endswith("."), "description must end with a period"
+
+    def test_required_frontmatter_fields(self):
+        text, _ = self._frontmatter()
+        for field in ("name:", "version:", "author:", "license:"):
+            assert field in text, f"missing {field}"
+
+    def test_referenced_files_exist(self):
+        text = (SKILL_DIR / "SKILL.md").read_text()
+        # Every scripts/... and references/... path mentioned must exist on disk.
+        for rel in re.findall(r"`?(scripts/[\w./-]+\.py)`?", text):
+            assert (SKILL_DIR / rel).exists(), f"missing {rel}"
+        for rel in re.findall(r"`(references/[\w./-]+\.md)`", text):
+            assert (SKILL_DIR / rel).exists(), f"missing {rel}"
+
+    def test_post_merge_script_is_executable_module(self):
+        # Import already succeeded at top of file; assert the public surface.
+        for fn in ("run", "main", "get_merge_info", "list_runs_for_sha",
+                   "classify_runs", "probe_url", "watch_runs"):
+            assert hasattr(pmv, fn), f"post_merge_verify.{fn} missing"


### PR DESCRIPTION
## Summary
- Adds post-merge verification guidance to the bundled `github-pr-workflow` skill.
- Adds a dependency-light `scripts/post_merge_verify.py` helper that uses `gh` + Python JSON parsing instead of `jq`.
- Adds a reference doc and mocked tests covering merge commit/run/probe classification behavior.

## Test Plan
- `python -m pytest tests/skills/test_github_pr_workflow_skill.py -q`

## Notes
- Created from a Claude Code lane to codify the PR merge verification workflow used by Coop/Hermes.
- Stops at approval gate; no merge requested.
