### PR TITLE
feat(skills): add PR visual QA workflow

### DIFF
--- a/skills/github/github-pr-visual-qa/SKILL.md
+++ b/skills/github/github-pr-visual-qa/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: github-pr-visual-qa
+description: "Use when verifying the visual/UI state of a web app for a specific PR or deploy — finding the preview/live URL from PR metadata, screenshotting changed pages, checking console/network errors, and comparing rendered UI against what the diff changed, reporting only evidence-backed findings."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [qa, visual, browser, pull-requests, deploy, preview, regression]
+    related_skills: [dogfood, github-pr-workflow, github-auth]
+---
+
+# PR / Deploy Visual QA
+
+## Overview
+
+After a PR opens or a deploy lands, the question is narrow and specific: *does the
+changed UI actually render correctly on the deployed app?* This skill answers it with
+a **diff-driven, evidence-only** workflow:
+
+1. Find the preview/live URL from the PR's own metadata (don't guess it).
+2. Open the pages the diff touched and capture screenshots + console + network.
+3. Compare what rendered against what the diff *says* should have changed.
+4. Report findings where every visual claim is backed by a capture.
+
+It deliberately scopes to *this change* — unlike the broader exploratory sweep in the
+[[dogfood]] skill. Use the two together: this skill for targeted post-PR regression,
+[[dogfood]] for whole-app exploration. It reuses [[github-pr-workflow]] conventions for
+auth and owner/repo extraction, and [[dogfood]]'s `references/issue-taxonomy.md` for
+severity.
+
+## When to Use
+
+- "QA this PR", "does the preview look right?", "verify the deploy", "screenshot the
+  changes", "check the staging URL for #1234".
+- After CI is green and a preview/deploy is available, before merge/sign-off.
+
+**Don't use for:**
+- Whole-site exploratory QA with no specific change in mind → use [[dogfood]].
+- Pure functional/unit testing with no rendered UI → run the test suite instead.
+- Performance regressions specifically → that's a benchmarking concern, not this.
+
+## The Iron Rule: never assert visual state without evidence
+
+LLMs hallucinate UI. This skill exists to prevent that. Bind every visual claim to a
+capture taken *this run*:
+
+- **No screenshot / DOM snapshot → no claim.** Say "not verified", never "looks fine".
+- **The URL must load before you describe it.** A guessed URL pattern that 404s, or a
+  stale cached screenshot, is worse than saying nothing.
+- **"Expected" comes from the diff, not from imagination.** If the diff changes a label
+  to "Save changes", that string is the expectation — quote it.
+- **Distinguish "I saw X" from "X should be there."** The report's Expected-vs-Observed
+  table forces this separation.
+- **Be explicit about what you could not reach** (auth wall, feature flag, missing seed
+  data) instead of silently skipping it.
+
+## Workflow
+
+### Phase 1 — Identify the change surface
+
+Find out *what* changed so you know what to look at. From the PR branch:
+
+```bash
+# Files touched by the PR (vs the base branch)
+git diff --name-only main...HEAD
+
+# The actual changes — read these to extract concrete expectations:
+#   new/changed copy strings, new routes, renamed components, toggled states.
+git diff main...HEAD -- '*.tsx' '*.jsx' '*.ts' '*.js' '*.vue' '*.html' '*.css'
+```
+
+Map changed files → user-facing pages/routes. A change to `src/pages/settings/Billing.tsx`
+means: go look at `/settings/billing`. Write down 3–8 **concrete, checkable expectations**
+(e.g. *"the Billing tab is now visible in Settings"*, *"primary button label reads
+'Save changes'"*). These become the rows of the report's Expected-vs-Observed table.
+
+### Phase 2 — Locate the preview/live URL (don't guess)
+
+Run the helper — it reads the PR's deployment statuses, commit statuses, check runs, and
+bot comments, and prints tagged candidate URLs:
+
+```bash
+bash skills/github/github-pr-visual-qa/scripts/find-preview-url.sh           # current branch
+bash skills/github/github-pr-visual-qa/scripts/find-preview-url.sh 1234       # by PR number
+bash skills/github/github-pr-visual-qa/scripts/find-preview-url.sh --sha <SHA>
+```
+
+It uses `gh` when authenticated, else falls back to `GITHUB_TOKEN` + `curl` (same
+detection as [[github-pr-workflow]]). Pick the best candidate by source trust:
+
+| Source | Meaning | Trust |
+|--------|---------|-------|
+| `deployment` | GitHub Deployment `environment_url` | highest — the platform's own record |
+| `status` / `check-run` | Provider posted a `target_url` (Vercel, Netlify, …) | high |
+| `pr-comment` | URL in a bot comment | medium — confirm it's the deploy, not docs |
+
+If nothing is found: **ask the user for the URL** or use a known staging/live URL. Never
+invent a URL pattern (`pr-1234.preview.app.com`) and report on it as if confirmed.
+
+**Then confirm the URL actually serves the app before trusting it:**
+
+```bash
+curl -sS -o /dev/null -w "%{http_code} %{url_effective}\n" -L "<candidate_url>"
+```
+
+A non-2xx/3xx code, an SSO/login wall, or a "deployment building" page means you are NOT
+looking at the change yet — note it as BLOCKED rather than proceeding.
+
+### Phase 3 — Capture evidence on changed pages
+
+Use the browser toolset (full mechanics in [[dogfood]]). For each changed page:
+
+```text
+browser_navigate(url="<verified_url>/settings/billing")
+browser_console(clear=true)          # baseline; capture again after interactions
+browser_vision(question="Does the Billing tab render? Read the primary button label verbatim.", annotate=true)
+browser_snapshot()                   # DOM/accessibility tree — ground-truth for copy/state
+```
+
+Capture, for every changed page:
+- A **screenshot** (save the returned `screenshot_path`).
+- **Console output** after load and after each interaction — uncaught errors are top findings.
+- **Network failures** — note any 4xx/5xx for the page's own requests (visible via the
+  browser's network panel / failed-request reporting).
+- The **verbatim rendered copy/state** for each expectation from Phase 1 (read it off the
+  snapshot or vision answer — do not paraphrase from memory).
+
+If the browser toolset isn't available, fall back to a headless screenshot + HTTP check
+and say so in the report — partial evidence labeled as partial, not dressed up as full QA.
+
+### Phase 4 — Compare expected vs. observed
+
+For each Phase 1 expectation, fill one row: Expectation (from diff) · Observed (from
+capture) · Match ✅/❌/➖ · Evidence path. A ❌ where the diff intended the change is a
+regression; a ➖ means you couldn't verify — state the blocker, don't assume pass.
+
+### Phase 5 — Report
+
+Fill `templates/visual-qa-report-template.md`. Required: the verdict line, the
+Expected-vs-Observed table, console/network captures, issues (severity per
+[[dogfood]]'s `references/issue-taxonomy.md`), and the honesty notes listing anything
+unreachable or inferred. When showing screenshots to the user, inline them with
+`MEDIA:<screenshot_path>`.
+
+Verdict scale: **PASS** (all expectations met, no new errors) · **PASS-WITH-NITS** (cosmetic
+only) · **FAIL** (a changed area is broken/regressed) · **BLOCKED** (couldn't reach the
+change — say why).
+
+## Common Pitfalls
+
+1. **Guessing the preview URL.** Run the finder; if it's empty, ask. A confidently-reported
+   404 is the worst outcome.
+2. **Reporting on a stale or "building" deploy.** Confirm HTTP 200 *and* that content
+   rendered for *this* SHA before describing anything.
+3. **Describing UI from the diff instead of the screen.** The diff is the *expectation*;
+   the screenshot is the *observation*. Never collapse the two.
+4. **Skipping the console.** Silent JS errors on a changed page are high-severity and
+   easy to miss without an explicit `browser_console()` call.
+5. **Silent skips.** An auth wall or feature flag that hides the change must appear in the
+   honesty notes as BLOCKED/not-verified, not be omitted.
+6. **Scope creep into full-site QA.** Stay on the changed surface; route broad sweeps to
+   [[dogfood]].
+7. **Paraphrasing copy.** Quote rendered strings verbatim from the snapshot — a near-match
+   ("Save" vs "Save changes") is exactly the kind of regression this skill should catch.
+
+## Verification Checklist
+
+- [ ] Identified changed files and wrote concrete, checkable expectations from the diff
+- [ ] Found the preview/live URL from PR metadata (or got it from the user) — not guessed
+- [ ] Confirmed the URL returns 2xx and renders the app for this SHA
+- [ ] Captured screenshot + console + network for every changed page
+- [ ] Filled the Expected-vs-Observed table; every ✅ has an evidence path
+- [ ] Every visual claim is backed by a capture; unreachable areas marked not-verified
+- [ ] Report saved from the template with a verdict and honesty notes

--- a/skills/github/github-pr-visual-qa/scripts/find-preview-url.sh
+++ b/skills/github/github-pr-visual-qa/scripts/find-preview-url.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# find-preview-url.sh — Discover preview / deploy URLs for a PR from GitHub metadata.
+#
+# Surfaces candidate URLs from four independent sources so you don't have to guess:
+#   1. Deployment statuses   (environment_url / target_url) — GitHub Deployments API
+#   2. Commit statuses       (target_url)                    — Vercel/Netlify/etc. post here
+#   3. Check runs            (details_url)                    — CI / preview check runs
+#   4. PR bot comments       (URLs in the body)              — Vercel/Netlify/Cloudflare bots
+#
+# It only REPORTS what GitHub returns — it never invents a URL. Each line is tagged
+# with its source so you can judge trustworthiness. Verify the URL actually loads
+# (see the github-pr-visual-qa skill) before reporting any visual state.
+#
+# Deps: bash + curl + python3. Uses `gh` automatically when authenticated (no token needed).
+#
+# Usage:
+#   ./find-preview-url.sh                 # current branch's open PR
+#   ./find-preview-url.sh 1234            # PR number
+#   ./find-preview-url.sh --sha <SHA>     # a specific commit SHA
+#
+set -euo pipefail
+
+PR_ARG=""
+SHA_OVERRIDE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sha) SHA_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) PR_ARG="$1"; shift ;;
+  esac
+done
+
+# --- Auth detection (mirrors github-pr-workflow) -----------------------------
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  AUTH="gh"
+else
+  AUTH="curl"
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    if [ -f "$HOME/.hermes/.env" ] && grep -q "^GITHUB_TOKEN=" "$HOME/.hermes/.env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$HOME/.hermes/.env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+    elif grep -q "github.com" "$HOME/.git-credentials" 2>/dev/null; then
+      GITHUB_TOKEN=$(grep "github.com" "$HOME/.git-credentials" 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
+    fi
+  fi
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "ERROR: no gh auth and no GITHUB_TOKEN found. Authenticate first (see github-auth skill)." >&2
+    exit 1
+  fi
+fi
+
+REMOTE_URL=$(git remote get-url origin)
+OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
+REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+
+# api PATH -> JSON on stdout. Works with gh or curl.
+api() {
+  local path="$1"
+  if [ "$AUTH" = "gh" ]; then
+    gh api "$path" 2>/dev/null || echo '{}'
+  else
+    curl -s -H "Authorization: token $GITHUB_TOKEN" \
+         -H "Accept: application/vnd.github+json" \
+         "https://api.github.com/$path" 2>/dev/null || echo '{}'
+  fi
+}
+
+# --- Resolve PR number + head SHA --------------------------------------------
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+PR_NUMBER="$PR_ARG"
+
+if [ -z "$PR_NUMBER" ] && [ -n "$BRANCH" ]; then
+  PR_NUMBER=$(api "repos/$OWNER/$REPO/pulls?head=$OWNER:$BRANCH&state=all" \
+    | python3 -c "import sys,json
+d=json.load(sys.stdin)
+print(d[0]['number'] if isinstance(d,list) and d else '')" 2>/dev/null || echo "")
+fi
+
+SHA="$SHA_OVERRIDE"
+if [ -z "$SHA" ] && [ -n "$PR_NUMBER" ]; then
+  SHA=$(api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('head',{}).get('sha',''))" 2>/dev/null || echo "")
+fi
+[ -z "$SHA" ] && SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+echo "# Preview/deploy URL candidates"
+echo "repo: $OWNER/$REPO   pr: ${PR_NUMBER:-<none>}   sha: ${SHA:-<none>}   auth: $AUTH"
+echo
+
+FOUND=0
+emit() { echo "[$1] $2"; FOUND=$((FOUND+1)); }
+
+# --- 1. Deployment statuses ---------------------------------------------------
+if [ -n "$SHA" ]; then
+  api "repos/$OWNER/$REPO/deployments?sha=$SHA" \
+    | python3 -c "import sys,json
+d=json.load(sys.stdin)
+print('\n'.join(str(x['id']) for x in d) if isinstance(d,list) else '')" 2>/dev/null \
+    | while read -r DID; do
+        [ -z "$DID" ] && continue
+        api "repos/$OWNER/$REPO/deployments/$DID/statuses" \
+          | python3 -c "import sys,json
+for s in json.load(sys.stdin):
+    u=s.get('environment_url') or s.get('target_url')
+    if u: print(f\"deployment:{s.get('state','?')} {u}\")" 2>/dev/null
+      done | sort -u | while read -r line; do emit deployment "$line"; done
+fi
+
+# --- 2. Commit statuses (Vercel/Netlify post target_url here) -----------------
+if [ -n "$SHA" ]; then
+  api "repos/$OWNER/$REPO/commits/$SHA/status" \
+    | python3 -c "import sys,json
+d=json.load(sys.stdin)
+for s in d.get('statuses',[]):
+    u=s.get('target_url')
+    if u and 'github.com' not in u: print(f\"{s.get('context','?')}:{s.get('state','?')} {u}\")" 2>/dev/null \
+    | sort -u | while read -r line; do emit status "$line"; done
+fi
+
+# --- 3. Check runs ------------------------------------------------------------
+if [ -n "$SHA" ]; then
+  api "repos/$OWNER/$REPO/commits/$SHA/check-runs" \
+    | python3 -c "import sys,json
+d=json.load(sys.stdin)
+for c in d.get('check_runs',[]):
+    u=c.get('details_url')
+    if u and 'github.com' not in u: print(f\"{c.get('name','?')}:{c.get('conclusion') or c.get('status')} {u}\")" 2>/dev/null \
+    | sort -u | while read -r line; do emit check-run "$line"; done
+fi
+
+# --- 4. PR bot comments -------------------------------------------------------
+if [ -n "$PR_NUMBER" ]; then
+  api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+    | python3 -c "import sys,json,re
+d=json.load(sys.stdin)
+seen=set()
+for c in d if isinstance(d,list) else []:
+    login=(c.get('user') or {}).get('login','')
+    for u in re.findall(r'https?://[^\s)\]\"<>]+', c.get('body','') or ''):
+        if 'github.com' in u or u in seen: continue
+        seen.add(u); print(f\"by {login}: {u}\")" 2>/dev/null \
+    | while read -r line; do emit pr-comment "$line"; done
+fi
+
+echo
+if [ "$FOUND" -eq 0 ]; then
+  echo "No preview/deploy URLs found in PR metadata."
+  echo "Fallbacks: ask the user for the URL, check the PR description, or use the known"
+  echo "live/staging URL for this app. Do NOT guess a URL pattern and report on it."
+fi

--- a/skills/github/github-pr-visual-qa/templates/visual-qa-report-template.md
+++ b/skills/github/github-pr-visual-qa/templates/visual-qa-report-template.md
@@ -1,0 +1,80 @@
+# Post-Deploy Visual QA — PR #{pr_number}
+
+**Target URL:** {verified_url}
+**URL source:** {url_source}  <!-- deployment status / commit status / check-run / bot comment / user-provided -->
+**Commit:** {sha}
+**Date:** {date}
+**Scope:** changes in this PR ({files_changed_count} files)
+
+> Every visual claim below is backed by a screenshot or console/network capture taken
+> during this run. Where evidence is missing, the row says **"not verified"** — it does
+> not assert a passing state.
+
+---
+
+## Verdict
+
+**Ship-readiness:** {PASS | PASS-WITH-NITS | FAIL | BLOCKED}
+**One-line:** {one_sentence}
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| Preview URL loads (HTTP 200, content rendered) | {pass/fail/not verified} | MEDIA:{screenshot} |
+| No console errors on changed pages | {pass/fail/not verified} | {count} errors — see below |
+| No failed network requests (4xx/5xx) | {pass/fail/not verified} | {count} failures |
+| Changed UI copy/states render as expected | {pass/fail/not verified} | per-expectation table |
+
+---
+
+## Expected vs. Observed (diff-driven)
+
+<!-- One row per concrete, checkable expectation derived from the PR diff. -->
+<!-- "Expected" must come from the code/copy in the diff — NOT from assumption. -->
+
+| # | Expectation (from diff) | Observed | Match? | Evidence |
+|---|-------------------------|----------|--------|----------|
+| 1 | {e.g. button label reads "Save changes"} | {what the screenshot/DOM actually showed} | ✅/❌/➖ | MEDIA:{path} |
+| 2 | {e.g. /settings renders new "Billing" tab} | {observed} | ✅/❌/➖ | MEDIA:{path} |
+
+Legend: ✅ matches · ❌ mismatch (regression) · ➖ could not verify (state the blocker)
+
+---
+
+## Console & Network
+
+**Console errors:**
+```
+{console_output_or "none captured"}
+```
+
+**Failed network requests:**
+```
+{method url -> status, or "none captured"}
+```
+
+---
+
+## Issues Found
+
+<!-- Repeat per issue. Severity per dogfood references/issue-taxonomy.md. -->
+
+### Issue #{n}: {title}
+| Field | Value |
+|-------|-------|
+| Severity | {Critical/High/Medium/Low} |
+| Category | {Functional/Visual/Console/Network/Content/UX} |
+| Page | {url_path} |
+| Introduced by this PR? | {yes/likely/pre-existing/unknown} |
+
+**Steps to reproduce:** {steps}
+**Expected:** {expected}
+**Actual:** {actual}
+**Evidence:** MEDIA:{screenshot}
+
+---
+
+## Coverage & Honesty Notes
+
+- **Pages checked:** {list}
+- **Changed areas NOT reachable** (and why): {list — auth wall, feature flag, no seed data, etc.}
+- **Anything inferred without direct evidence:** {state it explicitly, or "none — all claims have evidence"}


### PR DESCRIPTION
## Summary
- Adds a new bundled `github-pr-visual-qa` skill for evidence-only visual QA after PR/deploy changes.
- Includes a `find-preview-url.sh` helper to locate preview/deploy URLs from deployment statuses, commit statuses, check runs, and PR comments without guessing.
- Adds a visual QA report template for screenshot/console/network evidence and expected-vs-observed reporting.

## Test Plan
- `bash -n skills/github/github-pr-visual-qa/scripts/find-preview-url.sh`
- Frontmatter validation for `skills/github/github-pr-visual-qa/SKILL.md`

## Notes
- Created from a Claude Code lane to reduce hallucinated visual QA and make PR preview verification more reusable.
- Stops at approval gate; no merge requested.
