### PR TITLE
fix(memory): auto-start local OpenViking server

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -29,8 +29,12 @@ import json
 import logging
 import mimetypes
 import os
+import shutil
+import signal
+import subprocess
 import tempfile
 import threading
+import time
 import uuid
 import zipfile
 from pathlib import Path
@@ -46,6 +50,9 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
+_OPENVIKING_STARTUP_TIMEOUT = 30.0
+_OPENVIKING_STARTUP_POLL_INTERVAL = 0.5
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -84,6 +91,10 @@ def _atexit_commit_sessions():
     _last_active_provider = None
     try:
         provider.on_session_end([])
+    except Exception:
+        pass  # best-effort at shutdown time
+    try:
+        provider.shutdown()
     except Exception:
         pass  # best-effort at shutdown time
 
@@ -422,6 +433,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
+        self._server_proc: Optional[subprocess.Popen] = None
+        self._auto_started_server = False
 
     @property
     def name(self) -> str:
@@ -481,8 +494,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 account=self._account, user=self._user, agent=self._agent,
             )
             if not self._client.health():
-                logger.warning("OpenViking server at %s is not reachable", self._endpoint)
-                self._client = None
+                if not self._auto_start_server():
+                    logger.warning("OpenViking server at %s is not reachable", self._endpoint)
+                    self._client = None
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
@@ -490,6 +504,78 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # Register as the last active provider for atexit safety net
         global _last_active_provider
         _last_active_provider = self
+
+    def _auto_start_port(self) -> Optional[int]:
+        parsed = urlparse(self._endpoint)
+        if parsed.scheme != "http":
+            return None
+        host = (parsed.hostname or "").strip().lower()
+        if host not in _LOOPBACK_HOSTS:
+            return None
+        return parsed.port or 80
+
+    @staticmethod
+    def _openviking_server_command() -> Optional[List[str]]:
+        server = shutil.which("openviking-server")
+        if server:
+            return [server]
+        uvx = shutil.which("uvx")
+        if uvx:
+            return [uvx, "--from", "openviking", "openviking-server"]
+        uv = shutil.which("uv")
+        if uv:
+            return [uv, "tool", "run", "--from", "openviking", "openviking-server"]
+        return None
+
+    def _auto_start_server(self) -> bool:
+        """Start a local OpenViking server for loopback endpoints."""
+        port = self._auto_start_port()
+        if port is None:
+            return False
+
+        command = self._openviking_server_command()
+        if not command:
+            logger.warning(
+                "OpenViking server at %s is not reachable and no "
+                "openviking-server/uvx/uv command was found",
+                self._endpoint,
+            )
+            return False
+
+        try:
+            proc = subprocess.Popen(
+                [*command, "--port", str(port)],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except Exception as exc:
+            logger.warning("Failed to auto-start OpenViking server: %s", exc)
+            return False
+
+        self._server_proc = proc
+        self._auto_started_server = True
+
+        deadline = time.monotonic() + _OPENVIKING_STARTUP_TIMEOUT
+        while True:
+            if self._client and self._client.health():
+                logger.info("OpenViking server auto-started at %s", self._endpoint)
+                return True
+            if proc.poll() is not None:
+                logger.warning(
+                    "Auto-started OpenViking server exited before becoming healthy"
+                )
+                self._stop_auto_started_server()
+                return False
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Timed out waiting for OpenViking server at %s", self._endpoint
+                )
+                self._stop_auto_started_server()
+                return False
+            time.sleep(_OPENVIKING_STARTUP_POLL_INTERVAL)
 
     def system_prompt_block(self) -> str:
         if not self._client:
@@ -689,10 +775,39 @@ class OpenVikingMemoryProvider(MemoryProvider):
         for t in (self._sync_thread, self._prefetch_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
+        self._stop_auto_started_server()
         # Clear atexit reference so it doesn't double-commit
         global _last_active_provider
         if _last_active_provider is self:
             _last_active_provider = None
+
+    def _stop_auto_started_server(self) -> None:
+        proc = self._server_proc
+        if not self._auto_started_server or proc is None:
+            return
+        self._server_proc = None
+        self._auto_started_server = False
+        if proc.poll() is not None:
+            return
+        killpg = getattr(os, "killpg", None)
+        try:
+            if killpg is not None:
+                killpg(proc.pid, signal.SIGTERM)
+            else:
+                proc.terminate()
+            proc.wait(timeout=5.0)
+        except Exception:
+            try:
+                if killpg is not None:
+                    killpg(proc.pid, signal.SIGKILL)
+                else:
+                    proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5.0)
+            except Exception:
+                pass
 
     # -- Tool implementations ------------------------------------------------
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -420,3 +420,248 @@ def test_viking_client_health_sends_auth_headers(monkeypatch):
     assert client.health() is True
     assert captured["url"] == "https://example.com/health"
     assert captured["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_initialize_auto_starts_local_server_when_health_fails(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    monkeypatch.delenv("OPENVIKING_ENDPOINT", raising=False)
+    clients = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            clients.append((args, kwargs))
+            self._health_results = [False, True]
+
+        def health(self):
+            return self._health_results.pop(0)
+
+    class FakeProc:
+        pid = 1234
+
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    fake_proc = FakeProc()
+    popen_calls = []
+    signals = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return fake_proc
+
+    monkeypatch.setattr(ov_mod, "_VikingClient", FakeClient)
+    monkeypatch.setattr(
+        ov_mod.shutil,
+        "which",
+        lambda name: "/bin/openviking-server" if name == "openviking-server" else None,
+    )
+    monkeypatch.setattr(ov_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        ov_mod.os,
+        "killpg",
+        lambda pid, sig: signals.append((pid, sig)),
+        raising=False,
+    )
+
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session-1")
+
+    assert len(clients) == 1
+    assert provider._client is not None
+    assert provider._auto_started_server is True
+    assert popen_calls[0][0][0] == ["/bin/openviking-server", "--port", "1933"]
+    assert popen_calls[0][1]["start_new_session"] is True
+
+    provider.shutdown()
+
+    assert signals == [(1234, ov_mod.signal.SIGTERM)]
+    assert fake_proc.terminated is False
+    assert fake_proc.killed is False
+
+
+def test_initialize_does_not_auto_start_non_loopback_endpoint(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://openviking.example.com:1933")
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def health(self):
+            return False
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("remote OpenViking endpoint must not spawn local server")
+
+    monkeypatch.setattr(ov_mod, "_VikingClient", FakeClient)
+    monkeypatch.setattr(ov_mod.subprocess, "Popen", fail_popen)
+
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session-1")
+
+    assert provider._client is None
+    assert provider._auto_started_server is False
+
+
+def test_atexit_commit_sessions_stops_auto_started_server(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    class FakeProvider:
+        def __init__(self):
+            self.committed = False
+            self.shutdown_called = False
+
+        def on_session_end(self, messages):
+            self.committed = messages == []
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    provider = FakeProvider()
+    monkeypatch.setattr(ov_mod, "_last_active_provider", provider)
+
+    ov_mod._atexit_commit_sessions()
+
+    assert provider.committed is True
+    assert provider.shutdown_called is True
+    assert ov_mod._last_active_provider is None
+
+
+def test_stop_auto_started_server_terminates_process_group(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    class FakeProc:
+        pid = 1234
+
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+            self.waited = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, timeout=None):
+            self.waited = True
+            return 0
+
+    signals = []
+    monkeypatch.setattr(
+        ov_mod.os,
+        "killpg",
+        lambda pid, sig: signals.append((pid, sig)),
+        raising=False,
+    )
+
+    provider = OpenVikingMemoryProvider()
+    provider._auto_started_server = True
+    proc = FakeProc()
+    provider._server_proc = proc
+
+    provider._stop_auto_started_server()
+
+    assert signals == [(1234, ov_mod.signal.SIGTERM)]
+    assert proc.waited is True
+    assert proc.terminated is False
+    assert proc.killed is False
+    assert provider._auto_started_server is False
+    assert provider._server_proc is None
+
+
+def test_stop_auto_started_server_kills_process_group_after_timeout(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    class FakeProc:
+        pid = 1234
+
+        def __init__(self):
+            self.wait_count = 0
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.wait_count += 1
+            if self.wait_count == 1:
+                raise ov_mod.subprocess.TimeoutExpired(cmd="openviking-server", timeout=timeout)
+            return 0
+
+    signals = []
+    monkeypatch.setattr(
+        ov_mod.os,
+        "killpg",
+        lambda pid, sig: signals.append((pid, sig)),
+        raising=False,
+    )
+
+    proc = FakeProc()
+    provider = OpenVikingMemoryProvider()
+    provider._auto_started_server = True
+    provider._server_proc = proc
+
+    provider._stop_auto_started_server()
+
+    assert signals == [
+        (1234, ov_mod.signal.SIGTERM),
+        (1234, ov_mod.signal.SIGKILL),
+    ]
+    assert proc.wait_count == 2
+
+
+def test_openviking_server_command_uses_uvx_fallback(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    def fake_which(name):
+        if name == "uvx":
+            return "/bin/uvx"
+        return None
+
+    monkeypatch.setattr(ov_mod.shutil, "which", fake_which)
+
+    assert OpenVikingMemoryProvider._openviking_server_command() == [
+        "/bin/uvx",
+        "--from",
+        "openviking",
+        "openviking-server",
+    ]
+
+
+def test_openviking_server_command_uses_uv_fallback(monkeypatch):
+    from plugins.memory import openviking as ov_mod
+
+    def fake_which(name):
+        if name == "uv":
+            return "/bin/uv"
+        return None
+
+    monkeypatch.setattr(ov_mod.shutil, "which", fake_which)
+
+    assert OpenVikingMemoryProvider._openviking_server_command() == [
+        "/bin/uv",
+        "tool",
+        "run",
+        "--from",
+        "openviking",
+        "openviking-server",
+    ]


### PR DESCRIPTION
Fixes #39981

## Summary
- auto-start a loopback OpenViking server when the initial health check fails
- support installed `openviking-server`, `uvx --from openviking`, and `uv tool run --from openviking` commands
- keep non-loopback endpoints fail-closed so remote URLs never spawn a local process
- stop provider-owned auto-started servers on shutdown and the atexit safety path

## Tests
- `uv run --extra dev python -m pytest -q tests/plugins/memory/test_openviking_provider.py`
- `uv run --extra dev python -m ruff check plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
- `uv run --extra dev python -m py_compile plugins/memory/openviking/__init__.py`
- `git diff --check`