### PR TITLE
fix(gateway): dedupe webhook retries without delivery headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -492,13 +492,21 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        # Build a unique delivery ID.  Provider-supplied delivery headers
+        # (GitHub, Svix, generic X-Request-ID) are reused across retries, so
+        # they make the idempotency cache work.  When a sender includes none
+        # of them — common for custom monitors, Supabase triggers, and other
+        # bespoke webhooks — fall back to a hash of the route + raw body so a
+        # retried POST resolves to the same ID instead of a fresh time-based
+        # one, which would defeat idempotency and double-deliver.
+        delivery_id = (
+            request.headers.get("X-GitHub-Delivery")
+            or request.headers.get("svix-id")
+            or request.headers.get("X-Request-ID")
+            or "sha256:"
+            + hashlib.sha256(
+                route_name.encode("utf-8") + b"\x00" + raw_body
+            ).hexdigest()
         )
 
         # ── Idempotency ─────────────────────────────────────────

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -611,6 +611,58 @@ class TestIdempotency:
             assert resp2.status == 202  # re-accepted
 
     @pytest.mark.asyncio
+    async def test_headerless_retry_deduplicated_by_body_hash(self):
+        """Retries with no delivery header dedupe on the route + body hash.
+
+        Custom senders (monitoring, Supabase triggers, bespoke scripts)
+        often retry after a timeout/5xx without any X-GitHub-Delivery /
+        svix-id / X-Request-ID header.  Without a content-based fallback
+        each retry got a fresh time-based ID, missed the idempotency cache,
+        and re-ran the agent — duplicate delivery.  The same raw body on the
+        same route must resolve to the same delivery ID.
+        """
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            # No delivery headers at all — identical payload sent twice.
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1})
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/idem", json={"a": 1})
+            assert resp2.status == 200
+            data = await resp2.json()
+            assert data["status"] == "duplicate"
+
+        # The agent must have been dispatched exactly once.
+        await asyncio.sleep(0.05)
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_headerless_distinct_bodies_not_deduplicated(self):
+        """Different bodies on the same header-less route stay independent.
+
+        The body-hash fallback must not collapse genuinely distinct events
+        into one delivery — only byte-identical retries should dedupe.
+        """
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1})
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/idem", json={"a": 2})
+            assert resp2.status == 202
+
+        await asyncio.sleep(0.05)
+        assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_svix_id_used_as_delivery_id_for_deduplication(self):
         """Svix retries reuse svix-id, so use it as the delivery ID when present."""
         routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}


### PR DESCRIPTION

## What

When a webhook route runs in `deliver_only` or agent mode, the
adapter deduplicates provider retries via an idempotency cache
keyed on `delivery_id`. That ID is read from the first available
delivery header — `X-GitHub-Delivery`, `svix-id`, or
`X-Request-ID`. When a sender carries **none** of them, the old
code fell back to a time-based value:

​```python
request.headers.get("X-Request-ID", str(int(time.time() * 1000)))
​```

Every retry produced a *new* timestamp → a new `delivery_id` →
an idempotency cache miss → the agent (or the `deliver_only`
message) ran a second time.

This change makes the fallback content-based: when no delivery
header is present, `delivery_id` becomes
`sha256(route_name + "\x00" + raw_body)`. Byte-identical retries
on the same route now resolve to the same ID and dedupe.
Provider-supplied headers keep priority, so GitHub and Svix
behavior is unchanged.

## Why

Header-less retries are common — custom monitoring webhooks,
Supabase database triggers, and bespoke scripts that resend the
identical payload after a timeout or 5xx (standard webhook retry
behavior) often send no delivery header at all.

User impact of the bug:
- Duplicate notifications / duplicate chat messages
- Duplicate agent turns
- Wasted LLM cost on the re-run

The existing suite only covered the header-bearing path, so the
bug was invisible to CI.

## Tests

Two regression tests added to `TestIdempotency`:

- `test_headerless_retry_deduplicated_by_body_hash` — two
  identical POSTs with no delivery header → the second returns
  `{"status": "duplicate"}` (HTTP 200) and `handle_message` is
  dispatched exactly once.
- `test_headerless_distinct_bodies_not_deduplicated` — two POSTs
  with different bodies on the same header-less route stay
  independent (the hash fallback must not merge distinct events).

## How to test

​```
scripts/run_tests.sh \
  tests/gateway/test_webhook_adapter.py::TestIdempotency -q
​```

## Test results

​```
tests/gateway/test_webhook_adapter.py::TestIdempotency
5 passed

tests/gateway/test_webhook_adapter.py
67 passed
​```

## Notes

- `hashlib` is already imported in `webhook.py`; no new deps.
- A `\x00` separator between `route_name` and the body prevents
  cross-route hash collisions (the cache is shared across routes).
- The `or`-chain also fixes a latent edge case: an empty-string
  delivery header now falls through to the next source instead of
  being used as the ID.
- The idempotency window is bounded by the existing 1-hour TTL.
