### PR TITLE
fix(agent): sync logging session context on compaction id rotation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -513,6 +513,21 @@ def compress_context(
                 set_current_session_id(agent.session_id)
             except Exception:
                 os.environ["HERMES_SESSION_ID"] = agent.session_id
+            # The gateway/tools session context (ContextVar + env) and the
+            # logging session context are SEPARATE mechanisms. The call above
+            # moves the former; the ``[session_id]`` tag on log lines comes
+            # from ``hermes_logging._session_context`` (set once per turn in
+            # conversation_loop.py). Without this, post-rotation log lines in
+            # the same turn keep the STALE old id while the message/DB/gateway
+            # state carry the new one — breaking log correlation exactly at the
+            # compaction boundary (see #34089). Guarded separately so a logging
+            # failure can never regress the routing update above.
+            try:
+                from hermes_logging import set_session_context
+
+                set_session_context(agent.session_id)
+            except Exception:
+                pass
             agent._session_db_created = False
             agent._session_db.create_session(
                 session_id=agent.session_id,

--- a/tests/agent/test_compression_logging_session_context.py
+++ b/tests/agent/test_compression_logging_session_context.py
@@ -1,0 +1,80 @@
+"""Regression: compaction must move the LOGGING session context with the id.
+
+When ``compress_context`` rotates ``agent.session_id`` it updates the
+gateway/tools session context (``gateway.session_context.set_current_session_id``,
+which moves ``HERMES_SESSION_ID`` env + ContextVar). The ``[session_id]`` tag on
+log lines comes from a SEPARATE mechanism — ``hermes_logging._session_context``
+(a threading.local read by the global LogRecord factory), set once per turn in
+``conversation_loop.py``. Before the fix, the rotation block never updated it, so
+log lines emitted after a mid-turn compaction carried the STALE old id while the
+message body / session DB / gateway state carried the new one (see #34089). This
+asserts the logging context follows the rotation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import hermes_logging
+from hermes_state import SessionDB
+
+
+def _build_agent_with_db(db: SessionDB, session_id: str):
+    """Mirror tests/agent/test_compression_concurrent_fork.py's harness."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    return agent
+
+
+def test_logging_session_context_follows_compression_rotation(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "PARENT_LOGCTX_SESSION"
+    db.create_session(parent_sid, source="cli")
+
+    agent = _build_agent_with_db(db, parent_sid)
+
+    # conversation_loop.py pins the logging tag to the ORIGINAL id at turn start.
+    hermes_logging.set_session_context(parent_sid)
+    try:
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+        # The id actually rotated (sanity — otherwise the assertion is vacuous).
+        assert agent.session_id != parent_sid
+
+        # The logging context must now match the NEW id, not the stale one.
+        current = getattr(hermes_logging._session_context, "session_id", None)
+        assert current == agent.session_id, (
+            "Logging session context did not follow the compaction rotation: "
+            f"log tag still {current!r}, agent.session_id is {agent.session_id!r} "
+            "(see #34089)."
+        )
+    finally:
+        hermes_logging.clear_session_context()


### PR DESCRIPTION
## What does this PR do?

Context compaction rotates `agent.session_id` mid-turn. The rotation block in `agent/conversation_compression.py` updates the gateway/tools session context (`set_current_session_id` → `HERMES_SESSION_ID` env + ContextVar) but never updates the SEPARATE **logging** session context. The `[session_id]` tag on log lines comes from `hermes_logging._session_context` (a `threading.local` read by the global LogRecord factory), set once per turn in `conversation_loop.py`. So after a mid-turn compaction, log lines in the same turn carry the **stale old** id while the message body, session DB, and gateway routing carry the new id (e.g. API-call logs appear under the old id while `Turn ended … session=<new id>`). This breaks `hermes logs --session <id>` correlation exactly at the compaction boundary.

This is the logging half of #34089 — Anomaly A explicitly notes "the bracketed logger context still refer to the original." The issue's prior fixes addressed the gateway-routing desync but not the logging tag.

## Related Issue

Refs #34089

(Addresses the logging-context sub-symptom only — the broader P1 has additional routing/aliasing scope, so this intentionally does **not** auto-close it.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` — in the session-id rotation block, after the existing `set_current_session_id(agent.session_id)`, also call `hermes_logging.set_session_context(agent.session_id)`, in its own guarded `try/except` so a logging-context failure can never regress the gateway-context update. Logs-only; no runtime/caching impact.
- `tests/agent/test_compression_logging_session_context.py` — pins the old id as the turn does, runs `_compress_context`, asserts `hermes_logging._session_context.session_id` now equals the rotated id.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_compression_logging_session_context.py` — passes (the existing `test_compression_concurrent_fork.py` still passes too).
2. Repro: trigger a mid-turn compaction (long session crossing the threshold). Before: post-compaction `agent.conversation_loop` log lines show `[<old session id>]` while `Turn ended … session=<new id>`. After: the `[session_id]` tag follows the rotation.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (none touch the logging tag; #39005/#11212/#32070 touch the file but not this)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests via `scripts/run_tests.sh` and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5, Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — logs-only behavior change; no docs, config keys, or schemas changed