### PR TITLE
fix(desktop): stop pinning stale message at top on chat switch / compaction (#39959)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -341,6 +341,7 @@ export function ChatView({
       >
         <AssistantRuntimeProvider runtime={runtime}>
           <Thread
+            key={threadKey}
             clampToComposer={showChatBar}
             cwd={currentCwd}
             gateway={gateway}

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -23,7 +23,9 @@ const POST_RUN_BOTTOM_LOCK_MS = 1_200
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
-type MessageGroup = { id: string; index: number; kind: 'standalone' } | { id: string; indices: number[]; kind: 'turn' }
+type MessageGroup =
+  | { id: string; index: number; kind: 'standalone' }
+  | { id: string; indices: { index: number; id: string }[]; kind: 'turn' }
 
 interface VirtualizedThreadProps {
   clampToComposer: boolean
@@ -55,10 +57,11 @@ function buildGroups(signature: string): MessageGroup[] {
       continue
     }
 
-    const indices = [message.index]
+    const indices = [{ index: message.index, id: message.id }]
 
     while (i + 1 < messages.length && messages[i + 1].role !== 'user') {
-      indices.push(messages[++i].index)
+      i++
+      indices.push({ index: messages[i].index, id: messages[i].id })
     }
 
     groups.push({ id: message.id, indices, kind: 'turn' })
@@ -186,8 +189,8 @@ const VirtualizedThreadInner: FC<VirtualizedThreadProps> = ({
                         className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
                         data-slot="aui_turn-pair"
                       >
-                        {group.indices.map(index => (
-                          <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
+                        {group.indices.map(({ index, id }) => (
+                          <ThreadPrimitive.MessageByIndex components={components} index={index} key={id} />
                         ))}
                       </div>
                     ) : (


### PR DESCRIPTION
Fixes #39959

## Problem
After switching chats while a session is busy — or when automatic context compaction rotates to a successor session — the last sent message becomes pinned to the top of the viewport, and the pinned item *changes* while scrolling up. Classic virtualization row-reuse.

## Root cause
- `thread-virtualizer.tsx` keyed the inner turn rows with the **array index** (`key={index}`), not the message id. On a session swap the new messages occupy the same indices, so React/`@tanstack/react-virtual` reuse the previous session's row DOM and state. (The *outer* virtual rows were already correctly keyed via `getItemKey`.)
- User bubbles use `position: sticky` (`StickyHumanMessageContainer`), so a reused/stale row is what visibly sticks to the top.
- `<Thread>` was never remounted per session — only passed `sessionKey` as a prop — so scroll-anchor / sticky state leaked across sessions.

## Fix
1. Key inner turn rows by **stable message id**. `turn` groups now carry `{ index, id }[]` instead of `number[]`; `buildGroups` populates both (iteration is unchanged).
2. Add `key={threadKey}` to `<Thread>` so it fully remounts on session switch/compaction, resetting leaked scroll-anchor and sticky state. `AssistantRuntimeProvider` stays mounted above it, so in-flight streams are unaffected.

## Verification
- `npx tsc -b` in `apps/desktop` passes (exit 0).
- Manual: open two long sessions, send a message, switch chats while busy / trigger compaction → the correct session's user bubble sticks; no stale message pins to the top; scrolling no longer swaps the pinned row.
