### PR TITLE
docs(contributing): document local checks matching CI gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,7 +46,7 @@ Fixes #
 - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
 - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
 - [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
-- [ ] I've run `pytest tests/ -q` and all tests pass
+- [ ] I've run the local checks that mirror CI's blocking gates (see [Before submitting](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#before-submitting)): `scripts/run_tests.sh`, `ruff check .`, and `python scripts/check-windows-footguns.py --diff main`
 - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
 - [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -857,10 +857,31 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `scripts/run_tests.sh` (recommended; same as CI) or `pytest tests/ -v` with the project venv activated
-2. **Test manually**: Run `hermes` and exercise the code path you changed
-3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
-4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.
+**Run the local checks that mirror CI.** Catching a failure here takes seconds;
+finding it in a failed PR run costs a round-trip. These three commands match the
+**blocking** required checks that gate every PR — all ship with the `[dev]`
+install, so no extra setup is needed:
+
+```bash
+# 1. Tests — same hermetic env as CI (see AGENTS.md). Matches the Tests workflow.
+scripts/run_tests.sh
+
+# 2. Lint enforcement — flags bare open()/read_text()/write_text() without an
+#    explicit encoding= (silently corrupts non-ASCII files on Windows).
+#    Matches the "ruff enforcement (blocking)" check.
+ruff check .
+
+# 3. Windows cross-platform footguns in your changes — os.kill(pid, 0),
+#    os.setsid, SIGKILL without a getattr fallback, etc. Matches the
+#    "Windows footguns (blocking)" check. Add --all to scan the whole tree.
+python scripts/check-windows-footguns.py --diff main
+```
+
+Then, before opening the PR:
+
+1. **Test manually**: Run `hermes` and exercise the code path you changed
+2. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
+3. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.
 
 ### PR description
 


### PR DESCRIPTION
## Summary
- Documents local pre-submit checks that mirror blocking CI gates for contributors.
- Aligns the PR template checklist with the documented ruff, Windows-footgun, and test checks.
- Keeps this contributor-facing guidance separate from post-merge verification and visual QA workflows.

## Verification
```bash
python - <<'PY'
from pathlib import Path
c=Path('CONTRIBUTING.md').read_text()
pr=Path('.github/PULL_REQUEST_TEMPLATE.md').read_text()
for s in ['ruff check .','check-windows-footguns.py --diff main','pytest']:
    assert s in c or s in pr, s
print('contributor validation docs sanity OK')
PY
```

Claude reported validating the documented commands against the repo workflows; no code, secrets, deploys, or merges.
